### PR TITLE
AreValuesEqual - making arguments non-mandatory

### DIFF
--- a/Scripts/script-AreValuesEqual.yml
+++ b/Scripts/script-AreValuesEqual.yml
@@ -33,8 +33,7 @@ outputs:
 - contextPath: no
   description: if left is not equal to right
 scripttarget: 0
-comment: Check whether the values provided in arguments are equal. If either of the
-  arguments are missing, no is returned.
+comment: Check whether the values provided in arguments are equal. If either of the arguments are missing, no is returned.
 dependson: {}
 timeout: 0s
-releaseNotes: Arguments are not mandatory anymore. If an argument is missing (or provided with an empty value), no is returned.
+releaseNotes: Arguments are not mandatory anymore. If either of the arguments are missing, no is returned.

--- a/Scripts/script-AreValuesEqual.yml
+++ b/Scripts/script-AreValuesEqual.yml
@@ -20,6 +20,7 @@ type: javascript
 tags:
 - Utility
 - Condition
+system: true
 args:
 - name: left
   default: true

--- a/Scripts/script-AreValuesEqual.yml
+++ b/Scripts/script-AreValuesEqual.yml
@@ -3,27 +3,28 @@ commonfields:
   version: -1
 name: AreValuesEqual
 script: |
+  if (!args.left || !args.right) {
+      return 'no';
+  }
+
   var left = (typeof args.left === 'string') ? args.left : args.left + '';
   var right = (typeof args.right === 'string') ? args.right : args.right + '';
   var answer = 'no';
   if (left === right) {
     answer = 'yes';
   }
-  
+
   setContext('AreValuesEqual', answer)
   return answer;
 type: javascript
 tags:
 - Utility
 - Condition
-system: true
 args:
 - name: left
-  required: true
   default: true
   description: First value for comparison
 - name: right
-  required: true
   description: Second value for comparison
 outputs:
 - contextPath: yes
@@ -31,6 +32,8 @@ outputs:
 - contextPath: no
   description: if left is not equal to right
 scripttarget: 0
-comment: Check whether the values provided in arguments are equal.
+comment: Check whether the values provided in arguments are equal. If either of the
+  arguments are missing, no is returned.
 dependson: {}
 timeout: 0s
+releaseNotes: Arguments are not mandatory anymore. If an argument is missing (or provided with an empty value), no is returned.

--- a/Scripts/script-AreValuesEqual.yml
+++ b/Scripts/script-AreValuesEqual.yml
@@ -3,7 +3,7 @@ commonfields:
   version: -1
 name: AreValuesEqual
 script: |
-  if (!args.left || !args.right) {
+  if (args.left === undefined || args.right === undefined) {
       return 'no';
   }
 


### PR DESCRIPTION
In order to handle correctly situations where one of the arguments is empty/missing - returning no instead of raising an error in the playbook and awaiting users intervention