### PR TITLE
Okta bug fix

### DIFF
--- a/Integrations/integration-Okta.yml
+++ b/Integrations/integration-Okta.yml
@@ -837,6 +837,7 @@ script:
             break;
         case 'okta-remove-from-group':
             entry = removeUserFromGroupCommand();
+            break;
         case 'okta-get-logs':
             entry = getLogsCommand();
             break;

--- a/Integrations/integration-Okta.yml
+++ b/Integrations/integration-Okta.yml
@@ -1657,3 +1657,4 @@ script:
     description: Get logs by providing optional filters
   runonce: false
 fromversion: 3.6.0
+releaseNotes: "-"


### PR DESCRIPTION
Fixed missing break on switch-case. It caused unnecessary execution of a command.