### PR TITLE
detailed documentation added

### DIFF
--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
@@ -38,8 +38,7 @@ configuration:
   name: fetch_time
   required: false
   type: 0
-description: Cortex XDR is the world's first detection and response app that natively
-  integrates network, endpoint and cloud data to stop sophisticated attacks.
+description: Cortex XDR is the world's first detection and response app that natively integrates network, endpoint and cloud data to stop sophisticated attacks.
 display: Palo Alto Networks Cortex XDR - Investigation and Response
 name: Cortex XDR - IR
 script:
@@ -52,22 +51,19 @@ script:
       required: false
       secret: false
     - default: false
-      description: Returned incidents that were created on or after the specified
-        date/time, in the format 2019-12-31T23:59:00.
+      description: Returned incidents that were created on or after the specified date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: gte_creation_time
       required: false
       secret: false
     - default: false
-      description: Filters returned incidents that were created on or before the specified
-        date/time, in the format 2019-12-31T23:59:00.
+      description: Filters returned incidents that were created on or before the specified date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: lte_modification_time
       required: false
       secret: false
     - default: false
-      description: Filters returned incidents that were modified on or after the specified
-        date/time, in the format 2019-12-31T23:59:00.
+      description: Filters returned incidents that were modified on or after the specified date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: gte_modification_time
       required: false
@@ -90,10 +86,8 @@ script:
       required: false
       secret: false
       description: Filters returned incidents that were modified on or after the specified date/time range, for example, 1 month, 2 days, 1 hour, and so on.
-      auto: PREDEFINED
-    - default: false
-      description: Sorts returned incidents by the date/time that the incident was
-        last modified ("asc" - ascending, "desc" - descending).
+    - auto: PREDEFINED
+      default: false
       isArray: false
       name: sort_by_modification_time
       predefined:
@@ -101,10 +95,9 @@ script:
       - desc
       required: false
       secret: false
+      description: Sorts returned incidents by the date/time that the incident was last modified ("asc" - ascending, "desc" - descending).
     - auto: PREDEFINED
       default: false
-      description: Sorts returned incidents by the date/time that the incident was
-        created ("asc" - ascending, "desc" - descending).
       isArray: false
       name: sort_by_creation_time
       predefined:
@@ -112,6 +105,7 @@ script:
       - desc
       required: false
       secret: false
+      description: Sorts returned incidents by the date/time that the incident was created ("asc" - ascending, "desc" - descending).
     - default: false
       defaultValue: '0'
       description: Page number (for pagination). The default is 0 (the first page).
@@ -121,8 +115,7 @@ script:
       secret: false
     - default: false
       defaultValue: '100'
-      description: Maximum number of incidents to return per page. The default and
-        maximum is 100.
+      description: Maximum number of incidents to return per page. The default and maximum is 100.
       isArray: false
       name: limit
       required: false
@@ -138,8 +131,7 @@ script:
       description: Unique ID assigned to each returned incident.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_severity
-      description: Incident severity assigned by the user. This does not affect the
-        calculated severity (LOW, MEDIUM, HIGH).
+      description: Incident severity assigned by the user. This does not affect the calculated severity (LOW, MEDIUM, HIGH).
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_description
       description: Incident description provided by the user.
@@ -211,8 +203,8 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: Returns additional data for the specified incident, for example,
-      related alerts, file artifacts, network artifacts, and so on.
+    description: Returns additional data for the specified incident, for example, related alerts,
+      file artifacts, network artifacts, and so on.
     execution: false
     name: xdr-get-incident-extra-data
     outputs:
@@ -220,8 +212,7 @@ script:
       description: Unique ID assigned to each returned incident.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_severity
-      description: Incident severity assigned by the user. This does not affect the
-        calculated severity (LOW, MEDIUM, HIGH).
+      description: Incident severity assigned by the user. This does not affect the calculated severity (LOW, MEDIUM, HIGH).
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_description
       description: Incident description provided by the user.
@@ -279,8 +270,7 @@ script:
       description: Date and time that the incident was last modified.
       type: date
     - contextPath: PaloAltoNetworksXDR.Incident.alerts.category
-      description: Category of the alert, for example, Spyware Detected via Anti-Spyware
-        profile.
+      description: Category of the alert, for example, Spyware Detected via Anti-Spyware profile.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.alerts.action_pretty
       description: The action that triggered the alert.
@@ -359,8 +349,7 @@ script:
       type: String
   - arguments:
     - default: false
