### PR TITLE
Extract Indicators From File - Generic - multiple fixes and updates

### DIFF
--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic.yml
@@ -1,7 +1,6 @@
-id: extract_indicators_from_file_-_generic
+id: Extract Indicators From File - Generic
 version: -1
 name: Extract Indicators From File - Generic
-fromversion: 3.6.0
 description: |-
   Extract indicators from a file.
   Currently supports PDFs and text-based file types (e.g., .txt, .htm, .html, and so on).
@@ -15,7 +14,6 @@ tasks:
       id: da3a5643-2e84-43b5-8e37-60032a95355b
       version: -1
       name: ""
-      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -26,10 +24,11 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 50
+          "y": -20
         }
       }
     note: false
+    timertriggers: []
   "1":
     id: "1"
     taskid: 1189dbf0-6420-4533-8c76-e6cb3083e9a7
@@ -45,7 +44,7 @@ tasks:
       brand: ""
     nexttasks:
       '#default#':
-      - "3"
+      - "10"
       "yes":
       - "2"
     separatecontext: false
@@ -63,10 +62,11 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 195
+          "y": 115
         }
       }
     note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: 49a307bb-ec5a-41bb-8f75-658e444f1f94
@@ -94,11 +94,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 377.5,
-          "y": 370
+          "x": 510,
+          "y": 350
         }
       }
     note: false
+    timertriggers: []
   "3":
     id: "3"
     taskid: 3c91d141-7645-4300-8610-51328a06369a
@@ -115,17 +116,18 @@ tasks:
     view: |-
       {
         "position": {
-          "x": -73,
-          "y": 1027
+          "x": 420,
+          "y": 1240
         }
       }
     note: false
+    timertriggers: []
   "4":
     id: "4"
-    taskid: 190a8c7e-cdaf-4b32-8e28-f93153071b5a
+    taskid: 6173b352-964a-40f2-825d-8c0346ef8910
     type: title
     task:
-      id: 190a8c7e-cdaf-4b32-8e28-f93153071b5a
+      id: 6173b352-964a-40f2-825d-8c0346ef8910
       version: -1
       name: Extract Indicators from file
       description: ""
@@ -136,31 +138,33 @@ tasks:
       '#none#':
       - "5"
       - "7"
+      - "9"
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 377.5,
-          "y": 545
+          "x": 510,
+          "y": 535
         }
       }
     note: false
+    timertriggers: []
   "5":
     id: "5"
-    taskid: 6dd8fd00-b025-4c12-89d5-b78e3d356be4
+    taskid: 3ca29382-1b0a-4638-84ad-10fe5fcaefcc
     type: condition
     task:
-      id: 6dd8fd00-b025-4c12-89d5-b78e3d356be4
+      id: 3ca29382-1b0a-4638-84ad-10fe5fcaefcc
       version: -1
-      name: Is there a text-based file
-      description: Check if there is a text-based file in context Skips .msg and .eml
-        files.
+      name: Is there a text-based file?
+      description: Checks if there is a text-based file in context. Skips .msg and
+        .eml files.
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
       '#default#':
-      - "3"
+      - "10"
       "yes":
       - "6"
     separatecontext: false
@@ -219,20 +223,21 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 690
+          "x": 92.5,
+          "y": 700
         }
       }
     note: false
+    timertriggers: []
   "6":
     id: "6"
-    taskid: 01cd1380-8b6c-4a75-8602-832daeb2bfd5
+    taskid: 6bc70b1a-93a4-4e4e-827e-0627901f9618
     type: regular
     task:
-      id: 01cd1380-8b6c-4a75-8602-832daeb2bfd5
+      id: 6bc70b1a-93a4-4e4e-827e-0627901f9618
       version: -1
       name: Extract indicators from text-based file
-      description: Extract indicators from text-based files.
+      description: Extracts indicators from text-based files.
       scriptName: ExtractIndicatorsFromTextFile
       type: regular
       iscommand: false
@@ -254,6 +259,38 @@ tasks:
                 value:
                   simple: ASCII text
               ignorecase: true
+          - - operator: notContainsString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: news or mail
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: eml
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: msg
+          - - operator: notContainsString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: Composite Document File V2 Document, No summary info
           accessor: EntryID
       maxFileSize: {}
     reputationcalc: 2
@@ -261,26 +298,27 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 865
+          "x": 92.5,
+          "y": 990
         }
       }
     note: false
