### PR TITLE
Context path for reputation values - new context paths, cleanup, test script + test playbook

### DIFF
--- a/Misc/reputations.json
+++ b/Misc/reputations.json
@@ -32,9 +32,10 @@
       "regex": "\\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\b",
       "reputationCommand": "ip",
       "details": "IP",
+      "contextValue": "Address",
+      "contextPath": "IP(val.Address && val.Address === obj.Address)",
       "enhancementScriptNames": [
-        "IPReputation",
-        "SplunkSearch"
+        "IPReputation"
       ],
       "fromVersion": "3.1.0"
     },
@@ -44,9 +45,10 @@
       "regex": "\\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\[\\.\\]){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\b",
       "reputationCommand": "ip",
       "details": "IP",
+      "contextValue": "Address",
+      "contextPath": "IP(val.Address && val.Address === obj.Address)",
       "enhancementScriptNames": [
         "IPReputation",
-        "SplunkSearch",
         "SplunkPySearch"
       ],
       "formatScript": "UnEscapeIPs",
@@ -71,10 +73,10 @@
       "regex": "\\b[a-fA-F\\d]{32}\\b",
       "reputationCommand": "file",
       "details": "File MD5",
+      "contextValue": "MD5",
+      "contextPath": "File(val.MD5 && val.MD5 === obj.MD5)",
       "enhancementScriptNames": [
         "FileReputation",
-        "SplunkSearch",
-        "WildfireReport",
         "SplunkPySearch"
       ],
       "fromVersion": "3.1.0"
@@ -98,10 +100,10 @@
       "regex": "\\b[a-fA-F\\d]{40}\\b",
       "reputationCommand": "file",
       "details": "File SHA1",
+      "contextValue": "SHA1",
+      "contextPath": "File(val.SHA1 && val.SHA1 === obj.SHA1)",
       "enhancementScriptNames": [
         "FileReputation",
-        "SplunkSearch",
-        "WildfireReport",
         "SplunkPySearch"
       ],
       "fromVersion": "3.1.0"
@@ -115,8 +117,7 @@
       "contextValue": "SHA256",
       "contextPath": "File(val.SHA256 && val.SHA256 === obj.SHA256)",
       "enhancementScriptNames": [
-        "FileReputation",
-        "SplunkSearch"
+        "FileReputation"
       ],
       "fromVersion": "3.1.0"
     },
@@ -164,7 +165,6 @@
       "details": "URL",
       "enhancementScriptNames": [
         "URLReputation",
-        "SplunkSearch",
         "SplunkPySearch"
       ],
       "formatScript": "UnEscapeURLs",
@@ -237,6 +237,8 @@
       "regex": "(?i)(?:(?:https?|ftp|hxxps?):\\/\\/|www\\[?\\.\\]?|ftp\\[?\\.\\]?)(?:[-A-Z0-9]+\\[?\\.\\]?)+[-A-Z0-9]+(?::[0-9]+)?(?:(?:\\/|\\?)[-A-Z0-9+&@#\\/%=~_$?!\\-:,.\\(\\);]*[A-Z0-9+&@#\\/%=~_$\\(\\);])?|\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
       "reputationCommand": "domain",
       "details": "Domain",
+      "contextValue": "Name",
+      "contextPath": "Domain(val.Name && val.Name === obj.Name)",
       "enhancementScriptNames": [
         "DomainReputation"
       ],

