### PR TITLE
[Bug] Nexpose nexpose-get-assets returns a date format error

### DIFF
--- a/Integrations/Rapid7_Nexpose/Pipfile
+++ b/Integrations/Rapid7_Nexpose/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pylint = "*"
+pytest = "*"
+pytest-mock = "*"
+
+[packages]
+
+[requires]
+python_version = "2.7"

--- a/Integrations/Rapid7_Nexpose/Pipfile
+++ b/Integrations/Rapid7_Nexpose/Pipfile
@@ -9,6 +9,7 @@ pytest = "*"
 pytest-mock = "*"
 
 [packages]
+requests = "*"
 
 [requires]
 python_version = "2.7"

--- a/Integrations/Rapid7_Nexpose/Pipfile.lock
+++ b/Integrations/Rapid7_Nexpose/Pipfile.lock
@@ -1,0 +1,240 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "73c4b534031f8318ec6903fbaa068b0bf0e2be5f86c3cfb708683f542b13df2e"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
+                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
+            ],
+            "version": "==1.6.5"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "backports.functools-lru-cache": {
+            "hashes": [
+                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
+                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==1.5"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:27594cf4fc279f321974061ac69164aaebd2749af962ac8686b20503ac0bcf2d",
+                "sha256:9d51fe0a382f05b6b117c5e601fc219fede4a8c71703324af3f7d883aef476a3"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==3.7.3"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
+        },
+        "futures": {
+            "hashes": [
+                "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
+                "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.2.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:18c796c2cd35eb1a1d3f012a214a542790a1aed95e29768bdcb9f2197eccbd0b",
+                "sha256:96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6"
+            ],
+            "version": "==4.3.15"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==2.0.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+            ],
+            "markers": "python_version <= '2.7'",
+            "version": "==5.0.0"
+        },
+        "pathlib2": {
+            "hashes": [
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+            ],
+            "markers": "python_version < '3.6'",
+            "version": "==2.3.3"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:8257baf496c8522437e8a6cfe0f15e00aedc6c0e0e7c9d55eeeeab31e0853843",
+                "sha256:8c361cc353d988e4f5b998555c88098b9d5964c2e11acf7b0d21925a66bb5824"
+            ],
+            "version": "==5.1.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+            ],
+            "version": "==0.9.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:02c2b6d268695a8b64ad61847f92e611e6afcff33fd26c3a2125370c4662905d",
+                "sha256:ee1e85575587c5b58ddafa25e1c1b01691ef172e139fc25585e5d3f02451da93"
+            ],
+            "index": "pypi",
+            "version": "==1.9.4"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
+            ],
+            "index": "pypi",
+            "version": "==4.3.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:4d0d06d173eecf172703219a71dbd4ade0e13904e6bbce1ce660e2e0dc78b5c4",
+                "sha256:bfdf02789e3d197bd682a758cae0a4a18706566395fbe2803badcd1335e0173e"
+            ],
+            "index": "pypi",
+            "version": "==1.10.1"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.10.0"
+        },
+        "singledispatch": {
+            "hashes": [
+                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
+                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==3.4.0.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
+        }
+    }
+}

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose.py
@@ -225,7 +225,7 @@ def get_list_response(path, method='get', limit=None, body={}, params={}):
 def get_last_scan(asset):
     if asset['history'] is None:
         return "-"
-    sorted_dates = sorted(asset['history'], key=lambda h: time.strptime(h['date'], "%Y-%m-%dT%H:%M:%S.%fZ"),
+    sorted_dates = sorted(asset['history'], key=get_datetime_from_asset_history_item,
                           reverse=True)
 
     if sorted_dates[0] is not None:
@@ -238,6 +238,13 @@ def get_last_scan(asset):
             'date': '-',
             'id': '-'
         }
