### PR TITLE
tableToMarkdown null removal fix

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -559,7 +559,7 @@ script: |-
               sep = '-|'
           mdResult += '|'.join([sep] * len(headers)) + '\n'
           for entry in t:
-              vals = [(formatCell(entry[h], False) if h in entry else '') for h in headers]
+              vals = [(formatCell(entry[h], False) if entry[h] else '') for h in headers]
               if len(vals) == 1:
                   mdResult += vals[0] + '|' + '\n'
               else:
@@ -1003,4 +1003,4 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
-releaseNotes: "Added documentation to each common server function"
+releaseNotes: "Fixed functionality of null removal from cells in tableToMarkdown"

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -559,7 +559,7 @@ script: |-
               sep = '-|'
           mdResult += '|'.join([sep] * len(headers)) + '\n'
           for entry in t:
-              vals = [(formatCell(entry[h], False) if entry[h] else '') for h in headers]
+              vals = [(formatCell(entry.get(h, ''), False) if entry.get(h) is not None else '') for h in headers]
               if len(vals) == 1:
                   mdResult += vals[0] + '|' + '\n'
               else:


### PR DESCRIPTION
Improved condition that checks if cell value is `null` in tableToMarkdown  