### PR TITLE
CreateEmailHtmlBody improvement

### DIFF
--- a/Scripts/script-CreateEmailHtmlBody.yml
+++ b/Scripts/script-CreateEmailHtmlBody.yml
@@ -83,5 +83,8 @@ args:
 - name: object
   description: Values object
   isArray: true
+outputs:
+- contextPath: htmlBody
+  description: HTML Body
 scripttarget: 0
 releaseNotes: "Added the ability to provide values in object as argument. Returning the HTML body as an object for non-incident usage (i.e. pre-processing scripts)."

--- a/Scripts/script-CreateEmailHtmlBody.yml
+++ b/Scripts/script-CreateEmailHtmlBody.yml
@@ -6,7 +6,7 @@ script: |
   //replace all occurences of textToReplace with replaceWith string
   String.prototype.replaceAll = function(textToReplace,replaceWith) {
       return this.split(textToReplace).join(replaceWith);
-  }
+  };
 
   // get a specific label from incident labels
   var getLabel = function(incident,path) {
@@ -17,7 +17,7 @@ script: |
           }
       }
       return null;
-  }
+  };
 
   var res = executeCommand("getList", {"listName":args.listTemplate});
 
@@ -31,17 +31,21 @@ script: |
   var map = {};
   while (found = reg.exec(html)) {
       var path = found[1];
-      if (path.indexOf('incident.labels.')===0) {
-          map[path] = getLabel(incidents[0],path);
-      } else if (path.indexOf('incident.')===0) {
-          map[path] = dq({'incident':incidents[0]},path);
-      } else if (path.indexOf('args.')===0) {
-          map[path] = dq({'args':args},path);
+
+      if (path.indexOf('incident.labels.') === 0) {
+          map[path] = getLabel(incidents[0], path);
+      } else if (path.indexOf('incident.') === 0) {
+          map[path] = dq({'incident': incidents[0]}, path);
+      } else if (path.indexOf('args.') === 0) {
+          map[path] = dq({'args': args}, path);
+      } else if (path.indexOf('object.') === 0) {
+          var obj = (typeof args.object === 'string') ? JSON.parse(args.object) : object;
+          map[path] = dq({'object': obj}, path);
       } else {
-          map[path] = dq(invContext,path);
+          map[path] = dq(invContext, path);
       }
       if (!map[path]) {
-          map[path]=false
+          map[path]=false;
       }
   }
 
@@ -54,26 +58,32 @@ script: |
   }
 
   setContext(args.key,html);
-  return "Context set to context key " + args.key;
+  return { ContentsFormat: formats.json, Type: entryTypes.note, Contents: {htmlBody:html}, HumanReadable: 'htmlBody set to context key ' + args.key } ;
 type: javascript
 tags:
 - email
 - communication
 comment: |-
-  This script allows creating an HTML email body, using a template stored as a list item under Lists (Settings -> Advanced -> Lists).
-  Placeholders are marked in DQ format (i.e. ${incident.id} for incident ID).
+  This script allows sending an HTML email, using a template stored as a list item under Lists (Settings -> Advanced -> Lists).
+  Placeholders are marked in DT format (i.e. ${incident.id} for incident ID).
   Available placeholders for example:
   - ${incident.labels.Email/from}
   - ${incident.name}
   - ${args.subject}
   See incident Context Data menu for available placeholders
+
+  Note: Sending emails require an active  Mail Sender integration instance.
 enabled: true
 args:
 - name: listTemplate
   required: true
   default: true
-  description: The list name where the template is stored
+  description: The list where the template is stored
 - name: key
   required: true
   description: Context key to store the HTML body
+- name: object
+  description: Values object
+  isArray: true
 scripttarget: 0
+releaseNotes: "Added the ability to provide values in object as argument. Returning the HTML body as an object for non-incident usage (i.e. pre-processing scripts)."

--- a/Scripts/script-CreateEmailHtmlBody.yml
+++ b/Scripts/script-CreateEmailHtmlBody.yml
@@ -36,8 +36,6 @@ script: |
           map[path] = getLabel(incidents[0], path);
       } else if (path.indexOf('incident.') === 0) {
           map[path] = dq({'incident': incidents[0]}, path);
-      } else if (path.indexOf('args.') === 0) {
-          map[path] = dq({'args': args}, path);
       } else if (path.indexOf('object.') === 0) {
           var obj = (typeof args.object === 'string') ? JSON.parse(args.object) : object;
           map[path] = dq({'object': obj}, path);
@@ -69,7 +67,7 @@ comment: |-
   Available placeholders for example:
   - ${incident.labels.Email/from}
   - ${incident.name}
-  - ${args.subject}
+  - ${object.value}
   See incident Context Data menu for available placeholders
 
   Note: Sending emails require an active  Mail Sender integration instance.

--- a/Scripts/script-CreateEmailHtmlBody.yml
+++ b/Scripts/script-CreateEmailHtmlBody.yml
@@ -81,7 +81,7 @@ args:
   required: true
   description: Context key to store the HTML body
 - name: object
-  description: Values object
+  description: Values object provided as stringified JSON
   isArray: true
 outputs:
 - contextPath: htmlBody


### PR DESCRIPTION
1. added ability to provide placeholder values as an object
2. returning the HTML body for use with non-incident scenarios (pre-processing)
3. removed args as no needed anymore
4. adding outputs