### PR TITLE
Added Account Enrichment v2.1 + Test v2.1

### DIFF
--- a/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
+++ b/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
@@ -155,7 +155,7 @@ tasks:
       id: 97ec5ca3-8754-49ff-8797-627ef7e6cd33
       version: -1
       name: Get account info from Active Directory
-      description: Queries Active Directory for the username’s information.
+      description: Queries Active Directory and returns information for the specified username.
       script: '|||ad-get-user'
       type: regular
       iscommand: true
@@ -218,14 +218,14 @@ outputs:
   description: The account object.
   type: unknown
 - contextPath: ActiveDirectory.Users.sAMAccountName
-  description: The user's sAMAccountName.
+  description: The user's samAccountName.
 - contextPath: ActiveDirectory.Users.userAccountControl
   description: The user's account control flag.
 - contextPath: ActiveDirectory.Users.mail
   description: The user's email address.
 - contextPath: ActiveDirectory.Users.memberOf
   description: Groups the user is a member of.
-releaseNotes: "Replaced old Active Directory integration with the new Active Directory v2 Query integration.
+releaseNotes: "Replaced the Active Directory integration with the Active Directory v2 Query integration.
 Removed redundant outputs."
 tests:
   - Account Enrichment - Generic v2.1 - Test

--- a/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
+++ b/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
@@ -226,6 +226,6 @@ outputs:
 - contextPath: ActiveDirectory.Users.memberOf
   description: Groups the user is a member of.
 releaseNotes: "Replaced old Active Directory integration with the new Active Directory v2 Query integration.
-  Removed redundant outputs."
+Removed redundant outputs."
 tests:
   - Account Enrichment - Generic v2.1 - Test

