### PR TITLE
Parse email files "smtp mail" type

### DIFF
--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3332,16 +3332,17 @@ def main():
         return_error("Failed to load file entry with entryid: {}. Error: {}".format(entry_id, ex.message))
 
     try:
-        if 'Composite Document File V2 Document'.lower() in file_type.lower() \
-                or 'CDFV2 Microsoft Outlook Message'.lower() in file_type.lower():
+        file_type_lower = file_type.lower()
+        if 'composite document file v2 document' in file_type_lower \
+                or 'cdfv2 microsoft outlook message' in file_type_lower:
             handle_msg(file_path)
             return
 
-        elif 'rfc 822 mail' in file_type.lower():
+        elif 'rfc 822 mail' in file_type_lower or 'smpt mail' in file_type_lower:
             handle_eml(file_path)
             return
 
-        elif 'ASCII text' in file_type:
+        elif 'ascii text' in file_type_lower:
             try:
                 # Try to open the email as-is
                 with open(file_path, 'rb') as f:

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 import sys
 import email.utils
 from email.parser import HeaderParser
+import traceback
 
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python
@@ -3329,7 +3330,8 @@ def main():
 
         file_type = result[0]['FileMetadata']['info']
     except Exception, ex:
-        return_error("Failed to load file entry with entryid: {}. Error: {}".format(entry_id, ex.message))
+        return_error("Failed to load file entry with entryid: {}. Error: {}".format(entry_id,
+                     str(ex) + "\n\nTrace:\n" + traceback.format_exc(ex)))
 
     try:
         file_type_lower = file_type.lower()
@@ -3338,7 +3340,7 @@ def main():
             handle_msg(file_path)
             return
 
-        elif 'rfc 822 mail' in file_type_lower or 'smpt mail' in file_type_lower:
+        elif 'rfc 822 mail' in file_type_lower or 'smtp mail' in file_type_lower:
             handle_eml(file_path)
             return
 
@@ -3366,7 +3368,7 @@ def main():
             return_error("Unknown file format: " + file_type)
 
     except Exception, ex:
-        return_error(ex.message)
+        return_error(str(ex) + "\n\nTrace:\n" + traceback.format_exc(ex))
 
 
 if __name__ == "__builtin__":

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -81,6 +81,6 @@ outputs:
 scripttarget: 0
 runonce: false
 runas: DBotWeakRole
-releaseNotes: fix - parsing recursively msg in msg file
+releaseNotes: Fix - support email files with type 'SMTP Mail'
 tests:
   - "ParseEmailFiles-test"

--- a/Scripts/ParseEmailFiles/Pipfile
+++ b/Scripts/ParseEmailFiles/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 pylint = "*"
 pytest = "*"
 flake8 = "*"
+pytest-mock = "*"
 
 [packages]
 olefile = "*"

--- a/Scripts/ParseEmailFiles/Pipfile.lock
+++ b/Scripts/ParseEmailFiles/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ce23ee89316de3f5327afc1765c92fc809470c1da8bb0100b3dbad784873609e"
+            "sha256": "a3e37fdb5bcf2d72c0cfdac445190ec8e9085fa601f5ea9e19a9bb3538002cd3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -51,7 +51,7 @@
                 "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
                 "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
             ],
-            "markers": "python_version < '3.4'",
+            "markers": "python_version == '2.7'",
             "version": "==1.5"
         },
         "configparser": {
@@ -60,7 +60,7 @@
                 "sha256:c114ff90ee2e762db972fa205f02491b1f5cf3ff950decd8542c62970c9bedac",
                 "sha256:df28e045fbff307a28795b18df6ac8662be3219435560ddb068c283afab1ea7a"
             ],
-            "markers": "python_version == '2.7'",
+            "markers": "python_version < '3.2'",
             "version": "==3.7.1"
         },
         "entrypoints": {
@@ -160,6 +160,14 @@
             ],
             "version": "==0.6.1"
         },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==2.0.0"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
