### PR TITLE
PhishTank integration context update

### DIFF
--- a/Integrations/integration-PhishTank.yml
+++ b/Integrations/integration-PhishTank.yml
@@ -111,6 +111,9 @@ script:
             md += 'Additional details at ['+phishTankURL+']('+phishTankURL+')\n';
         } else {
             md += "#### No matches for URL " + args.url + "\n";
+            ec.URL = {
+                Data: args.url
+            };
             ec.DBotScore = {Indicator: args.url, Type: 'url', Vendor: 'PhishTank', Score: 0};
         }
         var res = {'url':args.url, 'match': true};
@@ -178,3 +181,4 @@ script:
     arguments: []
     description: Show PhishTank database status
   runonce: false
+releaseNotes: "-"


### PR DESCRIPTION
Updated context according to the standard, so the url address will always be pushed to context under `URL.Data` and not only when the url is malicious. 