### PR TITLE
FireEye URL submissions

### DIFF
--- a/Integrations/integration-fireeye.yml
+++ b/Integrations/integration-fireeye.yml
@@ -2,8 +2,7 @@ commonfields:
   id: fireeye
   version: -1
 name: fireeye
-fromversion: 3.5.0
-display: FireEye (AX Series)
+display: gps_fireeye_integration
 category: Forensics & Malware Analysis
 image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHMAAAAhCAYAAADqBZQaAAAGqUlEQVR4Ae3ZA3AcfR/A8V/Y6GI711xSK8ldH9u2bdu2bdsoHte2bdt2+3u/M+9mZmdnb7N1b2Y782mM/X/zx+3Jnvg3qbIuFSGIZ//ZU98oGm+hFBLJvJjAJXgCEvm8mI3wN1pDIpkXE/gN70IinxezA7pCIpsXMwbj8AEksnkx67ACbXEd2kIikxfzRbyOIqzEoZDI48WMRQcU4Wgo7oJEHi9mBd6B4GIo5sEPiSBezOmBYJpxBygOT+I2jMdwZEMighcTWFgdqptbFSqfEwhWQHhfayzHVFRCIoAX00EQS7EA7SEOopGARi4kIAqCHJQhEbK3iWRHQQ5Mu/aFUUhDAYpFsniZ6YNYGTN0qaENJIzmGI1xmOhgKgYjH4IOUJy8D0KehtEYjGENGI+jD9SYCTgSL6EH5mA5VmAlFqELYa/Kjc2LHu6vLZlTFToP5iV3HkogNtphGxSrHazHHBRB0A2KM/dBzMuhhq3Y5kBxJmRviorNi0I0RPjPEV8QwNMYAw1jG2ZgPKYxI/883VcSmBEIPjW1Mvg8xJg5il8gNtpCMQuNkYMCB9EQtMHxyNkHMS+GYiiKUYbyMPxI2gchT8ZtaO4UsQRvYK0l2jKoyQAcyoyMhyAGh4mknntfduPERdXtJ0ysrLsUwoC8CcWJDjFnIg3ikg9ZiIMYElCKPAjScApuRR3EJAVBXI6bcC78iHaI2QfiUiZKkQ1xkItypEJM8nAULsWFqEWyETMRN+AZHGEXMQ3PWSLOxvsI4TGoYQJyIVY1CUVRkFmB4F2T/7/PRSMPW/BpAzMzA+JSR5s983jswJ9ogmlQw2cQw6WYAbXYjh+QGyZmP4hLJ2Iz5qAMYqMFlhpaQpCB97EOajENZxlB89EaPnPEGFyO6VCswdc4B6kQw+dQw/WQeguqQjHEu35eVegQCITHoOcZA3QwBF0xFtFhYk6HD+LSP1CcCjGcBMUkTMZqdEBHPATBPVBswze4CufiHoyFYjDXkwGBOWZfiEvR6AvFExAb70DRwRSyHxRz8Cyuwg34GtuhuNp6AGqEELpAsRQvohRi42sodqA9pB4X/wCehdSbyEywHFCewSIk2cTcji0YhH7ob2MUHmsg5glQQ18UQkzaYBMUV0IsktENyqryHAQiklUfcy0GY2gYI9EVORBcDcVsm+W2GEuhOAGC96EYhQKIxSVQLEaxOeZlWGX6YBOIgwehhhMtMXvhNIjhVii2oBUE92EOEmxiboW68IXLmKtQCbF4ymbJtToIihmzq4KpEJHMi12eZhWLTCFSMA6KayAmt0DRDYIsLMZ2BCFh/ATFneaYgoPQDYou8EHCqMZKKL6G1GNJ/YqZuM6YjQOghvcghtfQx2HPnIs2qEDARjXyXcYcBrHRAYqx6IJeFj3RHVugLLEhmGfmUJSgHBU2/ChFDMRwMxT9EA1BIkZDcR4EIezAenRAR3Sy+BljoPgZpphANO7BFgxDISSMp6HYgbMhkFH+2pzF1e07QQmrRF3DYLxvWVKH4KE9eJp1ijkYYuM/KOZgMqbZmIrRmEDIgywx+0B2Ui4WQnESBBdAMRkpEBwDxSbMxDwb8zEDs/GFNaZZBf7BCpwHCeMlKLbgYZagZMgTOdWxb+Q39Xcta1MzLRAsMN12E1yMQUjeg6dZp5hDIDY+hOJhCBrZiIYgnpAxlpj9ILvgOSg6QfA3FLdDDFXYjEXIRxySLRIQhRgkOMQEcBGGogNqITZOQAcsxwgu9mOC3iviK4GYMSgX4j80huznmOe5eJruQvTEsxCY98zekF1QhmVYhfOwHnORDTHEYTAUT0Fs+PA6fkVNwzGBRNyOwfgWZyAnzDdvhiqRjFQIZAZ/0QxCDV7GK8iE7OGYf+9CzDh0hWIcjoEPCcjGLdgA5RpOhsD80GQizsTZOCeMC9ECYvERFKugeB1icTbU8AwKEIt4BPAbFH3sZ6azeByLt9EZn+ImHI8qJELMuCfbgj3zTgbkbjSHNKAGivnIgrjU1ebe7GlQjICEkY3/oIaVmI1NUCzHOZabBldBd8IbEIsabDYFDUBsXI2NUGzCZMzCdii6IHd3nzVJQluci3twKdqJZPkgkJmBYBwXX450iEv5eAA3IAHi0rl4FJUQgx8P41KIg3icjY8wEGPxLx6CH2KJ2QrP4FE81oBncQzERkco3oM4aIan0B3TMAk/4WIkQKwxPftWAeZBcTDEpSiDAPBi7nfvm0+0O8+Lub/dgCEYBcVa1HoxI9NtWI7ZGIzTIHva/wAx/Zd/Mj383wAAAABJRU5ErkJggg==
 description: Perform malware dynamic analysis
