### PR TITLE
DataXreputation manual override

### DIFF
--- a/Scripts/script-DataHashReputation.yml
+++ b/Scripts/script-DataHashReputation.yml
@@ -1,29 +1,43 @@
 commonfields:
-  id: DataHashReputation
+  id: DataHashReputationV2
   version: 1
-name: DataHashReputation
+name: DataHashReputationV2
 script: |-
   var score = -1;
-  var rep = executeCommand('file', {file: args.input});
-  var scores = dq(rep, 'EntryContext.DBotScore.Score');
-  for (var i = 0; scores && i < scores.length; i++) {
-    if (scores[i] && score < scores[i]) {
-      score = scores[i];
-    }
+  var res = executeCommand("findIndicators", {"query": "type:File* and value:\"" + args.input + "\" and manualScore:T"})
+  if (args.forceCalc != 'yes' && res[0] && res[0].Contents[0]) {
+      score = res[0].Contents[0].score;
+  } else {
+      var rep = executeCommand('file', {file: args.input});
+      var scores = dq(rep, 'EntryContext.DBotScore.Score');
+      for (var i = 0; scores && i < scores.length; i++) {
+          if (scores[i] && score < scores[i]) {
+            score = scores[i];
+          }
+      }
   }
   return score < 0 ? 0 : score;
 type: javascript
 tags:
 - reputation
-comment: Evaluate reputation of a hash and return a score between 0 and 3 (0 - unknown, 1 - known good, 2 - suspicious, 3 - known bad)
+comment: Evaluate reputation of a hash and return a score between 0 and 3 (0 - unknown, 1 - known good, 2 - suspicious, 3 - known bad). If the indicator reputation was
+  manually set, the manual value will be returned.
 system: true
 args:
 - name: input
   required: true
   default: true
   description: Hash value to look up
+- name: forceCalc
+  auto: PREDEFINED
+  predefined:
+  - "yes"
+  - "no"
+  defaultValue: "no"
+  description: Whether to calculate reputation even if it is manual set - yes/no
 scripttarget: 0
 dependson:
   must:
   - file
 timeout: 0s
+releaseNotes: Manually set value of indicator reputation will now superceed threat intel sites

--- a/Scripts/script-DataHashReputation.yml
+++ b/Scripts/script-DataHashReputation.yml
@@ -1,7 +1,7 @@
 commonfields:
-  id: DataHashReputationV2
+  id: DataHashReputation
   version: 1
-name: DataHashReputationV2
+name: DataHashReputation
 script: |-
   var score = -1;
   var res = executeCommand("findIndicators", {"query": "type:File* and value:\"" + args.input + "\" and manualScore:T"})

--- a/Scripts/script-DataIPReputation.yml
+++ b/Scripts/script-DataIPReputation.yml
@@ -4,26 +4,40 @@ commonfields:
 name: DataIPReputation
 script: |-
   var score = -1;
-  var rep = executeCommand('ip', {ip: args.input});
-  var scores = dq(rep, 'EntryContext.DBotScore.Score');
-  for (var i = 0; scores && i < scores.length; i++) {
-    if (scores[i] && score < scores[i]) {
-      score = scores[i];
-    }
+  var res = executeCommand("findIndicators", {"query": "type:IP and value:\"" + args.input + "\" and manualScore:T"})
+  if (args.forceCalc != 'yes' && res[0] && res[0].Contents[0]) {
+      score = res[0].Contents[0].score;
+  } else {
+      var rep = executeCommand('ip', {ip: args.input});
+      var scores = dq(rep, 'EntryContext.DBotScore.Score');
+      for (var i = 0; scores && i < scores.length; i++) {
+          if (scores[i] && score < scores[i]) {
+            score = scores[i];
+          }
+      }
   }
   return score < 0 ? 0 : score;
 type: javascript
 tags:
 - reputation
-comment: Evaluate reputation of an IP and return a score between 0 and 3 (0 - unknown, 1 - known good, 2 - suspicious, 3 - known bad)
+comment: Evaluate reputation of an IP and return a score between 0 and 3 (0 - unknown, 1 - known good, 2 - suspicious, 3 - known bad). If the indicator reputation was
+  manually set, the manual value will be returned.
 system: true
 args:
 - name: input
   required: true
   default: true
   description: IP address to look up
+- name: forceCalc
+  auto: PREDEFINED
+  predefined:
+  - "yes"
+  - "no"
+  defaultValue: "no"
+  description: Whether to calculate reputation even if it is manual set - yes/no
 scripttarget: 0
 dependson:
   should:
   - ip
 timeout: 0s
+releaseNotes: Manually set value of indicator reputation will now superceed threat intel sites

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -16,7 +16,7 @@ script: |-
         }
       }
   }
-  return score < 0 ? 0 : score; 
+  return score < 0 ? 0 : score;
 type: javascript
 tags:
 - reputation

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,22 +1,30 @@
+versionedfields: {}
 commonfields:
   id: DataURLReputation
   version: -1
 name: DataURLReputation
 script: |-
   var score = -1;
