### PR TITLE
Detonate file playbooks upload add filter

### DIFF
--- a/Playbooks/playbook-BitDam_Scan_File.yml
+++ b/Playbooks/playbook-BitDam_Scan_File.yml
@@ -1,11 +1,11 @@
 id: Detonate File - BitDam
 version: 18
 name: Detonate File - BitDam
+fromversion: 4.0.0
 description: |-
   Detonates one or more files using BitDam integration.
   Returns verdict to the War Room and file reputations to the context data.
   Supported file types are mainly PDF & microsoft office software/
-fromversion: 4.0.0
 starttaskid: "0"
 tasks:
   "0":
@@ -13,10 +13,10 @@ tasks:
     taskid: cf22dcbc-af9c-42fa-8963-205d412e6965
     type: start
     task:
-      description: ""
       id: cf22dcbc-af9c-42fa-8963-205d412e6965
       version: -1
       name: ""
+      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -31,36 +31,7 @@ tasks:
         }
       }
     note: false
-  "1":
-    id: "1"
-    taskid: 4c2c547d-ad8a-4e52-8bab-63760b7677cc
-    type: regular
-    task:
-      description: ""
-      id: 4c2c547d-ad8a-4e52-8bab-63760b7677cc
-      version: -1
-      name: BitDam Upload File
-      script: '|||bitdam-upload-file'
-      type: regular
-      iscommand: true
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "2"
-    scriptarguments:
-      entryId:
-        complex:
-          root: inputs.File
-          accessor: EntryID
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 272.5,
-          "y": 905
-        }
-      }
-    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: 19ace356-7eb1-491e-8b42-9d755950312c
@@ -109,20 +80,21 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 272.5,
-          "y": 1080
+          "x": 387.5,
+          "y": 1070
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: aa6d7b50-e89e-4046-8245-91d4e430544d
     type: title
     task:
-      description: ""
       id: aa6d7b50-e89e-4046-8245-91d4e430544d
       version: -1
       name: Done
+      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -135,6 +107,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "6":
     id: "6"
     taskid: 840243b7-07df-471e-8cab-7dc8080ce28c
@@ -171,6 +144,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 03079660-b680-41d1-847d-4d667e3bc404
@@ -224,6 +198,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "8":
     id: "8"
     taskid: 2610cf49-d119-4065-861c-c7b3a5ffd0c8
@@ -248,11 +223,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 272.5,
-          "y": 1255
+          "x": 387.5,
+          "y": 1245
         }
       }
     note: false
+    timertriggers: []
   "9":
     id: "9"
     taskid: 5f4539b9-bf85-42e5-8892-f12714a02869
@@ -261,11 +237,11 @@ tasks:
       id: 5f4539b9-bf85-42e5-8892-f12714a02869
       version: -1
       name: Set file to context
+      description: ""
       scriptName: Set
       type: regular
       iscommand: false
       brand: ""
-      description: ""
     nexttasks:
       '#none#':
       - "10"
@@ -285,6 +261,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "10":
     id: "10"
     taskid: 699619cb-33c2-4b32-88ef-ba0844c2cddf
@@ -293,15 +270,15 @@ tasks:
       id: 699619cb-33c2-4b32-88ef-ba0844c2cddf
       version: -1
       name: Is File type supported?
+      description: ""
       type: condition
       iscommand: false
       brand: ""
-      description: ""
     nexttasks:
       '#default#':
       - "5"
       "yes":
-      - "1"
+      - "12"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -344,18 +321,80 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 272.5,
+          "x": 275,
           "y": 720
         }
       }
     note: false
