### PR TITLE
Skipping CreatePhishingClassifierMLTest, Autoextract tests, and McAfee TIE tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1703,6 +1703,8 @@
         }
     ],
     "skipped_tests": {
+        "CreatePhishingClassifierMLTest": "Test is unstable and fails with no reason from time to time (issue ##18349)",
+        "Autoextract - Test": "See issue #18343 for further information",
         "rsa_packets_and_logs_test": "A command searches for a session ID which doesn't exist on our local server - asked RSA to help (issue #18332)",
         "reputations.json Test": "Reverting the fqdn indicator due to glichtman request, will handled next release(end july 19)",
         "Cybereason Test": "Integration instance being disabled in the middle of test playbook (issue 17394)",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1703,6 +1703,8 @@
         }
     ],
     "skipped_tests": {
+        "search_endpoints_by_hash_-_tie_-_test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
+        "McAfee-TIE Test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "CreatePhishingClassifierMLTest": "Test is unstable and fails with no reason from time to time (issue ##18349)",
         "Autoextract - Test": "See issue #18343 for further information",
         "rsa_packets_and_logs_test": "A command searches for a session ID which doesn't exist on our local server - asked RSA to help (issue #18332)",


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18349
https://github.com/demisto/etc/issues/18343
https://github.com/demisto/etc/issues/18350

## Description
Autoextract - skipped because of changes in reputations.json file
CreatePhishingClassifierMLTest - skipped because test is unstable
TIE - tests fail to create instance from time to time - a rerun solves the problem