### PR TITLE
trying to upload CRLF

### DIFF
--- a/TestData/Malicious_attachment_simple_phishing.eml
+++ b/TestData/Malicious_attachment_simple_phishing.eml
@@ -1,40 +1,40 @@
 MIME-Version: 1.0
-Date: Thu, 6 Jun 2019 13:24:43 +0300
-Message-ID: <CAJaFoecd2+wJ_ypaAimWSCdBOorfo+WzJZVB2ZQFZmbWLEsAsA@mail.gmail.com>
+Date: Thu, 6 Jun 2019 16:17:41 +0300
+Message-ID: <CAJaFoefy_acEKaqSMGfojbLzKoUnzfpPcnNemuD6K0oQZ2PikQ@mail.gmail.com>
 Subject: This is the subject
 From: Example Man <example1@example.com>
 To: Example Woman <example2@example.com>
-Content-Type: multipart/mixed; boundary="00000000000056b831058aa51fac"
+Content-Type: multipart/mixed; boundary="000000000000e5d161058aa7893a"
 
---00000000000056b831058aa51fac
-Content-Type: multipart/alternative; boundary="00000000000056b82a058aa51faa"
+--000000000000e5d161058aa7893a
+Content-Type: multipart/alternative; boundary="000000000000e5d15a058aa78938"
 
---00000000000056b82a058aa51faa
+--000000000000e5d15a058aa78938
 Content-Type: text/plain; charset="UTF-8"
 
-This is the body. Enjoy the files
+This is the body
 
---00000000000056b82a058aa51faa
+--000000000000e5d15a058aa78938
 Content-Type: text/html; charset="UTF-8"
 
-<div dir="ltr">This is the body. Enjoy the files</div>
+<div dir="ltr">This is the body</div>
 
---00000000000056b82a058aa51faa--
---00000000000056b831058aa51fac
+--000000000000e5d15a058aa78938--
+--000000000000e5d161058aa7893a
 Content-Type: text/plain; charset="US-ASCII"; name="malicious_present_url.txt"
 Content-Disposition: attachment; filename="malicious_present_url.txt"
 Content-Transfer-Encoding: base64
-X-Attachment-Id: f_jwkik7kh1
-Content-ID: <f_jwkik7kh1>
+X-Attachment-Id: f_jwkor4tj1
+Content-ID: <f_jwkor4tj1>
 
 aHR0cDovL3d3dy5ndWdvcmlzdG9iYXIuaXQvdmVydGVtYXRlL2NzY3MvDQpodHRwczovL2Ricy1z
 dXBwb3J0LWluZm8uY29tL2FwL2RiLw==
---00000000000056b831058aa51fac
+--000000000000e5d161058aa7893a
 Content-Type: application/pdf; name="malicious_pdf_3.pdf"
 Content-Disposition: attachment; filename="malicious_pdf_3.pdf"
 Content-Transfer-Encoding: base64
-X-Attachment-Id: f_jwkijpb10
-Content-ID: <f_jwkijpb10>
+X-Attachment-Id: f_jwkor4t30
+Content-ID: <f_jwkor4t30>
 
 JVBERi0xLjcNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFIvTGFu
 Zyhlbi1VUykgL1N0cnVjdFRyZWVSb290IDE1IDAgUi9NYXJrSW5mbzw8L01hcmtlZCB0cnVlPj4v
@@ -1194,4 +1194,4 @@ JUVPRg0KeHJlZg0KMCAwDQp0cmFpbGVyDQo8PC9TaXplIDQ0L1Jvb3QgMSAwIFIvSW5mbyAxNCAw
 IFIvSURbPDM1MENBRjFGRjI2QjBBNDFCMTcwQjdDQkM1MzMxMDRGPjwzNTBDQUYxRkYyNkIwQTQx
 QjE3MEI3Q0JDNTMzMTA0Rj5dIC9QcmV2IDY0NzQ3L1hSZWZTdG0gNjQ0MTM+Pg0Kc3RhcnR4cmVm
 DQo2NTc4NA0KJSVFT0Y=
---00000000000056b831058aa51fac--
+--000000000000e5d161058aa7893a--


### PR DESCRIPTION
## Description
I was having problems with the EML file having LF line separators, instead of CRLF.
There were lots of issues with forcing the CRLF change. Trying it now here.
The reason for this is that `Process Email - Generic` has a conditional task with a DT that expects CRLF but not LF, so LF EMLs are not detected as attached emails.


## Does it break backward compatibility?
   - No
