### PR TITLE
fix parse email headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CommonServerPython.py
 CommonServerUserPython.py
 demistomock.py
 Tests/filter_file.txt
+Tests/id_set.json

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3525,8 +3525,8 @@ def main():
                         return_error("Could not extract email from file. Base64 decode did not include rfc 822 strings")
 
             except Exception as e:
-                return_error("Exception while trying to decode email from within base64: " +
-                             str(e) + "\n\nTrace:\n" + traceback.format_exc(e))
+                return_error("Exception while trying to decode email from within base64: {}\n\nTrace:\n{}"
+                             .format(str(e), traceback.format_exc(e)))
         else:
             return_error("Unknown file format: " + file_type)
 

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3448,7 +3448,8 @@ def main():
                     file_contents = f.read()
 
                 if 'Content-Type:'.lower() in file_contents.lower():
-                    email_data = handle_eml(file_path, b64=False, file_name=file_name, parse_only_headers=parse_only_headers)
+                    email_data = handle_eml(file_path, b64=False, file_name=file_name,
+                                            parse_only_headers=parse_only_headers)
                     return_outputs(
                         readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                         outputs={
@@ -3461,7 +3462,8 @@ def main():
                     # Try a base64 decode
                     b64decode(file_contents)
                     if 'Content-Type:'.lower() in file_contents.lower():
-                        email_data = handle_eml(file_path, b64=True, file_name=file_name, parse_only_headers=parse_only_headers)
+                        email_data = handle_eml(file_path, b64=True, file_name=file_name,
+                                                parse_only_headers=parse_only_headers)
                         return_outputs(
                             readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                             outputs={

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -40,6 +40,8 @@ from struct import unpack
 reload(sys)
 sys.setdefaultencoding('utf8')
 
+MAX_DEPTH_CONST = 3
+
 """
 https://github.com/vikramarsid/msg_parser
 
@@ -2666,10 +2668,9 @@ class Message(object):
 
         return attachments
 
-    def as_dict(self):
-        embedded_messages_list = []
-        for embedded_message in self.embedded_messages:
-            embedded_messages_list.append(embedded_message.as_dict())
+    def as_dict(self, max_depth):
+        if max_depth == 0:
+            return None
 
         def join(arr):
             if isinstance(arr, list):
@@ -2709,15 +2710,19 @@ class Message(object):
             'HTML': html,
             'Headers': str(self.header) if self.header is not None else None,
             'HeadersMap': self.header_dict,
-            'AttachedEmails': embedded_messages_list
+            'Depth': MAX_DEPTH_CONST-max_depth
         }
+
         return message_dict
 
-    def get_attached_emails_hierarchy(self):
+    def get_attached_emails_hierarchy(self, max_depth):
+        if max_depth == 0:
+            return []
+
         attached_emails = []
         for embedded_message in self.embedded_messages:
-            attached_emails.append(embedded_message.as_dict())
-            attached_emails.extend(embedded_message.get_attached_emails_hierarchy())
+            attached_emails.append(embedded_message.as_dict(max_depth))
+            attached_emails.extend(embedded_message.get_attached_emails_hierarchy(max_depth-1))
 
         return attached_emails
 
@@ -3078,8 +3083,8 @@ class MsOxMessage(object):
             if ole_file is not None:
                 ole_file.close()
 
-    def as_dict(self):
-        return self._message.as_dict()
+    def as_dict(self, max_depth):
+        return self._message.as_dict(max_depth)
 
     def get_email_mime_content(self):
         email_obj = EmailFormatter(self)
@@ -3090,8 +3095,8 @@ class MsOxMessage(object):
         email_obj.save_file(file_path)
         return True
 
-    def get_attached_emails_hierarchy(self):
-        return self._message.get_attached_emails_hierarchy()
+    def get_attached_emails_hierarchy(self, max_depth):
+        return self._message.get_attached_emails_hierarchy(max_depth)
 
     def is_valid_msg_file(self):
         if not os.path.exists(self.msg_file_path):
@@ -3166,7 +3171,7 @@ def data_to_md(email_data, email_file_name=None, parent_email_file=None, print_o
         return tableToMarkdown("Email Headers: " + email_file_name, email_data['HeadersMap'])
 
     if parent_email_file:
-        md += "### Parent email: {}\n".format(parent_email_file)
+        md += "### Containing email: {}\n".format(parent_email_file)
 
     md += "* {0}:\t{1}\n".format('From', email_data['From'] or "")
     md += "* {0}:\t{1}\n".format('To', email_data['To'] or "")
@@ -3180,26 +3185,27 @@ def data_to_md(email_data, email_file_name=None, parent_email_file=None, print_o
         md += u"* {0}:\t{1}\n".format('Body/HTML', email_data['HTML'] or "")
 
     md += "* {0}:\t{1}\n".format('Attachments', email_data['Attachments'] or "")
-    md += "* {0}:\t{1}\n".format('Headers', email_data['Headers'] or "")
+    md += "\n\n" + tableToMarkdown("Headers", email_data['HeadersMap'])
     return md
 
 
-def save_attachments(attachments, root_email_file_name):
+def save_attachments(attachments, root_email_file_name, max_depth):
     attached_emls = []
     for attachment in attachments:
         if attachment.data is not None:
             demisto.results(fileResult(attachment.DisplayName, attachment.data))
 
-            if attachment.DisplayName.endswith(".eml"):
+            if max_depth > 0 and attachment.DisplayName.lower().endswith(".eml"):
                 tf = tempfile.NamedTemporaryFile(delete=False)
 
                 try:
                     tf.write(attachment.data)
                     tf.close()
 
-                    inner_eml = handle_eml(tf.name, file_name=root_email_file_name)
+                    inner_eml, attached_inner_emails = handle_eml(tf.name, file_name=root_email_file_name, max_depth=max_depth)
                     return_outputs(readable_output=data_to_md(inner_eml, attachment.DisplayName, root_email_file_name))
                     attached_emls.append(inner_eml)
+                    attached_emls.extend(attached_inner_emails)
                 finally:
                     os.remove(tf.name)
 
@@ -3247,31 +3253,36 @@ def convert_to_unicode(s):
     return s
 
 
-def handle_msg(file_path, file_name, parse_only_headers=False):
+def handle_msg(file_path, file_name, parse_only_headers=False, max_depth=3):
+    if max_depth == 0:
+        return None
+
     msg = MsOxMessage(file_path)
     if not msg:
         raise Exception("Could not parse msg file!")
 
-    email_data = msg.as_dict()
+    email_data = msg.as_dict(max_depth)
+
     if parse_only_headers:
         return {
             "HeadersMap": email_data.get("HeadersMap")
         }
 
-    attached_emails_emls = save_attachments(msg.get_all_attachments(), file_name)
-
+    attached_emails_emls = save_attachments(msg.get_all_attachments(), file_name, max_depth-1)
     # add eml attached emails
-    email_data["AttachedEmails"].extend(attached_emails_emls)
 
-    attached_emails_msg = msg.get_attached_emails_hierarchy()
+    attached_emails_msg = msg.get_attached_emails_hierarchy(max_depth-1)
     for attached_email in attached_emails_msg:
         return_outputs(readable_output=data_to_md(attached_email, None, file_name), outputs=None)
 
-    return email_data
+    return email_data, attached_emails_emls + attached_emails_msg
 
 
-def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False):
+def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, max_depth=3):
     global ENCODINGS_TYPES
+
+    if max_depth == 0:
+        return None
 
     with open(file_path, 'rb') as emlFile:
 
@@ -3352,30 +3363,43 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False):
                         demisto.debug("found eml attachment with Content-Type=message/rfc822 but has no payload")
 
                     demisto.results(fileResult(attachment_file_name, file_content))
-                    f = tempfile.NamedTemporaryFile(delete=False)
-                    f.write(file_content)
-                    f.close()
-                    inner_eml = handle_eml(file_path=f.name, file_name=attachment_file_name)
-                    attached_emails.append(inner_eml)
-                    os.remove(f.name)
-                    return_outputs(readable_output=data_to_md(inner_eml, attachment_file_name, file_name), outputs=None)
+
+                    if max_depth-1 > 0:
+                        f = tempfile.NamedTemporaryFile(delete=False)
+                        try:
+                            f.write(file_content)
+                            f.close()
+                            inner_eml, inner_attached_emails = handle_eml(file_path=f.name,
+                                                                          file_name=attachment_file_name,
+                                                                          max_depth=max_depth - 1)
+                            attached_emails.append(inner_eml)
+                            attached_emails.extend(inner_attached_emails)
+                            return_outputs(readable_output=data_to_md(inner_eml, attachment_file_name, file_name),
+                                           outputs=None)
+                        finally:
+                            os.remove(f.name)
+
                 else:
                     # .msg and other files (png, jpeg)
                     file_content = part.get_payload(decode=True)
                     demisto.results(fileResult(attachment_file_name, file_content))
 
-                    if attachment_file_name.endswith(".msg"):
+                    if attachment_file_name.endswith(".msg") and max_depth-1 > 0:
                         f = tempfile.NamedTemporaryFile(delete=False)
-                        f.write(file_content)
-                        f.close()
-                        inner_msg = handle_msg(f.name, attachment_file_name)
-                        attached_emails.append(inner_msg)
-                        os.remove(f.name)
+                        try:
+                            f.write(file_content)
+                            f.close()
+                            inner_msg, inner_attached_emails = handle_msg(f.name, attachment_file_name, False,
+                                                                          max_depth-1)
+                            attached_emails.append(inner_msg)
+                            attached_emails.extend(inner_attached_emails)
 
-                        # will output the inner email to the UI
-                        return_outputs(
-                            readable_output=data_to_md(inner_msg, attachment_file_name, file_name),
-                            outputs=None)
+                            # will output the inner email to the UI
+                            return_outputs(
+                                readable_output=data_to_md(inner_msg, attachment_file_name, file_name),
+                                outputs=None)
+                        finally:
+                            os.remove(f.name)
 
                 attachment_names.append(attachment_file_name)
                 demisto.setContext('AttachmentName', attachment_file_name)
@@ -3397,15 +3421,26 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False):
             'HeadersMap': headers_map,
             'Attachments': ','.join(attachment_names) if attachment_names else '',
             'Format': eml.get_content_type(),
-            'AttachedEmails': attached_emails
+            'Depth': MAX_DEPTH_CONST-max_depth
         }
 
-        return email_data
+        return email_data, attached_emails
 
 
 def main():
     file_type = ''
     entry_id = demisto.args()['entryid']
+    max_depth = int(demisto.args().get('max_depth', '3'))
+
+    # we use the MAX_DEPTH_CONST to calculate the depth of the email
+    # each level will reduce the max_depth by 1
+    # not the best way to do it
+    global MAX_DEPTH_CONST
+    MAX_DEPTH_CONST = max_depth
+
+    if max_depth < 1:
+        return_error('Minimum max_depth is 1, the script will parse just the top email')
+
     parse_only_headers = demisto.args().get('parse_only_headers', 'false').lower() == 'true'
 
     try:
@@ -3430,24 +3465,24 @@ def main():
         file_type_lower = file_type.lower()
         if 'composite document file v2 document' in file_type_lower \
                 or 'cdfv2 microsoft outlook message' in file_type_lower:
-            email_data = handle_msg(file_path, file_name, parse_only_headers)
+            email_data, attached_emails = handle_msg(file_path, file_name, parse_only_headers, max_depth)
             return_outputs(
                 readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                 outputs={
-                    'Email': email_data
+                    'Email': [email_data] + attached_emails
                 },
-                raw_response=email_data
+                raw_response=[email_data] + attached_emails
             )
             return
 
         elif 'rfc 822 mail' in file_type_lower or 'smtp mail' in file_type_lower:
-            email_data = handle_eml(file_path, False, file_name)
+            email_data, attached_emails = handle_eml(file_path, False, file_name, parse_only_headers, max_depth)
             return_outputs(
                 readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                 outputs={
-                    'Email': email_data
+                    'Email': [email_data] + attached_emails
                 },
-                raw_response=email_data
+                raw_response=[email_data] + attached_emails
             )
             return
 
@@ -3458,35 +3493,38 @@ def main():
                     file_contents = f.read()
 
                 if 'Content-Type:'.lower() in file_contents.lower():
-                    email_data = handle_eml(file_path, b64=False, file_name=file_name,
-                                            parse_only_headers=parse_only_headers)
+                    email_data, attached_emails = handle_eml(file_path, b64=False, file_name=file_name,
+                                                             parse_only_headers=parse_only_headers, max_depth=max_depth)
+
                     return_outputs(
                         readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                         outputs={
-                            'Email': email_data
+                            'Email': [email_data] + attached_emails
                         },
-                        raw_response=email_data
+                        raw_response=[email_data] + attached_emails
                     )
                     return
                 else:
                     # Try a base64 decode
                     b64decode(file_contents)
                     if 'Content-Type:'.lower() in file_contents.lower():
-                        email_data = handle_eml(file_path, b64=True, file_name=file_name,
-                                                parse_only_headers=parse_only_headers)
+                        email_data, attached_emails = handle_eml(file_path, b64=True, file_name=file_name,
+                                                                 parse_only_headers=parse_only_headers,
+                                                                 max_depth=max_depth)
+
                         return_outputs(
                             readable_output=data_to_md(email_data, file_name, print_only_headers=parse_only_headers),
                             outputs={
-                                'Email': email_data
+                                'Email': [email_data] + attached_emails
                             },
-                            raw_response=email_data
+                            raw_response=[email_data] + attached_emails
                         )
                         return
                     else:
                         return_error("Could not extract email from file. Base64 decode did not include rfc 822 strings")
 
             except Exception as e:
-                return_error("Exception while trying to decode email from within base64: " + str(e))
+                return_error("Exception while trying to decode email from within base64: " + str(e) + "\n\nTrace:\n" + traceback.format_exc(e))
         else:
             return_error("Unknown file format: " + file_type)
 

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3294,7 +3294,17 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False):
             header_list.append(item_dict)
 
             # new way to map headers - dictionary
-            headers_map[item[0]] = convert_to_unicode(item[1])
+            if item[0] in headers_map:
+                # in case there is already such header
+                # then add that header value to value array
+                if not isinstance(headers_map[item[0]], list):
+                    # convert the existing value to array
+                    headers_map[item[0]] = [headers_map[item[0]]]
+
+                # add the new value to the value array
+                headers_map[item[0]].append(convert_to_unicode(item[1]))
+            else:
+                headers_map[item[0]] = convert_to_unicode(item[1])
 
         if parse_only_headers:
             return {

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -2710,7 +2710,7 @@ class Message(object):
             'HTML': html,
             'Headers': str(self.header) if self.header is not None else None,
             'HeadersMap': self.header_dict,
-            'Depth': MAX_DEPTH_CONST-max_depth
+            'Depth': MAX_DEPTH_CONST - max_depth
         }
 
         return message_dict
@@ -2722,7 +2722,7 @@ class Message(object):
         attached_emails = []
         for embedded_message in self.embedded_messages:
             attached_emails.append(embedded_message.as_dict(max_depth))
-            attached_emails.extend(embedded_message.get_attached_emails_hierarchy(max_depth-1))
+            attached_emails.extend(embedded_message.get_attached_emails_hierarchy(max_depth - 1))
 
         return attached_emails
 
@@ -3202,7 +3202,8 @@ def save_attachments(attachments, root_email_file_name, max_depth):
                     tf.write(attachment.data)
                     tf.close()
 
-                    inner_eml, attached_inner_emails = handle_eml(tf.name, file_name=root_email_file_name, max_depth=max_depth)
+                    inner_eml, attached_inner_emails = handle_eml(tf.name, file_name=root_email_file_name,
+                                                                  max_depth=max_depth)
                     return_outputs(readable_output=data_to_md(inner_eml, attachment.DisplayName, root_email_file_name))
                     attached_emls.append(inner_eml)
                     attached_emls.extend(attached_inner_emails)
@@ -3268,10 +3269,10 @@ def handle_msg(file_path, file_name, parse_only_headers=False, max_depth=3):
             "HeadersMap": email_data.get("HeadersMap")
         }
 
-    attached_emails_emls = save_attachments(msg.get_all_attachments(), file_name, max_depth-1)
+    attached_emails_emls = save_attachments(msg.get_all_attachments(), file_name, max_depth - 1)
     # add eml attached emails
 
-    attached_emails_msg = msg.get_attached_emails_hierarchy(max_depth-1)
+    attached_emails_msg = msg.get_attached_emails_hierarchy(max_depth - 1)
     for attached_email in attached_emails_msg:
         return_outputs(readable_output=data_to_md(attached_email, None, file_name), outputs=None)
 
@@ -3364,7 +3365,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
 
                     demisto.results(fileResult(attachment_file_name, file_content))
 
-                    if max_depth-1 > 0:
+                    if max_depth - 1 > 0:
                         f = tempfile.NamedTemporaryFile(delete=False)
                         try:
                             f.write(file_content)
@@ -3384,13 +3385,13 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                     file_content = part.get_payload(decode=True)
                     demisto.results(fileResult(attachment_file_name, file_content))
 
-                    if attachment_file_name.endswith(".msg") and max_depth-1 > 0:
+                    if attachment_file_name.endswith(".msg") and max_depth - 1 > 0:
                         f = tempfile.NamedTemporaryFile(delete=False)
                         try:
                             f.write(file_content)
                             f.close()
                             inner_msg, inner_attached_emails = handle_msg(f.name, attachment_file_name, False,
-                                                                          max_depth-1)
+                                                                          max_depth - 1)
                             attached_emails.append(inner_msg)
                             attached_emails.extend(inner_attached_emails)
 
@@ -3421,7 +3422,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
             'HeadersMap': headers_map,
             'Attachments': ','.join(attachment_names) if attachment_names else '',
             'Format': eml.get_content_type(),
-            'Depth': MAX_DEPTH_CONST-max_depth
+            'Depth': MAX_DEPTH_CONST - max_depth
         }
 
         return email_data, attached_emails
@@ -3524,7 +3525,8 @@ def main():
                         return_error("Could not extract email from file. Base64 decode did not include rfc 822 strings")
 
             except Exception as e:
-                return_error("Exception while trying to decode email from within base64: " + str(e) + "\n\nTrace:\n" + traceback.format_exc(e))
+                return_error("Exception while trying to decode email from within base64: " +
+                             str(e) + "\n\nTrace:\n" + traceback.format_exc(e))
         else:
             return_error("Unknown file format: " + file_type)
 

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -21,21 +21,26 @@ args:
   default: true
   description: Entry ID with the Email as a file in msg or eml format
 - name: parse_only_headers
-  description: Will parse only the headers and return headers table
   auto: PREDEFINED
   predefined:
   - "true"
   - "false"
+  description: Will parse only the headers and return headers table
   defaultValue: "false"
+- name: max_depth
+  description: How many levels deep we should parse the attached emails (e.g. email contains an emails contains an email). Default depth level is 3. Minimum level is 1, if set to 1 the script will parse only the first level email
+  defaultValue: "3"
 outputs:
 - contextPath: Email.To
-  description: This shows to whom the message was addressed, but may not contain the recipient's address.
+  description: This shows to whom the message was addressed, but may not contain the
+    recipient's address.
   type: string
 - contextPath: Email.CC
   description: Email 'cc' addresses
   type: string
 - contextPath: Email.From
-  description: This displays who the message is from, however, this can be easily forged and can be the least reliable.
+  description: This displays who the message is from, however, this can be easily
+    forged and can be the least reliable.
   type: string
 - contextPath: Email.Subject
   description: Email subject
@@ -47,38 +52,36 @@ outputs:
   description: Email 'text' body if exists
   type: string
 - contextPath: Email.Headers
-  description: Deprecated - use Email.HeadersMap output instead. The full email headers as a single string
+  description: Deprecated - use Email.HeadersMap output instead. The full email headers
+    as a single string
   type: string
 - contextPath: Email.HeadersMap
   description: The full email headers json
   type: Unknown
-- contextPath: Email.AttachedEmails
-  description: Array of attached .msg files
-  type: string
-- contextPath: Email.AttachedEmails.From
-  description: Email 'from' sender
-  type: string
-- contextPath: Email.AttachedEmails.To
-  description: Email 'to' addresses
-  type: string
-- contextPath: Email.AttachedEmails.CC
+- contextPath: Email.HeadersMap.From
+  description: This displays who the message is from, however, this can be easily forged and can be the least reliable.
+  type: Unknown
+- contextPath: Email.HeadersMap.To
+  description: This shows to whom the message was addressed, but may not contain the recipient's address.
+  type: Unknown
+- contextPath: Email.HeadersMap.Subject
+  description: Email subject
+  type: String
+- contextPath: Email.HeadersMap.Date
+  description: The date and time the email message was composed
+  type: Unknown
+- contextPath: Email.HeadersMap.CC
   description: Email 'cc' addresses
-  type: string
-- contextPath: Email.AttachedEmails.Subject
-  description: Attached email subject
-  type: string
-- contextPath: Email.AttachedEmails.Text
-  description: Email 'text' body if exists
-  type: string
-- contextPath: Email.AttachedEmails.HTML
-  description: Email 'html' body if exists
-  type: string
-- contextPath: Email.AttachedEmails.AttachedEmails
-  description: Array of attached .msg files of the attached .msg file (it is recursive)
-  type: string
-- contextPath: Email.AttachedEmails.Attachments
-  description: The list of attachment names in the email
-  type: string
+  type: Unknown
+- contextPath: Email.HeadersMap.Reply-To
+  description: The email address for return mail
+  type: String
+- contextPath: Email.HeadersMap.Received
+  description: List of all the servers/computers through which the message traveled
+  type: String
+- contextPath: Email.HeadersMap.Message-ID
+  description: A unique string assigned by the mail system when the message is first created. These can easily be forged. (e.g. 5c530c1b.1c69fb81.bd826.0eff@mx.google.com)
+  type: String
 - contextPath: Email.Attachments
   description: The list of attachment names in the email
   type: string
@@ -89,8 +92,7 @@ scripttarget: 0
 runonce: false
 runas: DBotWeakRole
 releaseNotes: 'Fix - support email files with type ''SMTP Mail'' eml contains eml
-  - inner eml will be extracted eml parsed recursively
-  - support parsing only email headers
-  '
+  - inner eml will be extracted eml parsed recursively - support parsing only email
+  headers '
 tests:
 - ParseEmailFiles-test

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -51,6 +51,9 @@ outputs:
 - contextPath: Email.Text
   description: Email 'text' body if exists
   type: string
+- contextPath: Email.Depth
+  description: The depth of the email. Depth=0 for the first level email. If email1 contains email2 contains email3. Then email1 depth is 0, email2 depth is 1, email3 depth is 2
+  type: number
 - contextPath: Email.Headers
   description: Deprecated - use Email.HeadersMap output instead. The full email headers
     as a single string

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -20,6 +20,13 @@ args:
   required: true
   default: true
   description: Entry ID with the Email as a file in msg or eml format
+- name: parse_only_headers
+  description: Will parse only the headers and return headers table
+  auto: PREDEFINED
+  predefined:
+  - "true"
+  - "false"
+  defaultValue: "false"
 outputs:
 - contextPath: Email.To
   description: Email 'to' addresses
@@ -81,9 +88,9 @@ outputs:
 scripttarget: 0
 runonce: false
 runas: DBotWeakRole
-releaseNotes: "
-Fix - support email files with type 'SMTP Mail'
-eml contains eml - inner eml will be extracted
-eml parsed recursively"
+releaseNotes: 'Fix - support email files with type ''SMTP Mail'' eml contains eml
+  - inner eml will be extracted eml parsed recursively
+  - support parsing only email headers
+  '
 tests:
-  - "ParseEmailFiles-test"
+- ParseEmailFiles-test

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -29,13 +29,13 @@ args:
   defaultValue: "false"
 outputs:
 - contextPath: Email.To
-  description: Email 'to' addresses
+  description: This shows to whom the message was addressed, but may not contain the recipient's address.
   type: string
 - contextPath: Email.CC
   description: Email 'cc' addresses
   type: string
 - contextPath: Email.From
-  description: Email 'from' sender
+  description: This displays who the message is from, however, this can be easily forged and can be the least reliable.
   type: string
 - contextPath: Email.Subject
   description: Email subject
@@ -47,7 +47,7 @@ outputs:
   description: Email 'text' body if exists
   type: string
 - contextPath: Email.Headers
-  description: The full email headers as a single string
+  description: Deprecated - use Email.HeadersMap output instead. The full email headers as a single string
   type: string
 - contextPath: Email.HeadersMap
   description: The full email headers json

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -6,7 +6,7 @@ import demistomock as demisto
 def test_msg_html_with_attachments():
     msg = MsOxMessage('test_data/html_attachment.msg')
     assert msg is not None
-    msg_dict = msg.as_dict()
+    msg_dict = msg.as_dict(max_depth=2)
     assert 'This is an html email' in msg_dict['Text']
     attachments_list = msg.get_all_attachments()
     assert len(attachments_list) == 1
@@ -19,7 +19,7 @@ def test_msg_html_with_attachments():
 def test_msg_utf_encoded_subject():
     msg = MsOxMessage('test_data/utf_subject.msg')
     assert msg is not None
-    msg_dict = msg.as_dict()
+    msg_dict = msg.as_dict(max_depth=2)
     # we test that subject which has utf-8 encoding (in the middle) is actually decoded
     assert '?utf-8' in msg_dict['HeadersMap']['Subject']
     subj = msg_dict['Subject']
@@ -63,7 +63,7 @@ def test_eml_smtp_type(mocker):
     results = demisto.results.call_args[0]
     assert len(results) == 1
     assert results[0]['Type'] == entryTypes['note']
-    assert results[0]['EntryContext']['Email']['Subject'] == 'Test Smtp Email'
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Test Smtp Email'
 
 
 def test_eml_contains_eml(mocker):
@@ -102,11 +102,14 @@ def test_eml_contains_eml(mocker):
     results = demisto.results.call_args[0]
     assert len(results) == 1
     assert results[0]['Type'] == entryTypes['note']
-    assert results[0]['EntryContext']['Email']['Subject'] == 'Fwd: test - inner attachment eml'
-    assert 'ArcSight_ESM_fixes.yml' in results[0]['EntryContext']['Email']['Attachments']
-    assert 'test - inner attachment eml.eml' in results[0]['EntryContext']['Email']['Attachments']
-    assert results[0]['EntryContext']['Email']['AttachedEmails'][0]["Subject"] == 'test - inner attachment eml'
-    assert 'CS Training 2019 - EWS.pptx' in results[0]['EntryContext']['Email']['AttachedEmails'][0]["Attachments"]
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Fwd: test - inner attachment eml'
+    assert 'ArcSight_ESM_fixes.yml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert 'test - inner attachment eml.eml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert results[0]['EntryContext']['Email'][0]['Depth'] == 0
+
+    assert results[0]['EntryContext']['Email'][1]["Subject"] == 'test - inner attachment eml'
+    assert 'CS Training 2019 - EWS.pptx' in results[0]['EntryContext']['Email'][1]["Attachments"]
+    assert results[0]['EntryContext']['Email'][1]['Depth'] == 1
 
 
 def test_eml_contains_msg(mocker):
@@ -145,6 +148,52 @@ def test_eml_contains_msg(mocker):
     results = demisto.results.call_args[0]
     assert len(results) == 1
     assert results[0]['Type'] == entryTypes['note']
-    assert results[0]['EntryContext']['Email']['Subject'] == 'DONT OPEN - MALICIOS'
-    assert 'Attacker+email+.msg' in results[0]['EntryContext']['Email']['Attachments']
-    assert results[0]['EntryContext']['Email']['AttachedEmails'][0]["Subject"] == 'Attacker email '
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'DONT OPEN - MALICIOS'
+    assert results[0]['EntryContext']['Email'][0]['Depth'] == 0
+
+    assert 'Attacker+email+.msg' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert results[0]['EntryContext']['Email'][1]["Subject"] == 'Attacker email '
+    assert results[0]['EntryContext']['Email'][1]['Depth'] == 1
+
+
+def test_eml_contains_eml_depth(mocker):
+    def executeCommand(name, args=None):
+        if name == 'getFilePath':
+            return [
+                {
+                    'Type': entryTypes['note'],
+                    'Contents': {
+                        'path': 'test_data/Fwd_test-inner_attachment_eml.eml',
+                        'name': 'Fwd_test-inner_attachment_eml.eml'
+                    }
+                }
+            ]
+        elif name == 'getEntry':
+            return [
+                {
+                    'Type': entryTypes['file'],
+                    'FileMetadata': {
+                        'info': 'news or mail text, ASCII text'
+                    }
+                }
+            ]
+        else:
+            raise ValueError('Unimplemented command called: {}'.format(name))
+
+    mocker.patch.object(demisto, 'args', return_value={'entryid': 'test', 'max_depth': '1'})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=executeCommand)
+    mocker.patch.object(demisto, 'results')
+    # validate our mocks are good
+    assert demisto.args()['entryid'] == 'test'
+
+    main()
+    assert demisto.results.call_count == 3
+    # call_args is tuple (args list, kwargs). we only need the first one
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0]['Type'] == entryTypes['note']
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Fwd: test - inner attachment eml'
+    assert 'ArcSight_ESM_fixes.yml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert 'test - inner attachment eml.eml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert len(results[0]['EntryContext']['Email']) == 1
+    assert results[0]['EntryContext']['Email'][0]['Depth'] == 0

--- a/Scripts/script-ParseEmailHeaders.yml
+++ b/Scripts/script-ParseEmailHeaders.yml
@@ -47,7 +47,7 @@ script: |-
 type: python
 tags:
 - email
-comment: This automation parses headers from an email file.
+comment: Deprecated - use `ParseEmailFiles parse_only_headers=true`. This automation parses headers from an email file.
 enabled: true
 args:
 - name: entryId
@@ -85,4 +85,5 @@ outputs:
 scripttarget: 0
 runonce: false
 runas: DBotWeakRole
+deprecated: true
 releaseNotes: support eml and msg headers parsing - using ParseEmailFiles internally

--- a/Scripts/script-ParseEmailHeaders.yml
+++ b/Scripts/script-ParseEmailHeaders.yml
@@ -3,46 +3,47 @@ commonfields:
   version: -1
 name: ParseEmailHeaders
 script: |-
-  from email.parser import HeaderParser
+  import json
 
-  ec = {"Email.Headers" : {}}
-  md = "";
 
-  arrFiles = demisto.context()["File"];
-  for file in arrFiles:
-      if 'EntryID' in file and file["EntryID"] == demisto.args()['entryId'] and 'Info' in file and file["Info"] == "eml":
-          # Get the file path of the email file as it located in Demisto server
-          filePath = demisto.executeCommand('getFilePath', {'id': demisto.args()['entryId']})[0]['Contents']['path']
+  def main():
+      execute_command_result = demisto.executeCommand("ParseEmailFiles", {
+          "entryid": demisto.args().get("entryId"),
+          "parse_only_headers": "true"
+      })
+      if is_error(execute_command_result):
+          return_error(get_error(execute_command_result))
 
-          # Read the content of the file
-          with open(filePath, 'rb') as f:
-              fileContents = f.read()
+      parsed_email_headers = None
+      readable_output = ""
+      for command_result in execute_command_result:
+          if command_result.get("EntryContext") is not None \
+             and "Email" in command_result.get("EntryContext"):
+              parsed_email = command_result.get("EntryContext").get("Email")
 
-          # Parse the headers from the email file
-          parser = HeaderParser()
-          h = parser.parsestr(fileContents)
+              if "HeadersMap" in parsed_email:
+                  # msg files will have HeadersMap as dict
+                  parsed_email_headers = parsed_email.get("HeadersMap")
 
-          # Add all the headers to context
-          for key in h.keys():
-              # Handle multi-values headers (e.g. Received header)
-              if key in ec["Email.Headers"]:
-                  ec["Email.Headers"][key] = []
-                  for line in h.get_all(key):
-                      ec["Email.Headers"][key].append(line)
-              else:
-                  ec["Email.Headers"][key] = h[key]
+              readable_output = command_result.get('HumanReadable')
 
-          # Print all the headers
-          for hKey in ec["Email.Headers"]:
-              if type (ec["Email.Headers"][hKey]) == list:
-                  for value in ec["Email.Headers"][hKey]:
-                      md += hKey + " : " + value + "\n"
-              else:
-                  md += hKey + " : " + h[hKey] + "\n"
+      if parsed_email_headers is None:
+          return_outputs(readable_output="Couldn't find Headers outputs" + demisto.args()['entryId'] + "\n",
+                         outputs=None)
 
-          demisto.results({"ContentsFormat": formats["json"], "Type": entryTypes["note"], "Contents": h.keys(), "HumanReadable": md, "EntryContext": ec})
-      else:
-          demisto.results("Couldn't find EML file for entry ID: " + demisto.args()['entryId'] + "\n");
+      return_outputs(
+          readable_output=readable_output,
+          outputs={
+              "Email": {
+                  "Headers": parsed_email_headers
+              }
+          },
+          raw_response=parsed_email_headers
+      )
+
+
+  if __name__ == '__builtin__':
+      main()
 type: python
 tags:
 - email
@@ -56,4 +57,32 @@ args:
 outputs:
 - contextPath: Email.Headers
   description: The headers of the email
+  type: Unknown
+- contextPath: Email.Headers.From
+  description: This displays who the message is from, however, this can be easily forged and can be the least reliable.
+  type: Unknown
+- contextPath: Email.Headers.To
+  description: This shows to whom the message was addressed, but may not contain the recipient's address.
+  type: Unknown
+- contextPath: Email.Headers.Subject
+  description: Email subject
+  type: String
+- contextPath: Email.Headers.Date
+  description: The date and time the email message was composed
+  type: Unknown
+- contextPath: Email.Headers.CC
+  description: Email 'cc' addresses
+  type: Unknown
+- contextPath: Email.Headers.Reply-To
+  description: The email address for return mail
+  type: String
+- contextPath: Email.Headers.Received
+  description: List of all the servers/computers through which the message traveled
+  type: String
+- contextPath: Email.Headers.Message-ID
+  description: A unique string assigned by the mail system when the message is first created. These can easily be forged. (e.g. 5c530c1b.1c69fb81.bd826.0eff@mx.google.com)
+  type: String
 scripttarget: 0
+runonce: false
+runas: DBotWeakRole
+releaseNotes: support eml and msg headers parsing - using ParseEmailFiles internally

--- a/TestPlaybooks/playbook-TestParseEmailHeaders.yml
+++ b/TestPlaybooks/playbook-TestParseEmailHeaders.yml
@@ -1,0 +1,385 @@
+id: TestParseEmailHeaders
+version: -1
+name: TestParseEmailHeaders
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: bacbcb43-8045-4612-8c01-748580664a76
+    type: start
+    task:
+      id: bacbcb43-8045-4612-8c01-748580664a76
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: 72b466ef-e2ea-419f-8f22-48cdcf203279
+    type: regular
+    task:
+      id: 72b466ef-e2ea-419f-8f22-48cdcf203279
+      version: -1
+      name: Download EML file
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      body: {}
+      filename:
+        simple: EmailWithNonAsciiSubject.eml
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password:
+        simple: '{ENCRYPTED}73CUHPcGaqWCBzx1eWdWPnTNZJtJ/1cx4/Bn+nC8OCydev0AcnyHOUv8MRHlhZNu+d2rsWGIBWI8vJV8hgjskA=='
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/EmailWithNonAsciiSubject.eml
+      username: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: 10941233-eea6-4e27-8fca-71546d698650
+    type: regular
+    task:
+      id: 10941233-eea6-4e27-8fca-71546d698650
+      version: -1
+      name: ParseEmailHeaders
+      scriptName: ParseEmailHeaders
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      entryId:
+        complex:
+          root: File
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: eml
+          accessor: EntryID
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: 628764b5-e41d-492b-8dfc-7c9e78256eda
+    type: condition
+    task:
+      id: 628764b5-e41d-492b-8dfc-7c9e78256eda
+      version: -1
+      name: Validate Headers outputs
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "4"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              simple: Email.Headers.From
+            iscontext: true
+          right:
+            value:
+              simple: Shai Yaakovi <Yaakovi@demisto.com>
+      - - operator: isEqualString
+          left:
+            value:
+              simple: Email.Headers.Subject
+            iscontext: true
+          right:
+            value:
+              simple: cãcao is not taçóánd taco is not à çãcao
+      - - operator: containsGeneral
+          left:
+            value:
+              simple: Email.Headers.Received
+            iscontext: true
+          right:
+            value:
+              simple: DM6PR11MB2842.namprd11.prod.outlook.com
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: 6012b9c8-88fb-4bd3-836c-5ac7fb8118bd
+    type: regular
+    task:
+      id: 6012b9c8-88fb-4bd3-836c-5ac7fb8118bd
+      version: -1
+      name: Download MSG file
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
+    scriptarguments:
+      body: {}
+      filename:
+        simple: utf_subject.msg
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password:
+        simple: '{ENCRYPTED}TjxAu8YVJac7qSpZfpgc4fDDavutkY4vYzTmyAwC1yRbXA+65KXrufr4Nt5++PjNMUywmua3oLOsqyRYKiFgWA=='
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        simple: https://github.com/demisto/content/raw/master/Scripts/ParseEmailFiles/test_data/utf_subject.msg
+      username: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: 858f097b-e6a2-499b-863b-5c38427b4a4a
+    type: regular
+    task:
+      id: 858f097b-e6a2-499b-863b-5c38427b4a4a
+      version: -1
+      name: ParseEmailHeaders - last entry id
+      scriptName: ParseEmailHeaders
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      entryId:
+        complex:
+          root: File
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: msg
+          accessor: EntryID
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "6":
+    id: "6"
+    taskid: 81bb52c7-3a03-45a0-847d-c0994cea6542
+    type: condition
+    task:
+      id: 81bb52c7-3a03-45a0-847d-c0994cea6542
+      version: -1
+      name: Validate outputs
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "8"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: Email.Headers.Received
+                transformers:
+                - operator: atIndex
+                  args:
+                    index:
+                      value:
+                        simple: "1"
+            iscontext: true
+          right:
+            value:
+              simple: DM6PR11MB2810.namprd11.prod.outlook.com
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: Email.Headers.Subject
+                transformers:
+                - operator: atIndex
+                  args:
+                    index:
+                      value:
+                        simple: "1"
+            iscontext: true
+          right:
+            value:
+              simple: '[TESTING] =?utf-8?q?=F0=9F=94=92_=E2=9C=94_Votre_colis_est_disponible_chez_votre_co?=
+                =?utf-8?q?mmer=C3=A7ant_Pickup_!?='
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: Email.Headers.X-MS-TrafficTypeDiagnostic
+            iscontext: true
+          right:
+            value:
+              simple: 'DM6PR11MB2810:'
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "7":
+    id: "7"
+    taskid: 6c0cb32a-5f91-4713-8400-23f85bb0b042
+    type: regular
+    task:
+      id: 6c0cb32a-5f91-4713-8400-23f85bb0b042
+      version: -1
+      name: DeleteContext
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "8":
+    id: "8"
+    taskid: 3b9d03bd-c002-4c70-8665-c6676d5c35f2
+    type: title
+    task:
+      id: 3b9d03bd-c002-4c70-8665-c6676d5c35f2
+      version: -1
+      name: Test Done - Success
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1420
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1435,
+        "width": 380,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/TestPlaybooks/playbook-TestParseEmailHeaders.yml
+++ b/TestPlaybooks/playbook-TestParseEmailHeaders.yml
@@ -112,10 +112,10 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: 628764b5-e41d-492b-8dfc-7c9e78256eda
+    taskid: bd8abf89-f58a-4758-8a4c-8c3bb1605411
     type: condition
     task:
-      id: 628764b5-e41d-492b-8dfc-7c9e78256eda
+      id: bd8abf89-f58a-4758-8a4c-8c3bb1605411
       version: -1
       name: Validate Headers outputs
       type: condition
@@ -147,7 +147,14 @@ tasks:
       - - operator: containsGeneral
           left:
             value:
-              simple: Email.Headers.Received
+              complex:
+                root: Email.Headers.Received
+                transformers:
+                - operator: atIndex
+                  args:
+                    index:
+                      value:
+                        simple: "0"
             iscontext: true
           right:
             value:
@@ -247,10 +254,10 @@ tasks:
     ignoreworker: false
   "6":
     id: "6"
-    taskid: 81bb52c7-3a03-45a0-847d-c0994cea6542
+    taskid: ffebbd9c-076c-449e-82e0-f5cd1c9fd6a5
     type: condition
     task:
-      id: 81bb52c7-3a03-45a0-847d-c0994cea6542
+      id: ffebbd9c-076c-449e-82e0-f5cd1c9fd6a5
       version: -1
       name: Validate outputs
       type: condition
@@ -267,13 +274,17 @@ tasks:
           left:
             value:
               complex:
-                root: Email.Headers.Received
-                transformers:
-                - operator: atIndex
-                  args:
-                    index:
+                root: Email.Headers
+                filters:
+                - - operator: isEqualString
+                    left:
                       value:
-                        simple: "1"
+                        simple: Email.Headers.Message-ID
+                      iscontext: true
+                    right:
+                      value:
+                        simple: <5c530c1b.1c69fb81.bd826.0eff@mx.google.com>
+                accessor: Received
             iscontext: true
           right:
             value:
@@ -282,13 +293,17 @@ tasks:
           left:
             value:
               complex:
-                root: Email.Headers.Subject
-                transformers:
-                - operator: atIndex
-                  args:
-                    index:
+                root: Email.Headers
+                filters:
+                - - operator: isEqualString
+                    left:
                       value:
-                        simple: "1"
+                        simple: Email.Headers.Message-ID
+                      iscontext: true
+                    right:
+                      value:
+                        simple: <5c530c1b.1c69fb81.bd826.0eff@mx.google.com>
+                accessor: Subject
             iscontext: true
           right:
             value:
@@ -298,7 +313,17 @@ tasks:
           left:
             value:
               complex:
-                root: Email.Headers.X-MS-TrafficTypeDiagnostic
+                root: Email.Headers
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: Email.Headers.Message-ID
+                      iscontext: true
+                    right:
+                      value:
+                        simple: <5c530c1b.1c69fb81.bd826.0eff@mx.google.com>
+                accessor: X-MS-TrafficTypeDiagnostic
             iscontext: true
           right:
             value:

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3,6 +3,9 @@
     "testInterval": 20,
     "tests": [
         {
+            "playbookID": "TestParseEmailHeaders"
+        },
+        {
             "playbookID": "TestParseEmailFile-deprecated-script"
         },
         {

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -714,6 +714,7 @@
   },
   "generic_strings":
   [
+    "max_depth_const-max_depth",
     "self.conf_json_validator",
     "self.IMAGE_MAX_SIZE:",
     "arcsight_esm_fixes.yml",

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -582,6 +582,7 @@
       "768:p7xinhxznvj8cc1rbxdo0zekxud3cdpjxb7mnmdzkukmkzqbftikkazt6:yht8c+fuiohq1kefoa8"
     ],
     "emails": [
+      "5c530c1b.1c69fb81.bd826.0eff@mx.google.com",
       "vikramarsid@gmail.com",
       "soso@demisto.com",
       "koko@demisto.com",

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -206,8 +206,8 @@ def __print_investigation_error(client, playbook_id, investigation_id):
         for entry in entries:
             if entry['type'] == ENTRY_TYPE_ERROR:
                 if entry['parentContent']:
-                    print_error('\t- Command: ' + str(entry['parentContent']))
-                print_error('\t- Body: ' + str(entry['contents']))
+                    print_error('\t- Command: ' + entry['parentContent'].encode('utf-8'))
+                print_error('\t- Body: ' + entry['contents'].encode('utf-8'))
 
 
 # 1. create integrations instances


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/13217

## Description
ParseEmailHeaders using ParseEmailFiles.
ParseEmailHeaders will be deprecated - instead use ParseEmailFiles

## Screenshots
Paste here any images that will help the reviewer

## Does it break backward compatibility?
   - Yes

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review
