### PR TITLE
Add String to Boolean function in CommonServerPython

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1545,8 +1545,6 @@ script: |-
           string = True
       elif string == 'false' or string == 'False':
           string = False
-      else:
-          string = string
       return string
 
 type: python

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1540,6 +1540,8 @@ script: |-
 
         :type string: `str`
         :param string: String to be converted. (required)
+
+        :return: Boolean
         :rtype: `bool`
       """
       if string == 'true' or string == 'True':

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1535,11 +1535,11 @@ script: |-
 
   def string_to_bool(string):
   """
-      Converts argument string of 'True'/'true' and 'False'/'false' to their respective boolean values.
-      Example: ("True" becomes True, "False" becomes False)
+    Converts argument string of 'True'/'true' and 'False'/'false' to their respective boolean values.
+    Example: ("True" becomes True, "False" becomes False)
 
-      :type string: `str`
-      :param string: String to be converted. (required)
+    :type string: `str`
+    :param string: String to be converted. (required)
   """
       if string == 'true' or string == 'True':
           string = True

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1540,6 +1540,7 @@ script: |-
 
         :type string: `str`
         :param string: String to be converted. (required)
+        :rtype: `bool`
       """
       if string == 'true' or string == 'True':
           string = True

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1532,6 +1532,23 @@ script: |-
       # otherwise datetime.datetime
       return int(time.mktime(date_str_or_dt.timetuple())*1000)
 
+
+  def string_to_bool(string):
+  """
+      Converts argument string of 'True'/'true' and 'False'/'false' to their respective boolean values.
+      Example: ("True" becomes True, "False" becomes False)
+
+      :type string: `str`
+      :param string: String to be converted. (required)
+  """
+      if string == 'true' or string == 'True':
+          string = True
+      elif string == 'false' or string == 'False':
+          string = False
+      else:
+          string = string
+      return string
+
 type: python
 tags:
 - infra
@@ -1541,6 +1558,6 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
-releaseNotes: "Added proxy enable/disable methods."
+releaseNotes: "Added string to boolean function"
 tests:
   - TestPYCommonServer

--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1534,13 +1534,13 @@ script: |-
 
 
   def string_to_bool(string):
-  """
-    Converts argument string of 'True'/'true' and 'False'/'false' to their respective boolean values.
-    Example: ("True" becomes True, "False" becomes False)
+      """
+        Converts argument string of 'True'/'true' and 'False'/'false' to their respective boolean values.
+        Example: ("True" becomes True, "False" becomes False)
 
-    :type string: `str`
-    :param string: String to be converted. (required)
-  """
+        :type string: `str`
+        :param string: String to be converted. (required)
+      """
       if string == 'true' or string == 'True':
           string = True
       elif string == 'false' or string == 'False':


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Converts argument string of `'True'`/`'true'` and `'False'`/`'false'` to their respective boolean values.

Example: (`"True"` becomes `True`, `"False"` becomes `False`)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review