### PR TITLE
Fixed proxy handling. Fixed domain type in dbotscore.

### DIFF
--- a/Integrations/integration-Alexa.yml
+++ b/Integrations/integration-Alexa.yml
@@ -22,6 +22,11 @@ script:
     import xml.etree.ElementTree as ET
     from collections import defaultdict
 
+    del os.environ['HTTP_PROXY']
+    del os.environ['HTTPS_PROXY']
+    del os.environ['http_proxy']
+    del os.environ['https_proxy']
+
 
     """GLOBAL VARIABLES/CONSTANTS"""
     THRESHOLD = int(demisto.params().get('threshold'))
@@ -53,6 +58,7 @@ script:
             'Score': dbot_score,
             'Vendor': 'Alexa',
             'Domain': domain,
+            'Type': 'domain'
         }
         ec = {
             'Domain(val.Name && val.Name == obj.Name)': dom_ec,
@@ -126,5 +132,6 @@ script:
     description: Provides an Alexa ranking of the Domain in question.
   runonce: false
 fromversion: 3.5.0
+releaseNotes: '-'
 tests:
   - Alexa Test Playbook


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15914
fixes: https://github.com/demisto/etc/issues/15913

## Description
Fixed: Alexa would go through proxy even though it should never do that.
Fixed: No "type" key in DbotScore.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - Yes
       - Further details: If, by some miracle, someone configured alexa and a proxy in demsito, and it worked for him, it won't go through the proxy now, so there is a slim chance that it will stop working.
This case brought up before @anara123 and he authorized the change.

## Must have
- [X] Tests
- [X] Documentation (with link to it) - no need
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] Alexa Test Playbook

## Additional changes
Describe additional changes done, for example adding a function to common server.
