### PR TITLE
remove FE HX test from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -811,7 +811,6 @@
         "Jask_Test": "Need to check the reason for skipping",
         "Qualys-Test": "Need to check the reason for skipping",
         "sep_-_test_endpoint_search": "Failed test, need to fix",
-        "FireEye HX Test": "fireeye-hx-file-acquisition failed on timeout",
         "tenable-sc-scan-test": "Scan takes too long",
         "Microsoft Graph Test": "DB is missing alerts to test on - in work of DevOps"
     },


### PR DESCRIPTION
## Status
In Progress:

## Related Issues
fixes: https://github.com/demisto/etc/issues/14128

## Description
command 'fireeye-hx-file-acquisition' not failing on timeout as described on the issue.
will observe the behavior as the command runs as part of HX test on circleci.