### PR TITLE
Handled nightly failed tests: ThreatMiner and TCPIPUtils

### DIFF
--- a/Integrations/integration-ThreatMiner.yml
+++ b/Integrations/integration-ThreatMiner.yml
@@ -666,6 +666,7 @@ script:
 
 
     try:
+        delete_proxy_if_asked()
         demisto_command = demisto.command()
         if demisto_command == 'test-module':
             report = get_ip_whois_rawdata('8.8.8.8')
@@ -680,8 +681,6 @@ script:
             max_array_size = -1
         else:
             max_array_size = int(demisto.params().get('limit_results', MAX_RETURNED_ARRAY_SIZE))
-
-        delete_proxy_if_asked()
 
         if demisto_command == 'domain':
             domain_command(max_array_size)
@@ -911,5 +910,6 @@ script:
       type: string
     description: Retrieves data from ThreatMiner about a specified file.
   runonce: false
+releaseNotes: "-"
 tests:
   - ThreatMiner-Test

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1254,6 +1254,7 @@
         "TruSTAR"
     ],
     "unmockable_integrations": {
+        "TCPIPUtils": "Integration requires SSL",
         "Palo Alto Minemeld": "Pending check: issue 16072",
         "PagerDuty v2": "Integration requires SSL",
         "Autofocus": "JS integration, problem listed in issue 15544",


### PR DESCRIPTION
## Status
Ready

## Description
Moved AbuseIPDB to unmockable - no insecure checkbox.
Changed proxy logic of ThreatMiner to work before the module test.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.
