### PR TITLE
Unskip Cybereason test

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -779,7 +779,8 @@
         {
             "playbookID": "Cybereason Test",
             "integrations": "Cybereason",
-            "timeout": 1200
+            "timeout": 1200,
+            "fromversion": "4.1.0"
         },
         {
             "integrations": "VirusTotal - Private API",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1283,8 +1283,7 @@
         "Test-Detonate URL - ThreatGrid": "Outdated test",
         "JoeSecurityTestDetonation": "command joe-download-report fails (issue 16118)",
         "af2f5a99-d70b-48c1-8c25-519732b733f2": "Added here because test existed but was not configured - need to review the test",
-        "Zoom_test": "Added here because test existed but was not configured - need to review the test",
-        "Cybereason Test": "Test is failing due to connection issues though it's in unmockable (issue 16555)"
+        "Zoom_test": "Added here because test existed but was not configured - need to review the test"
     },
     "skipped_integrations": {
       "_comment": "~~~ NO INSTANCE - will not be resolved ~~~",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16555

## Description
Cybereason instance is alive, and added `fromversion: 4.1.0` cause of fetch test

## Required version of Demisto
4.1.0 for the test

## Does it break backward compatibility?
   - Yes

## Must have
- [x] Tests
- [ ] Code Review

## Dependencies
None

