### PR TITLE
Parse email files fix bugs

### DIFF
--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3409,7 +3409,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                         and attachment_file_name.endswith(".eml")):
 
                     # .eml files
-                    file_content = None
+                    file_content = ""  # type: str
                     base64_encoded = "base64" in part.get("Content-Transfer-Encoding", "")
 
                     if isinstance(part.get_payload(), list) and len(part.get_payload()) > 0:

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3554,11 +3554,6 @@ def main():
             "Failed to load file entry with entry id: {}. Error: {}".format(
                 entry_id, str(ex) + "\n\nTrace:\n" + traceback.format_exc()))
 
-    # parse_only_headers = False
-    # max_depth = 3
-    # file_type = "rfc 822 mail text, ascii text, with crlf line terminators"
-    # file_name = "[WO0000001423906]Analisi mail spam.eml"
-    # file_path = "/Users/aazadaliyev/Downloads/[WO0000001423906]Analisi mail spam.eml"
     try:
         file_type_lower = file_type.lower()
         if 'composite document file v2 document' in file_type_lower \

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3416,22 +3416,6 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                     if "base64" in part.get("Content-Transfer-Encoding", ""):
                         base64_encoded = True
                         file_content = part.get_payload()
-                        # attachment_file_name = part.get("Content-Description")
-                        # if attachment_file_name == "":
-                        #     # if there is no such header "Content-Description"
-                        #     # then we will check for file name from "Content-Type"
-                        #     if "name=" in part.get("Content-Type", ""):
-                        #         attachment_file_name = re.search(r'name=".+"$', part.get("Content-Type", "")).group()\
-                        #             .replace('name=', '').replace('"', '')
-                        #
-                        # if attachment_file_name == "":
-                        #     # if we still haven't found the name of the file then we should try to look in
-                        #     # Content-Disposition header
-                        #     # Example:
-                        #     # Content - Disposition: attachment; filename = "some+example.eml"; size = 15380;
-                        #     if "filename=" in part.get("Content-Disposition", ""):
-                        #         attachment_file_name = re.search(r'filename=".+"', part.get("Content-Disposition", ""))\
-                        #             .group().replace('filename=', '').replace('"', '')
 
                     elif not base64_encoded and isinstance(part.get_payload(), list) and len(part.get_payload()) > 0:
                         if attachment_file_name is None or attachment_file_name == "":

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -368,3 +368,48 @@ def test_eml_contains_eml_with_status(mocker):
     assert len(results) == 1
     assert results[0]['Type'] == entryTypes['note']
     assert results[0]['EntryContext']['Email'][1]['Subject'] == subject_attach
+
+
+def test_eml_contains_base64_encoded_eml(mocker):
+    def executeCommand(name, args=None):
+        if name == 'getFilePath':
+            return [
+                {
+                    'Type': entryTypes['note'],
+                    'Contents': {
+                        'path': 'test_data/Fwd_test-inner_attachment_eml.eml',
+                        'name': 'Fwd_test-inner_attachment_eml.eml'
+                    }
+                }
+            ]
+        elif name == 'getEntry':
+            return [
+                {
+                    'Type': entryTypes['file'],
+                    'FileMetadata': {
+                        'info': 'news or mail text, ASCII text'
+                    }
+                }
+            ]
+        else:
+            raise ValueError('Unimplemented command called: {}'.format(name))
+
+    mocker.patch.object(demisto, 'args', return_value={'entryid': 'test'})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=executeCommand)
+    mocker.patch.object(demisto, 'results')
+    # validate our mocks are good
+    assert demisto.args()['entryid'] == 'test'
+
+    main()
+    assert demisto.results.call_count == 5
+    # call_args is tuple (args list, kwargs). we only need the first one
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0]['Type'] == entryTypes['note']
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Fwd: test - inner attachment eml'
+    assert 'ArcSight_ESM_fixes.yml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert 'test - inner attachment eml.eml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert results[0]['EntryContext']['Email'][0]['Depth'] == 0
+
+    assert results[0]['EntryContext']['Email'][1]["Subject"] == 'test - inner attachment eml'
+    assert results[0]['EntryContext']['Email'][1]['Depth'] == 1

--- a/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -1,6 +1,7 @@
 from ParseEmailFiles import MsOxMessage, main, convert_to_unicode, unfold
 from CommonServerPython import entryTypes
 import demistomock as demisto
+import pytest
 
 
 def exec_command_for_file(path):
@@ -370,45 +371,22 @@ def test_eml_contains_eml_with_status(mocker):
     assert results[0]['EntryContext']['Email'][1]['Subject'] == subject_attach
 
 
-def test_eml_contains_base64_encoded_eml(mocker):
-    def executeCommand(name, args=None):
-        if name == 'getFilePath':
-            return [
-                {
-                    'Type': entryTypes['note'],
-                    'Contents': {
-                        'path': 'test_data/Fwd_test-inner_attachment_eml.eml',
-                        'name': 'Fwd_test-inner_attachment_eml.eml'
-                    }
-                }
-            ]
-        elif name == 'getEntry':
-            return [
-                {
-                    'Type': entryTypes['file'],
-                    'FileMetadata': {
-                        'info': 'news or mail text, ASCII text'
-                    }
-                }
-            ]
-        else:
-            raise ValueError('Unimplemented command called: {}'.format(name))
-
+@pytest.mark.parametrize('email_file', ['eml_contains_base64_eml.eml', 'eml_contains_base64_eml2.eml'])
+def test_eml_contains_base64_encoded_eml(mocker, email_file):
     mocker.patch.object(demisto, 'args', return_value={'entryid': 'test'})
