### PR TITLE
Added python3 support for camelize method, fixed return type

### DIFF
--- a/Scripts/script-CommonServerPython.yml
+++ b/Scripts/script-CommonServerPython.yml
@@ -1297,13 +1297,14 @@ script: |-
           :rtype: ``dict`` or ``list``
       """
       def camelize_str(src_str, delim):
+          if callable(getattr(src_str, "decode", None)):
+              src_str = src_str.decode('utf-8')
           components = src_str.split(delim)
-          return ''.join(map(lambda x: x.decode('utf-8').title(), components))
+          return ''.join(map(lambda x: x.title(), components))
 
       if isinstance(src, list):
-          return map(lambda x: camelize(x, delim), src)
-      src = {camelize_str(k, delim): v for k,v in src.iteritems()}
-      return src
+          return [camelize(x, delim) for x in src]
+      return {camelize_str(k, delim): v for k, v in src.items()}
 
 
   # Constants for common merge paths
@@ -1538,5 +1539,6 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
+releaseNotes: "Added python3 support for camelize method, fixed issue in camelize method."
 tests:
   - TestCommonPython

--- a/Scripts/script-CommonServerPython_4_1.yml
+++ b/Scripts/script-CommonServerPython_4_1.yml
@@ -1311,13 +1311,14 @@ script: |-
           :rtype: ``dict`` or ``list``
       """
       def camelize_str(src_str, delim):
+          if callable(getattr(src_str, "decode", None)):
+              src_str = src_str.decode('utf-8')
           components = src_str.split(delim)
-          return ''.join(map(lambda x: x.decode('utf-8').title(), components))
+          return ''.join(map(lambda x: x.title(), components))
 
       if isinstance(src, list):
-          return map(lambda x: camelize(x, delim), src)
-      src = {camelize_str(k, delim): v for k,v in src.iteritems()}
-      return src
+          return [camelize(x, delim) for x in src]
+      return {camelize_str(k, delim): v for k, v in src.items()}
 
 
   # Constants for common merge paths
@@ -1552,5 +1553,6 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
+releaseNotes: "Added python3 support for camelize method, fixed issue in camelize method."
 tests:
   - TestCommonPython

--- a/TestPlaybooks/script-TestPyCommonServer.yml
+++ b/TestPlaybooks/script-TestPyCommonServer.yml
@@ -335,7 +335,9 @@ script: |-
 
 
   def test_camelize():
-      assert str(camelize([{'chookity_bop': 'asdasd'}, {'ab_c': 'd e', 'fgh_ijk': 'lm', 'nop': 'qr_st'}], '_')) == "[{u'ChookityBop': 'asdasd'}, {u'AbC': 'd e', u'Nop': 'qr_st', u'FghIjk': 'lm'}]"
+      camelized_list = camelize([{'chookity_bop': 'asdasd'}, {'ab_c': 'd e', 'fgh_ijk': 'lm', 'nop': 'qr_st'}], '_')
+      assert isinstance(camelized_list, list)
+      assert str(camelized_list) == "[{u'ChookityBop': 'asdasd'}, {u'AbC': 'd e', u'Nop': 'qr_st', u'FghIjk': 'lm'}]"
       assert str(camelize({'ab_c': 'd e', 'fgh_ijk': 'lm', 'nop': 'qr_st'}, '_')) == "{u'AbC': 'd e', u'Nop': 'qr_st', u'FghIjk': 'lm'}"
       demisto.results("Camelize test finished successfuly!")
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
required for resolution of https://github.com/demisto/etc/issues/16097
* Does not fix the issue directly, but implements prerequisites for the fix.

## Description
1. Fixed issue where in some cases, `camelize()` would return a `map` object instead of a `list`.
2. python 3 support: `decode('utf-8')` will be called for any  built-in "string"-type python object that has it. This includes python2 `str` and python3 `bytes`.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
looker-full | 
looker | 


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.
