### PR TITLE
Validate widget isPredefined property is true

### DIFF
--- a/Tests/schemas/widget.yml
+++ b/Tests/schemas/widget.yml
@@ -25,6 +25,7 @@ mapping:
   isPredefined:
     type: bool
     required: yes
+    enum: [true]
   releaseNotes:
     type: str
   dateRange:


### PR DESCRIPTION
Output in case some widget has 
`isPredefined: false`

```bash
Starting validate Widgets...
Failed: Widgets/widget-IncidentInErrorNumber.json failed
<SchemaError: error code 2: Schema validation failed:
 - Enum 'False' does not exist. Path: '/isPredefined'.: Path: '/'>
Finished validate Widgets
validate_files_structure.sh exiting with error
```