### PR TITLE
Phishing layout fix

### DIFF
--- a/Layouts/layout-details-Phishing.json
+++ b/Layouts/layout-details-Phishing.json
@@ -1,7 +1,7 @@
 {
 	"typeId": "Phishing",
 	"kind": "details",
-	"releaseNotes": "Apply incident source fields",
+	"releaseNotes": "Remove 'Email Body HTML' from default Phishing incident type summary layout",
 	"fromVersion": "4.1.0",
 	"layout": {
 		"id": "Phishing",
@@ -198,13 +198,6 @@
 						"version": 0,
 						"modified": "0001-01-01T00:00:00Z",
 						"fieldId": "incident_emailbodyformat",
-						"isVisible": true
-					},
-					{
-						"id": "",
-						"version": 0,
-						"modified": "0001-01-01T00:00:00Z",
-						"fieldId": "incident_emailbodyhtml",
 						"isVisible": true
 					}
 				],


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15340

## Description
Remove `Email Body HTML` custom field from default Phishing incident Summary.

## Does it break backward compatibility?
   - I do not believe so

## Must have
- Tests - N/A
- Documentation - N/A
- [ ] Code Review

## Additional changes
Altered the `validate_version` function in `validate_files_structure.py` to correctly fetch the version field from a layouts-*.json file as per the layouts schema.
