### PR TITLE
[Bug] Rich Text Files are not inspected with 'Extract Indicators From File - Generic v2'

### DIFF
--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
@@ -13,13 +13,13 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 7c475fe8-ef6f-4203-8649-88c8ee1355a4
+    taskid: 7820586b-f2e6-4673-8dd8-08caab0d1173
     type: start
     task:
-      id: 7c475fe8-ef6f-4203-8649-88c8ee1355a4
+      id: 7820586b-f2e6-4673-8dd8-08caab0d1173
       version: -1
+      description: Start
       name: ""
-      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -38,10 +38,10 @@ tasks:
     ignoreworker: false
   "1":
     id: "1"
-    taskid: 7d301230-7301-4a9c-879f-2e3b4366a3d7
+    taskid: 7872ce6f-5e06-4c00-846b-6de0d54307b1
     type: condition
     task:
-      id: 7d301230-7301-4a9c-879f-2e3b4366a3d7
+      id: 7872ce6f-5e06-4c00-846b-6de0d54307b1
       version: -1
       name: Is there a file?
       description: |
@@ -77,10 +77,10 @@ tasks:
     ignoreworker: false
   "2":
     id: "2"
-    taskid: 864c6f5e-7214-4a36-8c37-80f7057bd36e
+    taskid: e06408f8-c0cb-4516-87c0-014108497f20
     type: regular
     task:
-      id: 864c6f5e-7214-4a36-8c37-80f7057bd36e
+      id: e06408f8-c0cb-4516-87c0-014108497f20
       version: -1
       name: Set file to local context
       description: Set the input file into local context.
@@ -112,13 +112,13 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: cc0c7ac6-f764-47df-8f1e-cfbdcbd25c4e
+    taskid: 832242ed-942e-4094-8cf4-003921e7ef7a
     type: title
     task:
-      id: cc0c7ac6-f764-47df-8f1e-cfbdcbd25c4e
+      id: 832242ed-942e-4094-8cf4-003921e7ef7a
       version: -1
       name: Done
-      description: ""
+      description: Done
       type: title
       iscommand: false
       brand: ""
@@ -135,13 +135,13 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 94a70634-4521-42ed-8830-9673d9b25e1b
+    taskid: ab59c7dd-3e82-4efe-8e36-d3065d88a590
     type: title
     task:
-      id: 94a70634-4521-42ed-8830-9673d9b25e1b
+      id: ab59c7dd-3e82-4efe-8e36-d3065d88a590
       version: -1
       name: Extract Indicators From Files
-      description: ""
+      description: Extracts indicators from files
       type: title
       iscommand: false
       brand: ""
@@ -163,10 +163,10 @@ tasks:
     ignoreworker: false
   "5":
     id: "5"
-    taskid: 5e2997db-65a5-49a7-8f9a-87892701e8fe
+    taskid: 6bc85e4c-1f70-41b7-8bec-3c6410c9ad53
     type: condition
     task:
-      id: 5e2997db-65a5-49a7-8f9a-87892701e8fe
+      id: 6bc85e4c-1f70-41b7-8bec-3c6410c9ad53
       version: -1
       name: Is there a text-based file?
       description: Checks if there is a text-based file in context. Skips MSG and
@@ -198,6 +198,14 @@ tasks:
                       value:
                         simple: ASCII text
                     ignorecase: true
+                  - operator: containsString
+                    left:
+                      value:
+                        simple: File.Type
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Rich Text Format
                 - - operator: notContainsString
                     left:
                       value:
@@ -254,10 +262,10 @@ tasks:
     ignoreworker: false
   "6":
     id: "6"
-    taskid: ded29993-f01d-4b33-8a4a-9d2453eaab31
+    taskid: d2c83c31-2092-4c86-81ad-359fcf0ee1e6
     type: regular
     task:
-      id: ded29993-f01d-4b33-8a4a-9d2453eaab31
+      id: d2c83c31-2092-4c86-81ad-359fcf0ee1e6
       version: -1
       name: Extract indicators from text-based file
       description: Extracts indicators from text-based files.
@@ -282,6 +290,14 @@ tasks:
                 value:
                   simple: ASCII text
               ignorecase: true
