### PR TITLE
fix test playbook - change Context check condition

### DIFF
--- a/TestPlaybooks/playbook-CrowdStrike_Endpoint_Enrichment_-_Test.yml
+++ b/TestPlaybooks/playbook-CrowdStrike_Endpoint_Enrichment_-_Test.yml
@@ -172,10 +172,11 @@ tasks:
           left:
             value:
               simple: Endpoint.OS
+            iscontext: true
           right:
             value:
               simple: Windows
-        - operator: isEqualString
+        - operator: containsGeneral
           left:
             value:
               simple: Endpoint.OS


### PR DESCRIPTION
## Status
Ready

## Description
The test CrowdStrike Endpoint Enrichment - Test failed on the task `Context check` on validate if windows is in `Endpoint.OS` context path. I changed the condition type from 'As value' to 'From previous tasks'

## Screenshots
**before:**
![Screen Shot 2019-05-20 at 14 01 03](https://user-images.githubusercontent.com/46249224/58017224-4d661000-7b08-11e9-806f-4657af19ad08.png)

**after:**
![Screen Shot 2019-05-20 at 14 00 48](https://user-images.githubusercontent.com/46249224/58017237-5656e180-7b08-11e9-8172-757ab3c4f556.png)
