### PR TITLE
Change time to wait for Wildfire analysis before pulling report

### DIFF
--- a/Scripts/script-CheckFilesWildfirePy.yml
+++ b/Scripts/script-CheckFilesWildfirePy.yml
@@ -26,9 +26,9 @@ script: |-
                   upReply = demisto.executeCommand('wildfire-upload', {'upload': entry['ID']})
                   if upReply[0]['Type'] != entryTypes['error']:
                       uploaded.append(demisto.get(entry, 'FileMetadata.md5'))
-  # Wait for the uploaded files to be processed - 15 min
+  # Wait for the uploaded files to be processed - 6 min
   if len(uploaded) > 0:
-      time.sleep(15 * 60)
+      time.sleep(6 * 60)
   for u in uploaded:
       rep = demisto.executeCommand('wildfire-report', {'md5': u})
       notFound = False


### PR DESCRIPTION
## Status
Ready

## Description
Sleep time before trying to fetch Wildfire report reduced from 15 to 6 minutes as the report should be available within that time.

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [X] Code Review