### PR TITLE
Exchange 2016 Compliance Search - integration and playbook

### DIFF
--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -469,3 +469,5 @@ script:
     description: Check the status of the purge operation on the compliance search.
   dockerimage: demisto/py-ews:2.0
   runonce: false
+tests:
+  - No test

--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -5,7 +5,11 @@ name: Exchange 2016 Compliance Search
 display: Exchange 2016 Compliance Search
 category: Messaging
 image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAF8ElEQVRo3tVaa2wUVRQ+lUeolLZQHwQxEUIi/GgpakvTst2d7fax7RaEUFOIRW2x7e7cme220BawNSQ1MQZFgYaH8gvlFVAxUYIIJPxRA7FSLCpBJMYnL5FEyh8cvzttodvd6e527izpJCezO3Pn3Pvde853zzkzRKKPAmUOScp+Kg/MoVF7FCiZJLHz5JA1nL8jlzxzxLoklgw908iBc5xBZKPTSzqIAcmvPU3Ltk+NSc/S5vGUz9YASBd0XIXOb2jpKm+cQDAnOvw9CAQXm1ej0ubj9PW5yVHpaXplLJU3bKN83xA9+F+gtJAnkGAdCIm50dm1EBADYgeYrJrDlF0d2UTscj7ZfXcMdN2kJW2PWwPCIZdC/jYEESwHATopwsquHVZHgb9IPAinvhI3owTRJ5L8ITm8xisjye8N+7xLtQk2JyUHPnElJhB3CcB7hCpff9TATI8bPmfzXUCfqeJAuPyzoPinEYEYkMKGr8jtnztkhbmZ3gr1MYiTXaPFgWKRFDuenMpBUyD0wemsBGqVt2EVWmgRmMoh3wjTthdAdlGpP120cz8EO/7FNJBQswm95mR7qKTBoujAqUzADJ4QDiREWDe5lInWbn5FgWysyiEAOmNgDuZFkt+N107+AGw3hUrU6VSsLsTvo4LBHMFEJVDcD7syBh1vEQikFz5SRPflkNRU2PY5cebF/oBPLjM/sMWBVEShKpRuJxeLjsMdyibx/sL2UUXHCNmrtiUZ9n/0bhSaW3uL1A2RuVxiqy1ismvQvR7ycKxx1GuUP0hRdo1GLVvfjsK8NlpMzRdhbowKlSmRQVSumg/kt4csr0Y5dZepyvuEMXh/Ctr1kA1t56vDC28jmaLnbkQZ9VSoJhqxzzh08rmhguyXPqI9xxINzOotPsDkhbXavMZlWmZgeVjh93gbHYx5//kWYFZQkfLg0P2hAg3+M3xwQb1GFe0nacVaDz3XOB3m9xiU5UP64i/M9rzG5dq+6xnanqsZ2u4rc4OEX+P3eBt9ZYQRgnf/4IAwERe7IsyARnl1PBTX9IRKYteD7mNwfNb5gD+4nKG9/9fcIOHX+D3eRggQbp42Pp616wYBUVeaVtwPhM8+H/iuPzODhF/j94QB4RNaFviR1h1K6wPxYkcyZvqHUQckC2y6utN3bzWatzDKqtZGHZDcuh56oWNSH4h3dqRRSdP5frsfXUAkVn1vNTxyO+V5zfG6GGe/ohMIn1BOKFJEej5NBfKEwfHRAWE0OBL6ldh+0H4ussRpOqVXrfFQRdtJneqN+7qD+G9J8N7hbkzEalRBusynrDFuiE7lzbCbK990s6s/Ns732WGkweMMQgxs95JSB0BnzPF61CHKWVC+cY1rZWAG5fmuhs1Vlq96JprsbzLyZRmoL1gaADrZGxHHsiSwKagwwUtDLmV9rBEwKiasvb9sY0FezgIRx/BsUybCoN5Bz32G2CppZLlJTfNssrO94sEoG6MrCLIytN8KS/EB/CQBNS1WCflNIJgeOHvKfcrLlULd2YT5ibwZ5zHxB+JAicbBjgg1MV5KcjcuIk/TdFBrKnwzTsCcyk6LmIynBd04f0Lu1qctNi05CZ2dtbxkKiknyNmQaA0Il5qOTkLDmZyXrQDzMyRNLACPmgmlu+Ebt0MTG991Yhs6sUM34n6nvufYTfsMJ4G9VMjGigNR0+LRbTf84P4lW31wWdOtZlCx8qUpMPw9fZEyUxyI1rYpCA8uGQ5Kkr8I+5y39RFa4Ds8QiCXwVpZYk2q1C9FeIexw/BZm5yMmY01PbgBJ7egcF3oLxnWjl1Kc4Ty6USAPRBDSbTYGpZqacMGJf8TvnqBxEaS8yLqyKpJhnyqfzRgHPrzzzQsfIWweE0CuHw12euHMpVG5f7N+Nwiuh2Yf77hbj6mf84Rap6/YoO1x2cnL3m1Dp2e0h1RwtkuB5CSxhZGPL9zKj4UONX/NncAxEWS/E/FOcaSJ+mfHDlNhNFlrTP0l5x9weL38LF0GrWHq2m2/uLGpT4pWvX/zRDqQjZWrVoAAAAASUVORK5CYII=
-description: Exchange 2016 Compliance Search o
+description: Exchange 2016 Compliance Search to search for and delete an email message
+  from all mailboxes in company organization.
+detaileddescription: |-
+  The Compliance Search feature in Exchange 2016 Server allows you to search all mailboxes in your organization. The integration must run **only on engine** that is installed on a target machine which is part of a domain.
+  The user need to be assigned permissions before running commands of the integration.
 configuration:
 - display: DOMAIN\USERNAME (e.g. DEMISTO.INT\admin)
   name: credentials
@@ -286,7 +290,7 @@ script:
     def create_ps_file(ps_name, ps_content):
         temp_path = os.getenv('TEMP')
         if not temp_path:
