### PR TITLE
Added dependency on trendmicro-alert-status command

### DIFF
--- a/Scripts/script-TrendMicroClassifier.yml
+++ b/Scripts/script-TrendMicroClassifier.yml
@@ -142,5 +142,7 @@ tags:
 comment: Classifying TrendMicro incidents
 system: true
 scripttarget: 0
-dependson: {}
+dependson:
+  must:
+  - trendmicro-alert-status
 timeout: 0s


### PR DESCRIPTION
Added trendmicro-alert-status dependency, so the classifier script won't show up in CLI if no trendmicro instance is configured