### PR TITLE
moving scadafence test to skip

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -448,13 +448,13 @@
         {
             "integrations": "RTIR",
             "playbookID": "RTIR Test"
-        },
-        {
-            "integrations": "SCADAfence CNM",
-            "playbookID": "SCADAfence_test"
         }
     ],
     "skipped": [
+        {
+            "integrations": "SCADAfence CNM",
+            "playbookID": "SCADAfence_test"
+        },
         {
             "integrations": "RedLock",
             "playbookID": "RedLockTest",


### PR DESCRIPTION
It seems that the credentials have expired, moving the test to skip