### PR TITLE
Fix EPOFindSystem bug

### DIFF
--- a/Scripts/script-EPOFindSystem.yml
+++ b/Scripts/script-EPOFindSystem.yml
@@ -60,6 +60,7 @@ script: |2
 
 
   resp = demisto.executeCommand("epo-command", {"command":"system.find", "searchText": demisto.args()["searchText"]})
+  res_error=[]
   for res in resp:
       if isError(res):
           res_error.append(res)


### PR DESCRIPTION
Declare res_error variable to prevent script from breaking inside isError conditional block.