### PR TITLE
EWS v2 - fixed compliance commands check

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -224,6 +224,10 @@ script:
         return Build(*build_params)
 
 
+    def get_endpoint_autodiscover(context_dict):
+        return context_dict["service_endpoint"]
+
+
     def get_version(version_str):
         if version_str not in VERSIONS:
             raise Exception("%s is unsupported version: %s. Choose one of" % (version_str, "\\".join(VERSIONS.keys())))
@@ -241,7 +245,7 @@ script:
 
     def prepare_context(credentials):
         context_dict = demisto.getIntegrationContext()
-        global SERVER_BUILD
+        global SERVER_BUILD, EWS_SERVER
         if not context_dict:
             try:
                 account = Account(
@@ -255,6 +259,7 @@ script:
                 return_error("Auto discovery failed. Check credentials or configure manually")
         else:
             SERVER_BUILD = get_build_autodiscover(context_dict)
+            EWS_SERVER = get_endpoint_autodiscover(context_dict)
 
 
     def prepare():
@@ -2431,6 +2436,7 @@ script:
   dockerimage: demisto/py-ews:2.0
   isfetch: true
   runonce: false
+releaseNotes: "-"
 tests:
   - pyEWS_Test
   - 'EWS search-mailbox test'


### PR DESCRIPTION
## Status
Ready

## Description
In case of using auto-discovery instance configuration without filling Exchange Server Hostname or IP address, caused error in the following EWS compliance commands:
- ews-o365-get-compliance-search
- ews-o365-remove-compliance-search
- ews-o365-start-compliance-search
- ews-o365-purge-compliance-search-results
- ews-o365-get-compliance-search-purge-status

Attached screen shot of the error.

## Screenshots
![image](https://user-images.githubusercontent.com/45535078/54487721-ee82e100-48a1-11e9-8f25-50a9a9a75f07.png)


## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Tests:
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] pyEWS_Test
- [x] EWS search-mailbox test
- [x] Phishing test - Inline
- [x] process_email_-_generic_-_test
