### PR TITLE
QRadar - get offense correlations

### DIFF
--- a/Playbooks/playbook-QRadar_-_Get_offense_correlations_.yml
+++ b/Playbooks/playbook-QRadar_-_Get_offense_correlations_.yml
@@ -1,0 +1,209 @@
+id: 'QRadar - Get offense correlations '
+version: -1
+name: 'QRadar - Get offense correlations '
+description: |-
+  Run on a QRadar offense to get more information
+
+  * Get all correlations relevant to the offense
+  * Get all logs relevant to the correlations (not done by default, set "GetCorrelationLogs" to "True")
+
+  Inputs:
+  * GetCorrelationLogs (default: False)
+  * MaxLogsCount (default: 20)
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: efaa120a-35d6-437c-8ac7-0ece067386c6
+    type: start
+    task:
+      id: efaa120a-35d6-437c-8ac7-0ece067386c6
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 51
+        }
+      }
+  "1":
+    id: "1"
+    taskid: 12b7da80-4881-428c-8d37-f513dadd6480
+    type: condition
+    task:
+      id: 12b7da80-4881-428c-8d37-f513dadd6480
+      version: -1
+      name: Is this a QRadar offense?
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "5"
+    scriptarguments:
+      value: ${incident.labels(val.Brand=="QRadar")}
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+  "2":
+    id: "2"
+    taskid: 79031f54-97bb-4a27-84d1-665f762c3428
+    type: title
+    task:
+      id: 79031f54-97bb-4a27-84d1-665f762c3428
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1040
+        }
+      }
+  "3":
+    id: "3"
+    taskid: 777beed6-580b-4cc6-82c6-1a23309d8313
+    type: regular
+    task:
+      id: 777beed6-580b-4cc6-82c6-1a23309d8313
+      version: -1
+      name: Get Offense correlations
+      scriptName: QRadarGetOffenseCorrelations
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      fields: ""
+      headers: ""
+      interval: ""
+      offenseID: ""
+      range: ""
+      startTime: ""
+      timeout: ""
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 515
+        }
+      }
+  "4":
+    id: "4"
+    taskid: 09959beb-a116-4202-8bd1-8388eac3d3b3
+    type: regular
+    task:
+      id: 09959beb-a116-4202-8bd1-8388eac3d3b3
+      version: -1
+      name: Get correlations' logs
+      scriptName: QRadarGetCorrelationLogs
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      additionalQueryFields: ""
+      fields: ""
+      headers: ""
+      interval: ""
+      offenseID: ""
+      qid: ""
+      range: 0-${inputs.MaxLogsCount}
+      startTime: ""
+      timeout: ""
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 865
+        }
+      }
+  "5":
+    id: "5"
+    taskid: 449b51e7-fde6-49a9-8cc3-6231bcc7c358
+    type: title
+    task:
+      id: 449b51e7-fde6-49a9-8cc3-6231bcc7c358
+      version: -1
+      name: Get offense information
+      type: title
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 370
+        }
+      }
+  "6":
+    id: "6"
+    taskid: 2e19a41a-872f-40ca-840d-af419b4ea32d
+    type: condition
+    task:
+      id: 2e19a41a-872f-40ca-840d-af419b4ea32d
+      version: -1
+      name: Should query for the correlations' logs?
+      scriptName: AreValuesEqual
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "4"
+    scriptarguments:
+      left: ${inputs.=(val.GetCorrelationLogs.toLowerCase())}
+      right: "true"
+    results:
+    - AreValuesEqual
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 690
+        }
+      }
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1054,
+        "width": 605,
+        "x": 50,
+        "y": 51
+      }
+    }
+  }
+inputs:
+- key: GetCorrelationLogs
+  value: "False"
+  description: If "True" will get all of the offense's correlations logs
+- key: MaxLogsCount
+  value: "20"
+  description: 'Maximum number of log entires to query from QRadar (default: 20)'

--- a/Scripts/script-QRadarClassifier.yml
+++ b/Scripts/script-QRadarClassifier.yml
@@ -3,7 +3,7 @@ commonfields:
   version: -1
 name: QRadarClassifier
 deprecated: true