@@ -175,6 +183,13 @@
             ],
             "markers": "python_version < '3.6'",
             "version": "==2.3.3"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:a7953f66e1f82e4b061f43096a4bcc058f7d3d41de9b94ac871770e8bdd831a2",
+                "sha256:d717573351cfe09f49df61906cd272abaa759b3e91744396b804965ff7bff38b"
+            ],
+            "version": "==5.1.2"
         },
         "pluggy": {
             "hashes": [
@@ -219,6 +234,14 @@
             ],
             "index": "pypi",
             "version": "==4.2.0"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:4d0d06d173eecf172703219a71dbd4ade0e13904e6bbce1ce660e2e0dc78b5c4",
+                "sha256:bfdf02789e3d197bd682a758cae0a4a18706566395fbe2803badcd1335e0173e"
+            ],
+            "index": "pypi",
+            "version": "==1.10.1"
         },
         "scandir": {
             "hashes": [

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -1,4 +1,6 @@
-from ParseEmailFiles import MsOxMessage
+from ParseEmailFiles import MsOxMessage, main
+from CommonServerPython import entryTypes
+import demistomock as demisto
 
 
 def test_msg_html_with_attachments():
@@ -22,3 +24,29 @@ def test_msg_utf_encoded_subject():
     assert '?utf-8' in msg_dict['HeadersMap']['Subject']
     subj = msg_dict['Subject']
     assert 'TESTING' in subj and '?utf-8' not in subj
+
+
+def test_eml_smtp_type(mocker):
+
+    def executeCommand(name, args=None):
+        if name == 'getFilePath':
+            return [{'Type': entryTypes['note'], 'Contents': {'path': 'test_data/smtp_email_type.eml'}}]
+        elif name == 'getEntry':
+            return [{'Type': entryTypes['file'], 'FileMetadata':
+                    {'info': 'SMTP mail, UTF-8 Unicode text, with CRLF terminators'}}]
+        else:
+            raise ValueError('Unimplemented command called: {}'.format(name))
+
+    mocker.patch.object(demisto, 'args', return_value={'entryid': 'test'})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=executeCommand)
+    mocker.patch.object(demisto, 'results')
+    # validate our mocks are good
+    assert demisto.args()['entryid'] == 'test'
+    # assert demisto.executeCommand('getFilePath', {})[0]['Type'] == entryTypes['note']
+    main()
+    assert demisto.results.call_count == 1
+    # call_args is tuple (args list, kwargs). we only need the first one
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0]['Type'] == entryTypes['note']
+    assert results[0]['EntryContext']['Email']['Subject'] == 'Test Smtp Email'

--- a/Scripts/ParseEmailFiles/test_data/smtp_email_type.eml
+++ b/Scripts/ParseEmailFiles/test_data/smtp_email_type.eml
@@ -1,0 +1,20 @@
+Return-Path: <test@test.com>
+X-Original-To: user1@test.com
+Delivered-To: user1@test.com
+Received: from [10.19.120.67] (unknown [10.19.120.67])
+	by test.com (Postfix) with ESMTPA id F3B4A40055
+	for <user1@test.com>; Wed, 23 Jan 2019 18:55:56 +0100 (CET)
+To: user1@test.com
+From: "test@test.com" <test@test.com>
+Subject: Test Smtp Email
+Message-ID: <5b4831d0-5322-ea23-6312-864ff419a1f1@test.com>
+Date: Wed, 23 Jan 2019 18:55:56 +0100
+User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101
+ Thunderbird/60.4.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 8bit
+Content-Language: en-US
+
+This is a test smtp type email
+

--- a/Tests/scripts/update_id_set.py
+++ b/Tests/scripts/update_id_set.py
@@ -333,6 +333,8 @@ def get_code_file(package_path, script_type):
 
 
 def get_script_package_data(package_path):
+    if package_path[-1] != os.sep:
+        package_path = os.path.join(package_path, '')
     yml_path = glob.glob(package_path + '*.yml')[0]
     code_type = get_json(yml_path).get('type')
     code_path = get_code_file(package_path, TYPE_TO_EXTENSION[code_type])

