### PR TITLE
utility to add specific entry comments to context

### DIFF
--- a/Scripts/script-commentsToContext.yml
+++ b/Scripts/script-commentsToContext.yml
@@ -1,0 +1,30 @@
+commonfields:
+  id: 120c861a-e0ae-417e-8dcf-c3ee1dc15a42
+  version: 38
+name: commentsToContext
+script: |-
+  var entry = executeCommand("getEntry", {"id":args.entryId});
+  var key=args.contextKey;
+  var comments=entry[0].Contents;
+
+  var md =  'Comments set to context - '+key+':' + comments + '\n';
+  var ec={};
+  ec[key]=comments;
+
+  return {Type: entryTypes.note, Contents: entry, ContentsFormat: formats.json, HumanReadable: md, EntryContext: ec};
+type: javascript
+tags:
+- Utility
+comment: "Takes the comments of a given entry ID and stores them in the incident context,
+  under a provided context key. \nFor accessing the last executed task's comments,
+  provide ${lastCompletedTaskEntries.[0]} as the value for the entryId input parameter."
+enabled: true
+args:
+- name: entryId
+  required: true
+  default: true
+  description: Entry ID to get the comments from
+- name: contextKey
+  required: true
+  description: Context key to store comments into
+scripttarget: 0


### PR DESCRIPTION
Use case: analyst puts some comments on a manual task he is doing. Later in playbook a task takes those comments and adds them to a sent email. (SureScripts)