### PR TITLE
Update Get File Sample By Hash playbook to support Cylance v2

### DIFF
--- a/Integrations/integration-Cylance_Protect.yml
+++ b/Integrations/integration-Cylance_Protect.yml
@@ -212,7 +212,7 @@ script:
             var context = {};
             context.Cylance = {};
             context.Cylance[contextType] = [];
-            
+
             if (!Array.isArray(body)) {
                 body = [body];
             }
@@ -389,7 +389,7 @@ script:
             return runAndParseCommand(command,args,"data",parseGeneric('Threat'));
         case 'cp-download-threat': //deprecated
         case 'cylance-protect-download-threat':
-            return runAndParseCommand(command,args,"");
+            return runAndParseCommand(command,args,"",parseGeneric('Threat'));
         case 'cp-get-threat-details': //deprecated
         case 'cylance-protect-get-threat-details':
             return runAndParseCommand(command,args,"",parseGeneric('Threat'));
@@ -516,7 +516,7 @@ script:
     - contextPath: Endpoint.IP
       description: List of endpoint IP addresses
     - contextPath: Endpoint.MAC
-      description: List of endpoint MAC addresses 
+      description: List of endpoint MAC addresses
     - contextPath: Endpoint.DNSName
       description: Endpoint DNS name
   - name: cylance-protect-get-threats
@@ -744,7 +744,7 @@ script:
     - contextPath: Endpoint.IP
       description: List of endpoint IP addresses
     - contextPath: Endpoint.MAC
-      description: List of endpoint MAC addresses 
+      description: List of endpoint MAC addresses
     - contextPath: Endpoint.DNSName
       description: Endpoint DNS name
     - contextPath: Endpoint.CylanceThreat.Abnormal
@@ -1110,3 +1110,4 @@ script:
       is retrieved
   isfetch: true
 hidden: false
+releaseNotes: Update 'cp-download-threat' and 'cylance-protect-download-threat' commands - add url to context data

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect.yml
@@ -14,7 +14,6 @@ tasks:
       id: d947a1c1-7312-4f99-8f56-bfcb4b0c3dfe
       version: -1
       name: ""
-      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -28,39 +27,40 @@ tasks:
           "y": 50
         }
       }
+    note: false
+    timertriggers: []
   "1":
     id: "1"
-    taskid: c7ac9a5c-a5c1-4d97-8c8a-17bb763b6bc1
+    taskid: bb196c7a-ff84-44c7-81fd-625038a5bcf4
     type: condition
     task:
-      id: c7ac9a5c-a5c1-4d97-8c8a-17bb763b6bc1
+      id: bb196c7a-ff84-44c7-81fd-625038a5bcf4
       version: -1
-      name: Is Cylance Protect enabled?
-      description: Checks if the the "Cylance Protect" integration is enabled
+      name: Is Cylance V2 Protect enabled?
+      description: Checks if the the "Cylance Protect V2" integration is enabled
       scriptName: Exists
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
       '#default#':
-      - "2"
+      - "9"
       "yes":
       - "3"
     scriptarguments:
-      extend-context: {}
       value:
         complex:
           root: modules
           filters:
-          - - operator: string.isEqual
+          - - operator: isEqualString
               left:
                 value:
                   simple: modules.brand
                 iscontext: true
               right:
                 value:
-                  simple: Cylance Protect
-          - - operator: string.isEqual
+                  simple: Cylance Protect v2
+          - - operator: isEqualString
               left:
                 value:
                   simple: modules.state
@@ -77,6 +77,8 @@ tasks:
           "y": 195
         }
       }
+    note: false
+    timertriggers: []
   "2":
     id: "2"
     taskid: af2e86ff-6413-4cd8-8d5f-799edb0770e6
@@ -85,7 +87,6 @@ tasks:
       id: af2e86ff-6413-4cd8-8d5f-799edb0770e6
       version: -1
       name: Done
-      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -93,10 +94,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 70,
-          "y": 1420
+          "x": -180,
+          "y": 1930
         }
       }
+    note: false
+    timertriggers: []
   "3":
     id: "3"
     taskid: b17b16b8-78a7-4522-89ce-890839581757
@@ -123,52 +126,51 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 160,
           "y": 370
         }
       }
+    note: false
+    timertriggers: []
   "4":
     id: "4"
