### PR TITLE
Create script-AsciiEncode

### DIFF
--- a/Scripts/script-AsciiEncode
+++ b/Scripts/script-AsciiEncode
@@ -1,0 +1,46 @@
+commonfields:
+  id: AsciiEncode
+  version: 21
+name: AsciiEncode
+script: |-
+  """
+  AsciiEncode - Demisto Automation
+
+  Takes 'data' string as an input and outputs the data encoded in an ASCII string, while ignoring any characters that are unrecognizable.
+
+  """
+
+  # Grab 'data' from Demisto Arguments
+  data = demisto.args()['data']
+
+  # Encode the data, ignoring characters
+  try:
+      encoded_data = data.encode('ascii', 'ignore')
+  except:
+      myErrorText  = "There was an error encoding the data."
+      demisto.results( { "Type" : entryTypes["error"], "ContentsFormat" : formats["text"], "Contents" : myErrorText } )
+
+  # Output the data and add results to war room
+
+  demisto.results(
+      {'ContentsFormat': formats['text'],
+      'Type': entryTypes['note'],
+      'Contents': 'Success: ' + encoded_data,
+      'EntryContext': {'asciiencode' : {'encoded' : encoded_data}}
+      })
+type: python
+tags: []
+comment: Input Text Data to Encode as ASCII (Ignores any chars that aren't interpreted
+  as ASCII)
+enabled: true
+args:
+- name: data
+  required: true
+  description: Data to be encoded
+outputs:
+- contextPath: asciiencode.encoded
+  description: Data encoded in ASCII
+  type: string
+scripttarget: 0
+runonce: false
+releaseNotes: "New automation for encoding data in ASCII"


### PR DESCRIPTION
Due to an issue in SplunkPy, I came across the need to encode some data into ascii before calling splunk-submit event. There weren't any automations around this, so I made one myself. I'm sure there will be other times in the future where someone could use this.