### PR TITLE
Wildfire fix - ignoring SHA1

### DIFF
--- a/Integrations/integration-Wildfire.yml
+++ b/Integrations/integration-Wildfire.yml
@@ -136,7 +136,10 @@ script:
         var hash = args.md5 || args.hash || args.file;
         if(!hash)
             throw 'Missing md5/hash argument.';
-
+        if (hash.length === 40) {
+            // SHA1 not supported.
+            return 'No results';
+        }
         var bodyXML = 'apikey='+params.token+'&format=xml&hash='+hash;
         var resXML = sendRequest(url, bodyXML, headers);
         if(!resXML){
@@ -283,3 +286,4 @@ script:
       description: ID of the entry containing the file to upload
     description: Upload file to WildFire for analysis.
 hidden: false
+releaseNotes: "Ignoring SHA1 hashes"


### PR DESCRIPTION
Ignoring sha1 hashes so it doesnt break playbooks