### PR TITLE
Process Email - Generic - fix for SetIncident retrieving data from wrong context fields

### DIFF
--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -115,7 +115,9 @@ tasks:
       id: 4ac2b332-b76d-463e-824e-717895c5b644
       version: -1
       name: Add original email attachments to context
-      description: "Parses an email from an EML or MSG file and populates all relevant context data to investigate the email. Also extracts indicators from the email messages."
+      description: Parses an email from an EML or MSG file and populates all relevant
+        context data to investigate the email. Also extracts indicators from the email
+        messages.
       scriptName: ParseEmailFiles
       type: regular
       iscommand: false
@@ -726,10 +728,10 @@ tasks:
     ignoreworker: false
   "19":
     id: "19"
-    taskid: 6b5282f7-4f21-4791-894e-c3f7e148c166
+    taskid: a9d9a40a-ba68-4c09-8ceb-f021d95539c5
     type: regular
     task:
-      id: 6b5282f7-4f21-4791-894e-c3f7e148c166
+      id: a9d9a40a-ba68-4c09-8ceb-f021d95539c5
       version: -1
       name: Set incident with the Email object data
       description: Updates Demisto incident fields using data from the email object.
@@ -825,10 +827,23 @@ tasks:
       emailbcc:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.BCC
+                iscontext: true
           accessor: HeadersMap.BCC
           transformers:
           - operator: uniq
           - operator: Stringify
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
       emailbody:
         complex:
           root: Email
@@ -849,6 +864,12 @@ tasks:
       emailcc:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.CC
+                iscontext: true
           accessor: HeadersMap.CC
           transformers:
           - operator: uniq
@@ -867,6 +888,12 @@ tasks:
       emailfrom:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.From
+                iscontext: true
           accessor: HeadersMap.From
           transformers:
           - operator: uniq
@@ -894,6 +921,12 @@ tasks:
       emailmessageid:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.Message-ID
+                iscontext: true
           accessor: HeadersMap.Message-ID
           transformers:
           - operator: RegexGroups
@@ -907,12 +940,24 @@ tasks:
       emailreceived:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.Received
+                iscontext: true
           accessor: HeadersMap.Received
           transformers:
           - operator: uniq
       emailreplyto:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.Reply-To
+                iscontext: true
           accessor: HeadersMap.Reply-To
           transformers:
           - operator: RegexGroups
@@ -943,6 +988,12 @@ tasks:
       emailsubject:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.Subject
+                iscontext: true
           accessor: HeadersMap.Subject
           transformers:
           - operator: uniq
@@ -951,6 +1002,12 @@ tasks:
       emailto:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.To
+                iscontext: true
           accessor: HeadersMap.To
           transformers:
           - operator: uniq
@@ -964,6 +1021,12 @@ tasks:
       emailtocount:
         complex:
           root: Email
+          filters:
+          - - operator: isNotEmpty
+              left:
+                value:
+                  simple: Email.HeadersMap.To
+                iscontext: true
           accessor: HeadersMap.To
           transformers:
           - operator: uniq

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -29,6 +29,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "1":
     id: "1"
     taskid: 70863b9a-af3f-4f0a-8e91-cae2c88f5488
@@ -50,14 +52,13 @@ tasks:
       - "3"
     scriptarguments:
       value:
-        simple: ${inputs.File(val.Type.toLowerCase().indexOf('rfc 822 mail') >= 0 ||  
-          val.Type.toLowerCase().indexOf('smtp mail') >= 0 || 
-          val.Type.toLowerCase().indexOf('cdfv2 microsoft outlook message') >= 0 || 
-          val.Type.toLowerCase().indexOf('news or mail') >= 0 || 
-          (val.Type.toLowerCase().indexOf('composite document file v2 document') >= 0 && 
-          val.Extension.toLowerCase() == 'msg') || 
-          (val.Extension.toLowerCase() == 'eml' && val.Type.toLowerCase().indexOf('text') >= 0 && 
-          val.Type.toLowerCase().indexOf('crlf') >= 0)).EntryID}
+        simple: ${inputs.File(val.Type.toLowerCase().indexOf('rfc 822 mail') >= 0
+          || val.Type.toLowerCase().indexOf('smtp mail') >= 0 || val.Type.toLowerCase().indexOf('cdfv2
+          microsoft outlook message') >= 0 || val.Type.toLowerCase().indexOf('news
+          or mail') >= 0 || (val.Type.toLowerCase().indexOf('composite document file
+          v2 document') >= 0 && val.Extension.toLowerCase() == 'msg') || (val.Extension.toLowerCase()
+          == 'eml' && val.Type.toLowerCase().indexOf('text') >= 0 && val.Type.toLowerCase().indexOf('crlf')
+          >= 0)).EntryID}
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -68,6 +69,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
     taskid: 0dd910be-f198-4b5d-8dbb-8d7170049463
