### PR TITLE
ThreatGrid fix

### DIFF
--- a/Integrations/integration-Threat_Grid.yml
+++ b/Integrations/integration-Threat_Grid.yml
@@ -320,7 +320,7 @@ script:
         """
         Encodes sample file name
         """
-        return filename.encode('ascii', 'ignore').replace('"', '').replace('\\n', '')
+        return filename.encode('ascii', 'ignore').replace('"', '').replace('\n', '')
 
 
     def get_html_report_by_id():
@@ -2268,3 +2268,4 @@ script:
   runonce: false
 tests:
   - ThreatGridTest
+releaseNotes: "The command threat-grid-upload-sample now works properly with file names that contain new line characters."

--- a/Playbooks/playbook-Detonate_URL_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_URL_-_ThreatGrid.yml
@@ -374,4 +374,5 @@ outputs:
 - contextPath: Sample.ID
   description: The sample ID
 tests:
-  - Test-Detonate URL - ThreatGrid
+  - Detonate URL - Generic Test
+releaseNotes: "-"

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -15594,14 +15594,6 @@
             }
         }, 
         {
-            "Test-Detonate URL - ThreatGrid": {
-                "name": "Test-Detonate URL - ThreatGrid", 
-                "implementing_playbooks": [
-                    "Detonate URL - ThreatGrid"
-                ]
-            }
-        }, 
-        {
             "test-domain-indicator": {
                 "name": "test-domain-indicator", 
                 "implementing_scripts": [

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -5829,7 +5829,7 @@
                     "threat-grid-url-to-file": "Threat Grid"
                 }, 
                 "tests": [
-                    "Test-Detonate URL - ThreatGrid"
+                    "Detonate URL - Generic Test"
                 ]
             }
         }, 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15126

## Description
The command threat-grid-upload-sample now works properly with file names that contain new line characters.

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [X] Documentation (https://support.demisto.com/hc/en-us/articles/360007818394-Cisco-Threat-Grid)
- [ ] Code Review