### PR TITLE
Update process email + phishing layout

### DIFF
--- a/IncidentFields/incidentfields.json
+++ b/IncidentFields/incidentfields.json
@@ -1,4 +1,5 @@
 {
+	"releaseNotes": "Add HTML Image field",
 	"incidentFields": [{
 		"id": "incident_attachmenthash",
 		"version": 1,

--- a/IncidentFields/incidentfields.json
+++ b/IncidentFields/incidentfields.json
@@ -1096,8 +1096,8 @@
 	{
 		"id": "incident_htmlimage",
 		"version": 1,
-		"modified": "2018-07-17T07:55:24.242287006Z",
-		"name": "HTM Image",
+		"modified": "2018-07-19T07:29:11.711847656Z",
+		"name": "HTML Image",
 		"ownerOnly": false,
 		"placeholder": "",
 		"description": "",

--- a/IncidentFields/incidentfields.json
+++ b/IncidentFields/incidentfields.json
@@ -1094,14 +1094,14 @@
 		"unsearchable": false
 	},
 	{
-		"id": "incident_htmlrenderedimage",
+		"id": "incident_htmlimage",
 		"version": 1,
 		"modified": "2018-07-17T07:55:24.242287006Z",
-		"name": "HTML Rendered Image",
+		"name": "HTM Image",
 		"ownerOnly": false,
 		"placeholder": "",
 		"description": "",
-		"cliName": "htmlrenderedimage",
+		"cliName": "htmlimage",
 		"type": "markdown",
 		"closeForm": false,
 		"editForm": true,

--- a/IncidentFields/incidentfields.json
+++ b/IncidentFields/incidentfields.json
@@ -1094,6 +1094,38 @@
 		"unsearchable": false
 	},
 	{
+		"id": "incident_htmlrenderedimage",
+		"version": 1,
+		"modified": "2018-07-17T07:55:24.242287006Z",
+		"name": "HTML Rendered Image",
+		"ownerOnly": false,
+		"placeholder": "",
+		"description": "",
+		"cliName": "htmlrenderedimage",
+		"type": "markdown",
+		"closeForm": false,
+		"editForm": true,
+		"required": false,
+		"script": "",
+		"fieldCalcScript": "",
+		"neverSetAsRequired": false,
+		"isReadOnly": false,
+		"selectValues": null,
+		"validationRegex": "",
+		"useAsKpi": false,
+		"locked": false,
+		"system": false,
+		"content": false,
+		"group": 0,
+		"hidden": false,
+		"associatedTypes": [
+			"Phishing"
+		],
+		"associatedToAll": false,
+		"unmapped": false,
+		"unsearchable": false
+	},
+	{
 		"id": "incident_malwarefamily",
 		"version": 1,
 		"modified": "2018-05-01T11:10:16.822110755Z",

--- a/Integrations/integration-rasterize.yml
+++ b/Integrations/integration-rasterize.yml
@@ -4,6 +4,7 @@ commonfields:
 name: Rasterize
 display: Rasterize
 category: Utilities
+releaseNotes: "Add base64 output to rasterize-email"
 image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAA10lEQVR4Ae3TYQ3CQAwFYCQgAQlIOCmTMAnnYBJOAhImYRImYRJKSfrrBXoXDkrJtcnLEtaQr9fdiYhcJ4AugAHkIgdJAfwrYAC/eTO51nGAv1x7AAPoH2h4w02AXFdOfjyVngtnNQdyTdC3vOgr8j5ZA/dan5weSbYuICdLWoFHA3CBnqkHiKkBcZgbvD8/GWI3AcJ3mDmzrHPGATAmQDwpWGXBT8AcKKgkzw378bd3gFmJCpRVHtXBOoBq9D/FE/MHLBxyCfx0RgDaJ4AB9AJ0nAAOALwDFV7f8k1w4yAAAAAASUVORK5CYII=
 description: Rasterize URLs or emails given to it
 detaileddescription: Take a URL or HTML body and create an image or PDF out of it
@@ -17,6 +18,8 @@ configuration:
 script:
   script: |-
     import os, subprocess,sys
+    import base64
+
     reload(sys)
     sys.setdefaultencoding("utf-8")
     proxy = demisto.get(demisto.params(),"proxy")
@@ -64,8 +67,13 @@ script:
         rasterize_email(html, friendlyName)
         if return_code == 0:
             filename = demisto.uniqueFile()
-            subprocess.call(['mv', friendlyName, demisto.investigation()['id'] + '_' + filename])
-            demisto.results({'ContentsFormat': 'text', 'Type': entryTypes['image'], 'File': friendlyName, 'FileID': filename, 'Contents': ''})
+            path = demisto.investigation()['id'] + '_' + filename
+            subprocess.call(['mv', friendlyName, path])
+
+            with open(path, "rb") as image_file:
+                encoded_string = base64.b64encode(image_file.read())
+
+            demisto.results({'ContentsFormat': 'text', 'Type': entryTypes['image'], 'File': friendlyName, 'FileID': filename, 'Contents': '','EntryContext' : {"Base64.encoded": encoded_string}})
         else:
             demisto.results({'ContentsFormat': 'text', 'Type': entryTypes['error'], 'Contents': 'PhantomJS returned - ' + error_message})
         sys.exit(0)
@@ -135,6 +143,10 @@ script:
       description: The page height, e.g. 50px (empty is entire email)
     - name: type
       description: pdf or png. Default is png.
+    outputs:
+    - contextPath: Base64.encoded
+      description: The image base64
+      type: string
     description: Rasterize an email body into an image
   dockerimage: demisto/rasterize
 hidden: false

--- a/Layouts/layout-details-Phishing.json
+++ b/Layouts/layout-details-Phishing.json
@@ -188,7 +188,7 @@
 						"id": "",
 						"version": 0,
 						"modified": "0001-01-01T00:00:00Z",
-						"fieldId": "incident_htmlrenderedimage",
+						"fieldId": "incident_htmlimage",
 						"isVisible": true
 					}
 				],

--- a/Layouts/layout-details-Phishing.json
+++ b/Layouts/layout-details-Phishing.json
@@ -1,4 +1,5 @@
 {
+	"releaseNotes": "Add HTML Image field",
 	"typeId": "Phishing",
 	"kind": "details",
 	"layout": {

--- a/Layouts/layout-details-Phishing.json
+++ b/Layouts/layout-details-Phishing.json
@@ -4,7 +4,7 @@
 	"layout": {
 		"id": "Phishing",
 		"version": -1,
-		"modified": "2018-04-08T19:57:25.247211344Z",
+		"modified": "2018-07-17T07:56:11.209263825Z",
 		"name": "",
 		"sections": [
 			{
@@ -182,6 +182,13 @@
 						"version": 0,
 						"modified": "0001-01-01T00:00:00Z",
 						"fieldId": "incident_emailbodyhtml",
+						"isVisible": true
+					},
+					{
+						"id": "",
+						"version": 0,
+						"modified": "0001-01-01T00:00:00Z",
+						"fieldId": "incident_htmlrenderedimage",
 						"isVisible": true
 					}
 				],

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -519,6 +519,7 @@ tasks:
       id: 50661f40-4640-4b90-8f01-8143cec44c79
       version: -1
       name: Is there a base64 encoding for the rendered image?
+      description: ""
       type: condition
       iscommand: false
       brand: ""

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -461,7 +461,7 @@ tasks:
       filehash: {}
       filename: {}
       filepath: {}
-      htmlrenderedimage:
+      htmlimage:
         simple: '![HTML render](data:image/png;base64,${Base64.encoded})'
       id: {}
       important: {}

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -178,7 +178,7 @@ tasks:
       script: Rasterize|||rasterize-email
       type: regular
       iscommand: true
-      brand: Rasterizedescription: ""
+      brand: Rasterize: ""
     nexttasks:
       '#none#':
       - "15"

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -178,7 +178,7 @@ tasks:
       script: Rasterize|||rasterize-email
       type: regular
       iscommand: true
-      brand: Rasterize: ""
+      brand: Rasterize
     nexttasks:
       '#none#':
       - "15"

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -2,6 +2,7 @@ id: process_email_-_generic
 version: -1
 name: Process Email - Generic
 fromversion: 3.6.0
+releaseNotes: "Upload HTML rendered image to the Summary page"
 description: Add email details to the relevant context entities and handle the case
   where original emails are attached.
 starttaskid: "0"
@@ -92,7 +93,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 45,
+          "x": 51,
           "y": 370
         }
       }
@@ -167,20 +168,20 @@ tasks:
       }
   "5":
     id: "5"
-    taskid: 0c8947d2-ede9-41d6-862d-1aba4611a826
+    taskid: 2373f9de-c13d-42ca-84be-8735743156e6
     type: regular
     task:
-      id: 0c8947d2-ede9-41d6-862d-1aba4611a826
+      id: 2373f9de-c13d-42ca-84be-8735743156e6
       version: -1
       name: Render HTML to an image
       description: ""
       script: Rasterize|||rasterize-email
       type: regular
       iscommand: true
-      brand: Rasterize
+      brand: Rasterizedescription: ""
     nexttasks:
       '#none#':
-      - "6"
+      - "15"
     scriptarguments:
       height: {}
       htmlBody:
@@ -216,7 +217,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 1215
+          "y": 1565
         }
       }
   "11":
