### PR TITLE
Phish.AI integration logic and detonate url playbook fixes

### DIFF
--- a/Integrations/integration-PhishAI.yml
+++ b/Integrations/integration-PhishAI.yml
@@ -42,6 +42,7 @@ script:
         var report = JSON.parse(res.Body);
 
         md = tableToMarkdown('Phish.AI Scan report ' + scan_id, report);
+
         return {
             Type: entryTypes.note,
             Contents: report,
@@ -269,9 +270,6 @@ script:
     outputs:
     - contextPath: URL.Data
       description: URL's Address
-      type: string
-    - contextPath: URL.Status
-      description: URL's Status
       type: string
     - contextPath: PhishAI.Status
       description: Scan status

--- a/Integrations/integration-PhishAI.yml
+++ b/Integrations/integration-PhishAI.yml
@@ -19,34 +19,12 @@ configuration:
   type: 8
   required: false
 script:
-  script: |
+  script: |-
     var DONT_CHECK_CERTIFICATE = false;
 
-    function checkStatus(url, apiKey){
-        var initialRes = http(
-            'https://app.phish.ai/api/url/scan',
-            {
-                Method: 'POST',
-                Headers: {
-                    'Content-Type': ['application/json'],
-                    'Accept': ['application/json'],
-                    'Authorization': [apiKey]
-                },
-                Body: JSON.stringify({'url': url})
-            },
-            DONT_CHECK_CERTIFICATE,
-            params.proxy
-        );
-
-        // check status code is valid
-        if (initialRes.StatusCode !== 200 && initialRes.StatusCode !== 201) {
-            throw 'Failed to send url ' + url + ' for scan. Response error: ' + initialRes.Body;
-        }
-
-        var scanId = JSON.parse(initialRes.Body).scan_id;
-
+    function checkStatus(scan_id, apiKey){
         var res = http(
-            'https://app.phish.ai/api/url/report?scan_id=' + scanId,
+            'https://app.phish.ai/api/url/report?scan_id=' + scan_id,
             {
                 Method: 'GET',
                 Headers: {
@@ -59,10 +37,11 @@ script:
         );
 
         if (res.StatusCode !== 200) {
-            throw 'Failed to get scan results for ' + url + '. scan_id: ' + scanId + '. Response error: ' + res.Body;
+            throw 'Failed to get scan results for scan_id: ' + scan_id + '. Response error: ' + res.Body;
         }
         var report = JSON.parse(res.Body);
-        md = tableToMarkdown('Phish.AI Scan report ' + url, report);
+
+        md = tableToMarkdown('Phish.AI Scan report ' + scan_id, report);
         return {
             Type: entryTypes.note,
             Contents: report,
@@ -70,22 +49,25 @@ script:
             HumanReadable: md,
             EntryContext: {
                 'URL(val.Data === obj.Data)' : {
-                    'Data': url,
-                    'Status': report.status
+                    'Data': report.url,
                 },
+                'PhishAI(val.ScanID === obj.ScanID)': {
+                    'ScanID': scan_id,
+                    'Status': report.status
+                }
             }
         };
     }
 
 
-    function analayzeResult(report, url, scanId) {
+    function analayzeResult(report, url, scan_id) {
         delete report.user_email;
         var DBotScore = {
             Indicator: url,
             Score: 0,
             Type: 'url',
             Vendor: 'Phish.AI',
-            ScanID: scanId
+            ScanID: scan_id
         };
         if (report.verdict == 'malicious') {
             DBotScore.Score = 3;
@@ -106,7 +88,7 @@ script:
             delete report.url;
 
         }
-        md = tableToMarkdown('Phish.AI Scan report ' + url + '. Scan ID: ' + scanId, report);
+        md = tableToMarkdown('Phish.AI Scan report ' + url + '. Scan ID: ' + scan_id, report);
         return {
             Type: entryTypes.note,
             Contents: report,
@@ -123,7 +105,12 @@ script:
                         'Country':report.iso_code
                     }
                 },
-                'DBotScore' : DBotScore
+                'DBotScore' : DBotScore,
+                'PhishAI(val.ScanID === obj.ScanID)': {
+                    'ScanID': scan_id,
+                    'URL': url,
+                    'Status': report.status
+                }
             }
         };
     }
@@ -150,9 +137,9 @@ script:
             throw 'Failed to send url ' + url + ' for scan. Response error: ' + initialRes.Body;
         }
 
-        var scanId = JSON.parse(initialRes.Body).scan_id;
+        var scan_id = JSON.parse(initialRes.Body).scan_id;
         var res = http(
-            'https://app.phish.ai/api/url/report?scan_id=' + scanId,
+            'https://app.phish.ai/api/url/report?scan_id=' + scan_id,
             {
                 Method: 'GET',
                 Headers: {
@@ -165,12 +152,12 @@ script:
         );
 
         if (res.StatusCode !== 200) {
-            throw 'Failed to get scan results for ' + url + '. scan_id: ' + scanId + '. Response error: ' + res.Body;
+            throw 'Failed to get scan results for ' + url + '. scan_id: ' + scan_id + '. Response error: ' + res.Body;
         }
 
         var report = JSON.parse(res.Body);
 
-        return analayzeResult(report, url, scanId);
+        return analayzeResult(report, url, scan_id);
     }
 
 
@@ -220,7 +207,7 @@ script:
             return phishAiScan(args.url, params.apiKey);
 
         case 'phish-ai-check-status':
-            return checkStatus(args.url, params.apiKey);
+            return checkStatus(args.scan_id, params.apiKey);
 
         case 'phish-ai-dispute-url':
             return phishAiDispute(args.scan_id, params.apiKey);
@@ -263,21 +250,36 @@ script:
     - contextPath: IP.Geo.Country
       description: Geo location of the url
       type: string
-    - contextPath: DBotScore.ScanID
-      description: Phish AI scan ID
+    - contextPath: PhishAI.ScanID
+      description: Phish.AI scan ID
+      type: string
+    - contextPath: PhishAI.Status
+      description: Scan status
+      type: string
+    - contextPath: PhishAI.URL
+      description: URL address
       type: string
     description: Check if url is phishing and get details about the brand that is
       being phished
   - name: phish-ai-check-status
     arguments:
-    - name: url
-      description: url to check status for
+    - name: scan_id
+      required: true
+      description: Scan ID of the URL to check its status
     outputs:
     - contextPath: URL.Data
       description: URL's Address
+      type: string
     - contextPath: URL.Status
       description: URL's Status
-    description: Checks on url's status, e.g. completed/in progress
+      type: string
+    - contextPath: PhishAI.Status
+      description: Scan status
+      type: string
+    - contextPath: PhishAI.ScanID
+      description: Phish.AI scan ID
+      type: string
+    description: Checks on url's status, e.g. completed, in progress
   - name: phish-ai-dispute-url
     arguments:
     - name: scan_id
@@ -287,3 +289,4 @@ script:
   runonce: false
 tests:
 - PhishAi-Test
+releaseNotes: fix logic of check-status command and add proper outputs to initiate successfully the Detonate URL playbook

--- a/Playbooks/playbook-Detonate_URL_-_PhishAI.yml
+++ b/Playbooks/playbook-Detonate_URL_-_PhishAI.yml
@@ -339,3 +339,4 @@ outputs:
   type: string
 tests:
   - Test-Detonate URL - Phish.AI
+releaseNotes: Fix logic of playbook, add outputs

--- a/Playbooks/playbook-Detonate_URL_-_PhishAI.yml
+++ b/Playbooks/playbook-Detonate_URL_-_PhishAI.yml
@@ -23,17 +23,19 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
+          "x": 162.5,
           "y": 50
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
-    taskid: 22ee088d-a727-45d6-876b-da7f5e7366e9
+    taskid: a9d60056-7ef8-4164-8748-f5016616e779
     type: playbook
     task:
-      id: 22ee088d-a727-45d6-876b-da7f5e7366e9
+      id: a9d60056-7ef8-4164-8748-f5016616e779
       version: -1
       name: GenericPolling
       description: |-
@@ -53,19 +55,21 @@ tasks:
       - "10"
     scriptarguments:
       Ids:
-        simple: ${inputs.URL}
+        complex:
+          root: PhishAI
+          accessor: ScanID
       Interval:
         complex:
           root: inputs.Interval
       PollingCommandArgName:
-        simple: url
+        simple: scan_id
       PollingCommandName:
         simple: phish-ai-check-status
       Timeout:
         complex:
           root: inputs.Timeout
       dt:
-        simple: URL(val.Status === 'in progress')
+        simple: PhishAI(val.Status === 'in progress')
     separatecontext: true
     loop:
       iscommand: false
@@ -75,16 +79,18 @@ tasks:
       {
         "position": {
           "x": 162.5,
-          "y": 840
+          "y": 720
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
-    taskid: 8202a867-8ad7-4b4b-87f5-bc9e501c5260
+    taskid: 574c57f0-c341-4fb0-8576-5acd9a2ba120
     type: condition
     task:
-      id: 8202a867-8ad7-4b4b-87f5-bc9e501c5260
+      id: 574c57f0-c341-4fb0-8576-5acd9a2ba120
       version: -1
       name: Is there a URL to detonate?
       description: Checks that there is a URL in the playbook’s input.
@@ -104,17 +110,18 @@ tasks:
           left:
             value:
               complex:
-                root: ${inputs
-                accessor: URL}
+                root: inputs.URL
             iscontext: true
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 410
+          "x": 50,
+          "y": 370
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "6":
     id: "6"
     taskid: 586f9a47-8d2a-4ff5-8ad5-788ddc8310ed
@@ -123,7 +130,7 @@ tasks:
       id: 586f9a47-8d2a-4ff5-8ad5-788ddc8310ed
       version: -1
       name: Done
-      description: "Done"
+      description: Done
       type: title
       iscommand: false
       brand: ""
@@ -131,17 +138,19 @@ tasks:
     view: |-
       {
         "position": {
-          "x": -110,
-          "y": 1230
+          "x": 162.5,
+          "y": 1070
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "9":
     id: "9"
-    taskid: 28c25e00-7d40-4198-8851-81f597651fb0
+    taskid: 20e936c1-98ba-4255-8042-101aa9bcaf5a
     type: condition
     task:
-      id: 28c25e00-7d40-4198-8851-81f597651fb0
+      id: 20e936c1-98ba-4255-8042-101aa9bcaf5a
       version: -1
       name: Is Phish.AI enabled?
       description: |
@@ -171,7 +180,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: Phish.AI_copy
+                        simple: Phish.AI
                 - - operator: isEqualString
                     left:
                       value:
@@ -185,21 +194,23 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 50,
+          "x": 162.5,
           "y": 195
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "10":
     id: "10"
-    taskid: 353cf72a-fae0-4289-87fc-0e3146ec97cb
+    taskid: 744dfdfb-f55d-4586-8783-addf3cd6fd12
     type: regular
     task:
-      id: 353cf72a-fae0-4289-87fc-0e3146ec97cb
+      id: 744dfdfb-f55d-4586-8783-addf3cd6fd12
       version: -1
-      name: Analyze URL
-      description: Updates the status of the tasks in the context.
-      script: '|||phish-ai-scan-url'
+      name: Get Report URL
+      description: Checks on url's status, e.g. completed, in progress
+      script: '|||phish-ai-check-status'
       type: regular
       iscommand: true
       brand: ""
@@ -207,27 +218,32 @@ tasks:
       '#none#':
       - "6"
     scriptarguments:
-      url:
-        simple: ${inputs.URL}
+      scan_id:
+        complex:
+          root: PhishAI
+          accessor: ScanID
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 162.5,
-          "y": 1020
+          "y": 895
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "11":
     id: "11"
-    taskid: 9cb09aaf-bd5f-4f98-8810-d44aa492c6b1
+    taskid: 46100a3a-dc92-4c08-8098-8baff8320399
     type: regular
     task:
-      id: 9cb09aaf-bd5f-4f98-8810-d44aa492c6b1
+      id: 46100a3a-dc92-4c08-8098-8baff8320399
       version: -1
-      name: Check status
-      description: "checks url's status"
-      script: '|||phish-ai-check-status'
+      name: Scan URL
+      description: Check if url is phishing and get details about the brand that is
+        being phished
+      script: '|||phish-ai-scan-url'
       type: regular
       iscommand: true
       brand: ""
@@ -236,27 +252,29 @@ tasks:
       - "2"
     scriptarguments:
       url:
-        simple: ${inputs.URL}
+        complex:
+          root: inputs.URL
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 162.5,
-          "y": 660
+          "y": 545
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {
-      "5_11_yes": 0.9,
-      "9_6_#default#": 0.9
+      "5_11_yes": 0.9
     },
     "paper": {
       "dimensions": {
-        "height": 1245,
-        "width": 652.5,
-        "x": -110,
+        "height": 1085,
+        "width": 492.5,
+        "x": 50,
         "y": 50
       }
     }
@@ -280,47 +298,44 @@ inputs:
   required: false
   description: How much time to wait before a timeout occurs (minutes)
 outputs:
-- contextPath: File.Size
-  description: File size (only in case of report type=json)
-  type: number
+- contextPath: PhishAI.ScanID
+  description: Phish.AI scan ID
+  type: string
+- contextPath: PhishAI.Status
+  description: Scan status
+  type: string
+- contextPath: PhishAI.URL
+  description: URL address
+  type: string
+- contextPath: URL.Malicious.Vendor
+  description: For malicious URLs, the vendor that made the decision
+  type: string
+- contextPath: URL.Malicious.Description
+  description: For malicious URLs, the reason for the vendor to make the decision
+  type: string
 - contextPath: DBotScore.Indicator
-  description: The indicator we tested (only in case of report type=json)
-  type: string
-- contextPath: DBotScore.Vendor
-  description: Vendor used to calculate the score (only in case of report type=json)
-  type: string
-- contextPath: DBotScore.Score
-  description: The actual score (only in case of report type=json)
-  type: number
-- contextPath: IP.Address
-  description: IP's relevant to the sample
+  description: The indicator we tested
   type: string
 - contextPath: DBotScore.Type
-  description: The type of the indicator (only in case of report type=json)
+  description: The type of the indicator
   type: string
-- contextPath: File.Name
-  description: Filename (only in case of report type=json)
+- contextPath: DBotScore.Vendor
+  description: Vendor used to calculate the score
   type: string
-- contextPath: File.Type
-  description: File type e.g. "PE" (only in case of report type=json)
+- contextPath: DBotScore.Score
+  description: The actual score
+  type: number
+- contextPath: IP.Address
+  description: IP address of the url
   type: string
-- contextPath: File.MD5
-  description: MD5 hash of the file (only in case of report type=json)
+- contextPath: IP.Geo.Country
+  description: Geo location of the url
   type: string
-- contextPath: File.SHA1
-  description: SHA1 hash of the file (only in case of report type=json)
+- contextPath: URL.Status
+  description: URL's Status
   type: string
-- contextPath: File.SHA256
-  description: SHA256 hash of the file (only in case of report type=json)
-  type: string
-- contextPath: File.EntryID
-  description: The Entry ID of the sample
-  type: string
-- contextPath: File.Malicious.Vendor
-  description: For malicious files, the vendor that made the decision
-  type: string
-- contextPath: File.Malicious.Description
-  description: For malicious files, the reason for the vendor to make the decision
+- contextPath: URL.Data
+  description: URL's Address
   type: string
 tests:
   - Test-Detonate URL - Phish.AI

--- a/TestPlaybooks/playbook-Detonate_URL_PhishAI-Test.yml
+++ b/TestPlaybooks/playbook-Detonate_URL_PhishAI-Test.yml
@@ -1,15 +1,15 @@
 id: Test-Detonate URL - Phish.AI
 version: -1
-rolename: []
 name: Test-Detonate URL - Phish.AI
+description: Test-Detonate URL - Phish.AI
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 83a84f16-003e-4940-8754-7956165fe409
+    taskid: 138c609d-c485-4d5b-8d15-5f46586c7873
     type: start
     task:
-      id: 83a84f16-003e-4940-8754-7956165fe409
+      id: 138c609d-c485-4d5b-8d15-5f46586c7873
       version: -1
       name: ""
       iscommand: false
@@ -26,12 +26,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "1":
     id: "1"
-    taskid: e094f3d0-8162-452e-8a06-126c457e8dc9
+    taskid: b4ed39bf-ede4-4e75-88f0-0440ccf86a66
     type: playbook
     task:
-      id: e094f3d0-8162-452e-8a06-126c457e8dc9
+      id: b4ed39bf-ede4-4e75-88f0-0440ccf86a66
       version: -1
       name: Detonate URL - Phish.AI
       description: Detonates a URL using the McAfee Advanced Threat Defense sandbox
@@ -40,6 +42,9 @@ tasks:
       type: playbook
       iscommand: false
       brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
     scriptarguments:
       Interval:
         simple: "1"
@@ -60,12 +65,74 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: bd05a14f-b2f6-48e3-8380-b0042105d135
+    type: condition
+    task:
+      id: bd05a14f-b2f6-48e3-8380-b0042105d135
+      version: -1
+      name: 'Check status '
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "3"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: PhishAI
+                accessor: Status
+            iscontext: true
+          right:
+            value:
+              simple: completed
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 440
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: ff3002c3-42c6-4971-86e4-ec599efef4ac
+    type: title
+    task:
+      id: ff3002c3-42c6-4971-86e4-ec599efef4ac
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 640
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 295,
+        "height": 655,
         "width": 380,
         "x": 450,
         "y": 50
@@ -74,5 +141,3 @@ view: |-
   }
 inputs: []
 outputs: []
-tests:
-  - 'No test'


### PR DESCRIPTION
## Status
In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/16435

## Description
fix logic of check-status, add outputs, fix logic of detonate playbook, add a meaningful test to it.

## Does it break backward compatibility?
   - Yes
phish-ai-scan-url - change of context from DBotScore.ScanID to PhishAI.ScanID
since we shouldn't save the scanid under DBotScore
phish-ai-check-status - change of argument from url to scan_id
since we want to pull on a specific scan its status, and not scan a new url.

## Must have
- [x] Tests
- [x] Documentation - https://github.com/demisto/etc/issues/16455
- [x] Code Review