### PR TITLE
BuildEWSQuery: fixed illegal query

### DIFF
--- a/Scripts/script-BuildEWSQuery.yml
+++ b/Scripts/script-BuildEWSQuery.yml
@@ -18,12 +18,12 @@ script: |-
   if demisto.args().get("subject"):
       args["Subject"] = demisto.args().get("subject")
   if demisto.args().get("attachmentName"):
-      args["AttachmentName"] = demisto.args().get("attachmentName")
+      args["Attachment"] = demisto.args().get("attachmentName")
   if demisto.args().get("body"):
       args["Body"] = demisto.args().get("body")
 
   stripSubject = True if demisto.args().get("stripSubject").lower() == "true" else False
-  if stripSubject and args["Subject"]:
+  if stripSubject and args.get("Subject"):
       # Recursively remove the regex matches only from the beginning of the string
       match_string = args["Subject"]
       location_match = p.match(match_string)
@@ -84,5 +84,6 @@ outputs:
   type: string
 scripttarget: 0
 runonce: false
+releaseNotes: "-"
 tests:
   - buildewsquery_test


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16242

## Description
BuildEWSQuery was building illegal query that contains invalid search property `AttachmentName`.
The fix is to change `AttachmentName` property to `Attachment`.
Additional information about AQS syntax: 
[Microsoft Documentation](https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/how-to-perform-an-aqs-search-by-using-ews-in-exchange) 

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Scripts:
- [x] BuildEWSQuery

Playbooks:
- [x] Search And Delete Emails - EWS
- [x] Phishing Investigation - Generic
- [x] Search And Delete Emails - Generic

Tests:
- [x] Phishing test - Inline
- [x] Phishing test - attachment
- [x] buildewsquery_test

