### PR TITLE
EWS: Fixed filter in search_mailboxes function

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -585,7 +585,6 @@ script:
             return result
 
         def call(self, query, mailboxes):
-            query = query.replace(".", "\\.")
             if self.protocol.version.build < EXCHANGE_2013:
                 raise NotImplementedError('%s is only supported for Exchange 2013 servers and later' % self.SERVICE_NAME)
             elements = list(self._get_elements(payload=self.get_payload(query, mailboxes)))


### PR DESCRIPTION
## Status
Ready

## Description
Removed unnecessary escape character of dot in `SearchMailboxes.call` function.
Escaping the dot character caused breaking the search query and thus search results were filtered incorrectly.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Tests:
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] pyEWS_Test
- [x] Process Email - Generic - Test
- [x] EWS search-mailbox test
- [x] Get Original Email - EWS - Test
- [x] Phishing test - Inline

