### PR TITLE
enable back duo test playbook after configuring the user

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1049,7 +1049,6 @@
         "FireEye HX Test": "Problem with file acquisition - need to contact FireEye ",
         "RedLockTest": "RedLock has API issues - opened an issue (15493)",
         "GsuiteTest": "error was fixed only on server master and not on ",
-        "DUO Test Playbook": "DUO integration is failing",
         "MISP V2 Test": "MISP V2 Test misp-search value command fails (issue 15574)",
         "CreatePhishingClassifierMLTest": "fails",
         "GmailTest": "Gmail test is failing on gmail-list-users command (issue 15571)",


### PR DESCRIPTION
## Status
Ready

## Description
If configured the `active-user` we use for testing in Duo to have a phone numbrer. The test playbook should pass now.

