### PR TITLE
Now CRLF!

### DIFF
--- a/TestData/Malicious_attachment_simple_phishing.eml
+++ b/TestData/Malicious_attachment_simple_phishing.eml
@@ -17,7 +17,7 @@ This is the body. Enjoy the files
 --00000000000056b82a058aa51faa
 Content-Type: text/html; charset="UTF-8"
 
-<div dir="ltr">This is the body. Enjoy the files</div>
+<div dir="ltr">This is the body. Enjoy the files.</div>
 
 --00000000000056b82a058aa51faa--
 --00000000000056b831058aa51fac


### PR DESCRIPTION

## Status
Ready

## Description
I was having problems with the EML file having LF line separators, instead of CRLF.
There were lots of issues with forcing the CRLF change. Trying it now here.
The reason for this is that `Process Email - Generic` has a conditional task with a DT that expects CRLF but not LF, so LF EMLs are not detected as attached emails.

## Related PRs
https://github.com/demisto/content/pull/3656/

## Does it break backward compatibility?
   - No

