### PR TITLE
EWS: Fixed Exchange 2010 issue with folder fields.

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -402,7 +402,7 @@ script:
                        repr((self.account, '[self]', self.name, self.total_count, self.child_folder_count, self.folder_class, self.changekey))
 
             exchangelib.Folder.__repr__ = repr1
-            exchangelib.folders.Inbox.__repr__ = repr2
+            exchangelib.folders.Inbox.__repr__ = exchangelib.folders.JunkEmail.__repr__ = repr2
             exchangelib.folders.Root.__repr__ = repr3
 
         start_logging()
@@ -2344,6 +2344,7 @@ script:
   dockerimage: demisto/py-ews:2.0
   isfetch: true
   runonce: false
+releaseNotes: "Fixed issue with 2016-2010 mixed environments"
 tests:
   - pyEWS_Test
   - 'EWS search-mailbox test'


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14969

## Description
Exchange 2010 has some compatibility issues which are fixed in the `fix_2010()` function.

## Screenshots
In the issue

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests - No environment
- [ ] Documentation (with link to it) - Nothing to document
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Collected the following tests:
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] pyEWS_Test
- [x] EWS search-mailbox test
- [ ] Phishing test - Inline
- [x] process_email_-_generic_-_test