### PR TITLE
Fix Type for hashes when no results are returned

### DIFF
--- a/Integrations/integration-VirusTotal.yml
+++ b/Integrations/integration-VirusTotal.yml
@@ -757,3 +757,4 @@ script:
     description: Private API. Retrieve comments for a given resource
 hidden: false
 fromversion: 2.5.0
+releaseNotes: "Fixed DBotScore when return no file reputation"

--- a/Integrations/integration-VirusTotal.yml
+++ b/Integrations/integration-VirusTotal.yml
@@ -109,7 +109,7 @@ script:
         var o = res.obj;
         var ec = {};
         if (o.response_code === 0) {
-            ec.DBotScore = {Indicator: hash, Type: 'file', Vendor: 'VirusTotal', Score: 0};
+            ec.DBotScore = {Indicator: hash, Type: 'hash', Vendor: 'VirusTotal', Score: 0};
             return {Type: entryTypes.note, Contents: res.body, ContentsFormat: formats.json, EntryContext: ec,
                 HumanReadable: 'VirusTotal does not have details about ' + hash + '\n' + res.obj.verbose_msg};
         }


### PR DESCRIPTION
In the VT Integration, if you scan a file hash and no results are returned,
the context adds an entry with Type 'file', however in all other cases it
adds Type 'hash' to the context. This fixes the behavior to consistently apply
'hash' in all cases.

related https://github.com/demisto/content/pull/1263