### PR TITLE
Reverse Insecure logic for Cisco Umbrella

### DIFF
--- a/Integrations/Cisco-umbrella/Cisco-umbrella.py
+++ b/Integrations/Cisco-umbrella/Cisco-umbrella.py
@@ -22,18 +22,13 @@ requests.packages.urllib3.disable_warnings()
 
 API_TOKEN = demisto.params()['APIToken']
 BASE_URL = demisto.params()['baseURL']
-USE_SSL = True if demisto.params().get('insecure') else False
+USE_SSL = demisto.params().get('insecure') if demisto.params().get('insecure') else \
+    not demisto.params().get('insecure_new')  # Backward compatibility issue, the old logic of insecure was reversed
 DEFAULT_HEADERS = {
     'Authorization': 'Bearer {}'.format(API_TOKEN),
     'Accept': 'application/json'
 }
 MALICIOUS_THRESHOLD = int(demisto.params().get('dboscore_threshold', -100))
-# remove proxy if not set to true in params
-if not demisto.params().get('proxy'):
-    del os.environ['HTTP_PROXY']
-    del os.environ['HTTPS_PROXY']
-    del os.environ['http_proxy']
-    del os.environ['https_proxy']
 
 ''' MAPS '''
 
@@ -1756,6 +1751,7 @@ def get_url_timeline(url):
 
 LOG('command is %s' % (demisto.command(),))
 try:
+    handle_proxy()
     if demisto.command() == 'test-module':
         # This is the call made when pressing the integration test button.
         http_request('/domains/categorization/google.com?showLabels')

--- a/Integrations/Cisco-umbrella/Cisco-umbrella.py
+++ b/Integrations/Cisco-umbrella/Cisco-umbrella.py
@@ -7,7 +7,6 @@ from CommonServerUserPython import *
 import sys
 import requests
 import json
-import os
 import time
 import re
 import urllib

--- a/Integrations/Cisco-umbrella/Cisco-umbrella.yml
+++ b/Integrations/Cisco-umbrella/Cisco-umbrella.yml
@@ -17,7 +17,7 @@ configuration:
   type: 8
   required: false
 - display: Trust any certificate (unsecure)
-  name: insecure
+  name: insecure_new
   defaultvalue: ""
   type: 8
   required: false

--- a/Releases/LatestRelease/Cisco-umbrella.md
+++ b/Releases/LatestRelease/Cisco-umbrella.md
@@ -1,1 +1,1 @@
-* Packaged to follow new conventions
+* Reversed logic of the "Trust any certificate" setting.

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1811,7 +1811,6 @@
         "Pwned": "Integration has no proxy checkbox",
         "Shodan": "Integration has no proxy checkbox",
         "Google BigQuery": "Integration has no proxy checkbox",
-        "Cisco Umbrella Investigate": "Pending merge of branch proxy-unsecure-checks",
         "InfoArmor VigilanteATI": "Pending merge of branch proxy-unsecure-checks",
         "GoogleSafeBrowsing": "Pending merge of branch proxy-unsecure-checks",
         "Cisco Meraki": "Pending merge of branch proxy-unsecure-checks",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: demisto/etc#17937

## Description
* Reversed logic of Insecure setting while preserving backwards compatibility.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation (with link to it)
- [ ] Code Review
