### PR TITLE
Update nightly build trigger time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 5 * * *" # UTC time
+          cron: "0 2 * * *" # UTC time
           filters:
             branches:
               only:


### PR DESCRIPTION
Update the time in which we trigger the nightly build.
Now It will be 4 AM, which means the build will finish around 7AM