### PR TITLE
Adding support for mixed CR/LF in ParseEmailFiles

### DIFF
--- a/Scripts/script-ParseEmailFiles.yml
+++ b/Scripts/script-ParseEmailFiles.yml
@@ -559,7 +559,7 @@ script: |-
       temp1, temp2 = handleEml(filePath)
       res += temp1
       res += temp2
-  elif 'ASCII text, with CRLF line terminators' in fileType or 'ASCII text, with very long lines, with CRLF line terminators' in fileType:
+  elif 'ASCII text, with CRLF line terminators' in fileType or 'ASCII text, with very long lines, with CRLF line terminators' in fileType or 'ASCII text, with CRLF, LF line terminators' in fileType:
       try:
           # Try to open the email as-is
           with open(filePath, 'rb') as f:

--- a/Scripts/script-ParseEmailFiles.yml
+++ b/Scripts/script-ParseEmailFiles.yml
@@ -623,3 +623,4 @@ outputs:
 scripttarget: 0
 dependson: {}
 timeout: 0s
+releaseNotes: Adding support for mixed CR/LF in fileType


### PR DESCRIPTION
When raw messages are retrieved from a server, there sometimes have mixed line terminations. These messages are still parsable by Python's email module, but the filetype string is not recognized in this Script.