### PR TITLE
404 from api call to "not found message" instead of raising exception

### DIFF
--- a/Integrations/integration-Cylance_Protect_v2.yml
+++ b/Integrations/integration-Cylance_Protect_v2.yml
@@ -121,13 +121,14 @@ script:
         return epoch_time, epoch_timeout
 
 
-    def api_call(uri, method = 'post', headers = {}, body = {}, params = {}):
+    def api_call(uri, method = 'post', headers = {}, body = {}, params = {}, accept_404 = False):
         '''
         Makes an API call to the server URL with the supplied uri, method, headers, body and params
         '''
         url = '%s/%s' % (SERVER_URL, uri)
         res = requests.request(method, url, headers=headers, data=json.dumps(body), params=params)
         if res.status_code < 200 or res.status_code >= 300:
+            if res.status_code == 404 and not accept_404:
                 raise Exception('Got status code ' + str(res.status_code) + ' with body ' + res.content + ' with headers ' + str(res.headers))
         return json.loads(res.text) if res.text else res.ok
 
@@ -702,7 +703,7 @@ script:
             'Authorization': 'Bearer ' + access_token
         }
         uri = '%s/%s' % (URI_THREATS, hash)
-        res = api_call(uri=uri, method='get', headers=headers)
+        res = api_call(uri=uri, method='get', headers=headers, body = {}, params = {}, accept_404 = True)
         return res
 
     def get_threats():
@@ -1580,3 +1581,4 @@ script:
     description: Gets a list of global list resources for a tenant
   dockerimage: demisto/cylance_protect_v2
   isfetch: true
+releaseNotes: "-"

--- a/Integrations/integration-Cylance_Protect_v2.yml
+++ b/Integrations/integration-Cylance_Protect_v2.yml
@@ -1582,3 +1582,5 @@ script:
   dockerimage: demisto/cylance_protect_v2
   isfetch: true
 releaseNotes: "-"
+tests:
+  - Cylance Protect v2 Test

--- a/Integrations/integration-Cylance_Protect_v2.yml
+++ b/Integrations/integration-Cylance_Protect_v2.yml
@@ -128,7 +128,7 @@ script:
         url = '%s/%s' % (SERVER_URL, uri)
         res = requests.request(method, url, headers=headers, data=json.dumps(body), params=params)
         if res.status_code < 200 or res.status_code >= 300:
-            if res.status_code == 404 and not accept_404:
+            if not res.status_code == 404 and not accept_404:
                 raise Exception('Got status code ' + str(res.status_code) + ' with body ' + res.content + ' with headers ' + str(res.headers))
         return json.loads(res.text) if res.text else res.ok
 


### PR DESCRIPTION
Some responses for specific api calls return 404 status when no data is found, added ability to treat those as "no data found" message to user instead of throwing exception.