### PR TITLE
Changes to phishing test to prevent VT quota errors

### DIFF
--- a/TestData/Inline_malicious_url.eml
+++ b/TestData/Inline_malicious_url.eml
@@ -1,0 +1,155 @@
+Received: from SN1PR11MB0447.namprd11.prod.outlook.com (2603:10b6:805:66::33)
+ by SN6PR11MB3183.namprd11.prod.outlook.com with HTTPS via
+ SN6PR08CA0020.NAMPRD08.PROD.OUTLOOK.COM; Tue, 29 Jan 2019 11:31:40 +0000
+Authentication-Results: demisto.com; dkim=none (message not signed)
+ header.d=none;demisto.com; dmarc=none action=none header.from=demisto.com;
+Received: from SN1PR11MB0638.namprd11.prod.outlook.com (10.163.132.152) by
+ SN1PR11MB0447.namprd11.prod.outlook.com (10.162.103.27) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.20.1558.17; Tue, 29 Jan 2019 11:31:39 +0000
+Received: from SN1PR11MB0638.namprd11.prod.outlook.com
+ ([fe80::4017:daf9:8d97:93bb]) by SN1PR11MB0638.namprd11.prod.outlook.com
+ ([fe80::4017:daf9:8d97:93bb%3]) with mapi id 15.20.1558.023; Tue, 29 Jan 2019
+ 11:31:39 +0000
+From: Ido Van Dijk <idov@demisto.com>
+To: Bar Hochman <Bar.Hochman@demisto.com>
+Subject: malicious url for phishing
+Thread-Topic: malicious url for phishing
+Thread-Index: AdS3xjLcldTZL078S/aGNuo9SuFq4g==
+Date: Tue, 29 Jan 2019 11:31:39 +0000
+Message-ID:
+ <SN1PR11MB0638D849680E1325BC4F7951CC970@SN1PR11MB0638.namprd11.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-Exchange-Organization-SCL: -1
+X-MS-TNEF-Correlator:
+ <SN1PR11MB0638D849680E1325BC4F7951CC970@SN1PR11MB0638.namprd11.prod.outlook.com>
+MIME-Version: 1.0
+X-MS-Exchange-Organization-MessageDirectionality: Originating
+X-MS-Exchange-Organization-AuthSource: SN1PR11MB0638.namprd11.prod.outlook.com
+X-MS-Exchange-Organization-AuthAs: Internal
+X-MS-Exchange-Organization-AuthMechanism: 04
+X-Originating-IP: [94.188.164.68]
+X-MS-Exchange-Organization-Network-Message-Id:
+ 699f5756-cbd0-469c-e523-08d685dd5616
+X-MS-PublicTrafficType: Email
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0638;35:Tf/r5Wjn6tg+Lqjd0jaknDpq0yAZYNPjCYM1o/B7zUO85GJRAuIUFeGzDWvUiHFXH/Zv10MrqPQOuNopKlL4GA==
+Return-Path: idov@demisto.com
+X-MS-Exchange-Organization-ExpirationStartTime: 29 Jan 2019 11:31:39.8667
+ (UTC)
+X-MS-Exchange-Organization-ExpirationStartTimeReason: OriginalSubmit
+X-MS-Exchange-Organization-ExpirationInterval: 2:00:00:00.0000000
+X-MS-Exchange-Organization-ExpirationIntervalReason: OriginalSubmit
+X-MS-Office365-Filtering-Correlation-Id: 699f5756-cbd0-469c-e523-08d685dd5616
+X-Microsoft-Antispam:
+ BCL:0;PCL:0;RULEID:(2390118)(7020095)(4652040)(8989299)(4534185)(4627221)(201703031133081)(201702281549075)(8990200)(5600110)(711020)(4605077)(2017052603328)(7153060)(7193020);SRVR:SN1PR11MB0447;
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0447;3:K0P93rz9gA1WT2+F31p1mNi8tWpwOslj8Llg/47eGCSoEiT7HNzq3nuBknPHGfu6NtF207+zCZwKVhtBxAGyv/1F62g9szKaPb0Q90N8XZtOrfJ1J2ejghj58TmO0F5LYPudKellsKIVxeWaoV6t/qxkavThBg20pppj95Thn1mg4cdOopeYQ6tmIJp/OGyYtFLBPW2Ul9orTPjtaAxYas9G/n4Xuj6m/usXZUjEJakcfDYv9uYzRyV24zRyzUFAhCOW5b21T8FB7qGJNvwH6Q==;25:nICHBBEMy3vHG+W6fV8nk9JFibEeULrdZ0sfq88E/SIK+FeoSsM4Mu5rpdBZ4kDNEMNWqYZ9/Qeq1w9xY4puonrHdkGCyfGPI8ihf3iTGh10mq9kHdpUTYpSSiZFDUFltb/iNtweO9mapgtl0ANRaAI/GLuCqNfp8hg3Ro88GBsB6WbiX9w4KBzHeVHUdGrA5SYYteMTTWcmrLM13HZ3SuVWlnlpHWzAuE3QH+uyd6peEC/M8vxg/asgvDLJ1fw1JWmQKHYO5kMkLR67Ts7ug66KdQl4+2v0+mvTcJO1OpXif6E0tXI1wQ0TmVULncPwbrfRKjm+OftxvsVIB97oLyg1f+xCHPWZPCbrOPRo9Mc=;31:wxumPLMQad8Wc02trkWRvmRVJVm+dTek9fVwIVZWUurVbwsZDAgrG8NJx+lxODgo5IzcHNrmpQKSBX2YhWTIgTFm5UoqAFHJWR9dmd+k2893K1quuG/sJjRYjjwv7Nrkmi80N1ZQeXYXd7WGtrkdZrg+efxo9hn94uB/xRreR0bWh+UwvT6Bx+tcRJ1tAjCan2wqQ5sYE9Cm+1HCCSgrEXukSzGEKqtfTrsL7zUhFXg=
+X-MS-TrafficTypeDiagnostic: SN1PR11MB0447:
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0447;20:g/wqzdbrfuLKUAPeLG1aK381jfIjzXeRz5yqr7R2Fevm87Qu5iyuEXF4swtLKMtYaMAKVu5QwDtGuIXyE40iePL5Ac1uOnsbCUNL+CUlYzAy9dG0eHZ9qTTzbFNRR6Xo0XYBPf4GI3MNZ2z0hQCT7qlTwZdp1SNCUqKZ8E2ItfE=;4:D/oxD4aU1rME55swKUM/976EquMyd6CFQGNvBQ0Nhqq5CRtP9eq6o0s25UAri2+E6F2PtRTX2jHV/6GGuyqALhrykgj+OykzFQ/qTLrilnuIVW9t7M6knEt8B5YkY9MPpLqDDaDKL9x07gfWUf6hi1WCGdGQnBFeGIENyTFyVvUkEKM6ybpC6u+Bah2ZdWLMBAOLizNzgGEgsWcnZJ0lZlFbHZqWL1njlkWFUGnZawEYmc1P/MDnOLP4mW9RNaPPY/jMpRinBhOSsR4S2msjFILExXhxl9FljO8/xAY64FQ=;23:PNKyhEBUnTQdb8ir85orr4BSsEJRqtESLltcVHC7ms47AX5WoPWbrnSeWgAgmNZ3zYrk93RRegvZZdqwP+xyeQdH8J2CZ4VfEzas3yflr8mW84aVlcmApfbO5vhq9KEIW3MoCePFd0OrhYrdB6RN+g==
+X-Forefront-Antispam-Report:
+ SFV:SKI;SFS:;DIR:INB;SFP:;SCL:-1;SRVR:SN1PR11MB0447;H:SN1PR11MB0638.namprd11.prod.outlook.com;FPR:;SPF:None;LANG:en;
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0447;6:oAzQkldPA1e0j7mKPhIz4IYc0LnUvdUOY39OKz/5BkfoFvXoDUGeswA1Am4DsB8jP4JBbOjjUnFawoQd6rEQl9V7yz/R5q4kiui+GZw9lcu44zo0scOulqrGCChmYwIBdZrA2ag3O27QtmOBJYnY4BSflnCIFCKkKFpcSxjuSsqP+2SeLd3gcXpWjTE7EPgXeHp99eVt+xBjspyRXziKBvb0y0zbeOggTRQBLFQcPpQLPm3293woBf+1vIoo19+S01UpA1CTn+viwCgXHTyUCrEp8n3IZ/7ry4vCJKRK+5PE1SAOYEhv43mow6LYFXekX3ct69sNvf74uD1/pLPzkFnr8X0bDX1FMG9gVk5E1RXxF78Ih2GKO2duAKG4eAgVu9IqvrI6QYezdTU+tmputmQsDA3h7RFg+66a//Oh1+ow52zyVcADI4KzxVcXInsF8aIXwPCZsq9vuGA/rn9XZQ==;5:6PD+YTpsSuuqv9Nmtv5ACCCCqWQrdH7zSPGDw1TvQUNGkhwBZF2ebPhZu65dSVVKqLvOnUnXVcHmXHofPVKZX3qfXguTeZqqcaMztc26IY3P7+sLvyLVDv0Wp/yCghUXOPOVVJT7t5N33vSENwfSEjNpacbELHsN23n+k7HRNL4W5MUMC6gRRAjCN2x3yO+5YWQYErMfi4tajvLCnh6vhQ==;7:VzO3EBYCB1ITDgPNP/1TtJYfEX/1I8RRUqfcdOsGJm0STGBfrkroxw0jfwXOKv9E8K+INK1fZp5tVSJYZymou9ja2/U3BvzV0klHnuleNzezhRswjVHtulZSE+JGRfEHReXucCBNJoVHqllWtWZMOw==
+X-MS-Exchange-CrossTenant-OriginalArrivalTime: 29 Jan 2019 11:31:39.7173
+ (UTC)
+X-MS-Exchange-CrossTenant-FromEntityHeader: Hosted
+X-MS-Exchange-CrossTenant-Id: 0d6161d7-4be3-4abd-90f9-d94f81b27dd3
+X-MS-Exchange-CrossTenant-Network-Message-Id: 699f5756-cbd0-469c-e523-08d685dd5616
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: SN1PR11MB0447
+X-MS-Exchange-Transport-EndToEndLatency: 00:00:00.4309480
+X-MS-Exchange-Processed-By-BccFoldering: 15.20.1558.000
+X-Microsoft-Exchange-Diagnostics:
+	1;SN6PR11MB3183;9:jeeqHDL4HjTOrRwCKz0gtX6W9F7paayIgZqh/FHPMpinmZHR8D1uwic3K9DcZLryUoBUI4jvs88nC7ycree7mX1DUOPx+nZEaeao3JFYAATcyGMAfLmL+GyANX7ON38gj/YLjK5p09bHRIxwW0SSIrR5Ce1w3bEcq+CDmC7Z4eI=
+X-Microsoft-Antispam-Mailbox-Delivery:
+	ucf:0;jmr:0;ex:0;auth:0;dest:I;ENG:(750119)(520011016)(706158)(944506303)(944626516);
+X-Microsoft-Antispam-Message-Info:
+	6gyEmTUI2ANUXSwOf1jFxTvynwCO+CQithKELZCs97FblOdLMVtP3nfakuIRU/EpwXqBhtMSIKTRHX84mfsDKHW325FmqP4Gupfw1u7Bi92xlJkrwN1fPXg2JwSz+hysiuCv+2nzDOMIunwPzPvdiHubvPOgF3jtlTSAoSif8gkBu1/zEuHQvQSpTPy0bdMqOCAUNDyJ6YRqc2WHpxsOd6rXyRnwdkFEubRO120sPESQ7Oe6jIANERl0GTyC8Su95nh1D56x1cUTQPx7BjeDUHvV3kKIf8BqzCDr2oxQUBEOl0NrXgi8LfjLidbuEL5nIw71gSLS9A/ui3A97PvENhCPbP3D4XGeJIDvPzK2rmJCAZjpv6het31iG7Y2yrt1XS9r6DtGCMKGDEQNKnqCNsJoXJZLoxyj1d6ccj7mWafsY8B1oZ232DhgSVUMCXvUR86a1KgZW6NC0Y6spnkVG2VUDGkofnseGXdzNOrSySfWgIQwKCaCZIRKsDdeOqFyCIry5QxDulwe2uHXyBUM1gQ4YAIWh6L+Ma3VgS8z0IvY/f4D4/rOxoEoBks/dOowzJCMCqgZePzBzoHyAyElelSzjkPNUu+9y1WNyBs7jHsVuowbEQGcvxzCKA1jmH1eWtfv71ajvqehWjDJLAvFptB3AvczQeuZDsZFo9aBIw4WnvyQK7WzRmssj72i99kE
+X-Microsoft-Exchange-Diagnostics:
+	1;SN6PR11MB3183;27:TVNna5TIlOcwikEenyR58UD1kQD6mRab/itIpfVzrTx6kTKM9s/NHnfZroAWnjLGrs93Y4F2CnCFlsh7kRJ/h5KWExfuL9EQ9kSl/hnqYVmJVs2Y7r5+FGFHUPAX4eYA4LkVpBnHsBoddN8t/pHbFbgifmaR8rAyHpLwhQ9bURkNvOaqUssDE94TzQG20P3/hgMMX/gMKzAhXHD0B12CW5hFY1RqqgJ0xfkP0PYTe5X6yTTZbY2bazyPCSwcTXs0vbLG4k1sDsFfzpjPinl6Y3ih6iVTOQtp66xgQDN06NdbufP2yUWDVuDHsOk5KyO1wCQFklUEJxc7yBBy6nCj1XStewHq+wYGPLqdpNpC7xi6Kgdz4igVhkHWiVvNhhBZgliTD1vafPowarF6ZOSkTwLhN8/DI5+2326FNLoDa6I=
+Content-type: multipart/alternative;
+	boundary="B_3631613801_1400590922"
+
+> This message is in MIME format. Since your mail reader does not understand
+this format, some or all of this message may not be legible.
+
+--B_3631613801_1400590922
+Content-type: text/plain;
+	charset="UTF-8"
+Content-transfer-encoding: 7bit
+
+http://tpb.crushus.com/www.paperstreetcash.com
+
+ 
+
+
+--B_3631613801_1400590922
+Content-type: text/html;
+	charset="UTF-8"
+Content-transfer-encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-microsof=
+t-com:office:office" xmlns:w=3D"urn:schemas-microsoft-com:office:word" xmlns:m=
+=3D"http://schemas.microsoft.com/office/2004/12/omml" xmlns=3D"http://www.w3.org=
+/TR/REC-html40">
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dutf-8">
+<meta name=3D"Generator" content=3D"Microsoft Word 15 (filtered medium)">
+<style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:#0563C1;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:#954F72;
+	text-decoration:underline;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri",sans-serif;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]-->
+</head>
+<body lang=3D"en-IL" link=3D"#0563C1" vlink=3D"#954F72">
+<div class=3D"WordSection1">
+<p class=3D"MsoNormal"><span lang=3D"en-IL"><a href=3D"http://tpb.crushus.com/www=
+.paperstreetcash.com">http://tpb.crushus.com/www.paperstreetcash.com</a><o:p=
+></o:p></span></p>
+<p class=3D"MsoNormal"><span lang=3D"en-IL"><o:p>&nbsp;</o:p></span></p>
+</div>
+</body>
+</html>
+
+
+--B_3631613801_1400590922--
+

