### PR TITLE
Enforce playbooks fromversion

### DIFF
--- a/Playbooks/playbook-ATD-sandbox.yml
+++ b/Playbooks/playbook-ATD-sandbox.yml
@@ -1,6 +1,7 @@
 id: ATD - Detonate File
 version: -1
 name: ATD - Detonate File
+fromversion: ""
 description: Detonate a file in McAfee ATD, wait for results, then get the report
   as both json and PDF.
 starttaskid: "0"

--- a/Playbooks/playbook-ATD-sandbox.yml
+++ b/Playbooks/playbook-ATD-sandbox.yml
@@ -2,6 +2,7 @@ id: ATD - Detonate File
 version: -1
 name: ATD - Detonate File
 fromversion: ""
+releaseNotes: "-"
 description: Detonate a file in McAfee ATD, wait for results, then get the report
   as both json and PDF.
 starttaskid: "0"

--- a/Playbooks/playbook-Archer_initiate_incident.yml
+++ b/Playbooks/playbook-Archer_initiate_incident.yml
@@ -1,6 +1,7 @@
 id: Archer initiate incident
 version: -1
 name: Archer initiate incident
+fromversion: "3.5.0"
 starttaskid: "0"
 description: "initiate Archer incident"
 tasks:

--- a/Playbooks/playbook-Archer_initiate_incident.yml
+++ b/Playbooks/playbook-Archer_initiate_incident.yml
@@ -2,6 +2,7 @@ id: Archer initiate incident
 version: -1
 name: Archer initiate incident
 fromversion: "3.5.0"
+releaseNotes: "-"
 starttaskid: "0"
 description: "initiate Archer incident"
 tasks:

--- a/Playbooks/playbook-Arcsight_-_Get_events_related_to_the_Case.yml
+++ b/Playbooks/playbook-Arcsight_-_Get_events_related_to_the_Case.yml
@@ -1,6 +1,7 @@
 id: Arcsight - Get events related to the Case
 version: -1
 name: Arcsight - Get events related to the Case
+fromversion: ""
 description: |-
   Get the Case's Arcsight ResourceID from the FetchID field, or the "ID" label. If neither is there, ask user for the ID.
   Use the resource ID to get full data for the case, the correlated/aggregate events underneath it, and all base events underneath them.

--- a/Playbooks/playbook-Arcsight_-_Get_events_related_to_the_Case.yml
+++ b/Playbooks/playbook-Arcsight_-_Get_events_related_to_the_Case.yml
@@ -2,6 +2,7 @@ id: Arcsight - Get events related to the Case
 version: -1
 name: Arcsight - Get events related to the Case
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Get the Case's Arcsight ResourceID from the FetchID field, or the "ID" label. If neither is there, ask user for the ID.
   Use the resource ID to get full data for the case, the correlated/aggregate events underneath it, and all base events underneath them.

--- a/Playbooks/playbook-D2_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-D2_-_Endpoint_data_collection.yml
@@ -1,6 +1,7 @@
 id: D2 - Endpoint data collection
 version: -1
 name: D2 - Endpoint data collection
+fromversion: ""
 description: |-
   Uses Demisto's d2 agent to collect data from an endpoint for IR purposes.
 

--- a/Playbooks/playbook-D2_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-D2_-_Endpoint_data_collection.yml
@@ -2,6 +2,7 @@ id: D2 - Endpoint data collection
 version: -1
 name: D2 - Endpoint data collection
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Uses Demisto's d2 agent to collect data from an endpoint for IR purposes.
 

--- a/Playbooks/playbook-Endpoint_data_collection.yml
+++ b/Playbooks/playbook-Endpoint_data_collection.yml
@@ -1,6 +1,7 @@
 id: Endpoint data collection
 version: -1
 name: Endpoint data collection
+fromversion: ""
 description: Generic playbook to collect data from endpoints for IR purposes. Will
   use whichever integrations are configured and available.
 starttaskid: "0"

--- a/Playbooks/playbook-Endpoint_data_collection.yml
+++ b/Playbooks/playbook-Endpoint_data_collection.yml
@@ -2,6 +2,7 @@ id: Endpoint data collection
 version: -1
 name: Endpoint data collection
 fromversion: ""
+releaseNotes: "-"
 description: Generic playbook to collect data from endpoints for IR purposes. Will
   use whichever integrations are configured and available.
 starttaskid: "0"

--- a/Playbooks/playbook-Enrich_DXL_with_ATD_verdict.yml
+++ b/Playbooks/playbook-Enrich_DXL_with_ATD_verdict.yml
@@ -1,6 +1,7 @@
 id: Enrich DXL with ATD verdict
 version: -1
 name: Enrich DXL with ATD verdict
+fromversion: ""
 description: |-
   Example of using McAfee ATD and pushing any malicious verdicts over DXL.
   Detonates a file in ATD and if malicious - push its MD5, SHA1 and SHA256 hashes to McAfee DXL.

