### PR TITLE
fixed dedup conditional task

### DIFF
--- a/Playbooks/playbook-DeDup_incidents.yml
+++ b/Playbooks/playbook-DeDup_incidents.yml
@@ -119,7 +119,12 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: general.isExists
+      - - operator: isExists
+          left:
+            value:
+              simple: isSimilarIncidentFound
+            iscontext: true
+      - - operator: isTrue
           left:
             value:
               simple: isSimilarIncidentFound
@@ -131,6 +136,7 @@ tasks:
           "y": 369
         }
       }
+    note: false
   "5":
     id: "5"
     taskid: 813eba13-6ed9-4050-8d77-f9c3e0a3d07c
@@ -194,3 +200,4 @@ inputs:
 outputs:
 - contextPath: isSimilarIncidentFound
   description: Is similar incident found? (true\false)
+- releaseNotes: "-"


### PR DESCRIPTION
## Status
Ready

## Related Issues
N/A

## Description
Conditional task in the playbook requires boolean comparison for isSimilarIncidentFound

## Screenshots
Current
![screen shot 2018-12-19 at 3 04 44 pm](https://user-images.githubusercontent.com/9125387/50253619-9cfcb000-039f-11e9-98ee-6aea90069f32.png)

Required
![screen shot 2018-12-19 at 3 04 26 pm](https://user-images.githubusercontent.com/9125387/50253572-73dc1f80-039f-11e9-931a-df67fc582931.png)



## Required version of Demisto
3.5.0

## Does it break backward compatibility?
   - No