+    timertriggers: []
+  "12":
+    id: "12"
+    taskid: 5e010413-b8e7-4562-8fc6-cddc2168851f
+    type: regular
+    task:
+      id: 5e010413-b8e7-4562-8fc6-cddc2168851f
+      version: -1
+      name: BItDam Upload File
+      description: Upload a file sample to BitDam's service
+      script: '|||bitdam-upload-file'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      entryId:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:PDF|DOT|DOCX|DOCM|DOTX|DOTM|RTF|XLS|XLT|XLSX|XLSM|XLTX|XLTM|XLSB|XLAM|CSV|PPT|PPTX|PPTM|POTX|POTM|PPAM|PPSX|PPSM|PPS)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:PDF|DOT|DOCX|DOCM|DOTX|DOTM|RTF|XLS|XLT|XLSX|XLSM|XLTX|XLTM|XLSB|XLAM|CSV|PPT|PPTX|PPTM|POTX|POTM|PPAM|PPSX|PPSM|PPS)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:PDF|DOT|DOCX|DOCM|DOTX|DOTM|RTF|XLS|XLT|XLSX|XLSM|XLTX|XLTM|XLSB|XLAM|CSV|PPT|PPTX|PPTM|POTX|POTM|PPAM|PPSX|PPSM|PPS)\b
+              ignorecase: true
+          accessor: EntryID
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 387.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
-    "linkLabelsPosition": {},
+    "linkLabelsPosition": {
+      "10_12_yes": 0.89
+    },
     "paper": {
       "dimensions": {
         "height": 1435,
-        "width": 605,
+        "width": 717.5,
         "x": 50,
         "y": 50
       }
@@ -400,3 +439,6 @@ outputs:
 - contextPath: DBotScore.Score
   description: The actual score
   type: number
+releaseNotes: "Submit only supported files to BitDam"
+tests:
+- Detonate File - BitDam Test

--- a/Playbooks/playbook-Detonate_File_-_Lastline.yml
+++ b/Playbooks/playbook-Detonate_File_-_Lastline.yml
@@ -26,47 +26,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 60,
           "y": 50
         }
       }
     note: false
-  "1":
-    id: "1"
-    taskid: b22f116d-2041-4a0e-832d-3ff0e9dfbff5
-    type: regular
-    task:
-      id: b22f116d-2041-4a0e-832d-3ff0e9dfbff5
-      version: -1
-      name: Lastline Upload File
-      description: Uploads the submission to Lastline.
-      script: Lastline|||lastline-upload-file
-      type: regular
-      iscommand: true
-      brand: Lastline
-    nexttasks:
-      '#none#':
-      - "13"
-    scriptarguments:
-      EntryID:
-        complex:
-          root: inputs.File
-          accessor: EntryID
-      entryID:
-        complex:
-          root: inputs.File
-          accessor: EntryID
-      pushToPortal: {}
-      threshold: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 500,
-          "y": 895
-        }
-      }
-    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: 3a6ac4c3-7fc4-4af3-87e7-ae5c78160d11
@@ -115,11 +80,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 387.5,
+          "x": 510,
           "y": 1245
         }
       }
     note: false
+    timertriggers: []
   "3":
     id: "3"
     taskid: d372022a-88a0-4312-8ee7-6f0ebe64533e
@@ -146,11 +112,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 500,
+          "x": 397.5,
           "y": 1420
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: 6185e7bf-d4ea-428f-84f3-8f69c900e8e8
@@ -172,6 +139,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 5c234487-81fd-4b4f-8ae1-0b8fd37b942c
@@ -221,11 +189,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 60,
           "y": 195
         }
       }
     note: false
+    timertriggers: []
   "10":
     id: "10"
     taskid: fea8caab-2280-4b3a-81ca-0477bc5d1854
@@ -242,7 +211,7 @@ tasks:
       '#default#':
       - "5"
       "yes":
-      - "1"
+      - "15"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -286,11 +255,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 387.5,
+          "x": 285,
           "y": 720
         }
       }
     note: false
+    timertriggers: []
   "11":
     id: "11"
     taskid: 880a4474-6ff0-4426-83c3-38bbf36f090e
@@ -318,11 +288,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 387.5,
+          "x": 285,
           "y": 545
         }
       }
     note: false
+    timertriggers: []
   "12":
     id: "12"
     taskid: 823f4f10-b0d8-4c6b-8bc0-b7ec01897534
@@ -352,11 +323,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 172.5,
           "y": 370
         }
       }
     note: false
+    timertriggers: []
   "13":
     id: "13"
     taskid: cec4ac98-aed7-4400-824b-2244a72dcc1a
@@ -397,18 +369,79 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 500,
+          "x": 397.5,
           "y": 1070
         }
       }
     note: false
