### PR TITLE
Fix phishing playbook

### DIFF
--- a/Playbooks/playbook-Account_Enrichment.yml
+++ b/Playbooks/playbook-Account_Enrichment.yml
@@ -3,6 +3,7 @@ version: -1
 name: Account Enrichment
 system: true
 fromversion: 2.5.0
+releaseNotes: "-"
 description: Enrich the accounts under the Account context key with details from relevant
   integrations such as AD.
 starttaskid: "0"
@@ -72,7 +73,7 @@ tasks:
       - "3"
     scriptarguments:
       attributes: ""
-      customFieldData: ${Account.Email}
+      customFieldData: ${Account.Email.Address}
       customFieldType: mail
       dn: ""
       headers: ""

--- a/Playbooks/playbook-PhishingAutomated.yml
+++ b/Playbooks/playbook-PhishingAutomated.yml
@@ -3,6 +3,7 @@ version: -1
 system: true
 fromversion: 2.5.0
 name: Phishing Playbook - Automated
+releaseNotes: "-"
 description: |-
   This is an automated playbook to investigate suspected Phishing attempts.
   It picks up the required information from the incident metadata as created by the mail listener.
@@ -86,7 +87,7 @@ tasks:
       htmlBody: ""
       noteEntryID: ""
       subject: 'Re: Phishing Investigation - ${incident.name}'
-      to: ${Account.Email}
+      to: ${incident.labels.Email/from}
     view: |-
       {
         "position": {
@@ -208,7 +209,7 @@ tasks:
     scriptarguments:
       distance: ""
       domain: ${inputs.CompanyDomains}
-      sender: ${Account.Email}
+      sender: ${incident.labels.Email/from}
     results:
     - LevenshteinDistance
     view: |-
@@ -387,7 +388,7 @@ tasks:
       htmlBody: ""
       noteEntryID: ""
       subject: 'Re: Phishing Investigation - ${incident.name}'
-      to: ${Account.Email}
+      to: ${incident.labels.Email/from}
     view: |-
       {
         "position": {
@@ -446,7 +447,7 @@ tasks:
       htmlBody: ""
       noteEntryID: ""
       subject: 'Re: Phishing Investigation - ${incident.name}'
-      to: ${Account.Email}
+      to: ${incident.labels.Email/from}
     view: |-
       {
         "position": {
@@ -632,8 +633,9 @@ tasks:
       '#none#':
       - "98"
     scriptarguments:
-      key: Account.Email
+      key: Account.Email.Address
       value: ${incident.labels.Email/from}
+      append: true
     view: |-
       {
         "position": {


### PR DESCRIPTION
1. Set sender properly into context
2. Use the sender from incident label instead of context, since context can contain many other emails as well