+    timertriggers: []
   "7":
     id: "7"
-    taskid: 07542fb0-0931-468e-89ab-5d6550e1f99a
+    taskid: 6f18e685-32a4-4d00-88f6-f06c3132a8ba
     type: condition
     task:
-      id: 07542fb0-0931-468e-89ab-5d6550e1f99a
+      id: 6f18e685-32a4-4d00-88f6-f06c3132a8ba
       version: -1
-      name: Is there a PDF file
-      description: Check if there is a PDF file in context.
+      name: Is there a PDF file?
+      description: Checks if there is a PDF file in context.
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
       '#default#':
-      - "3"
+      - "10"
       "yes":
       - "8"
     separatecontext: false
@@ -317,20 +355,21 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 582,
-          "y": 690
+          "x": 510,
+          "y": 700
         }
       }
     note: false
+    timertriggers: []
   "8":
     id: "8"
-    taskid: 458345d2-ad32-449f-8c3d-0a54c61dc24d
+    taskid: a9484da9-878d-4ddc-8ed1-83d1da6b9775
     type: regular
     task:
-      id: 458345d2-ad32-449f-8c3d-0a54c61dc24d
+      id: a9484da9-878d-4ddc-8ed1-83d1da6b9775
       version: -1
       name: Read PDF file
-      description: Extract indicators from PDF files.
+      description: Extracts indicators from PDF files.
       scriptName: ReadPDFFile
       type: regular
       iscommand: false
@@ -367,20 +406,182 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 582,
-          "y": 865
+          "x": 510,
+          "y": 990
         }
       }
     note: false
+    timertriggers: []
+  "9":
+    id: "9"
+    taskid: 13fc7107-a648-4a45-8240-342f43d4540d
+    type: condition
+    task:
+      id: 13fc7107-a648-4a45-8240-342f43d4540d
+      version: -1
+      name: Is there a word document?
+      description: Checks if there is a word document  in context. This looks for
+        DOC and DOCXs files.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "11"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: containsString
+                    left:
+                      value:
+                        simple: File.Type
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Composite Document File V2 Document
+                  - operator: containsString
+                    left:
+                      value:
+                        simple: File.Type
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Microsoft Word
+                accessor: EntryID
+            iscontext: true
+      - - operator: isEqualString
+          left:
+            value:
+              simple: File.Info
+            iscontext: true
+          right:
+            value:
+              simple: doc
+        - operator: isEqualString
+          left:
+            value:
+              simple: File.Info
+            iscontext: true
+          right:
+            value:
+              simple: docs
+    view: |-
+      {
+        "position": {
+          "x": 920,
+          "y": 700
+        }
+      }
+    note: false
+    timertriggers: []
+  "10":
+    id: "10"
+    taskid: f97f529a-4428-4639-83a0-799106ca755e
+    type: title
+    task:
+      id: f97f529a-4428-4639-83a0-799106ca755e
+      version: -1
+      name: No File To Parse
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -530,
+          "y": 890
+        }
+      }
+    note: false
+    timertriggers: []
+  "11":
+    id: "11"
+    taskid: 9e130d59-4984-4699-810e-b95da0f8d32f
+    type: regular
+    task:
+      id: 9e130d59-4984-4699-810e-b95da0f8d32f
+      version: -1
+      name: Read word document
+      description: Extracts indicators from word documents (DOC / DOCX files).
+      scriptName: ExtractIndicatorsFromWordDocument
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      entryID:
+        complex:
+          root: File
+          filters:
+          - - operator: containsString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: Composite Document File V2 Document
+            - operator: containsString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: Microsoft Word
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: doc
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: docx
+          accessor: EntryID
+    reputationcalc: 2
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 920,
+          "y": 990
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1042,
-        "width": 1035,
-        "x": -73,
-        "y": 50
+        "height": 1325,
+        "width": 1830,
+        "x": -530,
+        "y": -20
       }
     }
   }
@@ -392,28 +593,6 @@ inputs:
   required: false
   description: The file to extract indicators from.
 outputs:
