### PR TITLE
add is_error and get_error helper functions to common server python

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -337,18 +337,50 @@ script: |-
       return {'ContentsFormat': formats['text'], 'Type': entryTypes['error'], 'Contents': 'Unknown provider for result: ' + entry['Brand']}
 
 
-  def isError(entry):
+  def get_error(execute_command_result):
       """
-         Check if the given entry is an error entry
+          execute_command_result must contain error entry - check the result first with is_error function
+          if there is no error entry in the result then it will raise an Exception
 
-         :type entry: ``dict``
-         :param entry: Demisto entry (required)
+          :type execute_command_result: ``dict`` or  ``list``
+          :param execute_command_result: result of demisto.executeCommand()
 
-         :return: True if the entry is an error entry, false otherwise
-         :rtype: ``bool``
+          :return: Error message extracted from the demisto.executeCommand() result
+          :rtype: ``string``
       """
+
+      if not is_error(execute_command_result):
+          raise ValueError("execute_command_result has no error entry. before using get_error use is_error")
+
+      error_messages = []
+      for entry in execute_command_result:
+          is_error_entry = type(entry) == dict and entry['Type'] == entryTypes['error']
+          if is_error_entry:
+              error_messages.append(entry['Contents'])
+
+      return '\n'.join(error_messages)
+
+
+  def is_error(execute_command_result):
+      """
+          Check if the given execute_command_result has an error entry
+
+          :type execute_command_result: ``dict`` or ``list``
+          :param execute_command_result: Demisto entry (required) or result of demisto.executeCommand()
+
+          :return: True if the execute_command_result has an error entry, false otherwise
+          :rtype: ``bool``
+      """
+      if isinstance(execute_command_result, list):
+          if len(execute_command_result) > 0:
+              for entry in execute_command_result:
+                  if type(entry) == dict and entry['Type'] == entryTypes['error']:
+                      return True
+
       return type(entry) == dict and entry['Type'] == entryTypes['error']
 
+
+  isError = is_error
 
   def FormatADTimestamp(ts):
       """
@@ -1410,3 +1442,4 @@ dependson: {}
 timeout: 0s
 tests:
   - TestPYCommonServer
+releaseNotes: "add is_error and get_error helper functions check and extract error out of demisto.executeCommand() result"

--- a/TestPlaybooks/script-TestPyCommonServer.yml
+++ b/TestPlaybooks/script-TestPyCommonServer.yml
@@ -3,7 +3,12 @@ commonfields:
   version: -1
 name: TestPYCommonServer
 script: |-
+  #!/usr/bin/env python
+  # -*- coding: utf-8 -*-
+
   import copy
+  import unittest
+
   INFO = {'b' : 1,
       'a': {
           'safd' : 3,
@@ -357,6 +362,7 @@ script: |-
 
       demisto.results('ok')
 
+
   ''' MAIN TEST RUNNER '''
   TESTS = {
       'DQ' : test_dq,
@@ -370,11 +376,91 @@ script: |-
       'PASCAL_TO_SPACE' : test_pascalToSpace,
   }
 
-  test_type = demisto.args()['test_type']
-  if test_type not in TESTS:
-      demisto.results('Invalid test: %s' % (test_type, ))
-  else:
-      TESTS[test_type]()
+
+  class TestIsError(unittest.TestCase):
+
+      def test_is_error_true(self):
+          execute_command_results = [
+              {
+                  "Type": entryTypes["error"],
+                  "ContentsFormat": formats["text"],
+                  "Contents": "this is error message"
+              }
+          ]
+          self.assertTrue(is_error(execute_command_results))
+
+
+      def test_is_error_single_entry(self):
+          execute_command_results = {
+              "Type": entryTypes["error"],
+              "ContentsFormat": formats["text"],
+              "Contents": "this is error message"
+          }
+
+          self.assertTrue(is_error(execute_command_results))
+
+      def test_is_error_false(self):
+          execute_command_results = [
+              {
+                  "Type": entryTypes["note"],
+                  "ContentsFormat": formats["text"],
+                  "Contents": "this is regular note"
+              }
+          ]
+          self.assertFalse(is_error(execute_command_results))
+
+      def test_not_error_entry(self):
+          execute_command_results = "invalid command results as string"
+          self.assertFalse(is_error(execute_command_results))
+
+
+  class TestGetError(unittest.TestCase):
+      def test_get_error(self):
+          execute_command_results = [
+              {
+                  "Type": entryTypes["error"],
+                  "ContentsFormat": formats["text"],
+                  "Contents": "this is error message"
+              }
+          ]
+          error = get_error(execute_command_results)
+          self.assertEquals(error, "this is error message")
+
+      def test_get_error_single_entry(self):
+          execute_command_results = {
+              "Type": entryTypes["error"],
+              "ContentsFormat": formats["text"],
+              "Contents": "this is error message"
+          }
+
+          error = get_error(execute_command_results)
+          self.assertEquals(error, "this is error message")
+
+      def test_get_error_need_raise_error_on_non_error_input(self):
+          execute_command_results = [
+              {
+                  "Type": entryTypes["note"],
+                  "ContentsFormat": formats["text"],
+                  "Contents": "this is not an error"
+              }
+          ]
+          try:
+              get_error(execute_command_results)
+              self.fail("get_error should raise an error")
+          except ValueError, e:
+              self.assertEquals(e.message, "execute_command_result has no error entry. before using get_error use is_error")
+
+
+  def main():
+      test_type = demisto.args()['test_type']
+      if test_type not in TESTS:
+          demisto.results('Invalid test: %s' % (test_type,))
+      else:
+          TESTS[test_type]()
+
+
+  if __name__ == '__builtin__':
+      main()
 type: python
 tags: []
 comment: Tests for common function dq
@@ -383,7 +469,6 @@ args:
 - name: test_type
   required: true
   default: true
-  auto: PREDEFINED
   predefined:
   - DQ
   - ENTRY
@@ -398,5 +483,6 @@ args:
   defaultValue: dq
 scripttarget: 0
 runonce: false
+runas: DBotWeakRole
 tests:
   - Test CommonServer


### PR DESCRIPTION
## Status
Ready


## Description
Usually it is very confusing and unknown to users the structure of the demisto.executeCommand()
Added 2 commands:
is_error - returns true if the results of executeCommand is error
get_error - extract the error from error entry

## Related PRs
https://github.com/demisto/content/pull/2911

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation - 
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.