--- a/TestData/attachment_malicious_url.eml
+++ b/TestData/attachment_malicious_url.eml
@@ -1,0 +1,168 @@
+Received: from SN1PR11MB0910.namprd11.prod.outlook.com (2603:10b6:805:3e::47)
+ by SN6PR11MB3183.namprd11.prod.outlook.com with HTTPS via
+ SN6PR04CA0034.NAMPRD04.PROD.OUTLOOK.COM; Tue, 29 Jan 2019 11:43:24 +0000
+Authentication-Results: demisto.com; dkim=none (message not signed)
+ header.d=none;demisto.com; dmarc=none action=none header.from=demisto.com;
+Received: from SN1PR11MB0638.namprd11.prod.outlook.com (10.163.132.152) by
+ SN1PR11MB0910.namprd11.prod.outlook.com (10.164.25.28) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.20.1558.17; Tue, 29 Jan 2019 11:43:23 +0000
+Received: from SN1PR11MB0638.namprd11.prod.outlook.com
+ ([fe80::4017:daf9:8d97:93bb]) by SN1PR11MB0638.namprd11.prod.outlook.com
+ ([fe80::4017:daf9:8d97:93bb%3]) with mapi id 15.20.1558.023; Tue, 29 Jan 2019
+ 11:43:23 +0000
+From: Ido Van Dijk <idov@demisto.com>
+To: Bar Hochman <Bar.Hochman@demisto.com>
+Subject: Malicious url present for you
+Thread-Topic: Malicious url present for you
+Thread-Index: AdS3x9DrNG8HlwWxQYalcba8lnbVZQ==
+Date: Tue, 29 Jan 2019 11:43:23 +0000
+Message-ID:
+ <SN1PR11MB0638E0FE698BFE52F27748A8CC970@SN1PR11MB0638.namprd11.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Has-Attach: yes
+X-MS-Exchange-Organization-SCL: -1
+X-MS-TNEF-Correlator:
+ <SN1PR11MB0638E0FE698BFE52F27748A8CC970@SN1PR11MB0638.namprd11.prod.outlook.com>
+MIME-Version: 1.0
+X-MS-Exchange-Organization-MessageDirectionality: Originating
+X-MS-Exchange-Organization-AuthSource: SN1PR11MB0638.namprd11.prod.outlook.com
+X-MS-Exchange-Organization-AuthAs: Internal
+X-MS-Exchange-Organization-AuthMechanism: 04
+X-Originating-IP: [94.188.164.68]
+X-MS-Exchange-Organization-Network-Message-Id:
+ 496ef15d-0d77-4d17-44fb-08d685def9b7
+X-MS-PublicTrafficType: Email
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0638;35:mdyNhy0DKPE8ZUV2NfRdLB/wTsBbChxWFbDSkWRXe4YFm/iTfbKzBGjyxBs96RTsorjNS6UvJyNwnoBgDnL20A==
+Return-Path: idov@demisto.com
+X-MS-Exchange-Organization-ExpirationStartTime: 29 Jan 2019 11:43:23.9647
+ (UTC)
+X-MS-Exchange-Organization-ExpirationStartTimeReason: OriginalSubmit
+X-MS-Exchange-Organization-ExpirationInterval: 2:00:00:00.0000000
+X-MS-Exchange-Organization-ExpirationIntervalReason: OriginalSubmit
+X-MS-Office365-Filtering-Correlation-Id: 496ef15d-0d77-4d17-44fb-08d685def9b7
+X-Microsoft-Antispam:
+ BCL:0;PCL:0;RULEID:(2390118)(7020095)(4652040)(8989299)(4534185)(4627221)(201703031133081)(201702281549075)(8990200)(5600110)(711020)(4605077)(2017052603328)(7153060)(49563074)(7193020);SRVR:SN1PR11MB0910;
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0910;3:tBt5vCRic7GG1vC1rcgEOwS4w/jYwuKmlOeGfFCJN0Q/GOx4ydec648epcPLp66JaKd5CBp2Pz6viSU0mWZ9kacxMn/fvX+p+m9tJWBaVga0cDF5om3r7DzI7w//0W5GAJ7C73j8zOQzcPFU0rnM72ho9dpM4PSvl5Bz2ylwF1nljEU1b+Ko1VmofKmFQS4sQWmrUr+NYqU1VgC3HsBGqComP5mX/iXKPsXG4nY9Egk0xcZ0oChxV6ZVPO4PO8OE9EHREaq0Ju6vuUsZU0vo4g==;25:c6lLmJ6Uj15LncshchXXyYCJbotHoiMtVQ3TetO0ypJSZrqyuyUPk0lraM87hFXBGp0XBLAK5TpakweLdNoDCXERZkQbhvVDdnu5pwnV8THGAc4aSp68sXz1Qe1ndMmXx/axSaq6iYCIlgT5Wf539Dw0YE2GMVYQN6ADv3Srj16gR1yzHtnz1C6xXHJScfOFYC8N7uotX7jxWNMasB2ZOiHJHwSDRb2C7zCwArjXmlrgvhr3I0osxFBDodS4LDkVnXemlsH3euGV99tfpQQiecntX0AMJ7QzfLd7j6Fo5U6xfTYgaLBCguJsr3WaMBCCJhwd31CFP/H6Bp6odobLivyuC66XdC44gsUroer/ImI=;31:lI3aNegdtU5Pp4ZV43xjgri83hUAdQVNy5HbKAHvq29Zia21g79nw+4YnoqI1C5YY5beMx+btdVI3M5mYfj3rwDDJ0lE/Ajuj5hJwkFw82VWqmpYTDGOqPXPR4AnAZfMgfpC9Pvl1x3bT4+ZVc2g/5/rRMv7fX/mU2kzyo2iNy3GE1DK3RY+lgHvOMaWKnWsXSEYaAyt2AJzFdGoio52VSoh89fanU8RUM4lUhG39kg=
+X-MS-TrafficTypeDiagnostic: SN1PR11MB0910:
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0910;20:VEqp+v+HjWp2m5r8fS653DXOke0ZsnXxlXbMzZ/z1sHeWQXLza//695DOsXttkGHfwW3zX0nv2C5DorVc8tw8MZM8b/ysCwfx7M6zoEVW1VC8RjuLMJfaBugMW2bRfQSkvdoTC3g///5A/5bR9qZJ18l+f3Sd1zC+9VqQAA8shk=;4:QWVUFA+fH8Zg6ytKMhC3CnXjWlR97cxrDvfDWzp3Zq+tCJXI5h/F7nhjjyO//A5ogd/WwKJOPXsIGszZ4q5u6TStx7YWGwOqi1lemPF6xcB1iVsgp9IrtnZ1iOBZBmtBcilDiRpBOk2m5pt7Z6Cc8AUioIRf0MEBoWYxvs7hTjY0eGHL3CxZwjhKdp4DtVewH4QGIe6veyx/MOBrJLMf1eJtfIwbK5ytIYNgH6aIpSc0PygphLcDjbllCpVk45w5oqr59Rri3IONtXLEQdTPws8dbx43eJ54PjGbXZu24Jw=;23:zqnL/twOwhA9VFwBcGLHrDyNpyvSNim972ewBWXNTH5x1mtk2opnSC3WgFrd0xYk01WBr5B3nTI7gCNgMkvjJPF39s/D3+PBAwmqd8/D4IF1ZxkeZNt2+MHopuomvZO363SjXXjPg5sBqLPoH9iiqA==
+X-Forefront-Antispam-Report:
+ SFV:SKI;SFS:;DIR:INB;SFP:;SCL:-1;SRVR:SN1PR11MB0910;H:SN1PR11MB0638.namprd11.prod.outlook.com;FPR:;SPF:None;LANG:en;
+X-Microsoft-Exchange-Diagnostics:
+ 1;SN1PR11MB0910;6:tGfi4vJSuejJ29V48Q3x7VHSeVpLka3PvO5rhwBJFZnAg+/nUb3fJ815X4mwygRW0nXrMVqOD4tUMUj8fz7gSIRx8F4cnDcdg5PtKT7ulKfi0i3o62nXOH6qdKkjWYOyNwzkvo7/pd+oHPmHZ6OHV0eKiIuLBUE/SoYxJo5HOR47dCGkhvS4GyFU90K+xKT+g44FRtws7BTBGeiPB7pyYDMLYzcesobqch1k9ZbrN6XGojnk+wqM32mMQlRe1DjplqDxLSlcn7fkqQKuo9RYJumlT0T0IB8fd5OZe+pirkOFQBbpdCphIGI9ztGVNFryBCtYUYnsUkdDMXWMDt5ulyo2XPuzkIfKEYcuYIuL65pc8GRFDBYtU20HLKn2FZKamVQRftrm1cX8qyoUidX1JOE4mN4ppD9yHsbtefErhCpR8buAD0GDOEwjAtR3P9XPSd/QTwqslA56h34MQpi+Xw==;5:rajwvktDqL6CoT9Jxg479wT72pmm/j6FWMO8Lg63KawqCDm+yiLbCAwsj2l39GGUevL8xVn/RPF/DRXiV+zioDCEh2YeABXw0LmFU9pGlaUP3+Fmr6bItdiBPNawrT9pNL/aDtD3sRnewPJZTlqhbz1e11LWBYNgfsqoPpAJ3FPK8MlRlvoEwr7rPo4VwkQcGEWdLCRPQroAJ/6K/7sJ7g==;7:WEcxSlkeVIZ+NJiRl7bN8Ltmj4eJv4UNNL9SnxiQCdTMxD/CdheCMdWg0UCGGRQ2hEyBVoG7omhE3bKr8Z8KAH29N86w38a7RTsvWxijJBGjavWJvezOOL72t3r0/K/gWIiX8nRH8pIY2+KFOLzflw==
+X-MS-Exchange-CrossTenant-OriginalArrivalTime: 29 Jan 2019 11:43:23.7025
+ (UTC)
+X-MS-Exchange-CrossTenant-FromEntityHeader: Hosted
+X-MS-Exchange-CrossTenant-Id: 0d6161d7-4be3-4abd-90f9-d94f81b27dd3
+X-MS-Exchange-CrossTenant-Network-Message-Id: 496ef15d-0d77-4d17-44fb-08d685def9b7
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: SN1PR11MB0910
+X-MS-Exchange-Transport-EndToEndLatency: 00:00:00.7968566
+X-MS-Exchange-Processed-By-BccFoldering: 15.20.1558.000
+X-Microsoft-Exchange-Diagnostics:
+	1;SN6PR11MB3183;9:eHyeXFhZCmyg2rM+4MoqUwUae9clsvZjinTooIsG22G9i37Ul36m6DIWr5ntbaGFg9pbNerK8UwEgk43YE/7mYuhnFdZpFCVp04wkbY2dzXvPwGzGZy6lkfgGdsJ7dyfgkSVps2+57iO6lIUnjU2eoCqqD3dLw/B3Bb4DhyrXtE=
+X-Microsoft-Antispam-Mailbox-Delivery:
+	ucf:0;jmr:0;ex:0;auth:0;dest:I;ENG:(750119)(520011016)(706158)(944506303)(944626516);
+X-Microsoft-Antispam-Message-Info:
+	Gnz6f5FyycOSRvEOerbeKSlFvzoNZHMUsGVpjPtcL1pNeihFZufn+m07E9lYfLvpQTUD1DkHlaAXsM7yVEmZvah5m6DtO9Oj5O9MvsCmE+kfHEpZQAs8o9CowOdg9VWo0ULzGj5izLeQAkm5FseEv9FIoumm/F3YpZJdEggjoFR7LgVqzUy8fjCiD2ujtqoBQUu4mbofqo/hFFJNKQjgDnI01rVgIulf8BUUxHIbiX6JH5uMn0IoMeqx6B8UpBZpdnLKw/87ndVfB6nFK6MBCtnUQghZud8NvElcERj+QUQvt9trl1DHop6aRPyBZoX3vT6FCEuWxg0+bOvMyNVUDTP8rM3QR/KMBo4f4F0rP960GWJLlM6wgWPUhdbWbklYiegZOrUpPv4nbTYRfWTMMNdAbEHFkD8LJaGaU0DyAdekMkm7aPYz6v7E3gIlki2F
+X-Microsoft-Exchange-Diagnostics:
+	1;SN6PR11MB3183;27:TrhCNeESHOHAKQ6uxAd+tddrNRXPu+Hs/sWIS49+Rg3TKRD8C58NpG7R9yePGt2bSfE7yisCIErzXXwRNgfGJ0OTwQsIA21pdkZeqI4xC7LKW+6GlK3nzsxgkV8jwGQwjUiRTFfTBojvB+zQlzqA1OmqgF7ajC+OpuNXJJz1etYqZ1UgdeBO7vNmN79tC+YTtvT8OZE8OfdRZId1fWbfyq/9y2G0nuEL6GoeUxZ2HohrW91ex42BUW3FifVdU9NPZkHSGWvS+uVzQqKsiv1AnNzP9yHfU8yZj+Byf47Prv3s/Z/z4x6723huJhFXeGnMfRmes0ZJtghDDW9jEsJk46WKL4FRemqdv809W3BTcLLU4eZa9ysoVDOCCslVRF6p080vHrStFkMjrkQ+QPH7e2rDii3N1sqmGqi2icGg2VQ=
+Content-type: multipart/mixed;
+	boundary="B_3631614248_2114704363"
+
+> This message is in MIME format. Since your mail reader does not understand
+this format, some or all of this message may not be legible.
+
+--B_3631614248_2114704363
+Content-type: multipart/alternative;
+	boundary="B_3631614248_1037961307"
+
+
+--B_3631614248_1037961307
+Content-type: text/plain;
+	charset="UTF-8"
+Content-transfer-encoding: 7bit
+
+Have fun, my friend
+
+
+--B_3631614248_1037961307
+Content-type: text/html;
+	charset="UTF-8"
+Content-transfer-encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-microsof=
+t-com:office:office" xmlns:w=3D"urn:schemas-microsoft-com:office:word" xmlns:m=
+=3D"http://schemas.microsoft.com/office/2004/12/omml" xmlns=3D"http://www.w3.org=
+/TR/REC-html40">
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dutf-8">
+<meta name=3D"Generator" content=3D"Microsoft Word 15 (filtered medium)">
+<style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:#0563C1;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:#954F72;
+	text-decoration:underline;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri",sans-serif;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]-->
+</head>
+<body lang=3D"en-IL" link=3D"#0563C1" vlink=3D"#954F72">
+<div class=3D"WordSection1">
+<p class=3D"MsoNormal"><span lang=3D"EN-US">Have fun, my friend<o:p></o:p></spa=
+n></p>
+</div>
+</body>
+</html>
+
+
+--B_3631614248_1037961307--
+
+
+--B_3631614248_2114704363
+Content-type: text/plain; name="malicious_present_url.txt";
+ x-mac-creator="4F50494D"
+Content-disposition: attachment;
+	filename="malicious_present_url.txt"
+Content-transfer-encoding: base64
+
+
+aHR0cDovL3RwYi5jcnVzaHVzLmNvbS93d3cucGFwZXJzdHJlZXRjYXNoLmNvbQ==
+--B_3631614248_2114704363--
+

--- a/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
@@ -166,7 +166,7 @@ tasks:
         simple: "yes"
       unsecure: {}
       url:
-        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/Inline_malicious.eml
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/Inline_malicious_url.eml
       username: {}
     separatecontext: false
     view: |-

--- a/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
@@ -166,7 +166,7 @@ tasks:
         simple: "yes"
       unsecure: {}
       url:
-        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/attachment_malicious.eml
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/attachment_malicious_url.eml
       username: {}
     separatecontext: false
     view: |-

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -942,7 +942,6 @@
             "integrations": [
                 "EWS Mail Sender",
                 "Pwned",
-                "VirusTotal - Private API",
                 "Demisto REST API"
             ]
         },
@@ -953,7 +952,6 @@
             "integrations": [
                 "EWS Mail Sender",
                 "Pwned",
-                "VirusTotal - Private API",
                 "Demisto REST API"
             ]
         },


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15281

## Description
- Changed test data for phishing - now has a malicious URL instead of SHA256
- Changed phishing test - inline and phishing test - attachment, both to use the new testdata for phishing
- Disabled VirusTotal Private API for phishing tests. Quota makes tons of tests fail

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review