--- a/Playbooks/playbook-Enrich_DXL_with_ATD_verdict.yml
+++ b/Playbooks/playbook-Enrich_DXL_with_ATD_verdict.yml
@@ -2,6 +2,7 @@ id: Enrich DXL with ATD verdict
 version: -1
 name: Enrich DXL with ATD verdict
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Example of using McAfee ATD and pushing any malicious verdicts over DXL.
   Detonates a file in ATD and if malicious - push its MD5, SHA1 and SHA256 hashes to McAfee DXL.

--- a/Playbooks/playbook-Enrich_McAfee_DXL_using_3rd_party_sandbox.yml
+++ b/Playbooks/playbook-Enrich_McAfee_DXL_using_3rd_party_sandbox.yml
@@ -1,6 +1,7 @@
 id: Enrich McAfee DXL using 3rd party sandbox
 version: -1
 name: Enrich McAfee DXL using 3rd party sandbox
+fromversion: ""
 description: |-
   Example of bridging DXL to a third party sandbox.
   Detonate a file in Wildfire and if malicious - push its MD5, SHA1 and SHA256 hashes to McAfee DXL.

--- a/Playbooks/playbook-Enrich_McAfee_DXL_using_3rd_party_sandbox.yml
+++ b/Playbooks/playbook-Enrich_McAfee_DXL_using_3rd_party_sandbox.yml
@@ -2,6 +2,7 @@ id: Enrich McAfee DXL using 3rd party sandbox
 version: -1
 name: Enrich McAfee DXL using 3rd party sandbox
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Example of bridging DXL to a third party sandbox.
   Detonate a file in Wildfire and if malicious - push its MD5, SHA1 and SHA256 hashes to McAfee DXL.

--- a/Playbooks/playbook-Get_File_Sample_From_Hash_-_Generic.yml
+++ b/Playbooks/playbook-Get_File_Sample_From_Hash_-_Generic.yml
@@ -2,6 +2,7 @@ id: Get File Sample From Hash - Generic
 version: -1
 name: Get File Sample From Hash - Generic
 toversion: 3.1.0
+fromversion: ""
 description: Returns to the war-room a file sample correlating from a hash using one
   or more products
 starttaskid: "0"

--- a/Playbooks/playbook-Get_File_Sample_From_Hash_-_Generic.yml
+++ b/Playbooks/playbook-Get_File_Sample_From_Hash_-_Generic.yml
@@ -3,6 +3,7 @@ version: -1
 name: Get File Sample From Hash - Generic
 toversion: 3.1.0
 fromversion: ""
+releaseNotes: "-"
 description: Returns to the war-room a file sample correlating from a hash using one
   or more products
 starttaskid: "0"

--- a/Playbooks/playbook-MAR_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-MAR_-_Endpoint_data_collection.yml
@@ -1,6 +1,7 @@
 id: MAR - Endpoint data collection
 version: -1
 name: MAR - Endpoint data collection
+fromversion: ""
 description: |-
   Use McAfee Active Response to collect data from an endpoint for IR purposes (requires ePO as well)
 

--- a/Playbooks/playbook-MAR_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-MAR_-_Endpoint_data_collection.yml
@@ -2,6 +2,7 @@ id: MAR - Endpoint data collection
 version: -1
 name: MAR - Endpoint data collection
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Use McAfee Active Response to collect data from an endpoint for IR purposes (requires ePO as well)
 

--- a/Playbooks/playbook-Packetsled.yml
+++ b/Playbooks/playbook-Packetsled.yml
@@ -2,6 +2,7 @@ id: TestPacketsled
 version: -1
 name: TestPacketsled
 fromversion: ""
+releaseNotes: "-"
 description: Enumerate the packetsled entities with incidents, and query each entity
   for artifacts (metadata, extracted files, and packet capture) that are then delivered
   into the demisto War Room.

--- a/Playbooks/playbook-Packetsled.yml
+++ b/Playbooks/playbook-Packetsled.yml
@@ -1,6 +1,7 @@
 id: TestPacketsled
 version: -1
 name: TestPacketsled
+fromversion: ""
 description: Enumerate the packetsled entities with incidents, and query each entity
   for artifacts (metadata, extracted files, and packet capture) that are then delivered
   into the demisto War Room.

--- a/Playbooks/playbook-Process_Email.yml
+++ b/Playbooks/playbook-Process_Email.yml
@@ -2,6 +2,7 @@ id: Process Email
 version: -1
 name: Process Email
 fromversion: ""
+releaseNotes: "-"
 description: Add email details into the relevant context entities and handle the case
   where you have attached original emails.
 starttaskid: "0"

--- a/Playbooks/playbook-Process_Email.yml
+++ b/Playbooks/playbook-Process_Email.yml
@@ -1,6 +1,7 @@
 id: Process Email
 version: -1
 name: Process Email
