### PR TITLE
Gmail fix gmail-revoke-user-role command

### DIFF
--- a/Integrations/integration-Gmail.yml
+++ b/Integrations/integration-Gmail.yml
@@ -582,6 +582,7 @@ script:
         user_key = args.get('user-id')
         role_assignment_id = args['role-assignment-id']
 
+        revoke_user_roles(user_key, role_assignment_id)
         return 'Role has been deleted.'
 
 
@@ -595,9 +596,9 @@ script:
             raise ValueError('Must provide Immutable GoogleApps Id')
 
         credentials = get_credentials(
-            ['https://www.googleapis.com/auth/admin.directory.rolemanagement'], user_id)
+            ['https://www.googleapis.com/auth/admin.directory.rolemanagement'])
         service = discovery.build('admin', 'directory_v1', credentials=credentials)
-        result = service.roleAssignments().delete(**command_args).execute()
+        return service.roleAssignments().delete(**command_args).execute()
 
 
     def get_user_tokens_command():
@@ -1820,3 +1821,4 @@ script:
 tests:
   - Gmail Convert Html Test
   - GmailTest
+releaseNotes: "Fixed gmail-revoke-user-role command"


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15092

## Description
Fixed gmail-revoke-user-role command.

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [X] Documentation (https://support.demisto.com/hc/en-us/articles/360007598794-Gmail)
- [ ] Code Review