### PR TITLE
Added logic to ensure malicious indicator is found in phishing tests

### DIFF
--- a/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
@@ -5,10 +5,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: fc2ec0f9-a350-46e6-82c6-66920f1418ec
+    taskid: 4fc9bbe3-e88c-4ef7-8bc5-25f1b292ca72
     type: start
     task:
-      id: fc2ec0f9-a350-46e6-82c6-66920f1418ec
+      id: 4fc9bbe3-e88c-4ef7-8bc5-25f1b292ca72
       version: -1
       name: ""
       iscommand: false
@@ -21,16 +21,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 50
+          "y": -110
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
-    taskid: b4c9009f-25fc-4be2-8979-9a9ebb70f9af
+    taskid: 2dea1994-eb8f-4085-80f6-40372b4bfdb5
     type: title
     task:
-      id: b4c9009f-25fc-4be2-8979-9a9ebb70f9af
+      id: 2dea1994-eb8f-4085-80f6-40372b4bfdb5
       version: -1
       name: Done
       type: title
@@ -41,16 +43,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 895
+          "y": 1050
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "4":
     id: "4"
-    taskid: da0e5042-5f15-44da-8b57-db3fee4ccf67
+    taskid: 122b2819-9d09-4f15-8f29-6613f232a602
     type: regular
     task:
-      id: da0e5042-5f15-44da-8b57-db3fee4ccf67
+      id: 122b2819-9d09-4f15-8f29-6613f232a602
       version: -1
       name: PhishingIncident - Inline
       scriptName: PhishingIncident
@@ -59,7 +63,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "11"
+      - "13"
     scriptarguments:
       malicious_location:
         simple: inline
@@ -68,16 +72,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 370
+          "y": 210
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "8":
     id: "8"
-    taskid: fb159225-2183-45e8-8088-0c58b80f0ceb
+    taskid: 33dd4a3c-e68e-42ca-8409-332ff2703185
     type: regular
     task:
-      id: fb159225-2183-45e8-8088-0c58b80f0ceb
+      id: 33dd4a3c-e68e-42ca-8409-332ff2703185
       version: -1
       name: Close Manual review
       scriptName: ScheduleCommand
@@ -86,7 +92,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
+      - "14"
     scriptarguments:
       command:
         simple: '!CompleteManualTask id=${incident.id}'
@@ -104,12 +110,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "9":
     id: "9"
-    taskid: e59e5250-3002-4ad7-8edd-501f9792ba0f
+    taskid: 1de72998-1096-4d03-82ee-c9f8d44f706e
     type: regular
     task:
-      id: e59e5250-3002-4ad7-8edd-501f9792ba0f
+      id: 1de72998-1096-4d03-82ee-c9f8d44f706e
       version: -1
       name: Delete Context
       scriptName: DeleteContext
@@ -131,16 +139,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 195
+          "y": 35
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "11":
     id: "11"
-    taskid: 50f1826c-6f40-401c-845a-1f38a499e537
+    taskid: 7c8581c0-ce57-4219-8a97-d8ff9f7eec3b
     type: regular
     task:
-      id: 50f1826c-6f40-401c-845a-1f38a499e537
+      id: 7c8581c0-ce57-4219-8a97-d8ff9f7eec3b
       version: -1
       name: Download EML file
       description: Sends http request. Returns the response as json.
@@ -177,12 +187,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "12":
     id: "12"
-    taskid: 9ad66888-26ce-4ec4-8190-2bb9176bd87b
+    taskid: e7b4130d-a0fd-4315-8316-19992bf53e1e
     type: playbook
     task:
-      id: 9ad66888-26ce-4ec4-8190-2bb9176bd87b
+      id: e7b4130d-a0fd-4315-8316-19992bf53e1e
       version: -1
       name: Phishing Investigation - Generic
       playbookName: Phishing Investigation - Generic
@@ -191,7 +203,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
+      - "14"
     scriptarguments:
       Role:
         simple: Administrator
@@ -208,15 +220,85 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
+  "13":
+    id: "13"
+    taskid: c69b15a4-19c6-4f79-8468-2c2b4eaeede0
+    type: regular
+    task:
+      id: c69b15a4-19c6-4f79-8468-2c2b4eaeede0
+      version: -1
+      name: minemeld-add-to-miner
+      description: Add indicator to a miner.
+      script: Palo Alto Minemeld|||minemeld-add-to-miner
+      type: regular
+      iscommand: true
+      brand: Palo Alto Minemeld
+    nexttasks:
+      '#none#':
+      - "11"
+    scriptarguments:
+      comment:
+        simple: Malicious website for test
+      indicator:
+        simple: http://tpb.crushus.com/www.paperstreetcash.com
+      miner:
+        simple: Malicious
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 380
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "14":
+    id: "14"
+    taskid: 7d868670-4c86-4b6f-8712-5dc23e001fad
+    type: regular
+    task:
+      id: 7d868670-4c86-4b6f-8712-5dc23e001fad
+      version: -1
+      name: minemeld-remove-from-miner
+      description: Remove an indicator from a miner.
+      script: Palo Alto Minemeld|||minemeld-remove-from-miner
+      type: regular
+      iscommand: true
+      brand: Palo Alto Minemeld
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      indicator:
+        simple: http://tpb.crushus.com/www.paperstreetcash.com
+      miner:
+        simple: Malicious
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 890
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 910,
+        "height": 1225,
         "width": 810,
         "x": 50,
