### PR TITLE
Fix separator line in tableToMarkdown function

### DIFF
--- a/Scripts/script-CommonServer.yml
+++ b/Scripts/script-CommonServer.yml
@@ -273,7 +273,7 @@ script: |-
           }
           var sep = [];
           headers.forEach(function(h){
-              sep.push('-');
+              sep.push('---');
           });
           if (sep.length === 1) {
               sep[0] = sep[0]+'|';
@@ -1958,3 +1958,4 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
+releaseNotes: 'Fix separator line of MD tables'


### PR DESCRIPTION
Putting `---` for separator line as the standard requires