### PR TITLE
Rerun test playbook if failed

### DIFF
--- a/Tests/scripts/create_instance.sh
+++ b/Tests/scripts/create_instance.sh
@@ -12,7 +12,7 @@ IMAGE_ID="ami-d2c924b2" # centos
 INSTANCE_ID=$(aws ec2 run-instances \
     --image-id ${IMAGE_ID} \
     --security-group-ids sg-714f3816 \
-    --instance-type t2.small \
+    --instance-type t2.large \
     --key-name ci-key \
     --instance-initiated-shutdown-behavior terminate \
     --block-device-mappings DeviceName=/dev/sda1,Ebs={DeleteOnTermination=true} \

--- a/Tests/scripts/pull_docker_images.sh
+++ b/Tests/scripts/pull_docker_images.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-farm_hosts=(
+
+USER="centos"
+
+# collect log file to artifacts
+PUBLIC_IP=$(cat public_ip)
+
+images=(
     "demisto/python3" 
     "demisto/bs4" 
     "demisto/dxl" 
@@ -23,7 +29,6 @@ farm_hosts=(
     "demisto/unrar:1.4"
 )
 
-for i in ${farm_hosts[@]}; do
-    foo="docker pull ${i}"
-    eval "$foo"
+for i in ${images[@]}; do
+    ssh -t ${USER}@${PUBLIC_IP} "sudo docker pull ${i}"
 done

--- a/Tests/scripts/pull_docker_images.sh
+++ b/Tests/scripts/pull_docker_images.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+farm_hosts=(
+    "demisto/python3" 
+    "demisto/bs4" 
+    "demisto/dxl" 
+    "demisto/nmap" 
+    "demisto/psycopg2"
+    "demisto/rasterize"
+    "demisto/splunksdk:1.0"
+    "demisto/symantec_mss"
+    "demisto/pytan"
+    "demisto/threatconnect-sdk"
+    "demisto/vmray"
+    "demisto/vmware:1.0-alpine"
+    "demisto/machine-learning:latest"
+    "demisto/langdetect"
+    "demisto/word-parser"
+    "demisto/trorabaugh/dempcap:1.0"
+    "demisto/pypdf2"
+    "demisto/pyping"
+    "demisto/pdfx"
+    "demisto/stix"
+    "demisto/unrar:1.4"
+)
+
+for i in ${farm_hosts[@]}; do
+    foo="docker pull ${i}"
+    eval "$foo"
+done

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -128,10 +128,6 @@ def main():
         else:
             # run test
             succeed = test_integration(c, integrations, playbook_id, test_options)
-            if not succeed:
-                print 'Trying to run the playbook second time after failure'
-                # try one more time to run the same test if failed
-                succeed = test_integration(c, integrations, playbook_id, test_options)
 
             # use results
             if succeed:

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -129,6 +129,7 @@ def main():
             # run test
             succeed = test_integration(c, integrations, playbook_id, test_options)
             if not succeed:
+                print 'Trying to run the playbook second time after failure'
                 # try one more time to run the same test if failed
                 succeed = test_integration(c, integrations, playbook_id, test_options)
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -128,6 +128,9 @@ def main():
         else:
             # run test
             succeed = test_integration(c, integrations, playbook_id, test_options)
+            if not succeed:
+                # try one more time to run the same test if failed
+                succeed = test_integration(c, integrations, playbook_id, test_options)
 
             # use results
             if succeed:

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -137,12 +137,13 @@ def __create_incident_with_playbook(client, name, playbook_id):
     incidents = client.SearchIncidents(0, 50, 'id:' + inc_id)
 
     # poll up to 1 second
-    timeout = time.time() + 3
+    timeout = time.time() + 10
     while incidents['total'] != 1:
         incidents = client.SearchIncidents(0, 50, 'id:' + inc_id)
         if time.time() > timeout:
             print_error('failed to get incident with id:' + inc_id)
             return False
+        time.sleep(1)
 
     return incidents['data'][0]
 

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ test:
     - ./Tests/scripts/wait_until_server_ready.sh
 
     # pull all non default docker images
-    - ./Tests/scripts/pull_docker_images.sh
+    #- ./Tests/scripts/pull_docker_images.sh
 
     # run tests
     - ./Tests/scripts/run_tests.sh

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,9 @@ test:
     # wait until server is ready
     - ./Tests/scripts/wait_until_server_ready.sh
 
+    # pull all non default docker images
+    - ./Tests/scripts/pull_docker_images.sh
+
     # run tests
     - ./Tests/scripts/run_tests.sh
 


### PR DESCRIPTION
- run test playbook second time if for the first time it failed
- increase the timeout for getting incident (from 3 seconds to 10)
- pull docker images before the tests started to run