@@ -395,14 +396,162 @@ tasks:
           "y": 545
         }
       }
+  "14":
+    id: "14"
+    taskid: 89a7a856-46ff-46f6-8f1c-b2f772c12881
+    type: regular
+    task:
+      id: 89a7a856-46ff-46f6-8f1c-b2f772c12881
+      version: -1
+      name: Set HTML Image custom field
+      description: Set the base64 of the rendered image to the custom field and the
+        Summary page
+      script: Builtin|||setIncident
+      type: regular
+      iscommand: true
+      brand: Builtin
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      addLabels: {}
+      app: {}
+      assetid: {}
+      attachmentcount: {}
+      attachmentextension: {}
+      attachmenthash: {}
+      attachmentid: {}
+      attachmentitem: {}
+      attachmentname: {}
+      attachmentsize: {}
+      attachmenttype: {}
+      backupowner: {}
+      bugtraq: {}
+      customFields: {}
+      cve: {}
+      cvss: {}
+      daysbetweenreportcreation: {}
+      dest: {}
+      destntdomain: {}
+      details: {}
+      duration: {}
+      emailbcc: {}
+      emailbody: {}
+      emailbodyformat: {}
+      emailbodyhtml: {}
+      emailcc: {}
+      emailclientname: {}
+      emailfrom: {}
+      emailkeywords: {}
+      emailmessageid: {}
+      emailreceived: {}
+      emailreplyto: {}
+      emailreturnpath: {}
+      emailsenderip: {}
+      emailsize: {}
+      emailsource: {}
+      emailsubject: {}
+      emailto: {}
+      emailtocount: {}
+      emailurlclicked: {}
+      eventid: {}
+      falses: {}
+      fetchid: {}
+      fetchtype: {}
+      filehash: {}
+      filename: {}
+      filepath: {}
+      htmlrenderedimage:
+        simple: '![HTML render](data:image/png;base64,${Base64.encoded})'
+      id: {}
+      important: {}
+      importantfield: {}
+      labels: {}
+      malwarefamily: {}
+      mdtest: {}
+      myfield: {}
+      name: {}
+      occurred: {}
+      owner: {}
+      phase: {}
+      replacePlaybook: {}
+      reporteduser: {}
+      roles: {}
+      screenshot: {}
+      screenshot2: {}
+      selector: {}
+      severity: {}
+      signature: {}
+      single: {}
+      single2: {}
+      sla: {}
+      source: {}
+      src: {}
+      srcntdomain: {}
+      srcuser: {}
+      systems: {}
+      test: {}
+      test2: {}
+      testfield: {}
+      timeassignedtolevel2: {}
+      timefield1: {}
+      timelevel1: {}
+      type: {}
+      user: {}
+      username: {}
+      vendorid: {}
+      vendorproduct: {}
+      vulnerabilitycategory: {}
+    reputationcalc: 0
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 490,
+          "y": 1390
+        }
+      }
+  "15":
+    id: "15"
+    taskid: 50661f40-4640-4b90-8f01-8143cec44c79
+    type: condition
+    task:
+      id: 50661f40-4640-4b90-8f01-8143cec44c79
+      version: -1
+      name: Is there a base64 encoding for the rendered image?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "6"
+      "yes":
+      - "14"
+    reputationcalc: 0
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: general.isExists
+          left:
+            value:
+              simple: Base64.encoded
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 377.5,
+          "y": 1215
+        }
+      }
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1230,
-        "width": 815,
-        "x": 45,
+        "height": 1580,
+        "width": 819,
+        "x": 51,
         "y": 50
       }
     }

--- a/Tests/schemas/incidentfields.yml
+++ b/Tests/schemas/incidentfields.yml
@@ -30,6 +30,8 @@ schema;field_schema:
       type: str
     description:
       type: str
+    fieldCalcScript:
+      type: str
     cliName:
       type: str
       required: yes


### PR DESCRIPTION
* And `HTML Rendered Image` MD field to phishing layout
* Add Base64 output to the `rasterize-email` command
* Update rasterized image to the Phishing summary page

TODO:
* Remove the HTML field mapping in the relevant integrations

Fixes: https://github.com/demisto/etc/issues/12327