-      description: XDR incident ID. You can get the incident ID from the output of
-        the 'xdr-get-incidents' command or the 'xdr-get-incident-extra-details' command.
+      description: XDR incident ID. You can get the incident ID from the output of the 'xdr-get-incidents' command or the 'xdr-get-incident-extra-details' command.
       isArray: false
       name: incident_id
       required: true
@@ -390,8 +379,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Status of the incident (NEW, UNDER_INVESTIGATION, RESOLVED_THREAT_HANDLED,
-        RESOLVED_KNOWN_ISSUE, RESOLVED_DUPLICATE, RESOLVED_FALSE_POSITIVE, RESOLVED_OTHER).
+      description: Status of the incident (NEW, UNDER_INVESTIGATION, RESOLVED_THREAT_HANDLED, RESOLVED_KNOWN_ISSUE, RESOLVED_DUPLICATE, RESOLVED_FALSE_POSITIVE, RESOLVED_OTHER).
       isArray: false
       name: status
       predefined:
@@ -405,8 +393,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Comment explaining why the incident was resolved. This should be
-        set when the incident is resolved.
+      description: Comment explaining why the incident was resolved. This should be set when the incident is resolved.
       isArray: false
       name: resolve_comment
       required: false
@@ -421,9 +408,8 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: Updates one or more fields of a specified incident. Missing fields
-      will be ignored. To remove the assignment for an incident, pass a null value
-      in assignee email argument.
+    description: |-
+      Updates one or more fields of a specified incident. Missing fields will be ignored. To remove the assignment for an incident, pass a null value in assignee email argument.
     execution: false
     name: xdr-update-incident
   dockerimage: demisto/python3:3.7.4.977

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
@@ -79,14 +79,19 @@ script:
       required: false
       secret: false
     - default: false
-      description: Filters returned incidents that were created on or after the specified
-        date/time range, for example, 1 month, 2 days, 1 hour, and so on.
       isArray: false
       name: since_creation_time
       required: false
       secret: false
