### PR TITLE
validate_files: new_added_files logic fix

### DIFF
--- a/Tests/scripts/validate_files.py
+++ b/Tests/scripts/validate_files.py
@@ -152,12 +152,12 @@ class FilesValidator(object):
             modified_files = modified_files - set(non_committed_deleted_files)
             added_files = added_files - set(non_committed_modified_files) - set(non_committed_deleted_files)
 
-            new_added_files = set([])
-            for added_file in added_files:
-                if added_file in non_committed_added_files:
-                    new_added_files.add(added_file)
+            # new_added_files = set([])
+            # for added_file in added_files:
+            #     if added_file in non_committed_added_files:
+            #         new_added_files.add(added_file)
 
-            added_files = new_added_files
+            # added_files = new_added_files
 
         return modified_files, added_files, old_format_files
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
It seems that the `new_added_files` logic removes all new_files from validation (at least those that are fully committed). They are verified during circle build as this happens only during a local validation (pre-commit hooks). 

I've commented this out. Need to better understand why this was added.
