### PR TITLE
PANW Cortex - handle logging query status

### DIFF
--- a/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.py
+++ b/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.py
@@ -661,8 +661,11 @@ def fetch_incidents():
         response_json = response.json()
         query_status = response_json.get('queryStatus', '')
         if query_status == 'JOB_FAILED':
-            raise Exception('Logging query job failed with status: JOB_FAILED')
+            raise Exception(f'Logging query job failed with status: JOB_FAILED\nResponse: {response.text}')
         elif query_status == 'RUNNING':
+            if isinstance(last_fetched_event_timestamp, datetime):
+                # In case we don't have query ID from previous run
+                last_fetched_event_timestamp = last_fetched_event_timestamp.strftime('%Y-%m-%dT%H:%M:%S.%f')
             # If query job is still running after 30 seconds (max timeout), pass it to next run
             demisto.setLastRun({
                 'last_fetched_event_timestamp': last_fetched_event_timestamp,

--- a/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.py
+++ b/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.py
@@ -211,10 +211,7 @@ def get_access_token():
     return access_token
 
 
-def query_loggings(query_data):
-    """
-    This function handles all the querying of Cortex Logging service
-    """
+def initial_logging_service():
     api_url = demisto.getIntegrationContext().get('api_url', 'https://api.us.paloaltonetworks.com')
     credentials = Credentials(
         access_token=get_access_token(),
@@ -224,6 +221,30 @@ def query_loggings(query_data):
         url=api_url,
         credentials=credentials
     )
+
+    return logging_service
+
+
+def poll_query_result(query_id):
+
+    logging_service = initial_logging_service()
+
+    poll_params = {  # Prepare 'poll' params
+        "maxWaitTime": 30000  # waiting for response up to 3000ms
+    }
+
+    # we poll the logging service until we have a complete response
+    response = logging_service.poll(query_id, 0, poll_params)
+
+    return response
+
+
+def query_loggings(query_data):
+    """
+    This function handles all the querying of Cortex Logging service
+    """
+
+    logging_service = initial_logging_service()
 
     response = logging_service.query(query_data)
     query_result = response.json()
@@ -238,17 +259,9 @@ def query_loggings(query_data):
         query_id = query_result['queryId']  # access 'queryId' from 'query' response
     except Exception as e:
         raise Exception('Received error %s when querying logs.' % e)
-    poll_params = {  # Prepare 'poll' params
-        "maxWaitTime": 3000  # waiting for response up to 3000ms
-    }
 
-    # we poll the logging service until we have a complete response
-    full_response = logging_service.poll(query_id, 0, poll_params)
-
-    # delete the query from the service
-    logging_service.delete(query_id)
-
-    return full_response
+    poll_response = poll_query_result(query_id)
+    return poll_response
 
 
 def transform_row_keys(row):
@@ -363,7 +376,11 @@ def query_logs_command():
     response = query_loggings(query_data)
 
     try:
-        result = response.json()['result']
+        response_json = response.json()
+        query_status = response_json.get('queryStatus', '')
+        if query_status in {'RUNNING', 'JOB_FAILED'}:
+            raise Exception(f'Logging query job failed with status: {query_status}')
+        result = response_json.get('result', {})
         pages = result['esResult']['hits']['hits']
         table_name = result['esQuery']['table'][0].split('.')[1]
     except ValueError:
@@ -608,32 +625,52 @@ def process_incident_pairs(incident_pairs, max_incidents):
 
 
 def fetch_incidents():
-    last_fetched_event_timestamp = demisto.getLastRun().get('last_fetched_event_timestamp')
-    if last_fetched_event_timestamp is not None:
-        last_fetched_event_timestamp = datetime.strptime(last_fetched_event_timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+
+    last_run = demisto.getLastRun()
+    last_fetched_event_timestamp = last_run.get('last_fetched_event_timestamp')
+    last_query_id = last_run.get('last_query_id')
+
+    if last_query_id:
+        # Need to poll query results fron last run
+        response = poll_query_result(last_query_id)
     else:
-        last_fetched_event_timestamp, _ = parse_date_range(FIRST_FETCH_TIMESTAMP)
+        if last_fetched_event_timestamp is not None:
+            last_fetched_event_timestamp = datetime.strptime(last_fetched_event_timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+        else:
+            last_fetched_event_timestamp, _ = parse_date_range(FIRST_FETCH_TIMESTAMP)
 
-    # Need sometime in the future, so the timestamp will be taken from the query
-    service_end_date_epoch = int(datetime.now().strftime('%s')) + 1000
+        # Need sometime in the future, so the timestamp will be taken from the query
+        service_end_date_epoch = int(datetime.now().strftime('%s')) + 1000
 
-    if 'Firewall' in FETCH_QUERY:  # type: ignore
-        fetch_timestamp = int(last_fetched_event_timestamp.strftime('%s'))
-    elif 'Traps' in FETCH_QUERY:  # type: ignore
-        fetch_timestamp = last_fetched_event_timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        if 'Firewall' in FETCH_QUERY:  # type: ignore
+            fetch_timestamp = int(last_fetched_event_timestamp.strftime('%s'))
+        elif 'Traps' in FETCH_QUERY:  # type: ignore
+            fetch_timestamp = last_fetched_event_timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
-    query = prepare_fetch_query(fetch_timestamp)
+        query = prepare_fetch_query(fetch_timestamp)
 
-    query_data = {
-        'query': query,
-        'startTime': 0,
-        'endTime': service_end_date_epoch,
-    }
+        query_data = {
+            'query': query,
+            'startTime': 0,
+            'endTime': service_end_date_epoch,
+        }
 
-    response = query_loggings(query_data)
+        response = query_loggings(query_data)
 
     try:
-        result = response.json()['result']
+        response_json = response.json()
+        query_status = response_json.get('queryStatus', '')
+        if query_status == 'JOB_FAILED':
+            raise Exception('Logging query job failed with status: JOB_FAILED')
+        elif query_status == 'RUNNING':
+            # If query job is still running after 30 seconds (max timeout), pass it to next run
+            demisto.setLastRun({
+                'last_fetched_event_timestamp': last_fetched_event_timestamp,
+                'last_query_id': response_json.get('queryId', '')
+            })
+            demisto.incidents([])
+            return
+        result = response_json.get('result', {})
         pages = result['esResult']['hits']['hits']
     except ValueError:
         raise Exception('Failed to parse the response from Cortex')

--- a/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.yml
+++ b/Integrations/PaloAltoNetworksCortex/PaloAltoNetworksCortex.yml
@@ -198,14 +198,14 @@ script:
       type: Unknown
   - arguments:
     - default: false
-      defaultValue: Thu Jan 01 02:00:00 IST 1970
+      defaultValue: '1970-01-01 00:00:00'
       description: The query start time. For example, startTime="2018-04-26 00:00:00"
       isArray: false
       name: startTime
       required: false
       secret: false
     - default: false
-      defaultValue: Wed Jan 01 02:00:00 IST 2020
+      defaultValue: '2020-01-01 00:00:00'
       description: The query end time. For example, endTime="2018-04-26 00:00:00"
       isArray: false
       name: endTime
@@ -327,14 +327,14 @@ script:
       type: Unknown
   - arguments:
     - default: false
-      defaultValue: Thu Jan 01 02:00:00 IST 1970
+      defaultValue: '1970-01-01 00:00:00'
       description: Query start time. For example, startTime="2018-04-26 00:00:00"
       isArray: false
       name: startTime
       required: false
       secret: false
     - default: false
-      defaultValue: Wed Jan 01 02:00:00 IST 2020
+      defaultValue: '2020-01-01 00:00:00'
       description: Query end time. For example, endTime="2018-04-26 00:00:00"
       isArray: false
       name: endTime
@@ -441,14 +441,14 @@ script:
       type: Unknown
   - arguments:
     - default: false
-      defaultValue: Thu Jan 01 02:00:00 IST 1970
+      defaultValue: '1970-01-01 00:00:00'
       description: The query start time. For example, startTime="2018-04-26 00:00:00"
       isArray: false
       name: startTime
       required: false
       secret: false
     - default: false
-      defaultValue: Wed Jan 01 02:00:00 IST 2020
+      defaultValue: '2020-01-01 00:00:00'
       description: The query end time. For example, endTime="2018-04-26 00:00:00"
       isArray: false
       name: endTime

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1552,7 +1552,6 @@
         "RSA NetWitness Endpoint": "Instance is down, waiting for devops to rebuild",
         "BitDam": "Changes in service (issue #16247)",
         "Zoom": "Added here because test existed but was not configured - need to review the test",
-        "Palo Alto Networks Cortex": "Changing the auth flow, will unskip when ready",
 
       "_comment": "~~~ QUOTA ISSUES ~~~",
         "Joe Security": "Monthly quota exceeded, remove from skipped on or after April 1st",


### PR DESCRIPTION
## Status
Ready

## Description
Added handling for logging query status.
Increased the max time out of logging query to 30 seconds.
For commands, if query status is `RUNNING` or `FAILED` - an error will be raised.
For fetch, if status is `RUNNING`, the query id will be passed to next run, which will try poll the results of query job is finished.
Removed the deletion of query from the service cause it is not longer needed in current sdk version.

## Required version of Demisto
4.1
## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation
- [ ] Code Review

## Dependencies
None

