### PR TITLE
EWS Mail Sender - subject truncate

### DIFF
--- a/Integrations/integration-EWSMailSender.yml
+++ b/Integrations/integration-EWSMailSender.yml
@@ -161,6 +161,7 @@ script:
         cc = cc.split(",") if cc else None
         to = to.split(",") if to else None
         manualAttachObj = manualAttachObj if manualAttachObj is not None else []
+        subject = subject[:252] + '...' if len(subject) > 255 else subject
 
         file_entries_for_attachments = []
         attachments_names = []
@@ -315,6 +316,7 @@ script:
         Should be the same number of elements as attachIDs.
     description: Send email via EWS
   dockerimage: demisto/py-ews
+releaseNotes: "-"
 tests:
   - "EWS Mail Sender Test"
   - "EWS Mail Sender Test 2"

--- a/TestPlaybooks/NonCircleTests/playbook-Send-Email-To-Recipients-Test.yml
+++ b/TestPlaybooks/NonCircleTests/playbook-Send-Email-To-Recipients-Test.yml
@@ -49,7 +49,7 @@ tasks:
       htmlBody: {}
       replyTo: {}
       subject:
-        simple: EWS Mail Sender Test
+        simple: EWS Mail Sender Test - UT8uFQBBVcJeqAC4t4XvzZ9bBvfLYSk1zST8Fkx7rtHs4SfjvtYzCv1ElFGsX10gNWZlH7XpHGgWv31KI3LbDGBGPLPckyPaZvujMZRa6JloV22SIH0wqvPGYiFcYPm9muVjDyj75R4QTyatXimGcdOcdKwt2Rofv0UFDAKW2W2EU9tKoeGIy5p2DEvKk12qgiCxqNFd4mqCXoR1P9rypsuYlQ3OaIa6hzvoZMrH0qWSqL43wjGbM25d8OhKcoda
       to:
         simple: ${inputs.to}
     separatecontext: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16425

## Description
Truncated the subject of email in case subject is more than 255 chars. 
Added subject with more than 255 chars to `EWS Mail Sender Test 2` test.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Phishing Investigation - Generic

Integrations:
- [x] EWS Mail Sender

Tests:
- [x] EWS Mail Sender Test
- [x] Phishing test - attachment
- [x] No test
- [x] EWS search-mailbox test
- [x] EWS Mail Sender Test 2
- [x] Phishing test - Inline