-    - auto: PREDEFINED
-      default: false
+      description: Filters returned incidents that were created on or after the specified date/time range, for example, 1 month, 2 days, 1 hour, and so on.
+    - default: false
+      isArray: false
+      name: since_modification_time
+      required: false
+      secret: false
+      description: Filters returned incidents that were modified on or after the specified date/time range, for example, 1 month, 2 days, 1 hour, and so on.
+      auto: PREDEFINED
+    - default: false
       description: Sorts returned incidents by the date/time that the incident was
         last modified ("asc" - ascending, "desc" - descending).
       isArray: false

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR.yml
@@ -12,8 +12,7 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- defaultvalue: ""
-  display: Server URL (e.g. https://<tenant_url>/public_api_request)
+- display: Server URL (copy url from XDR - press ? to see more info)
   name: url
   required: true
   type: 0
@@ -39,7 +38,8 @@ configuration:
   name: fetch_time
   required: false
   type: 0
-description: Cortex XDR is the world's first detection and response app that natively integrates network, endpoint and cloud data to stop sophisticated attacks.
+description: Cortex XDR is the world's first detection and response app that natively
+  integrates network, endpoint and cloud data to stop sophisticated attacks.
 display: Palo Alto Networks Cortex XDR - Investigation and Response
 name: Cortex XDR - IR
 script:
@@ -52,19 +52,22 @@ script:
       required: false
       secret: false
     - default: false
-      description: Returned incidents that were created on or after the specified date/time, in the format 2019-12-31T23:59:00.
+      description: Returned incidents that were created on or after the specified
+        date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: gte_creation_time
       required: false
       secret: false
     - default: false
-      description: Filters returned incidents that were created on or before the specified date/time, in the format 2019-12-31T23:59:00.
+      description: Filters returned incidents that were created on or before the specified
+        date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: lte_modification_time
       required: false
       secret: false
     - default: false
-      description: Filters returned incidents that were modified on or after the specified date/time, in the format 2019-12-31T23:59:00.
+      description: Filters returned incidents that were modified on or after the specified
+        date/time, in the format 2019-12-31T23:59:00.
       isArray: false
       name: gte_modification_time
       required: false
@@ -76,19 +79,16 @@ script:
       required: false
       secret: false
     - default: false
+      description: Filters returned incidents that were created on or after the specified
+        date/time range, for example, 1 month, 2 days, 1 hour, and so on.
       isArray: false
       name: since_creation_time
       required: false
       secret: false
-      description: Filters returned incidents that were created on or after the specified date/time range, for example, 1 month, 2 days, 1 hour, and so on.
-    - default: false
-      isArray: false
-      name: since_modification_time
-      required: false
-      secret: false
-      description: Filters returned incidents that were modified on or after the specified date/time range, for example, 1 month, 2 days, 1 hour, and so on.    
-      auto: PREDEFINED
+    - auto: PREDEFINED
       default: false
+      description: Sorts returned incidents by the date/time that the incident was
+        last modified ("asc" - ascending, "desc" - descending).
       isArray: false
       name: sort_by_modification_time
       predefined:
@@ -96,9 +96,10 @@ script:
       - desc
       required: false
       secret: false
-      description: Sorts returned incidents by the date/time that the incident was last modified ("asc" - ascending, "desc" - descending).
     - auto: PREDEFINED
       default: false
+      description: Sorts returned incidents by the date/time that the incident was
+        created ("asc" - ascending, "desc" - descending).
       isArray: false
       name: sort_by_creation_time
       predefined:
@@ -106,7 +107,6 @@ script:
       - desc
       required: false
       secret: false
-      description: Sorts returned incidents by the date/time that the incident was created ("asc" - ascending, "desc" - descending).
     - default: false
       defaultValue: '0'
       description: Page number (for pagination). The default is 0 (the first page).
@@ -116,7 +116,8 @@ script:
       secret: false
     - default: false
       defaultValue: '100'
-      description: Maximum number of incidents to return per page. The default and maximum is 100.
+      description: Maximum number of incidents to return per page. The default and
+        maximum is 100.
       isArray: false
       name: limit
       required: false
@@ -132,7 +133,8 @@ script:
       description: Unique ID assigned to each returned incident.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_severity
-      description: Incident severity assigned by the user. This does not affect the calculated severity (LOW, MEDIUM, HIGH).
+      description: Incident severity assigned by the user. This does not affect the
+        calculated severity (LOW, MEDIUM, HIGH).
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_description
       description: Incident description provided by the user.
@@ -204,8 +206,8 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: Returns additional data for the specified incident, for example, related alerts,
-      file artifacts, network artifacts, and so on.
+    description: Returns additional data for the specified incident, for example,
+      related alerts, file artifacts, network artifacts, and so on.
     execution: false
     name: xdr-get-incident-extra-data
     outputs:
@@ -213,7 +215,8 @@ script:
       description: Unique ID assigned to each returned incident.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_severity
-      description: Incident severity assigned by the user. This does not affect the calculated severity (LOW, MEDIUM, HIGH).
+      description: Incident severity assigned by the user. This does not affect the
+        calculated severity (LOW, MEDIUM, HIGH).
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.manual_description
       description: Incident description provided by the user.
@@ -271,7 +274,8 @@ script:
       description: Date and time that the incident was last modified.
       type: date
     - contextPath: PaloAltoNetworksXDR.Incident.alerts.category
-      description: Category of the alert, for example, Spyware Detected via Anti-Spyware profile.
+      description: Category of the alert, for example, Spyware Detected via Anti-Spyware
+        profile.
       type: String
     - contextPath: PaloAltoNetworksXDR.Incident.alerts.action_pretty
       description: The action that triggered the alert.
@@ -350,7 +354,8 @@ script:
       type: String
   - arguments:
     - default: false
-      description: XDR incident ID. You can get the incident ID from the output of the 'xdr-get-incidents' command or the 'xdr-get-incident-extra-details' command.
+      description: XDR incident ID. You can get the incident ID from the output of
+        the 'xdr-get-incidents' command or the 'xdr-get-incident-extra-details' command.
       isArray: false
       name: incident_id
       required: true
@@ -380,7 +385,8 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Status of the incident (NEW, UNDER_INVESTIGATION, RESOLVED_THREAT_HANDLED, RESOLVED_KNOWN_ISSUE, RESOLVED_DUPLICATE, RESOLVED_FALSE_POSITIVE, RESOLVED_OTHER).
+      description: Status of the incident (NEW, UNDER_INVESTIGATION, RESOLVED_THREAT_HANDLED,
+        RESOLVED_KNOWN_ISSUE, RESOLVED_DUPLICATE, RESOLVED_FALSE_POSITIVE, RESOLVED_OTHER).
       isArray: false
       name: status
       predefined:
@@ -394,7 +400,8 @@ script:
       required: false
       secret: false
     - default: false
-      description: Comment explaining why the incident was resolved. This should be set when the incident is resolved.
+      description: Comment explaining why the incident was resolved. This should be
+        set when the incident is resolved.
       isArray: false
       name: resolve_comment
       required: false
@@ -409,8 +416,9 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: |-
-      Updates one or more fields of a specified incident. Missing fields will be ignored. To remove the assignment for an incident, pass a null value in assignee email argument.
+    description: Updates one or more fields of a specified incident. Missing fields
+      will be ignored. To remove the assignment for an incident, pass a null value
+      in assignee email argument.
     execution: false
     name: xdr-update-incident
   dockerimage: demisto/python3:3.7.4.977

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
@@ -1,8 +1,0 @@
- 1) API Key:
-- Go to Settings
-- Click the **+New Key** button in the top right corner
-- Generate a key from type **Advanced**
-- Copy + Paste the key
-- Copy the Key ID from the ID column
-2) URL:
-- Click the **Copy URL** button in the top right corner

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
@@ -1,8 +1,8 @@
  1) API Key:
 - Go to Settings
