### PR TITLE
Unpack file supports multiple formats

### DIFF
--- a/Scripts/UnPackFile.yml
+++ b/Scripts/UnPackFile.yml
@@ -1,0 +1,123 @@
+commonfields:
+  id: 611c3259-b47f-4ceb-830d-f031731a3c3a
+  version: 68
+name: UnPackFile
+script: |-
+  from pyunpack import Archive
+  import os
+  import tempfile
+  from os.path import isfile, join
+
+  filePath = None
+  fileEntryID = ''
+  if demisto.args().has_key('fileName') or demisto.args().has_key('lastPackedFileInWarroom'):
+      entries = demisto.executeCommand('getEntries', {})
+      for entry in entries:
+          fn = demisto.get(entry, 'File')
+
+          is_text = type(fn) in [unicode, str]
+          is_correct_file = demisto.args().get('fileName', '').lower() == fn.lower()
+
+          if is_text:
+              if demisto.args().has_key('fileName') and is_correct_file:
+                  fileEntryID = entry['ID']
+                  break
+              if demisto.args().has_key('lastPackedFileInWarroom') and fn.lower().endswith(demisto.args().get('lastPackedFileInWarroom', '').lower()):
+                  fileEntryID = entry['ID']
+
+      if fileEntryID == '':
+          errorMessage = ''
+          if demisto.args().has_key('fileName'):
+              demisto.results({
+                  'Type': entryTypes['error'],
+                  'ContentsFormat': formats['text'],
+                  'Contents': '"' + demisto.args().get('fileName') + '" no such file in the war room'
+              })
+          if demisto.args().has_key('lastPackedFileInWarroom'):
+              demisto.results({
+                  'Type': entryTypes['error'],
+                  'ContentsFormat': formats['text'],
+                  'Contents': 'Could not find "' + demisto.args().get('lastPackedFileInWarroom', '') + '" file in war room'
+              })
+
+          sys.exit(0)
+
+  if demisto.args().has_key('entryID'):
+      fileEntryID = demisto.args().get('entryID')
+
+  if not fileEntryID:
+      demisto.results({
+          'Type': entryTypes['error'],
+          'ContentsFormat': formats['text'],
+          'Contents': 'You must set entryID or fileName or lastPackedFileInWarroom=i.e.(zip) when executing Unpack script'
+      })
+      sys.exit(0)
+
+  res = demisto.executeCommand('getFilePath', {'id': fileEntryID})
+  if res[0]['Type'] == entryTypes['error']:
+      demisto.results({
+          'Type': entryTypes['error'],
+          'ContentsFormat': formats['text'],
+          'Contents': 'Failed to get the file path for entry: ' + fileEntryID
+      })
+      sys.exit(0)
+
+  filePath = res[0]['Contents']['path']
+
+  password = demisto.args().get('password', None)
+
+  filenames = []
+  tempdir = tempfile.mkdtemp(prefix='demisto_rar_')
+  Archive(filePath).extractall(tempdir)
+  for root, directories, files in os.walk(tempdir):
+      for name in files:
+          if isfile(join(tempdir, name)):
+              filenames.append(name)
+
+  results = []
+  for filename in filenames:
+      ## Open extracted filename read and copy to warroom.
+      with open(join(tempdir, filename), 'r') as f:
+          data = f.read()
+      if data:
+          demisto.results(fileResult(filename,  data))
+
+  results.append(
+      {
+          'Type': entryTypes['note'],
+          'ContentsFormat': formats['json'],
+          'Contents': { 'extractedFiles': filenames },
+          'EntryContext': { 'ExtractedFiles': filenames },
+          'ReadableContentsFormat' : formats['markdown'],
+          'HumanReadable': tableToMarkdown('Extracted Files', [ { 'name': x } for x in filenames ])
+      })
+
+  demisto.results(results)
+type: python
+tags:
+- Utility
+- file
+comment: |-
+  UnPack a file using fileName or entryID to specify a file. Files unpacked will be pushed to the war room and names will be pushed to the context.
+  supported types are:
+  7z (.7z), ACE (.ace), ALZIP (.alz), AR (.a), ARC (.arc), ARJ (.arj), BZIP2 (.bz2), CAB (.cab), compress (.Z), CPIO (.cpio), DEB (.deb), DMS (.dms), GZIP (.gz), LRZIP (.lrz), LZH (.lha, .lzh), LZIP (.lz), LZMA (.lzma), LZOP (.lzo), RPM (.rpm), RAR (.rar), RZIP (.rz), TAR (.tar), XZ (.xz), ZIP (.zip, .jar) and ZOO (.zoo)
+enabled: true
+args:
+- name: fileName
+  deprecated: true
+  default: true
+  description: Name of the file to unpack
+- name: password
+  secret: true
+  description: optional password which packed file protected by
+- name: entryID
+  description: entry id of the attached packed file in the warroom
+- name: lastPackedFileInWarroom
+  deprecated: true
+  description: Set to package file extension to look for the last of its kind in the
+    war room
+outputs:
+- contextPath: ExtractedFiles
+  description: list of file names which extracted from package
+scripttarget: 0
+dockerimage: demisto/unrar:1.3


### PR DESCRIPTION
Supports multiple file formats to unpack.
7z (.7z), ACE (.ace), ALZIP (.alz), AR (.a), ARC (.arc), ARJ (.arj), BZIP2 (.bz2), CAB (.cab), compress (.Z), CPIO (.cpio), DEB (.deb), DMS (.dms), GZIP (.gz), LRZIP (.lrz), LZH (.lha, .lzh), LZIP (.lz), LZMA (.lzma), LZOP (.lzo), RPM (.rpm), RAR (.rar), RZIP (.rz), TAR (.tar), XZ (.xz), ZIP (.zip, .jar) and ZOO (.zoo)
