### PR TITLE
vt - add fullresponseglobal param

### DIFF
--- a/Integrations/integration-VirusTotal.yml
+++ b/Integrations/integration-VirusTotal.yml
@@ -73,6 +73,14 @@ configuration:
   defaultvalue: ""
   type: 0
   required: false
+- display: Determines whether to return all results, which can number in the thousands.
+    If “true”, returns all results and overrides the _fullResponse_, _long_ arguments
+    (if set to “false”) in a command. If “false”, the _fullResponse_, _long_ arguments
+    in the command determines how results are returned.
+  name: fullResponseGlobal
+  defaultvalue: "false"
+  type: 8
+  required: false
 script:
   script: |-
     var serverUrl = params.Server;
@@ -87,7 +95,7 @@ script:
     var DOMAIN_THRESHOLD = params.domainThreshold;
     var PREFERRED_VENDORS = params.preferredVendors
     var PREFERRED_VENDORS_THRESHOLD = params.preferredVendorsThreshold
-
+    var FULL_RESPONSE = params.fullResponseGlobal
     if (isNaN(FILE_THRESHOLD) || isNaN(IP_THRESHOLD) || isNaN(URL_THRESHOLD) || isNaN(DOMAIN_THRESHOLD)) {
         throw 'Threshold parameters must be numbers.\n';
     }
@@ -294,6 +302,7 @@ script:
             }
             ec.DBotScore.push({Indicator: hash, Type: 'hash', Vendor: 'VirusTotal', Score: dbotScore});
             md += 'MD5 / SHA1 / SHA256: **' + r[i].md5 + ' / ' + r[i].sha1 + ' / ' + r[i].sha256 + '**\n';
+            longFormat = FULL_RESPONSE? 'true': longFormat;
             if (longFormat === 'true' && r[i].scans) { // add scans table
                 scansTable = createScansTable(r[i].scans);
                 md += tableToMarkdown('Scans', scansTable);
@@ -395,6 +404,7 @@ script:
             return {Type: entryTypes.note, Contents: res.body, ContentsFormat: formats.json, EntryContext: ec,
                 HumanReadable: 'VirusTotal does not have details about ' + ip + ' ,it sent the following response:\n' + res.obj.verbose_msg};
         }
+        full_response = FULL_RESPONSE? 'true': fullResponse;
         if (fullResponse === 'true'){
             maxLen = 1000;
         } else {
@@ -468,6 +478,7 @@ script:
         } else { // not malicious
             ec[outputPaths.ip] = ip_ec;
         }
+        longFormat = FULL_RESPONSE? 'true': longFormat;
         if (longFormat === 'true') {
             for (var j=0; j<arrTitle.length; j++) {
                 if (arrTitle[j].a) {
@@ -555,6 +566,7 @@ script:
             }
             ec.DBotScore = {Indicator: url, Type: 'url', Vendor: 'VirusTotal', Score: dbotScore};
 
+            longFormat = FULL_RESPONSE? 'true': longFormat;
             if (longFormat === 'true') { // add scans table
                 scansTable = createScansTable(o.scans);
                 md += tableToMarkdown('Scans', scansTable);
@@ -616,7 +628,8 @@ script:
             return {Type: entryTypes.note, Contents: res.body, ContentsFormat: formats.json, EntryContext: ec,
                 HumanReadable: 'VirusTotal does not have details about ' + domain + '\n' + res.obj.verbose_msg};
         }
-        if (fullResponse === 'true'){
+        full_response = FULL_RESPONSE? 'true': fullResponse;
+        if (fullResponse === 'true') {
             maxLen = 1000;
         } else {
             maxLen = 50;
@@ -658,6 +671,7 @@ script:
                 md += arrTitle[i].t + ' count: **' + arrTitle[i].a.length + '**\n';
             }
         }
+        longFormat = FULL_RESPONSE? 'true': longFormat;
         if (longFormat === 'true') {
             for (var j = 0; j<arrTitle.length; j++) {
                 if (arrTitle[j].a) {
@@ -1303,3 +1317,4 @@ script:
   runonce: false
 tests:
 - virusTotal-test-playbook
+releaseNotes: Added fullResponseGlobal parameter. Determines whether to return all results, which can number in the thousands. If "true", returns all results and overrides the _fullResponse_, _long_ arguments (if set to "false") in a command. If "false", the _fullResponse_, _long_ arguments in the command determines how results are returned.


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16483

## Description
Added fullResponseGlobal parameter. Determines whether to return all results, which can number in the thousands. If "true", returns all results and overrides the _fullResponse_, _long_ arguments (if set to "false") in a command. If "false", the _fullResponse_, _long_ arguments in the command determines how results are returned.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation - https://github.com/demisto/etc/issues/16629
- [ ] Code Review