### PR TITLE
ignore warning error

### DIFF
--- a/Integrations/integration-AbuseDB.yml
+++ b/Integrations/integration-AbuseDB.yml
@@ -56,6 +56,9 @@ script:
     import os
     import csv
 
+    # disable insecure warnings
+    requests.packages.urllib3.disable_warnings()
+
     ''' GLOBALS '''
     VERBOSE = True
     SERVER = demisto.params().get('server')
@@ -464,3 +467,4 @@ script:
   runonce: false
 tests:
   - AbuseIPDB Test
+releaseNotes: "Ignore 'Unverified HTTPS request is being made' warning when Trust any certificate checked to be true"


### PR DESCRIPTION
## Status
Ready

## Description
In some case where the user checks `Trust any certificate` option 
All the commands in the warroom get the error
![image](https://user-images.githubusercontent.com/7270217/52127777-cca80480-263b-11e9-848c-92a5b78dd879.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation - no need
- [ ] Code Review

