### PR TITLE
set server version to latest when running with non-ami

### DIFF
--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -611,6 +611,8 @@ def main():
                 sleep(8)
 
     else:  # Run tests in Server build configuration
+        server_numeric_version = '99.99.98'  # assume latest
+        print("Using server version: {} (assuming latest for non-ami)".format(server_numeric_version))
         with open('./Tests/instance_ips.txt', 'r') as instance_file:
             instance_ips = instance_file.readlines()
             instance_ip = [line.strip('\n').split(":")[1] for line in instance_ips][0]


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/18233

## Description
Just use latest version when testing non-ami

