### PR TITLE
EWS v2 - fetch incident error fix

### DIFF
--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -966,13 +966,13 @@ script:
         if item.headers:
             headers = []
             for header in item.headers:
-                labels.append({'type': 'Email/Header/' + str(header.name), 'value': str(header.value)})
-                headers.append(str(header.name) + ": " + str(header.value))
+                labels.append({'type': 'Email/Header/{}'.format(header.name), 'value': header.value})
+                headers.append("{}: {}".format(header.name, header.value))
             labels.append({'type': 'Email/headers', 'value': "\r\n".join(headers)})
 
         # handle item id
         if item.message_id:
-            labels.append({'type': 'Email/MessageId', 'value': str(item.message_id)})
+            labels.append({'type': 'Email/MessageId', 'value': item.message_id})
 
         if item.item_id:
             labels.append({'type': 'Email/ID', 'value': item.item_id})

--- a/Integrations/integration-EWSv2.yml
+++ b/Integrations/integration-EWSv2.yml
@@ -966,13 +966,13 @@ script:
         if item.headers:
             headers = []
             for header in item.headers:
-                labels.append({'type': 'Email/Header/' + header.name, 'value': header.value})
-                headers.append(header.name + ": " + header.value)
+                labels.append({'type': 'Email/Header/' + str(header.name), 'value': str(header.value)})
+                headers.append(str(header.name) + ": " + str(header.value))
             labels.append({'type': 'Email/headers', 'value': "\r\n".join(headers)})
 
         # handle item id
         if item.message_id:
-            labels.append({'type': 'Email/MessageId', 'value': item.message_id})
+            labels.append({'type': 'Email/MessageId', 'value': str(item.message_id)})
 
         if item.item_id:
             labels.append({'type': 'Email/ID', 'value': item.item_id})


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16011

## Description
Added str to headers values and headers names so in case one of them is None, concatenation of two strings will be available and will not raise exception.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Tests:
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] pyEWS_Test
- [x] EWS search-mailbox test
- [x] Phishing test - Inline
- [x] process_email_-_generic_-_test


