### PR TITLE
Add Carbon Black Enterprise Protection V2 Test to skipped tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1501,7 +1501,8 @@
         "2cddaacb-4e4c-407e-8ef5-d924867b810c": "Skipped pending PR",
         "3da2e31b-f114-4d7f-8702-117f3b498de9": "Skipped pending PR",
         "d66e5f86-e045-403f-819e-5058aa603c32": "skipped until PR is merged (pr 3220)",
-        "113aca8a-ee52-419f-89a6-150ee232d0d1": "skipped until PR is merged (pr 3512)"
+        "113aca8a-ee52-419f-89a6-150ee232d0d1": "skipped until PR is merged (pr 3512)",
+        "Carbon Black Enterprise Protection V2 Test": "Data changes within Carbon Black on a weekly basis - which requires to update the test"
     },
     "skipped_integrations": {
       "_comment": "~~~ NO INSTANCE - will not be resolved ~~~",


### PR DESCRIPTION
## Status
Ready

## Description
skip Carbon Black test until test will be update