### PR TITLE
handle `R093` Status

### DIFF
--- a/release_notes.py
+++ b/release_notes.py
@@ -252,6 +252,11 @@ def createFileReleaseNotes(fileName, deleteFilePath):
         if changeType == "D":
             handleDeletedFiles(deleteFilePath, fullFileName)
         elif changeType != "R100" and changeType != "R094":
+            if changeType == "R093":
+                # handle the same as modified
+                fullFileName = names[2]
+                changeType = 'M'
+
             with open(contentLibPath + fullFileName, 'r') as f:
                 data = f.read()
                 if "/" in fullFileName:


### PR DESCRIPTION
@meirwah has noticed that if file is renamed in some PR (& merged) and in a later PR modified - the build fails

This fix support this scenario
