### PR TITLE
Added missing closing parentheses

### DIFF
--- a/Scripts/script-SendEmailToManager.yml
+++ b/Scripts/script-SendEmailToManager.yml
@@ -36,7 +36,7 @@ script: |-
       sys.exit(0)
   allowReply = demisto.get(demisto.args(), 'allowReply')
   if allowReply:
-      res = demisto.executeCommand('addEntitlement', {'persistent': demisto.get(demisto.args(), 'persistent', 'replyEntriesTag': demisto.get(demisto.args(), 'replyEntriesTag'})
+      res = demisto.executeCommand('addEntitlement', {'persistent': demisto.get(demisto.args(), 'persistent'), 'replyEntriesTag': demisto.get(demisto.args(), 'replyEntriesTag')})
       if isError(res[0]):
           demisto.results(res)
           sys.exit(0)


### PR DESCRIPTION
Missing closing parentheses cause a syntax error when attempting to run the command in the SOAR platform.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
The calls to `demisto.get()` were no closed, causing a syntax error when attempting to run the command from Demisto

## Does it break backward compatibility?
No


