### PR TITLE
Microsoft Graph - 206 Partial Content handling

### DIFF
--- a/Integrations/integration-Microsoft_Graph.yml
+++ b/Integrations/integration-Microsoft_Graph.yml
@@ -107,8 +107,10 @@ script:
                 'Accept': 'application/json'
             }
         )
-        if r.status_code not in {200, 204}:
+        if r.status_code not in {200, 204, 206}:
             return_error('Error in API call to Microsoft Graph [%d] - %s' % (r.status_code, r.reason))
+        elif r.status_code == 206: # 206 indicates Partial Content, and the reason for that will be in the Warning header
+            demisto.debug(str(r.headers))
         if not r.text:
             return {}
         return r.json()
@@ -732,3 +734,4 @@ script:
       type: string
     description: Retrieve the properties and relationships of user object.
   runonce: false
+releaseNotes: "Improved partial content handling"


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15526

## Description
Handling 206 - Partial Content response returned from Microsoft Graph.
This means a response was returned successfully, but with warning.
Adding to warning to the logs and processing the response as success.

## Required version of Demisto
Any

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation - https://github.com/demisto/etc/issues/15532
- [ ] Code Review

## Dependencies
None