### PR TITLE
MailSenderNew add support for custom headers

### DIFF
--- a/Integrations/MailSenderNew/MailSenderNew.py
+++ b/Integrations/MailSenderNew/MailSenderNew.py
@@ -223,6 +223,7 @@ def create_msg():
     to = argToList(demisto.getArg('to'))
     cc = argToList(demisto.getArg('cc'))
     bcc = argToList(demisto.getArg('bcc'))
+    additional_header = argToList(demisto.getArg('additionalHeader'))
     subject = demisto.getArg('subject') or ''
     body = demisto.getArg('body') or ''
     htmlBody = demisto.getArg('htmlBody') or ''
@@ -286,6 +287,10 @@ def create_msg():
         msg['To'] = header(','.join(to))
     if cc:
         msg['CC'] = header(','.join(cc))
+    if additional_header:
+        for h in additional_header:
+            header_name_value = h.split('=')
+            msg.add_header(header_name_value[0], header(header_name_value[1]))
     # Notice we should not add BCC header since Python2 does not filter it
     return msg.as_string(), to, cc, bcc
 

--- a/Integrations/MailSenderNew/MailSenderNew.py
+++ b/Integrations/MailSenderNew/MailSenderNew.py
@@ -289,8 +289,8 @@ def create_msg():
         msg['CC'] = header(','.join(cc))
     if additional_header:
         for h in additional_header:
-            header_name_value = h.split('=')
-            msg.add_header(header_name_value[0], header(header_name_value[1]))
+            header_name_and_value = h.split('=')
+            msg[header_name_and_value[0]] = header(header_name_and_value[1])
     # Notice we should not add BCC header since Python2 does not filter it
     return msg.as_string(), to, cc, bcc
 

--- a/Integrations/MailSenderNew/MailSenderNew.yml
+++ b/Integrations/MailSenderNew/MailSenderNew.yml
@@ -98,6 +98,10 @@ script:
         values are in the form of a JSON document like {"varname": {"value": "some
         value", "key": "context key"}}. Each var name can either be provided with
         the value or a context key to retrieve the value from.'
+    - name: additionalHeader
+      description: Additional header in the form headerName=headerValue. Multiple headers are supported as comma-separated
+        list. (e.g. headerName1=headerValue1,headerName2=headerValue2)
+      isArray: true
     description: Send an email
   runonce: false
 tests:


### PR DESCRIPTION
## Status
Ready

## Description
This PR adds support for custom mail headers to the MailSenderNew integration. Users can simply add additional one or multiple mail headers to an email by providing `headerName1=headerName1,headerName2=headerName2`

## Required version of Demisto
4.5.0

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [x] Documentation: provided within the command description
- [ ] Code Review

