### PR TITLE
Ews search mailboxes: skip invalid addresses

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -523,7 +523,7 @@ script:
                     if MAILBOX in mailbox and email_address.lower() == mailbox[MAILBOX].lower():
                         mailbox_ids.append(mailbox[MAILBOX_ID])
             if len(mailbox_ids) == 0:
-                return "No searchable mailboxes were found for the provided email addresses."
+                raise Exception("No searchable mailboxes were found for the provided email addresses.")
         elif mailbox_search_scope:
             mailbox_ids = mailbox_search_scope if type(mailbox_search_scope) is list else [mailbox_search_scope]
         else:

--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -520,12 +520,10 @@ script:
             all_mailboxes = get_searchable_mailboxes(protocol)[ENTRY_CONTEXT]['EWS.Mailboxes']
             for email_address in email_addresses:
                 for mailbox in all_mailboxes:
-                    if MAILBOX not in mailbox:
-                        continue
-                    if email_address.lower() == mailbox[MAILBOX].lower():
+                    if MAILBOX in mailbox and email_address.lower() == mailbox[MAILBOX].lower():
                         mailbox_ids.append(mailbox[MAILBOX_ID])
-            if len(mailbox_ids) != len(email_addresses):
-                raise Exception("Did not find one or more of the specified email addresses")
+            if len(mailbox_ids) == 0:
+                return "No searchable mailboxes were found for the provided email addresses."
         elif mailbox_search_scope:
             mailbox_ids = mailbox_search_scope if type(mailbox_search_scope) is list else [mailbox_search_scope]
         else:


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14344

## Description
In the ews-search-mailboxes command email-addresses argument: If an email address is invalid or not searchable, skip it instead of returning and error. If no searchable addresses are in the list, return an error.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review
