### PR TITLE
Disable SSL verification warnings

### DIFF
--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -4,6 +4,8 @@ from requests import get
 
 from Tests.test_utils import print_error, get_yaml
 
+# disable insecure warnings
+requests.packages.urllib3.disable_warnings()
 
 class IntegrationValidator(object):
     """IntegrationValidator is designed to validate the correctness of the file structure we enter to content repo. And

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -7,6 +7,7 @@ from Tests.test_utils import print_error, get_yaml
 # disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
+
 class IntegrationValidator(object):
     """IntegrationValidator is designed to validate the correctness of the file structure we enter to content repo. And
     also try to catch possible Backward compatibility breaks due to the preformed changes.

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -1,6 +1,6 @@
 import os
 import yaml
-from requests import get
+import requests
 
 from Tests.test_utils import print_error, get_yaml
 
@@ -28,12 +28,12 @@ class IntegrationValidator(object):
             # The replace in the end is for Windows support
             if old_file_path:
                 git_hub_path = os.path.join(self.CONTENT_GIT_HUB_LINK, old_file_path).replace("\\", "/")
-                file_content = get(git_hub_path, verify=False).content
+                file_content = requests.get(git_hub_path, verify=False).content
                 self.old_integration = yaml.safe_load(file_content)
             else:
                 try:
                     file_path_from_master = os.path.join(self.CONTENT_GIT_HUB_LINK, file_path).replace("\\", "/")
-                    self.old_integration = yaml.safe_load(get(file_path_from_master, verify=False).content)
+                    self.old_integration = yaml.safe_load(requests.get(file_path_from_master, verify=False).content)
                 except Exception as e:
                     print(str(e))
                     print_error("Could not find the old integration please make sure that you did not break "


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
when running files validations we are using the requests library to retrieve the original (deleted) files from github-master.
this is spamming the build logs with warning errors about SSL verification.

## Screenshots
![image](https://user-images.githubusercontent.com/30797606/60162802-ede3da00-9802-11e9-83f8-6cedf194157a.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review