--- a/TestPlaybooks/playbook-Autoextract_-_Test.yml
+++ b/TestPlaybooks/playbook-Autoextract_-_Test.yml
@@ -1,0 +1,683 @@
+id: Autoextract - Test
+version: -1
+name: Autoextract - Test
+description: |-
+  This is a test playbook for the sole function of auto-extract. It tests if auto-extract finds indicators and puts them in context, by printing them to the war room.
+  The test currently tests auto-extract on:
+  - IPs
+  - Escaped IPs
+  - URLs
+  - Escaped URLs
+  - MD5 hash
+  - SHA1 hash
+  - SHA256 hash
+  - Email addresses
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 2fe21461-bf20-4252-87d9-9cc8936634c4
+    type: start
+    task:
+      id: 2fe21461-bf20-4252-87d9-9cc8936634c4
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+  "1":
+    id: "1"
+    taskid: ea8daebe-5b96-4418-8ed6-5063f0d45f55
+    type: regular
+    task:
+      id: ea8daebe-5b96-4418-8ed6-5063f0d45f55
+      version: -1
+      name: Delete context
+      description: Deletes the context to start the test with a clean context.
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 200
+        }
+      }
+    note: false
+    timertriggers: []
+  "2":
+    id: "2"
+    taskid: 6b41e663-db7a-4bad-8666-995e93a83da3
+    type: regular
+    task:
+      id: 6b41e663-db7a-4bad-8666-995e93a83da3
+      version: -1
+      name: Print indicators
+      description: Prints indicators to the war room and lets auto-extract put them
+        in context.
+      scriptName: autoextract_test
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "17"
+      - "3"
+      - "8"
+      - "11"
+      - "15"
+    reputationcalc: 2
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "3":
+    id: "3"
+    taskid: e6d0c59e-21d1-4cca-8bff-d9ad1c87f54f
+    type: condition
+    task:
+      id: e6d0c59e-21d1-4cca-8bff-d9ad1c87f54f
+      version: -1
+      name: Were the IP addresses extracted?
+      description: Checks whether the internal, external and escaped IP addresses
+        that were printed are found in context.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "22"
+      "yes":
+      - "23"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: IP
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: IP.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 98.222.222.9
+                accessor: Address
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: IP
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: IP.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 23.223.223.233
+                accessor: Address
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: IP
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: IP.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 172.16.0.10
+                accessor: Address
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: IP
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: IP.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 111.11.11.111
+                accessor: Address
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 1280
+        }
+      }
+    note: false
+    timertriggers: []
+  "8":
+    id: "8"
+    taskid: 549fc882-fd38-432e-8059-1a1fd8f644e3
+    type: condition
+    task:
+      id: 549fc882-fd38-432e-8059-1a1fd8f644e3
+      version: -1
+      name: Were the URLs extracted?
+      description: Checks whether the URLs and escaped URLs that were printed are
+        found in context.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "22"
+      "yes":
+      - "23"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: URL
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: URL.Data
+                      iscontext: true
+                    right:
+                      value:
+                        simple: http://www.thisurlwillneverexist4444.co.il
+                    ignorecase: true
+                accessor: Data
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: URL
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: URL.Data
+                      iscontext: true
+                    right:
+                      value:
+                        simple: http://www.thisoneshouldnotexisteither4444.com
+                    ignorecase: true
+                accessor: Data
+            iscontext: true
+          ignorecase: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: URL
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: URL.Data
+                      iscontext: true
+                    right:
+                      value:
+                        simple: http://www.letsseeifyoucanfindthisone4444.co.il
+                accessor: Data
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 1110
+        }
+      }
+    note: false
+    timertriggers: []
+  "11":
+    id: "11"
+    taskid: b4c3ac46-08cc-407e-87f1-b0a1dd5d46b4
+    type: condition
+    task:
+      id: b4c3ac46-08cc-407e-87f1-b0a1dd5d46b4
+      version: -1
+      name: Were the hashes extracted?
+      description: Checks whether the MD5, SHA1 and SHA256 hashes that were printed
+        are found in context.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "22"
+      "yes":
+      - "23"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.MD5
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 999d8c71dd6dddd77777777b85734318
+                    ignorecase: true
+                accessor: MD5
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.MD5
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 44f03f1a5280bbb7f4c2550b222bb88c
+                    ignorecase: true
+                accessor: MD5
+            iscontext: true
+          ignorecase: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.SHA256
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 0a92f2312a95f807fd192c9c25cb6ae502b564c9a8ae013ff88888888ff77ddd
+                    ignorecase: true
+                accessor: SHA256
+            iscontext: true
+          ignorecase: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.SHA256
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 1ebf92fc2cb3cf75da3131ef3b13abf36a90fa7aaff3a2451f99999a122aaabb
+                    ignorecase: true
+                accessor: SHA256
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.SHA1
+                      iscontext: true
+                    right:
+                      value:
+                        simple: bc44444dd6f5c1111ffbbb139e2af09db9f0000d
+                accessor: SHA1
+            iscontext: true
+          ignorecase: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.SHA1
+                      iscontext: true
+                    right:
+                      value:
+                        simple: 444444c6cccc250e98be5c2ed5346f79dc333dd4
+                accessor: SHA1
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 750
+        }
+      }
+    note: false
+    timertriggers: []
+  "15":
+    id: "15"
+    taskid: bf681094-49c7-4ccf-8719-721be65759fb
+    type: condition
+    task:
+      id: bf681094-49c7-4ccf-8719-721be65759fb
+      version: -1
+      name: Were the email addresses extracted?
+      description: Checks whether the email addresses that were printed are found
+        in context.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "22"
+      "yes":
+      - "23"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Account
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Account.Email.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: iamtheeggman@demisto.com
+                    ignorecase: true
+                accessor: Email.Address
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Account
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Account.Email.Address
+                      iscontext: true
+                    right:
+                      value:
+                        simple: iamthewalrus@demisto.com
+                    ignorecase: true
+                accessor: Email.Address
+            iscontext: true
+          ignorecase: true
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 570
+        }
+      }
+    note: false
+    timertriggers: []
+  "17":
+    id: "17"
+    taskid: 4a63db05-d3ae-49e1-81e2-a44c0ad68eea
+    type: condition
+    task:
+      id: 4a63db05-d3ae-49e1-81e2-a44c0ad68eea
+      version: -1
+      name: Were the domains extracted?
+      description: Checks whether domains were extracted from URLs and email addresses
+        that were printed to context.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "22"
+      "yes":
+      - "23"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Domain
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Domain.Name
+                      iscontext: true
+                    right:
+                      value:
+                        simple: thisurlwillneverexist4444.co.il
+                    ignorecase: true
+                accessor: Name
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Domain
+                filters:
+                - - operator: containsGeneral
+                    left:
+                      value:
+                        simple: Domain.Name
+                      iscontext: true
+                    right:
+                      value:
+                        simple: thisoneshouldnotexisteither4444.com
+                    ignorecase: true
+                accessor: Name
+            iscontext: true
+          ignorecase: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Domain
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Domain.Name
+                      iscontext: true
+                    right:
+                      value:
+                        simple: letsseeifyoucanfindthisone4444.co.il
+                accessor: Name
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Domain
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Domain.Name
+                      iscontext: true
+                    right:
+                      value:
+                        simple: demisto.com
+                    ignorecase: true
+                accessor: Name
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 935
+        }
+      }
+    note: false
+    timertriggers: []
+  "22":
+    id: "22"
+    taskid: 7e852556-2c01-4abd-84e0-37102eee07ef
+    type: regular
+    task:
+      id: 7e852556-2c01-4abd-84e0-37102eee07ef
+      version: -1
+      name: Make test fail
+      description: Fail the test if not all indicators were extracted.
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "24"
+    scriptarguments:
+      message:
+        simple: Extraction of an indicator has failed. Check which indicators were
+          not found in the previous conditions of the playbook.
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -190,
+          "y": 1495
+        }
+      }
+    note: false
+    timertriggers: []
+  "23":
+    id: "23"
+    taskid: 41880aab-f713-4c35-828e-7cc62077b61e
+    type: title
+    task:
+      id: 41880aab-f713-4c35-828e-7cc62077b61e
+      version: -1
+      name: All Indicators Extracted
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "24"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1080,
+          "y": 1510
+        }
+      }
+    note: false
+    timertriggers: []
+  "24":
+    id: "24"
+    taskid: 18f01873-bf58-4fe0-8bed-3c649c3dbfff
+    type: title
+    task:
+      id: 18f01873-bf58-4fe0-8bed-3c649c3dbfff
+      version: -1
+      name: Done
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 440,
+          "y": 1670
+        }
+      }
+    note: false
+    timertriggers: []
+view: |-
+  {
+    "linkLabelsPosition": {
+      "11_22_#default#": 0.36,
+      "11_23_yes": 0.4,
+      "15_22_#default#": 0.31,
+      "15_23_yes": 0.35,
+      "17_22_#default#": 0.42,
+      "17_23_yes": 0.7,
+      "3_22_#default#": 0.63,
+      "3_23_yes": 0.72,
+      "8_22_#default#": 0.5,
+      "8_23_yes": 0.55
+    },
+    "paper": {
+      "dimensions": {
+        "height": 1685,
+        "width": 1650,
+        "x": -190,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/TestPlaybooks/script-autoextract_test.yml
+++ b/TestPlaybooks/script-autoextract_test.yml
@@ -1,0 +1,38 @@
+commonfields:
+  id: autoextract_test
+  version: -1
+name: autoextract_test
+script: |
+
+  ###  Creating fake data ###
+  ip_context_output = ["98.222.222.9", "23.223.223.233", "172.16.0.10"]  # External + internal
+  ipescaped_context_output = ["111[.]11[.]11[.]111"]
+  url_context_output = ["http://www.thisurlwillneverexist4444.co.il", "www.thisoneshouldnotexisteither4444.com"]
+  urlescaped_context_output = ["hxxp://www.letsseeifyoucanfindthisone4444.co.il"]
+  md5_context_output = ["999d8c71dd6dddd77777777b85734318", "44f03f1a5280bbb7f4c2550b222bb88c"]
+  sha1_context_output = ["bc44444dd6f5c1111ffbbb139e2af09db9f0000d", "444444c6cccc250e98be5c2ed5346f79dc333dd4"]
+  sha256_context_output = ["0a92f2312a95f807fd192c9c25cb6ae502b564c9a8ae013ff88888888ff77ddd", "1ebf92fc2cb3cf75da3131ef3b13abf36a90fa7aaff3a2451f99999a122aaabb"]
+  email_context_output = ["iamtheeggman@demisto.com", "iamthewalrus@demisto.com"]
+
+  ###  Aggregating all indicator data ###
+  indicator_data = ip_context_output + ipescaped_context_output + url_context_output + urlescaped_context_output + md5_context_output +\
+  sha1_context_output + sha256_context_output + email_context_output
+
+
+  ###  Printing humanreadable to the war room, for auto-extract to work on ###
+  demisto.results( {
+      'Type': entryTypes['note'],
+      'ContentsFormat': formats['text'],
+      'Contents': indicator_data,
+      'HumanReadable': indicator_data
+                   })
+type: python
+tags:
+- autoextract
+comment: Prints different types of "fake", or made up indicators, to the war room.
+  This script is used to test the bare function of auto-extract, without the help
+  of any integration enrichment.
+enabled: true
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1029,7 +1029,8 @@
         "Lastline": "Out of quota",
         "Netskope": "instance is down",
         "Joe Security": "Reached number of allowed submissions per month, untill 1/2/19",
-        "Google Resource Manager": "Cannot create projects because have reached alloted quota"
+        "Google Resource Manager": "Cannot create projects because have reached alloted quota",
+        "RSA NetWitness Endpoint": "Instance is down, waiting for devops to rebuild"
     },
     "nigthly_integrations": [
         "Lastline",

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -15562,6 +15562,16 @@
                     "query": "mysql"
                 }
             }
+        }, 
+        {
+            "Autoextract - Test": {
+                "name": "Autoextract - Test", 
+                "implementing_scripts": [
+                    "autoextract_test", 
+                    "DeleteContext", 
+                    "PrintErrorEntry"
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14953

## Description
This change should fix problems resulting from indicator types not being put into context.
The following indicator types should now be put into context as part of the **auto-extract** process, **regardless of available integrations / calculated reputations.**

- Added context path for reputation values for:
MD5 hash
SHA1 hash
SHA256 hash (from referenced PR, and now removed a deprecated script from it too)
IP
Escaped IP
Domain

- Removed deprecated enhancementScriptNames from all of the above

- Replaced old `reputationScriptName` with the new `reputationCommand` (e.g., "IPReputation" will not be used. "!ip" will).

- Added test script + test playbook for:
Email addresses
MD5 hash
SHA1 hash
SHA256 hash
Domains from URL
Domain from email address
URLs
Escaped URLs
IPs
Escaped IPs

## Related PRs
Related to: https://github.com/demisto/content/pull/2886 (completes the process)

## Does it break backward compatibility?
   - No

## Additional changes
Did not make changes to pre-3.0.1 values.
