### PR TITLE
Fixed pdf outputs while maintaining 4.1 extractIndicators functionality

### DIFF
--- a/Scripts/script-ReadPDFFile.yml
+++ b/Scripts/script-ReadPDFFile.yml
@@ -31,6 +31,12 @@ script: |-
           'Contents': "Missing EOF, file may be corrupted or suspicious file in id: {}".format(entryID),
           })
 
+
+  #File entity
+  pdfFile = {
+      "EntryID" : entryID
+  }
+
   #URLS
   URLs = []
 
@@ -62,14 +68,23 @@ script: |-
 
           # Get metadata:
           metadata = pdf.get_metadata()
+  
           # Get text:
           text = pdf.get_text()
+  
           # Get URLs:
           references_dict = pdf.get_references_as_dict()
           if "url" in references_dict.keys():
               for url in references_dict['url']:
                   URLs.append({'Data':url})
+          
+          #Add Text to file entity
+          pdfFile["Text"] = text
 
+          #Add Metadata to file entity
+          for k in metadata.keys():
+              pdfFile[k] = metadata[k]
+  
           md = "### Metadata\n"
           md += "* " if metadata else ""
           md += "\n* ".join(["{0}: {1}".format(k,v) for k,v in metadata.iteritems()])
@@ -84,7 +99,8 @@ script: |-
           demisto.results({"Type" : entryTypes["note"],
                           "ContentsFormat" : formats["markdown"],
                           "Contents" : md,
-                          "HumanReadable": md
+                          "HumanReadable": md,
+                          "EntryContext": {"File(val.EntryID == obj.EntryID)" : pdfFile, "URL" : URLs}
                           })
 
           all_pdf_data = ""
@@ -150,5 +166,6 @@ scripttarget: 0
 runonce: false
 dockerimage: demisto/pdfx
 runas: DBotWeakRole
+releaseNotes: "Fixed script outputs. Script should now output everything again while also extracting indicators."
 tests:
   - Extract Indicators From File - test

--- a/Scripts/script-ReadPDFFile.yml
+++ b/Scripts/script-ReadPDFFile.yml
@@ -8,48 +8,48 @@ script: |-
   from pdfminer.psparser import PSEOF
   import sys
   reload(sys)
-  sys.setdefaultencoding('utf-8')
+  sys.setdefaultencoding("utf-8")
 
-  entryID = demisto.args()['entryID']
+  entry_id = demisto.args()["entryID"]
 
   def mark_suspicious():
       """Missing EOF, file may be corrupted or suspicious file"""
 
       dbot = {
-          'DBotScore':
+          "DBotScore":
           {
-              'Indicator': entryID,
-              'Type': 'file',
-              'Vendor': 'PDFx',
-              'Score': 2
+              "Indicator": entry_id,
+              "Type": "file",
+              "Vendor": "PDFx",
+              "Score": 2
           }
       }
       demisto.results({
-          'EntryContext': dbot,
-          'Type': entryTypes["error"],
-          'ContentsFormat': formats["text"],
-          'Contents': "Missing EOF, file may be corrupted or suspicious file in id: {}".format(entryID),
+          "EntryContext": dbot,
+          "Type": entryTypes["error"],
+          "ContentsFormat": formats["text"],
+          "Contents": "Missing EOF, file may be corrupted or suspicious file in id: {}".format(entry_id),
           })
 
 
   #File entity
