### PR TITLE
Edit 'anyrun-get-report' argument 'task' description to be more infor…

### DIFF
--- a/Integrations/ANYRUN/ANYRUN.yml
+++ b/Integrations/ANYRUN/ANYRUN.yml
@@ -30,7 +30,8 @@ script:
     - auto: PREDEFINED
       default: true
       defaultValue: 'false'
-      description: If true, gets team history. If empty, gets your submitted analyses history.
+      description: If true, gets team history. If empty, gets your submitted analyses
+        history.
       isArray: false
       name: team
       predefined:
@@ -49,7 +50,8 @@ script:
       secret: false
     - default: true
       defaultValue: '25'
-      description: Limits the history retrieved/searched to the specified number of executed analyses. The range is 1-100.
+      description: Limits the history retrieved/searched to the specified number of
+        executed analyses. The range is 1-100.
       isArray: false
       name: limit
       required: false
@@ -97,7 +99,10 @@ script:
       type: String
   - arguments:
     - default: false
-      description: Task UUID.
+      description: Unique task ID. A task ID is returned when submitting a file or
+        URL for analysis using the `anyrun-run-analysis` command. Task IDs can also
+        be located in the `ID` field of the output of executing the `anyrun-get-history`
+        command.
       isArray: false
       name: task
       required: true
@@ -234,7 +239,8 @@ script:
       description: SSDeep hash of the file submitted for analysis.
       type: String
     - contextPath: ANYRUN.Task.Verdict
-      description: ANY.RUN verdict for the maliciousness of the submitted file or URL.
+      description: ANY.RUN verdict for the maliciousness of the submitted file or
+        URL.
       type: String
     - contextPath: ANYRUN.Task.Process.FileName
       description: File name of the process.


### PR DESCRIPTION
## Status
Ready

## Description
Edit 'anyrun-get-report' argument 'task' description to be more informative: Added details of where one could find task IDs for use as a value for this command argument.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests - N/A
- [x] Documentation - https://github.com/demisto/etc/issues/16701
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] N/A

