### PR TITLE
removed tenable io tests from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1074,8 +1074,6 @@
         "tenable-sc-test": "Unstable instance = flaky test",
         "XFE Test": "License expired",
         "TruSTAR Test": "The test runs even when not supposed to, which causes its quota to run out",
-        "Tenable.io test": "Error 409 ISSUE OPENED",
-        "Tenable.io Scan Test": "Error 409 ISSUE OPENED",
         "FireEye HX Test": "Problem with file acquisition - need to contact FireEye ",
         "RedLockTest": "RedLock has API issues - opened an issue (15493)",
         "GsuiteTest": "error was fixed only on server master and not on ",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15212

## Description
Removed tenable io tests from skipped as the instance is no longer stuck.