### PR TITLE
Ews fix folder get items

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -1246,7 +1246,7 @@ script:
         limit = int(limit)
         is_public = is_default_folder(folder_path, is_public)
         folder = get_folder_by_path(account, folder_path, is_public)
-        qs = folder.filter().order_by('-datetime_created')
+        qs = folder.filter().order_by('-datetime_created')[:limit]
         items = get_limited_number_of_messages_from_qs(qs, limit)
         items_result = map(lambda item: parse_item_as_dict(item, account.primary_smtp_address, camel_case=True, compact_fields=True), items)
         hm_headers = ['sender', 'subject', 'hasAttachments', 'datetimeReceived',


### PR DESCRIPTION
## Status
Ready/In Progress/In Hold(Reason for hold)

## Description
fixes: fixes folder get items.  Some mailboxes caused and exception if the limit is not set.  Also the documentation for exchangelib reccommends setting this limit on query strings.


branch | PR
------ | ------


## Required version of Demisto
3.6

## Does it break backward compatibility?
   - Yes


## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Additional changes
Describe additional changes done, for example adding a function to common server.
