### PR TITLE
SetByIncidentId (#2468)

### DIFF
--- a/Scripts/script-SetByIncidentId.yml
+++ b/Scripts/script-SetByIncidentId.yml
@@ -1,0 +1,45 @@
+commonfields:
+  id: 46e2109c-b735-458e-884f-030229a20830
+  version: 209
+name: SetByIncidentId
+script: |-
+  incident_id = demisto.args()['id'] if 'id' in demisto.args() else demisto.incidents()[0]['id']
+  key = demisto.args()['key']
+  value = demisto.args()['value']
+  append = demisto.args()['append']
+
+  args = {'key': key, 'value': value, 'append': append}
+
+  res = demisto.executeCommand('executeCommandAt',
+                              {'incidents': incident_id,
+                               'command':'Set',
+                               'arguments': args})
+
+  demisto.results(res)
+type: python
+tags:
+- DemistoAPI
+comment: Works the same as the 'Set' command, but can work across incidents by specifying
+  'id' as an argument. Sets a value into the context with the given context key. Doesn't
+  append by default.
+enabled: true
+args:
+- name: id
+  default: true
+  description: Incident to set context values in (Default is current incident)
+- name: key
+  required: true
+  description: The key to set
+- name: value
+  required: true
+  description: The value to set to the key. Can be an array. Usually, a dq expression.
+- name: append
+  auto: PREDEFINED
+  predefined:
+  - "true"
+  - "false"
+  description: If false then the context key will be overwritten. If set to true then
+    the script will append to existing context key
+  defaultValue: "false"
+scripttarget: 0
+runonce: false

--- a/Scripts/script-SetByIncidentId.yml
+++ b/Scripts/script-SetByIncidentId.yml
@@ -43,3 +43,5 @@ args:
   defaultValue: "false"
 scripttarget: 0
 runonce: false
+tests:
+- Forgive me for my sins but I did not create any test


### PR DESCRIPTION
* New Automation for 'Set' in other incidents

I created this automation, which is able to call the 'Set' command on incidents from anywhere, by allowing the user to specify Incident ID. I think this is a valuable script to have. I know I definitely needed it.

* Updated SetByIncidentId

+ Added output identical to that of 'Set' command
+ Added a second output that verifies the command was successful.

* Rename SetByIncidentId.yml to script-SetByIncidentId.yml

+ Renamed to follow naming convention

* Simplified Results in SetByIncidentId

Additions had been made to SetByIncidentId, which used another Demisto API call and some additional logic to verify whether the context key had indeed been set. This has been instead changed to use the return value from 'executeCommandAt', which already verifies whether the command has been ran successfully.

* Update script-SetByIncidentId.yml

Removed import of the time module, as this script is no longer waiting on additional API calls.

