### PR TITLE
Extract Indicators From File - Generic and v2 fix

### DIFF
--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic.yml
@@ -485,22 +485,6 @@ tasks:
                     right:
                       value:
                         simple: Microsoft Word
-                  - operator: isEqualString
-                    left:
-                      value:
-                        simple: File.Info
-                      iscontext: true
-                    right:
-                      value:
-                        simple: doc
-                  - operator: isEqualString
-                    left:
-                      value:
-                        simple: File.Info
-                      iscontext: true
-                    right:
-                      value:
-                        simple: docx
                 - - operator: isNotEqualString
                     left:
                       value:
@@ -636,22 +620,6 @@ tasks:
               right:
                 value:
                   simple: Microsoft Word
-            - operator: isEqualString
-              left:
-                value:
-                  simple: File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: doc
-            - operator: isEqualString
-              left:
-                value:
-                  simple: File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: docx
           - - operator: isNotEqualString
               left:
                 value:
@@ -725,6 +693,7 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
@@ -780,6 +749,6 @@ outputs:
 - contextPath: URL.Data
   description: List of URLs that were extracted from the PDF file
   type: unknown
-releaseNotes: "Fixed mistaken identification of excel files as word documents."
+releaseNotes: "Fixed mistaken identification of excel files as word document. Word document check now ignores file info data"
 tests:
   - Extract Indicators From File - test

--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
@@ -495,22 +495,6 @@ tasks:
                     right:
                       value:
                         simple: Microsoft Word
-                  - operator: isEqualString
-                    left:
-                      value:
-                        simple: File.Info
-                      iscontext: true
-                    right:
-                      value:
-                        simple: doc
-                  - operator: isEqualString
-                    left:
-                      value:
-                        simple: File.Info
-                      iscontext: true
-                    right:
-                      value:
-                        simple: docx
                 - - operator: isNotEqualString
                     left:
                       value:
@@ -998,6 +982,6 @@ outputs:
 - contextPath: URL.Data
   description: List of URLs that were extracted from the PDF file.
   type: unknown
-releaseNotes: "Extracts images and text from PDF files. Images are extractd using the Image OCR integration."
+releaseNotes: "Extracts images and text from PDF files. Images are extractd using the Image OCR integration. "
 tests:
   - Extract Indicators From File - Generic v2 - Test


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17351

## Description
Removed `File.Info` check for word files in the playbooks `Extract Indicators From File - Generic` after a customer encountered a malicious file that pretended to have file info of doc. The reason I removed it and not changed it to an `and` condition is because while testing the condition I found online some word files that did not have doc or docx file info, as such the field is unreliable.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation (with link to it)
- [ ] Code Review