### PR TITLE
PhishMe - added correct email output paths

### DIFF
--- a/Integrations/integration-PhishMe.yml
+++ b/Integrations/integration-PhishMe.yml
@@ -187,9 +187,15 @@ script:
         var threatArray = [];
         if (threats.length !== 0) {
             ec.Email = {
-                          Data: sender_name,
-                          Malicious: {Vendor: 'PhishMe', Description: 'Match found in PhishMe database'}
-                        };
+                'Data': sender_name,
+                'Malicious': {'Vendor': 'PhishMe', 'Description': 'Match found in PhishMe database'}
+            };
+            ec.Account = {
+                outputPaths['email']: {
+                    'Address': sender_name,
+                    'Malicious': {'Vendor': 'PhishMe', 'Description': 'Match found in PhishMe database'}
+                }
+            };
             for (var k = 0; k < threats.length; k++) {
                 for (var i = 0; i < threats[0].blockSet.length; i++){
                     if (threats[0].blockSet[i]['data'].indexOf(sender_name) !== -1) {
@@ -446,8 +452,15 @@ script:
       default: true
       description: Sender address
     outputs:
-    - contextPath: Email.From
-      description: Sender address to check
+    - contextPath: Email.Data
+      description: Sender address to check.
+    - contextPath: Account.Email.Address
+      description: Sender address to check.
+    - contextPath: Account.Email.Malicious.Vendor
+      description: For malicious emails, the vendor that made the decision.
+    - contextPath: Account.Email.Malicious.Description
+      description: For malicious emails, the reason for the vendor to make the decision.
+    - contextPath: Account.Email.
     - contextPath: DBotScore.Indicator
       description: The indicator we tested
     - contextPath: DBotScore.Type
@@ -458,3 +471,6 @@ script:
       description: The actual score
     description: Check if sender address is malicious
 hidden: false
+releaseNotes: "Added new outputs !email commands"
+tests:
+  - Test - PhishMe

--- a/Integrations/integration-PhishMe.yml
+++ b/Integrations/integration-PhishMe.yml
@@ -460,7 +460,6 @@ script:
       description: For malicious emails, the vendor that made the decision.
     - contextPath: Account.Email.Malicious.Description
       description: For malicious emails, the reason for the vendor to make the decision.
-    - contextPath: Account.Email.
     - contextPath: DBotScore.Indicator
       description: The indicator we tested
     - contextPath: DBotScore.Type

--- a/TestPlaybooks/playbook-PhishMe.yml
+++ b/TestPlaybooks/playbook-PhishMe.yml
@@ -1,4 +1,4 @@
-id: 8984405a-4274-470a-8a34-a437d8e2e1c5
+id: Test - PhishMe
 version: 1
 name: Test - PhishMe
 starttaskid: "0"

--- a/TestPlaybooks/playbook-PhishMe.yml
+++ b/TestPlaybooks/playbook-PhishMe.yml
@@ -1,5 +1,5 @@
 id: Test - PhishMe
-version: 1
+version: -1
 name: Test - PhishMe
 starttaskid: "0"
 tasks:

--- a/TestPlaybooks/playbook-PhishMe_test.yml
+++ b/TestPlaybooks/playbook-PhishMe_test.yml
@@ -1,4 +1,4 @@
-id: 8984405a-4274-470a-8a34-a437d8e2e1c5
+id: Test - PhishMe
 version: 1
 name: Test - PhishMe
 starttaskid: "0"

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -948,6 +948,10 @@
         },
         {
             "playbookID": "Ping Test Playbook"
+        },
+        {
+            "integrations": "Phishme Intelligence",
+            "playbookID": "Test - PhishMe"
         }
     ],
     "skipped_tests": {

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -11634,7 +11634,7 @@
             }
         }, 
         {
-            "8984405a-4274-470a-8a34-a437d8e2e1c5": {
+            "Test - PhishMe": {
                 "name": "Test - PhishMe", 
                 "implementing_scripts": [
                     "CloseInvestigation", 

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -7683,6 +7683,9 @@
                     "ip", 
                     "phishme-search", 
                     "email"
+                ], 
+                "tests": [
+                    "Test - PhishMe"
                 ]
             }
         }, 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14508

## Description
Added the right output paths (i.e. `Account.Email.Malicious` and `Account.Email.Address`), while keeping the old output paths for backward compatibility.

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review