+    timertriggers: []
+  "15":
+    id: "15"
+    taskid: 224d3a13-cd7a-405a-8241-4624625ab3d1
+    type: regular
+    task:
+      id: 224d3a13-cd7a-405a-8241-4624625ab3d1
+      version: -1
+      name: Lastline Upload File
+      description: Upload file for analysis
+      script: '|||lastline-upload-file'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "13"
+    scriptarguments:
+      EntryID:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+          accessor: EntryID
+      threshold: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 397.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
         "height": 1610,
-        "width": 830,
+        "width": 840,
         "x": 50,
         "y": 50
       }
@@ -535,5 +568,6 @@ outputs:
 - contextPath: Lastline.Submission.YaraSignatures.internal
   description: True if the signature is only for internal usage
   type: boolean
+releaseNotes: "Submit only supported files to Lastline"
 tests:
 - Lastline - testplaybook

--- a/Playbooks/playbook-Detonate_File_-_McAfee_ATD.yml
+++ b/Playbooks/playbook-Detonate_File_-_McAfee_ATD.yml
@@ -31,7 +31,7 @@ tasks:
       id: 489b704c-bef9-40e7-8aa8-f74cca308a94
       version: -1
       name: ""
-      description: "-"
+      description: '-'
       iscommand: false
       brand: ""
     nexttasks:
@@ -43,48 +43,6 @@ tasks:
         "position": {
           "x": 50,
           "y": 50
-        }
-      }
-    note: false
-    timertriggers: []
-  "1":
-    id: "1"
-    taskid: d146afc4-bfe2-492e-87a3-0f66f3af74d7
-    type: regular
-    task:
-      id: d146afc4-bfe2-492e-87a3-0f66f3af74d7
-      version: -1
-      name: McafeeATD Upload File
-      description: Uploads the submission to McAfee ATD.
-      script: '|||atd-file-upload'
-      type: regular
-      iscommand: true
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "8"
-    scriptarguments:
-      analyzeAgain: {}
-      dstIp: {}
-      entryID:
-        complex:
-          root: inputs.File.EntryID
-      fileName: {}
-      filePriorityQ: {}
-      messageId: {}
-      skipTaskId: {}
-      srcIp: {}
-      submitType:
-        simple: "0"
-      url: {}
-      vmProfileList: {}
-      xMode: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 387.5,
-          "y": 895
         }
       }
     note: false
@@ -144,12 +102,12 @@ tasks:
     timertriggers: []
   "3":
     id: "3"
-    taskid: 6c564961-e548-4542-8056-6b98cc14286d
+    taskid: b0cb6625-0e6c-44ae-835c-684b21d0a6c1
     type: regular
     task:
-      id: 6c564961-e548-4542-8056-6b98cc14286d
+      id: b0cb6625-0e6c-44ae-835c-684b21d0a6c1
       version: -1
-      name: McAfeeATD Get Report
+      name: McAfee ATD Get Report
       description: Retrieve the reports from McAfee ATD.
       script: '|||atd-get-report'
       type: regular
@@ -350,7 +308,7 @@ tasks:
       '#default#':
       - "5"
       "yes":
-      - "1"
+      - "14"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -502,6 +460,78 @@ tasks:
       }
     note: false
     timertriggers: []
+  "14":
+    id: "14"
+    taskid: 6e299488-408a-4b9d-82d0-cb053caf322e
+    type: regular
+    task:
+      id: 6e299488-408a-4b9d-82d0-cb053caf322e
+      version: -1
+      name: Mcafee ATD Upload File
+      description: upload a file/web URL for dynamic analysis by using the provided
+        Analyzer Profile. Only single file/web URL can be submitted at a time.
+      script: '|||atd-file-upload'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      analyzeAgain: {}
+      dstIp: {}
+      entryID:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|SYS|DLL|COM|SCR|CPL|OCX|CGI|DOC|DOTM|DOCX|DOTX|XLS|PPAM|XSLX|PPS|XLSB|PPSX|XLSM|PPSM|PPT|PPTX|PPTM|RTF|SHS|XLTM|SLDM|XLTX|SLDX|XLAM|THMX|DOCM|XAR|JTD|JTDC|PDF|SWF|GZ|7Z|TGZ|MSI|ZIP|LZH|CAB|LZMA|APK|JAR|CLASS|JPEG|PNG|GIF|CMD|ACE|BAT|ARJ|VBS|CHM|XML|LNK|URL|MOF|HTM|OCX|HTML|POTM|EML|POTX|MSG|PS1|VB|REG|VBA|WSC|VBE|WSF|VBS|WSH)\b
+              ignorecase: true
+          accessor: EntryID
+      fileName: {}
+      filePriorityQ: {}
+      messageId: {}
+      skipTaskId: {}
+      srcIp: {}
+      submitType:
+        simple: "0"
+      url: {}
+      vmProfileList: {}
+      xMode: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 387.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
@@ -616,6 +646,7 @@ outputs:
 - contextPath: InfoFile.Type
   description: The type of the report file
   type: string
