### PR TITLE
setIntegrationContext bug bypass

### DIFF
--- a/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -112,7 +112,8 @@ def login():
         res_json = res.json()
         if 'log.loginResponse' in res_json and 'log.return' in res_json.get('log.loginResponse'):
             auth_token = res_json.get('log.loginResponse').get('log.return')
-            if demisto.command() != 'test-module':
+            if demisto.command() not in ['test-module', 'fetch-incidents']:
+                # this is done to bypass setting integration context with commands outside of the cli
                 demisto.setIntegrationContext({'auth_token': auth_token})
             return auth_token
 
@@ -775,10 +776,6 @@ try:
     elif demisto.command() == 'as-get-all-query-viewers':
         get_all_query_viewers_command()
 
-    LOG.print_log()
-
 
 except Exception, e:
-    LOG(e.message)
-    LOG.print_log()
-    return_error(e.message)
+    return_error(str(e))

--- a/Integrations/ArcSightESMv2/ArcSightESMv2.yml
+++ b/Integrations/ArcSightESMv2/ArcSightESMv2.yml
@@ -8,7 +8,7 @@ description: ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).
 configuration:
 - display: Server full URL (e.g., https://192.168.0.1:8443)
   name: server
-  defaultvalue: "<your.server>:<port>"
+  defaultvalue: ""
   type: 0
   required: true
 - display: Credentials


### PR DESCRIPTION
## Status
Ready


## Description
when setting integration context outside of the CLI we're getting time outs. this is a content side bypass for ArcSight ESM. (bug only occurs in engines).

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review