-        "y": 50
+        "y": -110
       }
     }
   }

--- a/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_Inline.yml
@@ -43,7 +43,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 1050
+          "y": 910
         }
       }
     note: false
@@ -92,7 +92,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "14"
+      - "3"
     scriptarguments:
       command:
         simple: '!CompleteManualTask id=${incident.id}'
@@ -147,10 +147,10 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 7c8581c0-ce57-4219-8a97-d8ff9f7eec3b
+    taskid: 31e8f913-3159-4361-8816-077e1301a80f
     type: regular
     task:
-      id: 7c8581c0-ce57-4219-8a97-d8ff9f7eec3b
+      id: 31e8f913-3159-4361-8816-077e1301a80f
       version: -1
       name: Download EML file
       description: Sends http request. Returns the response as json.
@@ -203,7 +203,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "14"
+      - "3"
     scriptarguments:
       Role:
         simple: Administrator
@@ -257,45 +257,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "14":
-    id: "14"
-    taskid: 7d868670-4c86-4b6f-8712-5dc23e001fad
-    type: regular
-    task:
-      id: 7d868670-4c86-4b6f-8712-5dc23e001fad
-      version: -1
-      name: minemeld-remove-from-miner
-      description: Remove an indicator from a miner.
-      script: Palo Alto Minemeld|||minemeld-remove-from-miner
-      type: regular
-      iscommand: true
-      brand: Palo Alto Minemeld
-    nexttasks:
-      '#none#':
-      - "3"
-    scriptarguments:
-      indicator:
-        simple: http://tpb.crushus.com/www.paperstreetcash.com
-      miner:
-        simple: Malicious
-    reputationcalc: 1
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 265,
-          "y": 890
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1225,
+        "height": 1085,
         "width": 810,
         "x": 50,
         "y": -110

--- a/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
@@ -5,10 +5,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: fc2ec0f9-a350-46e6-82c6-66920f1418ec
+    taskid: 481af9ab-18cf-4136-8166-e5e8944ee635
     type: start
     task:
-      id: fc2ec0f9-a350-46e6-82c6-66920f1418ec
+      id: 481af9ab-18cf-4136-8166-e5e8944ee635
       version: -1
       name: ""
       iscommand: false
@@ -21,16 +21,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 50
+          "y": -140
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
-    taskid: b4c9009f-25fc-4be2-8979-9a9ebb70f9af
+    taskid: 4c8d0c27-dbda-4d46-8303-be6b77739b74
     type: title
     task:
-      id: b4c9009f-25fc-4be2-8979-9a9ebb70f9af
+      id: 4c8d0c27-dbda-4d46-8303-be6b77739b74
       version: -1
       name: Done
       type: title
@@ -41,16 +43,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 895
+          "y": 1075
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "12":
     id: "12"
-    taskid: 9bc5325d-a4ce-4354-813c-6466dd3219db
+    taskid: 38497387-45a4-48e2-816c-c7515cec13f0
     type: regular
     task:
-      id: 9bc5325d-a4ce-4354-813c-6466dd3219db
+      id: 38497387-45a4-48e2-816c-c7515cec13f0
       version: -1
       name: PhishingIncident - Attachment
       scriptName: PhishingIncident
@@ -59,7 +63,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       malicious_location:
         simple: attachment
@@ -68,16 +72,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 370
+          "y": 180
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "16":
     id: "16"
-    taskid: 7b42f99f-f88a-453e-8554-4dfbdf302ba3
+    taskid: a98152ae-e294-43c0-8c8d-0fcd5d8d061d
     type: regular
     task:
-      id: 7b42f99f-f88a-453e-8554-4dfbdf302ba3
+      id: a98152ae-e294-43c0-8c8d-0fcd5d8d061d
       version: -1
       name: Close Manual review
       scriptName: ScheduleCommand
@@ -86,7 +92,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
+      - "22"
     scriptarguments:
       command:
         simple: '!CompleteManualTask id=${incident.id}'
@@ -104,12 +110,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "17":
     id: "17"
-    taskid: 56e1e113-22d3-4943-8de5-8bf8d1b6eb70
+    taskid: a0d311dd-acf3-4bfb-856f-5474624593c8
     type: regular
     task:
