### PR TITLE
p3 support for `logger`

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -552,7 +552,7 @@ script: |-
       :rtype: ``any``
       """
       def func_wrapper(*args, **kwargs):
-          LOG('calling {}({})'.format(func.func_name, formatAllArgs(args, kwargs)))
+          LOG('calling {}({})'.format(func.__name__, formatAllArgs(args, kwargs)))
           return func(*args, **kwargs)
 
       return func_wrapper


### PR DESCRIPTION
## Status
Ready

## Description
common serever function `logger` used function attributes ```func.func_name``` which is not supported in py3. Using ```__name__``` is the preferred method as it applies uniformly

