### PR TITLE
fix Carbon Black Response test playbook

### DIFF
--- a/TestPlaybooks/playbook-CB-Response-Test.yml
+++ b/TestPlaybooks/playbook-CB-Response-Test.yml
@@ -274,8 +274,8 @@ tasks:
       '#none#':
       - "11"
     scriptarguments:
-      sensor: ${CbResponse.Sessions.CbSensorID}
-      session: ${CbResponse.Sessions.CbSessionID}
+      sensor: ${CbResponse.Sessions.[0].CbSensorID}
+      session: ${CbResponse.Sessions.[0].CbSessionID}
     view: |-
       {
         "position": {

--- a/TestPlaybooks/playbook-CB-Response-Test.yml
+++ b/TestPlaybooks/playbook-CB-Response-Test.yml
@@ -316,3 +316,4 @@ view: |-
     }
   }
 inputs: []
+releaseNotes: "-"


### PR DESCRIPTION
Don't know why till now it worked. But most probably something changed.
Same session was exported to the context, so the step cb-close-session was executed twice. The first run it closed the session, but second time the session was already closed so we got exception 404