-      id: 56e1e113-22d3-4943-8de5-8bf8d1b6eb70
+      id: a0d311dd-acf3-4bfb-856f-5474624593c8
       version: -1
       name: Delete Context
       scriptName: DeleteContext
@@ -131,16 +139,18 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 195
+          "y": 5
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "19":
     id: "19"
-    taskid: 8aeed5dc-3c58-4b71-8e83-69c5b0dc92b1
+    taskid: 815c4ae8-af63-42cd-8dc7-caf0bd4bb8e9
     type: regular
     task:
-      id: 8aeed5dc-3c58-4b71-8e83-69c5b0dc92b1
+      id: 815c4ae8-af63-42cd-8dc7-caf0bd4bb8e9
       version: -1
       name: Download EML file
       description: Sends http request. Returns the response as json.
@@ -177,12 +187,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "20":
     id: "20"
-    taskid: c9adfbba-b2eb-47f1-8994-d880fd5b4713
+    taskid: 85612cdb-60c2-450f-8be1-f48fa2abc94c
     type: playbook
     task:
-      id: c9adfbba-b2eb-47f1-8994-d880fd5b4713
+      id: 85612cdb-60c2-450f-8be1-f48fa2abc94c
       version: -1
       name: Phishing Investigation - Generic
       playbookName: Phishing Investigation - Generic
@@ -191,7 +203,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
+      - "22"
     separatecontext: false
     view: |-
       {
@@ -201,15 +213,86 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
+  "21":
+    id: "21"
+    taskid: d7d26d34-f14a-4cde-863b-a616b309e06e
+    type: regular
+    task:
+      id: d7d26d34-f14a-4cde-863b-a616b309e06e
+      version: -1
+      name: minemeld-add-to-miner
+      description: Add indicator to a miner.
+      script: Palo Alto Minemeld|||minemeld-add-to-miner
+      type: regular
+      iscommand: true
+      brand: Palo Alto Minemeld
+    nexttasks:
+      '#none#':
+      - "19"
+    scriptarguments:
+      comment:
+        simple: Malicious website for test
+      indicator:
+        simple: http://tpb.crushus.com/www.paperstreetcash.com
+      miner:
+        simple: Malicious
+    reputationcalc: 1
+    continueonerror: true
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 360
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "22":
+    id: "22"
+    taskid: 8e0d4244-be82-4e10-8525-13ad3eaad7b4
+    type: regular
+    task:
+      id: 8e0d4244-be82-4e10-8525-13ad3eaad7b4
+      version: -1
+      name: minemeld-remove-from-miner
+      description: Remove an indicator from a miner.
+      script: Palo Alto Minemeld|||minemeld-remove-from-miner
+      type: regular
+      iscommand: true
+      brand: Palo Alto Minemeld
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      indicator:
+        simple: http://tpb.crushus.com/www.paperstreetcash.com
+      miner:
+        simple: Malicious
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 905
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 910,
+        "height": 1280,
         "width": 810,
         "x": 50,
-        "y": 50
+        "y": -140
       }
     }
   }

--- a/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
+++ b/TestPlaybooks/playbook-Phishing_test_-_attachment.yml
@@ -43,7 +43,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 1075
+          "y": 895
         }
       }
     note: false
@@ -92,7 +92,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "22"
+      - "3"
     scriptarguments:
       command:
         simple: '!CompleteManualTask id=${incident.id}'
@@ -203,7 +203,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "22"
+      - "3"
     separatecontext: false
     view: |-
       {
@@ -251,45 +251,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "22":
-    id: "22"
-    taskid: 8e0d4244-be82-4e10-8525-13ad3eaad7b4
-    type: regular
-    task:
-      id: 8e0d4244-be82-4e10-8525-13ad3eaad7b4
-      version: -1
-      name: minemeld-remove-from-miner
-      description: Remove an indicator from a miner.
-      script: Palo Alto Minemeld|||minemeld-remove-from-miner
-      type: regular
-      iscommand: true
-      brand: Palo Alto Minemeld
-    nexttasks:
-      '#none#':
-      - "3"
-    scriptarguments:
-      indicator:
-        simple: http://tpb.crushus.com/www.paperstreetcash.com
-      miner:
-        simple: Malicious
-    reputationcalc: 1
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 265,
-          "y": 905
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1280,
+        "height": 1100,
         "width": 810,
         "x": 50,
         "y": -140


### PR DESCRIPTION
## Status
Ready

## Description
- Added tasks that add (and at the end, also remove) a malicious URL to Minemeld miner. This way, Minemeld, which we rely on in the phishing tests, will always find this indicator malicious.

## Screenshots
![image](https://user-images.githubusercontent.com/43602124/55499174-0bfbcd00-564e-11e9-85fe-9c2b731aba5b.png)
