### PR TITLE
remove validation for email and password outputs

### DIFF
--- a/TestPlaybooks/playbook-InfoArmorVigilanteATITest.yml
+++ b/TestPlaybooks/playbook-InfoArmorVigilanteATITest.yml
@@ -1,6 +1,6 @@
-id: InfoArmorVigilanteATITest2
+id: InfoArmorVigilanteATITest
 version: -1
-name: InfoArmorVigilanteATITest2
+name: InfoArmorVigilanteATITest
 starttaskid: "0"
 tasks:
   "0":

--- a/TestPlaybooks/playbook-InfoArmorVigilanteATITest.yml
+++ b/TestPlaybooks/playbook-InfoArmorVigilanteATITest.yml
@@ -1,6 +1,6 @@
-id: InfoArmorVigilanteATITest
+id: InfoArmorVigilanteATITest2
 version: -1
-name: InfoArmorVigilanteATITest
+name: InfoArmorVigilanteATITest2
 starttaskid: "0"
 tasks:
   "0":
@@ -864,8 +864,6 @@ tasks:
     nexttasks:
       '#none#':
       - "35"
-      - "36"
-      - "37"
     scriptarguments:
       days_ago: {}
       domain:
@@ -1002,66 +1000,6 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 2440
-        }
-      }
-    note: false
-    timertriggers: []
-  "36":
-    id: "36"
-    taskid: 3ae50076-e77e-467b-82b6-6485b048aa95
-    type: regular
-    task:
-      id: 3ae50076-e77e-467b-82b6-6485b048aa95
-      version: -1
-      name: Verify output -  VigilanteATI.Domain.accounts.email
-      scriptName: VerifyContext
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "17"
-    scriptarguments:
-      expectedValue: {}
-      fields: {}
-      path:
-        simple: VigilanteATI.Domain.accounts.email
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 695,
-          "y": 2440
-        }
-      }
-    note: false
-    timertriggers: []
-  "37":
-    id: "37"
-    taskid: 4a85fcd7-0f41-4c04-8af4-a564a5acfd0c
-    type: regular
-    task:
-      id: 4a85fcd7-0f41-4c04-8af4-a564a5acfd0c
-      version: -1
-      name: Verify output -  VigilanteATI.Domain.accounts.password
-      scriptName: VerifyContext
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "17"
-    scriptarguments:
-      expectedValue: {}
-      fields: {}
-      path:
-        simple: VigilanteATI.Domain.accounts.password
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 1125,
           "y": 2440
         }
       }


### PR DESCRIPTION
## Status
Ready

## Related Issues
opened issue to be track later https://github.com/demisto/etc/issues/17022

## Description
The test failed because the command vigilante-query-domains output missing the email and the password for the account.

## Screenshots
![Screen Shot 2019-05-16 at 15 02 11](https://user-images.githubusercontent.com/46249224/57856555-002b2b00-77f6-11e9-8e5f-7ac0308da6ac.png)

![Screen Shot 2019-05-16 at 15 03 43](https://user-images.githubusercontent.com/46249224/57856583-0c16ed00-77f6-11e9-953f-ed18596988dc.png)