+releaseNotes: "Submit only supported files to McAfee ATD"
 tests:
 - Test Playbook McAfee ATD
 - Detonate File - Generic Test

--- a/Playbooks/playbook-Detonate_File_-_SNDBOX.yml
+++ b/Playbooks/playbook-Detonate_File_-_SNDBOX.yml
@@ -38,37 +38,7 @@ tasks:
         }
       }
     note: false
-  "1":
-    id: "1"
-    taskid: f19dcf74-9e66-4389-8f37-bf17bca542fd
-    type: regular
-    task:
-      id: f19dcf74-9e66-4389-8f37-bf17bca542fd
-      version: -1
-      name: SNDBOX Upload File
-      description: Uploads the submission to McAfee ATD.
-      script: SNDBOX|||sndbox-analysis-submit-sample
-      type: regular
-      iscommand: true
-      brand: SNDBOX
-    nexttasks:
-      '#none#':
-      - "2"
-    scriptarguments:
-      file_id:
-        complex:
-          root: inputs.File
-          accessor: EntryID
-      should_wait: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 387.5,
-          "y": 895
-        }
-      }
-    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: cf1337d2-c99c-450b-8901-49614b2d9c39
@@ -122,19 +92,20 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "3":
     id: "3"
-    taskid: ea41c6c0-0f07-4a68-8d33-1d55bedb8f6b
+    taskid: ff8f8315-a4a4-4fe8-8008-c8ed819d3787
     type: regular
     task:
-      id: ea41c6c0-0f07-4a68-8d33-1d55bedb8f6b
+      id: ff8f8315-a4a4-4fe8-8008-c8ed819d3787
       version: -1
       name: SNDBOX Get Report
       description: Retrieve the reports from McAfee ATD.
-      script: SNDBOX|||sndbox-download-report
+      script: '|||sndbox-download-report'
       type: regular
       iscommand: true
-      brand: SNDBOX
+      brand: ""
     nexttasks:
       '#none#':
       - "5"
@@ -163,11 +134,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 500,
           "y": 1770
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: e589b774-3cee-4dff-8e14-788ef3590dfa
@@ -184,11 +156,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
+          "x": 70,
           "y": 1945
         }
       }
     note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 638f2725-3b53-453a-8c6d-6924686d24fa
@@ -243,19 +216,20 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "9":
     id: "9"
-    taskid: f85c1378-7d87-43ee-8e31-f2789b7b9bcb
+    taskid: 105ec989-1fbe-4631-8eb8-4a1e10c68c85
     type: regular
     task:
-      id: f85c1378-7d87-43ee-8e31-f2789b7b9bcb
+      id: 105ec989-1fbe-4631-8eb8-4a1e10c68c85
       version: -1
       name: SNDBOX Get Info
       description: Updates the status of the tasks in the context.
-      script: SNDBOX|||sndbox-analysis-info
+      script: '|||sndbox-analysis-info'
       type: regular
       iscommand: true
-      brand: SNDBOX
+      brand: ""
     nexttasks:
       '#none#':
       - "13"
@@ -273,6 +247,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "10":
     id: "10"
     taskid: ecc6003d-d40d-48d4-85fc-b7ffa076196d
@@ -289,7 +264,7 @@ tasks:
       '#default#':
       - "5"
       "yes":
-      - "1"
+      - "15"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -338,6 +313,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "11":
     id: "11"
     taskid: 3814f559-a639-4e80-8d6e-c74b9e96e495
@@ -370,6 +346,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "12":
     id: "12"
     taskid: 9b8022fc-dfd0-4806-8ead-65f53804065f
