### PR TITLE
fix bug in lr-get-alarm-events-by-id command

### DIFF
--- a/Integrations/integration-LogRhythm.yml
+++ b/Integrations/integration-LogRhythm.yml
@@ -680,6 +680,15 @@ script:
         if (mdRaw['-i']) {
             delete mdRaw['-i'];
         }
+
+        if(!mdRaw['LogDataModel']){
+            return {
+                Type: entryTypes.note,
+                Contents: "No events found for this alarm",
+                ContentsFormat: formats.text
+            };
+        }
+
         var processedMd = processAlarmEventsMd(mdRaw);
 
 

--- a/Releases/LatestRelease/integration-LogRhythm.md
+++ b/Releases/LatestRelease/integration-LogRhythm.md
@@ -1,1 +1,1 @@
-fix bug in lr-get-alarm-events-by-id command when there are no events for the alarm
+Improved handling of the lr-get-alarm-events-by-id command when there are no events for the alarm.

--- a/Releases/LatestRelease/integration-LogRhythm.md
+++ b/Releases/LatestRelease/integration-LogRhythm.md
@@ -1,0 +1,1 @@
+fix bug in lr-get-alarm-events-by-id command when there are no events for the alarm


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17739

## Description
The command !lr-get-alarm-events-by-id crash when there was no events for the alarm

