### PR TITLE
Update script-RepopulateFiles.yml

### DIFF
--- a/Scripts/script-RepopulateFiles.yml
+++ b/Scripts/script-RepopulateFiles.yml
@@ -17,8 +17,8 @@ script: |
               'SHA256': e['FileMetadata'].get('sha256'),
               'SSDeep': e['FileMetadata'].get('ssdeep'),
               'Size': e['FileMetadata'].get('size'),
-              'Info': e['FileMetadata'].get('info'),
-              'Type': e['FileMetadata'].get('type'),
+              'Info': e['FileMetadata'].get('type'),
+              'Type': e['FileMetadata'].get('info'),
               'Extension': ext[1:] if ext else '',
               'EntryID': e['ID']
           })


### PR DESCRIPTION
Swapping File.Info and File.Type

When an incident is first created the File attributes are as follows:
Info: application/pdf
Type: PDF document, version 1.7

If you delete the context with !DeleteContext and then run !RePopulateFiles, this gets turned around.
Since !RePopulateFiles is usually run on the Playground, this makes testing File.Info or File.Type not work properly on the Playground when compared to the context in an Incident.

Unless/Until the context data between the Playground an Incident matches, this seems like a good interim fix.