### PR TITLE
Jira integration: add support for remote application links

### DIFF
--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -519,7 +519,7 @@ def get_file(entry_id):
     return file_name, file_bytes
 
 
-def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None):
+def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None, application_type=None, application_name=None):
     req_url = f'rest/api/latest/issue/{issue_id}/remotelink'
     link = {
         "object": {
@@ -534,6 +534,12 @@ def add_link_command(issue_id, title, url, summary=None, global_id=None, relatio
         link['globalId'] = global_id
     if relationship:
         link['relationship'] = relationship
+    if application_type or application_name:
+        link['application'] = {}
+    if application_type:
+        link['application']['type'] = application_type
+    if application_type:
+        link['application']['name'] = application_name
 
     result = jira_req('POST', req_url, json.dumps(link))
     data = result.json()

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -305,9 +305,10 @@ def get_issue_fields(issue_creating=False, **issue_args):
     if issue_args.get('summary'):
         issue['fields']['summary'] = issue_args['summary']
 
-    if not issue['fields'].get('project'):
+    # if project key or name is given, add it to the fields, else skip it
+    if (issue_args.get('projectKey') or issue_args.get('projectName')) and not issue['fields'].get('project'):
         issue['fields']['project'] = {}
-
+        
     if issue_args.get('projectKey'):
         issue['fields']['project']['key'] = issue_args.get('projectKey', '')
     if issue_args.get('projectName'):

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -305,8 +305,7 @@ def get_issue_fields(issue_creating=False, **issue_args):
     if issue_args.get('summary'):
         issue['fields']['summary'] = issue_args['summary']
 
-    # if project key or name is given, add it to the fields, else skip it
-    if (issue_args.get('projectKey') or issue_args.get('projectName')) and not issue['fields'].get('project'):
+    if not issue['fields'].get('project'):
         issue['fields']['project'] = {}
 
     if issue_args.get('projectKey'):

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -308,7 +308,7 @@ def get_issue_fields(issue_creating=False, **issue_args):
     # if project key or name is given, add it to the fields, else skip it
     if (issue_args.get('projectKey') or issue_args.get('projectName')) and not issue['fields'].get('project'):
         issue['fields']['project'] = {}
-        
+
     if issue_args.get('projectKey'):
         issue['fields']['project']['key'] = issue_args.get('projectKey', '')
     if issue_args.get('projectName'):

--- a/Integrations/JiraV2/JiraV2.yml
+++ b/Integrations/JiraV2/JiraV2.yml
@@ -230,6 +230,10 @@ script:
     - name: issueId
       required: true
       description: The ID of the issue.
+    - name: applicationType
+      description: The application type of the linked remote application. E.g "com.atlassian.confluence".
+    - name: applicationName
+      description: The application name of the linked remote application. E.g "My Confluence Instance".
     description: Creates (or updates) an issue link.
   - name: jira-edit-issue
     arguments:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
This PR adds support to provide the application when created a remote issue link.
This is useful if there are other Atlassian products connected to Jira, like Confluence. 
Especially if linked Confluence Articles are forced somewhere in the issue workflow.

API details here:
https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-issueIdOrKey-remotelink-get

## Screenshots
Before (resolves as generic URL):
![image](https://user-images.githubusercontent.com/1359917/61062062-cf363380-a3fd-11e9-91e5-b6f29d3ef5e8.png)

After (resolves as Confluence Article): 
![image](https://user-images.githubusercontent.com/1359917/61062209-102e4800-a3fe-11e9-8c71-c11c9007ca75.png)

## Required version of Demisto
4.5

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests: test playbook did not change
- [x] Documentation (with link to it): Documentation added to parameter description
- [ ] Code Review

