### PR TITLE
fix intezer test

### DIFF
--- a/TestPlaybooks/playbook-Intezer_Test.yml
+++ b/TestPlaybooks/playbook-Intezer_Test.yml
@@ -792,7 +792,7 @@ tasks:
               complex:
                 root: DBotScore
                 filters:
-                - - operator: isEqualString
+                - - operator: containsGeneral
                     left:
                       value:
                         simple: DBotScore.Indicator
@@ -800,14 +800,7 @@ tasks:
                     right:
                       value:
                         simple: fa5953e0c34a4bbf69ac31f3a1360024101c1232bb45cccaad3611b682c92387
-                - - operator: isEqualString
-                    left:
-                      value:
-                        simple: DBotScore.Vendor
-                      iscontext: true
-                    right:
-                      value:
-                        simple: Intezer
+                accessor: Indicator
             iscontext: true
     view: |-
       {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1709,7 +1709,7 @@
         "okta_test_playbook": "test failed (Issue 17041)",
         "Detonate File - FireEye AX - Test": "No instance",
         "Cofense Triage Test": "Creds only works on demo4",
-        "Intezer": "Old test for old version of inteze"
+        "Intezer Testing": "Old test for old version of inteze"
     },
     "skipped_integrations": {
       "_comment": "~~~ NO INSTANCE - will not be resolved ~~~",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1708,7 +1708,8 @@
         "search_endpoints_by_hash_-_carbon_black_response_-_test": "old test, needs to check if relevant",
         "okta_test_playbook": "test failed (Issue 17041)",
         "Detonate File - FireEye AX - Test": "No instance",
-        "Cofense Triage Test": "Creds only works on demo4"
+        "Cofense Triage Test": "Creds only works on demo4",
+        "Intezer": "Old test for old version of inteze"
     },
     "skipped_integrations": {
       "_comment": "~~~ NO INSTANCE - will not be resolved ~~~",


### PR DESCRIPTION
## Status
Ready

## Description
The test failed on 'Test enrichment with sha256 exist' task when checking if DBotScore.Indicator equals to sha256 value while DBotScore.Indicator is array. Changed the 'equals' condition to 'contains'
