### PR TITLE
Default playbook fix

### DIFF
--- a/Playbooks/playbook-default.yml
+++ b/Playbooks/playbook-default.yml
@@ -1,7 +1,7 @@
 id: playbook0
 version: -1
 name: Default
-fromversion: 4.1.0
+fromversion: 3.5.0
 description: Default playbook, Enrich indicators in incident using one or more integrations
 starttaskid: "0"
 tasks:
@@ -51,7 +51,7 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isEqualString
+      - - operator: string.isEqual
           left:
             value:
               complex:

--- a/Playbooks/playbook-default.yml
+++ b/Playbooks/playbook-default.yml
@@ -272,3 +272,6 @@ inputs:
   required: false
   description: Should preform enrichment on all indicators in the incident
 outputs: []
+releaseNotes: "-"
+tests:
+  - No test

--- a/Playbooks/playbook-default.yml
+++ b/Playbooks/playbook-default.yml
@@ -1,7 +1,7 @@
 id: playbook0
 version: -1
 name: Default
-fromversion: 3.5.0
+fromversion: 4.1.0
 description: Default playbook, Enrich indicators in incident using one or more integrations
 starttaskid: "0"
 tasks:
@@ -13,7 +13,6 @@ tasks:
       id: 08854949-08a5-4873-8f01-b3935c78675f
       version: -1
       name: ""
-      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -27,6 +26,8 @@ tasks:
           "y": 50
         }
       }
+    note: false
+    timertriggers: []
   "1":
     id: "1"
     taskid: a8430dac-8cbb-47b3-8a87-2752cab0f36c
@@ -35,7 +36,6 @@ tasks:
       id: a8430dac-8cbb-47b3-8a87-2752cab0f36c
       version: -1
       name: Should perform enrichment?
-      description: ""
       type: condition
       iscommand: false
       brand: ""
@@ -51,7 +51,7 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: string.isEqual
+      - - operator: isEqualString
           left:
             value:
               complex:
@@ -68,6 +68,8 @@ tasks:
           "y": 195
         }
       }
+    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: 145e7a29-471e-4702-8493-65b7abbea30c
@@ -76,7 +78,6 @@ tasks:
       id: 145e7a29-471e-4702-8493-65b7abbea30c
       version: -1
       name: Choose analyst
-      description: ""
       scriptName: AssignAnalystToIncident
       type: regular
       iscommand: false
@@ -98,6 +99,8 @@ tasks:
           "y": 1040
         }
       }
+    note: false
+    timertriggers: []
   "3":
     id: "3"
     taskid: 09e4583d-597f-4955-897c-5bb5f24f4f57
@@ -106,7 +109,6 @@ tasks:
       id: 09e4583d-597f-4955-897c-5bb5f24f4f57
       version: -1
       name: Enrich indicators
-      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -121,6 +123,8 @@ tasks:
           "y": 370
         }
       }
+    note: false
+    timertriggers: []
   "4":
     id: "4"
     taskid: 44e6a83f-14cd-49f4-8c41-0ffde22d3c4f
@@ -129,7 +133,6 @@ tasks:
       id: 44e6a83f-14cd-49f4-8c41-0ffde22d3c4f
       version: -1
       name: ""
-      description: ""
       playbookName: Extract Indicators - Generic
       type: playbook
       iscommand: false
@@ -145,6 +148,8 @@ tasks:
           "y": 515
         }
       }
+    note: false
+    timertriggers: []
   "5":
     id: "5"
     taskid: 49cd29a6-4a83-44e6-8bdc-86136341411a
@@ -153,7 +158,6 @@ tasks:
       id: 49cd29a6-4a83-44e6-8bdc-86136341411a
       version: -1
       name: ""
-      description: ""
       playbookName: Entity Enrichment - Generic
       type: playbook
       iscommand: false
@@ -169,6 +173,8 @@ tasks:
           "y": 690
         }
       }
+    note: false
+    timertriggers: []
   "6":
     id: "6"
     taskid: 0e467280-8c85-40e6-84a0-4b11305dbcd7
@@ -177,7 +183,6 @@ tasks:
       id: 0e467280-8c85-40e6-84a0-4b11305dbcd7
       version: -1
       name: ""
-      description: ""
       playbookName: Calculate Severity - Generic
       type: playbook
       iscommand: false
@@ -193,6 +198,8 @@ tasks:
           "y": 865
         }
       }
+    note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 52714931-6ca9-42ff-854f-af9d3bc9e3d0
@@ -201,7 +208,6 @@ tasks:
       id: 52714931-6ca9-42ff-854f-af9d3bc9e3d0
       version: -1
       name: Manually review the incident
-      description: ""
       type: regular
       iscommand: false
       brand: ""
@@ -216,37 +222,43 @@ tasks:
           "y": 1215
         }
       }
+    note: false
+    timertriggers: []
   "8":
     id: "8"
-    taskid: 982a3b2c-9a7a-4367-8605-d3e639ef3d5f
+    taskid: e39abb8a-2dbe-415e-8541-ba414ee3dfa6
     type: regular
     task:
-      id: 982a3b2c-9a7a-4367-8605-d3e639ef3d5f
+      id: e39abb8a-2dbe-415e-8541-ba414ee3dfa6
       version: -1
-      name: Close investigation
-      description: ""
-      scriptName: CloseInvestigation
+      name: Close Investigation
+      description: Close the current incident
+      script: Builtin|||closeInvestigation
       type: regular
-      iscommand: false
-      brand: ""
+      iscommand: true
+      brand: Builtin
     scriptarguments:
-      notes:
-        simple: 'Default enrichment playbook '
-      reason: {}
+      assetid: {}
+      closeNotes:
+        simple: Default Enrichment Playbook
+      closeReason: {}
+      id: {}
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1390
+          "y": 1395
         }
       }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1435,
+        "height": 1440,
         "width": 492.5,
         "x": 50,
         "y": 50

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -6820,13 +6820,18 @@
                 "name": "Default", 
                 "fromversion": "3.5.0", 
                 "implementing_scripts": [
-                    "CloseInvestigation", 
                     "AssignAnalystToIncident"
                 ], 
                 "implementing_playbooks": [
                     "Extract Indicators - Generic", 
                     "Entity Enrichment - Generic", 
                     "Calculate Severity - Generic"
+                ], 
+                "implementing_commands": [
+                    "closeInvestigation"
+                ], 
+                "tests": [
+                    "No test"
                 ]
             }
         }, 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14732

## Description
Replace deprecated CloseInvestigation script task at the end of the Default playbook with the builtin closeInvestigation script.

## Required version of Demisto
4.1.0

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [x] Code Review