-releaseNotes: 'Deprecated, use "Mapping" feture instead'
+releaseNotes: 'Deprecated, use the Demisto "Classification and Mapping" tool instead'
 script: |
   var QRADAR_CATEGORIES = {
       'Recon' : 'Reconnaissance',

--- a/Scripts/script-QRadarClassifier.yml
+++ b/Scripts/script-QRadarClassifier.yml
@@ -2,6 +2,8 @@ commonfields:
   id: QRadarClassifier
   version: -1
 name: QRadarClassifier
+deprecated: true
+releaseNotes: 'Deprecated, use "Mapping" feture instead'
 script: |
   var QRADAR_CATEGORIES = {
       'Recon' : 'Reconnaissance',

--- a/Scripts/script-QRadarFullSearch.yml
+++ b/Scripts/script-QRadarFullSearch.yml
@@ -2,6 +2,7 @@ commonfields:
   id: QRadarFullSearch
   version: -1
 name: QRadarFullSearch
+releaseNotes: 'Bug fix'
 script: |-
   res = [];
 
@@ -12,6 +13,9 @@ script: |-
   var interval = ('interval' in args) ? parseInt(args.interval) : 10;
 
   var search_args = {};
+  if ('query_expression' in args) {
+      search_args.query_expression = args.query_expression;
+  }
   if ('fields' in args) {
       search_args.fields = args.fields;
   }
@@ -24,7 +28,7 @@ script: |-
   }
 
   //submit query, retrive  search_id
-  var query_res = executeCommand("qradar-searches", args);
+  var query_res = executeCommand("qradar-searches", search_args);
 
   if (isError(query_res[0])) {
       return query_res;

--- a/Scripts/script-QRadarGetCorrelationLogs.yml
+++ b/Scripts/script-QRadarGetCorrelationLogs.yml
@@ -2,18 +2,82 @@ commonfields:
   id: QRadarGetCorrelationLogs
   version: -1
 name: QRadarGetCorrelationLogs
+releaseNotes: 'Context outputs added'
 script: |-
-  QUERY = "select RULENAME({0}), sourceip, destinationip, eventcount, sourceport, username, starttime, destinationport, magnitude, identityip, CATEGORYNAME(category), PROTOCOLNAME(protocolid), LOGSOURCENAME(logsourceid) from events where \"CRE Name\" IS NULL AND INOFFENSE({1}) START '{2}'"
+  QUERY = "select RULENAME({0}), sourceip, destinationip, eventcount, sourceport, username, starttime, destinationport, magnitude, identityip, CATEGORYNAME(category), PROTOCOLNAME(protocolid), LOGSOURCENAME(logsourceid){1} from events where \"CRE Name\" IS NULL AND INOFFENSE({2}) START '{3}'"
 
   d_args = demisto.args()
 
   offense_id = demisto.get(d_args, 'offenseID')
   start_time = demisto.get(d_args, 'startTime')
   correlation_id = demisto.get(d_args, 'qid')
+  additional_query_fields = demisto.get(d_args,'additionalQueryFields')
 
-  d_args["query_expression"] = QUERY.format(correlation_id,offense_id,start_time)
+  d_args["query_expression"] = QUERY.format(correlation_id,additional_query_fields,offense_id,start_time)
 
-  demisto.results(demisto.executeCommand('QRadarFullSearch',d_args))
+  resp = demisto.executeCommand('QRadarFullSearch',d_args)
+  if isError(resp[0]):
+      demisto.results(resp)
+  else:
+      data = demisto.get(resp[0],'Contents.events')
+
+      if not data:
+          resp[0]['HumanReadable'] = "No logs were found for correlation id {0}".format(correlation_id)
+      else:
+          data = data if isinstance(data,list) else [data]
+
+          QRadar = {}
+          QRadar['Log'] = []
+
+          for corr in data:
+
+              keys = corr.keys()
+              log = {}
+              log["QID"] = correlation_id
+              #Standardized known keys
+              log["SourceIP"] = demisto.get(corr,"sourceip")
+              keys.remove("sourceip") if "sourceip" in keys else None
+
+              log["DestinationPort"] = demisto.get(corr,"destinationport")
+              keys.remove("destinationport") if "destinationport" in keys else ""
+
+              log["SourcePort"] = demisto.get(corr,"sourceport")
+              keys.remove("sourceport") if "sourceport" in keys else ""
+
+              log["EventCount"] = demisto.get(corr,"eventcount")
+              keys.remove("eventcount") if "eventcount" in keys else ""
+
+              log["DestinationIP"] = demisto.get(corr,"destinationip")
+              keys.remove("destinationip") if "destinationip" in keys else ""
+
+              log["Category"] = demisto.get(corr,"categoryname_category")
+              keys.remove("categoryname_category") if "categoryname_category" in keys else ""
+
+              log["IdentityIP"] = demisto.get(corr,"identityip")
+              keys.remove("identityip") if "identityip" in keys else ""
+
+              log["Username"] = demisto.get(corr,"username")
+              keys.remove("username") if "username" in keys else ""
+
+              log["StartTime"] = demisto.get(corr,"starttime")
+              keys.remove("starttime") if "starttime" in keys else ""
+
+              log["Magnitude"] = demisto.get(corr,"magnitude")
+              keys.remove("magnitude") if "magnitude" in keys else ""
+
+              log["ProtocolName"] = demisto.get(corr,"protocolname_protocolid")
+              keys.remove("protocolname_protocolid") if "protocolname_protocolid" in keys else ""
+
+              #Push to context rest of the keys (won't be shown in 'outputs')
+              for key in keys:
+                  log[''.join(x for x in key.title() if not x.isspace())] = demisto.get(corr,key)
+
+              QRadar['Log'].append(log)
+
+          context = {"QRadar":QRadar}
+          resp[0]['EntryContext'] = context
+
+  demisto.results(resp)
 type: python
 tags:
 - QRadar
@@ -27,7 +91,7 @@ args:
   defaultValue: ${incident.labels.id}
 - name: startTime
   required: true
-  description: query from startTime (in timestamp format).    
+  description: query from startTime (in timestamp format).
   defaultValue: ${incident.labels.start_time}
 - name: headers
   description: Table headers
@@ -43,6 +107,35 @@ args:
   required: true
   description: The Correlation QID to query.
   defaultValue: ${Correlation.QID}
+- name: additionalQueryFields
+  description: Add more fields for basic query (a list with comma separators)
+outputs:
+- contextPath: QRadar
+  description: QRadar context output
+- contextPath: QRadar.Log
+  description: The QRadar offense correlation logs
+- contextPath: QRadar.Log.QID
+  description: The log's correlation ID
+- contextPath: QRadar.Log.SourceIP
+  description: The log's source IP
+- contextPath: QRadar.Log.DestinationPort
+  description: The log's destination port
+- contextPath: QRadar.Log.SourcePort
+  description: The log's source port
+- contextPath: QRadar.Log.DestinationIP
+  description: The log's destination IP
+- contextPath: QRadar.Log.Category
+  description: The log's category
+- contextPath: QRadar.Log.IdentityIP
+  description: The log's identity IP
+- contextPath: QRadar.Log.Username
+  description: The log's username
+- contextPath: QRadar.Log.StartTime
+  description: The log's start time
+- contextPath: QRadar.Log.Magnitude
+  description: The log's magnitude
+- contextPath: QRadar.Log.ProtocolName
+  description: The log's protocol name
 scripttarget: 0
 dependson:
   must:

--- a/Scripts/script-QRadarGetOffenseCorrelations.yml
+++ b/Scripts/script-QRadarGetOffenseCorrelations.yml
@@ -2,6 +2,7 @@ commonfields:
   id: QRadarGetOffenseCorrelations
   version: -1
 name: QRadarGetOffenseCorrelations
+releaseNotes: 'Updated context outputs'
 script: |-
   QUERY = "SELECT *,\"CRE Name\",\"CRE Description\",CATEGORYNAME(highlevelcategory) FROM events WHERE \"CRE NAME\" <> NULL AND INOFFENSE({0}) START '{1}'"
 
@@ -23,26 +24,50 @@ script: |-
       else:
           data = data if isinstance(data,list) else [data]
 
-          context = {}
-          context['Correlation'] = []
+          QRadar = {}
+          QRadar['Correlation'] = []
 
           for corr in data:
+              keys = corr.keys()
               correlation = {}
+              #Standardized known keys
               correlation["SourceIP"] = demisto.get(corr,"sourceip")
+              keys.remove("sourceip") if "sourceip" in keys else None
+
               correlation["CREDescription"] = demisto.get(corr,"CRE Description")
+              keys.remove("CRE Description") if "CRE Description" in keys else ""
+
               correlation["CREName"] = demisto.get(corr,"CRE Name")
+              keys.remove("CRE Name") if "CRE Name" in keys else ""
+
               correlation["QID"] = demisto.get(corr,"qid")
+              keys.remove("qid") if "qid" in keys else ""
+
               correlation["DestinationIP"] = demisto.get(corr,"destinationip")
+              keys.remove("destinationip") if "destinationip" in keys else ""
+
               correlation["Category"] = demisto.get(corr,"categoryname_highlevelcategory")
+              keys.remove("categoryname_highlevelcategory") if "categoryname_highlevelcategory" in keys else ""
+
+              correlation["CategoryID"] = demisto.get(corr,"category")
+              keys.remove("category") if "category" in keys else ""
+
               correlation["Username"] = demisto.get(corr,"username")
+              keys.remove("username") if "username" in keys else ""
+
               correlation["StartTime"] = demisto.get(corr,"starttime")
+              keys.remove("starttime") if "starttime" in keys else ""
 
-              context['Correlation'].append(correlation)
+              #Push to context rest of the keys (won't be shown in 'outputs')
+              for key in keys:
+                  correlation[''.join(x for x in key.title() if not x.isspace())] = demisto.get(corr,key)
 
+              QRadar['Correlation'].append(correlation)
+
+          context = {"QRadar":QRadar}
           resp[0]['EntryContext'] = context
 
   demisto.results(resp)
-
 type: python
 tags:
 - QRadar
@@ -56,7 +81,7 @@ args:
   defaultValue: ${incident.labels.id}
 - name: startTime
   required: true
-  description: query from startTime (in timestamp format).    
+  description: query from startTime (in timestamp format).
   defaultValue: ${incident.labels.start_time}
 - name: headers
   description: Table headers
@@ -67,26 +92,30 @@ args:
 - name: timeout
   description: Timeout in seconds. Default is 10 minutes.
 - name: fields
+outputs:
+- contextPath: QRadar.Correlation
+  description: The QRadar offense correlations
+- contextPath: QRadar.Correlation.QID
+  description: The correlation QID identifier
+- contextPath: QRadar.Correlation.CREName
+  description: The correlation name
+- contextPath: QRadar.Correlation.CREDescription
+  description: The correlation description
+- contextPath: QRadar.Correlation.SourceIP
+  description: The correlation source IP
+- contextPath: QRadar.Correlation.DestinationIP
+  description: The correlation destination IP
+- contextPath: QRadar.Correlation.Category
+  description: The correlation high level category
+- contextPath: QRadar.Correlation.Username
+  description: The correlation username
+- contextPath: QRadar.Correlation.StartTime
+  description: The correlation start time
+- contextPath: QRadar.Correlation.CategoryID
+  description: 'The correlation category id '
+- contextPath: QRadar
+  description: QRadar context output
 scripttarget: 0
 dependson:
   must:
   - qradar-searches
-outputs:
-- contextPath: Correlation
-  description: The QRadar offense correlations
-- contextPath: Correlation.QID
-  description: The correlation QID identifier
-- contextPath: Correlation.CREName
-  description: The correlation name
-- contextPath: Correlation.CREDescription
-  description: The correlation description
-- contextPath: Correlation.SourceIP
-  description: The correlation source IP
-- contextPath: Correlation.DestinationIP
-  description: The correlation destination IP
-- contextPath: Correlation.Category
-  description: The correlation high level category
-- contextPath: Correlation.Username
-  description: The correlation username
-- contextPath: Correlation.StartTime
-  description: The correlation start time


### PR DESCRIPTION
Added playbook
* `QRadar - get offense correlations`

Updated qradar scripts:
* `QRadarClassifier` - deprecated (use mapping feature instead)
* `QRadarFullSearch` - fix bug
* updated context output in rest

![qradar_-_get_offense_correlations__wed_nov_01_2017](https://user-images.githubusercontent.com/23148119/32282750-1dabb094-bf2b-11e7-9d61-66b86a978c6e.png)
