### PR TITLE
FireeEye HX: Fixed issue where key exists but value was not checked.

### DIFF
--- a/Integrations/integration-FireEyeHX.yml
+++ b/Integrations/integration-FireEyeHX.yml
@@ -1137,7 +1137,9 @@ script:
             headers=ALERT_MAIN_ATTRIBUTES
         )
 
-        event_type = re.sub("([a-z])([A-Z])","\g<1> \g<2>",alert.get('event_type','NewEvent')).title()
+        event_type = alert.get('event_type')
+        event_type = 'NewEvent' if not event_type else event_type
+        event_type = re.sub("([a-z])([A-Z])","\g<1> \g<2>", event_type).title()
         event_table = tableToMarkdown(
             event_type,
             alert.get('event_values')
@@ -2237,7 +2239,8 @@ script:
 
     def parse_alert_to_incident(alert):
 
-        event_type = alert.get('event_type', 'NewEvent')
+        event_type = alert.get('event_type')
+        event_type = 'NewEvent' if not event_type else event_type
         event_values = alert.get('event_values', {})
         event_indicators_map = {
             'fileWriteEvent': 'fileWriteEvent/fileName',
@@ -3244,5 +3247,6 @@ script:
       domain names and IP addresses. '
   isfetch: true
   runonce: false
+releaseNotes: "Fixed issue which caused error when running fetch-incidents and get-alert."
 tests:
   - FireEye HX Test


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/13365

## Description
Fix issue where `<dict>.get(<key>, <default value>)` was used, but `<dict>[<key>]` had a value of `None`.

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests - no instance, was tested on production environment.
- [X] Documentation (with link to it) - unnecessary
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3
