### PR TITLE
Add freshdesk to skipped integrations

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1065,7 +1065,8 @@
         "Netskope": "instance is down",
         "Google Resource Manager": "Cannot create projects because have reached alloted quota",
         "RSA NetWitness Endpoint": "Instance is down, waiting for devops to rebuild",
-        "WildFire": "Quota is temporarily over due to circle ci issues"
+        "WildFire": "Quota is temporarily over due to circle ci issues",
+        "Freshdesk": "Trial account expired"
     },
     "nigthly_integrations": [
         "Lastline",


### PR DESCRIPTION
## Status
Ready

## Description
Add Freshdesk integration to the skipped integration list because the credentials for the nightly test along with the Trial account that they are associated with have expired.

## Related PRs
List related PRs against other branches:

branch | PR
freshdesk-integration | https://github.com/demisto/content/pull/2916

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review

## Dependencies
- N/A
