### PR TITLE
Fix Whois Test issue

### DIFF
--- a/Integrations/integration-Whois.yml
+++ b/Integrations/integration-Whois.yml
@@ -192,5 +192,6 @@ script:
   dockerimage: demisto/ippysocks
   runonce: false
 fromversion: 4.1.0
+releaseNotes: Removed from default
 tests:
   - whois_test

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1244,6 +1244,7 @@
         "Thinkst Canary": "Checking",
         "Cymon": "Checking",
         "SplunkPy": "Checking",
-        "Symantec Advanced Threat Protection": "Checking"
+        "Symantec Advanced Threat Protection": "Checking",
+        "Whois": "Integration socks proxy on tcp connection not http/s"
     }
 }

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -923,6 +923,7 @@
             "nightly": true
         },
         {
+            "integrations": "Whois",
             "playbookID": "whois_test"
         },
         {


### PR DESCRIPTION
## Status
Ready

## Description
Added Whois to un-mockable integration and added Whois to config.json to add an instance since it is no longer a default.