@@ -28,7 +27,7 @@ configuration:
   defaultvalue: 1.1.0
   type: 0
   required: false
-- display: Trust any certificate (unsecure)
+- display: Do not validate server certificate (insecure)
   name: insecure
   defaultvalue: ""
   type: 8
@@ -54,7 +53,7 @@ script:
             url: 'reports/report',
             method: 'GET',
         },
-        'fe-submit-status': {
+        'fe-submit-file-status': {
             url: 'submissions/status/%submission_Key%',
             method: 'GET',
             setContentType: true,
@@ -66,6 +65,23 @@ script:
                     data: [
                         {to: 'Key', from: 'submission_Key'},
                         {to: 'Status', from: 'submissionStatus'},
+                    ]
+                }
+            ],
+        },
+        'fe-submit-url-status': {
+            url: 'submissions/status/%submission_Key%',
+            method: 'GET',
+            setContentType: true,
+            extended: true,
+            translator: [
+                {
+                    contextPath: 'FireEyeAX.Submissions(val.Key==obj.Key)',
+                    title: 'FireEye Submission',
+                    data: [
+                        {to: 'Key', from: 'submission_Key'},
+                        {to: 'Status', from: 'status'},
+                        {to: 'ID', from: 'response.id'},
                     ]
                 }
             ],
@@ -110,7 +126,7 @@ script:
                 }
             ],
         },
