### PR TITLE
Active Directory Query v2 - Fixed error when specifying a port

### DIFF
--- a/Integrations/Active_Directory_Query/Active_Directory_Query.py
+++ b/Integrations/Active_Directory_Query/Active_Directory_Query.py
@@ -882,7 +882,7 @@ def main():
     DEFAULT_PAGE_SIZE = int(demisto.params().get('page_size'))
     NTLM_AUTH = demisto.params().get('ntlm')
     UNSECURE = demisto.params().get('unsecure', False)
-    PORT = demisto.params().get('port')
+    PORT = int(demisto.params().get('port'))
 
     try:
         server = initialize_server(SERVER_IP, PORT, SECURE_CONNECTION, UNSECURE)


### PR DESCRIPTION
## Status
Ready

## Related Issues
No open issues

## Description
Because the port is given to the ldap3 library as a string, a "port must be an integer" error is thrown when you specify a port in the instance configuration. Casting this parameter to an integer resolves this issue.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.
