### PR TITLE
Remove unused variable

### DIFF
--- a/Scripts/script-ExtractDomain.yml
+++ b/Scripts/script-ExtractDomain.yml
@@ -55,7 +55,6 @@ script: |-
       reg = /(?:(?:https?|ftp):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])/gmi;
   }
 
-  var filtered = ['http://schemas.microsoft.com/office/2004/12/omml', 'http://www.w3.org/TR/REC-html40'];
   var whitelist = getCSVListAsArray('Indicators Whitelist');
   while (found = reg.exec(text)) {
       matches[found[0]] = true;
@@ -161,3 +160,4 @@ outputs:
 - contextPath: Domain.Name
   description: Extracted domains
 scripttarget: 0
+releaseNotes: "-"

--- a/Scripts/script-ExtractURL.yml
+++ b/Scripts/script-ExtractURL.yml
@@ -31,7 +31,6 @@ script: |-
       reg = /(?:(?:https?|ftp):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])/gmi;
   }
 
-  var filtered = ['http://schemas.microsoft.com/office/2004/12/omml', 'http://www.w3.org/TR/REC-html40'];
   var whitelist = getCSVListAsArray('Indicators Whitelist');
   while (found = reg.exec(text)) {
       matches[found[0]] = true;
@@ -94,3 +93,4 @@ outputs:
 - contextPath: URL.Data
   description: Extracted URLs
 scripttarget: 0
+releaseNotes: "-"


### PR DESCRIPTION
remove unused `filter` variable from ExtractDomain & ExtractURL

we are now filter only by indicators whitelist 