### PR TITLE
New script HostToIP -- resolves hostnames to IPv4 addresses.

### DIFF
--- a/Scripts/script-HostToIP.yml
+++ b/Scripts/script-HostToIP.yml
@@ -1,0 +1,63 @@
+commonfields:
+  id: HostToIP
+  version: -1
+name: HostToIP
+script: |
+  import socket
+
+  HOST = demisto.args().get('host')
+
+  try:
+      ip_addr = socket.gethostbyname(HOST)
+  except Exception as e:
+      demisto.results({
+          "Type" : entryTypes["error"],
+          "ContentsFormat" : formats["text"],
+          "Contents" : "Couln't resolve the host info. Error information: \"{0}\"".format(str(e))
+      })
+      sys.exit(0)
+
+  if not ip_addr:
+      demisto.results({
+          "Type" : entryTypes["error"],
+          "ContentsFormat" : formats["text"],
+          "Contents" : "Received an error while trying to lookup the IP information"
+      })
+      sys.exit(0)
+
+
+  output = {
+      "Hostname" : HOST,
+      "IP" : ip_addr
+  }
+
+  context = {}
+  context["Endpoint(val.Hostname && val.Hostname === obj.Hostname)"] = output
+
+  md = tableToMarkdown("Host to IP", [output])
+
+  demisto.results({
+      'Type' : entryTypes['note'],
+      'Contents': context,
+      'ContentsFormat' : formats['json'],
+      'HumanReadable': md,
+      'ReadableContentsFormat' : formats['markdown'],
+      'EntryContext' : context
+  })
+type: python
+tags: []
+comment: Resolves a domain name to an IP address.  Similar to 'nslookup'.
+system: true
+enabled: true
+args:
+- name: host
+  required: true
+  default: true
+  description: The hostname to resolve
+outputs:
+- contextPath: Endpoint.IP
+  description: The endpoint IP.
+  type: string
+scripttarget: 0
+runonce: false
+runas: DBotWeakRole

--- a/Scripts/script-HostToIP.yml
+++ b/Scripts/script-HostToIP.yml
@@ -6,9 +6,17 @@ script: |
   import socket
 
   HOST = demisto.args().get('host')
+  MULTI = True if demisto.args().get('multi').lower() == 'true' else False
+
+  ip_addr = None
 
   try:
-      ip_addr = socket.gethostbyname(HOST)
+      if MULTI:
+          ip_addr = socket.gethostbyname_ex(HOST)
+
+      else:
+          ip_addr = socket.gethostbyname(HOST)
+
   except Exception as e:
       demisto.results({
           "Type" : entryTypes["error"],
@@ -28,8 +36,12 @@ script: |
 
   output = {
       "Hostname" : HOST,
-      "IP" : ip_addr
   }
+
+  if MULTI:
+      output['IP'] = ip_addr[2]
+  else:
+      output['IP'] = ip_addr
 
   context = {}
   context["Endpoint(val.Hostname && val.Hostname === obj.Hostname)"] = output
@@ -46,7 +58,10 @@ script: |
   })
 type: python
 tags: []
-comment: Resolves a domain name to an IP address.  Similar to 'nslookup'.
+comment: |-
+  Resolves a domain name to an IP address.  Similar to 'nslookup'.  If muti=True, then it will return an array of all IP's the domain resolves to.
+
+  NOTE: This relies on the DNS settings of the host OS or on the Docker service/container, and on the configuration of the upstream DNS servers which are being queried.  If multi=true does not produce expected results (i.e. only one IP address returned when more than one IP is known to exist for the given host), the DNS servers' own configuration may be the cause (i.e. different DNS servers may return different results for the same host).  Changing the host OS DNS settings may require a restart of the Docker service or a reboot of the server in order to fully take effect.  A good method of troubleshooting is with 'dig @<someDNSserver> <hostname>'.
 system: true
 enabled: true
 args:
@@ -54,10 +69,17 @@ args:
   required: true
   default: true
   description: The hostname to resolve
+- name: multi
+  auto: PREDEFINED
+  predefined:
+  - "false"
+  - "true"
+  description: Returns all matching IP's in an array
+  defaultValue: "false"
 outputs:
 - contextPath: Endpoint.IP
-  description: The endpoint IP.
-  type: string
+  description: The endpoint IP or an array of IP's.
+  type: unknown
 scripttarget: 0
 runonce: false
 runas: DBotWeakRole


### PR DESCRIPTION
New script HostToIP

## Status
Ready

## Related Issues
N/A

## Description
Performs a simple hostname -> IP address resolution and writes to context Endpoint.IP.  It is derived from, and the inverse of script IPToHost.

It can also return an array of one or more IP's if multi=true (defaults to false).

## Screenshots
Paste here any images that will help the reviewer
![image](https://user-images.githubusercontent.com/44418498/59876682-3d915400-9372-11e9-8d0d-e5ddd8bfaa41.png)
![image](https://user-images.githubusercontent.com/44418498/59941134-7c82e080-942a-11e9-8135-293133fe23aa.png)


## Related PRs
N/A


## Required version of Demisto
4.x.x

## Does it break backward compatibility?
No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
No dependencies