-            return_error("TEMP enviroment variable is not defined. Please add TEMP variable to the enviroment varibes.")
+            return_error("Check that the integration is using single engine without docker. If so, add TEMP variable to the enviroment varibes.")
 
         ps_path = temp_path + '\\' + ps_name
         with open(ps_path, 'w+') as file:
@@ -467,7 +471,6 @@ script:
       default: true
       description: Name of the compliance search
     description: Check the status of the purge operation on the compliance search.
-  dockerimage: demisto/py-ews:2.0
   runonce: false
 tests:
   - No test

--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -29,12 +29,12 @@ configuration:
 script:
   script: |-
     import sys, subprocess
+    import uuid
 
     USERNAME = demisto.params()['credentials']['identifier'].replace("'", "''")
     PASSWORD = demisto.params()['credentials']['password'].replace("'", "''")
     EXCHANGE_FQDN = demisto.params()['exchangeFQDN'].replace("'", "''")
     UNSECURE = demisto.params()['insecure']
-
 
     STARTCS = '''
     [CmdletBinding()]
@@ -252,6 +252,8 @@ script:
     } catch {
         $e = $_.Exception
         echo $e.Message
+    } finally {
+        Remove-PSSession $session
     }
     '''
 
@@ -269,13 +271,6 @@ script:
 
     def encode_and_submit_results(obj):
         demisto.results(str_to_unicode(obj))
-
-    def get_cs_error(stderr):
-        return {
-            "Type": entryTypes["error"],
-            "ContentsFormat": formats["text"],
-            "Contents" : stderr
-        } if stderr else None
 
     def get_cs_status(search_name, status):
         return {
@@ -302,14 +297,14 @@ script:
             os.remove(ps_path)
 
     def start_compliance_search(query):
-        ps_path = create_ps_file('startcs.ps1', STARTCS)
-        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + query + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+        ps_path = create_ps_file('startcs_' + str(uuid.uuid4()).replace('-','') + '.ps1', STARTCS)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + query.replace("'", "''") + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
 
         if stderr:
-            return get_cs_error(stderr)
+            return_error(stderr)
         prefix = '"Action status: '
         pref_ind = stdout.find(prefix)
         sub_start = pref_ind + len(prefix)
@@ -325,14 +320,14 @@ script:
         }
 
     def get_compliance_search(search_name):
-        ps_path = create_ps_file('getcs.ps1', GETCS)
+        ps_path = create_ps_file('getcs_' + search_name + '.ps1', GETCS)
         output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
 
         if stderr:
-            return get_cs_error(stderr)
+            return_error(stderr)
         stdout = stdout.split('\n', 1)
         status = stdout[0].strip()
         results = [get_cs_status(search_name, status)]
@@ -352,43 +347,34 @@ script:
         return results
 
     def remove_compliance_search(search_name):
-        ps_path = create_ps_file('removecs.ps1', REMOVECS)
+        ps_path = create_ps_file('removecs_' + search_name + '.ps1', REMOVECS)
         output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
 
-        if stderr:
-            return get_cs_error(stderr)
-
-        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Removed')
+        return return_error(stderr) if stderr else get_cs_status(search_name, 'Removed')
 
     def purge_compliance_search(search_name):
-        ps_path = create_ps_file('startpurge.ps1', STARTPURGE)
+        ps_path = create_ps_file('startpurge_' + search_name + '.ps1', STARTPURGE)
         output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
 
-        if stderr:
-            return get_cs_error(stderr)
-
-        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Purging')
+        return return_error(stderr) if stderr else get_cs_status(search_name, 'Purging')
 
     def check_purge_compliance_search(search_name):
-        ps_path = create_ps_file('checkpurge.ps1', CHECKPURGE)
+        ps_path = create_ps_file('checkpurge_' + search_name + '.ps1', CHECKPURGE)
         output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
 
-        if stderr:
-            return get_cs_error(stderr)
-
-        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Purged' if stdout.strip() == 'Completed' else 'Purging')
+        return return_error(stderr) if stderr else get_cs_status(search_name, 'Purged' if stdout.strip() == 'Completed' else 'Purging')
 
     def test_module():
-        ps_path = create_ps_file('testcon.ps1', TESTCON)
+        ps_path = create_ps_file('testcon_' + str(uuid.uuid4()).replace('-','') + '.ps1', TESTCON)
         output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout = output.communicate()[0].strip()
@@ -397,7 +383,7 @@ script:
         if stdout == "successful connection":
             demisto.results('ok')
         else:
-            return_error(str(stdout))
+            return_error(stdout)
 
 
     args = prepare_args(demisto.args())
@@ -414,11 +400,11 @@ script:
             encode_and_submit_results(check_purge_compliance_search(**args))
         elif demisto.command() == 'test-module':
             test_module()
-
     except Exception, e:
         if isinstance(e, WindowsError):
             return_error("Could not open powershell on the target engine.")
-
+        else:
+            return_error(e)
   type: python
   commands:
   - name: exchange2016-start-compliance-search

