### PR TITLE
don't ignore proxy in as-get-security-events

### DIFF
--- a/Integrations/integration-ArcSightESM.yml
+++ b/Integrations/integration-ArcSightESM.yml
@@ -160,7 +160,7 @@ script:
                 Body: stringBody
             },
             params.insecure,
-            params.useproxy
+            params.proxy
         );
 
         if (res.StatusCode < 200 || res.StatusCode >= 300) {
@@ -1238,3 +1238,4 @@ script:
 hidden: false
 tests:
 - No test
+releaseNotes: "fixed - as-get-security-events was ignoring proxy param"


### PR DESCRIPTION
## Status
Ready

## Description
as-get-security-events command was using invalid param useproxy. So in env where proxy configured, it behaved improperly


## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests - tests will be added in the new ArcSight ESM integration
- [ ] Documentation  - docs the same
- [ ] Code Review

