### PR TITLE
remove old Cb Response testing (this version of cb response was depre…

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -481,13 +481,6 @@
             "playbookID": "test-ThreatConnect"
         },
         {
-            "integrations": {
-                "name": "carbonblack",
-                "byoi": false
-            },
-            "playbookID": "block_endpoint_-_carbon_black_response_-_test"
-        },
-        {
             "integrations": "VxStream",
             "playbookID": "VxStream Test",
             "nightly": true


### PR DESCRIPTION
- removing tests for the deprecated version of Cb response
- Cb response current version is tested (carbonblack-v2)