### PR TITLE
Constructed the URL in list-managed-urls more carefully, 

### DIFF
--- a/Integrations/integration-MimecastV2.yml
+++ b/Integrations/integration-MimecastV2.yml
@@ -712,6 +712,7 @@ script:
         contents = []
         context = {}
         managed_urls_context = []
+        full_url_response = ''
         url =  demisto.args().get('url')
         if url:
             url = url.encode('utf-8')
@@ -719,9 +720,12 @@ script:
         managed_urls = list_managed_url_request()
         for managed_url in managed_urls:
             query_string = ''
+            scheme = ''
             if managed_url.get('queryString'):
                 query_string = '?' + managed_url.get('queryString')
-            full_url_response = managed_url.get('scheme') + '://' + managed_url.get('domain') + managed_url.get('path') + query_string
+            if managed_url.get('scheme'):
+                scheme = managed_url.get('scheme') + '://'
+            full_url_response = scheme + managed_url.get('domain', '') + managed_url.get('path', '') + query_string
             if (url and url in full_url_response) or not url:
                 contents.append({
                     'URL': full_url_response,
@@ -2474,5 +2478,6 @@ script:
     description: Download attachments from a specified message
   isfetch: true
   runonce: false
+releaseNotes: "Fixed potential bug in mimecast-list-managed-url"
 tests:
  - Mimecast test


### PR DESCRIPTION
even if one of the components is missing the URL won't break.

## Status
Ready

## Related Issues
fixes: @vik-patel's issue in hosted poc

## Screenshots
![image](https://user-images.githubusercontent.com/12241410/53661894-341c9880-3c6a-11e9-985c-321d97b9aa70.png)

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Code Review
