### PR TITLE
Exchange 2016 Compliance - query escaping fix

### DIFF
--- a/Integrations/integration-Exchange2016_Compliance.yml
+++ b/Integrations/integration-Exchange2016_Compliance.yml
@@ -298,7 +298,7 @@ script:
 
     def start_compliance_search(query):
         ps_path = create_ps_file('startcs_' + str(uuid.uuid4()).replace('-','') + '.ps1', STARTCS)
-        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + query.replace("'", "''") + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
+        output = subprocess.Popen(["powershell.exe", ps_path, "'" + USERNAME + "'", "'" + PASSWORD + "'", "'" + str(query).replace("'", "''") + "'", "'" + EXCHANGE_FQDN + "'", "$" + str(UNSECURE)], \
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = output.communicate()
         delete_ps_file(ps_path)
@@ -458,5 +458,6 @@ script:
       description: Name of the compliance search
     description: Checks the status of the purge operation on the compliance search.
   runonce: false
+releaseNotes: "-"
 tests:
   - No test


### PR DESCRIPTION
## Status
Ready

## Description
Fixed query argument escaping while passing as unicode to poweshell subprocess.
The fix was to convert query from unicode to string.
 
## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Samples of start-compliance search query commands
**TEST 1:**
`!exchange2016-start-compliance-search query="subject:\"Email to search\""`
**TEST 2:**
`!exchange2016-start-compliance-search query="subject:\"Email to search\" AND to:\"DEM695412@lab-demisto.com\""`
**TEST 3:**
`!exchange2016-start-compliance-search query="body:\"Email to be searched and deleted.\""`
**TEST 4:**
`!exchange2016-start-compliance-search query="body: c025615b169bbe067afba2b64b149559"`

## Screen shots of the query that passed to compliance management in the Exchange admin-center during the manual tests
**TEST 1:**
![image](https://user-images.githubusercontent.com/45535078/53756127-0b421080-3ec1-11e9-89ed-ae56c0ea0536.png)
**TEST 2:**
![image](https://user-images.githubusercontent.com/45535078/53757192-bb187d80-3ec3-11e9-87bd-b79d5a092576.png)
**TEST 3:**
![image](https://user-images.githubusercontent.com/45535078/53759110-3e3bd280-3ec8-11e9-8ee3-107d62dd4219.png)
**TEST 4:**
![image](https://user-images.githubusercontent.com/45535078/53759554-42b4bb00-3ec9-11e9-8d86-6b9b36b6a150.png)

All manual tests passed and were saved as incidents in self-service.

## Dependencies
Playbooks:
- [x] Exchange 2016 Search and Delete

Integrations:
- [x] Exchange 2016 Compliance Search