### PR TITLE
added depends on a nexpose command vulnerability-list

### DIFF
--- a/Scripts/script-NexposeEmailParser.yml
+++ b/Scripts/script-NexposeEmailParser.yml
@@ -81,5 +81,7 @@ args:
 - name: defaultNexposeSeverity
   description: Severity to be set on triggered incidents
 scripttarget: 0
-dependson: {}
+dependson:
+  must:
+  - vulnerability-list
 timeout: 0s

--- a/Scripts/script-NexposeEmailParserForVuln.yml
+++ b/Scripts/script-NexposeEmailParserForVuln.yml
@@ -65,5 +65,7 @@ args:
   description: Full XML contents of the Nexpose report. If not provided, it will be
     taken from the Incident Details.
 scripttarget: 0
-dependson: {}
+dependson:
+  must:
+  - vulnerability-list
 timeout: 0s

--- a/Scripts/script-NexposeVulnExtractor.yml
+++ b/Scripts/script-NexposeVulnExtractor.yml
@@ -23,5 +23,7 @@ args:
   description: Full XML contents of the Nexpose report. If not provided, it will be
     taken from the Incident Details.
 scripttarget: 0
-dependson: {}
+dependson:
+  must:
+  - vulnerability-list
 timeout: 0s


### PR DESCRIPTION
Added the dependency on the Nexpose scripts to make sure we have the vulnerability-list command (part of Nexpose integration), so Nexpose scripts won't show up in the CLI when there is no Nexpose instance set up.