+            - operator: containsString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: Rich Text Format
           - - operator: notContainsString
               left:
                 value:
@@ -331,7 +347,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 92.5,
+          "x": 82.5,
           "y": 950
         }
       }
@@ -340,10 +356,10 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 542f7e7a-6978-480e-8356-cc7cda51a6d7
+    taskid: 79feacf1-749d-4213-85ce-9b87809c59cf
     type: condition
     task:
-      id: 542f7e7a-6978-480e-8356-cc7cda51a6d7
+      id: 79feacf1-749d-4213-85ce-9b87809c59cf
       version: -1
       name: Is there a PDF file?
       description: Checks if there is a PDF file in context.
@@ -399,10 +415,10 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: dbdad3fa-957f-490b-8fb5-3a827687360b
+    taskid: f954fb51-0ed0-44d2-837a-64f852f3dd9d
     type: regular
     task:
-      id: dbdad3fa-957f-490b-8fb5-3a827687360b
+      id: f954fb51-0ed0-44d2-837a-64f852f3dd9d
       version: -1
       name: Extract indicators from PDF file
       description: Load a PDF file's content and metadata into context.
@@ -454,10 +470,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: 6a791d6e-4678-44c7-8783-dad7ff0afdd3
+    taskid: 596a82ed-b1a5-4a82-8eca-c351ae07e8c3
     type: condition
     task:
-      id: 6a791d6e-4678-44c7-8783-dad7ff0afdd3
+      id: 596a82ed-b1a5-4a82-8eca-c351ae07e8c3
       version: -1
       name: Is there a Word file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
@@ -571,13 +587,12 @@ tasks:
     ignoreworker: false
   "10":
     id: "10"
-    taskid: c552720b-f6fc-49be-8c2a-1beb7178c737
+    taskid: 371fb092-fd79-4550-8b2e-d3c945d2cc10
     type: title
     task:
-      id: c552720b-f6fc-49be-8c2a-1beb7178c737
+      id: 371fb092-fd79-4550-8b2e-d3c945d2cc10
       version: -1
       name: No File To Parse
-      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -597,10 +612,10 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 9fe7f253-7529-438f-871b-5eba2873f43d
+    taskid: e08be4df-5efa-4f1a-834d-05a15f8fd63f
     type: regular
     task:
-      id: 9fe7f253-7529-438f-871b-5eba2873f43d
+      id: e08be4df-5efa-4f1a-834d-05a15f8fd63f
       version: -1
       name: Extract indicators from Word file
       description: Extracts indicators from word files (DOC, DOCX).
@@ -632,22 +647,6 @@ tasks:
               right:
                 value:
                   simple: Microsoft Word
-            - operator: isEqualString
-              left:
-                value:
-                  simple: File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: doc
-            - operator: isEqualString
-              left:
-                value:
-                  simple: File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: docx
           - - operator: isNotEqualString
               left:
                 value:
@@ -725,10 +724,10 @@ tasks:
     ignoreworker: false
   "12":
     id: "12"
-    taskid: 89a330ac-fde1-4324-8802-a6bd17d9375d
+    taskid: 01853d00-5297-4e59-83fa-1aec87f7b3aa
     type: condition
     task:
-      id: 89a330ac-fde1-4324-8802-a6bd17d9375d
+      id: 01853d00-5297-4e59-83fa-1aec87f7b3aa
       version: -1
       name: Were images extracted?
       description: Checks whether images were extracted from PDF files.
@@ -801,13 +800,14 @@ tasks:
     ignoreworker: false
   "13":
     id: "13"
-    taskid: 2d1ba725-7a79-4ea0-8c84-94ce9007608b
+    taskid: 60827e91-7450-4f79-8e82-863488b15371
     type: condition
     task:
-      id: 2d1ba725-7a79-4ea0-8c84-94ce9007608b
+      id: 60827e91-7450-4f79-8e82-863488b15371
       version: -1
       name: Is Image OCR enabled?
-      description: Checks whether there is an active instance of the Image OCR integration enabled.
+      description: Checks whether there is an active instance of the Image OCR integration
+        enabled.
       type: condition
       iscommand: false
       brand: ""
@@ -847,13 +847,14 @@ tasks:
     ignoreworker: false
   "14":
     id: "14"