-- contextPath: File.ModDate
-  description: The PDF File ModDate
-- contextPath: File.dc
-  description: The PDF File dc
-- contextPath: File.Producer
-  description: The PDF File producer
-- contextPath: File.Title
-  description: The PDF File Title
-- contextPath: File.xap
-  description: The PDF File xap
-- contextPath: File.Text
-  description: The PDF File extracted text
-- contextPath: File.Author
-  description: The PDF File Author
-- contextPath: URL.Data
-  description: List of URLs that were extracted from the PDF file
-- contextPath: File.xapmm
-  description: The PDF File xapmm
-- contextPath: File.CreationDate
-  description: The PDF File CreationDate
-- contextPath: File.Pages
-  description: Number of pages in PDF file
 - contextPath: Domain.Name
   description: Extracted domains
 - contextPath: Account.Email.Address
@@ -426,5 +605,29 @@ outputs:
   description: Extracted SHA256
 - contextPath: IP.Address
   description: Extracted IPs
+- contextPath: File.Text
+  description: The PDF File extracted text
+- contextPath: File.Producer
+  description: The PDF File producer
+- contextPath: File.Title
+  description: The PDF File Title
+- contextPath: File.xap
+  description: The PDF File xap
+- contextPath: File.Author
+  description: The PDF File Author
+- contextPath: File.dc
+  description: The PDF File dc
+- contextPath: File.xapmm
+  description: The PDF File xapmm
+- contextPath: File.ModDate
+  description: The PDF File ModDate
+- contextPath: File.CreationDate
+  description: The PDF File CreationDate
+- contextPath: File.Pages
+  description: Number of pages in PDF file
+- contextPath: URL.Data
+  description: List of URLs that were extracted from the PDF file
+  type: unknown
+releaseNotes: "Added the ability to extract indicators from word documents using the Extract Indicators From File playbook."
 tests:
   - Extract Indicators From File - test

--- a/Scripts/script-ExtractIndicatorsFromTextFile.yml
+++ b/Scripts/script-ExtractIndicatorsFromTextFile.yml
@@ -21,31 +21,10 @@ script: |-
   with open(filePath, mode='r') as f:
       data = f.read(maxFileSize).decode('unicode_escape').encode('utf-8')
 
-      # Extract Email
-      demisto.results(demisto.executeCommand("ExtractEmail", {
+      # Extract indicators (omitting context output, letting auto-extract work)
+      demisto.results(str(demisto.executeCommand("extractIndicators", {
           'text': data
-      }))
-
-      # Extract Domain
-      demisto.results(demisto.executeCommand("ExtractDomain", {
-          'text': data,
-          'calcReputation':'false'
-      }))
-
-      # Extract Hash
-      demisto.results(demisto.executeCommand("ExtractHash", {
-          'text': data
-      }))
-
-      # Extract IP
-      demisto.results(demisto.executeCommand("ExtractIP", {
-          'text': data
-      }))
-
-      # Extract URL
-      demisto.results(demisto.executeCommand("ExtractURL", {
-          'text': data
-      }))
+      })[0][u'Contents']))
 type: python
 tags: []
 comment: |-
@@ -87,3 +66,7 @@ outputs:
   type: string
 scripttarget: 0
 runonce: false
+runas: DBotWeakRole
+releaseNotes: "Enhanced indicator extraction from text-based files"
+tests:
+  - Extract Indicators From File - test

