### PR TITLE
change to use default docker image as it contains pyyaml

### DIFF
--- a/Scripts/script-DocumentationAutomation.yml
+++ b/Scripts/script-DocumentationAutomation.yml
@@ -257,6 +257,5 @@ args:
   defaultValue: "True"
 scripttarget: 0
 runonce: false
-dockerimage: demisto/docs
 tests:
   - No test - Test not needed

--- a/Scripts/script-DocumentationAutomation.yml
+++ b/Scripts/script-DocumentationAutomation.yml
@@ -257,5 +257,6 @@ args:
   defaultValue: "True"
 scripttarget: 0
 runonce: false
+releaseNotes: Changed to use default docker image
 tests:
   - No test - Test not needed


### PR DESCRIPTION
## Status
Ready

## Related Issues
demisto/etc#14871

## Description
Move to use default docker image for DocumentationAutomation

## Does it break backward compatibility?
- No

## Must have
- [ ] Tests : None provided
- [ ] Documentation (with link to it): Description is sufficient
- [ ] Code Review
