### PR TITLE
Hashicorp Vault Fixes

### DIFF
--- a/Integrations/integration-HashiCorp-Vault.yml
+++ b/Integrations/integration-HashiCorp-Vault.yml
@@ -105,7 +105,7 @@ script:
 
         url = '{}/{}'.format(SERVER_URL, path)
         res = requests.request('POST', url, headers=get_headers(), data=json.dumps(body), verify=VERIFY_SSL)
-        if (res.status_code < 200 or res.status_code) >= 300 and res.status_code not in DEFAULT_STATUS_CODES:
+        if (res.status_code < 200 or res.status_code >= 300) and res.status_code not in DEFAULT_STATUS_CODES:
             try:
                 error_body = res.json()
                 if 'errors' in error_body and isinstance(error_body['errors'], list):

--- a/Integrations/integration-HashiCorp-Vault.yml
+++ b/Integrations/integration-HashiCorp-Vault.yml
@@ -79,6 +79,12 @@ script:
     BASE_URL = get_server_url()
     SERVER_URL = BASE_URL + '/v1'
 
+    DEFAULT_STATUS_CODES = {
+        429,
+        472,
+        473
+    }
+
     ''' HELPER FUNCTIONS '''
 
     def get_headers():
@@ -99,7 +105,7 @@ script:
 
         url = '{}/{}'.format(SERVER_URL, path)
         res = requests.request('POST', url, headers=get_headers(), data=json.dumps(body), verify=VERIFY_SSL)
-        if res.status_code < 200 or res.status_code >= 300:
+        if (res.status_code < 200 or res.status_code) >= 300 and res.status_code not in DEFAULT_STATUS_CODES:
             try:
                 error_body = res.json()
                 if 'errors' in error_body and isinstance(error_body['errors'], list):
@@ -170,8 +176,9 @@ script:
 
     def list_secrets_command():
         engine = demisto.args()['engine']
+        version = demisto.args().get('version')
 
-        res = list_secrets(engine)
+        res = list_secrets(engine, version)
 
         if not res or 'data' not in res:
             return_error('Secrets not found')
@@ -192,8 +199,11 @@ script:
         })
 
 