@@ -404,6 +381,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "13":
     id: "13"
     taskid: 4076e5e1-d0fc-4bb0-8008-409053367a9e
@@ -437,6 +415,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "14":
     id: "14"
     taskid: 9caed2f8-0d19-4950-8c2c-5bfdf48f54b0
@@ -481,13 +460,73 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+  "15":
+    id: "15"
+    taskid: 06783b62-db07-4a32-8b18-17b530538c51
+    type: regular
+    task:
+      id: 06783b62-db07-4a32-8b18-17b530538c51
+      version: -1
+      name: SNDBOX Upload File
+      description: Uploads the submission to SNDBOX.
+      script: '|||sndbox-analysis-submit-sample'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      file_id:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:DOC|DOT|XLS|CSV|XLT|XLM|PPT|POT|PPS|DOCX|DOCM|DOTX|DOTM|DOTM|XLSX|XLSM|XLTX|XLTM|XLSB|XLA|XLAM|IQY|PPTX|PPTM|POTX|PPSX|XML|PE32|RTF|PDF|VBS|VBE|PS1|JS|LNK|HTML|BAT)\b
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:DOC|DOT|XLS|CSV|XLT|XLM|PPT|POT|PPS|DOCX|DOCM|DOTX|DOTM|DOTM|XLSX|XLSM|XLTX|XLTM|XLSB|XLA|XLAM|IQY|PPTX|PPTM|POTX|PPSX|XML|PE32|RTF|PDF|VBS|VBE|PS1|JS|LNK|HTML|BAT)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:DOC|DOT|XLS|CSV|XLT|XLM|PPT|POT|PPS|DOCX|DOCM|DOTX|DOTM|DOTM|XLSX|XLSM|XLTX|XLTM|XLSB|XLA|XLAM|IQY|PPTX|PPTM|POTX|PPSX|XML|PE32|RTF|PDF|VBS|VBE|PS1|JS|LNK|HTML|BAT)\b
+              ignorecase: true
+          accessor: EntryID
+      should_wait: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 387.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
         "height": 1960,
-        "width": 717.5,
+        "width": 830,
         "x": 50,
         "y": 50
       }
@@ -608,5 +647,6 @@ outputs:
 - contextPath: File.Extension
   description: File Extension
   type: string
+releaseNotes: "Submit only supported files to SNDBOX"
 tests:
   - Detonate File - SNDBOX - Test

--- a/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
@@ -499,3 +499,5 @@ outputs:
 - contextPath: Sample.ID
   description: The sample ID.
 releaseNotes: "Submit only supported files to ThreatGrid"
+tests:
+- Detonate File - Generic Test

--- a/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
@@ -18,9 +18,9 @@ tasks:
       id: 29dcbc1e-0bb0-45f1-82ed-eb65b6ce039d
       version: -1
       name: ""
+      description: Start
       iscommand: false
       brand: ""
-      description: "Start"
     nexttasks:
       '#none#':
       - "5"
@@ -28,11 +28,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 20,
-          "y": 60
+          "x": 162.5,
+          "y": 50
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: 1378d2a9-9fcc-47d0-817f-9d9145740752
@@ -83,11 +84,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 20,
+          "x": 162.5,
           "y": 195
         }
       }
     note: false
+    timertriggers: []
   "6":
     id: "6"
     taskid: e6a670a6-eff4-4b16-883b-f08e7d7e7bd3
@@ -96,32 +98,33 @@ tasks:
       id: e6a670a6-eff4-4b16-883b-f08e7d7e7bd3
       version: -1
       name: Done
+      description: Done
       type: title
       iscommand: false
       brand: ""
-      description: "Done"
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 10,
-          "y": 1450
+          "x": 162.5,
+          "y": 1420
         }
       }
     note: false
+    timertriggers: []
   "8":
     id: "8"
-    taskid: 2ef569c7-fa31-45cc-80a0-e03b12b49815
+    taskid: 80dc5945-a851-469d-8445-3930393aa5d0
     type: regular
     task:
-      id: 2ef569c7-fa31-45cc-80a0-e03b12b49815
+      id: 80dc5945-a851-469d-8445-3930393aa5d0
       version: -1
       name: ThreatGrid Get Samples State
       description: Get the sample state.