-- Click the `+New Key` button in the top right corner
-- Generate a key from type `Advanced`
+- Click the **+New Key** button in the top right corner
+- Generate a key from type **Advanced**
 - Copy + Paste the key
 - Copy the Key ID from the ID column
 2) URL:
-- Click the `Copy URL` button in the top right corner
+- Click the **Copy URL** button in the top right corner

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
@@ -1,1 +1,8 @@
- 
+ 1) API Key:
+- Go to Settings
+- Click the '+New Key' button in the top right corner
+- Generate a key from type 'Advanced'
+- Copy + Paste the key
+- Copy the Key ID from the ID column
+2) URL:
+- Click the 'Copy URL' button in the top right corner

--- a/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
+++ b/Integrations/PaloAltoNetworks_XDR/PaloAltoNetworks_XDR_description.md
@@ -1,8 +1,8 @@
  1) API Key:
 - Go to Settings
-- Click the '+New Key' button in the top right corner
-- Generate a key from type 'Advanced'
+- Click the `+New Key` button in the top right corner
+- Generate a key from type `Advanced`
 - Copy + Paste the key
 - Copy the Key ID from the ID column
 2) URL:
-- Click the 'Copy URL' button in the top right corner
+- Click the `Copy URL` button in the top right corner

--- a/Releases/LatestRelease/PaloAltoNetworks_XDR.md
+++ b/Releases/LatestRelease/PaloAltoNetworks_XDR.md
@@ -1,0 +1,1 @@
+- added detailed description on how to generate API KEY in Cortex XDR

--- a/Releases/LatestRelease/XDRSyncScript.md
+++ b/Releases/LatestRelease/XDRSyncScript.md
@@ -1,3 +1,3 @@
-- added verbose argument
-- all the arguments will have default incident field names
-- stop the previous scheduled task if playbook was re-executed
+- Added the *verbose* argument.
+- All arguments have default incident field names.
+- When a playbook is re-run, the previous scheduled task is terminated.

--- a/Releases/LatestRelease/XDRSyncScript.md
+++ b/Releases/LatestRelease/XDRSyncScript.md
@@ -1,0 +1,3 @@
+- added verbose argument
+- all the arguments will have default incident field names
+- stop the previous scheduled task if playbook was re-executed

--- a/Scripts/XDRSyncScript/XDRSyncScript.py
+++ b/Scripts/XDRSyncScript/XDRSyncScript.py
@@ -196,7 +196,8 @@ def get_latest_incident_from_xdr(incident_id):
     # get the latest incident from xdr
     latest_incident_in_xdr_result = demisto.executeCommand("xdr-get-incident-extra-data", {"incident_id": incident_id})
     if is_error(latest_incident_in_xdr_result):
-        raise ValueError("Failed to execute xdr-get-incident-extra-data command. Error: {}".format(get_error(latest_incident_in_xdr_result)))
+        raise ValueError("Failed to execute xdr-get-incident-extra-data command. Error: {}".format(
+            get_error(latest_incident_in_xdr_result)))
 
     latest_incident_in_xdr = latest_incident_in_xdr_result[0]["Contents"].get("incident")
     # no need to pass the whole incident with extra data - it will be too big json to pass

--- a/Scripts/XDRSyncScript/XDRSyncScript.py
+++ b/Scripts/XDRSyncScript/XDRSyncScript.py
@@ -374,6 +374,12 @@ def main():
     xdr_network_artifacts_field = demisto.args().get('xdr_network_artifacts')
     verbose = demisto.args().get('verbose') == 'true'
 
+    xdr_incident_markdown_field = demisto.args().get('xdr_incident_markdown_field')  # deprecated
+    if xdr_incident_markdown_field:
+        # deprecated field
+        raise ValueError('Deprecated xdr_incident_markdown_field argument, instead use xdr_alerts, xdr_file_artifacts, '
+                         'xdr_network_artifacts. For more information follow Demisto documentation.')
+
     previous_scheduled_task_id = demisto.get(demisto.context(), 'XDRSyncScriptTaskID')
     if first_run and previous_scheduled_task_id:
         if verbose:

