### PR TITLE
Upgrade transformers args

### DIFF
--- a/Playbooks/playbook-CrowdStrike_Endpoint_Enrichment.yml
+++ b/Playbooks/playbook-CrowdStrike_Endpoint_Enrichment.yml
@@ -132,8 +132,12 @@ tasks:
           transformers:
           - operator: string.concat
             args:
-              prefix: hostname:"
-              suffix: '"'
+              prefix:
+                value:
+                  simple: hostname:"
+              suffix:
+                value:
+                  simple: '"'
       limit: {}
       offset: {}
       query: {}

--- a/Playbooks/playbook-Endpoint_Enrichment_-_Generic.yml
+++ b/Playbooks/playbook-Endpoint_Enrichment_-_Generic.yml
@@ -532,8 +532,12 @@ tasks:
           transformers:
           - operator: string.concat
             args:
-              prefix: '[{"Field":"device_name","Operator":"IsEqualTo","Value":"'
-              suffix: '"}]'
+              prefix:
+                value:
+                  simple: '[{"Field":"device_name","Operator":"IsEqualTo","Value":"'
+              suffix:
+                value:
+                  simple: '"}]'
       headers: {}
       page_number: {}
       page_size: {}

--- a/Tests/scripts/server_get_artifact.sh
+++ b/Tests/scripts/server_get_artifact.sh
@@ -7,7 +7,7 @@ TOKEN_ATTR="circle-token=$SERVER_CI_TOKEN"
 
 echo "Getting latest build num"
 
-ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/master?limit=1&filter=successful&$TOKEN_ATTR" | jq '.[0].build_num')
+ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformer-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
 
 SERVER_DOWNLOAD_LINK=$(curl -s -H "$ACCEPT_TYPE" ${SERVER_API_URI}/${ARTIFACT_BUILD_NUM}/artifacts?${TOKEN_ATTR} | jq '.[].url' -r | grep demistoserver | grep /0/)
 

--- a/Tests/scripts/server_get_artifact.sh
+++ b/Tests/scripts/server_get_artifact.sh
@@ -7,7 +7,7 @@ TOKEN_ATTR="circle-token=$SERVER_CI_TOKEN"
 
 echo "Getting latest build num"
 
-ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformers-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
+ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformer-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
 
 SERVER_DOWNLOAD_LINK=$(curl -s -H "$ACCEPT_TYPE" ${SERVER_API_URI}/${ARTIFACT_BUILD_NUM}/artifacts?${TOKEN_ATTR} | jq '.[].url' -r | grep demistoserver | grep /0/)
 

--- a/Tests/scripts/server_get_artifact.sh
+++ b/Tests/scripts/server_get_artifact.sh
@@ -7,7 +7,7 @@ TOKEN_ATTR="circle-token=$SERVER_CI_TOKEN"
 
 echo "Getting latest build num"
 
-ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformer-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
+ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformers-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
 
 SERVER_DOWNLOAD_LINK=$(curl -s -H "$ACCEPT_TYPE" ${SERVER_API_URI}/${ARTIFACT_BUILD_NUM}/artifacts?${TOKEN_ATTR} | jq '.[].url' -r | grep demistoserver | grep /0/)
 

--- a/Tests/scripts/server_get_artifact.sh
+++ b/Tests/scripts/server_get_artifact.sh
@@ -7,7 +7,7 @@ TOKEN_ATTR="circle-token=$SERVER_CI_TOKEN"
 
 echo "Getting latest build num"
 
-ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/transformer-args?limit=1&$TOKEN_ATTR" | jq '.[0].build_num')
+ARTIFACT_BUILD_NUM=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/master?limit=1&filter=successful&$TOKEN_ATTR" | jq '.[0].build_num')
 
 SERVER_DOWNLOAD_LINK=$(curl -s -H "$ACCEPT_TYPE" ${SERVER_API_URI}/${ARTIFACT_BUILD_NUM}/artifacts?${TOKEN_ATTR} | jq '.[].url' -r | grep demistoserver | grep /0/)
 


### PR DESCRIPTION
We have changed transformers args to support complex args are well (i.e also take args from context)

this will upgrade playbooks transformers to the new schema

I also ran this branch against server `transformers-args` branch (contains the new schema) - https://circleci.com/gh/demisto/content/6460

will merge this after server build 
plz approve :)