-      script: Threat Grid|||threat-grid-get-samples-state
+      script: '|||threat-grid-get-samples-state'
       type: regular
       iscommand: true
-      brand: Threat Grid
+      brand: ""
     nexttasks:
       '#none#':
       - "6"
@@ -134,11 +137,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 10,
+          "x": 50,
           "y": 1245
         }
       }
     note: false
+    timertriggers: []
   "11":
     id: "11"
     taskid: 8377ba6f-c57d-4cd1-8a1f-5989f89978ac
@@ -166,59 +170,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 20,
-          "y": 555
+          "x": 162.5,
+          "y": 545
         }
       }
     note: false
-  "13":
-    id: "13"
-    taskid: 0245c2ab-485d-4994-8da0-63d10d247a77
-    type: regular
-    task:
-      id: 0245c2ab-485d-4994-8da0-63d10d247a77
-      version: -1
-      name: ThreatGrid Upload File
-      description: Uploads a file to Threat Grid
-      script: Threat Grid|||threat-grid-upload-sample
-      type: regular
-      iscommand: true
-      brand: Threat Grid
-    nexttasks:
-      '#none#':
-      - "15"
-    scriptarguments:
-      file-id:
-        complex:
-          root: File
-          accessor: EntryID
-      filename:
-        complex:
-          root: inputs.FileName
-      playbook:
-        complex:
-          root: inputs.Playbook
-      private:
-        complex:
-          root: inputs.Private
-      source:
-        complex:
-          root: inputs.Source
-      tags:
-        complex:
-          root: inputs.Tags
-      vm:
-        complex:
-          root: inputs.VM
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 10,
-          "y": 920
-        }
-      }
-    note: false
+    timertriggers: []
   "14":
     id: "14"
     taskid: c1d5b196-d934-4ef2-8e01-3487eae58533
@@ -235,7 +192,7 @@ tasks:
       '#default#':
       - "6"
       "yes":
-      - "13"
+      - "17"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -266,11 +223,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 20,
+          "x": 162.5,
           "y": 720
         }
       }
     note: false
+    timertriggers: []
   "15":
     id: "15"
     taskid: 97fcf073-c63a-42d4-8e65-ba6d4814d859
@@ -319,11 +277,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 10,
-          "y": 1080
+          "x": 50,
+          "y": 1070
         }
       }
     note: false
+    timertriggers: []
   "16":
     id: "16"
     taskid: 93e193f6-a438-4349-861c-f0f99b4b3997
@@ -354,23 +313,97 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 20,
-          "y": 380
+          "x": 275,
+          "y": 370
         }
       }
     note: false
+    timertriggers: []
+  "17":
+    id: "17"
+    taskid: 2665035c-2428-430e-8552-7ed3ee3c893b
+    type: regular
+    task:
+      id: 2665035c-2428-430e-8552-7ed3ee3c893b
+      version: -1
+      name: ThreatGrid Upload File
+      description: Submits a sample to threat grid for analysis
+      script: '|||threat-grid-upload-sample'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "15"
+    scriptarguments:
+      file-id:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+              ignorecase: true
+          accessor: EntryID
+      filename:
+        complex:
+          root: inputs.FileName
+      playbook:
+        complex:
+          root: inputs.playbook
+      private:
+        complex:
+          root: inputs.Private
+      tags:
+        complex:
+          root: inputs.Tags
+      vm:
+        complex:
+          root: inputs.VM
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {
-      "14_13_yes": 0.52,
-      "5_6_#default#": 0.37
+      "14_17_yes": 0.76,
+      "5_6_#default#": 0.44
     },
     "paper": {
       "dimensions": {
-        "height": 1455,
-        "width": 390,
-        "x": 10,
-        "y": 60
+        "height": 1435,
+        "width": 605,
+        "x": 50,
+        "y": 50
       }
     }
   }
@@ -465,3 +498,4 @@ outputs:
   description: The sample state.
 - contextPath: Sample.ID
   description: The sample ID.
+releaseNotes: "Submit only supported files to ThreatGrid"

--- a/Playbooks/playbook-Detonate_File_-_WildFire.yml
+++ b/Playbooks/playbook-Detonate_File_-_WildFire.yml
@@ -32,35 +32,7 @@ tasks:
         }
       }
     note: false
