### PR TITLE
Fix for type that came back as with very long lines. 

### DIFF
--- a/Scripts/script-ParseEmailFile.yml
+++ b/Scripts/script-ParseEmailFile.yml
@@ -574,7 +574,7 @@ script: |-
       temp1, temp2 = handleEml(filePath)
       res += temp1
       res += temp2
-  elif 'ASCII text, with CRLF line terminators' in fileType:
+  elif 'ASCII text, with CRLF line terminators' in fileType or 'ASCII text, with very long lines, with CRLF line terminators' in fileType:
       try:
           # Try to open the email as-is
           with open(filePath, 'rb') as f:


### PR DESCRIPTION
Simple fix as there was a type that came back as ASCII text, with very long lines, with CRLF line terminators which seemed to fix the problem. Might need further review down the road if there are other issues