### PR TITLE
Fix GRR paths input

### DIFF
--- a/Integrations/integration-GRR.yml
+++ b/Integrations/integration-GRR.yml
@@ -261,7 +261,14 @@ script:
             return getFlows('POST', server + '/api/clients/' + args.client_id + '/flows', 'post flow', '{"flow": ' + args.flow + '}',null,"Set Flow");
         case 'grr-get-files': 
         case 'grr_get_files'://deprecated
-            args.paths = JSON.parse(args.paths);
+            var pathsArr;
+            try {
+                pathsArr = JSON.parse(args.paths);
+            } catch (e) {
+                logDebug('input is not a valid JSON trying to split');
+                pathsArr = args.paths ? args.paths.split(",") : [];
+            }
+            args.paths = pathsArr;
             return sendRequestAndParse('POST', server + '/api/robot-actions/get-files', 'post get-files', JSON.stringify(args));
         case 'grr-get-hunts':
         case 'grr_get_hunts'://deprecated
@@ -560,3 +567,4 @@ script:
       description: Hunt arguments
     description: Handles hunt creation request
 system: true
+releaseNotes: Fixed parsing of paths for grr_get_files


### PR DESCRIPTION
Right now user has to wrap the input in `[]` and it's pretty hard to escape backslashes.
Before:
`paths="[\"c:\\\\documents\\\\a.txt\"]"`
After:
`paths="c:\\documents\\a.txt"`

also support old method for backward compatibility  