+fromversion: ""
 description: Add email details into the relevant context entities and handle the case
   where you have attached original emails.
 starttaskid: "0"

--- a/Playbooks/playbook-QRadar_-_Get_offense_correlations_V3_1_0.yml
+++ b/Playbooks/playbook-QRadar_-_Get_offense_correlations_V3_1_0.yml
@@ -2,6 +2,7 @@ id: 'QRadar - Get offense correlations '
 version: -1
 name: 'QRadar - Get offense correlations '
 toversion: 3.1.0
+fromversion: ""
 description: |-
   Run on a QRadar offense to get more information
 

--- a/Playbooks/playbook-QRadar_-_Get_offense_correlations_V3_1_0.yml
+++ b/Playbooks/playbook-QRadar_-_Get_offense_correlations_V3_1_0.yml
@@ -3,6 +3,7 @@ version: -1
 name: 'QRadar - Get offense correlations '
 toversion: 3.1.0
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Run on a QRadar offense to get more information
 

--- a/Playbooks/playbook-Sentinel_One_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-Sentinel_One_-_Endpoint_data_collection.yml
@@ -1,6 +1,7 @@
 id: Sentinel One - Endpoint data collection
 version: -1
 name: Sentinel One - Endpoint data collection
+fromversion: ""
 description: |-
   # Collect endpoint information based on SentinelOne commands.
 

--- a/Playbooks/playbook-Sentinel_One_-_Endpoint_data_collection.yml
+++ b/Playbooks/playbook-Sentinel_One_-_Endpoint_data_collection.yml
@@ -2,6 +2,7 @@ id: Sentinel One - Endpoint data collection
 version: -1
 name: Sentinel One - Endpoint data collection
 fromversion: ""
+releaseNotes: "-"
 description: |-
   # Collect endpoint information based on SentinelOne commands.
 

--- a/Playbooks/playbook-TIE_-_IOC_Hunt.yml
+++ b/Playbooks/playbook-TIE_-_IOC_Hunt.yml
@@ -2,6 +2,7 @@ id: TIE - IOC Hunt
 version: -1
 name: TIE - IOC Hunt
 fromversion: ""
+releaseNotes: "-"
 description: |-
   Hunt for sightings of MD5, SHA1 and/or SHA256 hashes on endpoints, using McAfee TIE (requires ePO as well).
 

--- a/Playbooks/playbook-TIE_-_IOC_Hunt.yml
+++ b/Playbooks/playbook-TIE_-_IOC_Hunt.yml
@@ -1,6 +1,7 @@
 id: TIE - IOC Hunt
 version: -1
 name: TIE - IOC Hunt
+fromversion: ""
 description: |-
   Hunt for sightings of MD5, SHA1 and/or SHA256 hashes on endpoints, using McAfee TIE (requires ePO as well).
 

--- a/Playbooks/playbook-WildFire_-_Detonate_file_V3_1_0.yml
+++ b/Playbooks/playbook-WildFire_-_Detonate_file_V3_1_0.yml
@@ -2,6 +2,7 @@ id: WildFire - Detonate file
 version: -1
 name: WildFire - Detonate file
 toversion: 3.1.0
+fromversion: ""
 description: ""
 starttaskid: "0"
 tasks:

--- a/Playbooks/playbook-WildFire_-_Detonate_file_V3_1_0.yml
+++ b/Playbooks/playbook-WildFire_-_Detonate_file_V3_1_0.yml
@@ -3,6 +3,7 @@ version: -1
 name: WildFire - Detonate file
 toversion: 3.1.0
 fromversion: ""
+releaseNotes: "-"
 description: ""
 starttaskid: "0"
 tasks:

--- a/Tests/schemas/playbook.yml
+++ b/Tests/schemas/playbook.yml
@@ -130,6 +130,7 @@ mapping:
     type: bool
   fromversion:
     type: text
+    required: yes
   toversion:
     type: text
   releaseNotes:

--- a/content_creator.py
+++ b/content_creator.py
@@ -46,7 +46,7 @@ def copy_dir_yml(dir_name, version_num, bundle_pre, bundle_post, bundle_test):
             yml_info = yaml.safe_load(f)
 
         ver = yml_info.get('fromversion', '0')
-        if is_ge_version(version_num, ver):
+        if ver == '' or is_ge_version(version_num, ver):
             print ' - marked as post: %s (%s)' % (ver, path, )
             shutil.copyfile(path, os.path.join(bundle_post, os.path.basename(path)))
             shutil.copyfile(path, os.path.join(bundle_test, os.path.basename(path)))


### PR DESCRIPTION
All playbook should have `fromversion` attribute
- added `fromversion: "3.5.0"` to Archer playbook
- added `fromversion: ""` to missing playbooks (though we can use also `fromversion: "2.5.0"`)
- change `fromversion` to be required in schema validation
