### PR TITLE
3.1.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ test:
     - ./Tests/yamlvalidator
 
     # build content descriptor
-    - ./setContentDescriptor.sh $CIRCLE_BUILD_NUM 606050fdb73897821ed2f48d67686fe424e95247 3.0.0
+    - ./setContentDescriptor.sh $CIRCLE_BUILD_NUM 606050fdb73897821ed2f48d67686fe424e95247 3.1.0
 
     # create content bundle
     - mkdir bundle


### PR DESCRIPTION
Update version number in content release to 3.1.0
(this version will not be release. only for demisto 3.1.0 release)

@dorsha we need to make sure will take content for master please
