### PR TITLE
Skipped Redlock test

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -407,11 +407,6 @@
             "playbookID": "test-domain-indicator"
         },
         {
-            "integrations": "RedLock",
-            "playbookID": "RedLockTest",
-            "nightly": true
-        },
-        {
             "integrations": "VirusTotal - Private API",
             "playbookID": "virusTotalPrivateAPI-test-playbook",
             "nightly": true
@@ -455,6 +450,11 @@
         }
     ],
     "skipped": [
+        {
+            "integrations": "RedLock",
+            "playbookID": "RedLockTest",
+            "nightly": true
+        },
         {
             "integrations": {
                 "name": "carbonblack",


### PR DESCRIPTION
Redlock suddenly cleared all the alerts.
Until we find a way to generate alerts, this test should be skipped.