### PR TITLE
Added transformer FormattedDateToEpoch

### DIFF
--- a/Scripts/script-FormattedDateToEpoch.yml
+++ b/Scripts/script-FormattedDateToEpoch.yml
@@ -1,0 +1,32 @@
+commonfields:
+  id: FormattedDateToEpoch
+  version: -1
+name: FormattedDateToEpoch
+script: |-
+  import datetime
+
+  dateValue = demisto.args()['value']
+  formatter = demisto.args()['formatter']
+
+  dateObj = datetime.datetime.strptime(dateValue, formatter)
+
+  demisto.results(int(dateObj.strftime('%s')))
+type: python
+tags:
+- transformer
+- date
+comment: 'Converts a custom-formatted timestamp to UNIX epoch time. Use it to convert
+  custom time stamps to a Demisto date field.  Uses the python strptime format.  For
+  more info, see: https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior'
+enabled: true
+args:
+- name: value
+  required: true
+  description: Time stamp to convert
+- name: formatter
+  required: true
+  description: Python 'strptime' formatter string
+scripttarget: 0
+runonce: false
+dockerimage: demisto/python3
+runas: DBotWeakRole


### PR DESCRIPTION
## Status
Ready

## Related Issues
N/A

## Description
New transformer which converts a custom-formatted timestamp to a UNIX epoch time, using a Python strptime format string.  Very useful for converting custom timestamps to a Demisto date field.  Parameters are the string to convert (value), and the formatter string (formatter).  Valid formatter values can be found at https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior.

## Screenshots
N/A 

## Related PRs
List related PRs against other branches:
N/A

## Required version of Demisto
4.x.x

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
 N/A

## Additional changes
Describe additional changes done, for example adding a function to common server.
N/A