### PR TITLE
Add generic proxy logic to CommonServerPython

### DIFF
--- a/Integrations/integration-Centreon.yml
+++ b/Integrations/integration-Centreon.yml
@@ -37,10 +37,7 @@ script:
     requests.packages.urllib3.disable_warnings()
 
     if not demisto.params().get('proxy', False):
-        del os.environ['HTTP_PROXY']
-        del os.environ['HTTPS_PROXY']
-        del os.environ['http_proxy']
-        del os.environ['https_proxy']
+        disable_proxy()
 
     ''' GLOBAL VARS '''
     SERVER_NAME=demisto.params()['server']
@@ -199,6 +196,8 @@ script:
         LOG(e.message)
         LOG.print_log()
         raise
+    finally:
+        enable_proxy()
   type: python
   commands:
   - name: centreon-get-host-status

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -28,6 +28,28 @@ script: |-
   thresholds = {'xfeScore': 4, 'vtPositives': 10, 'vtPositiveUrlsForIP': 30}
   dbotscores = {'Critical': 4, 'High': 3, 'Medium': 2,'Low': 1, 'Unknown': 0, 'Informational': 0.5}
 
+  SAVE_PROXIES = {}
+
+  def disable_proxy():
+      """
+          Disable routing traffic through the system proxy.
+          Should usually be called at the beginning of the integration, depeding on proxy checkbox state.
+      """
+      global SAVE_PROXIES
+      for k in ('HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'):
+          SAVE_PROXIES[k] = os.environ[k]
+          del os.environ[k]
+
+  def enable_proxy():
+      """
+          Re-enable routing traffic through the system proxy (for container re-use).
+          Should usually be called in a "finally" block at the bottom of the integration.
+      """
+      global SAVE_PROXIES
+      for k, v in SAVE_PROXIES.iteritems():
+          os.environ[k] = v
+      SAVE_PROXIES = {}
+
   def urljoin(url, suffix=""):
       """
           Will join url and its suffix

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -34,6 +34,8 @@ script: |-
       """
           Disable routing traffic through the system proxy.
           Should usually be called at the beginning of the integration, depeding on proxy checkbox state.
+          :rtype: ``None``
+          :return: None
       """
       global SAVE_PROXIES
       for k in ('HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'):
@@ -44,6 +46,8 @@ script: |-
       """
           Re-enable routing traffic through the system proxy (for container re-use).
           Should usually be called in a "finally" block at the bottom of the integration.
+          :rtype: ``None``
+          :return: None
       """
       global SAVE_PROXIES
       for k, v in SAVE_PROXIES.iteritems():


### PR DESCRIPTION
## Status
Ready

## Description
Due to container re-use, when deleting the proxy environment variables, they are not returned.
Added `disable_proxy()` and `enable_proxy()` commands to CommonServerPython to resolve this issue.

See screenshot for example usage.

## Screenshots
![Settings 2019-03-21 15-52-30](https://user-images.githubusercontent.com/39116813/54757092-33847b80-4bf2-11e9-847a-b96cc163628a.jpg)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Run all tests  - **Need force merge**

## Additional changes
This has been applied to centreon (because of nightly test failure)