--- a/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
+++ b/Playbooks/playbook-Account_Enrichment_-_Generic_v2.1.yml
@@ -1,0 +1,231 @@
+id: Account Enrichment - Generic v2.1
+version: -1
+fromversion: 4.1.0
+name: Account Enrichment - Generic v2.1
+description: |-
+  Enrich accounts using one or more integrations.
+  Supported integrations:
+  - Active Directory
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 03bb7183-afc8-4bcd-8f32-5c35d41fdcad
+    type: start
+    task:
+      id: 03bb7183-afc8-4bcd-8f32-5c35d41fdcad
+      version: -1
+      name: ""
+      description: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: f4d7cbdd-cd4a-48bd-8360-740b97fba2e0
+    type: condition
+    task:
+      id: f4d7cbdd-cd4a-48bd-8360-740b97fba2e0
+      version: -1
+      name: Is there an account to enrich?
+      description: Checks if there is at least one username to enrich.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "3"
+      "yes":
+      - "4"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              simple: inputs.Username
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 203
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: ee0fc2dd-d3aa-4e72-82ac-f12d9bd4a9fa
+    type: title
+    task:
+      id: ee0fc2dd-d3aa-4e72-82ac-f12d9bd4a9fa
+      version: -1
+      name: Done
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 765
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: 98e13761-b371-4380-8815-9081204309db
+    type: condition
+    task:
+      id: 98e13761-b371-4380-8815-9081204309db
+      version: -1
+      name: Is Active Directory Query v2 enabled?
+      description: Checks if there’s an active instance of the Active Directory Query
+        v2 integration enabled.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "3"
+      "yes":
+      - "5"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Active Directory Query v2
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 395
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: 97ec5ca3-8754-49ff-8797-627ef7e6cd33
+    type: regular
+    task:
+      id: 97ec5ca3-8754-49ff-8797-627ef7e6cd33
+      version: -1
+      name: Get account info from Active Directory
+      description: Queries Active Directory for the username’s information.
+      script: '|||ad-get-user'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      attributes: {}
+      custom-field-data: {}
+      custom-field-type: {}
+      dn: {}
+      email: {}
+      limit: {}
+      name: {}
+      user-account-control-out: {}
+      username:
+        complex:
+          root: inputs.Username
+          transformers:
+          - operator: uniq
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 320,
+          "y": 580
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {
+      "1_3_#default#": 0.62
+    },
+    "paper": {
+      "dimensions": {
+        "height": 780,
+        "width": 650,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: Username
+  value:
+    complex:
+      root: Account
+      accessor: Username
+      transformers:
+      - operator: uniq
+  required: false
+  description: The username to enrich.
+outputs:
+- contextPath: Account
+  description: The account object.
+  type: unknown
+- contextPath: ActiveDirectory.Users.sAMAccountName
+  description: The user's sAMAccountName.
+- contextPath: ActiveDirectory.Users.userAccountControl
+  description: The user's account control flag.
+- contextPath: ActiveDirectory.Users.mail
+  description: The user's email address.
+- contextPath: ActiveDirectory.Users.memberOf
+  description: Groups the user is a member of.
+releaseNotes: "Replaced old Active Directory integration with the new Active Directory v2 Query integration.
+  Removed redundant outputs."
+tests:
+  - Account Enrichment - Generic v2.1 - Test

--- a/TestPlaybooks/playbook-Account_Enrichment_-_Generic_v2.1_-_Test.yml
+++ b/TestPlaybooks/playbook-Account_Enrichment_-_Generic_v2.1_-_Test.yml
@@ -1,0 +1,242 @@
+id: Account Enrichment - Generic v2.1 - Test
+version: -1
+name: Account Enrichment - Generic v2.1 - Test
+description: A test for the Account Enrichment - Generic v2 playbook.
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: e730f65f-dac8-4988-8603-1f0d4d66dad6
+    type: start
+    task:
+      id: e730f65f-dac8-4988-8603-1f0d4d66dad6
+      version: -1
+      name: ""
+      description: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: b13d4e0f-214d-4a6e-8130-51aa93b7116a
+    type: regular
+    task:
+      id: b13d4e0f-214d-4a6e-8130-51aa93b7116a
+      version: -1
+      name: Delete Context
+      description: Clear the context for a fresh start of the test.
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 200
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: 402ad72f-caaa-49c7-8002-024c592825e8
+    type: condition
+    task:
+      id: 402ad72f-caaa-49c7-8002-024c592825e8
+      version: -1
+      name: Was the account enriched?
+      description: Checks whether the account was enriched.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "6"
+      "yes":
+      - "5"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: Account
+                filters:
+                - - operator: isExists
+                    left:
+                      value:
+                        simple: Account.Groups
+                      iscontext: true
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 710
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: 95918583-c914-41b3-89f8-248188060671
+    type: regular
+    task:
+      id: 95918583-c914-41b3-89f8-248188060671
+      version: -1
+      name: Set account username in context
+      description: Sets a value into the context with the given context key.
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+    scriptarguments:
+      append: {}
+      key:
+        simple: Account.Username
+      value:
+        simple: donotdelete
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: e317c164-089b-493b-8bf8-a4c7f790cf6a
+    type: title
+    task:
+      id: e317c164-089b-493b-8bf8-a4c7f790cf6a
+      version: -1
+      name: Done
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1060
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "6":
+    id: "6"
+    taskid: 619c7110-204c-4e78-8bd0-e2811237bb3c
+    type: regular
+    task:
+      id: 619c7110-204c-4e78-8bd0-e2811237bb3c
+      version: -1
+      name: Make test fail
+      description: Prints an error entry with a given message.
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
+    scriptarguments:
+      message:
+        simple: The account was not enriched as expected (did not get the outputs
+          that we expected from the Account Enrichment playbook). Check if the user
+          still exists in the integrations used by that playbook (Active Directory,
+          for example). Also check that the outputs are there and that they are the
+          outputs we are checking for.
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 770,
+          "y": 880
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "7":
+    id: "7"
+    taskid: bf2a892c-d930-41aa-8ca8-27f1581cace3
+    type: playbook
+    task:
+      id: bf2a892c-d930-41aa-8ca8-27f1581cace3
+      version: -1
+      name: Account Enrichment - Generic v2.1
+      description: ""
+      playbookName: Account Enrichment - Generic v2.1
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    separatecontext: true
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 540
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1075,
+        "width": 700,
+        "x": 450,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1295,6 +1295,10 @@
             "playbookID": "Snowflake-Test"
         },
         {
+            "playbookID": "Account Enrichment - Generic v2.1 - Test",
+            "integrations": "Active Directory Query v2"
+        },
+        {
             "integrations": "Cisco Umbrella Investigate",
             "playbookID": "Domain Enrichment - Generic v2 - Test"
         },


### PR DESCRIPTION
## Status
In Progress - need documentation

## Related Issues
Related to: https://github.com/demisto/etc/issues/16881

## Description
Added the `Account Enrichment - Generic v2.1` playbook. The playbook features the following improvements over the previous one:
- Changed AD to AD v2
- Updated descriptions of task names / playbook
- Removed redundant outputs

Also added the test playbook `Account Enrichment - Generic v2.1 - Test`.

## Screenshots
Playbook
![Account_Enrichment_-_Generic_v2 1_Thu_May_02_2019](https://user-images.githubusercontent.com/43602124/57079523-2da5ae00-6cf9-11e9-982b-ad79998ec2c8.png)

Test playbook
![Account_Enrichment_-_Generic_v2 1_-_Test_Thu_May_02_2019](https://user-images.githubusercontent.com/43602124/57079568-43b36e80-6cf9-11e9-9556-eacd7a50f8a8.png)


## Required version of Demisto
4.1.0


## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation
- [ ] Code Review

