### PR TITLE
Moving Pwned and AlienVault USM integrations to skipped until fixed

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1794,6 +1794,7 @@
         "Tenable.io": "Unstable instance (issue 16115)",
 
       "_comment": "~~~ OTHER ~~~",
+        "Pwned": "Changes in API - may require integration rewrite (issue #18102)",
         "SumoLogic": "Shelly working on fixing it",
         "Windows Defender Advanced Threat Protection": "Avidan working on fixing it",
         "iDefense": "DevOps investigation",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1761,6 +1761,7 @@
 
 
       "_comment": "~~~ INSTANCE ISSUES ~~~",
+        "AlienVault USM Anywhere": "License expired (issue #18273)",
         "Tufin": "Calls to instance return 502 error. @itay reached out (issue 16441)",
         "Dell Secureworks": "Instance locally installed on @liorblob PC",
         "MimecastV2": "Several issues with instance",


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18102
https://github.com/demisto/etc/issues/18273

## Description
Pwned API has changed, resulting in several of the integration commands not working (returning error 403 forbidden).

AlienVault USM license needs to be renewed

