### PR TITLE
Added transformer FormattedDateToEpoch (#3491)

### DIFF
--- a/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.py
+++ b/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.py
@@ -1,6 +1,4 @@
 import demistomock as demisto
-from CommonServerPython import *
-from CommonServerUserPython import *
 from datetime import datetime
 
 date_value = demisto.args()['value']

--- a/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.py
+++ b/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.py
@@ -1,0 +1,11 @@
+import demistomock as demisto
+from CommonServerPython import *
+from CommonServerUserPython import *
+from datetime import datetime
+
+date_value = demisto.args()['value']
+formatter = demisto.args()['formatter']
+
+date_obj = datetime.strptime(date_value, formatter)
+
+demisto.results(int(date_obj.strftime('%s')))

--- a/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.yml
+++ b/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.yml
@@ -2,15 +2,7 @@ commonfields:
   id: FormattedDateToEpoch
   version: -1
 name: FormattedDateToEpoch
-script: |-
-  import datetime
-
-  dateValue = demisto.args()['value']
-  formatter = demisto.args()['formatter']
-
-  dateObj = datetime.datetime.strptime(dateValue, formatter)
-
-  demisto.results(int(dateObj.strftime('%s')))
+script: '-'
 type: python
 tags:
 - transformer
@@ -24,9 +16,10 @@ args:
   required: true
   description: Time stamp to convert
 - name: formatter
+  defaultValue: '%Y-%m-%dT%H:%M:%S'
   required: true
   description: Python 'strptime' formatter string
 scripttarget: 0
 runonce: false
-dockerimage: demisto/python3
+dockerimage: demisto/python3:3.7.3.286
 runas: DBotWeakRole

--- a/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.yml
+++ b/Scripts/FormattedDateToEpoch/FormattedDateToEpoch.yml
@@ -23,3 +23,5 @@ scripttarget: 0
 runonce: false
 dockerimage: demisto/python3:3.7.3.286
 runas: DBotWeakRole
+tests:
+  - FormattedDateToEpochTest

--- a/Scripts/script-FormattedDateToEpoch.yml
+++ b/Scripts/script-FormattedDateToEpoch.yml
@@ -1,0 +1,32 @@
+commonfields:
+  id: FormattedDateToEpoch
+  version: -1
+name: FormattedDateToEpoch
+script: |-
+  import datetime
+
+  dateValue = demisto.args()['value']
+  formatter = demisto.args()['formatter']
+
+  dateObj = datetime.datetime.strptime(dateValue, formatter)
+
+  demisto.results(int(dateObj.strftime('%s')))
+type: python
+tags:
+- transformer
+- date
+comment: 'Converts a custom-formatted timestamp to UNIX epoch time. Use it to convert
+  custom time stamps to a Demisto date field.  Uses the python strptime format.  For
+  more info, see: https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior'
+enabled: true
+args:
+- name: value
+  required: true
+  description: Time stamp to convert
+- name: formatter
+  required: true
+  description: Python 'strptime' formatter string
+scripttarget: 0
+runonce: false
+dockerimage: demisto/python3
+runas: DBotWeakRole

--- a/TestPlaybooks/playbook-FormattedDateToEpochTest.yml
+++ b/TestPlaybooks/playbook-FormattedDateToEpochTest.yml
@@ -1,0 +1,568 @@
+id: FormattedDateToEpochTest
+version: 10
+name: FormattedDateToEpochTest
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: b9afd8b5-96f7-49b4-81a9-409d7ce15406
+    type: start
+    task:
+      id: b9afd8b5-96f7-49b4-81a9-409d7ce15406
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "13"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+  "1":
+    id: "1"
+    taskid: 77e962c5-7e72-4a3d-8419-edb07f578cbf
+    type: regular
+    task:
+      id: 77e962c5-7e72-4a3d-8419-edb07f578cbf
+      version: -1
+      name: Check 1991-05-20T20:37:43.000Z
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      append: {}
+      key:
+        simple: TimeToCheck_1
+      value:
+        simple: 1991-05-20T20:37:43.000Z
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "3":
+    id: "3"
+    taskid: 8189ee47-c322-4ab0-88ce-5307a0dcb360
+    type: regular
+    task:
+      id: 8189ee47-c322-4ab0-88ce-5307a0dcb360
+      version: -1
+      name: Convert to Epoch 1
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "12"
+    scriptarguments:
+      append: {}
+      key:
+        simple: Epoch_1
+      value:
+        complex:
+          root: TimeToCheck_1
+          transformers:
+          - operator: FormattedDateToEpoch
+            args:
+              formatter:
+                value:
+                  simple: '%Y-%m-%dT%H:%M:%S.%fZ'
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+  "4":
+    id: "4"
+    taskid: 7de6bc45-3ffa-4dce-8055-1b6a638dbc1c
+    type: regular
+    task:
+      id: 7de6bc45-3ffa-4dce-8055-1b6a638dbc1c
+      version: -1
+      name: Check 20:51:20
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+    scriptarguments:
+      append: {}
+      key:
+        simple: TimeToCheck_3
+      value:
+        simple: "20:51:20"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1165,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "5":
+    id: "5"
+    taskid: 4de18348-8498-428e-8470-0e4c08d3cba7
+    type: regular
+    task:
+      id: 4de18348-8498-428e-8470-0e4c08d3cba7
+      version: -1
+      name: Check 20-05-1991
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      append: {}
+      key:
+        simple: TimeToCheck_2
+      value:
+        simple: 20-05-1991
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+  "6":
+    id: "6"
+    taskid: ad9fe73f-5802-44fb-8dc4-a65d9f8e6331
+    type: regular
+    task:
+      id: ad9fe73f-5802-44fb-8dc4-a65d9f8e6331
+      version: -1
+      name: Convert to Epoch 2
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "11"
+    scriptarguments:
+      append: {}
+      key:
+        simple: Epoch_2
+      value:
+        complex:
+          root: TimeToCheck_2
+          transformers:
+          - operator: FormattedDateToEpoch
+            args:
+              formatter:
+                value:
+                  simple: '%d-%m-%Y'
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+  "7":
+    id: "7"
+    taskid: 8a67f5a2-4997-4c64-84b2-affa3806da00
+    type: regular
+    task:
+      id: 8a67f5a2-4997-4c64-84b2-affa3806da00
+      version: -1
+      name: Convert to Epoch 3
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      append: {}
+      key:
+        simple: Epoch_3
+      value:
+        complex:
+          root: TimeToCheck_3
+          transformers:
+          - operator: FormattedDateToEpoch
+            args:
+              formatter:
+                value:
+                  simple: '%H:%M:%S'
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1165,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+  "8":
+    id: "8"
+    taskid: 328738a9-c2dc-4fc2-8cd7-f4e49a5a399e
+    type: condition
+    task:
+      id: 328738a9-c2dc-4fc2-8cd7-f4e49a5a399e
+      version: -1
+      name: Validate result 3
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "14"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualNumber
+          left:
+            value:
+              simple: ${Epoch_3}
+            iscontext: true
+          right:
+            value:
+              simple: "-2208913720"
+    view: |-
+      {
+        "position": {
+          "x": 1165,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "9":
+    id: "9"
+    taskid: d141d4f3-2567-460c-85df-75a099f14e98
+    type: title
+    task:
+      id: d141d4f3-2567-460c-85df-75a099f14e98
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 1225
+        }
+      }
+    note: false
+    timertriggers: []
+  "10":
+    id: "10"
+    taskid: e60e6ea4-a14a-474b-8b3a-62d31b0d7b9d
+    type: regular
+    task:
+      id: e60e6ea4-a14a-474b-8b3a-62d31b0d7b9d
+      version: -1
+      name: Error
+      description: Prints an error entry with a given message
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    scriptarguments:
+      message:
+        simple: Conversion to epoch failed
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -380,
+          "y": 1130
+        }
+      }
+    note: false
+    timertriggers: []
+  "11":
+    id: "11"
+    taskid: cc7336f0-7aa0-407f-8418-ca6bc8f8f2e4
+    type: condition
+    task:
+      id: cc7336f0-7aa0-407f-8418-ca6bc8f8f2e4
+      version: -1
+      name: Validate result 2
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "16"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualNumber
+          left:
+            value:
+              simple: ${Epoch_2}
+            iscontext: true
+          right:
+            value:
+              simple: "674697600"
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "12":
+    id: "12"
+    taskid: f249a134-6e1b-41cb-8030-2fe096bdcf56
+    type: condition
+    task:
+      id: f249a134-6e1b-41cb-8030-2fe096bdcf56
+      version: -1
+      name: Validate result 1
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "15"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualNumber
+          left:
+            value:
+              simple: ${Epoch_1}
+            iscontext: true
+          right:
+            value:
+              simple: "674771863"
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+  "13":
+    id: "13"
+    taskid: be2ea045-f961-44c9-8196-e1a25bbe2b99
+    type: regular
+    task:
+      id: be2ea045-f961-44c9-8196-e1a25bbe2b99
+      version: -1
+      name: Start Clean
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
+      - "1"
+      - "4"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+  "14":
+    id: "14"
+    taskid: bfccaae9-9902-4d80-8f70-83e62166ff05
+    type: condition
+    task:
+      id: bfccaae9-9902-4d80-8f70-83e62166ff05
+      version: -1
+      name: Convert back to ISO date 3
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "9"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: Epoch_3
+                transformers:
+                - operator: TimeStampToDate
+            iscontext: true
+          right:
+            value:
+              simple: 1900-01-01T20:51:20.000Z
+    view: |-
+      {
+        "position": {
+          "x": 1165,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+  "15":
+    id: "15"
+    taskid: d8580132-d0f3-4e50-88f6-0f6aa1141b45
+    type: condition
+    task:
+      id: d8580132-d0f3-4e50-88f6-0f6aa1141b45
+      version: -1
+      name: Convert back to ISO date 1
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "9"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: Epoch_1
+                transformers:
+                - operator: TimeStampToDate
+            iscontext: true
+          right:
+            value:
+              simple: 1991-05-20T20:37:43.000Z
+    view: |-
+      {
+        "position": {
+          "x": 602.5,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+  "16":
+    id: "16"
+    taskid: c8b82ef9-06b1-4c95-8d30-e610bc6e1b63
+    type: condition
+    task:
+      id: c8b82ef9-06b1-4c95-8d30-e610bc6e1b63
+      version: -1
+      name: Convert back to ISO date 2
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "10"
+      "yes":
+      - "9"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: Epoch_2
+                transformers:
+                - operator: TimeStampToDate
+            iscontext: true
+          right:
+            value:
+              simple: 1991-05-20T00:00:00.000Z
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1240,
+        "width": 1925,
+        "x": -380,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -162,6 +162,9 @@
             "playbookID": "Fortigate Test"
         },
         {
+            "playbookID": "FormattedDateToEpochTest"
+        },
+        {
             "integrations": "SNDBOX",
             "playbookID": "SNDBOX_Test"
         },


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress

## Related PRs
external PR
fixes: https://github.com/demisto/content/pull/3491

## Description
New transformer which converts a custom-formatted timestamp to a UNIX epoch time, using a Python strptime format string. Very useful for converting custom timestamps to a Demisto date field. Parameters are the string to convert (value), and the formatter string (formatter). Valid formatter values can be found at https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior.


## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review