### PR TITLE
tabletomarkdown - handling with empty response

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -2,7 +2,7 @@ commonfields:
   id: CommonServerPython
   version: -1
 name: CommonServerPython
-releaseNotes: "empty response bug fix"
+releaseNotes: "tabletomarkdown - empty response bug fix"
 script: |-
   # Common functions script
   # =======================
@@ -527,6 +527,14 @@ script: |-
          :rtype: ``str``
       """
 
+      mdResult = ''
+      if name:
+          mdResult = '### ' + name + '\n'
+
+      if not t or len(t) == 0:
+          mdResult += '**No entries.**\n'
+          return mdResult
+
       if not isinstance(t, list):
           t = [t]
       # in case of headers was not provided (backward compatibility)
@@ -538,14 +546,6 @@ script: |-
           for header in headers_aux:
               if all(obj[header] is None for obj in t):
                   headers.remove(header)
-
-      mdResult = ''
-      if name:
-          mdResult = '### ' + name + '\n'
-
-      if not t or len(t) == 0:
-          mdResult += '**No entries.**\n'
-          return mdResult
 
       if t:
           newHeaders = []

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -2,6 +2,7 @@ commonfields:
   id: CommonServerPython
   version: -1
 name: CommonServerPython
+releaseNotes: "empty response bug fix"
 script: |-
   # Common functions script
   # =======================
@@ -541,6 +542,10 @@ script: |-
       mdResult = ''
       if name:
           mdResult = '### ' + name + '\n'
+
+      if not t or len(t) == 0:
+          mdResult += '**No entries.**\n'
+          return mdResult
 
       if t:
           newHeaders = []

--- a/TestPlaybooks/script-TestPyCommonServer.yml
+++ b/TestPlaybooks/script-TestPyCommonServer.yml
@@ -89,6 +89,27 @@ script: |-
           }
       ]
 
+      empty_data = []
+      empty_data2 = {}
+      empty_data3 = None
+
+      table = tableToMarkdown('tableToMarkdown test', data)
+      demisto.results(table)
+
+      table = tableToMarkdown('tableToMarkdown test with headerTransform', data, headerTransform=underscoreToCamelCase)
+      demisto.results(table)
+
+      table = tableToMarkdown('tableToMarkdown empty test', empty_data)
+      demisto.results(table)
+
+      table = tableToMarkdown('tableToMarkdown empty test2', empty_data2)
+      demisto.results(table)
+
+      table = tableToMarkdown('tableToMarkdown empty test3', empty_data3)
+      demisto.results(table)
+
+      demisto.results('ok')
+
       table = tableToMarkdown('tableToMarkdown test', data)
       expected_tbl = '''### tableToMarkdown test
   header_2|header_3|header_1


### PR DESCRIPTION
tableToMarkdown - if the response was empty, then in previous version it resulted an error
new branch due to other changes made in this function