### PR TITLE
QRadar entry context key comparison fix

### DIFF
--- a/Integrations/integration-QRadar.yml
+++ b/Integrations/integration-QRadar.yml
@@ -292,7 +292,6 @@ script:
     # Returns the result of a single offense request
     def get_offense_by_id(offense_id, _filter='', _fields=''):
         full_url = '{0}/api/siem/offenses/{1}'.format(SERVER, offense_id)
-        demisto.info(full_url)
         params = {"filter": _filter} if _filter else {}
         headers = dict(AUTH_HEADERS)
         if _fields:
@@ -605,14 +604,14 @@ script:
         search_id = demisto.args().get('search_id')
         raw_search = get_search(search_id)
         raw_search = filter_dict_nonintersection_key_to_value(replace_keys(raw_search, SEARCH_ID_NAMES_MAP), SEARCH_ID_NAMES_MAP)
-        return get_entry_for_object('QRadar Search Info', raw_search, demisto.args().get('headers'), 'QRadar.Search(val.ID === {0})'.format(search_id))
+        return get_entry_for_object('QRadar Search Info', raw_search, demisto.args().get('headers'), 'QRadar.Search(val.ID === "{0}")'.format(search_id))
 
     def get_search_results_command():
         search_id = demisto.args().get('search_id')
         raw_search_results = get_search_results(search_id, demisto.args().get('range'))
         result_key = raw_search_results.keys()[0]
         title = 'QRadar Search Results from ' + result_key
-        return get_entry_for_object(title, unicode_to_str_recur(raw_search_results[result_key]), demisto.args().get('headers'), 'QRadar.Search(val.ID === {0}).Result.{1}'.format(search_id, result_key))
+        return get_entry_for_object(title, unicode_to_str_recur(raw_search_results[result_key]), demisto.args().get('headers'), 'QRadar.Search(val.ID === "{0}").Result.{1}'.format(search_id, result_key))
 
     def get_assets_command():
         raw_assets = get_assets(demisto.args().get('range'), demisto.args().get('filter'), demisto.args().get('fields'))
@@ -652,7 +651,7 @@ script:
         human_readable_trans_assets = {}
         endpoint_dict = create_empty_endpoint_dict(full_values)
         for asset in assets:
-            asset_key = 'QRadar.Asset(val.ID === {0})'.format(asset['id'])
+            asset_key = 'QRadar.Asset(val.ID === "{0}")'.format(asset['id'])
             human_readable_key = 'Asset(ID:{0})'.format(asset['id'])
             populated_asset = create_single_asset_result_and_enrich_endpoint_dict(asset, endpoint_dict, full_values)
             trans_assets[asset_key] = populated_asset
@@ -750,7 +749,7 @@ script:
         note = replace_keys(raw_note, note_names_map)
         if 'CreateTime' in note:
           note['CreateTime'] = epoch_to_ISO(note['CreateTime'])
-        return get_entry_for_object('QRadar note created successfuly', note, demisto.args().get('headers'), 'QRadar.Note(val.ID === {0})'.format(demisto.args().get('note_id')))
+        return get_entry_for_object('QRadar note created successfuly', note, demisto.args().get('headers'), 'QRadar.Note(val.ID === "{0}")'.format(demisto.args().get('note_id')))
 
     def create_note_command():
         raw_note = create_note(demisto.args().get('offense_id'), demisto.args().get('note_text'), demisto.args().get('fields'))


### PR DESCRIPTION
## Status
Ready

## Description
In 3 commands the context key used for comparison was passed without wrapping parenthesis. This caused the comparison to not work as intended.
## Does it break backward compatibility?
   - No

## Additional changes
Removed logging line that was originally added for debugging purposes.