-    taskid: 7423c51e-e44c-4032-8367-fd7a8d61bfba
+    taskid: 886ea6f8-7fb2-4e7c-814e-3e6b9bb8fe8b
     type: regular
     task:
-      id: 7423c51e-e44c-4032-8367-fd7a8d61bfba
+      id: 886ea6f8-7fb2-4e7c-814e-3e6b9bb8fe8b
       version: -1
       name: Get download link from HASH
       description: Query Cylance Protect for HASH's link
-      script: Cylance Protect|||cylance-protect-download-threat
+      script: Cylance Protect v2|||cylance-protect-download-threat
       type: regular
       iscommand: true
-      brand: Cylance Protect
+      brand: Cylance Protect v2
     nexttasks:
       '#none#':
       - "5"
     scriptarguments:
-      extend-context:
-        simple: DownloadLink=url
-      filters: {}
-      headers: {}
-      page_number: {}
-      page_size: {}
       sha256:
         complex:
           root: inputs.SHA256
-      sorts: {}
+      threshold: {}
+      unzip: {}
     continueonerror: true
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 160,
           "y": 545
         }
       }
+    note: false
+    timertriggers: []
   "5":
     id: "5"
-    taskid: 48dcc1b9-1421-4626-80a8-fa0a364253a3
+    taskid: a2dfc6e8-e78a-4cc0-8de5-be4a8c155931
     type: condition
     task:
-      id: 48dcc1b9-1421-4626-80a8-fa0a364253a3
+      id: a2dfc6e8-e78a-4cc0-8de5-be4a8c155931
       version: -1
       name: Did we get a download link?
       description: Checks for a download link in context
@@ -182,26 +184,28 @@ tasks:
       "yes":
       - "6"
     scriptarguments:
-      extend-context: {}
       left: {}
       right: {}
       value:
         complex:
-          root: DownloadLink
+          root: File
+          accessor: DownloadURL
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 160,
           "y": 720
         }
       }
+    note: false
+    timertriggers: []
   "6":
     id: "6"
-    taskid: 2de88281-102e-4a58-8fea-cd3072417d05
+    taskid: d12daf11-c3b1-4079-8b6d-4bbc6023cc4d
     type: regular
     task:
-      id: 2de88281-102e-4a58-8fea-cd3072417d05
+      id: d12daf11-c3b1-4079-8b6d-4bbc6023cc4d
       version: -1
       name: Download File (ZIP format)
       description: Send an HTTP request to download the zip file
@@ -224,18 +228,22 @@ tasks:
       proxy: {}
       saveAsFile:
         simple: "yes"
+      unsecure: {}
       url:
         complex:
-          root: DownloadLink
+          root: File
+          accessor: DownloadURL
       username: {}
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 387.5,
+          "x": 160,
           "y": 895
         }
       }
+    note: false
+    timertriggers: []
   "7":
     id: "7"
     taskid: 917958d1-9c25-4f8d-84f3-5e272848d939
@@ -260,7 +268,7 @@ tasks:
         complex:
           root: File
           filters:
-          - - operator: string.isEqual
+          - - operator: isEqualString
               left:
                 value:
                   simple: File.Extension
@@ -273,10 +281,12 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 387.5,
+          "x": 160,
           "y": 1070
         }
       }
+    note: false
+    timertriggers: []
   "8":
     id: "8"
     taskid: 5492c4d0-b0c3-4245-8c14-e43fc3ce553f
@@ -299,7 +309,7 @@ tasks:
         complex:
           root: File
           filters:
-          - - operator: string.isEqual
+          - - operator: isEqualString
               left:
                 value:
                   simple: File.Extension
@@ -319,18 +329,307 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 500,
+          "x": 160,
           "y": 1245
         }
       }
