### PR TITLE
improved package_creator.py detailed description parsing

### DIFF
--- a/package_creator.py
+++ b/package_creator.py
@@ -99,7 +99,9 @@ def insert_description_to_yml(dir_name, package_path, yml_data, yml_text):
                          ' in the package: {}'.format(package_path))
     if desc_data:
         if not desc_data.startswith('"'):
-            desc_data = '"' + desc_data + '"'
+            # for multiline detailed-description, if it's not wrapped in quotation marks
+            # add | to the beginning of the description, and shift everything to the right
+            desc_data = '|\n  ' + desc_data.replace('\n', '\n  ')
         yml_text = "detaileddescription: " + desc_data + '\n' + yml_text
 
     return yml_text, found_desc_path


### PR DESCRIPTION
## Status
Ready

## Description
package_creator.py wraps `detaileddescription` in quotation marks, so any other quotation marks in the description will break the yml.
fix now only add `|` at the beginning, and shift everything to the right (for multilined `detaileddescription`)

## Before
![image](https://user-images.githubusercontent.com/44546251/54918778-d21d1f00-4f07-11e9-8bb4-f7fe1cab8767.png)

## After
![image](https://user-images.githubusercontent.com/44546251/54918882-08f33500-4f08-11e9-890e-acd4a7bd22fe.png)
