### PR TITLE
handle corrupted id_set.json file

### DIFF
--- a/Tests/scripts/update_id_set.py
+++ b/Tests/scripts/update_id_set.py
@@ -1,7 +1,6 @@
 import re
 import os
 import sys
-import time
 import glob
 import json
 import yaml

--- a/Tests/scripts/validate_files_structure.py
+++ b/Tests/scripts/validate_files_structure.py
@@ -327,7 +327,7 @@ def is_existing_image(file_path):
 
 def get_modified_and_added_files(branch_name, is_circle):
     if is_circle:
-        all_changed_files_string = run_git_command("git diff --name-status origin/master..{}".format(branch_name))
+        all_changed_files_string = run_git_command("git diff --name-status origin/master...{}".format(branch_name))
         modified_files, added_files = get_modified_files(all_changed_files_string)
 
     else:

--- a/Tests/scripts/validate_files_structure.py
+++ b/Tests/scripts/validate_files_structure.py
@@ -478,7 +478,15 @@ def integration_valid_in_id_set(file_path, integration_set):
 def validate_committed_files(branch_name, is_circle):
     modified_files, added_files = get_modified_and_added_files(branch_name, is_circle)
     with open('./Tests/id_set.json', 'r') as id_set_file:
-        id_set = json.load(id_set_file)
+        try:
+            id_set = json.load(id_set_file)
+        except ValueError, ex:
+            if "Expecting property name" in ex.message:
+                print_error("You probably merged from master and your id_set.json has conflicts. "
+                            "Run `python Tests/scripts/update_id_set.py`, it should reindex your id_set.json")
+                return
+            else:
+                raise ex
 
     script_set = id_set['scripts']
     playbook_set = id_set['playbooks']


### PR DESCRIPTION
## Status
Ready

## Description
When we merge from master and we have a conflict in id_set.json , and git can't handle the merge automatically, then it will corrupt it in most cases with `>>>> master` strings 
The json get corrupted , so validate_files_structure and update_id_set get JSON error, which is not indicative at all to the user
This PR will popup proper error to the user to run update_id_set.py
And update_id_set.py will checkout id_set.json to master and will update it again

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests - no tests
- [ ] Code Review

