### PR TITLE
Deprecate set incident custom fields

### DIFF
--- a/Scripts/script-SetIncidentCustomFields.yml
+++ b/Scripts/script-SetIncidentCustomFields.yml
@@ -15,7 +15,8 @@ script: |-
 type: javascript
 tags:
 - Utility
-comment: Sets current incident custom fields
+comment: Sets current incident custom fields. (Script deprecated. The correct way to set incident custom fields is with the setIncident script.)
+deprecated: true
 enabled: true
 args:
 - name: fields

--- a/Scripts/script-SetIncidentCustomFields.yml
+++ b/Scripts/script-SetIncidentCustomFields.yml
@@ -30,3 +30,5 @@ args:
   description: The list of values to match the fields - can be either array or comma
     separated
 scripttarget: 0
+tests:
+  - No test - script should be phased out of use

--- a/Scripts/script-SetIncidentCustomFields.yml
+++ b/Scripts/script-SetIncidentCustomFields.yml
@@ -30,5 +30,6 @@ args:
   description: The list of values to match the fields - can be either array or comma
     separated
 scripttarget: 0
+releaseNotes: "-"
 tests:
   - No test - script should be phased out of use

--- a/Scripts/script-SetIncidentCustomFields.yml
+++ b/Scripts/script-SetIncidentCustomFields.yml
@@ -15,7 +15,7 @@ script: |-
 type: javascript
 tags:
 - Utility
-comment: Sets current incident custom fields. (Script deprecated. The correct way to set incident custom fields is with the setIncident script.)
+comment: Sets current incident custom fields. (Deprecated. Use the setIncident command to set incident custom fields.)
 deprecated: true
 enabled: true
 args:

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -841,7 +841,11 @@
         }, 
         {
             "SetIncidentCustomFields": {
-                "name": "SetIncidentCustomFields"
+                "name": "SetIncidentCustomFields", 
+                "deprecated": true, 
+                "tests": [
+                    "No test - script should be phased out of use"
+                ]
             }
         }, 
         {


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14572

## Description
Deprecate the SetIncidentCustomFields script and alter description to state what to use instead.

## Screenshots
Paste here any images that will help the reviewer

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Code Review
