### PR TITLE
LR fetch incidents return on empty value

### DIFF
--- a/Integrations/integration-LogRhythm.yml
+++ b/Integrations/integration-LogRhythm.yml
@@ -471,6 +471,7 @@ script:
             if (alarms.length) {
                 return alarmsToIncident(alarms, lastRun);
             }
+            return '[]';
     }
   type: javascript
   commands:


### PR DESCRIPTION
In case there were no incidents found on the return a json of an empty array.
so there will be no errors in the server