### PR TITLE
Moved ArcSight ESM v2 to skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1761,6 +1761,7 @@
 
 
       "_comment": "~~~ INSTANCE ISSUES ~~~",
+        "ArcSight ESM v2": "License expired (issue #18328)",
         "AlienVault USM Anywhere": "License expired (issue #18273)",
         "Tufin": "Calls to instance return 502 error. @itay reached out (issue 16441)",
         "Dell Secureworks": "Instance locally installed on @liorblob PC",


### PR DESCRIPTION

## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18328

## Description
ArcSight ESM license has expired, moving the integration to skipped until renewal.