@@ -102,6 +105,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
     taskid: 4ac2b332-b76d-463e-824e-717895c5b644
@@ -120,14 +125,13 @@ tasks:
       - "19"
     scriptarguments:
       entryid:
-        simple: ${inputs.File(val.Type.toLowerCase().indexOf('rfc 822 mail') >= 0 ||  
-          val.Type.toLowerCase().indexOf('smtp mail') >= 0 || 
-          val.Type.toLowerCase().indexOf('cdfv2 microsoft outlook message') >= 0 || 
-          val.Type.toLowerCase().indexOf('news or mail') >= 0 || 
-          (val.Type.toLowerCase().indexOf('composite document file v2 document') >= 0 && 
-          val.Extension.toLowerCase() == 'msg') || 
-          (val.Extension.toLowerCase() == 'eml' && val.Type.toLowerCase().indexOf('text') >= 0 && 
-          val.Type.toLowerCase().indexOf('crlf') >= 0)).EntryID}
+        simple: ${inputs.File(val.Type.toLowerCase().indexOf('rfc 822 mail') >= 0
+          || val.Type.toLowerCase().indexOf('smtp mail') >= 0 || val.Type.toLowerCase().indexOf('cdfv2
+          microsoft outlook message') >= 0 || val.Type.toLowerCase().indexOf('news
+          or mail') >= 0 || (val.Type.toLowerCase().indexOf('composite document file
+          v2 document') >= 0 && val.Extension.toLowerCase() == 'msg') || (val.Extension.toLowerCase()
+          == 'eml' && val.Type.toLowerCase().indexOf('text') >= 0 && val.Type.toLowerCase().indexOf('crlf')
+          >= 0)).EntryID}
     reputationcalc: 2
     results:
     - AttachmentName
@@ -140,6 +144,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "4":
     id: "4"
     taskid: be6f6daf-0497-423e-8a48-d669ccad567f
@@ -176,6 +182,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
     taskid: c18ef7a3-f278-4255-86ac-5b127f991302
@@ -212,6 +220,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "6":
     id: "6"
     taskid: dd0d5106-965e-4a81-8e67-79392ea47d7f
@@ -233,6 +243,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "11":
     id: "11"
     taskid: 104966c4-8595-4a5a-8c75-c84f55e51c84
@@ -257,6 +269,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "13":
     id: "13"
     taskid: 9d6defc4-5ef1-4523-8136-08372aa15544
@@ -265,7 +279,8 @@ tasks:
       id: 9d6defc4-5ef1-4523-8136-08372aa15544
       version: -1
       name: Set incident with the Email object data
-      description: "Updates Demisto incident fields using data from the email object. Also extracts indicators from the email message."
+      description: Updates Demisto incident fields using data from the email object.
+        Also extracts indicators from the email message.
       script: Builtin|||setIncident
       type: regular
       iscommand: true
@@ -598,6 +613,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "16":
     id: "16"
     taskid: bc0dd5a2-6073-4f44-8abc-9bc48e3e08c1
@@ -636,6 +653,8 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "17":
     id: "17"
     taskid: e6915e5d-bdca-4d59-8636-2e65b2e680e1
