### PR TITLE
Parsecsv nullbyte

### DIFF
--- a/Scripts/script-ParseCSV.yml
+++ b/Scripts/script-ParseCSV.yml
@@ -218,4 +218,4 @@ runas: DBotWeakRole
 releaseNotes: "Updated to replace null byte character with the empty string"
 tests:
   - TestParseCSV
-  - ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings
+  - ParseCSVnullbytesTest

--- a/Scripts/script-ParseCSV.yml
+++ b/Scripts/script-ParseCSV.yml
@@ -7,9 +7,10 @@ script: |
   import socket
 
   def unicode_dict_reader(utf8_data, **kwargs):
-      csv_reader = csv.DictReader(utf8_data, **kwargs)
+      csv_reader = csv.DictReader((line.replace('\0', '') for line in utf8_data), **kwargs)
       for row in csv_reader:
           yield {unicode(key, 'utf-8'):(unicode(value, 'utf-8') if value is not None else None) for key, value in row.iteritems()}
+
 
   def is_valid_ipv4_address(address):
       try:
@@ -179,7 +180,7 @@ enabled: true
 args:
 - name: entryID
   default: true
-  description: 'The war room entryID of the file.'
+  description: The war room entryID of the file.
 - name: file
   deprecated: true
   description: The name of the file. The file must be uploaded to the War Room.
@@ -212,5 +213,8 @@ outputs:
 - contextPath: ParseCSV.ParsedCSV
   description: Parsed csv in form of JSON array
 scripttarget: 0
+runonce: false
+runas: DBotWeakRole
+releaseNotes: "Updated to replace null byte character with the empty string"
 tests:
-  - TestParseCSV
+  - No test - will update after making test playbook

--- a/Scripts/script-ParseCSV.yml
+++ b/Scripts/script-ParseCSV.yml
@@ -217,4 +217,4 @@ runonce: false
 runas: DBotWeakRole
 releaseNotes: "Updated to replace null byte character with the empty string"
 tests:
-  - No test - will update after making test playbook
+  - ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings

--- a/Scripts/script-ParseCSV.yml
+++ b/Scripts/script-ParseCSV.yml
@@ -217,4 +217,5 @@ runonce: false
 runas: DBotWeakRole
 releaseNotes: "Updated to replace null byte character with the empty string"
 tests:
+  - TestParseCSV
   - ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings

--- a/TestPlaybooks/playbook-ParseCSVnullbytesTest.yml
+++ b/TestPlaybooks/playbook-ParseCSVnullbytesTest.yml
@@ -131,18 +131,22 @@ tasks:
     timertriggers: []
   "14":
     id: "14"
-    taskid: 9374d397-6652-435c-8d2c-27ccda68b2b1
+    taskid: 8186a2a2-db48-44e7-8af2-e059345c529a
     type: regular
     task:
-      id: 9374d397-6652-435c-8d2c-27ccda68b2b1
+      id: 8186a2a2-db48-44e7-8af2-e059345c529a
       version: -1
-      name: Awesome - Script is Removing Nullbyte Chars
+      name: Print Success To The War Room
+      scriptName: Print
       type: regular
       iscommand: false
       brand: ""
     nexttasks:
       '#none#':
       - "16"