--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -5,18 +5,18 @@ name: Exchange 2016 Compliance Search
 display: Exchange 2016 Compliance Search
 category: Messaging
 image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAF8ElEQVRo3tVaa2wUVRQ+lUeolLZQHwQxEUIi/GgpakvTst2d7fax7RaEUFOIRW2x7e7cme220BawNSQ1MQZFgYaH8gvlFVAxUYIIJPxRA7FSLCpBJMYnL5FEyh8cvzttodvd6e527izpJCezO3Pn3Pvde853zzkzRKKPAmUOScp+Kg/MoVF7FCiZJLHz5JA1nL8jlzxzxLoklgw908iBc5xBZKPTSzqIAcmvPU3Ltk+NSc/S5vGUz9YASBd0XIXOb2jpKm+cQDAnOvw9CAQXm1ej0ubj9PW5yVHpaXplLJU3bKN83xA9+F+gtJAnkGAdCIm50dm1EBADYgeYrJrDlF0d2UTscj7ZfXcMdN2kJW2PWwPCIZdC/jYEESwHATopwsquHVZHgb9IPAinvhI3owTRJ5L8ITm8xisjye8N+7xLtQk2JyUHPnElJhB3CcB7hCpff9TATI8bPmfzXUCfqeJAuPyzoPinEYEYkMKGr8jtnztkhbmZ3gr1MYiTXaPFgWKRFDuenMpBUyD0wemsBGqVt2EVWmgRmMoh3wjTthdAdlGpP120cz8EO/7FNJBQswm95mR7qKTBoujAqUzADJ4QDiREWDe5lInWbn5FgWysyiEAOmNgDuZFkt+N107+AGw3hUrU6VSsLsTvo4LBHMFEJVDcD7syBh1vEQikFz5SRPflkNRU2PY5cebF/oBPLjM/sMWBVEShKpRuJxeLjsMdyibx/sL2UUXHCNmrtiUZ9n/0bhSaW3uL1A2RuVxiqy1ismvQvR7ycKxx1GuUP0hRdo1GLVvfjsK8NlpMzRdhbowKlSmRQVSumg/kt4csr0Y5dZepyvuEMXh/Ctr1kA1t56vDC28jmaLnbkQZ9VSoJhqxzzh08rmhguyXPqI9xxINzOotPsDkhbXavMZlWmZgeVjh93gbHYx5//kWYFZQkfLg0P2hAg3+M3xwQb1GFe0nacVaDz3XOB3m9xiU5UP64i/M9rzG5dq+6xnanqsZ2u4rc4OEX+P3eBt9ZYQRgnf/4IAwERe7IsyARnl1PBTX9IRKYteD7mNwfNb5gD+4nKG9/9fcIOHX+D3eRggQbp42Pp616wYBUVeaVtwPhM8+H/iuPzODhF/j94QB4RNaFviR1h1K6wPxYkcyZvqHUQckC2y6utN3bzWatzDKqtZGHZDcuh56oWNSH4h3dqRRSdP5frsfXUAkVn1vNTxyO+V5zfG6GGe/ohMIn1BOKFJEej5NBfKEwfHRAWE0OBL6ldh+0H4ussRpOqVXrfFQRdtJneqN+7qD+G9J8N7hbkzEalRBusynrDFuiE7lzbCbK990s6s/Ns732WGkweMMQgxs95JSB0BnzPF61CHKWVC+cY1rZWAG5fmuhs1Vlq96JprsbzLyZRmoL1gaADrZGxHHsiSwKagwwUtDLmV9rBEwKiasvb9sY0FezgIRx/BsUybCoN5Bz32G2CppZLlJTfNssrO94sEoG6MrCLIytN8KS/EB/CQBNS1WCflNIJgeOHvKfcrLlULd2YT5ibwZ5zHxB+JAicbBjgg1MV5KcjcuIk/TdFBrKnwzTsCcyk6LmIynBd04f0Lu1qctNi05CZ2dtbxkKiknyNmQaA0Il5qOTkLDmZyXrQDzMyRNLACPmgmlu+Ebt0MTG991Yhs6sUM34n6nvufYTfsMJ4G9VMjGigNR0+LRbTf84P4lW31wWdOtZlCx8qUpMPw9fZEyUxyI1rYpCA8uGQ5Kkr8I+5y39RFa4Ds8QiCXwVpZYk2q1C9FeIexw/BZm5yMmY01PbgBJ7egcF3oLxnWjl1Kc4Ty6USAPRBDSbTYGpZqacMGJf8TvnqBxEaS8yLqyKpJhnyqfzRgHPrzzzQsfIWweE0CuHw12euHMpVG5f7N+Nwiuh2Yf77hbj6mf84Rap6/YoO1x2cnL3m1Dp2e0h1RwtkuB5CSxhZGPL9zKj4UONX/NncAxEWS/E/FOcaSJ+mfHDlNhNFlrTP0l5x9weL38LF0GrWHq2m2/uLGpT4pWvX/zRDqQjZWrVoAAAAASUVORK5CYII=
-description: Exchange 2016 Compliance Search to search for and delete an email message
-  from all mailboxes in company organization.
+description: Exchange Server 2016 Compliance Search enables you to search for and delete an email message
+  from all mailboxes in your organization.
 detaileddescription: |-
-  The Compliance Search feature in Exchange 2016 Server allows you to search all mailboxes in your organization. The integration must run **only on engine** that is installed on a target machine which is part of a domain.
+  The Compliance Search feature in Exchange Server 2016 enables you to search all mailboxes in your organization. This integration must run on an engine that is installed on a target machine, which is part of a domain.
   The user need to be assigned permissions before running commands of the integration.
 configuration:
-- display: DOMAIN\USERNAME (e.g. DEMISTO.INT\admin)
+- display: DOMAIN\USERNAME (e.g., DEMISTO.INT\admin)
   name: credentials
   defaultvalue: ""
   type: 9
   required: true
-- display: Fully qualified domain name of Exchange server
+- display: Exchange Server fully qualified domain name (FQDN)
   name: exchangeFQDN
   defaultvalue: ""
   type: 0
@@ -426,7 +426,7 @@ script:
     - name: query
       required: true
       default: true
-      description: Query to use for finding mails
+      description: Query for finding mail messages
     outputs:
     - contextPath: EWS.ComplianceSearch.Name
       description: The name of the compliance search
@@ -434,7 +434,7 @@ script:
     - contextPath: EWS.ComplianceSearch.Status
       description: The status of the compliance search
       type: string
-    description: Start compliance search
+    description: Initiates a compliance search.
   - name: exchange2016-get-compliance-search
     arguments:
     - name: search-name
@@ -445,7 +445,7 @@ script:
     - contextPath: EWS.ComplianceSearch.Status
       description: The status of the compliance search
       type: string
