### PR TITLE
- Added reputation value and context path for SHA256

### DIFF
--- a/Misc/reputations.json
+++ b/Misc/reputations.json
@@ -106,6 +106,19 @@
       ],
       "fromVersion": "3.1.0"
     },
+      {
+      "id": "hashRepSHA256",
+      "version": -1,
+      "regex": "\\b[a-fA-F\\d]{64}\\b",
+      "reputationScriptName": "DataHashReputation",
+      "details": "File SHA256",
+      "enhancementScriptNames": [
+        "FileReputation",
+        "SplunkSearch",
+        "WildfireReport"
+      ],
+      "toVersion": "3.0.1"
+    },
     {
       "id": "hashRepSHA256",
       "version": -1,

--- a/Misc/reputations.json
+++ b/Misc/reputations.json
@@ -110,19 +110,6 @@
       "id": "hashRepSHA256",
       "version": -1,
       "regex": "\\b[a-fA-F\\d]{64}\\b",
-      "reputationScriptName": "DataHashReputation",
-      "details": "File SHA256",
-      "enhancementScriptNames": [
-        "FileReputation",
-        "SplunkSearch",
-        "WildfireReport"
-      ],
-      "toVersion": "3.0.1"
-    },
-    {
-      "id": "hashRepSHA256",
-      "version": -1,
-      "regex": "\\b[a-fA-F\\d]{64}\\b",
       "reputationCommand": "file",
       "details": "File SHA256",
       "contextValue": "SHA256",

--- a/Misc/reputations.json
+++ b/Misc/reputations.json
@@ -125,11 +125,11 @@
       "regex": "\\b[a-fA-F\\d]{64}\\b",
       "reputationCommand": "file",
       "details": "File SHA256",
+      "contextValue": "SHA256",
+      "contextPath": "File(val.SHA256 && val.SHA256 === obj.SHA256)",
       "enhancementScriptNames": [
         "FileReputation",
-        "SplunkSearch",
-        "WildfireReport",
-        "SplunkPySearch"
+        "SplunkSearch"
       ],
       "fromVersion": "3.1.0"
     },
@@ -256,5 +256,6 @@
       "formatScript": "ExtractDomainFromUrlAndEmail",
       "fromVersion": "3.6"
     }
-  ]
+  ],
+  "releaseNotes": "Added reputation value and context path for SHA256. Auto-Extract should now work properly for SHA256."
 }


### PR DESCRIPTION
## Status
Ready

## Related Issues
related to: https://github.com/demisto/etc/issues/14953 (partial fix)

## Description
SHA256 hash used to not be extracted and not get inserted into context. It should now work.
- Added reputation value and context path for SHA256
- Removed deprecated / useless scripts (should not break BC)

## Screenshots
This is what it would look like (except the name won't have "v2" in it and SplunkSearch would also be under `Enhancement Scripts`)
![image](https://user-images.githubusercontent.com/43602124/51800691-80c01e80-223b-11e9-9e33-c027a442e068.png)

## Does it break backward compatibility?
   - No

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [Script ] FileReputation

## Additional changes
Removed useless scripts too.
This fix should solve the problem of `Phishing test - Inline` failing due to the malicious SHA256 not appearing under File.SHA256 in context, thus not receiving a malicious score.