### PR TITLE
rate limit integration for use with automation scripts

### DIFF
--- a/Integrations/integration-DemistoRateLimit.yml
+++ b/Integrations/integration-DemistoRateLimit.yml
@@ -1,0 +1,116 @@
+commonfields:
+  id: demisto rate limit
+  version: -1
+name: Demisto Rate Limit
+display: Demisto Rate Limit
+category: Authentication
+image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAF8ElEQVRo3tVaa2wUVRQ+lUeolLZQHwQxEUIi/GgpakvTst2d7fax7RaEUFOIRW2x7e7cme220BawNSQ1MQZFgYaH8gvlFVAxUYIIJPxRA7FSLCpBJMYnL5FEyh8cvzttodvd6e527izpJCezO3Pn3Pvde853zzkzRKKPAmUOScp+Kg/MoVF7FCiZJLHz5JA1nL8jlzxzxLoklgw908iBc5xBZKPTSzqIAcmvPU3Ltk+NSc/S5vGUz9YASBd0XIXOb2jpKm+cQDAnOvw9CAQXm1ej0ubj9PW5yVHpaXplLJU3bKN83xA9+F+gtJAnkGAdCIm50dm1EBADYgeYrJrDlF0d2UTscj7ZfXcMdN2kJW2PWwPCIZdC/jYEESwHATopwsquHVZHgb9IPAinvhI3owTRJ5L8ITm8xisjye8N+7xLtQk2JyUHPnElJhB3CcB7hCpff9TATI8bPmfzXUCfqeJAuPyzoPinEYEYkMKGr8jtnztkhbmZ3gr1MYiTXaPFgWKRFDuenMpBUyD0wemsBGqVt2EVWmgRmMoh3wjTthdAdlGpP120cz8EO/7FNJBQswm95mR7qKTBoujAqUzADJ4QDiREWDe5lInWbn5FgWysyiEAOmNgDuZFkt+N107+AGw3hUrU6VSsLsTvo4LBHMFEJVDcD7syBh1vEQikFz5SRPflkNRU2PY5cebF/oBPLjM/sMWBVEShKpRuJxeLjsMdyibx/sL2UUXHCNmrtiUZ9n/0bhSaW3uL1A2RuVxiqy1ismvQvR7ycKxx1GuUP0hRdo1GLVvfjsK8NlpMzRdhbowKlSmRQVSumg/kt4csr0Y5dZepyvuEMXh/Ctr1kA1t56vDC28jmaLnbkQZ9VSoJhqxzzh08rmhguyXPqI9xxINzOotPsDkhbXavMZlWmZgeVjh93gbHYx5//kWYFZQkfLg0P2hAg3+M3xwQb1GFe0nacVaDz3XOB3m9xiU5UP64i/M9rzG5dq+6xnanqsZ2u4rc4OEX+P3eBt9ZYQRgnf/4IAwERe7IsyARnl1PBTX9IRKYteD7mNwfNb5gD+4nKG9/9fcIOHX+D3eRggQbp42Pp616wYBUVeaVtwPhM8+H/iuPzODhF/j94QB4RNaFviR1h1K6wPxYkcyZvqHUQckC2y6utN3bzWatzDKqtZGHZDcuh56oWNSH4h3dqRRSdP5frsfXUAkVn1vNTxyO+V5zfG6GGe/ohMIn1BOKFJEej5NBfKEwfHRAWE0OBL6ldh+0H4ussRpOqVXrfFQRdtJneqN+7qD+G9J8N7hbkzEalRBusynrDFuiE7lzbCbK990s6s/Ns732WGkweMMQgxs95JSB0BnzPF61CHKWVC+cY1rZWAG5fmuhs1Vlq96JprsbzLyZRmoL1gaADrZGxHHsiSwKagwwUtDLmV9rBEwKiasvb9sY0FezgIRx/BsUybCoN5Bz32G2CppZLlJTfNssrO94sEoG6MrCLIytN8KS/EB/CQBNS1WCflNIJgeOHvKfcrLlULd2YT5ibwZ5zHxB+JAicbBjgg1MV5KcjcuIk/TdFBrKnwzTsCcyk6LmIynBd04f0Lu1qctNi05CZ2dtbxkKiknyNmQaA0Il5qOTkLDmZyXrQDzMyRNLACPmgmlu+Ebt0MTG991Yhs6sUM34n6nvufYTfsMJ4G9VMjGigNR0+LRbTf84P4lW31wWdOtZlCx8qUpMPw9fZEyUxyI1rYpCA8uGQ5Kkr8I+5y39RFa4Ds8QiCXwVpZYk2q1C9FeIexw/BZm5yMmY01PbgBJ7egcF3oLxnWjl1Kc4Ty6USAPRBDSbTYGpZqacMGJf8TvnqBxEaS8yLqyKpJhnyqfzRgHPrzzzQsfIWweE0CuHw12euHMpVG5f7N+Nwiuh2Yf77hbj6mf84Rap6/YoO1x2cnL3m1Dp2e0h1RwtkuB5CSxhZGPL9zKj4UONX/NncAxEWS/E/FOcaSJ+mfHDlNhNFlrTP0l5x9weL38LF0GrWHq2m2/uLGpT4pWvX/zRDqQjZWrVoAAAAASUVORK5CYII=
+description: 'Rate limit api calls using integration context; NOTE: do NOT use a proxy
+  engine, set using and using-brand via cli and playbook calls'
+configuration: []
+script:
+  script: |
+    var createContext = function(name,rate_limit){
+        var integrationContext ;
+        if (getIntegrationContext()==='undefined'){
+            integrationContext={};
+        }
+        else{
+            integrationContext=getIntegrationContext();
+        }
+
+        integrationContext[name]={};
+        integrationContext[name].rate_limit=parseInt(rate_limit);
+        integrationContext[name].last = (new Date()).getTime();
+        setIntegrationContext(integrationContext);
+        var sc=integrationContext;
+        var md = "#NOTICE\n"
+        md+="be sure to close integration settings,set using,set using-brand,do not use a proxy engine or changes do not save.\n"
+        md += tableToMarkdown("info:",sc);
+        var resDis = [];
+        resDis.push({'ContentsFormat': formats.json, 'Type': entryTypes.note, 'Contents': sc, 'HumanReadable': md});
+        return resDis;
+    };
+
+    var contextWait = function(name,time_override){
+         //if not set then set seconds initially for integration
+        var integrationContext ;
+        if (getIntegrationContext()==='undefined'){
+            integrationContext={};
+        }
+        else{
+            integrationContext=getIntegrationContext();
+        }
+        if (typeof integrationContext[name]==='undefined'){
+            throw "First create context using rate-limit-create; do not use a proxy engine";
+        }
+        var rate_limit = time_override || integrationContext[name].rate_limit;
+        rate_limit = parseInt(rate_limit)
+
+
+        //current epoch
+        var cur_epoch;
+        cur_epoch = (new Date()).getTime();
+        var time_diff;
+        time_diff = (cur_epoch - integrationContext[name].last)/1000;
+        var totalwait = 0;
+        while( time_diff < rate_limit){
+            var waittime = rate_limit - time_diff
+            waittime = Math.ceil(waittime)
+            totalwait +=waittime;
+            wait(waittime); //wait the difference between the current rate limit and the time difference since last call
+            cur_epoch = (new Date()).getTime();
+            // get context again in the case of async runs
+            integrationContext = getIntegrationContext();
+            time_diff= (cur_epoch - integrationContext[name].last)/1000;
+        }
+        //set integration context
+        integrationContext[name].last=(new Date()).getTime();
+        setIntegrationContext(integrationContext);
+
+        var ec = {};
+        ec.rate_limitchange ={};
+        ec.rate_limitchange.name = name;
+        ec.rate_limitchange.totalwait = totalwait;
+        ec.rate_limitchange.last = integrationContext[name].last;
+        md = tableToMarkdown("info:", ec);
+        var resDis = [];
+        resDis.push({'ContentsFormat': formats.json, 'Type': entryTypes.note, 'Contents': integrationContext, 'HumanReadable': md, 'EntryContext': ec});
+        return resDis;
+
+    };
+
+    // The command input arg holds the command sent from the user.
+    switch (command) {
+        // This is the call made when pressing the integration test button.
+        case 'test-module':
+            var integrationContext = getIntegrationContext();
+            return 'ok';
+        case 'rate-limit-create':
+            if (!args.seconds || !args.name){
+                throw "missing argument value"
+            }
+            return createContext(args.name,args.seconds);
+        case 'rate-limit':
+            return contextWait(args.name,args.time_override);
+
+        default:
+            throw 'Unknown command - ' + command;
+    }
+  type: javascript
+  commands:
+  - name: rate-limit-create
+    arguments:
+    - name: name
+      required: true
+    - name: seconds
+      required: true
+      description: number of seconds to rate limit
+    description: create a rate limit instance
+  - name: rate-limit
+    arguments:
+    - name: name
+      required: true
+    - name: time_override
+    description: rate limit  before a call
+  runonce: false


### PR DESCRIPTION
## Status
- [ ] Ready
- [ ] In code review
- [ ] In Progress
- [ ] Hold
      Reason for hold:

## Description
This allows rate limiting inside an automation script.  It is handy for rate-limiting urlscan.io , qaradar, ews, etc.  I have been using this for a few months now.

## Required version of Demisto
3.6.2

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)

