### PR TITLE
Updating the exception catching form in PagerDuty integration

### DIFF
--- a/Integrations/integration-PagerDutyV2.yml
+++ b/Integrations/integration-PagerDutyV2.yml
@@ -118,7 +118,7 @@ script:
 
             return res.json()
 
-        except Exception, e:
+        except Exception as e:
             LOG(e)
             raise(e)
 
@@ -132,7 +132,7 @@ script:
     def test_module():
         try:
             get_on_call_now_users_command()
-        except Exception, e:
+        except Exception as e:
             raise Exception(e.message)
 
         demisto.results('ok')
@@ -599,7 +599,7 @@ script:
             demisto.results(get_users_notification_command(**demisto.args()))
 
 
-    except Exception, e:
+    except Exception as e:
         LOG(e.message)
         LOG.print_log()
         raise


### PR DESCRIPTION
This commit changes how exceptions are caught from 'Exception, e'
to 'Exception as e'. Among other things this makes the code Python
3 compatible.

## Status
Ready

## Description
Update PagerDuty integration to catch Exceptions in a Python3 compatible way.

## Does it break backward compatibility?
   - No
