### PR TITLE
Moved Zscaler to Skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1396,6 +1396,7 @@
         "Symantec MSS": "No instance, probably not going to get it (issue 15513)",
         "EclecticIQ Platform": "Instance Issues",
         "Google Cloud Compute": "Can't test yet",
+        "Zscaler": "No license, will be unskipped once it is renewed",
 
 
       "_comment": "~~~ INSTANCE ISSUES ~~~",


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/16927

## Description
Moving Zscaler to skipped since we have no license.

## Does it break backward compatibility?
   - No
