### PR TITLE
Added a new script to send email on SLA breach

### DIFF
--- a/Scripts/script-SendEmailOnSLABreach.yml
+++ b/Scripts/script-SendEmailOnSLABreach.yml
@@ -1,0 +1,68 @@
+commonfields:
+  id: SendEmailOnSLABreach
+  version: -1
+name: SendEmailOnSLABreach
+script: |-
+  """
+  This script is used to send an email about a breached SLA. The script, by default, sends the email to the assignee of the
+  incident. The email is sent using the send-email command, using all enabled integrations that support the command.
+  """
+
+  def get_owner_email():
+      owner_username = demisto.incidents()[0].get("owner")
+      if owner_username:
+          try:
+              owner_info = demisto.executeCommand('getUserByUsername', {"username":owner_username})[0]
+              owner_email = owner_info.get("EntryContext").get("UserByUsername").get("email")
+              return owner_email
+          except Exception, ex:
+              demisto.results
+              ({
+                  "Type" : entryTypes["error"],
+                  "ContentsFormat" : formats["text"],
+                  "Contents" : "Could not retrieve user email. Maybe the user has no associated email to it.\
+              Error: {}".format(ex)
+
+              })
+              return
+
+  def get_subject():
+      incident_name = demisto.incidents()[0].get("name")
+      incident_id = demisto.incidents()[0].get("id")
+      subject = "SLA Breached in incident \"{}\" #{}".format(incident_name, incident_id)
+      return subject
+
+  def send_email(to, subject, body):
+      demisto.results(demisto.executeCommand('send-mail', {
+          "to": to,
+          "subject": subject,
+          "body": body}))
+
+  def get_body():
+      field_name = demisto.args().get("field").get("cliName")
+      sla = demisto.args().get("fieldValue").get("sla")
+      start_date = demisto.args().get("fieldValue").get("startDate")
+      body = "We have detected a breach in your SLA \"{}\".\nThe SLA was set to {} minute and was started on {}.".format(
+          field_name, sla, start_date.split(".")[0])
+      return body
+
+  email_to = get_owner_email()
+  email_subject = get_subject()
+  email_body = get_body()
+
+  if email_to:
+      send_email(email_to, email_subject, email_body)
+type: python
+tags:
+- sla
+- example
+comment: |-
+  Sends an email informing the user of an SLA breach. The email is sent to the user who is assigned to the incident. It includes the incident name, ID, name of the SLA field that was breached, duration of that SLA field, and the date and time when that SLA was started.
+  In order to run successfully, the script should be configured to trigger on SLA breach, through field edit mode.
+enabled: true
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole
+releaseNotes: "A new script to send an email on SLA breach"
+tests:
+  - No test - Can't test script that triggers on SLA breach. Need a field to trigger it and need a configured mail sender. Also errors aren't accounted.

--- a/Scripts/script-SendEmailOnSLABreach.yml
+++ b/Scripts/script-SendEmailOnSLABreach.yml
@@ -25,6 +25,14 @@ script: |-
 
               })
               return
+      else:
+              demisto.results
+              ({
+                  "Type" : entryTypes["error"],
+                  "ContentsFormat" : formats["text"],
+                  "Contents" : "An email can't be sent to the owner of the incident, because no owner was assigned."
+
+              })
 
   def get_subject():
       incident_name = demisto.incidents()[0].get("name")

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -4765,6 +4765,17 @@
             "ConvertKeysToTableFieldFormat": {
                 "name": "ConvertKeysToTableFieldFormat"
             }
+        }, 
+        {
+            "SendEmailOnSLABreach": {
+                "name": "SendEmailOnSLABreach", 
+                "script_executions": [
+                    "getUserByUsername"
+                ], 
+                "tests": [
+                    "No test - Can't test script that triggers on SLA breach. Need a field to trigger it and need a configured mail sender. Also errors aren't accounted."
+                ]
+            }
         }
     ], 
     "playbooks": [

--- a/Tests/scripts/update_id_set.py
+++ b/Tests/scripts/update_id_set.py
@@ -34,11 +34,11 @@ def print_error(error_str):
 
 def run_git_command(command):
     p = Popen(command.split(), stdout=PIPE, stderr=PIPE)
-    p.wait()
-    if p.returncode != 0:
+    output, err = p.communicate()
+    if err and 'CRLF will be replaced by LF' not in err:
         print_error("Failed to run git command " + command)
         sys.exit(1)
-    return p.stdout.read()
+    return output
 
 
 def checked_type(file_path):
@@ -220,7 +220,7 @@ def get_script_data(file_path):
     deprecated = data_dictionary.get('deprecated')
     fromversion = data_dictionary.get('fromversion')
     depends_on, command_to_integration = get_depends_on(data_dictionary)
-    script_executions = sorted(list(set(re.findall("demisto.executeCommand\(['\"](\w+)['\"].*\)", script_code))))
+    script_executions = sorted(list(set(re.findall("demisto.executeCommand\(['\"](\w+)['\"].*", script_code))))
 
     script_data['name'] = name
     if toversion:
@@ -269,6 +269,7 @@ def update_object_in_id_set(obj_id, obj_data, file_path, instances_set):
             if is_added_from_version or (not is_added_from_version and file_from_version == integration_from_version):
                 if is_added_to_version or (not is_added_to_version and file_to_version == integration_to_version):
                     instance[obj_id] = obj_data[obj_id]
+                    break
 
 
 def add_new_object_to_id_set(obj_id, obj_data, file_path, instances_set):
@@ -336,7 +337,7 @@ def update_id_set():
     branch_name = branch_name_reg.group(1)
 
     print("Getting added files")
-    files_string = run_git_command("git diff --name-status")
+    files_string = run_git_command("git diff --name-status HEAD")
     second_files_string = run_git_command("git diff --name-status origin/master...{}".format(branch_name))
     added_files, modified_files = get_changed_files(files_string + '\n' + second_files_string)
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14785

## Description
- Added a new script to send email on SLA breach
- Added the new `update_id_set.py` file that Rony fixed with me on another branch I worked on, that should now accomodate for line breaks in the regex, and deal with CRLF / LF and more.

## Screenshots
![image](https://user-images.githubusercontent.com/43602124/51252559-cca1d680-19a4-11e9-8699-8d2496127426.png)


## Required version of Demisto
4.1.0+

## Does it break backward compatibility?
   - No