-    taskid: 9a4d578f-2723-4b9e-82c0-97bb5f7afccf
+    taskid: 19fe4f88-c55b-4f13-814c-1ad0aae31cae
     type: regular
     task:
-      id: 9a4d578f-2723-4b9e-82c0-97bb5f7afccf
+      id: 19fe4f88-c55b-4f13-814c-1ad0aae31cae
       version: -1
       name: Extract text from images
-      description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
+      description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract
+        to get reputation for indicators.
       script: '|||image-ocr-extract-text'
       type: regular
       iscommand: true

--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
@@ -593,6 +593,7 @@ tasks:
       id: 371fb092-fd79-4550-8b2e-d3c945d2cc10
       version: -1
       name: No File To Parse
+      description: No File To Parse
       type: title
       iscommand: false
       brand: ""

--- a/Releases/LatestRelease/ExtractIndicatorsFromTextFile.md
+++ b/Releases/LatestRelease/ExtractIndicatorsFromTextFile.md
@@ -1,1 +1,1 @@
--
+- Fixed a bug where the script would throw an error for certain texts with "\\" character

--- a/Releases/LatestRelease/playbook-Extract_Indicators_From_File_-_Generic_v2.md
+++ b/Releases/LatestRelease/playbook-Extract_Indicators_From_File_-_Generic_v2.md
@@ -1,0 +1,1 @@
+- Fixed an issue where certain RTF files were not handled correctly.

--- a/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
+++ b/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
@@ -17,7 +17,12 @@ except Exception:
     return_error("File was not found")
 
 with open(filePath, mode='r') as f:
-    data = f.read(maxFileSize).encode('utf-8')
+    data = f.read(maxFileSize)
+    try:
+        data = data.decode('unicode_escape').encode('utf-8')
+    # unicode_escape might throw UnicodeDecodeError for strings that contain \ char followed by ascii characters
+    except UnicodeDecodeError:
+        data = data.encode('utf-8')
 
     # Extract indicators (omitting context output, letting auto-extract work)
     indicators_hr = demisto.executeCommand("extractIndicators", {

--- a/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
+++ b/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
@@ -17,7 +17,7 @@ except Exception:
     return_error("File was not found")
 
 with open(filePath, mode='r') as f:
-    data = f.read(maxFileSize).decode('unicode_escape').encode('utf-8')
+    data = f.read(maxFileSize).encode('utf-8')
 
     # Extract indicators (omitting context output, letting auto-extract work)
     indicators_hr = demisto.executeCommand("extractIndicators", {

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
@@ -13,13 +13,12 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 8413e04e-c9ff-4942-85cf-50fe1f408808
+    taskid: acf29053-815f-4e96-8122-4781e4f967d7
     type: start
     task:
-      id: 8413e04e-c9ff-4942-85cf-50fe1f408808
+      id: acf29053-815f-4e96-8122-4781e4f967d7
       version: -1
       name: ""
-      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -38,10 +37,10 @@ tasks:
     ignoreworker: false
   "1":
     id: "1"
-    taskid: 437573fd-802e-4c52-81a1-95a9d3a9b45e
+    taskid: 8d01fbd2-8fe8-49f3-89ea-1c412a1c53a1
     type: regular
     task:
-      id: 437573fd-802e-4c52-81a1-95a9d3a9b45e
+      id: 8d01fbd2-8fe8-49f3-89ea-1c412a1c53a1
       version: -1
       name: Download TXT file
       description: Downloads a TXT file using HTTP GET.
@@ -81,10 +80,10 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: e824e975-52d6-40fc-850c-b28b17bf9f57
+    taskid: 36c14cb2-423d-4d53-8423-2f1a44f4875f
     type: condition
     task:
-      id: e824e975-52d6-40fc-850c-b28b17bf9f57
+      id: 36c14cb2-423d-4d53-8423-2f1a44f4875f
       version: -1
       name: Were the correct indicators extracted?
       description: Checks whether specific indicators were extracted from each one
@@ -169,6 +168,16 @@ tasks:
                 transformers:
                 - operator: toUpperCase
             iscontext: true
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: URL
+                accessor: Data
+            iscontext: true
+          right:
+            value:
+              simple: https://mock.com?e=P6wGLG
     view: |-
       {
         "position": {
@@ -181,13 +190,12 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 021f84a0-ec5e-499f-8d2e-e41e49a97827
+    taskid: 88666eac-de82-43cd-80e7-b7bcbd707c8b
     type: title
     task:
-      id: 021f84a0-ec5e-499f-8d2e-e41e49a97827
+      id: 88666eac-de82-43cd-80e7-b7bcbd707c8b
       version: -1
       name: Done
-      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -204,10 +212,10 @@ tasks:
     ignoreworker: false
   "5":
     id: "5"
-    taskid: eafc1ba0-7f53-448f-8775-8250d601451d
+    taskid: a7537367-cc86-4d5c-8179-eb9e3edbf463
     type: regular
     task:
-      id: eafc1ba0-7f53-448f-8775-8250d601451d
+      id: a7537367-cc86-4d5c-8179-eb9e3edbf463
       version: -1
       name: Make test fail
       description: Causes the test playbook to fail if the correct email addresses
@@ -236,13 +244,12 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 83802eda-2b9a-4008-8b80-82f764254dc9
+    taskid: 69f8a4ec-a422-4067-84d8-c09cf54de4a9
     type: title
     task:
-      id: 83802eda-2b9a-4008-8b80-82f764254dc9
+      id: 69f8a4ec-a422-4067-84d8-c09cf54de4a9
       version: -1
       name: Download Files
-      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -254,6 +261,7 @@ tasks:
       - "11"
       - "15"
       - "18"
+      - "20"
     separatecontext: false
     view: |-
       {
@@ -267,10 +275,10 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: b1e0c536-eca1-48fa-8809-912c83c6ee5a
+    taskid: d021722f-2461-4b45-863a-d17979a1988e
     type: regular
     task:
-      id: b1e0c536-eca1-48fa-8809-912c83c6ee5a
+      id: d021722f-2461-4b45-863a-d17979a1988e
       version: -1
       name: Download DOC file
       description: Downloads a DOC file using HTTP GET.
@@ -310,10 +318,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: f99b7564-3dfe-4f2a-8dff-9b11ca930d41
+    taskid: d79d8f9b-0d3d-479f-8fe1-1cf0902d8bf2
     type: regular
     task:
-      id: f99b7564-3dfe-4f2a-8dff-9b11ca930d41
+      id: d79d8f9b-0d3d-479f-8fe1-1cf0902d8bf2
       version: -1
       name: Download DOCX file
       description: Downloads a DOCX file using HTTP GET.
@@ -353,10 +361,10 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 75a86fbe-f1b2-4fc9-81a7-ce987066bd83
+    taskid: 2c831b40-0b51-4868-8d07-3452279b8f0b
     type: regular
     task:
-      id: 75a86fbe-f1b2-4fc9-81a7-ce987066bd83
+      id: 2c831b40-0b51-4868-8d07-3452279b8f0b
       version: -1
       name: Download PDF file
       description: Downloads a PDF file using HTTP GET.
@@ -396,10 +404,10 @@ tasks:
     ignoreworker: false
   "12":
     id: "12"
-    taskid: 7bc46c8b-8690-4f90-8361-7e5c27a6ba2f
+    taskid: 77764bdf-2752-45c1-845b-9912d826761d
     type: regular
     task:
-      id: 7bc46c8b-8690-4f90-8361-7e5c27a6ba2f
+      id: 77764bdf-2752-45c1-845b-9912d826761d
       version: -1
       name: Delete Context
       description: Delete the context of the incident to start with clear context.
@@ -431,10 +439,10 @@ tasks:
     ignoreworker: false
   "14":
     id: "14"
-    taskid: 4186830f-cf3e-49ed-8720-39125eb9de6e
+    taskid: 6d32259d-a837-4547-82d0-cf883f087d8b
     type: condition
     task:
-      id: 4186830f-cf3e-49ed-8720-39125eb9de6e
+      id: 6d32259d-a837-4547-82d0-cf883f087d8b
       version: -1
       name: Did the PDF file return outputs?
       description: |-
@@ -517,10 +525,10 @@ tasks:
     ignoreworker: false
   "15":
     id: "15"
-    taskid: a7f5c5b4-97e4-42d5-8a0b-a2434d3bd24c
+    taskid: 9ac7080d-c4dd-4b94-8fe0-4b182283c074
     type: regular
     task:
-      id: a7f5c5b4-97e4-42d5-8a0b-a2434d3bd24c
+      id: 9ac7080d-c4dd-4b94-8fe0-4b182283c074
       version: -1
       name: Download EML file
       description: Downloads an EML file using HTTP GET.
@@ -560,10 +568,10 @@ tasks:
     ignoreworker: false
   "18":
     id: "18"
-    taskid: bde0ac3e-6b86-4892-8903-b5eac5002a1e
+    taskid: b24d3e5f-c9a5-4d2a-851a-2e7d7aea1877
     type: regular
     task:
-      id: bde0ac3e-6b86-4892-8903-b5eac5002a1e
+      id: b24d3e5f-c9a5-4d2a-851a-2e7d7aea1877
       version: -1
       name: Download XLSX file
       description: Downloads an XLSX file using HTTP GET.
@@ -603,10 +611,10 @@ tasks:
     ignoreworker: false
   "19":
     id: "19"
-    taskid: a09c8414-f315-4943-86c7-6f02638de504
+    taskid: aaea1865-4ee1-4738-8d3a-794c62b22d03
     type: playbook
     task:
-      id: a09c8414-f315-4943-86c7-6f02638de504
+      id: aaea1865-4ee1-4738-8d3a-794c62b22d03
       version: -1
       name: Extract Indicators From File - Generic v2
       playbookName: Extract Indicators From File - Generic v2
@@ -615,14 +623,56 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
       - "14"
+      - "3"
     separatecontext: true
     view: |-
       {
         "position": {
           "x": 50,
           "y": 770
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "20":
+    id: "20"
+    taskid: 3f9b5e0d-cf2f-4305-8983-856df49f1b50
+    type: regular
+    task:
+      id: 3f9b5e0d-cf2f-4305-8983-856df49f1b50
+      version: -1
+      name: Download RTF file
+      description: Sends http request. Returns the response as json.
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "19"
+    scriptarguments:
+      body: {}
+      filename: {}
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password: {}
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/ACH.Payment.Advice.rtf
+      username: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -1380,
+          "y": 570
         }
       }
     note: false
@@ -637,8 +687,8 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1415,
-        "width": 2770,
-        "x": -910,
+        "width": 3240,
+        "x": -1380,
         "y": 50
       }
     }

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -1014,7 +1014,8 @@
       "www.beyondtrust.com",
       "securitycenter.windows.com",
       "oproxy-dev.demisto.ninja",
-      "oproxy.demisto.ninja"
+      "oproxy.demisto.ninja",
+      "https://mock.com"
     ],
     "md5": [
       "c8092abd8d581750c0530fa1fc8d8318",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17655

## Description
Fixed 
* playbook to handle a bug where `.rtf` files are not inspected with `Extract Indicators From File - Generic v2`.
* bug in `ExtractIndicatorsFromTextFile` script where certain strings had their escape characters removed, which created impossible characters (which threw an exception).
* Follow up of a previous bug that I noticed while working on this - in https://github.com/demisto/etc/issues/17351. (look for the next part in the comments).
Though there is a condition prior to this task that was fixed, I realised that in a multi-file scenario this task might still be reached, and so this task had to be changed as well

## Required version of Demisto
4.1.0+

## Does it break backward compatibility?
   - No

## Screenshots:
### Before:
#### Playbook:
![image](https://user-images.githubusercontent.com/20818773/60865494-d2c79000-a22e-11e9-9f5e-cc40cd19286d.png)

#### Script (before + after):
![image](https://user-images.githubusercontent.com/20818773/60865428-b3306780-a22e-11e9-853e-6b1a8ecde9e4.png)

## After:
#### Playbook:
![image](https://user-images.githubusercontent.com/20818773/60865820-77e26880-a22f-11e9-93ba-c5a8b9c72713.png)

#### Script (before + after):
![image](https://user-images.githubusercontent.com/20818773/60865422-aca1f000-a22e-11e9-917c-d8a8540e7383.png)

## Must have
- [x] Tests
- [x] Documentation
- [ ] Code Review