### PR TITLE
Update script-AddEvidence.yml

### DIFF
--- a/Scripts/script-AddEvidence.yml
+++ b/Scripts/script-AddEvidence.yml
@@ -13,13 +13,19 @@ script: |-
   entryIDs = (Array.isArray(entryIDs)) ? entryIDs : [entryIDs];
   entryTags = (Array.isArray(entryTags)) ? entryTags.join(',') : entryTags;
   
-  // Get the month, day, and year. Sample output: "2008-01-02T15:04:05"
+  // Add zeros to single-digit date values for proper formatting.
   function addZero(i) {
       if (i < 10) {
           i = "0" + i;
       }
       return i;
   }
+  
+  // If statement to see if an occurred time is manually set. If not, use the current time.
+  if (args.occurred) {
+      now = args.occurred;
+  } else {
+  // Get the current month, day, and year. Sample output: "2008-01-02T15:04:05"
   var d = new Date();
   var year = d.getFullYear();
   var month = addZero(d.getMonth());
@@ -28,6 +34,7 @@ script: |-
   var minutes = addZero(d.getMinutes());
   var seconds = addZero(d.getSeconds());
   var now = year + "-" + month + "-" + day + "T" + hours + ":" + minutes + ":" + seconds;
+  }
   
   for (var i=0;i<entryIDs.length;i++) {
       var entryID = entryIDs[i];
@@ -66,4 +73,6 @@ args:
   description: Description to add to Evidence Board
 - name: tags
   description: Evidence tags
+- name: occurred
+  description: Timestamp of when the evidence was added. If not specified, default to the current time.
 scripttarget: 0

--- a/Scripts/script-AddEvidence.yml
+++ b/Scripts/script-AddEvidence.yml
@@ -12,14 +12,30 @@ script: |-
   var desc = (args.description) ? args.description : args.desc ? args.desc : 'Evidence added by DBot';
   entryIDs = (Array.isArray(entryIDs)) ? entryIDs : [entryIDs];
   entryTags = (Array.isArray(entryTags)) ? entryTags.join(',') : entryTags;
-
+  
+  // Get the month, day, and year. Sample output: "2008-01-02T15:04:05"
+  function addZero(i) {
+      if (i < 10) {
+          i = "0" + i;
+      }
+      return i;
+  }
+  var d = new Date();
+  var year = d.getFullYear();
+  var month = addZero(d.getMonth());
+  var day = addZero(d.getDay());
+  var hours = addZero(d.getHours());
+  var minutes = addZero(d.getMinutes());
+  var seconds = addZero(d.getSeconds());
+  var now = year + "-" + month + "-" + day + "T" + hours + ":" + minutes + ":" + seconds;
+  
   for (var i=0;i<entryIDs.length;i++) {
       var entryID = entryIDs[i];
       entries = executeCommand('getEntry', {'id': entryID});
       if (isValidRes(entries)) {
           for (var j=0;j<entries.length;j++){
               var ent=entries[j];
-              var res = executeCommand('markAsEvidence', { 'id': entryID, 'description': desc, when: args.occurred, tags: entryTags });
+              var res = executeCommand('markAsEvidence', { 'id': entryID, 'description': desc, 'when': now, tags: entryTags });
               if (!isValidRes(res)) {
                   return res;
               }
@@ -48,8 +64,6 @@ args:
   deprecated: true
 - name: description
   description: Description to add to Evidence Board
-- name: occurred
-  description: "Occurred time of the evidence (time format: 2008-01-02T15:04:05)"
 - name: tags
   description: Evidence tags
 scripttarget: 0


### PR DESCRIPTION
Added a default timestamp of when the evidence is added to the board. I haven't found a good use case for manually entering a time for evidence to be found. Removed the 'occurred' arguments from the script.

Perhaps this could also just be added as a default option, while still allowing for an argument of 'occurred' to be entered.