### PR TITLE
Active Directory Query playbook fixed

### DIFF
--- a/TestPlaybooks/playbook-Active_Directory_Test.yml
+++ b/TestPlaybooks/playbook-Active_Directory_Test.yml
@@ -54,7 +54,7 @@ tasks:
       telephone-number: {}
       title: {}
       user-dn:
-        simple: cn=jack,dc=demisto,dc=int
+        simple: cn=jack,dc=demisto,dc=ninja
       username:
         simple: jack
     separatecontext: false
@@ -123,7 +123,7 @@ tasks:
       attribute-value:
         simple: Jack the ripper
       contact-dn:
-        simple: cn=Jack,dc=demisto,dc=int
+        simple: cn=Jack,dc=demisto,dc=ninja
     separatecontext: false
     view: |-
       {
@@ -314,7 +314,7 @@ tasks:
     scriptarguments:
       attributes: {}
       group-dn:
-        simple: CN=Users,CN=Builtin,DC=demisto,DC=int
+        simple: CN=Users,CN=Builtin,DC=demisto,DC=ninja
       member-type:
         simple: person
     separatecontext: false
@@ -359,7 +359,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: CN=jack,DC=demisto,DC=int
+                        simple: CN=jack,DC=demisto,DC=ninja
                 accessor: Groups.members.dn
             iscontext: true
     view: |-
@@ -463,7 +463,7 @@ tasks:
       brand: ""
     scriptarguments:
       user-dn:
-        simple: cn=jack,dc=demisto,dc=int
+        simple: cn=jack,dc=demisto,dc=ninja
     separatecontext: false
     view: |-
       {
@@ -595,7 +595,7 @@ tasks:
     scriptarguments:
       attributes: {}
       group-dn:
-        simple: CN=Users,CN=Builtin,DC=demisto,DC=int
+        simple: CN=Users,CN=Builtin,DC=demisto,DC=ninja
       member-type:
         simple: person
     separatecontext: false
@@ -791,7 +791,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "603"
+              simple: "10"
     view: |-
       {
         "position": {
@@ -825,7 +825,7 @@ tasks:
       context-output:
         simple: "no"
       filter:
-        simple: (&(objectCategory=person)(objectClass=user)(!(cn=andy)))
+        simple: (&(objectCategory=person)(objectClass=user)(cn=jack))
       size-limit:
         simple: "5"
       time-limit: {}

--- a/TestPlaybooks/playbook-Whois-Test.yml
+++ b/TestPlaybooks/playbook-Whois-Test.yml
@@ -268,15 +268,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: GOOGLE.COM
-      - - operator: isEqualString
-          left:
-            value:
-              simple: Domain.Whois.QueryStatus
-            iscontext: true
-          right:
-            value:
-              simple: Success
+              simple: google.com
       - - operator: isEqualString
           left:
             value:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Fixed Active Directory playbook and Whois playbook

## Description
changed AD playbook values and query to match actual server status. 
Whois playbook checked a non-existing field (Domain.Whois.QueryStatus) and an invalid value ("GOOGLE.COM" instead of simply "google.com") - changed both


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------


## Required version of Demisto
5.0.0

## Does it break backward compatibility?
   - No
