### PR TITLE
fixed typo in get original email task

### DIFF
--- a/Playbooks/playbook-Get_Original_Email_-_EWS.yml
+++ b/Playbooks/playbook-Get_Original_Email_-_EWS.yml
@@ -305,7 +305,7 @@ tasks:
           accessor: itemId
       target-mailbox:
         complex:
-          root: inputs.mailbox
+          root: inputs.Mailbox
     reputationcalc: 2
     separatecontext: false
     view: |-
@@ -516,6 +516,7 @@ outputs:
 - contextPath: File
   description: Original attachments
   type: unknown
+releaseNotes: "-"
 tests:
   - Phishing test - attachment
   - Phishing test - Inline

--- a/Playbooks/playbook-Get_Original_Email_-_EWS.yml
+++ b/Playbooks/playbook-Get_Original_Email_-_EWS.yml
@@ -1,7 +1,7 @@
 id: get_original_email_-_ews
 version: -1
 name: Get Original Email - EWS
-fromversion: 4.0
+fromversion: 4.0.0
 description: |-
   Use this playbook to retrieve the original email in the thread, including headers and attahcments, when the reporting user forwarded the original email not as an attachment.
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17014

## Description
Typo in `Get original email` task input, target-mailbox must receive `inputs.Mailbox` instead of `inputs.mailbox`.

## Required version of Demisto
4.0.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Phishing Investigation - Generic v2
- [x] Phishing Investigation - Generic
- [x] Get Original Email - Generic
- [x] Process Email - Generic
- [x] Get Original Email - EWS


Tests:
- [x] Phishing v2 Test - Inline
- [x] process_email_-_generic_-_test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] Phishing v2 Test - Attachment
- [x] Phishing test - Inline