### PR TITLE
EWS v2 - missing headers fix

### DIFF
--- a/Integrations/EWSv2/EWSv2.py
+++ b/Integrations/EWSv2/EWSv2.py
@@ -11,6 +11,7 @@ from cStringIO import StringIO
 import logging
 import warnings
 import subprocess
+import email
 from requests.exceptions import ConnectionError
 
 import exchangelib
@@ -873,8 +874,10 @@ def parse_incident_from_item(item):
 
                 # save the attachment
                 if attachment.item.mime_content:
-                    file_result = fileResult(get_attachment_name(attachment.name) + ".eml",
-                                             attachment.item.mime_content)
+                    attached_email = email.message_from_string(attachment.item.mime_content)
+                    if attachment.item.headers:
+                        map(lambda h: attached_email.add_header(h.name, h.value), attachment.item.headers)
+                    file_result = fileResult(get_attachment_name(attachment.name) + ".eml", attached_email.as_string())
 
                 if file_result:
                     # check for error


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16908

## Description
When fetching emails as incidents, the `eml` file (that was uploaded to war room) of attached email was created from `MimeContent` only that was decoded from Base64. The response could include additional x-headers that were not included in `MimeContent`. The fix is to create email from `MimeContent` and then add `InternetMessageHeaders` to email and return `eml` file to war room.

## Required version of Demisto
4.5.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Phishing Investigation - Generic v2
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Tests:
- [x] Phishing v2 Test - Inline
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] pyEWS_Test
- [x] Process Email - Generic for Rasterize
- [x] Phishing v2 Test - Attachment
- [x] EWS search-mailbox test
- [x] Phishing test - Inline
- [x] process_email_-_generic_-_test