### PR TITLE
Add dev instance names, and add ms graph integrations to unmockable

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -28,6 +28,7 @@
         },
         {
             "integrations": "MicrosoftGraphMail",
+            "instance_names": "ms_graph_mail_dev",
             "playbookID": "MicrosoftGraphMail-Test"
         },
         {
@@ -867,6 +868,7 @@
         },
         {
             "integrations": "Windows Defender Advanced Threat Protection",
+            "instance_names": "windows_defender_atp_dev",
             "playbookID": "Test - Windows Defender Advanced Threat Protection"
         },
         {
@@ -882,10 +884,12 @@
         },
         {
             "integrations": "Microsoft Graph",
+            "instance_names": "ms_graph_security_dev",
             "playbookID": "Microsoft Graph Test"
         },
         {
             "integrations": "Microsoft Graph User",
+            "instance_names": "ms_graph_user_dev",
             "playbookID": "Microsoft Graph - Test"
         },
         {
@@ -1755,6 +1759,9 @@
         "Recorded Future": "might be dynamic test",
         "Cylance Protect": "Test module issue",
         "AlphaSOC Wisdom": "Test module issue",
-        "Microsoft Graph": "Test"
+        "Microsoft Graph": "Test direct access to oproxy",
+        "MicrosoftGraphMail": "Test direct access to oproxy",
+        "Microsoft Graph User": "Test direct access to oproxy",
+        "Windows Defender Advanced Threat Protection": "Test direct access to oproxy"
     }
 }


### PR DESCRIPTION
## Status
Ready

## Description
Update Tests/conf.json with ms graph integrations development instance names. Add all ms graph integrations to unmockable list.

## Related PRs

| PR |
| ------ |
| https://github.com/demisto/content-test-conf/pull/451 |

## Does it break backward compatibility?
   - No

## Must have
- ~~[ ] Tests~~
- ~~[ ] Documentation (with link to it)~~
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] Microsoft Graph Test
- [x] Microsoft Graph - Test
- [ ] Test - Windows Defender Advanced Threat Protection
- [x] MicrosoftGraphMail-Test