-        'fe-submit': {
+        'fe-submit-file': {
             extended: true,
             translator: [
                 {
@@ -118,6 +134,18 @@ script:
                     title: 'FireEye Submission',
                     data: [
                         {to: 'Key', from: 'ID'},
+                    ]
+                }
+            ],
+        },
+        'fe-submit-url': {
+            extended: true,
+            translator: [
+                {
+                    contextPath: 'FireEyeAX.Submissions(val.Key==obj.Key)',
+                    title: 'FireEye Submission',
+                    data: [
+                        {to: 'Key', from: 'id'},
                     ]
                 }
             ],
@@ -235,7 +263,7 @@ script:
             var filename = getFileName(args);
             result = {Type: 9, FileID: saveFile(response.Bytes), File: filename, Contents: filename};
             break;
-        case 'fe-submit':
+        case 'fe-submit-file':
             if (args.profiles) {
                 args.profiles = args.profiles.split(',');
                 for (var k in args.profiles) {
@@ -269,6 +297,24 @@ script:
               }
               result = JSON.parse(res.Body);
               break;
+        case 'fe-submit-url':
+            var profiles = args.profiles.split(',');
+            var urls = args.urls.split(',');
+            var res = http(
+                server + 'submissions/url',
+                {
+                    Method: 'POST',
+                    Headers: {'Content-Type': ['application/json'],'X-FeApi-Token': token},
+                    Body: JSON.stringify({"timeout":args.timeout, "priority":args.priority, "profiles":profiles, "application":args.application, "force":args.force, "analysistype":args.analysistype, "prefetch":args.prefetch, "urls":urls})
+                },
+                params.insecure,
+                params.proxy
+             );
+            if (res.StatusCode < 200 || res.StatusCode >= 300 || res.success === false) {
+                throw 'FireEye URL Submission Request Failed.\nStatus code: ' + res.StatusCode + '.\nBody: ' + res.Body + '.';
+            }
+            result = JSON.parse(res.Body);
+            break;
         default:
             respoonse = sendRequest(replaceInTemplatesAndRemove(commandDictionary[command].url, args), commandDictionary[command].method, token, commandDictionary[command].setContentType, args);
             result = respoonse.Body;
@@ -289,6 +335,9 @@ script:
     currentCommand = commandDictionary[command];
     var entries = [];
     if (currentCommand.extended) {
+        if(command === 'fe-submit-url'){
+            result = result.response
+        }
         for (var j in currentCommand.translator) {
             var current = currentCommand.translator[j];
             var entry = {
@@ -347,7 +396,7 @@ script:
     - name: frame
       description: commands.server.feReport.arguments.frame.description
     description: commands.server.feReport.description
-  - name: fe-submit-status
+  - name: fe-submit-file-status
     arguments:
     - name: submission_Key
       required: true
@@ -414,8 +463,8 @@ script:
       description: Bad hash found
     - contextPath: File.Malicious.Vendor
       description: For malicious files, the vendor that made the decision
-    description: commands.server.feSubmit.arguments.submissionKey.description
-  - name: fe-submit
+    description: Results of the file submission
+  - name: fe-submit-file
     arguments:
     - name: upload
       description: commands.server.feSubmit.arguments.uploadFile.description
@@ -452,7 +501,6 @@ script:
     description: commands.server.feSubmit.description
   - name: fe-config
     arguments: []
-    description: commands.server.feConfig.description
     outputs:
     - contextPath: FireEyeAX.Sensors.Address
       description: Sensor IP address
@@ -468,3 +516,60 @@ script:
       description: FireEye application ID
     - contextPath: FFireEyeAX.Sensors.Profiles.Applications.-name
       description: FireEye application name
+    description: commands.server.feConfig.description
+  - name: fe-submit-url
+    arguments:
+    - name: analysistype
+      required: true
+      description: 'Specify live or sandbox analysis mode. 0—Live, analyze suspected
+        malware objects live within the MAS Multivector Virtual Execution (MVX) analysis
+        engine. 1—Sandbox, analyze suspected malware objects in a closed, protected
+        environment. Example: analysisType=live'
+    - name: profiles
+      required: true
+      description: Select the MAS profile to use for analysis. To determine the available
+        profiles, use the configuration command
+    - name: application
+      required: true
+      description: 'Specifies the application to be used for the analysis. To determine
+        the available applications  for a specific profile, use the configuration
+        command. Note: Setting the application value to 0, allows the MAS to determine
+        the file type for you'
+    - name: priority
+      required: true
+      description: 'Sets the analysis priority: 0—Normal, adds analysis to the bottom
+        of queue. 1—Urgent, places the analysis at the top of the queue'
+    - name: force
+      required: true
+      description: 'Specify whether to perform an analysis on the malware object even
+        if the object exactly matches an analysis that has already been performed.
+        In most cases, it is not necessary to reanalyze malware. (default: false)
+        0—False, Do not analyze duplicate objects. 1—True, Force analysis'
+    - name: prefetch
+      required: true
+      description: Specifies whether to determine the file target based on an internal
+        determination rather than browsing to the target location. 0—No 1—Yes
+    - name: timeout
+      required: true
+      description: Sets the analysis timeout (in seconds)
+    - name: urls
+      required: true
+      description: url to be analyzed
+    outputs:
+    - contextPath: FireEyeAX.Submissions.Key
+      description: The file submission key
+    description: Submit a url for analysis by FireEye
+  - name: fe-submit-url-status
+    arguments:
+    - name: submission_Key
+      required: true
+      description: Submission key of the submission
+    outputs:
+    - contextPath: FireEyeAX.Submissions.Key
+      description: The url submission key
+    - contextPath: FireEyeAX.Submissions.Status
+      description: The url submission status
+    - contextPath: FireEyeAX.Submissions.ID
+      description: The ID of URL submission results
+    description: Get a status for a url submitted to FireEye analysis
+  runonce: false


### PR DESCRIPTION
Added functionality to submit URLs to FireEye and retrieve their status. The functions created are fe-submit-url and fe-submit-url-status.  fe-submit had to be to fe-submit-file, and fe-submit-status to fe-submit-file-status.