### PR TITLE
Added commands without "internal-" prefix

### DIFF
--- a/Integrations/integration-MISP.yml
+++ b/Integrations/integration-MISP.yml
@@ -515,12 +515,16 @@ script:
             doIP('1.3.4.5');
             return 'ok';
         case 'internal-misp-upload-sample':
+        case 'misp-upload-sample:
             return doUploadSample(command);
         case 'internal-misp-download-sample':
+        case 'misp-download-sample':
             return doGeneralPost(command, args);
         case 'internal-misp-create-event':
+        case 'misp-create-event':
             return createEvent(command);
         case 'internal-misp-add-attribute':
+        case 'misp-add-attribute':
             return addAtribute(command)
         case 'misp-search':
             return translateEvents(doGeneralPost(command, args), commands[command].contextKey, commands[command].title);
@@ -807,3 +811,4 @@ script:
       required: true
       description: Value of the attribute
     description: Add attribute to existing MISP event
+releaseNotes: "Added commands without 'internal-' prefix"

--- a/Integrations/integration-MISP.yml
+++ b/Integrations/integration-MISP.yml
@@ -516,15 +516,19 @@ script:
             return 'ok';
         case 'internal-misp-upload-sample':
         case 'misp-upload-sample':
+            command = 'internal-misp-upload-sample';
             return doUploadSample(command);
         case 'internal-misp-download-sample':
         case 'misp-download-sample':
+            command = 'internal-misp-download-sample';
             return doGeneralPost(command, args);
         case 'internal-misp-create-event':
         case 'misp-create-event':
+            command = 'internal-misp-create-event';
             return createEvent(command);
         case 'internal-misp-add-attribute':
         case 'misp-add-attribute':
+            command = 'internal-misp-add-attribute';
             return addAtribute(command)
         case 'misp-search':
             return translateEvents(doGeneralPost(command, args), commands[command].contextKey, commands[command].title);

--- a/Integrations/integration-MISP.yml
+++ b/Integrations/integration-MISP.yml
@@ -515,7 +515,7 @@ script:
             doIP('1.3.4.5');
             return 'ok';
         case 'internal-misp-upload-sample':
-        case 'misp-upload-sample:
+        case 'misp-upload-sample':
             return doUploadSample(command);
         case 'internal-misp-download-sample':
         case 'misp-download-sample':
@@ -539,7 +539,7 @@ script:
 
   type: javascript
   commands:
-  - name: internal-misp-upload-sample
+  - name: misp-upload-sample
     arguments:
     - name: filename
       required: true
@@ -728,7 +728,7 @@ script:
     - contextPath: DBotScore.Score
       description: The actual score
     description: Check IP Reputation
-  - name: internal-misp-download-sample
+  - name: misp-download-sample
     arguments:
     - name: hash
       required: true
@@ -744,7 +744,7 @@ script:
       description: If set, it will return all samples from events that have a match
         for the hash provided above.
     description: Download malware sample by hash
-  - name: internal-misp-create-event
+  - name: misp-create-event
     arguments:
     - name: type
       description: Type of the event
@@ -784,7 +784,7 @@ script:
     - contextPath: MISP.ID
       description: MISP event ID
     description: Create new MISP event
-  - name: internal-misp-add-attribute
+  - name: misp-add-attribute
     arguments:
     - name: id
       required: true

--- a/Integrations/integration-MISP.yml
+++ b/Integrations/integration-MISP.yml
@@ -812,3 +812,5 @@ script:
       description: Value of the attribute
     description: Add attribute to existing MISP event
 releaseNotes: "Added commands without 'internal-' prefix"
+tests:
+  - Forgive me for my sins but I did not create any test


### PR DESCRIPTION
in addition to: https://github.com/demisto/etc/issues/14118#issuecomment-440638222
commands should be "misp-command" and not "internal-misp-command". It now supports those two conventions for backward compatibility 