### PR TITLE
Print ami info(server version and build) in content test run

### DIFF
--- a/Tests/scripts/create_instance.sh
+++ b/Tests/scripts/create_instance.sh
@@ -15,6 +15,7 @@ IMAGE_ID=$(aws ec2 describe-images \
     --query 'Images[*].[ImageId,CreationDate]' --output text | sort -k2 -r | head -n1)
 
 echo $IMAGE_ID > image_id.txt
+echo "AMI Name :$AMI_NAME, image ID: $IMAGE_ID"
 
 python ./Tests/scripts/update_image_id.py -i image_id.txt -c $CONFFILE
 

--- a/Tests/scripts/create_instance.sh
+++ b/Tests/scripts/create_instance.sh
@@ -12,10 +12,9 @@ AMI_NAME=$2
 #Get nightly image of the server
 IMAGE_ID=$(aws ec2 describe-images \
     --filters Name=name,Values=$AMI_NAME \
-    --query 'Images[*].[ImageId,CreationDate]' --output text | sort -k2 -r | head -n1)
+    --query 'Images[*].[ImageId,Name,CreationDate]' --output text | sort -k2 -r | head -n1)
 
 echo $IMAGE_ID > image_id.txt
-echo "AMI Name :$AMI_NAME, image ID: $IMAGE_ID"
 
 python ./Tests/scripts/update_image_id.py -i image_id.txt -c $CONFFILE
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -35,7 +35,8 @@ def create_instance(ami_name):
         image_data = image_id_file.read()
         print('Image data is {}.format(image_data))
         with open("./Tests/images_data.txt", "a") as image_data_file:
-            image_data_file.write('{name} Image info is: {data}\n'.format(name=AMI_NAME_TO_READABLE[ami_name], data=image_data))
+            image_data_file.write(
+                '{name} Image info is: {data}\n'.format(name=AMI_NAME_TO_READABLE[ami_name], data=image_data))
     return instance_id
 
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -31,6 +31,7 @@ def create_instance(ami_name):
     run_command("./Tests/scripts/create_instance.sh instance.json {}".format(ami_name))  # noqa
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
+        Print("Instance ID is {}".format(instance_id))
 
     return instance_id
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -32,8 +32,10 @@ def create_instance(ami_name):
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
     with open('image_id.txt', 'r') as image_id_file:
-        image_id = image_id_file.read()
-        print("image ID is {}".format(image_id))
+        image_data = image_id_file.read()
+        print('Image data is {}.format(image_data))
+        with open("./Tests/images_data.txt", "a") as image_data_file:
+            image_data_file.write('{name} Image info is: {data}\n'.format(name=AMI_NAME_TO_READABLE[ami_name], data=image_data))
     return instance_id
 
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -31,10 +31,9 @@ def create_instance(ami_name):
     run_command("./Tests/scripts/create_instance.sh instance.json {}".format(ami_name))  # noqa
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
-        print("Instance name is ".format(ami_name))
     with open('image_id.txt', 'r') as image_id_file:
         image_id = image_id_file.read()
-        print("image ID name is ".format(image_id))
+        print("image ID is {}".format(image_id))
     return instance_id
 
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -31,7 +31,7 @@ def create_instance(ami_name):
     run_command("./Tests/scripts/create_instance.sh instance.json {}".format(ami_name))  # noqa
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
-        Print("Instance ID is {}".format(instance_id))
+        print("Instance ID is {}".format(instance_id))
 
     return instance_id
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -33,7 +33,7 @@ def create_instance(ami_name):
         instance_id = instance_file.read()
     with open('image_id.txt', 'r') as image_id_file:
         image_data = image_id_file.read()
-        print('Image data is {}.format(image_data))
+        print('Image data is {}'.format(image_data))
         with open("./Tests/images_data.txt", "a") as image_data_file:
             image_data_file.write(
                 '{name} Image info is: {data}\n'.format(name=AMI_NAME_TO_READABLE[ami_name], data=image_data))

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -31,8 +31,10 @@ def create_instance(ami_name):
     run_command("./Tests/scripts/create_instance.sh instance.json {}".format(ami_name))  # noqa
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
-        print("Instance ID is {}".format(instance_id))
-
+        print("Instance name is ".format(ami_name))
+    with open('./Tests/image_id.txt', 'r') as image_id_file:
+        image_id = image_id_file.read()
+        print("image ID name is ".format(image_id))
     return instance_id
 
 

--- a/Tests/scripts/create_instances.py
+++ b/Tests/scripts/create_instances.py
@@ -32,7 +32,7 @@ def create_instance(ami_name):
     with open('./Tests/instance_ids.txt', 'r') as instance_file:
         instance_id = instance_file.read()
         print("Instance name is ".format(ami_name))
-    with open('./Tests/image_id.txt', 'r') as image_id_file:
+    with open('image_id.txt', 'r') as image_id_file:
         image_id = image_id_file.read()
         print("image ID name is ".format(image_id))
     return instance_id

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -487,7 +487,7 @@ def main():
     if is_ami:  # Run tests in AMI configuration
         with open('./Tests/images_data.txt', 'r') as image_data_file:
             image_data = [line for line in image_data_file if line.startswith(server_version)]
-            if len(image_data) != 0:
+            if len(image_data) != 1:
                 print('Did not get one image data for server version, got {}'.format(image_data))
             else:
                 print('Server image info: {}'.format(image_data[0]))

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -485,6 +485,12 @@ def main():
     server_version = options.serverVersion
 
     if is_ami:  # Run tests in AMI configuration
+        with open('./Tests/images_data.txt', 'r') as image_data_file:
+            image_data = [line for line in image_data_file if line.startswith(server_version)]
+            if len(image_data) != 0:
+                print('Did not get one image data for server version, got {}'.format(image_data))
+            else:
+                print('Server image info: {}'.format(image_data[0]))
         with open('./Tests/instance_ips.txt', 'r') as instance_file:
             instance_ips = instance_file.readlines()
             instance_ips = [line.strip('\n').split(":") for line in instance_ips]


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16265

## Description
this prints the ami info including the ami name in the beginning of contetnt test run.
so the name will include the version and build of the server running the content test

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests - the run in circle itself
- [ ] Code Review