-    mocker.patch.object(demisto, 'executeCommand', side_effect=executeCommand)
+    mocker.patch.object(demisto, 'executeCommand', side_effect=exec_command_for_file('test_data/' + email_file))
     mocker.patch.object(demisto, 'results')
     # validate our mocks are good
     assert demisto.args()['entryid'] == 'test'
 
     main()
-    assert demisto.results.call_count == 5
+    assert demisto.results.call_count == 3
     # call_args is tuple (args list, kwargs). we only need the first one
     results = demisto.results.call_args[0]
     assert len(results) == 1
     assert results[0]['Type'] == entryTypes['note']
-    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Fwd: test - inner attachment eml'
-    assert 'ArcSight_ESM_fixes.yml' in results[0]['EntryContext']['Email'][0]['Attachments']
-    assert 'test - inner attachment eml.eml' in results[0]['EntryContext']['Email'][0]['Attachments']
+    assert results[0]['EntryContext']['Email'][0]['Subject'] == 'Fwd: test - inner attachment eml (base64)'
+    assert 'message.eml' in results[0]['EntryContext']['Email'][0]['Attachments']
     assert results[0]['EntryContext']['Email'][0]['Depth'] == 0
 
     assert results[0]['EntryContext']['Email'][1]["Subject"] == 'test - inner attachment eml'

--- a/Scripts/ParseEmailFiles/test_data/eml_contains_base64_eml.eml
+++ b/Scripts/ParseEmailFiles/test_data/eml_contains_base64_eml.eml
@@ -1,0 +1,28 @@
+From: Koko Demisto <koko@demisto.com>
+Content-Type: multipart/mixed;
+	boundary="Apple-Mail=_BDE60A45-737F-4DD9-B4BB-08441E472087"
+Mime-Version: 1.0 (Mac OS X Mail 12.2 \(3445.102.3\))
+Subject: Fwd: test - inner attachment eml
+X-Universally-Unique-Identifier: 6B4B16BE-DC6F-42A2-A4F9-8C4366D1CA30
+Message-Id: <77069121-C854-4CA3-ABC0-C98D010A8209@demisto.com>
+Date: Mon, 25 Feb 2019 10:41:41 +0200
+To: Wowo Demisto <wowo@demisto.com>
+
+
+--Apple-Mail=_BDE60A45-737F-4DD9-B4BB-08441E472087
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain;
+	charset=us-ascii
+
+DONT REPLY - TEST EMAIL
+
+
+--Apple-Mail=_BDE60A45-737F-4DD9-B4BB-08441E472087
+Content-Type: application/octet-stream; name="message.eml"
+Content-Description: message.eml
+Content-Disposition: attachment; filename="message.eml"; size=15810;
+	creation-date="Thu, 13 Jun 2019 12:58:15 GMT";
+	modification-date="Thu, 13 Jun 2019 12:58:15 GMT"
+Content-Transfer-Encoding: base64
+
+RnJvbTogS29rbyBEZW1pc3RvIDxrb2tvQGRlbWlzdG8uY29tPgpDb250ZW50LVR5cGU6IG11bHRpcGFydC9taXhlZDsKCWJvdW5kYXJ5PSJBcHBsZS1NYWlsPV82QTEzRjUzRi02QkQyLTQ4NUMtODFBNS1FOTJGNjQyNkVERUMiCk1pbWUtVmVyc2lvbjogMS4wIChNYWMgT1MgWCBNYWlsIDEyLjIgXCgzNDQ1LjEwMi4zXCkpClN1YmplY3Q6IHRlc3QgLSBpbm5lciBhdHRhY2htZW50IGVtbApYLVVuaXZlcnNhbGx5LVVuaXF1ZS1JZGVudGlmaWVyOiA2QjRCMTZCRS1EQzZGLTQyQTItQTRGOS04QzQzNjZEMUNBMzAKTWVzc2FnZS1JZDogPDJGQzUwMTc5LTM2NjYtNDc3MC1BMzY1LTc0NDg4MkNEQTU0Q0BkZW1pc3RvLmNvbT4KRGF0ZTogTW9uLCAyNSBGZWIgMjAxOSAxMDozOTo1MCArMDIwMApDYzogTW9tbyBEZW1pc3RvIDxtb21vQGRlbWlzdG8uY29tPgpUbzogU29zbyBEZW1pc3RvIDxzb3NvQGRlbWlzdG8uY29tPgoKCi0tQXBwbGUtTWFpbD1fNkExM0Y1M0YtNkJEMi00ODVDLTgxQTUtRTkyRjY0MjZFREVDCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IDdiaXQKQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOwoJY2hhcnNldD11cy1hc2NpaQoKRE9OVCBSRVBMWQo=

--- a/Scripts/ParseEmailFiles/test_data/eml_contains_base64_eml2.eml
+++ b/Scripts/ParseEmailFiles/test_data/eml_contains_base64_eml2.eml
@@ -18,7 +18,7 @@ DONT REPLY - TEST EMAIL
 
 
 --Apple-Mail=_BDE60A45-737F-4DD9-B4BB-08441E472087
-Content-Type: application/octet-stream; name="message.eml"
+Content-Type: message/rfc822; name="message.eml"
 Content-Description: message.eml
 Content-Disposition: attachment; filename="message.eml"; size=15810;
 	creation-date="Thu, 13 Jun 2019 12:58:15 GMT";


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17526

## Description
Fixing the bug in ParseEmailFiles that was failing to parse base64 encoded eml inside of eml

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Code Review
