### PR TITLE
Skipped mimecast due to too many random errors from their service 

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -864,7 +864,8 @@
         "Service Manager": "Expired license",
         "Signal Sciences WAF": "API problems, not returning the correct data",
         "Server Message Block (SMB)": "No instance",
-        "ServiceNow": "Instance goes to hibernate every few hours"
+        "ServiceNow": "Instance goes to hibernate every few hours",
+        "MimecastV2": "Several issues with instance"
     },
     "nigthly_integrations": [
         "Lastline"


### PR DESCRIPTION
on different endpoints/commands.
Including error 500/error 405 and several others which started only few days ago.