### PR TITLE
BuildEWSQuery: handle non-ascii characters

### DIFF
--- a/Scripts/script-BuildEWSQuery.yml
+++ b/Scripts/script-BuildEWSQuery.yml
@@ -4,6 +4,9 @@ commonfields:
 name: BuildEWSQuery
 script: |-
   import re
+  import sys
+  reload(sys)
+  sys.setdefaultencoding("utf-8")
 
   # Regex for removing forward/replay prefixes
   p = re.compile('([\[\(] *)?(RE|FWD?) *([-:;)\]][ :;\])-]*|$)|\]+ *$', re.IGNORECASE)
@@ -81,3 +84,6 @@ outputs:
   type: string
 scripttarget: 0
 runonce: false
+releaseNotes: "-"
+tests:
+  - buildewsquery_test

--- a/TestPlaybooks/playbook-BuildEWSQuery_Test.yml
+++ b/TestPlaybooks/playbook-BuildEWSQuery_Test.yml
@@ -50,7 +50,7 @@ tasks:
       stripSubject:
         simple: "true"
       subject:
-        simple: 'RE: RE: FWD: hello RE: world'
+        simple: 'RE: RE: FWD: hello RE: w’orld'
     reputationcalc: 0
     separatecontext: false
     view: |-
@@ -77,7 +77,7 @@ tasks:
       - "3"
     scriptarguments:
       expectedValue:
-        simple: 'From:"jondoe@acme.com" AND Subject:"hello RE: world" AND Received:"this
+        simple: 'From:"jondoe@acme.com" AND Subject:"hello RE: w’orld" AND Received:"this
           week"'
       fields: {}
       path:


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14276

## Description
Some parameters of the BuildEWSQuery (such as subject) may contain non-ascii characters.
This change will parse these characters correctly.

## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Additional changes
Describe additional changes done, for example adding a function to common server.