--- a/Scripts/XDRSyncScript/XDRSyncScript.py
+++ b/Scripts/XDRSyncScript/XDRSyncScript.py
@@ -112,20 +112,14 @@ def compare_incident_in_demisto_vs_xdr_context(incident_in_demisto, xdr_incident
                 severity_current = incident_in_demisto.get(field_name_in_demisto)
 
                 severity_mapping = {
-                    0: None,
                     1: "low",
                     2: "medium",
                     3: "high",
                     4: "high"
                 }
-                if severity_mapping[severity_current] != severity_previous:
+                if severity_current != 0 and severity_mapping[severity_current] != severity_previous:
                     incident_in_demisto_was_modified = True
-
-                    if severity_current == 0:
-                        # Unknown severity equals to none
-                        xdr_update_args[MANUAL_SEVERITY_XDR_FIELD] = "none"
-                    else:
-                        xdr_update_args[MANUAL_SEVERITY_XDR_FIELD] = severity_mapping[severity_current]
+                    xdr_update_args[MANUAL_SEVERITY_XDR_FIELD] = severity_mapping[severity_current]
 
             else:
                 severity_current = incident_in_demisto.get("CustomFields").get(field_name_in_demisto)
@@ -202,8 +196,7 @@ def get_latest_incident_from_xdr(incident_id):
     # get the latest incident from xdr
     latest_incident_in_xdr_result = demisto.executeCommand("xdr-get-incident-extra-data", {"incident_id": incident_id})
     if is_error(latest_incident_in_xdr_result):
-        demisto.results(latest_incident_in_xdr_result)
-        return
+        raise ValueError("Failed to execute xdr-get-incident-extra-data command. Error: {}".format(get_error(latest_incident_in_xdr_result)))
 
     latest_incident_in_xdr = latest_incident_in_xdr_result[0]["Contents"].get("incident")
     # no need to pass the whole incident with extra data - it will be too big json to pass
@@ -224,7 +217,7 @@ def get_latest_incident_from_xdr(incident_id):
 
 
 def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_incident_from_previous_run, first_run,
-                      interval, xdr_incident_markdown_field):
+                      interval, xdr_alerts_field, xdr_file_artifacts_field, xdr_network_artifacts_field, verbose=True):
 
     latest_incident_in_xdr_result, latest_incident_in_xdr, latest_incident_in_xdr_markdown = \
         get_latest_incident_from_xdr(incident_id)
@@ -260,10 +253,16 @@ def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_inc
         latest_incident_in_xdr_result, latest_incident_in_xdr, latest_incident_in_xdr_markdown = \
             get_latest_incident_from_xdr(incident_id)
 
-        update_incident_markdown_field = dict()
-        update_incident_markdown_field[xdr_incident_markdown_field] = latest_incident_in_xdr_markdown
+        xdr_incident = latest_incident_in_xdr_result[0]['Contents']
+        update_incident = dict()
+        update_incident[xdr_alerts_field] = replace_in_keys(xdr_incident.get('alerts').get('data', []), '_', '')
+        update_incident[xdr_file_artifacts_field] = replace_in_keys(xdr_incident.get('file_artifacts').get('data', []),
+                                                                    '_', '')
+        update_incident[xdr_network_artifacts_field] = replace_in_keys(xdr_incident.get('network_artifacts').get('data',
+                                                                                                                 []),
+                                                                       '_', '')
 
-        res = demisto.executeCommand("setIncident", update_incident_markdown_field)
+        res = demisto.executeCommand("setIncident", update_incident)
         if is_error(res):
             raise ValueError(get_error(res))
 
@@ -283,10 +282,12 @@ def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_inc
 
         scheduled_task_id = res[0]["Contents"].get("id")
         demisto.setContext("XDRSyncScriptTaskID", scheduled_task_id)
