### PR TITLE
move qualys test to nightly - it requires only single run of build in parallel

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -162,7 +162,8 @@
         },
         {
             "integrations": "Qualys",
-            "playbookID": "Qualys-Test"
+            "playbookID": "Qualys-Test",
+            "nightly": true
         },
         {
             "integrations": {


### PR DESCRIPTION
```
Create integration Qualys succeed
Qualys-Test failed with error/s
Playbook Qualys-Test has failed:
	- Command: !qualys-pc-scan-list using-brand="Qualys"
	- Body: Error from Qualys is : Script failed to run: 
This API cannot be run again until 1 currently running instance has finished.
Code: 1960
HTTP Status Code: 409 at parseXMLAndCheckErrors (script:551:23(43)) (2603)
	- Body: Playbook **Qualys-Test** execution error
```
https://circleci.com/gh/demisto/content/10037