-  pdfFile = {
-      "EntryID" : entryID
+  pdf_file = {
+      "EntryID" : entry_id
   }
 
   #URLS
   URLs = []
 
-  maxFileSize = demisto.get(demisto.args(), 'maxFileSize')
+  maxFileSize = demisto.get(demisto.args(), "maxFileSize")
   if maxFileSize:
       maxFileSize = int(maxFileSize)
   else:
       maxFileSize = 1024**2
-  res = demisto.executeCommand('getFilePath', {'id': entryID})
+  res = demisto.executeCommand("getFilePath", {"id": entry_id})
   if isError(res[0]):
       demisto.results(res)
   else:
-      path = demisto.get(res[0],'Contents.path')
+      path = demisto.get(res[0],"Contents.path")
       if path:
           try:
               pdf = pdfx.PDFx(path)
@@ -61,30 +61,30 @@ script: |-
               demisto.results({
                   "Type": entryTypes["error"],
                   "ContentsFormat": formats["text"],
-                  "Contents" : "Could not load pdf file in EntryID {0}".format(entryID)
+                  "Contents" : "Could not load pdf file in EntryID {0}".format(entry_id)
               })
               sys.exit(0)
 
 
           # Get metadata:
           metadata = pdf.get_metadata()
-  
+
           # Get text:
           text = pdf.get_text()
-  
+
           # Get URLs:
           references_dict = pdf.get_references_as_dict()
           if "url" in references_dict.keys():
-              for url in references_dict['url']:
-                  URLs.append({'Data':url})
-          
+              for url in references_dict["url"]:
+                  URLs.append({"Data":url})
+
           #Add Text to file entity
-          pdfFile["Text"] = text
+          pdf_file["Text"] = text
 
           #Add Metadata to file entity
           for k in metadata.keys():
-              pdfFile[k] = metadata[k]
-  
+              pdf_file[k] = metadata[k]
+
           md = "### Metadata\n"
           md += "* " if metadata else ""
           md += "\n* ".join(["{0}: {1}".format(k,v) for k,v in metadata.iteritems()])
@@ -100,7 +100,7 @@ script: |-
                           "ContentsFormat" : formats["markdown"],
                           "Contents" : md,
                           "HumanReadable": md,
-                          "EntryContext": {"File(val.EntryID == obj.EntryID)" : pdfFile, "URL" : URLs}
+                          "EntryContext": {"File(val.EntryID == obj.EntryID)" : pdf_file, "URL" : URLs}
                           })
 
           all_pdf_data = ""
@@ -116,16 +116,20 @@ script: |-
 
           # Extract indicators (omitting context output, letting auto-extract work)
           indicators_hr = demisto.executeCommand("extractIndicators", {
-              'text': all_pdf_data})[0][u'Contents']
-          demisto.results( {
-              'Type': entryTypes['note'],
-              'ContentsFormat': formats['text'],
-              'Contents': indicators_hr,
-              'HumanReadable': indicators_hr
-                           })
+              "text": all_pdf_data})[0][u"Contents"]
+          demisto.results({
+              "Type": entryTypes["note"],
+              "ContentsFormat": formats["json"],
+              "Contents": indicators_hr,
+              "HumanReadable": indicators_hr
+               })
 
       else:
-          demisto.results( { "Type" : entryTypes["error"], "ContentsFormat" : formats["text"], "Contents" : "EntryID {0} path could not be found".format(entryID) } )
+          demisto.results({
+              "Type" : entryTypes["error"],
+              "ContentsFormat" : formats["text"],
+              "Contents" : "EntryID {0} path could not be found".format(entry_id)
+               })
 type: python
 tags:
 - Utility

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_test.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_test.yml
@@ -44,7 +44,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "6"
+      - "13"
     scriptarguments:
       body: {}
       filename: {}
@@ -136,8 +136,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 70,
-          "y": 1065
+          "x": 300,
+          "y": 1060
         }
       }
     note: false
@@ -159,7 +159,7 @@ tasks:
       {
         "position": {
           "x": 70,
-          "y": 1565
+          "y": 1480
         }
       }
     note: false
@@ -189,33 +189,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 470,
+          "x": 620,
           "y": 1300
-        }
-      }
-    note: false
-    timertriggers: []
-  "6":
-    id: "6"
-    taskid: 0e90c3d8-c63c-4222-8f9d-4121d997dc9f
-    type: playbook
-    task:
-      id: 0e90c3d8-c63c-4222-8f9d-4121d997dc9f
-      version: -1
-      name: Extract Indicators From File - Generic
-      playbookName: Extract Indicators From File - Generic
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "3"
-    separatecontext: true
-    view: |-
-      {
-        "position": {
-          "x": 70,
-          "y": 889
         }
       }
     note: false
