### PR TITLE
Added EmailDomainWhitelist / EmailDomainBlacklist transformers

### DIFF
--- a/Scripts/script-EmailDomainBlacklist.yml
+++ b/Scripts/script-EmailDomainBlacklist.yml
@@ -1,0 +1,38 @@
+commonfields:
+  id: EmailDomainBlacklist
+  version: -1
+name: EmailDomainBlacklist
+script: |-
+  domainList = demisto.args()['domainList'].replace(' ', '').replace('\n','').split(',')
+  emailAddresses = demisto.args()['value']
+
+  filteredAddresses = []
+
+  for address in emailAddresses:
+    [user, domain] = address.split('@')
+
+    if not domain in domainList:
+        filteredAddresses.append(address)
+
+  demisto.results(filteredAddresses)
+type: python
+tags:
+- transformer
+- general
+- entirelist
+comment: Accepts an array of domains as a blacklist, and a list of email addresses.   It
+  will then then filter out any email address whose domain is in the blacklist.  The
+  filtered list will be returned as an array.
+enabled: true
+args:
+- name: value
+  required: true
+  description: An array of email addresses to be filtered by domain
+  isArray: true
+- name: domainList
+  required: true
+  description: An array containing domains to blacklist
+  isArray: true
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole

--- a/Scripts/script-EmailDomainWhitelist.yml
+++ b/Scripts/script-EmailDomainWhitelist.yml
@@ -1,0 +1,39 @@
+commonfields:
+  id: EmailDomainWhitelist
+  version: -1
+name: EmailDomainWhitelist
+script: |-
+  domainList = demisto.args()['domainList'].replace(' ', '').replace('\n','').split(',')
+  emailAddresses = demisto.args()['value']
+
+  filteredAddresses = []
+
+  for address in emailAddresses:
+    [user, domain] = address.split('@')
+
+    if domain in domainList:
+        filteredAddresses.append(address)
+
+  demisto.results(filteredAddresses)
+type: python
+tags:
+- transformer
+- general
+- entirelist
+comment: Accepts an array of domains as a whitelist, and a list of email addresses.   It
+  will then then filter out any email address whose domain is not in the whitelist.  The
+  filtered list will be returned as an array.
+system: false
+enabled: true
+args:
+- name: value
+  required: true
+  description: An array of email addresses to be filtered by domain
+  isArray: true
+- name: domainList
+  required: true
+  description: An array containing domains to whitelist
+  isArray: true
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: N/A

## Description
Contributes two new transformers: EmailDomainWhitelist and EmailDomainBlacklist.  It accepts two parameters: an array containing email addresses and an array containing domains.  All email addresses whose domain is or is not (case depending) contained in whitelisted/blacklisted domains will be discarded.  Returns an array of filtered email addresses.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

  - N/A


## Required version of Demisto
4.x

## Does it break backward compatibility?
   No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
  - N/A

## Additional changes
Describe additional changes done, for example adding a function to common server.