@@ -663,10 +682,12 @@ tasks:
       {
         "position": {
           "x": 340,
-          "y": 430
+          "y": 450
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "18":
     id: "18"
     taskid: 9a505e0b-27c1-424a-880a-253135d80683
@@ -702,17 +723,18 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "19":
     id: "19"
-    taskid: 25b31351-c536-4730-8d45-d94bac0fb343
+    taskid: 6b5282f7-4f21-4791-894e-c3f7e148c166
     type: regular
     task:
-      id: 25b31351-c536-4730-8d45-d94bac0fb343
+      id: 6b5282f7-4f21-4791-894e-c3f7e148c166
       version: -1
       name: Set incident with the Email object data
+      description: Updates Demisto incident fields using data from the email object.
       script: Builtin|||setIncident
       type: regular
-      description: "Updates Demisto incident fields using data from the email object."
       iscommand: true
       brand: Builtin
     nexttasks:
@@ -779,6 +801,8 @@ tasks:
       ccc: {}
       ccipaddress: {}
       cleanname: {}
+      closeNotes: {}
+      closeReason: {}
       compliance: {}
       constvalue: {}
       customFields: {}
@@ -801,7 +825,7 @@ tasks:
       emailbcc:
         complex:
           root: Email
-          accessor: BCC
+          accessor: HeadersMap.BCC
           transformers:
           - operator: uniq
           - operator: Stringify
@@ -821,13 +845,21 @@ tasks:
           accessor: HTML
           transformers:
           - operator: Stringify
+      emailbodyhtmlraw: {}
       emailcc:
         complex:
           root: Email
-          accessor: CC
+          accessor: HeadersMap.CC
           transformers:
           - operator: uniq
           - operator: Stringify
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
       emailclientname:
         complex:
           root: Email
@@ -835,10 +867,18 @@ tasks:
       emailfrom:
         complex:
           root: Email
-          accessor: From
+          accessor: HeadersMap.From
           transformers:
           - operator: uniq
           - operator: Stringify
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
+      emailfromdisplayname: {}
       emailimage:
         complex:
           root: Email
@@ -854,19 +894,40 @@ tasks:
       emailmessageid:
         complex:
           root: Email
-          accessor: ID
+          accessor: HeadersMap.Message-ID
+          transformers:
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
+          - operator: uniq
       emailreceived:
         complex:
           root: Email
-          accessor: Received
+          accessor: HeadersMap.Received
+          transformers:
+          - operator: uniq
       emailreplyto:
         complex:
           root: Email
-          accessor: ReplyTo
+          accessor: HeadersMap.Reply-To
+          transformers:
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
+          - operator: uniq
       emailreturnpath:
         complex:
           root: Email
           accessor: ReturnPath
+      emailsenderdomain: {}
       emailsenderip:
         complex:
           root: Email
@@ -882,27 +943,37 @@ tasks:
       emailsubject:
         complex:
           root: Email
-          accessor: Subject
+          accessor: HeadersMap.Subject
           transformers:
           - operator: uniq
           - operator: Stringify
+      emailsubjectlanguage: {}
       emailto:
         complex:
           root: Email
-          accessor: To
+          accessor: HeadersMap.To
           transformers:
           - operator: uniq
-          - operator: join
+          - operator: RegexGroups
             args:
-              separator:
+              groups: {}
+              keys: {}
+              regex:
                 value:
-                  simple: ','
+                  simple: <(.*)>
       emailtocount:
         complex:
           root: Email
-          accessor: To
+          accessor: HeadersMap.To
           transformers:
           - operator: uniq
+          - operator: RegexGroups
+            args:
+              groups: {}
+              keys: {}
+              regex:
+                value:
+                  simple: <(.*)>
           - operator: count
       emailurlclicked:
         complex:
@@ -972,6 +1043,7 @@ tasks:
       relatedincidentssummary: {}
       replacePlaybook: {}
       reporteduser: {}
+      reportinguser: {}
       riskmitigationactionrequirements: {}
       riskscore: {}
       roles: {}
@@ -1045,6 +1117,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -1170,6 +1243,6 @@ outputs:
 - contextPath: File
   description: The File object
   type: unknown
+releaseNotes: "Fixed a bug where SetIncident was retreiving non-existent data from context."
 tests:
   - No test
-releaseNotes: "fix bug - process Email is extracting indicators twice on the same data"

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -728,10 +728,10 @@ tasks:
     ignoreworker: false
   "19":
     id: "19"
-    taskid: a9d9a40a-ba68-4c09-8ceb-f021d95539c5
+    taskid: 040c1852-c639-4322-80d0-e10d0dfc9b09
     type: regular
     task:
-      id: a9d9a40a-ba68-4c09-8ceb-f021d95539c5
+      id: 040c1852-c639-4322-80d0-e10d0dfc9b09
       version: -1
       name: Set incident with the Email object data
       description: Updates Demisto incident fields using data from the email object.
@@ -827,23 +827,10 @@ tasks:
       emailbcc:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.BCC
-                iscontext: true
           accessor: HeadersMap.BCC
           transformers:
           - operator: uniq
           - operator: Stringify
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
       emailbody:
         complex:
           root: Email
@@ -864,23 +851,10 @@ tasks:
       emailcc:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.CC
-                iscontext: true
-          accessor: HeadersMap.CC
+          accessor: CC
           transformers:
           - operator: uniq
           - operator: Stringify
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
       emailclientname:
         complex:
           root: Email
@@ -888,23 +862,10 @@ tasks:
       emailfrom:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.From
-                iscontext: true
-          accessor: HeadersMap.From
+          accessor: From
           transformers:
           - operator: uniq
           - operator: Stringify
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
       emailfromdisplayname: {}
       emailimage:
         complex:
@@ -921,80 +882,50 @@ tasks:
       emailmessageid:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.Message-ID
-                iscontext: true
           accessor: HeadersMap.Message-ID
           transformers:
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
           - operator: uniq
       emailreceived:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.Received
-                iscontext: true
           accessor: HeadersMap.Received
           transformers:
           - operator: uniq
       emailreplyto:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.Reply-To
-                iscontext: true
           accessor: HeadersMap.Reply-To
           transformers:
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
           - operator: uniq
       emailreturnpath:
         complex:
           root: Email
-          accessor: ReturnPath
+          accessor: HeadersMap.Return-Path
+          transformers:
+          - operator: uniq
       emailsenderdomain: {}
       emailsenderip:
         complex:
           root: Email
           accessor: SenderIP
+          transformers:
+          - operator: uniq
       emailsize:
         complex:
           root: Email
           accessor: Size
+          transformers:
+          - operator: uniq
       emailsource:
         complex:
           root: Email
           accessor: Source
+          transformers:
+          - operator: uniq
       emailsubject:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.Subject
-                iscontext: true
-          accessor: HeadersMap.Subject
+          accessor: Subject
           transformers:
           - operator: uniq
           - operator: Stringify
@@ -1002,41 +933,15 @@ tasks:
       emailto:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.To
-                iscontext: true
-          accessor: HeadersMap.To
+          accessor: To
           transformers:
           - operator: uniq
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
       emailtocount:
         complex:
           root: Email
-          filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: Email.HeadersMap.To
-                iscontext: true
-          accessor: HeadersMap.To
+          accessor: To
           transformers:
           - operator: uniq
-          - operator: RegexGroups
-            args:
-              groups: {}
-              keys: {}
-              regex:
-                value:
-                  simple: <(.*)>
           - operator: count
       emailurlclicked:
         complex:

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -885,12 +885,7 @@ tasks:
           accessor: HeadersMap.Message-ID
           transformers:
           - operator: uniq
-      emailreceived:
-        complex:
-          root: Email
-          accessor: HeadersMap.Received
-          transformers:
-          - operator: uniq
+      emailreceived: {}
       emailreplyto:
         complex:
           root: Email

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -1243,6 +1243,6 @@ outputs:
 - contextPath: File
   description: The File object
   type: unknown
-releaseNotes: "Fixed a bug where SetIncident was retreiving non-existent data from context."
+releaseNotes: "Fixed a bug where SetIncident was retrieving data from the wrong context fields."
 tests:
   - No test

--- a/Playbooks/playbook-Process_Email_-_Generic.yml
+++ b/Playbooks/playbook-Process_Email_-_Generic.yml
@@ -1213,4 +1213,4 @@ outputs:
   type: unknown
 releaseNotes: "Fixed a bug where SetIncident was retrieving data from the wrong context fields."
 tests:
-  - No test
+  - process_email_-_generic_-_test

--- a/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
+++ b/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
@@ -5,12 +5,13 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: ead303e7-4702-447f-8b86-97892809dc4a
+    taskid: cc87995f-62b2-4033-8ac7-9c5fa25f81bc
     type: start
     task:
-      id: ead303e7-4702-447f-8b86-97892809dc4a
+      id: cc87995f-62b2-4033-8ac7-9c5fa25f81bc
       version: -1
       name: ""
+      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -29,10 +30,10 @@ tasks:
     ignoreworker: false
   "1":
     id: "1"
-    taskid: 47bbbb35-643c-4697-80de-4f8bb9e3ff76
+    taskid: f5a18bac-07bf-497f-8712-ab165ae8fcce
     type: regular
     task:
-      id: 47bbbb35-643c-4697-80de-4f8bb9e3ff76
+      id: f5a18bac-07bf-497f-8712-ab165ae8fcce
       version: -1
       name: Download EML file
       description: Sends http request. Returns the response as json.
@@ -42,7 +43,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "5"
+      - "16"
     scriptarguments:
       body: {}
       filename:
@@ -73,10 +74,10 @@ tasks:
     ignoreworker: false
   "2":
     id: "2"
-    taskid: eea7485a-2b8d-4160-8e73-06555f6097c9
+    taskid: 1e112793-3e1f-402a-85eb-8021d202b3b7
     type: regular
     task:
-      id: eea7485a-2b8d-4160-8e73-06555f6097c9
+      id: 1e112793-3e1f-402a-85eb-8021d202b3b7
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -90,7 +91,11 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
+      index: {}
       key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    reputationcalc: 1
     separatecontext: false
     view: |-
       {
@@ -104,12 +109,13 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: d5a04d67-583c-4ddb-85fd-c238a66e13c7
+    taskid: cfdcb838-e4a5-4f89-8439-9c1c1d318f55
     type: title
     task:
-      id: d5a04d67-583c-4ddb-85fd-c238a66e13c7
+      id: cfdcb838-e4a5-4f89-8439-9c1c1d318f55
       version: -1
       name: Done
+      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -117,72 +123,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 30,
-          "y": 2430
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "5":
-    id: "5"
-    taskid: 4fd63104-4fff-4747-88af-14a657e47ad8
-    type: playbook
-    task:
-      id: 4fd63104-4fff-4747-88af-14a657e47ad8
-      version: -1
-      name: Process Email - Generic
-      playbookName: Process Email - Generic
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "6"
-    separatecontext: true
-    view: |-
-      {
-        "position": {
           "x": 50,
-          "y": 545
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "6":
-    id: "6"
-    taskid: 99482124-9179-4d10-8adb-6851a6baec2a
-    type: condition
-    task:
-      id: 99482124-9179-4d10-8adb-6851a6baec2a
-      version: -1
-      name: Verify context
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#default#':
-      - "7"
-      "yes":
-      - "8"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isEqualString
-          left:
-            value:
-              simple: Email.From
-            iscontext: true
-          right:
-            value:
-              simple: mlemos@acm.org # disable-secrets-detection
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 720
+          "y": 2440
         }
       }
     note: false
@@ -190,10 +132,10 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 7b8b96f8-7f36-45d2-8095-c1120ab759c8
+    taskid: c87b330c-fe70-4420-8bfc-015db4e27390
     type: regular
     task:
-      id: 7b8b96f8-7f36-45d2-8095-c1120ab759c8
+      id: c87b330c-fe70-4420-8bfc-015db4e27390
       version: -1
       name: Error Verifying Context Output
       description: Prints an error entry with a given message
@@ -208,8 +150,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 680,
-          "y": 2390
+          "x": 670,
+          "y": 2320
         }
       }
     note: false
@@ -217,10 +159,10 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: c5ea33ce-db3f-4cd5-81f1-672d57bad5de
+    taskid: 9263bd85-160b-401c-8518-1f5c154e6163
     type: regular
     task:
-      id: c5ea33ce-db3f-4cd5-81f1-672d57bad5de
+      id: 9263bd85-160b-401c-8518-1f5c154e6163
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -234,13 +176,17 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
+      index: {}
       key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    reputationcalc: 1
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 885
+          "y": 905
         }
       }
     note: false
