### PR TITLE
Cybereason integration test fix

### DIFF
--- a/TestPlaybooks/playbook-Cybereason_Test.yml
+++ b/TestPlaybooks/playbook-Cybereason_Test.yml
@@ -217,7 +217,7 @@ tasks:
     scriptarguments:
       expectedValue: {}
       fields:
-        simple: Name,CreationTime,EndTime,Parent,OwnerMachine,User
+        simple: Name,CreationTime,EndTime,OwnerMachine,User
       path:
         simple: Process
     separatecontext: false


### PR DESCRIPTION
Cause of changes in our instance DB, I've removed `Parent` field from verify context which is not populated for all processes