### PR TITLE
ThreatGrid - detonate File playbook fixes

### DIFF
--- a/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
@@ -28,7 +28,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 50,
           "y": 50
         }
       }
@@ -84,7 +84,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 50,
           "y": 195
         }
       }
@@ -106,8 +106,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 1420
+          "x": 50,
+          "y": 1595
         }
       }
     note: false
@@ -137,18 +137,18 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
-          "y": 1245
+          "x": 275,
+          "y": 1420
         }
       }
     note: false
     timertriggers: []
   "11":
     id: "11"
-    taskid: 8377ba6f-c57d-4cd1-8a1f-5989f89978ac
+    taskid: 754b0562-8ec3-4c58-8345-748d9cd51a72
     type: regular
     task:
-      id: 8377ba6f-c57d-4cd1-8a1f-5989f89978ac
+      id: 754b0562-8ec3-4c58-8345-748d9cd51a72
       version: -1
       name: Set file to context
       description: Set the file object into context.
@@ -158,7 +158,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "14"
+      - "18"
     scriptarguments:
       append: {}
       key:
@@ -170,61 +170,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 275,
           "y": 545
-        }
-      }
-    note: false
-    timertriggers: []
-  "14":
-    id: "14"
-    taskid: c1d5b196-d934-4ef2-8e01-3487eae58533
-    type: condition
-    task:
-      id: c1d5b196-d934-4ef2-8e01-3487eae58533
-      version: -1
-      name: Is the file type supported?
-      description: Will fail if file type is not supported.
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#default#':
-      - "6"
-      "yes":
-      - "17"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isExists
-          left:
-            value:
-              complex:
-                root: File
-                filters:
-                - - operator: match
-                    left:
-                      value:
-                        simple: File.Type
-                      iscontext: true
-                    right:
-                      value:
-                        simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
-                  - operator: match
-                    left:
-                      value:
-                        simple: File.Info
-                      iscontext: true
-                    right:
-                      value:
-                        simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
-            iscontext: true
-    view: |-
-      {
-        "position": {
-          "x": 162.5,
-          "y": 720
         }
       }
     note: false
@@ -277,8 +224,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
-          "y": 1070
+          "x": 275,
+          "y": 1245
         }
       }
     note: false
@@ -313,7 +260,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 162.5,
           "y": 370
         }
       }
@@ -386,7 +333,102 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
+          "x": 275,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+  "18":
+    id: "18"
+    taskid: 5eb99a51-d296-41dd-8a6e-93fceabc767f
+    type: condition
+    task:
+      id: 5eb99a51-d296-41dd-8a6e-93fceabc767f
+      version: -1
+      name: Is the file type supported?
+      description: Will not continue the execution if file type is not supported.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "6"
+      "yes":
+      - "19"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: match
+          left:
+            value:
+              simple: File.Type
+            iscontext: true
+          right:
+            value:
+              simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+          ignorecase: true
+        - operator: match
+          left:
+            value:
+              simple: File.Extension
+            iscontext: true
+          right:
+            value:
+              simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+          ignorecase: true
+        - operator: match
+          left:
+            value:
+              simple: File.Info
+            iscontext: true
+          right:
+            value:
+              simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+          ignorecase: true
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "19":
+    id: "19"
+    taskid: 701d7a32-0c81-4fd3-83c9-fbc7aa6efd30
+    type: condition
+    task:
+      id: 701d7a32-0c81-4fd3-83c9-fbc7aa6efd30
+      version: -1
+      name: Is the file size bigger than 0?
+      description: CHeck that fail size is bigger than 0
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "6"
+      "yes":
+      - "17"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: greaterThan
+          left:
+            value:
+              simple: File.Size
+            iscontext: true
+          right:
+            value:
+              simple: "0"
+    view: |-
+      {
+        "position": {
+          "x": 387.5,
           "y": 895
         }
       }
@@ -395,13 +437,12 @@ tasks:
 view: |-
   {
     "linkLabelsPosition": {
-      "14_17_yes": 0.76,
       "5_6_#default#": 0.44
     },
     "paper": {
       "dimensions": {
-        "height": 1435,
-        "width": 605,
+        "height": 1610,
+        "width": 717.5,
         "x": 50,
         "y": 50
       }
@@ -498,5 +539,6 @@ outputs:
   description: The sample state.
 - contextPath: Sample.ID
   description: The sample ID.
+releaseNotes: Fixes in supported file types and detonating only file with size greater than 0
 tests:
 - Detonate File - Generic Test

--- a/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
@@ -106,7 +106,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
+          "x": 70,
           "y": 1595
         }
       }
@@ -137,7 +137,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 500,
           "y": 1420
         }
       }
@@ -224,7 +224,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
+          "x": 500,
           "y": 1245
         }
       }