@@ -248,10 +194,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: 07257cda-0365-4b43-8d20-ec4fce1fb3c5
+    taskid: f87d7b81-0b57-4321-8f00-90a071c449a3
     type: regular
     task:
-      id: 07257cda-0365-4b43-8d20-ec4fce1fb3c5
+      id: f87d7b81-0b57-4321-8f00-90a071c449a3
       version: -1
       name: Download SMTP Email
       description: Sends http request. Returns the response as json.
@@ -261,7 +207,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "10"
+      - "17"
     scriptarguments:
       body: {}
       filename:
@@ -290,79 +236,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "10":
-    id: "10"
-    taskid: c5d26a90-4094-4f21-8c90-1d8c1466e528
-    type: playbook
-    task:
-      id: c5d26a90-4094-4f21-8c90-1d8c1466e528
-      version: -1
-      name: Process Email - Generic
-      description: Add email details to the relevant context entities and handle the
-        case where original emails are attached.
-      playbookName: Process Email - Generic
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "11"
-    separatecontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1240
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "11":
-    id: "11"
-    taskid: 706475b9-4943-4b04-8676-875f02386f4f
-    type: condition
-    task:
-      id: 706475b9-4943-4b04-8676-875f02386f4f
-      version: -1
-      name: Verify context
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#default#':
-      - "7"
-      "yes":
-      - "12"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: containsString
-          left:
-            value:
-              simple: Email.From
-            iscontext: true
-          right:
-            value:
-              simple: test@test.com
-          ignorecase: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1405
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
   "12":
     id: "12"
