### PR TITLE
Add broken master notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
 version: 2
+experimental:
+  notify:
+    branches:
+      only:
+        - master
 jobs:
   build:
     docker:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: demisto/etc#17037

## Description
Changed build config to send chat notifications on build fail/restored to the content team slack channel

## Screenshots
<img width="443" alt="Screen Shot 2019-05-20 at 18 52 36" src="https://user-images.githubusercontent.com/42912128/58034981-77cbc380-7b30-11e9-8943-eba0a9c973cd.png">

## Does it break backward compatibility?
   - No

