### PR TITLE
EmailAskUserResponse - Adding user's response to context

### DIFF
--- a/Scripts/script-EmailAskUserResponse.yml
+++ b/Scripts/script-EmailAskUserResponse.yml
@@ -8,6 +8,7 @@ script: |
   if (res[0].Type==entryTypes.note) {
       text = res[0].Contents;
       response = text.replace(/<(?:.|\n)*?>/gm, '').trim("\n").split("\n")[0].trim();
+      setContext('EmailAskUserResponse', response);
       return response;
   } else {
       return res;
@@ -25,3 +26,4 @@ args:
   default: true
   description: Entry ID where EmailAskUser will complete when user replies
 scripttarget: 0
+releaseNotes: Adding user's response to context for additional analysis


### PR DESCRIPTION
1. using setContext to override the value every time an EmailAskUser flow is executed
2. not declaring it, so if used as conditional task, user can set its labels as needed. System still shows this key in the Source window...