@@ -262,79 +262,6 @@ tasks:
         "position": {
           "x": 162.5,
           "y": 370
-        }
-      }
-    note: false
-    timertriggers: []
-  "17":
-    id: "17"
-    taskid: 2665035c-2428-430e-8552-7ed3ee3c893b
-    type: regular
-    task:
-      id: 2665035c-2428-430e-8552-7ed3ee3c893b
-      version: -1
-      name: ThreatGrid Upload File
-      description: Submits a sample to threat grid for analysis
-      script: '|||threat-grid-upload-sample'
-      type: regular
-      iscommand: true
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "15"
-    scriptarguments:
-      file-id:
-        complex:
-          root: inputs.File
-          filters:
-          - - operator: match
-              left:
-                value:
-                  simple: inputs.File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
-            - operator: match
-              left:
-                value:
-                  simple: inputs.File.Type
-                iscontext: true
-              right:
-                value:
-                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
-              ignorecase: true
-            - operator: match
-              left:
-                value:
-                  simple: inputs.File.Extension
-                iscontext: true
-              right:
-                value:
-                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
-              ignorecase: true
-          accessor: EntryID
-      filename:
-        complex:
-          root: inputs.FileName
-      playbook:
-        complex:
-          root: inputs.playbook
-      private:
-        complex:
-          root: inputs.Private
-      tags:
-        complex:
-          root: inputs.Tags
-      vm:
-        complex:
-          root: inputs.VM
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 275,
-          "y": 1070
         }
       }
     note: false
@@ -412,7 +339,7 @@ tasks:
       '#default#':
       - "6"
       "yes":
-      - "17"
+      - "20"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -434,6 +361,86 @@ tasks:
       }
     note: false
     timertriggers: []
+  "20":
+    id: "20"
+    taskid: 4fe8b8b6-097b-42e5-8d2a-7d7693101c90
+    type: regular
+    task:
+      id: 4fe8b8b6-097b-42e5-8d2a-7d7693101c90
+      version: -1
+      name: ThreatGrid Upload File
+      description: Submits a sample to threat grid for analysis
+      script: '|||threat-grid-upload-sample'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "15"
+    scriptarguments:
+      file-id:
+        complex:
+          root: File
+          filters:
+          - - operator: greaterThan
+              left:
+                value:
+                  simple: File.Size
+                iscontext: true
+              right:
+                value:
+                  simple: "0"
+          - - operator: match
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+              ignorecase: true
+            - operator: match
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: .*(?:EXE|DLL|JAR|JS|PDF|DOC|DOCX|RTF|XLS|PPT|PPTX|XML|ZIP|VBN|SEP|XZ|GZ|BZ2|TAR|MHTML|SWF|LNK|URL|MSI|JTD|JTT|JTDC|JTTC|HWP|HWT|HWPX|BAT|HTA|PS1|VBS|WSF|JSE|VBE|CHM)\b
+              ignorecase: true
+          accessor: EntryID
+      filename:
+        complex:
+          root: inputs.FileName
+      playbook: {}
+      private:
+        complex:
+          root: inputs.Private
+      tags:
+        complex:
+          root: inputs.Tags
+      vm:
+        complex:
+          root: inputs.VM
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 500,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
 view: |-
   {
     "linkLabelsPosition": {
@@ -442,7 +449,7 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1610,
-        "width": 717.5,
+        "width": 830,
         "x": 50,
         "y": 50
       }

--- a/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
+++ b/Playbooks/playbook-Detonate_File_-_ThreatGrid.yml
@@ -331,7 +331,7 @@ tasks:
       id: 701d7a32-0c81-4fd3-83c9-fbc7aa6efd30
       version: -1
       name: Is the file size bigger than 0?
-      description: CHeck that fail size is bigger than 0
+      description: Check that fail size is bigger than 0
       type: condition
       iscommand: false
       brand: ""

--- a/Tests/id_set.json
+++ b/Tests/id_set.json
@@ -5716,8 +5716,8 @@
                     "GenericPolling"
                 ], 
                 "command_to_integration": {
-                    "threat-grid-upload-sample": "", 
-                    "threat-grid-get-samples-state": ""
+                    "threat-grid-get-samples-state": "", 
+                    "threat-grid-upload-sample": ""
                 }, 
                 "tests": [
                     "Detonate File - Generic Test"


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15853, https://github.com/demisto/etc/issues/15767

## Description
ignore case for file.type/extension/info and adding filter for file.size bigger than 0

## Screenshots
<img width="1421" alt="threatgrid_deto" src="https://user-images.githubusercontent.com/37335599/53680014-c447f580-3cdd-11e9-9fe9-236bd7cc9796.png">

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation - no changes
- [x] Code Review