-    taskid: 0d7b819f-e2d0-458d-8c90-12714bb8d40d
+    taskid: 4280d26b-1b8d-4b45-8835-6b8e4dc24a46
     type: regular
     task:
-      id: 0d7b819f-e2d0-458d-8c90-12714bb8d40d
+      id: 4280d26b-1b8d-4b45-8835-6b8e4dc24a46
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -376,13 +255,17 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
+      index: {}
       key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    reputationcalc: 1
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 40,
-          "y": 1695
+          "x": 50,
+          "y": 1620
         }
       }
     note: false
@@ -390,21 +273,23 @@ tasks:
     ignoreworker: false
   "13":
     id: "13"
-    taskid: da19c36a-be4e-4b87-8d5d-4c0dd8b507e6
+    taskid: 50630427-aacb-49b4-8856-91e98ce44158
     type: regular
     task:
-      id: da19c36a-be4e-4b87-8d5d-4c0dd8b507e6
+      id: 50630427-aacb-49b4-8856-91e98ce44158
       version: -1
-      name: Download Word Doc
-      description: "Check that a word doc doesn't trigger processing the email. \n\nSee
-        issue: https://github.com/demisto/etc/issues/15743"
+      name: Download DOC file
+      description: |-
+        Checks that a Word file with the extension of DOC, does not trigger the processing of an email file.
+
+        See issue: https://github.com/demisto/etc/issues/15743
       scriptName: http
       type: regular
       iscommand: false
       brand: ""
     nexttasks:
       '#none#':
