### PR TITLE
Fix local file validation

### DIFF
--- a/Tests/scripts/validate_files.py
+++ b/Tests/scripts/validate_files.py
@@ -72,7 +72,10 @@ class FilesValidator(object):
 
             if checked_type(file_path, CODE_FILES_REGEX) and file_status.lower() != 'd':
                 dir_path = os.path.dirname(file_path)
-                file_path = glob.glob(dir_path + "/*.yml")[0]
+                try:
+                    file_path = list(filter(lambda x: not x.endswith('unified.yml'), glob.glob(dir_path + "/*.yml")))[0]
+                except IndexError:
+                    continue
             elif file_path.endswith('.js') or file_path.endswith('.py'):
                 continue
 


### PR DESCRIPTION
## Status
Ready

## Description
Fixes the issue of `validate_files.py` trying to validate `*_unified.yml` files locally if they appear before the integration yml in a given directory.
Also on occasion the `get_modified_files` function would raise an `IndexError`. I believe that that this would occur when `glob.glob` didn't return any results because the directory (and files of the directory) of the modified file in the list of modified files in `origin/master` do not exist in the local branch being worked on. Now the loop will continue if this happens.

## Screenshots
The `validate_files.py` mistakenly trying to validate an unstaged `*_unified.yml` file.
![image](https://user-images.githubusercontent.com/46294017/58494967-ecc97980-817e-11e9-953c-45b4f13424de.png)

## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - Don't think so

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Pre-commit hooks
