### PR TITLE
Parse email utf text file type

### DIFF
--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3516,7 +3516,7 @@ def main():
             )
             return
 
-        elif 'ascii text' in file_type_lower:
+        elif 'ascii text' in file_type_lower or 'unicode text' in file_type_lower:
             try:
                 # Try to open the email as-is
                 with open(file_path, 'rb') as f:

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.yml
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.yml
@@ -94,6 +94,6 @@ outputs:
 scripttarget: 0
 runonce: false
 runas: DBotWeakRole
-releaseNotes: "-"
+releaseNotes: "Email file type detection improvements"
 tests:
 - ParseEmailFiles-test

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -199,6 +199,44 @@ def test_eml_contains_eml_depth(mocker):
     assert results[0]['EntryContext']['Email']['Depth'] == 0
 
 
+def test_eml_utf_text(mocker):
+
+    def executeCommand(name, args=None):
+        if name == 'getFilePath':
+            return [
+                {
+                    'Type': entryTypes['note'],
+                    'Contents': {
+                        'path': 'test_data/utf_8_email.eml',
+                        'name': 'utf_8_email.eml'
+                    }
+                }
+            ]
+        elif name == 'getEntry':
+            return [
+                {
+                    'Type': entryTypes['file'],
+                    'FileMetadata': {
+                        'info': 'UTF-8 Unicode text, with very long lines, with CRLF line terminators'
+                    }
+                }
+            ]
+        else:
+            raise ValueError('Unimplemented command called: {}'.format(name))
+
+    mocker.patch.object(demisto, 'args', return_value={'entryid': 'test'})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=executeCommand)
+    mocker.patch.object(demisto, 'results')
+    # validate our mocks are good
+    assert demisto.args()['entryid'] == 'test'
+    main()
+    assert demisto.results.call_count == 1
+    # call_args is tuple (args list, kwargs). we only need the first one
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0]['Type'] == entryTypes['note']
+    assert results[0]['EntryContext']['Email']['Subject'] == 'Test UTF Email'
+
 def test_utf_subject_convert():
     subject = ('[TESTING] =?utf-8?q?=F0=9F=94=92_=E2=9C=94_Votre_colis_est_disponible_chez_votre_co?='
                ' =?utf-8?q?mmer=C3=A7ant_Pickup_!?=')

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -237,6 +237,7 @@ def test_eml_utf_text(mocker):
     assert results[0]['Type'] == entryTypes['note']
     assert results[0]['EntryContext']['Email']['Subject'] == 'Test UTF Email'
 
+
 def test_utf_subject_convert():
     subject = ('[TESTING] =?utf-8?q?=F0=9F=94=92_=E2=9C=94_Votre_colis_est_disponible_chez_votre_co?='
                ' =?utf-8?q?mmer=C3=A7ant_Pickup_!?=')

--- a/Scripts/ParseEmailFiles/test_data/utf_8_email.eml
+++ b/Scripts/ParseEmailFiles/test_data/utf_8_email.eml
@@ -1,4 +1,4 @@
-To: user1@test.com
+To: test@test.com
 From: "test@test.com" <test@test.com>
 Subject: Test UTF Email
 Message-ID: <5b4831d0-5322-ea23-6312-864ff419a1f1@test.com>

--- a/Scripts/ParseEmailFiles/test_data/utf_8_email.eml
+++ b/Scripts/ParseEmailFiles/test_data/utf_8_email.eml
@@ -1,0 +1,19 @@
+To: user1@test.com
+From: "test@test.com" <test@test.com>
+Subject: Test UTF Email
+Message-ID: <5b4831d0-5322-ea23-6312-864ff419a1f1@test.com>
+Date: Wed, 23 Jan 2019 18:55:56 +0100
+User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101
+ Thunderbird/60.4.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 8bit
+Content-Language: en-US
+
+This is a test smtp type email. With hebrew:
+
+עברית
+
+And a very long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long vvvlong long long long long long long long long long long long long long long long long long long long long long long long long long long long 
+
+Done body

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -718,7 +718,8 @@
       "emojiemail@xn--i-7iq.com",
       "example@lol_lol.lol.com",
       "JUSTAREASONABLEADDRESS@mail-out.nom.nom-mon.net",
-      "test@test.com"
+      "test@test.com",
+      "5b4831d0-5322-ea23-6312-864ff419a1f1@test.com"
     ],
     "false_positives": [
       "56.1.4.194",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16514

## Description
Fixes unicode text file type case



## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation (release notes)
- [x] Code Review

