### PR TITLE
check proxy parameter before client.connect()

### DIFF
--- a/Integrations/integration-SplunkPy.yml
+++ b/Integrations/integration-SplunkPy.yml
@@ -212,13 +212,8 @@ script:
             'headers': response.info().dict,
             'body': StringIO(response.read())
         }
-
-    service = client.connect(
-            host=demisto.params()['host'],
-            port=demisto.params()['port'],
-            username=demisto.params()['authentication']['identifier'],
-            password=demisto.params()['authentication']['password'])
-
+    
+    service = None
     proxy = demisto.params()['proxy']
     if proxy:
         try:
@@ -233,6 +228,12 @@ script:
                 pass
             else:
                 raise
+    else:
+        service = client.connect(
+            host=demisto.params()['host'],
+            port=demisto.params()['port'],
+            username=demisto.params()['authentication']['identifier'],
+            password=demisto.params()['authentication']['password'])
 
     # The command demisto.command() holds the command sent from the user.
     if demisto.command() == 'test-module':


### PR DESCRIPTION
Attempting to connect to the splunk server before checking for the proxy parameter causes a connection timeout if the splunk server is not accessible without using a proxy.