### PR TITLE
EWS Mail Sender: change service account to credentials.

### DIFF
--- a/Integrations/integration-EWSMailSender.yml
+++ b/Integrations/integration-EWSMailSender.yml
@@ -64,7 +64,7 @@ script:
 
     from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
     from exchangelib.version import EXCHANGE_2007, EXCHANGE_2010, EXCHANGE_2010_SP2, EXCHANGE_2013, EXCHANGE_2016
-    from exchangelib import HTMLBody, Message, FileAttachment, Account, IMPERSONATION, ServiceAccount, Configuration, NTLM, \
+    from exchangelib import HTMLBody, Message, FileAttachment, Account, IMPERSONATION, Credentials, Configuration, NTLM, \
         BASIC, DIGEST, Version, DELEGATE
 
     IS_TEST_MODULE = False
@@ -225,7 +225,7 @@ script:
             os.environ['NO_PROXY'] = EWS_SERVER
 
         version = get_version(VERSION_STR)
-        credentials = ServiceAccount(username=USERNAME, password=PASSWORD, max_wait=300)
+        credentials = Credentials(username=USERNAME, password=PASSWORD)
         config_args = {
             'credentials': credentials,
             'auth_type': get_auth_method(AUTH_METHOD_STR),

--- a/Integrations/integration-EWSMailSender.yml
+++ b/Integrations/integration-EWSMailSender.yml
@@ -315,5 +315,6 @@ script:
         Should be the same number of elements as attachIDs.
     description: Send email via EWS
   dockerimage: demisto/py-ews
+releaseNotes: "-"
 tests:
   - "EWS Mail Sender Test"


### PR DESCRIPTION
## Status
Ready

## Related Issues
None

## Description
Fix that was done in EWS v2 and is also relevant for EWS mail sender

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
ews-error-messages | https://github.com/demisto/content/pull/2674


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [X] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
Playbooks:
- [x] Phishing Investigation - Generic

Integrations:
- [x] EWS Mail Sender


Collected the following tests:
- [x] Phishing test - attachment
- [x] EWS search-mailbox test
- [x] Mail Sender (New) Test
- [x] EWS Mail Sender Test
- [x] Phishing test - Inline

## Additional changes
Describe additional changes done, for example adding a function to common server.
