### PR TITLE
temporary disable release notes

### DIFF
--- a/release_notes.py
+++ b/release_notes.py
@@ -277,14 +277,8 @@ class IncidentFieldContent(Content):
         return ""
 
     def modifiedReleaseNotes(self, cnt):
-        rn = cnt.get("releaseNotes", "")
-        if len(rn) == 0:
-            return None
-        res = ""
-        # Add a comment only if there are release notes
-        if rn != '-':
-            res += "- " + cnt["releaseNotes"] + "\n"
-        return res
+        # temporary disabled
+        return ""
 
 
 Content.register(IncidentFieldContent)


### PR DESCRIPTION
related to https://github.com/demisto/etc/issues/11463

temporary disabled release notes. disable this allows others to keep pushing to master

working on a better solution for having release notes for incident fields