### PR TITLE
removing Symantec Deepsight from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1274,7 +1274,6 @@
         "iDefense": "DevOps investigation",
         "RSA NetWitness Endpoint": "Instance is down, waiting for devops to rebuild",
         "BitDam": "Changes in service (issue #16247)",
-        "Symantec Deepsight Intelligence": "Issues related to id_set.json (issue 16461)",
         "Zoom": "Added here because test existed but was not configured - need to review the test",
 
       "_comment": "~~~ QUOTA ISSUES ~~~",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16461

## Description
Removing Symantec Deepsight from skipped

## Does it break backward compatibility?
   - No
