### PR TITLE
Allow publishing of entries to context

### DIFF
--- a/Scripts/script-PublishEntriesToContext.yml
+++ b/Scripts/script-PublishEntriesToContext.yml
@@ -1,0 +1,37 @@
+commonfields:
+  id: PublishEntriesToContext
+  version: -1
+name: PublishEntriesToContext
+script: |-
+  var ids = argToList(args.ids);
+  var out = args.out ? args.out : 'entries';
+  var data = [];
+
+  for (var i=0; i<ids.length; i++) {
+      var entryRes = executeCommand('getEntry', {id: ids[i]});
+      if (entryRes && Array.isArray(entryRes)) {
+          if (entryRes[0].Type !== entryTypes.error) {
+              data.push(entryRes[0].Contents);
+          }
+      }
+  }
+  if (data.length > 0) {
+      setContext(out, data);
+      return 'Published ' + data.length + ' entries to context under ' + out;
+  }
+  return 'No entries found';
+type: javascript
+tags:
+- util
+enabled: true
+args:
+- name: ids
+  required: true
+  default: true
+  description: The entry IDs we want to publish. Accepts comma separated IDs or a
+    list of strings.
+- name: out
+  description: The name of the context key. Default is "entries".
+scripttarget: 0
+dependson: {}
+timeout: 0s


### PR DESCRIPTION
 Mostly to be used with `context.lastCompletedTaskEntries`.