### PR TITLE
Threat Grid - Expand contents

### DIFF
--- a/Integrations/integration-Threat_Grid.yml
+++ b/Integrations/integration-Threat_Grid.yml
@@ -328,8 +328,8 @@ script:
                 'Type': entryTypes['note'],
                 'EntryContext': ec,
                 'HumanReadable': '### ThreatGrid Sample Run HTML Report -\n' + 'Your sample run HTML report download request has been completed successfully for ' + sample_id,
-                'Contents': ec,
-                'ContentsFormat': formats['json']
+                'Contents': r.content,
+                'ContentsFormat': formats['html']
             },
             fileResult(sample_id + '-report.html', r.content, file_type=entryTypes['entryInfoFile'])
         ])
@@ -366,7 +366,7 @@ script:
                 'Type': entryTypes['note'],
                 'EntryContext': ec,
                 'HumanReadable': '### ThreatGrid Sample Run Processes File -\n' + 'Your sample run processes file download request has been completed successfully for ' + sample_id,
-                'Contents': ec,
+                'Contents': r.json(),
                 'ContentsFormat': formats['json']
             },
             fileResult(sample_id + '-processes.json', r.content)
@@ -472,7 +472,7 @@ script:
                 'Type': entryTypes['note'],
                 'EntryContext': ec,
                 'HumanReadable': '### ThreatGrid Sample Run Video File -\n' + 'Your sample run video file download request has been completed successfully for ' + sample_id,
-                'Contents': ec,
+                'Contents': r.json(),
                 'ContentsFormat': formats['json']
             },
             fileResult(sample_id + '.webm', r.content)
@@ -619,7 +619,7 @@ script:
                 'Type': entryTypes['note'],
                 'EntryContext': ec,
                 'HumanReadable': hr,
-                'Contents': ec,
+                'Contents': r.json(),
                 'ContentsFormat': formats['json']
             },
             fileResult(sample_id + '-analysis.json', r.content, file_type=entryTypes['entryInfoFile'])
@@ -2259,5 +2259,11 @@ script:
       description: File containing result
     description: Returns data regarding the analysis processes
   runonce: false
+releaseNotes: "Expanded raw-response of the following commands:
+        threat-grid-get-html-report-by-id
+        threat-grid-get-processes-by-id
+        threat-grid-get-video-by-id
+        threat-grid-get-analysis-by-id
+        "
 tests:
   - ThreatGridTest


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14567

## Description
Expanded raw-response of the following commands:        
        threat-grid-get-html-report-by-id
        threat-grid-get-processes-by-id
        threat-grid-get-video-by-id
        threat-grid-get-analysis-by-id

## Does it break backward compatibility?
   - Yes
       - Further details: For customers who used the raw-response path of the above commands since the implementation of the integration.

## Must have
- [X] Tests
- [X] Documentation (with link to it)
- [x] Code Review