### PR TITLE
fix issue where fingerprint sometimes comes back as Null from the API

### DIFF
--- a/Integrations/ThreatX/ThreatX.py
+++ b/Integrations/ThreatX/ThreatX.py
@@ -423,8 +423,9 @@ def get_entities_command():
             if 'interval_time_stop' in actor:
                 actor['interval_time_stop'] = pretty_time(actor['interval_time_stop'])
 
-            if 'last_seen' in actor.get('fingerprint', {}):
-                actor['fingerprint']['last_seen'] = pretty_time(actor['fingerprint']['last_seen'])
+            if 'fingerprint' in actor and actor.get('fingerprint') is not None:           
+                if 'last_seen' in actor.get('fingerprint', {}):
+                    actor['fingerprint']['last_seen'] = pretty_time(actor['fingerprint']['last_seen'])
 
             dbscore = set_dbot_score(risk_score)
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
N/A

## Description
Fixes an issue where fingerprint sometimes comes back as Null from the API, creating the following error:

argument of type 'NoneType' is not iterable

## Screenshots
N/A

## Related PRs
N/A

branch | PR
------ | ------


## Required version of Demisto
None

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
N/A