-      - "14"
+      - "18"
     scriptarguments:
       body: {}
       filename:
@@ -426,36 +311,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 40,
-          "y": 1875
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "14":
-    id: "14"
-    taskid: c331e2a5-d755-4b88-827a-9d45969a62b0
-    type: playbook
-    task:
-      id: c331e2a5-d755-4b88-827a-9d45969a62b0
-      version: -1
-      name: Process Email - Generic
-      description: Add email details to the relevant context entities and handle the
-        case where original emails are attached.
-      playbookName: Process Email - Generic
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "15"
-    separatecontext: true
-    view: |-
-      {
-        "position": {
-          "x": 40,
-          "y": 2040
+          "x": 50,
+          "y": 1795
         }
       }
     note: false
@@ -463,12 +320,14 @@ tasks:
     ignoreworker: false
   "15":
     id: "15"
-    taskid: 758d3acb-2a0f-4a30-8af7-7981a9241821
+    taskid: 3cb572bf-9fd7-4aee-8ba2-ff3ba1287b86
     type: condition
     task:
-      id: 758d3acb-2a0f-4a30-8af7-7981a9241821
+      id: 3cb572bf-9fd7-4aee-8ba2-ff3ba1287b86
       version: -1
-      name: Verify Email is Null
+      name: Verify email is null
+      description: Verifies the email is "null" when we are downloading a DOC file
+        and not an email.
       type: condition
       iscommand: false
       brand: ""
