### PR TITLE
Suppressed warnings generated by out of date misp package

### DIFF
--- a/Integrations/integration-MISP_V2.yml
+++ b/Integrations/integration-MISP_V2.yml
@@ -34,6 +34,9 @@ script:
     import time
     import warnings
     from pymisp import ExpandedPyMISP, PyMISP, PyMISPError
+    import logging
+    logging.getLogger("pymisp").setLevel(logging.ERROR)
+
 
     def warn(*args, **kwargs):
         """
@@ -1735,5 +1738,6 @@ script:
     description: Add sighting to an attribute
   dockerimage: demisto/pymisp:1.0.0.52
   runonce: false
+releaseNotes: Disregarded warnings from PyMISP
 tests:
 - MISP V2 Test


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: demisto/etc#15835

## Description
Changed logger settings to only throw errors and not warnings

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Code Review

