### PR TITLE
Fix script DisplayHTML execution in case matkAsNote was not defined

### DIFF
--- a/Scripts/script-DisplayHTML.yml
+++ b/Scripts/script-DisplayHTML.yml
@@ -7,7 +7,7 @@ script: |
   note = demisto.args().get("markAsNote")
   header = demisto.args().get("header")
 
-  note = True if note.lower() == "true" else False
+  note = True if note and note.lower() == "true" else False
   if header:
       html = "<h1>{0}</h1></br>{1}".format(header,html)
 
@@ -35,3 +35,4 @@ args:
   description: Add a header text to the output
 scripttarget: 0
 runonce: false
+releaseNotes: Fix script execution in case matkAsNote was not defined


### PR DESCRIPTION
Until now you got an error since you can't do note.lower() for not existing var

![image](https://user-images.githubusercontent.com/5429033/41614014-f178d936-73ff-11e8-8821-9eea714b0f16.png)