--- a/Scripts/script-ExtractIndicatorsFromWordDocument.yml
+++ b/Scripts/script-ExtractIndicatorsFromWordDocument.yml
@@ -1,0 +1,120 @@
+commonfields:
+  id: ExtractIndicatorsFromWordDocument
+  version: 90
+name: ExtractIndicatorsFromWordDocument
+script: |-
+  import subprocess
+  import sys
+  from docx import Document
+  from docx.opc.exceptions import PackageNotFoundError
+
+  class WordParser:
+
+      def __init__(self):
+          self.res = []
+          self.errEntry = {
+            "Type": entryTypes["error"],
+            "ContentsFormat": formats["text"],
+            "Contents": ""
+          }
+          self.file_path = ""
+          self.file_name = ""
+          self.all_data = ""
+
+      def get_file_details(self):
+          cmd_res = demisto.executeCommand('getFilePath', {'id': demisto.args()['entryID']})
+          file_res = cmd_res[0]
+          if isError(file_res):
+              file_res["Contents"] = "Error fetching entryID: " + file_res["Contents"]
+              self.res = file_res
+          else:  # Got file path:
+              self.file_path = file_res['Contents']['path']
+              self.file_name = file_res['Contents']['name']
+
+      def convert_doc_to_docx(self):
+          conversion_res = subprocess.check_output(['soffice', '--headless', '--convert-to', 'docx', self.file_path])
+          output_file_name = self.file_name[0:self.file_name.rfind('.')] + '.docx'
+          self.file_path = self.file_path + ".docx"
+          with open(self.file_path, 'rb') as f:
+              contents = f.read()
+              f_data = f.read()
+              self.res = fileResult(output_file_name, f_data)
+
+      def extract_indicators(self):
+          try:
+              document = Document(self.file_path)
+              self.all_data = self.get_paragraphs(document)
+              self.all_data += self.get_tables(document)
+              self.all_data += self.get_core_properties(document)
+
+              output_file_name = self.file_name[0:self.file_name.rfind('.')] + '.txt'
+              self.res = fileResult(output_file_name, self.all_data.encode('utf8'))
+          except PackageNotFoundError as e:
+              self.errEntry["Contents"] = "Input file is not a valid docx/doc file."
+              self.res = self.errEntry
+          except BaseException as e:
+              self.errEntry["Contents"] = "Error occurred while parsing input file.\nException info: " + str(e)
+              self.res = self.errEntry
+
+      def get_paragraphs(self, document):
+          return '\n'.join([para.text for para in document.paragraphs])
+
+      def get_tables(self, document):
+          all_cells_txt = ""
+          if document.tables:
+              for table in document.tables:
+                  for row in table.rows:
+                      for cell in row.cells:
+                          for para in cell.paragraphs:
+                              all_cells_txt += (" " + para.text)
+          return " ".join(all_cells_txt.split())  # Removes extra whitespaces
+
+      def get_core_properties(self, document):
+          all_properties_txt = document.core_properties.author + " " +\
+          document.core_properties.category + " " +\
+          document.core_properties.comments + " " +\
+          document.core_properties.identifier + " " +\
+          document.core_properties.keywords + " " +\
+          document.core_properties.subject + " " +\
+          document.core_properties.title + " "
+          return " ".join(all_properties_txt.split())
+
+      def parse_word(self):
+          self.get_file_details()
+          if self.file_name.endswith(".doc"):
+              self.convert_doc_to_docx()
+              self.extract_indicators()
+          elif self.file_name.endswith(".docx"):
+              self.extract_indicators()
+          else:
+              return_error("Input file is not a doc file.")
+
+  parser = WordParser()
+  parser.parse_word()
+  # Extract indicators (omitting context output, letting auto-extract work)
+  demisto.results(str(demisto.executeCommand("extractIndicators", {
+      'text': parser.all_data
+  })[0][u'Contents']))
+type: python
+tags:
+- parser
+- autoextract
+- doc
+- docx
+- word
+comment: |-
+  Used to extract indicators from ".doc" and ".docx" files created using Microsoft Word.
+  Currently, the script extracts data from the main body of the document (the "paragraphs"), the tables, and the core properties, such as author, subject, comments and so on. The script does not support indicator extraction from macros embedded into the document.
+enabled: true
+args:
+- name: entryID
+  required: true
+  description: The entry ID of the word document to be parsed for indicators. The
+    document can be either in doc or docx format.
+scripttarget: 0
+runonce: false
+dockerimage: demisto/office-utils:1.0.0.45
+runas: DBotWeakRole
+releaseNotes: "New ability to extract indicators from word documents - works both on doc and docx formats."
+tests:
+  - Extract Indicators From File - test

--- a/Scripts/script-ReadPDFFile.yml
+++ b/Scripts/script-ReadPDFFile.yml
@@ -139,5 +139,6 @@ outputs:
 scripttarget: 0
 runonce: false
 dockerimage: demisto/pdfx
+releaseNotes: "Enhanced indicator extraction from pdf files"
 tests:
   - ReadPDFFile-Test


### PR DESCRIPTION
## Description
* Updated indicator extraction in ExtractIndicatorsFromTextFile script to use extractIndicators command.
* Updated indicator extraction in ReadPDFFile script to use extractIndicators command.
* Cleaned up and extended Extract Indicators From File playbook, to utilize the new ability to extract indicators from word documents.
* Fixed a bug where ".eml" and ".msg" files were skipped in one task, but not the task following that task.
* Added a whole new script that uses a dedicated and customized docker image, to convert doc to docx, and also parse those files for indicators. The script extracts indicators both from paragraphs, from tables AND from core properties of the file.


## Related Issues
fixes: https://github.com/demisto/etc/issues/14542
fixes: https://github.com/demisto/etc/issues/13588


