### PR TITLE
add option to run dev tasks (pytest/flake8/pylint/mypy) as part of pre-commit hook

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -9,7 +9,20 @@ if [[ -z "${WINDIR}" ]]
         python Tests/scripts/validate_files.py
 fi
 
-if [[ $? -ne 0 ]]
+RES=$?
+
+echo ""
+if [[ -n "$CONTENT_PRECOMMIT_RUN_DEV_TASKS" ]]; then
+    echo "Running content dev tasks (flake8, mypy, pylint, pytst) as env variable CONTENT_PRECOMMIT_RUN_DEV_TASKS is set."
+    ./Tests/scripts/run_all_pkg_dev_tasks.sh
+    RES=$(($RES + $?))
+else    
+    echo "Skipping running dev tasks (flake8, mypy, pylint, pytest). If you want to run this as part of the precommit hook"
+    echo 'set CONTENT_PRECOMMIT_RUN_DEV_TASKS=1. You can add the following line to ~/.zshrc:'
+    echo 'echo "export CONTENT_PRECOMMIT_RUN_DEV_TASKS=1" >> ~/.zshrc'
+fi
+
+if [[ $RES -ne 0 ]]
   then
     echo "Please fix the aforementioned errors and then commit again"
     exit 1

--- a/Tests/scripts/run_all_pkg_dev_tasks.sh
+++ b/Tests/scripts/run_all_pkg_dev_tasks.sh
@@ -10,7 +10,7 @@
 if [[ -z "${SKIP_GIT_COMPARE_FILTER}" ]]; then
     if [ -z "$CIRCLE_BRANCH" ]; then
         CIRCLE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-        echo "CIRCLE_BRANCH set to: ${CIRCLE_BRANCH}"
+        echo "Using following branch for comparison: ${CIRCLE_BRANCH}"
     fi
     # default compare against master
     DIFF_COMPARE=origin/master...${CIRCLE_BRANCH}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
If the following env variable is set: `CONTENT_PRECOMMIT_RUN_DEV_TASKS` pre-commit hook will run the dev tasks (pylint/pytest...) as we do in the build.

## Does it break backward compatibility?
   - No