--- a/Tests/scripts/validate_files_structure.py
+++ b/Tests/scripts/validate_files_structure.py
@@ -564,7 +564,7 @@ def validate_added_files(added_files, integration_set, playbook_set, script_set,
         elif re.match(SCRIPT_YML_REGEX, file_path, re.IGNORECASE) or \
                 re.match(SCRIPT_PY_REGEX, file_path, re.IGNORECASE) or \
                 re.match(SCRIPT_JS_REGEX, file_path, re.IGNORECASE):
-            yml_path, code = get_script_package_data(os.path.dirname(file_path) + '/')
+            yml_path, code = get_script_package_data(os.path.dirname(file_path))
             script_data = get_script_data(yml_path, script_code=code)
 
             if is_circle and not script_valid_in_id_set(yml_path, script_set, script_data):

--- a/package_extractor.py
+++ b/package_extractor.py
@@ -18,7 +18,7 @@ def extract_code(yml_path, output_path, demisto_mock, commonserver=None, yml_typ
             raise ValueError(
                 'Could not auto determine yml type ({}/{}) based on path: {}'.format(SCRIPT, INTEGRATION, yml_path))
     if commonserver is None:
-        commonserver = "CommonServerPython" not in yml_path 
+        commonserver = "CommonServerPython" not in yml_path
     with open(yml_path, 'rb') as yml_file:
         yml_data = yaml.safe_load(yml_file)
         script = yml_data['script']

--- a/package_extractor.py
+++ b/package_extractor.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import yaml
+import argparse
+from io import open
+
+INTEGRATION = 'integration'
+SCRIPT = 'script'
+
+
+def extract_code(yml_path, output_path, demisto_mock, commonserver=None, yml_type=None):
+    if not yml_type:
+        if SCRIPT in yml_path.lower():
+            yml_type = SCRIPT
+        elif INTEGRATION in yml_path.lower():
+            yml_type = INTEGRATION
+        else:
+            raise ValueError(
+                'Could not auto determine yml type ({}/{}) based on path: {}'.format(SCRIPT, INTEGRATION, yml_path))
+    if commonserver is None:
+        commonserver = "CommonServerPython" not in yml_path 
+    with open(yml_path, 'rb') as yml_file:
+        yml_data = yaml.safe_load(yml_file)
+        script = yml_data['script']
+        if yml_type == INTEGRATION:  # in integration the script is stored at a second level
+            script = script['script']
+    with open(output_path, 'w', encoding='utf-8') as code_file:
+        if demisto_mock:
+            code_file.write(u"import demistomock as demisto\n")
+        if commonserver:
+            code_file.write(u"from CommonServerPython import *\n")
+        if type(script) == str:  # pyyaml may return either a unicode or str depending upon the content of script
+            script = unicode(script)
+        code_file.write(script)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Extract code file from a demmisto integration or script yaml file',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-i", "--infile", help="The yml file to extract from", required=True)
+    parser.add_argument("-o", "--outfile", help="The output file to write the code to", required=True)
+    parser.add_argument("-t", "--type", help="Yaml type. If not specified will try to determine type based upon path.",
+                        choices=[SCRIPT, INTEGRATION], default=None)
+    parser.add_argument("-d", "--demistomock", help="Add an import for demisto mock",
+                        choices=[True, False], default=True)
+    parser.add_argument("-c", "--commonserver",
+                        help=("Add an import for CommonServerPython."
+                              + " If not specified will import unless this is CommonServerPython"),
+                        choices=[True, False], default=None)
+    args = parser.parse_args()
+    extract_code(args.infile, args.outfile, args.demistomock, args.commonserver, args.type)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-ignore = W605, F403, F405
+ignore = W605, F403, F405, W503
 max-line-length = 120
 exclude = _script_template_docker.py


### PR DESCRIPTION
## Status
Ready

## Related Issues
related to: https://github.com/demisto/etc/issues/15277

## Description
A fix to work with eml files which have an "smtp mail" type

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests: unit test run locally
- [x] Code Review

## Additional changes
Also added package_extractor.py script to extract python code from yml file. 
