### PR TITLE
Jask fixed fetch incidents

### DIFF
--- a/Integrations/integration-Jask.yml
+++ b/Integrations/integration-Jask.yml
@@ -499,7 +499,7 @@ script:
             last_run = last_run_object.get('time')
         else:
             last_run = now - 24 * 60 * 60 * 1000
-        last_fetch = last_run
+        next_fetch = last_run
         q = '* AND timestamp:[%d TO *]' % last_run
         if demisto.getParam('fetchQuery'):
             q += ' AND ' + demisto.getParam('fetchQuery')
@@ -517,8 +517,7 @@ script:
             if current_fetch:
                 current_fetch = datetime.strptime(current_fetch, "%Y-%m-%dT%H:%M:%S")
                 current_fetch = convert_date_to_unix(current_fetch)
-                if current_fetch > last_fetch:
-                    last_fetch = current_fetch
+                if current_fetch > last_run:
                     incidents.append({
                         'name': a.get('name', 'No name') + ' - ' + a.get('id'),
                         'occurred': a.get('timestamp') + 'Z',
@@ -526,9 +525,11 @@ script:
                         'severity': translate_severity(a.get('severity')),
                         'rawJSON': json.dumps(a)
                     })
+                if current_fetch > next_fetch:
+                    next_fetch = current_fetch
 
         demisto.incidents(incidents)
-        demisto.setLastRun({'time': last_fetch})
+        demisto.setLastRun({'time': next_fetch})
 
     if demisto.command() == 'test-module':
         req('GET', 'asset/whitelisted', QUERY)

--- a/Integrations/integration-Jask.yml
+++ b/Integrations/integration-Jask.yml
@@ -45,6 +45,11 @@ configuration:
   defaultvalue: ""
   type: 0
   required: false
+- display: Limit the maximum incidents amount per fetch
+  name: fetchLimit
+  defaultvalue: "100"
+  type: 0
+  required: false
 script:
   script: |
     import requests
@@ -61,7 +66,7 @@ script:
     if URL[-1] != '/':
         URL += '/'
     QUERY = {'username': demisto.getParam('Username'), 'api_key': demisto.getParam('APIKey')}
-
+    FETCH_LIMIT = int(demisto.params().get('fetchLimit', 100))
 
     def return_error(data):
         """
@@ -494,6 +499,7 @@ script:
             last_run = last_run_object.get('time')
         else:
             last_run = now - 24 * 60 * 60 * 1000
+        last_fetch = last_run
         q = '* AND timestamp:[%d TO *]' % last_run
         if demisto.getParam('fetchQuery'):
             q += ' AND ' + demisto.getParam('fetchQuery')
@@ -502,20 +508,27 @@ script:
         query = QUERY.copy()
         query['q'] = q
         query['offset'] = 0
-        query['limit'] = 100
-        query['sort_by'] = 'timestamp:desc'
+        query['limit'] = FETCH_LIMIT
+        query['sort_by'] = 'timestamp:asc'
         resp_json = req('GET', 'search/alerts', query)
         incidents = []
         for a in resp_json['objects']:
-            incidents.append({
-                'name': a.get('name', 'No name') + ' - ' + a.get('id'),
-                'occurred': a.get('timestamp') + 'Z',
-                'details': a.get('description'),
-                'severity': translate_severity(a.get('severity')),
-                'rawJSON': json.dumps(a)
-            })
+            current_fetch = a.get('timestamp')
+            if current_fetch:
+                current_fetch = datetime.strptime(current_fetch, "%Y-%m-%dT%H:%M:%S")
+                current_fetch = convert_date_to_unix(current_fetch)
+                if current_fetch > last_fetch:
+                    last_fetch = current_fetch
+                    incidents.append({
+                        'name': a.get('name', 'No name') + ' - ' + a.get('id'),
+                        'occurred': a.get('timestamp') + 'Z',
+                        'details': a.get('description'),
+                        'severity': translate_severity(a.get('severity')),
+                        'rawJSON': json.dumps(a)
+                    })
+
         demisto.incidents(incidents)
-        demisto.setLastRun({'time': now})
+        demisto.setLastRun({'time': last_fetch})
 
     if demisto.command() == 'test-module':
         req('GET', 'asset/whitelisted', QUERY)
@@ -1017,3 +1030,6 @@ script:
     description: Search entities using the given filters.
   isfetch: true
   runonce: false
+releaseNotes: "Fixed fetch incidents bug"
+tests:
+  - No test

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -8442,6 +8442,9 @@
                     "jask-search-insights", 
                     "jask-search-signals", 
                     "jask-search-entities"
+                ], 
+                "tests": [
+                    "No test"
                 ]
             }
         }, 
@@ -11599,7 +11602,7 @@
                     "Alexa Test Playbook"
                 ]
             }
-        },
+        }, 
         {
             "Google Resource Manager": {
                 "name": "Google Resource Manager", 
@@ -15547,7 +15550,7 @@
                     "domain"
                 ]
             }
-        },
+        }, 
         {
             "GoogleResourceManager-Test": {
                 "name": "GoogleResourceManager-Test", 


### PR DESCRIPTION
## Status
Ready

## Related Issues
@gshriki 

## Description
1. reverse the order we get from the service - acs instead of desc
2. set `lastRun` to latest incident we get from the service
3. keep limit ingestion and have it configurable

## Screenshots
![image](https://user-images.githubusercontent.com/12241410/51535648-bf2b9700-1e51-11e9-98ca-74d8a2e88860.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review
