### PR TITLE
Pipl integration email context path fix

### DIFF
--- a/Integrations/integration-Pipl.yml
+++ b/Integrations/integration-Pipl.yml
@@ -276,3 +276,4 @@ script:
     - contextPath: Account.Usernames
       description: Online platforms usernames
     description: Searches for information regarding given email address
+releaseNotes: "-"

--- a/Integrations/integration-Pipl.yml
+++ b/Integrations/integration-Pipl.yml
@@ -244,8 +244,8 @@ script:
       description: Order of columns to be displayed in results (comma seperated list
         of values)
     outputs:
-    - contextPath: Account.Email
-      description: 'Email addresses'
+    - contextPath: Account.Email.Address
+      description: Email addresses
     - contextPath: Account.IDs
       description: User IDs
     - contextPath: Account.Addresses
@@ -263,8 +263,8 @@ script:
       required: true
       description: Email address to search for
     outputs:
-    - contextPath: Account.Email
-      description: 'Email addresses'
+    - contextPath: Account.Email.Address
+      description: Email addresses
     - contextPath: Account.IDs
       description: User IDs
     - contextPath: Account.Addresses


### PR DESCRIPTION
Fixes https://github.com/demisto/etc/issues/10408

If an email is returned, then it is returned in an object with key `Address` and value that contains the address, so it is enough to change only the context path in order to fix the issue.