### PR TITLE
Opswat metadefender bug fix: corrupted file upload

### DIFF
--- a/Integrations/integration-opswat-metadefender-v2.yml
+++ b/Integrations/integration-opswat-metadefender-v2.yml
@@ -1,6 +1,7 @@
 commonfields:
   id: OPSWAT-Metadefender V2
   version: -1
+  sortvalues: []
 name: OPSWAT-Metadefender V2
 display: OPSWAT-Metadefender V2
 category: Data Enrichment & Threat Intelligence
@@ -77,19 +78,19 @@ script:
 
     ''' HELPER FUNCTIONS '''
     def http_req(method='GET', url_suffix='', file=None, parse_json=True):
-        files = None
+        data = None
         url = BASE_URL + url_suffix
         headers = DEFAULT_HEADERS
         if USE_CLOUD:
             headers['apikey'] = API_KEY
         if file:
             headers['filename'] = file['file_name']
-            files = {file['file_name']:file['file']}
-        LOG(f'running request with url={url}\n\tfiles={files}')
+            headers['content-type'] = 'application/json'
+            data=file['data']
         if method.upper() == 'GET':
             res = requests.get(url, verify=USE_SSL, headers=headers)
         elif method.upper() == 'POST':
-            res = requests.post(url, verify=USE_SSL, files=files, headers=headers)
+            res = requests.post(url, verify=USE_SSL, data=data, headers=headers)
         else:
             return_error(f'Got unsupporthed http method: {method}')
             return ''
@@ -113,7 +114,8 @@ script:
         shutil.copy(file_entry['path'], file_name)
         try:
             with open(file_name, 'rb') as f:
-                res = http_req(method='POST', url_suffix='file', file={'file_name': file_name, 'file':f})
+                fileContent = f.read()
+                res = http_req(method='POST', url_suffix='file', file={'file_name': file_name, 'data':fileContent})
         finally:
             shutil.rmtree(file_name, ignore_errors=True)
         return res, file_name
@@ -140,8 +142,15 @@ script:
             scan_results = res['scan_results']
             file_type_description = file_info['file_type_description']
             scan_all_result_a = scan_results['scan_all_result_a']
-            total_detected_avs = scan_results['total_detected_avs']
             total_avs = scan_results['total_avs']
+            scan_details = scan_results['scan_details']
+            total_detected_avs = 0
+            if 'total_detected_avs' in scan_results:
+                    total_detected_avs = scan_results['total_detected_avs']
+            else:
+                for key in scan_details:
+                    if scan_details[key]['threat_found'] != '':
+                        total_detected_avs = total_detected_avs +1
 
             md += f'File name: {display_name}\n';
             md += f'File description: {file_type_description}\n';
@@ -150,8 +159,7 @@ script:
             md += 'AV Name|Def Time|Threat Name Found\n';
             md += '---|---|---\n';
 
-            avRes = scan_results['scan_details']
-            for key, scan in avRes.items():
+            for key, scan in scan_details.items():
                 def_time = scan['def_time']
                 threat_found = scan['threat_found']
                 md += f'{key}|{def_time}|{threat_found}\n'
@@ -283,7 +291,7 @@ script:
         if demisto.command() == 'opswat-scan-result':
             get_scan_result_command()
     except Exception as e:
-        message = f'Unexpected error: {e}, traceback: {traceback.print_exc()}'
+        message = f'Unexpected error: {e}'
         LOG(str(e))
         LOG.print_log()
         return_error(message)

--- a/Releases/LatestRelease/integration-opswat-metadefender-v2.md
+++ b/Releases/LatestRelease/integration-opswat-metadefender-v2.md
@@ -1,0 +1,1 @@
+- fix corrupted file upload


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17189

## Description
Fixes the curated file upload by *not* using muiltipart
Handling responses when `total_detected_avs` is missing.

the one dose not have tests because we don't have an instance.
It was tested in the customer environment. this can be seen in the issue.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Code Review
