### PR TITLE
EWS v2: Fixed predefined command argument

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -1741,7 +1741,12 @@ script:
       description: The item ids to delete.
     - name: delete-type
       required: true
-      description: 'Deletion type, choose one of: trash, soft, hard.'
+      auto: PREDEFINED
+      predefined:
+      - soft
+      - hard
+      - trash
+      description: 'trash - move items to trash. soft - delete items with recovery option. hard -  delete items without recovery option.'
       defaultValue: soft
     - name: target-mailbox
       description: The mailbox to apply the command on.


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: link to the issue

## Description
ews-delete-items has a `delete-type` argument which only accepts one of 3 predefined values.
If no one of them is given, it throws an exception.
Changed that argument type to predefined, and put the values in the predefined list.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Additional changes
Describe additional changes done, for example adding a function to common server.
