### PR TITLE
added regex formatting for commonserverpython

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1063,6 +1063,19 @@ script: |-
     'cve': 'CVE(val.ID && val.ID == obj.ID)',
     'email': 'Account.Email(val.Address && val.Address == obj.Address)'
   }
+
+  ############################### REGEX FORMATTING ###############################
+  regexFlags = re.M #Multi line matching
+
+  ipv4Regex = r'\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
+  emailRegex = r'\b[^@]+@[^@]+\.[^@]+\b'
+  hashRegex = r'\b[0-9a-fA-F]+\b'
+
+  md5Regex = re.compile(r'\b[0-9a-fA-F]{32}\b', regexFlags)
+  sha1Regex = re.compile(r'\b[0-9a-fA-F]{40}\b', regexFlags)
+  sha256Regex = re.compile(r'\b[0-9a-fA-F]{64}\b', regexFlags)
+
+  ############################### REGEX FORMATTING end ###############################
 type: python
 tags:
 - infra

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1087,3 +1087,4 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
+releaseNotes: added regex formatting

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -13,6 +13,7 @@ script: |-
   import optparse
   import sys
   import os
+  import re
   from collections import OrderedDict
 
   import xml.etree.cElementTree as ET

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1066,6 +1066,8 @@ script: |-
 
   ############################### REGEX FORMATTING ###############################
   regexFlags = re.M #Multi line matching
+  #for the global(/g) flag use re.findall({regex_format},str)
+  #else, use re.match({regex_format},str)
 
   ipv4Regex = r'\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
   emailRegex = r'\b[^@]+@[^@]+\.[^@]+\b'


### PR DESCRIPTION
same format as commonserver(for js)
for the global(/g) flag use re.findall({regex_format},str)