-  "1":
-    id: "1"
-    taskid: 24797d30-9a36-4241-8093-4d65c89156a4
-    type: regular
-    task:
-      id: 24797d30-9a36-4241-8093-4d65c89156a4
-      version: -1
-      name: WildFire Upload File
-      description: ""
-      script: WildFire|||wildfire-upload
-      type: regular
-      iscommand: true
-      brand: WildFire
-    nexttasks:
-      '#none#':
-      - "2"
-    scriptarguments:
-      upload:
-        complex:
-          root: inputs.File.EntryID
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 387.5,
-          "y": 895
-        }
-      }
-    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: 15b7c096-8b60-403c-857b-703dc230d659
@@ -114,19 +86,20 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "3":
     id: "3"
-    taskid: 4f9d282f-30e2-42da-8a51-fa1d549337b8
+    taskid: f97bc658-fbb7-4793-8ad2-9b9f6244d221
     type: regular
     task:
-      id: 4f9d282f-30e2-42da-8a51-fa1d549337b8
+      id: f97bc658-fbb7-4793-8ad2-9b9f6244d221
       version: -1
       name: WildFire Get Report
       description: Retrieve results for a file hash using WildFire
-      script: WildFire|||wildfire-report
+      script: '|||wildfire-report'
       type: regular
       iscommand: true
-      brand: WildFire
+      brand: ""
     nexttasks:
       '#none#':
       - "5"
@@ -149,6 +122,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: 7cb53d1d-e613-47cd-847e-c1908e384d53
@@ -170,6 +144,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "6":
     id: "6"
     taskid: 5944d365-4547-4e91-8f62-fa295fa32b38
@@ -206,6 +181,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 1cee486c-4dbe-44ec-8b62-195a75ebed2e
@@ -259,6 +235,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "10":
     id: "10"
     taskid: 09aec71d-10ce-419d-836b-88f9d41a52eb
@@ -275,7 +252,7 @@ tasks:
       '#default#':
       - "5"
       "yes":
-      - "1"
+      - "12"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -315,6 +292,7 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
   "11":
     id: "11"
     taskid: 16c9088e-43fa-494a-80f2-646461c74a66
@@ -347,6 +325,66 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+  "12":
+    id: "12"
+    taskid: 9be683c0-b4f2-4622-8308-c0a2b8ee2539
+    type: regular
+    task:
+      id: 9be683c0-b4f2-4622-8308-c0a2b8ee2539
+      version: -1
+      name: WildFire Upload File
+      description: Upload file to WildFire for analysis.
+      script: WildFire|||wildfire-upload
+      type: regular
+      iscommand: true
+      brand: WildFire
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      upload:
+        complex:
+          root: inputs.File
+          filters:
+          - - operator: match
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:APK|JAR|DOC|DOCX|RTF|XLS|XLSX|PPT|PPTX|XML|PE32|PDF|DMG|PKG|RAR|7Z)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:APK|JAR|DOC|DOCX|RTF|XLS|XLSX|PPT|PPTX|XML|PE32|PDF|DMG|PKG|RAR|7Z)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:APK|JAR|DOC|DOCX|RTF|XLS|XLSX|PPT|PPTX|XML|PE32|PDF|DMG|PKG|RAR|7Z)\b
+              ignorecase: true
+          accessor: EntryID
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 387.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
@@ -463,3 +501,4 @@ outputs:
 - contextPath: WildFire.Report.Size
   description: The size of the submission
   type: number
+releaseNotes: "Submit only supported files to WildFire"

--- a/Playbooks/playbook-Detonate_File_-_WildFire.yml
+++ b/Playbooks/playbook-Detonate_File_-_WildFire.yml
@@ -502,3 +502,5 @@ outputs:
   description: The size of the submission
   type: number
 releaseNotes: "Submit only supported files to WildFire"
+tests:
+- Wildfire Test


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14424

## Description
add a filter in the upload file task to filter non supported file types. checked vs .png, .eml

## Screenshots
![screen shot 2018-12-17 at 16 12 38](https://user-images.githubusercontent.com/37335599/50094160-2fc01200-021b-11e9-9025-a9fc585e226a.png)