-    def list_secrets(engine_path):
-        path = engine_path + '/metadata'
+    def list_secrets(engine_path, version):
+        path = engine_path
+
+        if version == '2':
+            path += '/metadata'
 
         params = {
             'list': 'true'
@@ -602,12 +612,15 @@ script:
 
         for engine_type in ENGINES:
             engines_to_fetch = list(filter(lambda e: e['type'] == engine_type, ENGINE_CONFIGS))
-            if len(engines_to_fetch) == 0:
-                return_error('Engine type not configured, please use the configure-engine command to configure a secrets engine.')
             engines_to_fetch_from += engines_to_fetch
+
+        if len(engines_to_fetch_from) == 0:
+                return_error('Engine type not configured, please use the configure-engine command to configure a secrets engine.')
 
         for engine in engines_to_fetch_from:
             if engine['type'] == 'KV':
+                if 'version' not in engine:
+                    return_error('Version not configured for KV engine, please re-configure')
                 if engine['version'] == '1':
                     credentials += get_kv1_secrets(engine['path'])
                 elif engine['version'] == '2':
@@ -781,11 +794,18 @@ script:
       default: true
       description: Engine path, e.g.,"secret/". Use the list-secrets-engines command
         to retrieve the engine path. command.
+    - name: version
+      auto: PREDEFINED
+      predefined:
+      - "1"
+      - "2"
+      description: The version of the KV engine
+      defaultValue: "1"
     outputs:
     - contextPath: HashiCorp.Secret.Path
       description: Secret path
       type: string
-    description: List secrets (names) for a specified KV V2 engine
+    description: List secrets (names) for a specified KV engine
   - name: hashicorp-get-secret-metadata
     arguments:
     - name: engine_path
@@ -883,10 +903,10 @@ script:
       description: Human-friendly description of the mount
     - name: default_lease_ttl
       description: The default lease duration, specified as a string duration, e.g.,
-                     "5s" or "30m"
+        "5s" or "30m"
     - name: max_lease_ttl
       description: The maximum lease duration, specified as a string duration, e.g.,
-                     "5s" or "30m"
+        "5s" or "30m"
     - name: force_no_cache
       description: Disable caching
     - name: audit_non_hmac_request_keys
@@ -903,7 +923,7 @@ script:
       - unauth
       - hidden
       description: Whether to show this mount in the UI-specific listing endpoint;
-                     "unauth" or "hidden", default is "hidden" Default is hidden.
+        "unauth" or "hidden", default is "hidden" Default is hidden.
     - name: passthrough_request_headers
       description: CSV list of headers to whitelist and pass from the request to the
         backend
@@ -1011,8 +1031,8 @@ script:
       - "true"
       - "false"
       description: If set to false, the token cannot be renewed past its initial TTL.
-                     If set to true, the token can be renewed up to the system/mount maximum TTL.
-                     "true" or "false"
+        If set to true, the token can be renewed up to the system/mount maximum TTL.
+        "true" or "false"
     - name: ttl
       description: The TTL(lease duration) period of the token, provided as "10m"
         or "1h", where hour is the largest suffix. If not provided, the token is valid
@@ -1044,5 +1064,6 @@ script:
     description: Creates a new authentication token
   dockerimage: demisto/hashicorp:1.0.0.39
   runonce: false
+releaseNotes: "Fixed integration test error messages along with some bugs in credentials fetching. Now supporting KV1 engines in the list-secrets command"
 tests:
   - hashicorp_test

--- a/Integrations/integration-HashiCorp-Vault.yml
+++ b/Integrations/integration-HashiCorp-Vault.yml
@@ -615,12 +615,12 @@ script:
             engines_to_fetch_from += engines_to_fetch
 
         if len(engines_to_fetch_from) == 0:
-                return_error('Engine type not configured, please use the configure-engine command to configure a secrets engine.')
+                return_error('Engine type not configured, Use the configure-engine command to configure a secrets engine.')
 
         for engine in engines_to_fetch_from:
             if engine['type'] == 'KV':
                 if 'version' not in engine:
-                    return_error('Version not configured for KV engine, please re-configure')
+                    return_error('Version not configured for KV engine, Re-configure the engine')
                 if engine['version'] == '1':
                     credentials += get_kv1_secrets(engine['path'])
                 elif engine['version'] == '2':

--- a/TestPlaybooks/playbook-hashicorp_test.yml
+++ b/TestPlaybooks/playbook-hashicorp_test.yml
@@ -26,6 +26,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "1":
     id: "1"
     taskid: d8caa391-a351-42c5-8cbc-db60e34113bb
@@ -59,15 +60,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
-    taskid: a7ad5342-af8a-465e-897c-c0eda3ae1cf5
+    taskid: da89ff6b-99e7-4da7-8d94-4e0e6886b75a
     type: regular
     task:
-      id: a7ad5342-af8a-465e-897c-c0eda3ae1cf5
+      id: da89ff6b-99e7-4da7-8d94-4e0e6886b75a
       version: -1
       name: hashicorp-list-secrets-engines
-      description: List all secrets engines that exist in HashiCorp Vault
       script: HashiCorp Vault|||hashicorp-list-secrets-engines
       type: regular
       iscommand: true
@@ -85,15 +86,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
-    taskid: c2344a8e-bc97-4261-8748-f5f738d38a24
+    taskid: a3294a19-669b-46f9-8b41-8fcd19d8f4b6
     type: regular
     task:
-      id: c2344a8e-bc97-4261-8748-f5f738d38a24
+      id: a3294a19-669b-46f9-8b41-8fcd19d8f4b6
       version: -1
       name: hashicorp-list-secrets
-      description: List secrets (names) for a specified KV V2 engine
       script: HashiCorp Vault|||hashicorp-list-secrets
       type: regular
       iscommand: true
@@ -118,6 +119,8 @@ tasks:
               getField:
                 value:
                   simple: Path
+      version:
+        simple: "2"
     separatecontext: false
     view: |-
       {
@@ -128,16 +131,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "4":
     id: "4"
-    taskid: f41943d5-fd3d-4f81-8662-0a27ad6e43f5
+    taskid: 6e59529d-96ea-4763-88bf-774ab9a08fd6
     type: regular
     task:
-      id: f41943d5-fd3d-4f81-8662-0a27ad6e43f5
+      id: 6e59529d-96ea-4763-88bf-774ab9a08fd6
       version: -1
       name: hashicorp-get-secret-metadata
-      description: Returns information about a specified secret in a specified KV
-        V2 engine
       script: HashiCorp Vault|||hashicorp-get-secret-metadata
       type: regular
       iscommand: true
@@ -174,6 +176,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
     taskid: 505a18a3-7728-4862-8f47-35e3fe643df5
@@ -222,16 +225,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "6":
     id: "6"
-    taskid: dd22f8f9-ce54-4b5b-8f72-27eca69feb8c
+    taskid: ba770892-244b-4fa0-890c-bd26bdb8a323
     type: regular
     task:
-      id: dd22f8f9-ce54-4b5b-8f72-27eca69feb8c
+      id: ba770892-244b-4fa0-890c-bd26bdb8a323
       version: -1
       name: hashicorp-undelete-secret
-      description: Undeletes (restores) a secret on HashiCorp (for KV engine version
-        2)
       script: HashiCorp Vault|||hashicorp-undelete-secret
       type: regular
       iscommand: true
@@ -256,17 +258,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "7":
     id: "7"
-    taskid: 082d381a-7ac7-43ea-8412-58157d251488
+    taskid: 335f6eff-a46f-420c-88aa-8063672f178b
     type: regular
     task:
-      id: 082d381a-7ac7-43ea-8412-58157d251488
+      id: 335f6eff-a46f-420c-88aa-8063672f178b
       version: -1
       name: hashicorp-delete-secret
-      description: Deletes the data under a specified secret given the secret path.
-        Performs a soft delete that allows you to run the hashicorp-undelete-secret
-        command if necessary (for KV engine version 2)
       script: HashiCorp Vault|||hashicorp-delete-secret
       type: regular
       iscommand: true
@@ -291,16 +291,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "8":
     id: "8"
-    taskid: 64693243-4ce7-42d9-892d-9e7b741e038f
+    taskid: 05c1d2ab-e3ff-4c10-8cdd-e477eca1d79c
     type: regular
     task:
-      id: 64693243-4ce7-42d9-892d-9e7b741e038f
+      id: 05c1d2ab-e3ff-4c10-8cdd-e477eca1d79c
       version: -1
       name: hashicorp-undelete-secret
-      description: Undeletes (restores) a secret on HashiCorp (for KV engine version
-        2)
       script: HashiCorp Vault|||hashicorp-undelete-secret
       type: regular
       iscommand: true
@@ -325,15 +324,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "9":
     id: "9"
-    taskid: 98b2db1e-d670-4a6a-8a68-b8395a42c444
+    taskid: 83c352e1-c14b-43f6-8969-f13d444363be
     type: regular
     task:
-      id: 98b2db1e-d670-4a6a-8a68-b8395a42c444
+      id: 83c352e1-c14b-43f6-8969-f13d444363be
       version: -1
       name: hashicorp-destroy-secret
-      description: Permanently deletes a secret (for KV engine version 2)
       script: HashiCorp Vault|||hashicorp-destroy-secret
       type: regular
       iscommand: true
@@ -358,15 +357,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "10":
     id: "10"
-    taskid: 1b49ca60-403f-4363-884e-457e3289ce2e
+    taskid: d1e40572-6a52-41e5-83a0-0f37eb397c6e
     type: regular
     task:
-      id: 1b49ca60-403f-4363-884e-457e3289ce2e
+      id: d1e40572-6a52-41e5-83a0-0f37eb397c6e
       version: -1
       name: hashicorp-enable-engine
-      description: Enables a new secrets engine at the specified path
       script: HashiCorp Vault|||hashicorp-enable-engine
       type: regular
       iscommand: true
@@ -400,17 +399,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "11":
     id: "11"
-    taskid: e8ffe6fa-a8c3-492e-8ba0-96629e7b2b58
+    taskid: 08fae6fb-943a-4381-8966-c46a884b2820
     type: regular
     task:
-      id: e8ffe6fa-a8c3-492e-8ba0-96629e7b2b58
+      id: 08fae6fb-943a-4381-8966-c46a884b2820
       version: -1
       name: hashicorp-disable-engine
-      description: When a secrets engine is no longer needed, it can be disabled.
-        All secrets under the engine are revoked and the corresponding vault data
-        and configurations are removed.
       script: HashiCorp Vault|||hashicorp-disable-engine
       type: regular
       iscommand: true
@@ -431,15 +428,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "12":
     id: "12"
-    taskid: 0796bf6e-0deb-4b7b-846a-fd9f59b4ff17
+    taskid: e687c631-b4eb-4ba1-85f0-15b547f7513e
     type: regular
     task:
-      id: 0796bf6e-0deb-4b7b-846a-fd9f59b4ff17
+      id: e687c631-b4eb-4ba1-85f0-15b547f7513e
       version: -1
       name: hashicorp-list-policies
-      description: List all configured policies
       script: HashiCorp Vault|||hashicorp-list-policies
       type: regular
       iscommand: true
@@ -457,6 +454,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "13":
     id: "13"
     taskid: 801af8f1-fc76-4602-8b6e-6b11015e7a0b
@@ -500,15 +498,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "14":
     id: "14"
-    taskid: 6af3231e-333f-4e22-861c-1e882f75ba09
+    taskid: c742646b-b21d-43e9-802f-aef8ad5e0ef0
     type: regular
     task:
-      id: 6af3231e-333f-4e22-861c-1e882f75ba09
+      id: c742646b-b21d-43e9-802f-aef8ad5e0ef0
       version: -1
       name: hashicorp-create-token
-      description: Creates a new authentication token
       script: HashiCorp Vault|||hashicorp-create-token
       type: regular
       iscommand: true
@@ -542,15 +540,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "15":
     id: "15"
-    taskid: 50862b62-7095-4237-8edb-b1d41532497d
+    taskid: 1c9f3549-d0ee-4c2d-8b62-b7dcf7ea570d
     type: regular
     task:
-      id: 50862b62-7095-4237-8edb-b1d41532497d
+      id: 1c9f3549-d0ee-4c2d-8b62-b7dcf7ea570d
       version: -1
       name: hashicorp-configure-engine
-      description: Configure a secrets engine to fetch secrets from
       script: HashiCorp Vault|||hashicorp-configure-engine
       type: regular
       iscommand: true
@@ -575,6 +573,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "16":
     id: "16"
     taskid: ade8806b-6c71-4c6e-84eb-2270446828b4
@@ -609,15 +608,15 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "17":
     id: "17"
-    taskid: 7e17043c-4906-43f5-80c1-615b77c996bb
+    taskid: a6814aa4-b7c8-437a-8558-2598341b864a
     type: regular
     task:
-      id: 7e17043c-4906-43f5-80c1-615b77c996bb
+      id: a6814aa4-b7c8-437a-8558-2598341b864a
       version: -1
       name: hashicorp-reset-configuration
-      description: Reset the engines configuration
       script: HashiCorp Vault|||hashicorp-reset-configuration
       type: regular
       iscommand: true
@@ -632,6 +631,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},

--- a/TestPlaybooks/playbook-hashicorp_test.yml
+++ b/TestPlaybooks/playbook-hashicorp_test.yml
@@ -63,12 +63,13 @@ tasks:
     ignoreworker: false
   "2":
     id: "2"
-    taskid: da89ff6b-99e7-4da7-8d94-4e0e6886b75a
+    taskid: 33e66e93-8eee-4493-8572-d4ec6f0d9f7b
     type: regular
     task:
-      id: da89ff6b-99e7-4da7-8d94-4e0e6886b75a
+      id: 33e66e93-8eee-4493-8572-d4ec6f0d9f7b
       version: -1
       name: hashicorp-list-secrets-engines
+      description: List all secrets engines that exist in HashiCorp Vault
       script: HashiCorp Vault|||hashicorp-list-secrets-engines
       type: regular
       iscommand: true
@@ -89,12 +90,13 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: a3294a19-669b-46f9-8b41-8fcd19d8f4b6
+    taskid: 30242859-98e0-4219-86cc-5471f3187e1e
     type: regular
     task:
-      id: a3294a19-669b-46f9-8b41-8fcd19d8f4b6
+      id: 30242859-98e0-4219-86cc-5471f3187e1e
       version: -1
       name: hashicorp-list-secrets
+      description: List secrets (names) for a specified KV engine
       script: HashiCorp Vault|||hashicorp-list-secrets
       type: regular
       iscommand: true
@@ -134,12 +136,14 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 6e59529d-96ea-4763-88bf-774ab9a08fd6
+    taskid: 83416e0a-4e8d-44d1-8536-ad006381a31a
     type: regular
     task:
-      id: 6e59529d-96ea-4763-88bf-774ab9a08fd6
+      id: 83416e0a-4e8d-44d1-8536-ad006381a31a
       version: -1
       name: hashicorp-get-secret-metadata
+      description: Returns information about a specified secret in a specified KV
+        V2 engine
       script: HashiCorp Vault|||hashicorp-get-secret-metadata
       type: regular
       iscommand: true
@@ -179,10 +183,10 @@ tasks:
     ignoreworker: false
   "5":
     id: "5"
-    taskid: 505a18a3-7728-4862-8f47-35e3fe643df5
+    taskid: e277fc28-820e-41c4-8c52-dd815accf363
     type: condition
     task:
-      id: 505a18a3-7728-4862-8f47-35e3fe643df5
+      id: e277fc28-820e-41c4-8c52-dd815accf363
       version: -1
       name: Is deleted
       type: condition
@@ -228,12 +232,14 @@ tasks:
     ignoreworker: false
   "6":
     id: "6"
-    taskid: ba770892-244b-4fa0-890c-bd26bdb8a323
+    taskid: d5dcec3c-588b-46a0-8a4f-01f3a486bbc7
     type: regular
     task:
-      id: ba770892-244b-4fa0-890c-bd26bdb8a323
+      id: d5dcec3c-588b-46a0-8a4f-01f3a486bbc7
       version: -1
       name: hashicorp-undelete-secret
+      description: Undeletes (restores) a secret on HashiCorp (for KV engine version
+        2)
       script: HashiCorp Vault|||hashicorp-undelete-secret
       type: regular
       iscommand: true
@@ -261,12 +267,15 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 335f6eff-a46f-420c-88aa-8063672f178b
+    taskid: 3d06fa8a-8b6a-47a6-8ae0-f69e6faef56a
     type: regular
     task:
-      id: 335f6eff-a46f-420c-88aa-8063672f178b
+      id: 3d06fa8a-8b6a-47a6-8ae0-f69e6faef56a
       version: -1
       name: hashicorp-delete-secret
+      description: Deletes the data under a specified secret given the secret path.
+        Performs a soft delete that allows you to run the hashicorp-undelete-secret
+        command if necessary (for KV engine version 2)
       script: HashiCorp Vault|||hashicorp-delete-secret
       type: regular
       iscommand: true
@@ -294,12 +303,14 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: 05c1d2ab-e3ff-4c10-8cdd-e477eca1d79c
+    taskid: 82abb548-deed-4dec-8b35-5335cf1c81d6
     type: regular
     task:
-      id: 05c1d2ab-e3ff-4c10-8cdd-e477eca1d79c
+      id: 82abb548-deed-4dec-8b35-5335cf1c81d6
       version: -1
       name: hashicorp-undelete-secret
+      description: Undeletes (restores) a secret on HashiCorp (for KV engine version
+        2)
       script: HashiCorp Vault|||hashicorp-undelete-secret
       type: regular
       iscommand: true
@@ -327,12 +338,13 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: 83c352e1-c14b-43f6-8969-f13d444363be
+    taskid: 18c3323d-44c0-4ed6-8cb0-356bbecdc49e
     type: regular
     task:
-      id: 83c352e1-c14b-43f6-8969-f13d444363be
+      id: 18c3323d-44c0-4ed6-8cb0-356bbecdc49e
       version: -1
       name: hashicorp-destroy-secret
+      description: Permanently deletes a secret (for KV engine version 2)
       script: HashiCorp Vault|||hashicorp-destroy-secret
       type: regular
       iscommand: true
@@ -360,12 +372,13 @@ tasks:
     ignoreworker: false
   "10":
     id: "10"
-    taskid: d1e40572-6a52-41e5-83a0-0f37eb397c6e
+    taskid: 635b40e6-2966-4764-887a-1c89ccfe9196
     type: regular
     task:
-      id: d1e40572-6a52-41e5-83a0-0f37eb397c6e
+      id: 635b40e6-2966-4764-887a-1c89ccfe9196
       version: -1
       name: hashicorp-enable-engine
+      description: Enables a new secrets engine at the specified path
       script: HashiCorp Vault|||hashicorp-enable-engine
       type: regular
       iscommand: true
@@ -402,12 +415,15 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 08fae6fb-943a-4381-8966-c46a884b2820
+    taskid: fda2ed0d-6b78-4065-86a2-baa0f15ce8bd
     type: regular
     task:
-      id: 08fae6fb-943a-4381-8966-c46a884b2820
+      id: fda2ed0d-6b78-4065-86a2-baa0f15ce8bd
       version: -1
       name: hashicorp-disable-engine
+      description: When a secrets engine is no longer needed, it can be disabled.  All
+        secrets under the engine are revoked and the corresponding vault data and
+        configurations are removed.
       script: HashiCorp Vault|||hashicorp-disable-engine
       type: regular
       iscommand: true
@@ -431,12 +447,13 @@ tasks:
     ignoreworker: false
   "12":
     id: "12"
-    taskid: e687c631-b4eb-4ba1-85f0-15b547f7513e
+    taskid: 0656f23f-ff62-4ea4-8512-954739fb5228
     type: regular
     task:
-      id: e687c631-b4eb-4ba1-85f0-15b547f7513e
+      id: 0656f23f-ff62-4ea4-8512-954739fb5228
       version: -1
       name: hashicorp-list-policies
+      description: List all configured policies
       script: HashiCorp Vault|||hashicorp-list-policies
       type: regular
       iscommand: true
@@ -457,10 +474,10 @@ tasks:
     ignoreworker: false
   "13":
     id: "13"
-    taskid: 801af8f1-fc76-4602-8b6e-6b11015e7a0b
+    taskid: 756429e7-ab70-495a-8798-a36e2c94e0bb
     type: regular
     task:
-      id: 801af8f1-fc76-4602-8b6e-6b11015e7a0b
+      id: 756429e7-ab70-495a-8798-a36e2c94e0bb
       version: -1
       name: hashicorp-get-policy
       description: Get information for a policy
@@ -501,12 +518,13 @@ tasks:
     ignoreworker: false
   "14":
     id: "14"
-    taskid: c742646b-b21d-43e9-802f-aef8ad5e0ef0
+    taskid: d6906fce-6b76-4bb9-871c-889f986f18a3
     type: regular
     task:
-      id: c742646b-b21d-43e9-802f-aef8ad5e0ef0
+      id: d6906fce-6b76-4bb9-871c-889f986f18a3
       version: -1
       name: hashicorp-create-token
+      description: Creates a new authentication token
       script: HashiCorp Vault|||hashicorp-create-token
       type: regular
       iscommand: true
@@ -543,12 +561,13 @@ tasks:
     ignoreworker: false
   "15":
     id: "15"
-    taskid: 1c9f3549-d0ee-4c2d-8b62-b7dcf7ea570d
+    taskid: adf833e9-c1e1-41c8-8632-fb5f93610e56
     type: regular
     task:
-      id: 1c9f3549-d0ee-4c2d-8b62-b7dcf7ea570d
+      id: adf833e9-c1e1-41c8-8632-fb5f93610e56
       version: -1
       name: hashicorp-configure-engine
+      description: Configure a secrets engine to fetch secrets from
       script: HashiCorp Vault|||hashicorp-configure-engine
       type: regular
       iscommand: true
@@ -576,10 +595,10 @@ tasks:
     ignoreworker: false
   "16":
     id: "16"
-    taskid: ade8806b-6c71-4c6e-84eb-2270446828b4
+    taskid: 458e042c-19bb-45c8-8cf3-a35ef0eea37f
     type: regular
     task:
-      id: ade8806b-6c71-4c6e-84eb-2270446828b4
+      id: 458e042c-19bb-45c8-8cf3-a35ef0eea37f
       version: -1
       name: GetTime
       description: |
@@ -611,12 +630,13 @@ tasks:
     ignoreworker: false
   "17":
     id: "17"
-    taskid: a6814aa4-b7c8-437a-8558-2598341b864a
+    taskid: caa0912b-aef8-4d5a-8c90-0189955ea97f
     type: regular
     task:
-      id: a6814aa4-b7c8-437a-8558-2598341b864a
+      id: caa0912b-aef8-4d5a-8c90-0189955ea97f
       version: -1
       name: hashicorp-reset-configuration
+      description: Reset the engines configuration
       script: HashiCorp Vault|||hashicorp-reset-configuration
       type: regular
       iscommand: true


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16317

Support KV 1 engine in `list-secrets` command
Fix non-indicative test errors
Fix multiple engine configurations