### PR TITLE
Prettify splunk-search command output

### DIFF
--- a/Integrations/integration-SplunkPy.yml
+++ b/Integrations/integration-SplunkPy.yml
@@ -316,7 +316,16 @@ script:
         ec['Splunk.Result'] = res
         if len(dbot_scores) > 0:
             ec['DBotScore'] = dbot_scores
-        demisto.results({"Type": 1, "ContentsFormat": "json", "Contents": json.dumps(res), "EntryContext": ec})
+
+        headers=""
+        if (res and len(res)>0):
+            if not isinstance(res[0], dict):
+                headers = "results"
+
+        humanReadable = tableToMarkdown("Splunk Search results for: " + demisto.args()['query'], res, headers)
+
+        demisto.results({"Type": 1, "Contents": res, "ContentsFormat": "json", "EntryContext": ec, "HumanReadable": humanReadable})
+
         sys.exit(0)
     if demisto.command() == 'splunk-job-create':
         searchquery_normal = demisto.args()['query']
@@ -539,3 +548,4 @@ script:
     description: Parse the Raw part of the event
   dockerimage: demisto/splunksdk:1.0
   isfetch: true
+releaseNotes: "Prettify splunk-search command output - Add results to Markdown table"

--- a/Scripts/script-SplunkPySearch.yml
+++ b/Scripts/script-SplunkPySearch.yml
@@ -2,6 +2,7 @@ commonfields:
   id: SplunkPySearch
   version: -1
 name: SplunkPySearch
+deprecated: true
 script: |-
   query = demisto.args()['query']
   rows = demisto.args()['rows']
@@ -39,3 +40,4 @@ scripttarget: 0
 dependson:
   must:
   - splunk-search
+releaseNotes: "Deprecate SplunkPySearch script"

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -3849,6 +3849,7 @@
         {
             "SplunkPySearch": {
                 "name": "SplunkPySearch", 
+                "deprecated": true, 
                 "depends_on": [
                     "splunk-search"
                 ]


### PR DESCRIPTION
Prettify splunk-search command output - - Add results to Markdown table
 and Deprecate SplunkPySearch script

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15167