-        demisto.results("XDRSyncScriptTaskID: {}".format(scheduled_task_id))
-        return_outputs(
-            "Incident in Demisto was modified, updating incident in XDR accordingly.\n\n{}".format(xdr_update_args),
-            None)
+
+        if verbose:
+            demisto.results("XDRSyncScriptTaskID: {}".format(scheduled_task_id))
+            return_outputs(
+                "Incident in Demisto was modified, updating incident in XDR accordingly.\n\n{}".format(xdr_update_args),
+                None)
         return
 
     incident_in_xdr_was_modified, demisto_update_args = compare_incident_in_xdr_vs_previous_xdr_in_context(
@@ -298,16 +299,24 @@ def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_inc
         demisto.debug("the incident in xdr was modified, updating the incident in demisto")
         demisto.debug("demisto_update_args: {}".format(json.dumps(demisto_update_args, indent=4)))
 
-        demisto_update_args[xdr_incident_markdown_field] = latest_incident_in_xdr_markdown
+        xdr_incident = latest_incident_in_xdr_result[0]['Contents']
+        update_incident = dict()
+        update_incident[xdr_alerts_field] = replace_in_keys(xdr_incident.get('alerts').get('data', []), '_', '')
+        update_incident[xdr_file_artifacts_field] = replace_in_keys(xdr_incident.get('file_artifacts').get('data', []),
+                                                                    '_', '')
+        update_incident[xdr_network_artifacts_field] = replace_in_keys(xdr_incident.get('network_artifacts').get('data',
+                                                                                                                 []),
+                                                                       '_', '')
 
-        res = demisto.executeCommand("setIncident", demisto_update_args)
+        res = demisto.executeCommand("setIncident", update_incident)
         if is_error(res):
             raise ValueError(get_error(res))
 
         demisto.results(latest_incident_in_xdr_result)
-        return_outputs(
-            "Incident in XDR was modified, updating incident in Demisto accordingly.\n\n{}".format(demisto_update_args),
-            None)
+        if verbose:
+            return_outputs(
+                "Incident in XDR was modified, updating incident in Demisto accordingly.\n\n{}".format(demisto_update_args),
+                None)
 
         # rerun the playbook
         demisto.executeCommand("setPlaybook", {"name": playbook_name_to_run})
@@ -317,10 +326,19 @@ def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_inc
         demisto.results(latest_incident_in_xdr_result)
 
         # set the incident markdown field
-        update_incident_markdown_field = dict()
-        update_incident_markdown_field[xdr_incident_markdown_field] = latest_incident_in_xdr_markdown
+        # update_incident_markdown_field = dict()
+        # update_incident_markdown_field[xdr_incident_markdown_field] = latest_incident_in_xdr_markdown
+        xdr_incident = latest_incident_in_xdr_result[0]['Contents']
+        update_incident = dict()
+        update_incident[xdr_alerts_field] = replace_in_keys(xdr_incident.get('alerts').get('data', []), '_', '')
+        update_incident[xdr_file_artifacts_field] = replace_in_keys(xdr_incident.get('file_artifacts').get('data', []),
+                                                                    '_', '')
+        update_incident[xdr_network_artifacts_field] = replace_in_keys(xdr_incident.get('network_artifacts').get('data',
+                                                                                                                 []),
+                                                                       '_', '')
 
-        res = demisto.executeCommand("setIncident", update_incident_markdown_field)
+        demisto.results(update_incident)
+        res = demisto.executeCommand("setIncident", update_incident)
         if is_error(res):
             raise ValueError(get_error(res))
 
@@ -332,8 +350,10 @@ def xdr_incident_sync(incident_id, fields_mapping, playbook_name_to_run, xdr_inc
     })
     scheduled_task_id = res[0]["Contents"].get("id")
     demisto.setContext("XDRSyncScriptTaskID", scheduled_task_id)
-    demisto.results("XDRSyncScriptTaskID: {}".format(scheduled_task_id))
-    return_outputs("Nothing to sync.", None)
+
+    if verbose:
+        demisto.results("XDRSyncScriptTaskID: {}".format(scheduled_task_id))
+        return_outputs("Nothing to sync.", None)
 
 
 def main():
@@ -348,10 +368,21 @@ def main():
     first_run = demisto.args().get('first') == 'true'
     interval = int(demisto.args().get('interval'))
     xdr_incident_from_previous_run = demisto.args().get('xdr_incident_from_previous_run')
-    xdr_incident_markdown_field = demisto.args().get('xdr_incident_markdown_field')
+    xdr_alerts_field = demisto.args().get('xdr_alerts')
+    xdr_file_artifacts_field = demisto.args().get('xdr_file_artifacts')
+    xdr_network_artifacts_field = demisto.args().get('xdr_network_artifacts')
+    verbose = demisto.args().get('verbose') == 'true'
+
+    previous_scheduled_task_id = demisto.get(demisto.context(), 'XDRSyncScriptTaskID')
+    if first_run and previous_scheduled_task_id:
+        if verbose:
+            demisto.debug('Stopping previous scheduled task with ID: {}'.format(previous_scheduled_task_id))
+
+        demisto.executeCommand('StopScheduledTask', {'taskID': previous_scheduled_task_id})
+        demisto.setContext('XDRSyncScriptTaskID', '')
 
     xdr_incident_sync(incident_id, fields_mapping, playbook_to_run, xdr_incident_from_previous_run, first_run, interval,
-                      xdr_incident_markdown_field)
+                      xdr_alerts_field, xdr_file_artifacts_field, xdr_network_artifacts_field, verbose)
 
 
 if __name__ == 'builtins':

