### PR TITLE
Enabled keeping the existing data in update-policy

### DIFF
--- a/Integrations/integration-Fortigate.yml
+++ b/Integrations/integration-Fortigate.yml
@@ -119,6 +119,26 @@ script:
             return addr_string
 
 
+    def bool_to_str(str_representing_bool):
+        return str_representing_bool and str_representing_bool.lower() == 'true'
+
+
+    def generate_src_or_dst_request_data(policy_id, policy_field, policy_field_value, keep_original_data, add_or_remove):
+        address_list_for_request = policy_field_value.split(",")
+        if bool_to_str(keep_original_data):
+            policy_data = get_policy_request(policy_id)[0] # the return value is an array with one element
+            existing_adresses_list = policy_data.get(policy_field)
+            existing_adresses_list = [address_data["name"] for address_data in existing_adresses_list]
+            if add_or_remove.lower() == "add":
+                for address in existing_adresses_list:
+                    if not address in address_list_for_request:
+                        address_list_for_request.append(address)
+            else:
+                address_list_for_request = [address for address in existing_adresses_list if address not in address_list_for_request]
+        address_data_dicts_for_request = policy_addr_array_from_arg(address_list_for_request, False)
+        return address_data_dicts_for_request
+
+
     def logout(session):
         """
         Due to limited amount of simultaneous connections we log out after each API request. Simple post request to /logout endpoint without params.
@@ -127,8 +147,9 @@ script:
         params = {}
         session.post(SERVER+url_suffix, data=params, verify=USE_SSL)
 
-    def policy_addr_array_from_arg(policy_addr_str):
-        policy_adr_str_array = policy_addr_str.split(",")
+    def policy_addr_array_from_arg(policy_addr_data, is_data_string = True):
+        # if the data isn't in string format, it's already an array and requires no formatting
+        policy_adr_str_array = policy_addr_data.split(",") if is_data_string else policy_addr_data
         policy_addr_dict_array = []
         for src_addr_name in policy_adr_str_array:
             cur_addr_dict = {
@@ -523,8 +544,13 @@ script:
         policy_id = demisto.args().get('policyID')
         policy_field = demisto.args().get('field')
         policy_field_value = demisto.args().get('value')
+        keep_original_data = demisto.args().get('keep_original_data')
+        add_or_remove = demisto.args().get('add_or_remove')
 
-        update_policy = update_policy_request(policy_id, policy_field, policy_field_value)
+        if keep_original_data and keep_original_data.lower() == 'true' and not add_or_remove:
+            return_error("Error: add_or_remove must be specified if keep_original_data is true.")
+
+        update_policy = update_policy_request(policy_id, policy_field, policy_field_value, keep_original_data, add_or_remove)
         policy = get_policy_request(policy_id)[0]
         all_security_profiles = [ policy.get('webfilter-profile'), policy.get('ssl-ssh-profile'), policy.get('dnsfilter-profile'),                                                                                                     policy.get('profile-protocol-options'), policy.get('profile-type'), policy.get('av-profile') ]
 
@@ -581,7 +607,7 @@ script:
         })
 
 
-    def update_policy_request(policy_id, policy_field, policy_field_value):
+    def update_policy_request(policy_id, policy_field, policy_field_value, keep_original_data, add_or_remove):
         uri_suffix = 'cmdb/firewall/policy/' + policy_id
         if not does_path_exist(uri_suffix):
             return_error('Requested policy ID ' + policy_id + ' does not exist in Firewall config.')
@@ -597,7 +623,8 @@ script:
             policy_field = field_to_api_key[policy_field]
 
         if policy_field in {'srcaddr', 'dstaddr'}:
-            policy_field_value = policy_addr_array_from_arg(policy_field_value)
+            policy_field_value = generate_src_or_dst_request_data(policy_id, policy_field, policy_field_value, keep_original_data, add_or_remove)
+
         payload = {
             'policyid': int(policy_id),
             'q_origin_key': int(policy_id),
@@ -1176,6 +1203,23 @@ script:
     - name: value
       required: true
       description: Value of field parameter to update
+    - name: keep_original_data
+      auto: PREDEFINED
+      predefined:
+      - "true"
+      - "false"
+      description: Whether to keep the original data or not. Only relevant if the
+        updated field is "source" or "destination". If the supplied value is 'True',
+        the current data will not be replaced. Instead, the supplied addresses will
+        be added / removed from the existing data.
+    - name: add_or_remove
+      auto: PREDEFINED
+      predefined:
+      - add
+      - remove
+      description: Whether to add or remove the supplied addresses from the existing
+        data. Only relevant in case the field to update is "source" or "destination",
+        and keep_original_data is specified to 'True'.
     outputs:
     - contextPath: Fortigate.Policy.Name
       description: Policy name
@@ -1401,6 +1445,4 @@ script:
       type: boolean
     description: Delete an address group from FortiGate firewall
   runonce: false
-releaseNotes: "Fixed bug with src and dst addresses in human readable. Fixed policy creation - now supports multiple sources / destinations. Fixed update policy bug, now the command works. "
-tests:
-  - Fortigate Test
+releaseNotes: "Added enhancement to update-policy, enabled keeping the existing data."

--- a/Integrations/integration-Fortigate.yml
+++ b/Integrations/integration-Fortigate.yml
@@ -119,22 +119,23 @@ script:
             return addr_string
 
 
-    def bool_to_str(str_representing_bool):
+    def str_to_bool(str_representing_bool):
         return str_representing_bool and str_representing_bool.lower() == 'true'
 
 
     def generate_src_or_dst_request_data(policy_id, policy_field, policy_field_value, keep_original_data, add_or_remove):
         address_list_for_request = policy_field_value.split(",")
-        if bool_to_str(keep_original_data):
+        if str_to_bool(keep_original_data):
             policy_data = get_policy_request(policy_id)[0] # the return value is an array with one element
             existing_adresses_list = policy_data.get(policy_field)
             existing_adresses_list = [address_data["name"] for address_data in existing_adresses_list]
             if add_or_remove.lower() == "add":
                 for address in existing_adresses_list:
-                    if not address in address_list_for_request:
+                    if address not in address_list_for_request:
                         address_list_for_request.append(address)
             else:
                 address_list_for_request = [address for address in existing_adresses_list if address not in address_list_for_request]
+
         address_data_dicts_for_request = policy_addr_array_from_arg(address_list_for_request, False)
         return address_data_dicts_for_request
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17186

## Description
The update-policy command used to replace the existing data with the arguments supplied.
Now there is a possibility to keep the existing data and add / remove the supplied arguments to it.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Documentation (with link to it)
- [ ] Code Review
