### PR TITLE
Fix sign alignment

### DIFF
--- a/Widgets/widget-CPUUsageAvg.json
+++ b/Widgets/widget-CPUUsageAvg.json
@@ -8,7 +8,8 @@
   "query": "cpu.usedPercent",
   "isPredefined": true,
   "params": {
-    "currencySign": "%"
+    "currencySign": "%",
+    "signAlignment": "right"
   },
   "size": 0
 }

--- a/Widgets/widget-DiskUsageAvg.json
+++ b/Widgets/widget-DiskUsageAvg.json
@@ -8,7 +8,8 @@
   "query": "disk.usedPercent",
   "isPredefined": true,
   "params": {
-    "currencySign": "%"
+    "currencySign": "%",
+    "signAlignment": "right"
   },
   "size": 0
 }

--- a/Widgets/widget-MemoryUsageAvg.json
+++ b/Widgets/widget-MemoryUsageAvg.json
@@ -8,7 +8,8 @@
   "query": "memory.usedPercent",
   "isPredefined": true,
   "params": {
-    "currencySign": "%"
+    "currencySign": "%",
+    "signAlignment": "right"
   },
   "size": 0
 }


### PR DESCRIPTION
`currencySign` is not replaced with `sign` for backward compatibility 