### PR TITLE
Fix error in GeneratePassword documentation.

### DIFF
--- a/Scripts/script-GeneratePassword.yml
+++ b/Scripts/script-GeneratePassword.yml
@@ -87,7 +87,7 @@ comment: "This function generates a password and allows various parameters to cu
   requirements).  The default behavior is to generate a password of  *random length*
   including all four character classes (upper, lower, digits, symbols) with at least
   five and at most ten characters per class. \n\nThe min_* values all default to 0. This means that if the command
-  is executed in this way:\n!GeneratePassword default_sane=false max_lcase=10\nIt
+  is executed in this way:\n!GeneratePassword max_lcase=10\nIt
   is possible that a password of length zero could be generated. It is therefore recommended
   to always include a min_* parameter that matches. \n\nThe debug parameter will print
   certain properties of the command into the WarRoom for easy diagnostics."


### PR DESCRIPTION
There was a leftover comment referencing "default_sane" parameter which has been removed.