-  var rep = executeCommand('url', {url: args.input});
-  var scores = dq(rep, 'EntryContext.DBotScore.Score');
-  for (var i = 0; scores && i < scores.length; i++) {
-    if (scores[i] && score < scores[i]) {
-      score = scores[i];
-    }
+  var res = executeCommand("findIndicators", {"query": "type:URL and value:" + args.input})
+  if (res[0] && res[0].Contents[0] && res[0].Contents[0].manualScore) {
+      score = res[0].Contents[0].score;
+  } else {
+      var rep = executeCommand('url', {url: args.input});
+      var scores = dq(rep, 'EntryContext.DBotScore.Score');
+      for (var i = 0; scores && i < scores.length; i++) {
+        if (scores[i] && score < scores[i]) {
+          score = scores[i];
+        }
+      }
   }
   return score < 0 ? 0 : score;
 type: javascript
 tags:
 - reputation
-comment: Evaluate reputation of a URL and return a score between 0 and 3 (0 - unknown, 1 - known good, 2 - suspicious, 3 - known bad)
-system: true
+comment: Evaluate reputation of a URL and return a score between 0 and 3 (0 - unknown,
+  1 - known good, 2 - suspicious, 3 - known bad). If the indicator reputation was
+  manually set, the manual value will be returned.
+enabled: true
 args:
 - name: input
   required: true
@@ -28,3 +36,4 @@ dependson:
   - url
   - pt-malware
 timeout: 0s
+releaseNotes: Manually set value of indicator reputation will now superceed threat intel sites

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -4,7 +4,7 @@ commonfields:
 name: DataURLReputation
 script: |-
   var score = -1;
-  var res = executeCommand("findIndicators", {"query": "type:URL and value:" + args.input})
+  var res = executeCommand("findIndicators", {"query": "type:URL and value:\"" + args.input + "\" and manualScore:T"})
   if (res[0] && res[0].Contents[0] && res[0].Contents[0].manualScore) {
       score = res[0].Contents[0].score;
   } else {

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,11 +1,11 @@
 commonfields:
-  id: DataURLReputation
+  id: DataURLReputationV2
   version: -1
-name: DataURLReputation
+name: DataURLReputationV2
 script: |-
   var score = -1;
   var res = executeCommand("findIndicators", {"query": "type:URL and value:\"" + args.input + "\" and manualScore:T"})
-  if (args.forceCalc != 'yes' && res[0] && res[0].Contents[0] && res[0].Contents[0].manualScore) {
+  if (args.forceCalc != 'yes' && res[0] && res[0].Contents[0]) {
       score = res[0].Contents[0].score;
   } else {
       var rep = executeCommand('url', {url: args.input});
@@ -34,6 +34,7 @@ args:
   predefined:
   - "yes"
   - "no"
+  defaultValue: "no"
   description: Whether to calculate reputation even if it is manual set - yes/no
 scripttarget: 0
 dependson:

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -17,7 +17,7 @@ script: |-
         }
       }
   }
-  return score < 0 ? 0 : score;
+  return score < 0 ? 0 : score; 
 type: javascript
 tags:
 - reputation

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,4 +1,3 @@
-versionedfields: {}
 commonfields:
   id: DataURLReputation
   version: -1

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,7 +1,7 @@
 commonfields:
-  id: DataURLReputationV2
+  id: DataURLReputation
   version: -1
-name: DataURLReputationV2
+name: DataURLReputation
 script: |-
   var score = -1;
   var res = executeCommand("findIndicators", {"query": "type:URL and value:\"" + args.input + "\" and manualScore:T"})
@@ -11,9 +11,9 @@ script: |-
       var rep = executeCommand('url', {url: args.input});
       var scores = dq(rep, 'EntryContext.DBotScore.Score');
       for (var i = 0; scores && i < scores.length; i++) {
-        if (scores[i] && score < scores[i]) {
-          score = scores[i];
-        }
+          if (scores[i] && score < scores[i]) {
+            score = scores[i];
+          }
       }
   }
   return score < 0 ? 0 : score;

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,7 +1,7 @@
 commonfields:
-  id: DataURLReputationV2
+  id: DataURLReputation
   version: -1
-name: DataURLReputationV2
+name: DataURLReputation
 script: |-
   var score = -1;
   var res = executeCommand("findIndicators", {"query": "type:URL and value:\"" + args.input + "\" and manualScore:T"})

--- a/Scripts/script-DataURLReputation.yml
+++ b/Scripts/script-DataURLReputation.yml
@@ -1,11 +1,11 @@
 commonfields:
-  id: DataURLReputation
+  id: DataURLReputationV2
   version: -1
-name: DataURLReputation
+name: DataURLReputationV2
 script: |-
   var score = -1;
   var res = executeCommand("findIndicators", {"query": "type:URL and value:\"" + args.input + "\" and manualScore:T"})
-  if (res[0] && res[0].Contents[0] && res[0].Contents[0].manualScore) {
+  if (args.forceCalc != 'yes' && res[0] && res[0].Contents[0] && res[0].Contents[0].manualScore) {
       score = res[0].Contents[0].score;
   } else {
       var rep = executeCommand('url', {url: args.input});
@@ -29,6 +29,12 @@ args:
   required: true
   default: true
   description: URL to look up
+- name: forceCalc
+  auto: PREDEFINED
+  predefined:
+  - "yes"
+  - "no"
+  description: Whether to calculate reputation even if it is manual set - yes/no
 scripttarget: 0
 dependson:
   should:


### PR DESCRIPTION
Changing all dataXreputataion to take manual reputation before checking threat intel services.

Please review but do not merge. Once changes are agreed upon, will redo the changes in the other scripts.
