### PR TITLE
Circleci 2 server log on fail build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
               ./Tests/scripts/wait_until_server_ready.sh
       - run:
           name: Run Tests
+          shell: /bin/bash
           command: ./Tests/scripts/run_tests.sh
       - run:
           name: Destroy Instances

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -328,14 +328,6 @@
         {
             "integrations": "ReversingLabs A1000",
             "playbookID": "ReversingLabsA1000Test"
-        },
-        {
-            "integrations": "Centreon",
-            "playbookID": "Centreon-Test-Playbook"
-        },
-        {
-            "integrations": "TruSTAR",
-            "playbookID": "TruSTAR Test"
         }
     ],
     "skipped": [
@@ -458,6 +450,14 @@
         {
             "integrations": "Phish.AI",
             "playbookID": "PhishAi-Test"
+        },
+        {
+            "integrations": "Centreon",
+            "playbookID": "Centreon-Test-Playbook"
+        },
+        {
+            "integrations": "TruSTAR",
+            "playbookID": "TruSTAR Test"
         }
     ]
 }

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -328,6 +328,14 @@
         {
             "integrations": "ReversingLabs A1000",
             "playbookID": "ReversingLabsA1000Test"
+        },
+        {
+            "integrations": "Centreon",
+            "playbookID": "Centreon-Test-Playbook"
+        },
+        {
+            "integrations": "TruSTAR",
+            "playbookID": "TruSTAR Test"
         }
     ],
     "skipped": [
@@ -450,14 +458,6 @@
         {
             "integrations": "Phish.AI",
             "playbookID": "PhishAi-Test"
-        },
-        {
-            "integrations": "Centreon",
-            "playbookID": "Centreon-Test-Playbook"
-        },
-        {
-            "integrations": "TruSTAR",
-            "playbookID": "TruSTAR Test"
         }
     ]
 }

--- a/Tests/scripts/run_tests.sh
+++ b/Tests/scripts/run_tests.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 echo "start content tests"
 


### PR DESCRIPTION
example: https://circleci.com/gh/demisto/content/9398#artifacts/containers/0

Now server logs are added (destroy step is always running) when build fails.