### PR TITLE
deprecate CB Live Response older version commands

### DIFF
--- a/Integrations/integration-Carbon_Black_Enterprise_Live_Response.yml
+++ b/Integrations/integration-Carbon_Black_Enterprise_Live_Response.yml
@@ -1682,6 +1682,7 @@ script:
     description: Archive the given session (If the session has no content it will
       fail)
   - name: cb-command-cancel
+    deprecated: true
     arguments:
     - name: session
       required: true
@@ -1740,7 +1741,7 @@ script:
     - contextPath: CbLiveResponse.Files.Size
       description: The File size
     - contextPath: CbLiveResponse.Files.CbFileID
-      description: ID of the file within the Cb Session Storage - use with cb-file-get
+      description: ID of the file within the Cb Session Storage.
     - contextPath: CbLiveResponse.Files.Status
       description: File status (0 if no error, another number otherwise)
     - contextPath: CbLiveResponse.Files.Delete
@@ -2125,6 +2126,7 @@ script:
       description: Boolean flag indicating if memory dump is in progress.
     description: Endpoint memory dump.
   - name: cb-command-create
+    deprecated: true
     arguments:
     - name: name
       required: true
@@ -2201,6 +2203,7 @@ script:
       description: Result code
     description: Create a live response command
   - name: cb-command-create-and-wait
+    deprecated: true
     arguments:
     - name: name
       required: true


### PR DESCRIPTION
The following will be deprecated:

- cb-command-create
- cb-command-create-and-wait

This is a 'generic command' to execute specific commands on the endpoind. We added explicit commands in the last integration update.
e.g.  _cb-command-create name="directory-list" session=[sessionID] object=[path]_ is now available as _cb-directory-listing path=[path] sensor=[sensorID]_

- cb-command-cancel

To cancel a 'pending' command. Not usable if 'cb-command-create' is not available.