--- a/Scripts/XDRSyncScript/XDRSyncScript.yml
+++ b/Scripts/XDRSyncScript/XDRSyncScript.yml
@@ -6,6 +6,7 @@ args:
   required: true
   secret: false
 - default: false
+  defaultValue: xdrincidentid
   description: The ID of incident in XDR
   isArray: false
   name: incident_id
@@ -19,84 +20,98 @@ args:
   required: false
   secret: false
 - default: false
+  defaultValue: xdrassignedusermail
   description: assigned_user_mail field name in Demisto
   isArray: false
   name: assigned_user_mail
   required: false
   secret: false
 - default: false
+  defaultValue: xdrassigneduserprettyname
   description: assigned_user_pretty_name field name in Demisto
   isArray: false
   name: assigned_user_pretty_name
   required: false
   secret: false
 - default: false
+  defaultValue: xdrstatus
   description: status field name in Demisto
   isArray: false
   name: status
   required: false
   secret: false
 - default: false
+  defaultValue: severity
   description: severity field name in Demisto
   isArray: false
   name: severity
   required: false
   secret: false
 - default: false
+  defaultValue: xdrresolvecomment
   description: 'resolve_comment field name in Demisto '
   isArray: false
   name: resolve_comment
   required: false
   secret: false
 - default: false
+  defaultValue: xdralertcount
   description: alert_count field name in Demisto
   isArray: false
   name: alert_count
   required: false
   secret: false
 - default: false
+  defaultValue: xdrhostcount
   description: host_count field name in Demisto
   isArray: false
   name: host_count
   required: false
   secret: false
 - default: false
+  defaultValue: xdrdescription
   description: description field name in Demisto
   isArray: false
   name: description
   required: false
   secret: false
 - default: false
+  defaultValue: xdrurl
   description: xdr_url field name in Demisto
   isArray: false
   name: xdr_url
   required: false
   secret: false
 - default: false
+  defaultValue: xdrnotes
   description: notes field name in Demisto
   isArray: false
   name: notes
   required: false
   secret: false
 - default: false
+  defaultValue: xdrlowseverityalertcount
   description: low_severity_alert_count field name in Demisto
   isArray: false
   name: low_severity_alert_count
   required: false
   secret: false
 - default: false
+  defaultValue: xdrmedseverityalertcount
   description: med_severity_alert_count field name in Demisto
   isArray: false
   name: med_severity_alert_count
   required: false
   secret: false
 - default: false
+  defaultValue: xdrhighseverityalertcount
   description: high_severity_alert_count field name in Demisto
   isArray: false
   name: high_severity_alert_count
   required: false
   secret: false
 - default: false
+  defaultValue: xdrusercount
   description: user_count field name in Demisto
   isArray: false
   name: user_count
@@ -127,6 +142,39 @@ args:
     XDR
   isArray: false
   name: xdr_incident_from_previous_run
+  required: false
+  secret: false
+- auto: PREDEFINED
+  default: false
+  defaultValue: 'true'
+  description: if set to true, the script will print messages to warroom - more details
+    about status of the sync. By default set to true
+  isArray: false
+  name: verbose
+  predefined:
+  - 'true'
+  - 'false'
+  required: false
+  secret: false
+- default: false
+  defaultValue: xdralerts
+  description: XDR alerts field - must be of type grid
+  isArray: false
+  name: xdr_alerts
+  required: false
+  secret: false
+- default: false
+  defaultValue: xdrfileartifacts
+  description: 'XDR file artifacts field - this field is a grid field. '
+  isArray: false
+  name: xdr_file_artifacts
+  required: false
+  secret: false
+- default: false
+  defaultValue: xdrnetworkartifacts
+  description: XDR network artifacts field
+  isArray: false
+  name: xdr_network_artifacts
   required: false
   secret: false
 comment: This script compares between Demisto incident and incident in XDR and updates
@@ -292,4 +340,4 @@ timeout: '0'
 type: python
 dockerimage: demisto/python3:3.7.4.977
 tests:
-  - No test - there are unit tests instead
+- No test - there are unit tests instead

--- a/Scripts/XDRSyncScript/XDRSyncScript.yml
+++ b/Scripts/XDRSyncScript/XDRSyncScript.yml
@@ -124,6 +124,7 @@ args:
   name: xdr_incident_markdown_field
   required: true
   secret: false
