### PR TITLE
Increased Tenable.io Scan Test Timeout And Skipped Joe Security

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -139,7 +139,7 @@
           "integrations": "Tenable.io",
           "playbookID": "Tenable.io Scan Test",
           "nightly": true,
-          "timeout": 500
+          "timeout": 700
         },
         {
             "integrations": "Tenable.sc",
@@ -987,7 +987,7 @@
         "carbonblackprotection": "License expired",
         "Lastline": "Out of quota",
         "Netskope": "instance is down",
-        "Joe Security": "Reached number of allowed submissions per month"
+        "Joe Security": "Reached number of allowed submissions per month, untill 1/2/19"
     },
     "nigthly_integrations": [
         "Lastline",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -986,7 +986,8 @@
         "Attivo Botsink": "no instance, @Arian will update",
         "carbonblackprotection": "License expired",
         "Lastline": "Out of quota",
-        "Netskope": "instance is down"
+        "Netskope": "instance is down",
+        "Joe Security": "Reached number of allowed submissions per month"
     },
     "nigthly_integrations": [
         "Lastline",


### PR DESCRIPTION
## Status
Ready

## Description
Reached allowed number of submissions per month in Joe Security, until 1/2/19.
Increased the timeout for Tenable.io Scan Test to 700

## Does it break backward compatibility?
   - No