### PR TITLE
Fix bug in fetch incidets - integration duplicates the last ticket

### DIFF
--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -584,9 +584,10 @@ def fetch_incidents(query, id_offset=0, fetch_by_created=None, **_):
     if fetch_by_created:
         query = f'{query} AND created>-1m'
     res = run_query(query, '', max_results)
+    curr_id = id_offset
     for ticket in res.get('issues'):
         ticket_id = int(ticket.get("id"))
-        if ticket_id == id_offset:
+        if ticket_id == curr_id:
             continue
 
         id_offset = max(int(id_offset), ticket_id)

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -573,7 +573,7 @@ def test_module():
         demisto.results('ok')
 
 
-def fetch_incidents(query, id_offset=None, fetch_by_created=None, **_):
+def fetch_incidents(query, id_offset=0, fetch_by_created=None, **_):
     last_run = demisto.getLastRun()
     demisto.debug(f"last_run: {last_run}" if last_run else 'last_run is empty')
     id_offset = last_run.get("idOffset") if (last_run and last_run.get("idOffset")) else id_offset
@@ -585,7 +585,11 @@ def fetch_incidents(query, id_offset=None, fetch_by_created=None, **_):
         query = f'{query} AND created>-1m'
     res = run_query(query, '', max_results)
     for ticket in res.get('issues'):
-        id_offset = max(id_offset, ticket.get("id"))
+        ticket_id = int(ticket.get("id"))
+        if ticket_id == id_offset:
+            continue
+
+        id_offset = max(int(id_offset), ticket_id)
         incidents.append(create_incident_from_ticket(ticket))
 
     demisto.setLastRun({"idOffset": id_offset})

--- a/Releases/LatestRelease/JiraV2.md
+++ b/Releases/LatestRelease/JiraV2.md
@@ -1,0 +1,1 @@
+- Fix bug in fetch incidets - skip the ticket if incident with the same ticket id already created

--- a/Releases/LatestRelease/JiraV2.md
+++ b/Releases/LatestRelease/JiraV2.md
@@ -1,1 +1,1 @@
-- Fix bug in fetch incidets - skip the ticket if incident with the same ticket id already created
+- Fixed an issue when fetching incidents in which multiple incidents with the same ticket ID were fetched.


### PR DESCRIPTION
## Status
Ready

## Description
Fetch incidents in Jira integration creates new incident for the same ticket every fetch iteration.
The fix use to avoid incidents duplication