+  deprecated: true
 - auto: PREDEFINED
   default: false
   defaultValue: 'true'

--- a/Scripts/XDRSyncScript/XDRSyncScript_test.py
+++ b/Scripts/XDRSyncScript/XDRSyncScript_test.py
@@ -413,3 +413,72 @@ def test_args_to_str_2():
         .format(json.dumps(xdr_incident))
 
     assert expected == actual
+
+
+def test_compare_incident_in_demisto_when_the_severity_is_unknown():
+    """
+    Given
+    - incident in demisto
+    - incident from xdr - older
+    - fields_mapping:
+        severity: severity
+
+    When
+    - severity in demisto is unknown
+
+    Then
+    - ensure severity is not updated in XDR
+
+    """
+    incident_id = "100"
+    fields_mapping = {
+        "severity": "severity"
+    }
+
+    incident_in_demisto = copy.deepcopy(INCIDENT_IN_DEMISTO)
+    incident_in_demisto["severity"] = 0
+
+    xdr_incident_in_context = copy.deepcopy(INCIDENT_FROM_XDR)
+
+    is_modified, update_args = compare_incident_in_demisto_vs_xdr_context(incident_in_demisto, xdr_incident_in_context,
+                                                                          incident_id,
+                                                                          fields_mapping)
+
+    assert is_modified == False
+    assert {} == update_args
+
+
+def test_compare_incident_latest_xdr_incident_with_older_xdr_in_context____when_manual_severity_changed():
+    """
+    Given
+    - incident from xdr - latest
+    - incident from xdr - older
+    - fields_mapping:
+        severity: severity
+
+    When
+    - in
+
+    Then
+    - ensure compare returns is_modified=True
+    - ensure compare returns update_args contains severity=medium
+
+    """
+    fields_mapping = {
+        "severity": "severity"
+    }
+
+    incident_in_xdr_latest = copy.deepcopy(INCIDENT_FROM_XDR)
+    incident_in_xdr_latest["severity"] = "medium"
+    incident_in_xdr_latest["modification_time"] += 100
+
+    incident_from_xdr_in_context = copy.deepcopy(INCIDENT_FROM_XDR)
+
+    is_modified, update_args = compare_incident_in_xdr_vs_previous_xdr_in_context(incident_in_xdr_latest,
+                                                                                  incident_from_xdr_in_context,
+                                                                                  fields_mapping)
+
+    assert is_modified
+    assert {
+        "severity": "medium",
+    } == update_args

--- a/Scripts/XDRSyncScript/XDRSyncScript_test.py
+++ b/Scripts/XDRSyncScript/XDRSyncScript_test.py
@@ -444,41 +444,5 @@ def test_compare_incident_in_demisto_when_the_severity_is_unknown():
                                                                           incident_id,
                                                                           fields_mapping)
 
-    assert is_modified == False
+    assert is_modified is False
     assert {} == update_args
-
-
-def test_compare_incident_latest_xdr_incident_with_older_xdr_in_context____when_manual_severity_changed():
-    """
-    Given
-    - incident from xdr - latest
-    - incident from xdr - older
-    - fields_mapping:
-        severity: severity
-
-    When
-    - in
-
-    Then
-    - ensure compare returns is_modified=True
-    - ensure compare returns update_args contains severity=medium
-
-    """
-    fields_mapping = {
-        "severity": "severity"
-    }
-
-    incident_in_xdr_latest = copy.deepcopy(INCIDENT_FROM_XDR)
-    incident_in_xdr_latest["severity"] = "medium"
-    incident_in_xdr_latest["modification_time"] += 100
-
-    incident_from_xdr_in_context = copy.deepcopy(INCIDENT_FROM_XDR)
-
-    is_modified, update_args = compare_incident_in_xdr_vs_previous_xdr_in_context(incident_in_xdr_latest,
-                                                                                  incident_from_xdr_in_context,
-                                                                                  fields_mapping)
-
-    assert is_modified
-    assert {
-        "severity": "medium",
-    } == update_args


### PR DESCRIPTION
## Status
In progress

## Related Issues
https://github.com/demisto/etc/issues/18211

## Description
- sync will update grid fields instead of markdown field
- added verbose option

## Related PRs
https://github.com/demisto/content/pull/3875

## Does it break backward compatibility?
   - Yes
       - Currently yes, XDRSyncScript will populate alerts to xdralerts instead of markdown field

## Must have
- [x] Tests
- [x] Documentation https://github.com/demisto/etc/issues/18211
- [ ] Code Review

