### PR TITLE
Updating flattenFields

### DIFF
--- a/Scripts/script-CommonServer.yml
+++ b/Scripts/script-CommonServer.yml
@@ -761,7 +761,7 @@ script: |-
   /**
    * Flatten the fields into a map of dot notation key and value
    * @param {Object} obj - the object to iterate on
-   * @param {String} path - the path so far in dot notation
+   * @param {String} path - (optional) the path so far in dot notation
    * @param {Object} flat - the collected object result
    * @returns {Object} an object with keys that are dot notation and values
    */
@@ -770,11 +770,11 @@ script: |-
         if (typeof obj === 'object') {
             var keys = Object.keys(obj);
             for (var f=0; f<keys.length; f++) {
-                flattenFields(obj[keys[f]], path !== '' ? path + '.' + keys[f] : keys[f], flat);
+                flattenFields(obj[keys[f]], !!path ? path + '.' + keys[f] : keys[f], flat);
             }
         } else if (Array.isArray(obj)) {
             for (var i=0; i<obj.length; i++) {
-                flattenFields(obj[i], path !== '' ? path + '.' + i : '' + i, flat);
+                flattenFields(obj[i], !!path ? path + '.' + i : '' + i, flat);
             }
         } else {
             flat[path] = obj.toString();
@@ -1825,4 +1825,4 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
-releaseNotes: "Added entryInfoFile entry type"
+releaseNotes: "Updated flattenFields to support the case in which path is not given as argument"


### PR DESCRIPTION
In case no path was given to the function as argument, in the first iteration path would be undefined.key[0], which causes errors.