+
+
+def get_datetime_from_asset_history_item(item):
+    try:
+        return time.strptime(item['date'], "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        return time.strptime(item['date'], "%Y-%m-%dT%H:%M:%SZ")
 
 
 def get_asset_command():
@@ -1300,47 +1307,53 @@ def set_scan_status(scan_id, scan_status):
     return send_request(path, 'post')
 
 
-try:
-    if demisto.command() == 'test-module':
-        get_assets(limit=1)
-        demisto.results('ok')
-    if demisto.command() == 'nexpose-get-assets':
-        demisto.results(get_assets_command())
-    if demisto.command() == 'nexpose-get-asset':
-        demisto.results(get_asset_command())
-    if demisto.command() == 'nexpose-get-asset-vulnerability':
-        demisto.results(get_asset_vulnerability_command())
-    if demisto.command() == 'nexpose-search-assets':
-        demisto.results(search_assets_command())
-    if demisto.command() == 'nexpose-get-scan':
-        demisto.results(get_scan_command())
-    if demisto.command() == 'nexpose-get-sites':
-        demisto.results(get_sites_command())
-    if demisto.command() == 'nexpose-get-report-templates':
-        demisto.results(get_report_templates_command())
-    if demisto.command() == 'nexpose-create-assets-report':
-        demisto.results(create_assets_report_command())
-    if demisto.command() == 'nexpose-create-sites-report':
-        demisto.results(create_sites_report_command())
-    if demisto.command() == 'nexpose-create-scan-report':
-        demisto.results(create_scan_report_command())
-    if demisto.command() == 'nexpose-start-site-scan':
-        demisto.results(start_site_scan_command())
-    if demisto.command() == 'nexpose-start-assets-scan':
-        demisto.results(start_assets_scan_command())
-    if demisto.command() == 'nexpose-create-site':
-        demisto.results(create_site_command())
-    if demisto.command() == 'nexpose-delete-site':
-        demisto.results(delete_site_command())
-    if demisto.command() == 'nexpose-stop-scan':
-        demisto.results(stop_scan_command())
-    if demisto.command() == 'nexpose-pause-scan':
-        demisto.results(pause_scan_command())
-    if demisto.command() == 'nexpose-resume-scan':
-        demisto.results(resume_scan_command())
-    if demisto.command() == 'nexpose-get-scans':
-        demisto.results(get_scans_command())
-except Exception as e:
-    LOG(e)
-    LOG.print_log(False)
-    return_error(e.message)
+def main():
+    try:
+        if demisto.command() == 'test-module':
+            get_assets(limit=1)
+            demisto.results('ok')
+        if demisto.command() == 'nexpose-get-assets':
+            demisto.results(get_assets_command())
+        if demisto.command() == 'nexpose-get-asset':
+            demisto.results(get_asset_command())
+        if demisto.command() == 'nexpose-get-asset-vulnerability':
+            demisto.results(get_asset_vulnerability_command())
+        if demisto.command() == 'nexpose-search-assets':
+            demisto.results(search_assets_command())
+        if demisto.command() == 'nexpose-get-scan':
+            demisto.results(get_scan_command())
+        if demisto.command() == 'nexpose-get-sites':
+            demisto.results(get_sites_command())
+        if demisto.command() == 'nexpose-get-report-templates':
+            demisto.results(get_report_templates_command())
+        if demisto.command() == 'nexpose-create-assets-report':
+            demisto.results(create_assets_report_command())
+        if demisto.command() == 'nexpose-create-sites-report':
+            demisto.results(create_sites_report_command())
+        if demisto.command() == 'nexpose-create-scan-report':
+            demisto.results(create_scan_report_command())
+        if demisto.command() == 'nexpose-start-site-scan':
+            demisto.results(start_site_scan_command())
+        if demisto.command() == 'nexpose-start-assets-scan':
+            demisto.results(start_assets_scan_command())
+        if demisto.command() == 'nexpose-create-site':
+            demisto.results(create_site_command())
+        if demisto.command() == 'nexpose-delete-site':
+            demisto.results(delete_site_command())
+        if demisto.command() == 'nexpose-stop-scan':
+            demisto.results(stop_scan_command())
+        if demisto.command() == 'nexpose-pause-scan':
+            demisto.results(pause_scan_command())
+        if demisto.command() == 'nexpose-resume-scan':
+            demisto.results(resume_scan_command())
+        if demisto.command() == 'nexpose-get-scans':
+            demisto.results(get_scans_command())
+    except Exception as e:
+        LOG(e)
+        LOG.print_log(False)
+        return_error(e.message)
+
+
+# python2 uses __builtin__ python3 uses builtins
+if __name__ == "__builtin__" or __name__ == "builtins":
+    main()

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -14,6 +14,7 @@ ITEM_WITH_SCANID = {
     'scanId': '1'
 }
 
+
 class ResponseMock:
     def __init__(self):
         self.status_code = 200

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -1,13 +1,18 @@
 import demistomock as demisto
 import requests
 
-ITEM_WITH_MS = {
-    'date': '2019-05-03T03:02:54.123Z'
-}
 ITEM_WITHOUT_MS = {
     'date': '2019-05-03T03:01:54Z'
 }
 
+ITEM_WITH_MS = {
+    'date': '2019-05-03T03:02:54.123Z'
+}
+
+ITEM_WITH_SCANID = {
+    'date': '2019-05-03T03:03:54.123Z',
+    'scanId': '1'
+}
 
 class ResponseMock:
     def __init__(self):
@@ -45,3 +50,38 @@ def test_sort_with_and_without_ms(mocker):
     sorted_dt_arr = sorted(dt_arr, key=get_datetime_from_asset_history_item)
     assert(sorted_dt_arr[0] == ITEM_WITHOUT_MS)
     assert(sorted_dt_arr[1] == ITEM_WITH_MS)
+
+
+def test_get_last_scan(mocker):
+    init_integration(mocker)
+    from Rapid7_Nexpose import get_last_scan
+
+    # test empty history
+    expected = '-'
+    assert(get_last_scan({'history': None}) == expected)
+
+    # test history with assorted items
+    asset = {
+        'history': [
+            ITEM_WITH_MS,
+            ITEM_WITHOUT_MS
+        ]
+    }
+    expected = {
+        'date': '2019-05-03T03:02:54.123Z',
+        'id': '-'
+    }
+
+    # test history with assorted items + scanId
+    asset = {
+        'history': [
+            ITEM_WITH_MS,
+            ITEM_WITHOUT_MS,
+            ITEM_WITH_SCANID
+        ]
+    }
+    expected = {
+        'date': '2019-05-03T03:03:54.123Z',
+        'id': '1'
+    }
+    assert(get_last_scan(asset) == expected)

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -1,0 +1,46 @@
+import demistomock as demisto
+import requests
+
+ITEM_WITH_MS = {
+    'hour': '2019-05-03T03:02:54.123Z'
+}
+ITEM_WITHOUT_MS = {
+    'hour': '2019-05-03T03:01:54Z'
+}
+
+
+class RequestMock:
+    def __init__(self):
+        self.status_code = 200
+
+    def json(self):
+        return ''
+
+
+def init_integration(mocker):
+    mocker.patch.object(demisto, 'params', return_value={
+        'credentials': {
+            'identifier': 'a',
+            'password': 'a'
+        },
+        'server': 'nexpose.com'
+    })
+    mocker.patch.object(requests, 'post', return_value=RequestMock())
+
+
+def test_get_datetime_from_asset_history_item(mocker):
+    init_integration(mocker)
+    from Rapid7_Nexpose import get_datetime_from_asset_history_item
+
+    assert(get_datetime_from_asset_history_item(ITEM_WITH_MS))
+    assert(get_datetime_from_asset_history_item(ITEM_WITHOUT_MS))
+
+
+def test_sort_with_and_without_ms(mocker):
+    init_integration(mocker)
+    from Rapid7_Nexpose import get_datetime_from_asset_history_item
+
+    dt_arr = [ITEM_WITH_MS, ITEM_WITHOUT_MS]
+    sorted_dt_arr = sorted(dt_arr, key=get_datetime_from_asset_history_item)
+    assert(sorted_dt_arr[0].tm_hour == 2)
+    assert(sorted_dt_arr[1].tm_hour == 1)

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -9,7 +9,7 @@ ITEM_WITHOUT_MS = {
 }
 
 
-class RequestMock:
+class ResponseMock:
     def __init__(self):
         self.status_code = 200
 
@@ -23,9 +23,10 @@ def init_integration(mocker):
             'identifier': 'a',
             'password': 'a'
         },