-    description: Get compliance search status and results
+    description: Gets the status and results of a compliance search.
   - name: exchange2016-remove-compliance-search
     arguments:
     - name: search-name
@@ -456,21 +456,21 @@ script:
     - contextPath: EWS.ComplianceSearch.Status
       description: The status of the compliance search
       type: string
-    description: Remove the compliance search
+    description: Removes the compliance search from the Exchange Server.
   - name: exchange2016-purge-compliance-search-results
     arguments:
     - name: search-name
       required: true
       default: true
       description: Name of the compliance search
-    description: Purges the results found by the compliance search
+    description: Purges the results found during the compliance search.
   - name: exchange2016-get-compliance-search-purge-status
     arguments:
     - name: search-name
       required: true
       default: true
       description: Name of the compliance search
-    description: Check the status of the purge operation on the compliance search.
+    description: Checks the status of the purge operation on the compliance search.
   runonce: false
 tests:
   - No test

--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -1,0 +1,471 @@
+commonfields:
+  id: Exchange 2016 Compliance Search
+  version: -1
+name: Exchange 2016 Compliance Search
+display: Exchange 2016 Compliance Search
+category: Messaging
+image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAF8ElEQVRo3tVaa2wUVRQ+lUeolLZQHwQxEUIi/GgpakvTst2d7fax7RaEUFOIRW2x7e7cme220BawNSQ1MQZFgYaH8gvlFVAxUYIIJPxRA7FSLCpBJMYnL5FEyh8cvzttodvd6e527izpJCezO3Pn3Pvde853zzkzRKKPAmUOScp+Kg/MoVF7FCiZJLHz5JA1nL8jlzxzxLoklgw908iBc5xBZKPTSzqIAcmvPU3Ltk+NSc/S5vGUz9YASBd0XIXOb2jpKm+cQDAnOvw9CAQXm1ej0ubj9PW5yVHpaXplLJU3bKN83xA9+F+gtJAnkGAdCIm50dm1EBADYgeYrJrDlF0d2UTscj7ZfXcMdN2kJW2PWwPCIZdC/jYEESwHATopwsquHVZHgb9IPAinvhI3owTRJ5L8ITm8xisjye8N+7xLtQk2JyUHPnElJhB3CcB7hCpff9TATI8bPmfzXUCfqeJAuPyzoPinEYEYkMKGr8jtnztkhbmZ3gr1MYiTXaPFgWKRFDuenMpBUyD0wemsBGqVt2EVWmgRmMoh3wjTthdAdlGpP120cz8EO/7FNJBQswm95mR7qKTBoujAqUzADJ4QDiREWDe5lInWbn5FgWysyiEAOmNgDuZFkt+N107+AGw3hUrU6VSsLsTvo4LBHMFEJVDcD7syBh1vEQikFz5SRPflkNRU2PY5cebF/oBPLjM/sMWBVEShKpRuJxeLjsMdyibx/sL2UUXHCNmrtiUZ9n/0bhSaW3uL1A2RuVxiqy1ismvQvR7ycKxx1GuUP0hRdo1GLVvfjsK8NlpMzRdhbowKlSmRQVSumg/kt4csr0Y5dZepyvuEMXh/Ctr1kA1t56vDC28jmaLnbkQZ9VSoJhqxzzh08rmhguyXPqI9xxINzOotPsDkhbXavMZlWmZgeVjh93gbHYx5//kWYFZQkfLg0P2hAg3+M3xwQb1GFe0nacVaDz3XOB3m9xiU5UP64i/M9rzG5dq+6xnanqsZ2u4rc4OEX+P3eBt9ZYQRgnf/4IAwERe7IsyARnl1PBTX9IRKYteD7mNwfNb5gD+4nKG9/9fcIOHX+D3eRggQbp42Pp616wYBUVeaVtwPhM8+H/iuPzODhF/j94QB4RNaFviR1h1K6wPxYkcyZvqHUQckC2y6utN3bzWatzDKqtZGHZDcuh56oWNSH4h3dqRRSdP5frsfXUAkVn1vNTxyO+V5zfG6GGe/ohMIn1BOKFJEej5NBfKEwfHRAWE0OBL6ldh+0H4ussRpOqVXrfFQRdtJneqN+7qD+G9J8N7hbkzEalRBusynrDFuiE7lzbCbK990s6s/Ns732WGkweMMQgxs95JSB0BnzPF61CHKWVC+cY1rZWAG5fmuhs1Vlq96JprsbzLyZRmoL1gaADrZGxHHsiSwKagwwUtDLmV9rBEwKiasvb9sY0FezgIRx/BsUybCoN5Bz32G2CppZLlJTfNssrO94sEoG6MrCLIytN8KS/EB/CQBNS1WCflNIJgeOHvKfcrLlULd2YT5ibwZ5zHxB+JAicbBjgg1MV5KcjcuIk/TdFBrKnwzTsCcyk6LmIynBd04f0Lu1qctNi05CZ2dtbxkKiknyNmQaA0Il5qOTkLDmZyXrQDzMyRNLACPmgmlu+Ebt0MTG991Yhs6sUM34n6nvufYTfsMJ4G9VMjGigNR0+LRbTf84P4lW31wWdOtZlCx8qUpMPw9fZEyUxyI1rYpCA8uGQ5Kkr8I+5y39RFa4Ds8QiCXwVpZYk2q1C9FeIexw/BZm5yMmY01PbgBJ7egcF3oLxnWjl1Kc4Ty6USAPRBDSbTYGpZqacMGJf8TvnqBxEaS8yLqyKpJhnyqfzRgHPrzzzQsfIWweE0CuHw12euHMpVG5f7N+Nwiuh2Yf77hbj6mf84Rap6/YoO1x2cnL3m1Dp2e0h1RwtkuB5CSxhZGPL9zKj4UONX/NncAxEWS/E/FOcaSJ+mfHDlNhNFlrTP0l5x9weL38LF0GrWHq2m2/uLGpT4pWvX/zRDqQjZWrVoAAAAASUVORK5CYII=
+description: Exchange 2016 Compliance Search o
+configuration:
+- display: DOMAIN\USERNAME (e.g. DEMISTO.INT\admin)
+  name: credentials
+  defaultvalue: ""
+  type: 9
+  required: true
+- display: Fully qualified domain name of Exchange server
+  name: exchangeFQDN
+  defaultvalue: ""
+  type: 0
+  required: true
+- display: Trust any certificate (unsecure)
+  name: insecure
+  defaultvalue: ""
+  type: 8
+  required: false
+script:
+  script: |-
+    import sys, subprocess
+
+    USERNAME = demisto.params()['credentials']['identifier'].replace("'", "''")
+    PASSWORD = demisto.params()['credentials']['password'].replace("'", "''")
+    EXCHANGE_FQDN = demisto.params()['exchangeFQDN'].replace("'", "''")
+    UNSECURE = demisto.params()['insecure']
+
+
+    STARTCS = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$query,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    $searchName = [guid]::NewGuid().ToString() -replace '[-]'
+    $searchName = "DemistoSearch" + $searchName
+    if($unsecure){
+        $url = "http://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+    }else{
+        $url = "https://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+    }
+    if (!$session)
+    {
+        "Failed to create remote PS session"
+        return
+    }
+    Import-PSSession $session -CommandName *Compliance* -AllowClobber -DisableNameChecking -Verbose:$false | Out-Null
+    $compliance = New-ComplianceSearch -Name $searchName -ExchangeLocation All -ContentMatchQuery $query -Confirm:$false
+    Start-ComplianceSearch -Identity $searchName
+    $complianceSearchName = "Action status: " + $searchName
+    $complianceSearchName | ConvertTo-Json
+    Remove-PSSession $session
+    '''
+
+    GETCS = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$searchName,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    if($unsecure){
+        $url = "http://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+    }else{
+        $url = "https://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+    }
+    if (!$session)
+    {
+        "Failed to create remote PS session"
+        return
+    }
+    Import-PSSession $session -CommandName Get-ComplianceSearch -AllowClobber -DisableNameChecking -Verbose:$false | Out-Null
+    $searchStatus = Get-ComplianceSearch $searchName
+    $searchStatus.Status
+    if ($searchStatus.Status -eq "Completed")
+    {
+        $searchStatus.SuccessResults | ConvertTo-Json
+    }
+    Remove-PSSession $session
+    '''
+
+    REMOVECS = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$searchName,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    if($unsecure){
+        $url = "http://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+    }else{
+        $url = "https://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+    }
+    if (!$session)
+    {
+        "Failed to create remote PS session"
+        return
+    }
+    Import-PSSession $session -CommandName *Compliance* -AllowClobber -DisableNameChecking -Verbose:$false | Out-Null
+    Remove-ComplianceSearch $searchName -Confirm:$false
+    Remove-PSSession $session
+    '''
+
+    STARTPURGE = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$searchName,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    if($unsecure){
+        $url = "http://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+    }else{
+        $url = "https://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+    }
+    if (!$session)
+    {
+        "Failed to create remote PS session"
+        return
+    }
+    Import-PSSession $session -CommandName *Compliance* -AllowClobber -DisableNameChecking -Verbose:$false | Out-Null
+    $newActionResult = New-ComplianceSearchAction -SearchName $searchName -Purge -PurgeType SoftDelete -Confirm:$false
+    if (!$newActionResult)
+    {
+        "No action was created"
+    }
+    Remove-PSSession $session
+    return
+    '''
+
+    CHECKPURGE = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$searchName,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    if($unsecure){
+        $url = "http://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+    }else{
+        $url = "https://" + $server + "/PowerShell"
+        $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+    }
+    if (!$session)
+    {
+        "Failed to create remote PS session"
+        return
+    }
+    Import-PSSession $session -CommandName *Compliance* -AllowClobber -DisableNameChecking -Verbose:$false | Out-Null
+    $actionName = $searchName + "_Purge"
+    $actionStatus = Get-ComplianceSearchAction $actionName
+    ""
+    $actionStatus.Status
+    Remove-PSSession $session
+    '''
+
+    TESTCON = '''
+    [CmdletBinding()]
+    Param(
+    [Parameter(Mandatory=$True)]
+    [string]$username,
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+    [Parameter(Mandatory=$True)]
+    [string]$server,
+    [Parameter(Mandatory=$True)]
+    [bool]$unsecure
+    )
+    $errorActionPreference = 'Stop'
+    $WarningPreference = "silentlyContinue"
+    $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+    $UserCredential = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
+    try{
+        if($unsecure){
+            $url = "http://" + $server + "/PowerShell"
+            $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Kerberos
+        }else{
+            $url = "https://" + $server + "/PowerShell"
+            $session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri $url -Credential $UserCredential -Authentication Basic -AllowRedirection
+        }
+        echo "successful connection"
+    } catch {
+        $e = $_.Exception
+        echo $e.Message
+    }
+    '''
+
+    def prepare_args(d):
+        return dict((k.replace("-", "_"), v) for k, v in d.items())
+
+    def str_to_unicode(obj):
+        if isinstance(obj, dict):
+            obj = {k: str_to_unicode(v) for k,v in obj.iteritems()}
+        elif isinstance(obj, list):
+            obj = map(str_to_unicode, obj)
+        elif isinstance(obj, str):
+            obj = unicode(obj, "utf-8")
+        return obj
+
+    def encode_and_submit_results(obj):
+        demisto.results(str_to_unicode(obj))
+
+    def get_cs_error(stderr):
+        return {
+            "Type": entryTypes["error"],
+            "ContentsFormat": formats["text"],
+            "Contents" : stderr
+        } if stderr else None
+
+    def get_cs_status(search_name, status):
+        return {
+            'Type': entryTypes['note'],
+            'ContentsFormat': formats['text'],
+            'Contents': 'Search {} status: {}'.format(search_name, status),
+            'EntryContext': {
+                'EWS.ComplianceSearch(val.Name === obj.Name)': {'Name': search_name, 'Status': status}
+            }
+        }
+
+    def create_ps_file(ps_name, ps_content):
+        temp_path = os.getenv('TEMP')
+        if not temp_path:
+            return_error("TEMP enviroment variable is not defined. Please add TEMP variable to the enviroment varibes.")
+
+        ps_path = temp_path + '\\' + ps_name
+        with open(ps_path, 'w+') as file:
+            file.write(ps_content)
+        return ps_path
+
+    def delete_ps_file(ps_path):
+        if os.path.exists(ps_path):
+            os.remove(ps_path)
+
+    def start_compliance_search(query):
+        ps_path = create_ps_file('startcs.ps1', STARTCS)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + query + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = output.communicate()
+        delete_ps_file(ps_path)
+
+        if stderr:
+            return get_cs_error(stderr)
+        prefix = '"Action status: '
+        pref_ind = stdout.find(prefix)
+        sub_start = pref_ind + len(prefix)
+        sub_end = sub_start + 45
+        search_name = stdout[sub_start:sub_end]
+        return {
+            'Type': entryTypes['note'],
+            'ContentsFormat': formats['text'],
+            'Contents': 'Search started: {}'.format(search_name),
+            'EntryContext': {
+                'EWS.ComplianceSearch': {'Name': search_name, 'Status': 'Starting'}
+            }
+        }
+
+    def get_compliance_search(search_name):
+        ps_path = create_ps_file('getcs.ps1', GETCS)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = output.communicate()
+        delete_ps_file(ps_path)
+
+        if stderr:
+            return get_cs_error(stderr)
+        stdout = stdout.split('\n', 1)
+        status = stdout[0].strip()
+        results = [get_cs_status(search_name, status)]
+
+        if status == 'Completed' and len(stdout[1].strip()) > 4:
+            res = list(r[:-1].split(', ') if r[-1] == ',' else r.split(', ') for r in stdout[1][2:-4].split(r'\r\n'))
+            res = map(lambda x: {k: v for k,v in (s.split(': ') for s in x)}, res)
+            results.append(
+                {
+                    'Type': entryTypes['note'],
+                    'ContentsFormat': formats['text'],
+                    'Contents': stdout,
+                    'ReadableContentsFormat': formats['markdown'],
+                    'HumanReadable': tableToMarkdown('Exchange 2016 Compliance search results', res, ['Location', 'Item count', 'Total size'])
+                }
+            )
+        return results
+
+    def remove_compliance_search(search_name):
+        ps_path = create_ps_file('removecs.ps1', REMOVECS)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = output.communicate()
+        delete_ps_file(ps_path)
+
+        if stderr:
+            return get_cs_error(stderr)
+
+        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Removed')
+
+    def purge_compliance_search(search_name):
+        ps_path = create_ps_file('startpurge.ps1', STARTPURGE)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = output.communicate()
+        delete_ps_file(ps_path)
+
+        if stderr:
+            return get_cs_error(stderr)
+
+        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Purging')
+
+    def check_purge_compliance_search(search_name):
+        ps_path = create_ps_file('checkpurge.ps1', CHECKPURGE)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + search_name + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = output.communicate()
+        delete_ps_file(ps_path)
+
+        if stderr:
+            return get_cs_error(stderr)
+
+        return get_cs_error(stderr) if stderr else get_cs_status(search_name, 'Purged' if stdout.strip() == 'Completed' else 'Purging')
+
+    def test_module():
+        ps_path = create_ps_file('testcon.ps1', TESTCON)
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout = output.communicate()[0].strip()
+        delete_ps_file(ps_path)
+
+        if stdout == "successful connection":
+            demisto.results('ok')
+        else:
+            return_error(str(stdout))
+
+
+    args = prepare_args(demisto.args())
+    try:
+        if demisto.command() == 'exchange2016-start-compliance-search':
+            encode_and_submit_results(start_compliance_search(**args))
+        elif demisto.command() == 'exchange2016-get-compliance-search':
+            encode_and_submit_results(get_compliance_search(**args))
+        elif demisto.command() == 'exchange2016-remove-compliance-search':
+            encode_and_submit_results(remove_compliance_search(**args))
+        elif demisto.command() == 'exchange2016-purge-compliance-search-results':
+            encode_and_submit_results(purge_compliance_search(**args))
+        elif demisto.command() == 'exchange2016-get-compliance-search-purge-status':
+            encode_and_submit_results(check_purge_compliance_search(**args))
+        elif demisto.command() == 'test-module':
+            test_module()
+
+    except Exception, e:
+        if isinstance(e, WindowsError):
+            return_error("Could not open powershell on the target engine.")
+
+  type: python
+  commands:
+  - name: exchange2016-start-compliance-search
+    arguments:
+    - name: query
+      required: true
+      default: true
+      description: Query to use for finding mails
+    outputs:
+    - contextPath: EWS.ComplianceSearch.Name
+      description: The name of the compliance search
+      type: string
+    - contextPath: EWS.ComplianceSearch.Status
+      description: The status of the compliance search
+      type: string
+    description: Start compliance search
+  - name: exchange2016-get-compliance-search
+    arguments:
+    - name: search-name
+      required: true
+      default: true
+      description: Name of the compliance search
+    outputs:
+    - contextPath: EWS.ComplianceSearch.Status
+      description: The status of the compliance search
+      type: string
+    description: Get compliance search status and results
+  - name: exchange2016-remove-compliance-search
+    arguments:
+    - name: search-name
+      required: true
+      default: true
+      description: Name of the compliance search
+    outputs:
+    - contextPath: EWS.ComplianceSearch.Status
+      description: The status of the compliance search
+      type: string
+    description: Remove the compliance search
+  - name: exchange2016-purge-compliance-search-results
+    arguments:
+    - name: search-name
+      required: true
+      default: true
+      description: Name of the compliance search
+    description: Purges the results found by the compliance search
+  - name: exchange2016-get-compliance-search-purge-status
+    arguments:
+    - name: search-name
+      required: true
+      default: true
+      description: Name of the compliance search
+    description: Check the status of the purge operation on the compliance search.
+  dockerimage: demisto/py-ews:2.0
+  runonce: false

--- a/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
+++ b/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
@@ -358,4 +358,6 @@ inputs:
   description: Compliance Search query
 outputs: []
 fromversion: '4.1.0'
+tests:
+  - No test
 

--- a/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
+++ b/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
@@ -1,7 +1,7 @@
 id: Exchange 2016 Search and Delete
 version: -1
 name: Exchange 2016 Search and Delete
-description: Run a ComplianceSearch on Exchange 2016 and delete the results.
+description: Run a compliance search in Exchange Server 2016, and delete the results.
 starttaskid: "0"
 tasks:
   "0":
@@ -35,8 +35,8 @@ tasks:
     task:
       id: 7039555d-70e8-4c48-8629-9b8377054fe1
       version: -1
-      name: exchange2016-start-compliance-search
-      description: Start compliance search
+      name: Start compliance search
+      description: Initiates a compliance search.
       script: '|||exchange2016-start-compliance-search'
       type: regular
       iscommand: true
@@ -118,8 +118,8 @@ tasks:
     task:
       id: 5b175cb9-d3f6-4b54-8eac-7f64b17abc6e
       version: -1
-      name: exchange2016-get-compliance-search
-      description: Get compliance search status and results
+      name: Get compliance search
+      description: Gets the status and results of a compliance search.
       script: '|||exchange2016-get-compliance-search'
       type: regular
       iscommand: true
@@ -149,7 +149,7 @@ tasks:
     task:
       id: ba34205c-fc58-4017-8377-cffd6187b25a
       version: -1
-      name: Purge Compliance Search Results?
+      name: Purge compliance search results?
       description: Purge Compliance Search Results?
       type: condition
       iscommand: false
@@ -176,8 +176,8 @@ tasks:
     task:
       id: b05fb387-956b-4bd3-8250-ece9ec819df4
       version: -1
-      name: exchange2016-purge-compliance-search-results
-      description: Purges the results found by the compliance search
+      name: Purge compliance search results
+      description: Purges the results found during the compliance search.
       script: '|||exchange2016-purge-compliance-search-results'
       type: regular
       iscommand: true
@@ -281,8 +281,8 @@ tasks:
     task:
       id: d183b55d-38f2-4768-86f5-b4a935db4086
       version: -1
-      name: exchange2016-get-compliance-search-purge-status
-      description: Check the status of the purge operation on the compliance search.
+      name: Get compliance search purge status
+      description: Checks the status of the purge operation on the compliance search.
       script: '|||exchange2016-get-compliance-search-purge-status'
       type: regular
       iscommand: true
@@ -312,8 +312,8 @@ tasks:
     task:
       id: a17e54ba-09c7-4ec7-8350-3d64035b7eea
       version: -1
-      name: exchange2016-remove-compliance-search
-      description: Remove the compliance search
+      name: Remove compliance search
+      description: Removes the compliance search from the Exchange Server.
       script: '|||exchange2016-remove-compliance-search'
       type: regular
       iscommand: true
@@ -355,7 +355,7 @@ inputs:
 - key: Query
   value: {}
   required: true
-  description: Compliance Search query
+  description: Query for finding mail messages
 outputs: []
 fromversion: '4.1.0'
 tests:

--- a/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
+++ b/Playbooks/playbook-Exchange_2016_Search_and_Delete.yml
@@ -1,0 +1,361 @@
+id: Exchange 2016 Search and Delete
+version: -1
+name: Exchange 2016 Search and Delete
+description: Run a ComplianceSearch on Exchange 2016 and delete the results.
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 54ef50e9-fe1c-4750-8c0c-0f23d1adcc2f
+    type: start
+    task:
+      id: 54ef50e9-fe1c-4750-8c0c-0f23d1adcc2f
+      version: -1
+      name: ""
+      description: start
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+  "1":
+    id: "1"
+    taskid: 7039555d-70e8-4c48-8629-9b8377054fe1
+    type: regular
+    task:
+      id: 7039555d-70e8-4c48-8629-9b8377054fe1
+      version: -1
+      name: exchange2016-start-compliance-search
+      description: Start compliance search
+      script: '|||exchange2016-start-compliance-search'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      query:
+        complex:
+          root: inputs.Query
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+  "2":
+    id: "2"
+    taskid: 4bca699e-9654-4bd2-8b5f-56d98abb4714
+    type: playbook
+    task:
+      id: 4bca699e-9654-4bd2-8b5f-56d98abb4714
+      version: -1
+      name: GenericPolling
+      description: |-
+        Use as a sub-playbook to block execution of the master playbook until a remote action is complete.
+        This playbook implements polling by continually running the command in Step #2 until the operation completes.
+        The remote action should have the following structure:
+
+        1. Initiate the operation.
+        2. Poll to check if the operation completed.
+        3. (optional) Get the results of the operation.
+      playbookName: GenericPolling
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      Ids:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+      Interval:
+        simple: "15"
+      PollingCommandArgName:
+        simple: search-name
+      PollingCommandName:
+        simple: exchange2016-get-compliance-search
+      Timeout:
+        simple: "10080"
+      dt:
+        simple: EWS.ComplianceSearch(val.Status === 'InProgress' || val.Status ===
+          'Starting').Name
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "3":
+    id: "3"
+    taskid: 5b175cb9-d3f6-4b54-8eac-7f64b17abc6e
+    type: regular
+    task:
+      id: 5b175cb9-d3f6-4b54-8eac-7f64b17abc6e
+      version: -1
+      name: exchange2016-get-compliance-search
+      description: Get compliance search status and results
+      script: '|||exchange2016-get-compliance-search'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      search-name:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+  "4":
+    id: "4"
+    taskid: ba34205c-fc58-4017-8377-cffd6187b25a
+    type: condition
+    task:
+      id: ba34205c-fc58-4017-8377-cffd6187b25a
+      version: -1
+      name: Purge Compliance Search Results?
+      description: Purge Compliance Search Results?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "9"
+      Purge:
+      - "5"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "5":
+    id: "5"
+    taskid: b05fb387-956b-4bd3-8250-ece9ec819df4
+    type: regular
+    task:
+      id: b05fb387-956b-4bd3-8250-ece9ec819df4
+      version: -1
+      name: exchange2016-purge-compliance-search-results
+      description: Purges the results found by the compliance search
+      script: '|||exchange2016-purge-compliance-search-results'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+    scriptarguments:
+      search-name:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+  "6":
+    id: "6"
+    taskid: 5558f163-14fa-47e2-824f-a59ee77f6f05
+    type: title
+    task:
+      id: 5558f163-14fa-47e2-824f-a59ee77f6f05
+      version: -1
+      name: Done
+      description: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1595
+        }
+      }
+    note: false
+    timertriggers: []
+  "7":
+    id: "7"
+    taskid: 127a2261-119e-43d2-8e3d-14b73f72516c
+    type: playbook
+    task:
+      id: 127a2261-119e-43d2-8e3d-14b73f72516c
+      version: -1
+      name: GenericPolling
+      description: |-
+        Use as a sub-playbook to block execution of the master playbook until a remote action is complete.
+        This playbook implements polling by continually running the command in Step #2 until the operation completes.
+        The remote action should have the following structure:
+
+        1. Initiate the operation.
+        2. Poll to check if the operation completed.
+        3. (optional) Get the results of the operation.
+      playbookName: GenericPolling
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      Ids:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+      Interval:
+        simple: "15"
+      PollingCommandArgName:
+        simple: search-name
+      PollingCommandName:
+        simple: exchange2016-get-compliance-search-purge-status
+      Timeout:
+        simple: "1440"
+      dt:
+        simple: EWS.ComplianceSearch(val.Status === 'Purging').Name
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+  "8":
+    id: "8"
+    taskid: d183b55d-38f2-4768-86f5-b4a935db4086
+    type: regular
+    task:
+      id: d183b55d-38f2-4768-86f5-b4a935db4086
+      version: -1
+      name: exchange2016-get-compliance-search-purge-status
+      description: Check the status of the purge operation on the compliance search.
+      script: '|||exchange2016-get-compliance-search-purge-status'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "9"
+    scriptarguments:
+      search-name:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 162.5,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
+  "9":
+    id: "9"
+    taskid: a17e54ba-09c7-4ec7-8350-3d64035b7eea
+    type: regular
+    task:
+      id: a17e54ba-09c7-4ec7-8350-3d64035b7eea
+      version: -1
+      name: exchange2016-remove-compliance-search
+      description: Remove the compliance search
+      script: '|||exchange2016-remove-compliance-search'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      search-name:
+        complex:
+          root: EWS
+          accessor: ComplianceSearch.Name
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1420
+        }
+      }
+    note: false
+    timertriggers: []
+view: |-
+  {
+    "linkLabelsPosition": {
+      "4_5_Purge": 0.57,
+      "4_9_#default#": 0.1
+    },
+    "paper": {
+      "dimensions": {
+        "height": 1610,
+        "width": 492.5,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: Query
+  value: {}
+  required: true
+  description: Compliance Search query
+outputs: []
+fromversion: '4.1.0'
+

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -6013,6 +6013,25 @@
             }
         }, 
         {
+            "Exchange 2016 Search and Delete": {
+                "name": "Exchange 2016 Search and Delete", 
+                "fromversion": "4.1.0", 
+                "implementing_playbooks": [
+                    "GenericPolling"
+                ], 
+                "command_to_integration": {
+                    "exchange2016-get-compliance-search-purge-status": "", 
+                    "exchange2016-get-compliance-search": "", 
+                    "exchange2016-purge-compliance-search-results": "", 
+                    "exchange2016-start-compliance-search": "", 
+                    "exchange2016-remove-compliance-search": ""
+                }, 
+                "tests": [
+                    "No test"
+                ]
+            }
+        }, 
+        {
             "extract_indicators_-_generic": {
                 "name": "Extract Indicators - Generic", 
                 "fromversion": "3.5.0", 
@@ -8816,6 +8835,21 @@
                 "tests": [
                     "pyEWS_Test", 
                     "EWS search-mailbox test"
+                ]
+            }
+        }, 
+        {
+            "Exchange 2016 Compliance Search": {
+                "name": "Exchange 2016 Compliance Search", 
+                "commands": [
+                    "exchange2016-start-compliance-search", 
+                    "exchange2016-get-compliance-search", 
+                    "exchange2016-remove-compliance-search", 
+                    "exchange2016-purge-compliance-search-results", 
+                    "exchange2016-get-compliance-search-purge-status"
+                ], 
+                "tests": [
+                    "No test"
                 ]
             }
         }, 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/14122

## Description
The integration can run only on engine without docker as described in the integration tips. 

The integration has the following commands:
1. exchange2016-start-compliance-search
2. exchange2016-get-compliance-search
3. exchange2016-remove-compliance-search
4. exchange2016-purge-compliance-search-results
5. exchange2016-get-compliance-search-purge-status

Functionality and outputs of the commands are identical to `ews-0365` commands that are part of `EWS v2` integration.

Additionally added `Exchange 2016 Search and Delete` playbook that accepts as an input query (KQL) that is used as search conditions for compliance Search.
Structure of the playbook is identical to `Office 365 Search and Delete` playbook.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [x] Documentation https://github.com/demisto/etc/issues/15844
- [x] Code Review