+    scriptarguments:
+      value:
+        simple: Awesome - Script is Removing Nullbyte Chars
     separatecontext: false
     view: |-
       {
@@ -155,23 +159,16 @@ tasks:
     timertriggers: []
   "16":
     id: "16"
-    taskid: aca0f924-1c26-4fd1-89af-b82024acadf5
-    type: regular
+    taskid: 1a791e22-9f9b-4d65-8225-3b10f5a5f09d
+    type: title
     task:
-      id: aca0f924-1c26-4fd1-89af-b82024acadf5
+      id: 1a791e22-9f9b-4d65-8225-3b10f5a5f09d
       version: -1
-      name: closeInvestigation
+      name: Done
       description: Close the current incident
-      script: Builtin|||closeInvestigation
-      type: regular
-      iscommand: true
+      type: title
+      iscommand: false
       brand: Builtin
-    scriptarguments:
-      assetid: {}
-      closeNotes:
-        simple: ${AreValuesEqual}
-      closeReason: {}
-      id: {}
     separatecontext: false
     view: |-
       {
@@ -286,18 +283,22 @@ tasks:
     timertriggers: []
   "21":
     id: "21"
-    taskid: 452bc891-a295-497d-8b83-cecf2a019da9
+    taskid: d50b7273-025a-46df-8a00-c6f5ff156392
     type: regular
     task:
-      id: 452bc891-a295-497d-8b83-cecf2a019da9
+      id: d50b7273-025a-46df-8a00-c6f5ff156392
       version: -1
-      name: Uh-Oh - Script isn't removing nullbyte chars as expected
+      name: Print Failure To The War Room
+      scriptName: PrintErrorEntry
       type: regular
       iscommand: false
       brand: ""
     nexttasks:
       '#none#':
       - "16"
+    scriptarguments:
+      message:
+        simple: Uh-Oh - Script isn't removing nullbyte chars as expected
     separatecontext: false
     view: |-
       {

--- a/TestPlaybooks/playbook-ParseCSVnullbytesTest.yml
+++ b/TestPlaybooks/playbook-ParseCSVnullbytesTest.yml
@@ -1,0 +1,349 @@
+id: ParseCSVnullbytesTest
+version: -1
+name: ParseCSVnullbytesTest
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 75044ff9-6377-4b1e-8456-6401ef8ef1f0
+    type: start
+    task:
+      id: 75044ff9-6377-4b1e-8456-6401ef8ef1f0
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+  "1":
+    id: "1"
+    taskid: fcfbd7c0-e07c-4d6e-87a3-8f6edb6c6661
+    type: regular
+    task:
+      id: fcfbd7c0-e07c-4d6e-87a3-8f6edb6c6661
+      version: -1
+      name: DeleteContext
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "22"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+  "4":
+    id: "4"
+    taskid: 0fcc0334-ebcc-425e-87ce-2e3e325b5c3b
+    type: regular
+    task:
+      id: 0fcc0334-ebcc-425e-87ce-2e3e325b5c3b
+      version: -1
+      name: ParseCSV
+      description: This script will parse a CSV file and place the unique IPs, Domains
+        and Hashes into the context.
+      scriptName: ParseCSV
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "20"
+    scriptarguments:
+      domains: {}
+      entryID: {}
+      extend-context:
+        simple: W_NullbyteChars=
+      file:
+        simple: nullbytechars_in_data.csv
+      hashes: {}
+      ips: {}
+      parseAll: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 690
+        }
+      }
+    note: false
+    timertriggers: []
+  "5":
+    id: "5"
+    taskid: e59b751a-1dd7-4e7d-82bb-febe8652de3b
+    type: regular
+    task:
+      id: e59b751a-1dd7-4e7d-82bb-febe8652de3b
+      version: -1
+      name: FileCreateAndUpload (With Nullbyte Chars)
+      description: |
+        Will create a file (using the given data input or entry ID) and upload it to current investigation war room.
+      scriptName: FileCreateAndUpload
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      data:
+        simple: "name, age\ndave, 31\nzach, \0\nReggie, 40\nMol\0ly, twenty-one\n\0,12\nCatherine,\0"
+      entryId: {}
+      filename:
+        simple: nullbytechars_in_data.csv
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 515
+        }
+      }
+    note: false
+    timertriggers: []
+  "14":
+    id: "14"
+    taskid: 9374d397-6652-435c-8d2c-27ccda68b2b1
+    type: regular
+    task:
+      id: 9374d397-6652-435c-8d2c-27ccda68b2b1
+      version: -1
+      name: Awesome - Script is Removing Nullbyte Chars
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "16"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1040
+        }
+      }
+    note: false
+    timertriggers: []
+  "16":
+    id: "16"
+    taskid: aca0f924-1c26-4fd1-89af-b82024acadf5
+    type: regular
+    task:
+      id: aca0f924-1c26-4fd1-89af-b82024acadf5
+      version: -1
+      name: closeInvestigation
+      description: Close the current incident
+      script: Builtin|||closeInvestigation
+      type: regular
+      iscommand: true
+      brand: Builtin
+    scriptarguments:
+      assetid: {}
+      closeNotes:
+        simple: ${AreValuesEqual}
+      closeReason: {}
+      id: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 1215
+        }
+      }
+    note: false
+    timertriggers: []
+  "18":
+    id: "18"
+    taskid: 39ce617a-7e85-4d8c-8113-28e5eff7512a
+    type: regular
+    task:
+      id: 39ce617a-7e85-4d8c-8113-28e5eff7512a
+      version: -1
+      name: FileCreateAndUpload (Without Nullbyte Chars)
+      scriptName: FileCreateAndUpload
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "19"
+    scriptarguments:
+      data:
+        simple: "name, age\ndave, 31\nzach, \nReggie, 40\nMolly, twenty-one\n,12\nCatherine,"
+      entryId: {}
+      filename:
+        simple: data_without_nullbytechars.csv
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 515
+        }
+      }
+    note: false
+    timertriggers: []
+  "19":
+    id: "19"
+    taskid: 98ecaa2d-5711-40bf-81f5-84728fa992f5
+    type: regular
+    task:
+      id: 98ecaa2d-5711-40bf-81f5-84728fa992f5
+      version: -1
+      name: ParseCSV
+      scriptName: ParseCSV
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "20"
+    scriptarguments:
+      domains: {}
+      entryID: {}
+      extend-context:
+        simple: WO_NullbyteChars=
+      file:
+        simple: data_without_nullbytechars.csv
+      hashes: {}
+      ips: {}
+      parseAll: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 690
+        }
+      }
+    note: false
+    timertriggers: []
+  "20":
+    id: "20"
+    taskid: da070aed-79f3-40d6-8182-058af1155004
+    type: condition
+    task:
+      id: da070aed-79f3-40d6-8182-058af1155004
+      version: -1
+      name: AreValuesEqual
+      description: Check whether the values provided in arguments are equal. If either
+        of the arguments are missing, no is returned.
+      scriptName: AreValuesEqual
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "no":
+      - "21"
+      "yes":
+      - "14"
+    scriptarguments:
+      left:
+        simple: ${W_NullbyteChars}
+      right:
+        simple: ${WO_NullbyteChars}
+    results:
+    - AreValuesEqual
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 865
+        }
+      }
+    note: false
+    timertriggers: []
+  "21":
+    id: "21"
+    taskid: 452bc891-a295-497d-8b83-cecf2a019da9
+    type: regular
+    task:
+      id: 452bc891-a295-497d-8b83-cecf2a019da9
+      version: -1
+      name: Uh-Oh - Script isn't removing nullbyte chars as expected
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "16"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 1040
+        }
+      }
+    note: false
+    timertriggers: []
+  "22":
+    id: "22"
+    taskid: 9ff147d4-60e4-4fa6-87bf-89c9001693da
+    type: title
+    task:
+      id: 9ff147d4-60e4-4fa6-87bf-89c9001693da
+      version: -1
+      name: Create 2 Files Using Same Data Except One File Has Nullbyte Chars In It
+      type: title
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
+      - "18"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1260,
+        "width": 810,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3,6 +3,9 @@
     "testInterval": 20,
     "tests": [
         {
+            "playbookID": "ParseCSVnullbytesTest"
+        },
+        {
             "integrations": "CVE Search",
             "playbookID": "cveReputation Test"
         },

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -15203,13 +15203,12 @@
             "ParseCSVnullbytesTest": {
                 "name": "ParseCSVnullbytesTest", 
                 "implementing_scripts": [
-                    "DeleteContext", 
-                    "FileCreateAndUpload", 
                     "ParseCSV", 
+                    "FileCreateAndUpload", 
+                    "PrintErrorEntry", 
+                    "Print", 
+                    "DeleteContext", 
                     "AreValuesEqual"
-                ], 
-                "implementing_commands": [
-                    "closeInvestigation"
                 ]
             }
         }

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -2436,6 +2436,7 @@
                     "getEntries"
                 ], 
                 "tests": [
+                    "TestParseCSV", 
                     "ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings"
                 ]
             }

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -2436,7 +2436,7 @@
                     "getEntries"
                 ], 
                 "tests": [
-                    "TestParseCSV"
+                    "No test - will update after making test playbook"
                 ]
             }
         }, 

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -2437,7 +2437,7 @@
                 ], 
                 "tests": [
                     "TestParseCSV", 
-                    "ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings"
+                    "ParseCSVnullbytesTest"
                 ]
             }
         }, 

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -2436,7 +2436,7 @@
                     "getEntries"
                 ], 
                 "tests": [
-                    "No test - will update after making test playbook"
+                    "ParseCSVnullbytesTest - tests that script replaces nullbyte chars with empty strings"
                 ]
             }
         }, 
@@ -15180,6 +15180,20 @@
                     "misp-upload-sample", 
                     "file", 
                     "misp-delete-event"
+                ]
+            }
+        }, 
+        {
+            "ParseCSVnullbytesTest": {
+                "name": "ParseCSVnullbytesTest", 
+                "implementing_scripts": [
+                    "DeleteContext", 
+                    "FileCreateAndUpload", 
+                    "ParseCSV", 
+                    "AreValuesEqual"
+                ], 
+                "implementing_commands": [
+                    "closeInvestigation"
                 ]
             }
         }


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14873

## Description
Updated ParseCSV script to replace nullbyte chars with empty strings.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Code Review

## Additional changes
Created an additional test playbook - ParseCSVnullbytesTest - to test that the ParseCSV script is correctly replacing nullbyte chars with empty strings.