### PR TITLE
Moving "rsa_packets_and_logs_test" to skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1703,6 +1703,7 @@
         }
     ],
     "skipped_tests": {
+        "rsa_packets_and_logs_test": "A command searches for a session ID which doesn't exist on our local server - asked RSA to help (issue #18332)",
         "reputations.json Test": "Reverting the fqdn indicator due to glichtman request, will handled next release(end july 19)",
         "Cybereason Test": "Integration instance being disabled in the middle of test playbook (issue 17394)",
         "LogRhythmRest": "Unstable environment Adi is checking",


### PR DESCRIPTION

## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18332

## Description
Moved RSA NetWitness Packets and Logs test to skipped until a fix can be found for the command that fails it.

