### PR TITLE
Skipping SCADAfence CNM, Cortex XDR and LogRhythemRest tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1779,6 +1779,8 @@
 
 
       "_comment": "~~~ INSTANCE ISSUES ~~~",
+        "SCADAfence CNM": "Once in a while SCADAfence CNM integration fails to create an instance, throwing a '502 bad gateway' error (issue #18376)",
+        "Cortex XDR - IR": "Instance seems to have problems - returning 500 internal server error (issue #18377)",
         "ArcSight ESM v2": "License expired (issue #18328)",
         "AlienVault USM Anywhere": "License expired (issue #18273)",
         "Tufin": "Calls to instance return 502 error. @itay reached out (issue 16441)",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1716,6 +1716,7 @@
         }
     ],
     "skipped_tests": {
+        "LogRhythm-Test-Playbook": "A command's response doesnt match the expected results (issue #18385)",
         "search_endpoints_by_hash_-_tie_-_test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "McAfee-TIE Test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "CreatePhishingClassifierMLTest": "Test is unstable and fails with no reason from time to time (issue ##18349)",


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18376
https://github.com/demisto/etc/issues/18377
https://github.com/demisto/etc/issues/18385

## Description
SCADAfence CNM -  integration fails to create an instance, throwing a '502 bad gateway' error.
XDR instance seems to have problems - returning '500 Internal server error'.
LogRhytemRest - A command doesn't return the expected results - I couldn't find a way to skip it.
