### PR TITLE
Fix Jira integration: edit issue

### DIFF
--- a/Integrations/integration-jira.yml
+++ b/Integrations/integration-jira.yml
@@ -385,9 +385,6 @@ script:
         if (!issue.fields) {
             issue.fields= {};
         }
-        if (!issue.fields.project) {
-            issue.fields.project= {};
-        }
         if (!issue.fields.issuetype && command == "jira-create-issue"){
             issue.fields.issuetype = {};
         }
@@ -395,13 +392,22 @@ script:
             issue.fields.summary = args.summary;
         }
         if (args.projectKey && args.projectKey.length > 0 ){
+            if (!issue.fields.project) {
+                issue.fields.project= {};
+            }
             issue.fields.project.key = args.projectKey;
         }
 
         if (args.projectName && args.projectName.length > 0 ){
+            if (!issue.fields.project) {
+                issue.fields.project= {};
+            }
             issue.fields.project.name = args.projectName;
         }
         if (command == "jira-create-issue"){
+            if (!issue.fields.project) {
+                issue.fields.project= {};
+            }
             issue.fields.project.id = getProjectID(issue.fields.project.key, issue.fields.project.name);
         }
 


### PR DESCRIPTION
Edit issue functionality does not work properly.
When sending the command with all required parameters, the following error occurs:

`Script failed to run: Failed to send request, request status code: 400, {"errorMessages":[],"errors":{"project":"Could not find project by id or key."}} at sendRequest (script:51:23(108))`

Turns out that the "project" field is always being created, although it's not being edited.
E.g. if the summary of an Issue is edited, the current code generated the following request body:
`{"fields":{"project":{},"summary":"test123123123"}}`

This causes the problem mentioned above.

Solution: the "project" field should only be created, if it's needed, i.e. on issue creation.