@@ -492,8 +351,273 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 40,
-          "y": 2220
+          "x": 50,
+          "y": 2140
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "16":
+    id: "16"
+    taskid: 230e7c2b-b588-422c-8cbf-ccc8a51d62b7
+    type: playbook
+    task:
+      id: 230e7c2b-b588-422c-8cbf-ccc8a51d62b7
+      version: -1
+      name: Process Email - Generic_dev
+      playbookName: Process Email - Generic_dev
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "19"
+    separatecontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 540
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "17":
+    id: "17"
+    taskid: 5522f70a-4812-4712-8d58-38f870a5a927
+    type: playbook
+    task:
+      id: 5522f70a-4812-4712-8d58-38f870a5a927
+      version: -1
+      name: Process Email - Generic_dev
+      playbookName: Process Email - Generic_dev
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "20"
+    scriptarguments:
+      Email:
+        complex:
+          root: incident
+          accessor: labels.Email
+      Email/cc:
+        complex:
+          root: incident
+          accessor: labels.CC
+      Email/format:
+        complex:
+          root: incident
+          accessor: labels.Email/format
+      Email/from:
+        complex:
+          root: incident
+          accessor: labels.Email/from
+      Email/headers:
+        complex:
+          root: incident
+          accessor: labels.Email/headers
+      Email/html:
+        complex:
+          root: incident
+          accessor: labels.Email/html
+      Email/subject:
+        complex:
+          root: incident
+          accessor: labels.Email/subject
+      Email/text:
+        complex:
+          root: incident
+          accessor: labels.Email/text
+      File:
+        complex:
+          root: File
+      GetOriginalEmail:
+        simple: "False"
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1230
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "18":
+    id: "18"
+    taskid: 1af72dae-82c6-442d-8015-1e463a1ba289
+    type: playbook
+    task:
+      id: 1af72dae-82c6-442d-8015-1e463a1ba289
+      version: -1
+      name: Process Email - Generic_dev
+      playbookName: Process Email - Generic_dev
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "15"
+    separatecontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1970
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "19":
+    id: "19"
+    taskid: 3aea8f14-e16e-405d-81f0-6bb9c8f31992
+    type: condition
+    task:
+      id: 3aea8f14-e16e-405d-81f0-6bb9c8f31992
+      version: -1
+      name: Verify context
+      description: Verifies that the right values in context exist under Email.HeadersMap.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "8"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Message-ID
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Return-Path
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: From
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Subject
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Date
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: To
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 710
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "20":
+    id: "20"
+    taskid: b43d7841-a3a0-4a1a-85a7-b27e46ef3235
+    type: condition
+    task:
+      id: b43d7841-a3a0-4a1a-85a7-b27e46ef3235
+      version: -1
+      name: Verify context
+      description: Verifies that the values we expect ParseEmailFiles to put in context
+        are there.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "7"
+      "yes":
+      - "12"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Message-ID
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Return-Path
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: From
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Subject
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: HeadersMap.Date
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Email
+                accessor: To
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1410
         }
       }
     note: false
@@ -501,12 +625,14 @@ tasks:
     ignoreworker: false
 view: |-
   {
-    "linkLabelsPosition": {},
+    "linkLabelsPosition": {
+      "19_8_yes": 0.64
+    },
     "paper": {
       "dimensions": {
-        "height": 2445,
-        "width": 1030,
-        "x": 30,
+        "height": 2455,
+        "width": 1000,
+        "x": 50,
         "y": 50
       }
     }

--- a/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
+++ b/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
@@ -391,8 +391,8 @@ tasks:
     task:
       id: 5522f70a-4812-4712-8d58-38f870a5a927
       version: -1
-      name: Process Email - Generic_dev
-      playbookName: Process Email - Generic_dev
+      name: Process Email - Generic
+      playbookName: Process Email - Generic
       type: playbook
       iscommand: false
       brand: ""
@@ -459,8 +459,8 @@ tasks:
     task:
       id: 1af72dae-82c6-442d-8015-1e463a1ba289
       version: -1
-      name: Process Email - Generic_dev
-      playbookName: Process Email - Generic_dev
+      name: Process Email - Generic
+      playbookName: Process Email - Generic
       type: playbook
       iscommand: false
       brand: ""

--- a/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
+++ b/TestPlaybooks/playbook-Process_Email_-_Generic_-_Test.yml
@@ -365,8 +365,8 @@ tasks:
     task:
       id: 230e7c2b-b588-422c-8cbf-ccc8a51d62b7
       version: -1
-      name: Process Email - Generic_dev
-      playbookName: Process Email - Generic_dev
+      name: Process Email - Generic
+      playbookName: Process Email - Generic
       type: playbook
       iscommand: false
       brand: ""


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16127

## Description
Fixed the `SetIncident` task in `Process Email - Generic` where it was retrieving data from the wrong context fields.
The fix utilizes the new Email.HeadersMap outputs from the `ParseEmailFiles` script, **where applicable and where possible.**
The following fields are now populated:
- Email Subject
- Email Return Path
- Email Reply To
- Email Message ID
- Email To
- Email From
- Email CC
- Email Subject

Also added a test playbook for the new (and old) changes.

## Screenshots
![image](https://user-images.githubusercontent.com/43602124/56867064-9c2cf800-69e9-11e9-8cf8-92115ba528d8.png)


## Required version of Demisto
4.0.0

## Does it break backward compatibility?
   - No - it adds extra data

## Must have
- [x] Tests
- [ ] Code Review