-        'server': 'nexpose.com'
+        'server': 'nexpose.com',
+        'proxy': True
     })
-    mocker.patch.object(requests, 'post', return_value=RequestMock())
+    mocker.patch.object(requests, 'post', return_value=ResponseMock())
 
 
 def test_get_datetime_from_asset_history_item(mocker):

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -2,10 +2,10 @@ import demistomock as demisto
 import requests
 
 ITEM_WITH_MS = {
-    'hour': '2019-05-03T03:02:54.123Z'
+    'date': '2019-05-03T03:02:54.123Z'
 }
 ITEM_WITHOUT_MS = {
-    'hour': '2019-05-03T03:01:54Z'
+    'date': '2019-05-03T03:01:54Z'
 }
 
 

--- a/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
+++ b/Integrations/Rapid7_Nexpose/Rapid7_Nexpose_test.py
@@ -43,5 +43,5 @@ def test_sort_with_and_without_ms(mocker):
 
     dt_arr = [ITEM_WITH_MS, ITEM_WITHOUT_MS]
     sorted_dt_arr = sorted(dt_arr, key=get_datetime_from_asset_history_item)
-    assert(sorted_dt_arr[0].tm_hour == 2)
-    assert(sorted_dt_arr[1].tm_hour == 1)
+    assert(sorted_dt_arr[0] == ITEM_WITHOUT_MS)
+    assert(sorted_dt_arr[1] == ITEM_WITH_MS)

--- a/Releases/LatestRelease/Rapid7_Nexpose.md
+++ b/Releases/LatestRelease/Rapid7_Nexpose.md
@@ -1,1 +1,1 @@
--
+Fixed a bug in `nexpose-get-asset` where the command would fail to handle dates with no milliseconds


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17765

## Description
The issue was caused by a known behaviour of `time.strptime` function where if given the flag `%f` (milliseconds) when milliseconds is 0 will result in an exception.
The fix is to wrap the call with a function that contains a fallback if there aren't milliseconds.
## Does it break backward compatibility?
   - No

## Screenshots
### Unit test result on integration prior to fix:
![image](https://user-images.githubusercontent.com/20818773/61082587-70d77800-a432-11e9-9d73-939066450839.png)

## Must have
- [x] Tests
- [x] Code Review