### PR TITLE
Using ExtractURL instead of pdfx library

### DIFF
--- a/Scripts/script-ReadPDFFile.yml
+++ b/Scripts/script-ReadPDFFile.yml
@@ -2,6 +2,7 @@ commonfields:
   id: ReadPDFFile
   version: -1
 name: ReadPDFFile
+releaseNotes: "-"
 script: |-
   import pdfx
   import sys
@@ -46,9 +47,11 @@ script: |-
               pdfFile[k] = metadata[k]
 
           #Add URLs
-          if "url" in references_dict.keys():
-              for url in references_dict['url']:
-                  URLs.append({'Data':url})
+          res = demisto.executeCommand("ExtractURL", {"text":text})
+          urls = res[0]['Contents']
+          if urls:
+              for url in urls:
+                  URLs.append(url)
 
           md = "### Metadata\n"
           md += "* " if metadata else ""


### PR DESCRIPTION
pdfx library also categorizes domains as URLs.  Switching to ExtractURL to accurately display URLs presented in PDF

related to:
https://github.com/demisto/etc/issues/12962