### PR TITLE
Remove HTML mapping from default phishing mapping

### DIFF
--- a/Classifiers/classifier-EWS_v2.json
+++ b/Classifiers/classifier-EWS_v2.json
@@ -1,4 +1,5 @@
 {
+	"releaseNotes": "-",
 	"id": "c9332555-348b-4d91-85b4-e345cdba12c8",
 	"version": -1,
 	"modified": "2018-04-08T19:42:30.856069216Z",
@@ -148,10 +149,6 @@
 				},
 				"Email Body": {
 					"simple": "text_body",
-					"complex": null
-				},
-				"Email Body HTML": {
-					"simple": "body",
 					"complex": null
 				},
 				"Email CC": {

--- a/Classifiers/classifier-EWS_v2.json
+++ b/Classifiers/classifier-EWS_v2.json
@@ -1,5 +1,5 @@
 {
-	"releaseNotes": "-",
+	"releaseNotes": "Remove default mapping of the html-body to prevent the rendering of malicious links",
 	"id": "c9332555-348b-4d91-85b4-e345cdba12c8",
 	"version": -1,
 	"modified": "2018-04-08T19:42:30.856069216Z",

--- a/Classifiers/classifier-Mail-listener.json
+++ b/Classifiers/classifier-Mail-listener.json
@@ -1,4 +1,5 @@
 {
+	"releaseNotes": "-",
 	"id": "8e398f32-2af9-49a0-8702-e2eeeb0101e5",
 	"version": -1,
 	"modified": "2018-04-08T19:54:57.433647006Z",
@@ -16,10 +17,6 @@
 				},
 				"Email Body": {
 					"simple": "text",
-					"complex": null
-				},
-				"Email Body HTML": {
-					"simple": "html",
 					"complex": null
 				},
 				"Email CC": {


### PR DESCRIPTION
Removed from:
* EWSv2
* Mail-listener

Didn't remove from:
* Gmail - `body` field is mapped to `Email Body`, field that's not of type `html` and is not rendered (links aren't clickable)

fixes https://github.com/demisto/etc/issues/12327