+    note: false
+    timertriggers: []
+  "9":
+    id: "9"
+    taskid: 1a5cf78a-2b23-487e-8520-980ffc50bdf7
+    type: condition
+    task:
+      id: 1a5cf78a-2b23-487e-8520-980ffc50bdf7
+      version: -1
+      name: Is Cylance V1 Protect enabled?
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "10"
+    scriptarguments:
+      value:
+        complex:
+          root: modules
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: modules.brand
+                iscontext: true
+              right:
+                value:
+                  simple: Cylance Protect
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: modules.state
+                iscontext: true
+              right:
+                value:
+                  simple: active
+          accessor: brand
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -410,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+  "10":
+    id: "10"
+    taskid: 1eacec95-bc5e-4b25-8f30-f4ddbf1ddb9f
+    type: condition
+    task:
+      id: 1eacec95-bc5e-4b25-8f30-f4ddbf1ddb9f
+      version: -1
+      name: Do we have a SHA256?
+      description: Checks for SHA256 in context
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "11"
+    scriptarguments:
+      value:
+        complex:
+          root: inputs.SHA256
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "11":
+    id: "11"
+    taskid: 20c840b7-76ae-49b2-8402-d5300c570871
+    type: regular
+    task:
+      id: 20c840b7-76ae-49b2-8402-d5300c570871
+      version: -1
+      name: Get download link from HASH
+      description: Query Cylance Protect for HASH's link
+      script: Cylance Protect|||cylance-protect-download-threat
+      type: regular
+      iscommand: true
+      brand: Cylance Protect
+    nexttasks:
+      '#none#':
+      - "12"
+    scriptarguments:
+      sha256:
+        complex:
+          root: inputs.SHA256
+      threshold: {}
+      unzip: {}
+    continueonerror: true
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+  "12":
+    id: "12"
+    taskid: a5416443-e7db-45d3-86eb-86810cc208d6
+    type: condition
+    task:
+      id: a5416443-e7db-45d3-86eb-86810cc208d6
+      version: -1
+      name: Did we get a download link?
+      description: Checks for a download link in context
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "13"
+    scriptarguments:
+      left: {}
+      right: {}
+      value:
+        complex:
+          root: Cylance
+          accessor: Threat.Url
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "13":
+    id: "13"
+    taskid: 98e64df6-7105-455f-8298-9101e96b04a9
+    type: regular
+    task:
+      id: 98e64df6-7105-455f-8298-9101e96b04a9
+      version: -1
+      name: Download File (ZIP format)
+      description: Send an HTTP request to download the zip file
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "14"
+    scriptarguments:
+      body: {}
+      filename:
+        simple: ${inputs.SHA256}.zip
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password: {}
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        complex:
+          root: Cylance
+          accessor: Threat.Url
+      username: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+  "14":
+    id: "14"
+    taskid: 1f0dd602-7af3-4cf2-8d52-92fe5ab4ead0
+    type: condition
+    task:
+      id: 1f0dd602-7af3-4cf2-8d52-92fe5ab4ead0
+      version: -1
+      name: Did we successfully download the ZIP file?
+      description: Checks for ZIP file format in context
+      scriptName: Exists
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "15"
+    scriptarguments:
+      extend-context: {}
+      value:
+        complex:
+          root: File
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: zip
+          accessor: EntryID
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+  "15":
+    id: "15"
+    taskid: 7e6d9805-2917-46d9-891c-a944aa45b1f8
+    type: regular
+    task:
+      id: 7e6d9805-2917-46d9-891c-a944aa45b1f8
+      version: -1
+      name: Unzip File
+      description: Unzip a file using fileName or entryID to specify a file. Files
+        unzipped will be pushed to the war room and names will be pushed to the context.
+      scriptName: UnzipFile
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      entryID:
+        complex:
+          root: File
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: zip
+              ignorecase: true
+          accessor: EntryID
+      extend-context: {}
+      fileName: {}
+      lastZipFileInWarroom: {}
+      password:
+        complex:
+          root: inputs.ZipPassword
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -620,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
-    "linkLabelsPosition": {},
+    "linkLabelsPosition": {
+      "10_2_#default#": 0.23,
+      "9_2_#default#": 0.17
+    },
     "paper": {
       "dimensions": {
-        "height": 1435,
-        "width": 830,
-        "x": 50,
+        "height": 1945,
+        "width": 1160,
+        "x": -620,
         "y": 50
       }
     }
@@ -352,3 +651,4 @@ outputs:
 - contextPath: File
   description: The sample file
   type: unknown
+releaseNotes: Update playbook to support Cylance Protect v2 and Cylance Protect v1 integrations


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: Update playbook to support Cylance Protect v2 and Cylance Protect v1 integrations

## Description
'Get File Sample By Hash - Cylance Protect' playbook was able to works with only with the old Cylance Protect integration, now it works with the old Cylance Protect and the new Cylance Protect(v2)
## Screenshots
![image](https://user-images.githubusercontent.com/46249224/50835834-68f22a80-1360-11e9-8655-7a47accabbd8.png)


