### PR TITLE
Corrected dictionary syntax on line 39

### DIFF
--- a/Scripts/script-SendEmailToManager.yml
+++ b/Scripts/script-SendEmailToManager.yml
@@ -36,7 +36,7 @@ script: |-
       sys.exit(0)
   allowReply = demisto.get(demisto.args(), 'allowReply')
   if allowReply:
-      res = demisto.executeCommand('addEntitlement', {'persistent': demisto.get(demisto.args(), 'persistent', 'replyEntriesTag': demisto.get(demisto.args(), 'replyEntriesTag'})
+      res = demisto.executeCommand('addEntitlement', {'persistent': demisto.get(demisto.args(), 'replyEntriesTag': demisto.get(demisto.args()})
       if isError(res[0]):
           demisto.results(res)
           sys.exit(0)


### PR DESCRIPTION
Removed duplicate keys with no values.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Line 33 of the python script, 39 in the YAML contained duplicated keys with no values, causing a syntax error when attempting to use this function.

## Does it break backward compatibility?
   - No
