### PR TITLE
Handle non-string exceptions

### DIFF
--- a/Integrations/integration-ServiceNow.yml
+++ b/Integrations/integration-ServiceNow.yml
@@ -1453,7 +1453,7 @@ script:
     except Exception as e:
         LOG(e)
         LOG.print_log()
-        return_error(e.message)
+        return_error(str(e.message))
   type: python
   commands:
   - name: servicenow-get-ticket


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/15374

## Description
`urllib3` exception **message** is not a string type, needed to convert to string.