@@ -262,7 +237,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "6"
+      - "13"
     scriptarguments:
       body: {}
       filename: {}
@@ -304,7 +279,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "6"
+      - "13"
     scriptarguments:
       body: {}
       filename: {}
@@ -346,7 +321,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "6"
+      - "13"
     scriptarguments:
       body: {}
       filename: {}
@@ -407,12 +382,147 @@ tasks:
       }
     note: false
     timertriggers: []
+  "13":
+    id: "13"
+    taskid: be1c63ab-e412-432a-8379-3c343ea501f8
+    type: playbook
+    task:
+      id: be1c63ab-e412-432a-8379-3c343ea501f8
+      version: -1
+      name: Extract Indicators From File - Generic_dev
+      playbookName: Extract Indicators From File - Generic_dev
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+      - "14"
+    separatecontext: true
+    view: |-
+      {
+        "position": {
+          "x": 70,
+          "y": 869
+        }
+      }
+    note: false
+    timertriggers: []
+  "14":
+    id: "14"
+    taskid: 86e50667-958b-4156-8a5a-f2055b42080c
+    type: condition
+    task:
+      id: 86e50667-958b-4156-8a5a-f2055b42080c
+      version: -1
+      name: Did the PDF file return outputs?
+      description: |-
+        Checks if the PDF returned all of the expected outputs, except for title.
+        Checks for the following outputs:
+        - File.Text
+        - File.Producer
+        - File.xap
+        - File.Author
+        - File.dc
+        - File.xapmm
+        - File.ModDate
+        - File.CreationDate
+        - File.Pages
+
+        File.Title is not being checked because it doesn't exist in the test PDF provided.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "5"
+      "yes":
+      - "4"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Text
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Producer
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: xap
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Author
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: dc
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: xapmm
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: ModDate
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: CreationDate
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Pages
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": -160,
+          "y": 1060
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
-    "linkLabelsPosition": {},
+    "linkLabelsPosition": {
+      "14_4_yes": 0.65,
+      "3_4_yes": 0.65
+    },
     "paper": {
       "dimensions": {
-        "height": 1580,
+        "height": 1495,
         "width": 1820,
         "x": -660,
         "y": 50

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_test.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_test.yml
@@ -389,8 +389,8 @@ tasks:
     task:
       id: be1c63ab-e412-432a-8379-3c343ea501f8
       version: -1
-      name: Extract Indicators From File - Generic_dev
-      playbookName: Extract Indicators From File - Generic_dev
+      name: Extract Indicators From File - Generic
+      playbookName: Extract Indicators From File - Generic
       type: playbook
       iscommand: false
       brand: ""

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -12231,7 +12231,7 @@
                     "http"
                 ], 
                 "implementing_playbooks": [
-                    "Extract Indicators From File - Generic"
+                    "Extract Indicators From File - Generic_dev"
                 ]
             }
         }, 

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -12231,7 +12231,7 @@
                     "http"
                 ], 
                 "implementing_playbooks": [
-                    "Extract Indicators From File - Generic_dev"
+                    "Extract Indicators From File - Generic"
                 ]
             }
         }, 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15559#event-2137787152

## Description
Fixed outputs that were unintentionally removed while adding ExtractIndicators functionality for 4.1.
Everything should now work as expected again.

## Screenshots
![image](https://user-images.githubusercontent.com/43602124/52782333-7c776c00-3057-11e9-9653-4595eb4ca9c3.png)


![image](https://user-images.githubusercontent.com/43602124/52782355-88632e00-3057-11e9-84b7-0af6bd362aa1.png)


![image](https://user-images.githubusercontent.com/43602124/52782375-91ec9600-3057-11e9-8be6-0c1bc897b2db.png)


![image](https://user-images.githubusercontent.com/43602124/52782399-9ca72b00-3057-11e9-996f-112137b0b617.png)



## Required version of Demisto
4.1.0

## Does it break backward compatibility?
   - No
