### PR TITLE
Stix2 new indicators support

### DIFF
--- a/Releases/LatestRelease/StixParser.md
+++ b/Releases/LatestRelease/StixParser.md
@@ -1,2 +1,4 @@
 - fixed bug when unknown stix pattern presents the script crushed
 - fixed a bug that causes duplicate indicators
+- add indicators: CVE and Registry Key
+- fixed wrong format `ip` field

--- a/Scripts/StixParser/StixParser.py
+++ b/Scripts/StixParser/StixParser.py
@@ -14,10 +14,8 @@ PATTERNS_DICT = {
     "ipv4-addr:": "IP",
     "url:": "URL",
     "domain-name:": "Domain",
-    "email:": "Email",
-    "email-message": "Email",
-    "win-registry-key:key": "Registry Path Reputation",
-    "windows-registry-key:key": "Registry Path Reputation"
+    "email": "Email",
+    "registry-key:key": "Registry Path Reputation"
 }
 
 """ HELPER FUNCTIONS"""
@@ -27,13 +25,15 @@ def ip_parser(ip):
     """IP can be in the form of `ip-x-x-x-x`.
     function will return it to `x.x.x.x` format
 
+    if it's not an ip, will return `ip` arg back.
+
     Args:
         ip (str): ip to parse
 
     Returns:
         str: parsed ip indicator
     """
-    if ip.startswith("ip-"):
+    if ip.lower().startswith("ip-"):
         return ip.lower().replace("ip-", "").replace("-", ".")
     return ip
 
@@ -206,7 +206,7 @@ def get_indicators(indicators):
             {
                 "<key>": "<stix entry>"
             }
-            )
+        )
     """
 
     def indicators_parser(stix_indicator):

--- a/Scripts/StixParser/StixParser.py
+++ b/Scripts/StixParser/StixParser.py
@@ -245,7 +245,6 @@ def get_indicators(indicators):
         "Domain": list(),
         "Email": list(),
         "URL": list(),
-        # TODO implement below
         "Registry Path Reputation": list(),
         "CVE CVSS Score": list()
     }  # type: dict

--- a/Scripts/StixParser/StixParser.py
+++ b/Scripts/StixParser/StixParser.py
@@ -21,6 +21,19 @@ PATTERNS_DICT = {
 """ HELPER FUNCTIONS"""
 
 
+def ip_parser(ip):
+    """IP can be in the form of `ip-x-x-x-x`.
+    function will return it to `x.x.x.x` format
+
+    Args:
+        ip (str): ip to parse
+
+    Returns:
+        str: parsed ip indicator
+    """
+    return ip.lower().replace("ip-", "").replace("-", ".")
+
+
 def convert_to_json(string):
     """Will try to convert given string to json.
 
@@ -199,8 +212,11 @@ def get_indicators(indicators):
                         [`pattern`, `indicator`]
                         '''
                         if len(term) == 2 and key in term[0]:
-                            patterns_lists[value].append(term[1])
-                            entries_dict[term[1]] = stix_indicator
+                            new_indicator = term[1]
+                            if value == "IP":
+                                new_indicator = ip_parser(new_indicator)
+                            patterns_lists[value].append(new_indicator)
+                            entries_dict[new_indicator] = stix_indicator
 
     regex = re.compile("(\\w.*?) = '(.*?)'")
     patterns_lists = {

--- a/Scripts/StixParser/StixParser.py
+++ b/Scripts/StixParser/StixParser.py
@@ -33,7 +33,9 @@ def ip_parser(ip):
     Returns:
         str: parsed ip indicator
     """
-    return ip.lower().replace("ip-", "").replace("-", ".")
+    if ip.startswith("ip-"):
+        return ip.lower().replace("ip-", "").replace("-", ".")
+    return ip
 
 
 def convert_to_json(string):

--- a/Scripts/StixParser/StixParser.py
+++ b/Scripts/StixParser/StixParser.py
@@ -16,7 +16,8 @@ PATTERNS_DICT = {
     "domain-name:": "Domain",
     "email:": "Email",
     "email-message": "Email",
-    "win-registry-key:key": "Registry Path Reputation"
+    "win-registry-key:key": "Registry Path Reputation",
+    "windows-registry-key:key": "Registry Path Reputation"
 }
 
 """ HELPER FUNCTIONS"""
@@ -186,7 +187,6 @@ def build_entry(indicators_dict, stix_indicators_dict, pkg_id):
 
 
 def get_indicators(indicators):
-    # type: (list or dict) -> (dict, dict)
     """Gets a STIX entry and building the list
 
     Args:
@@ -229,6 +229,12 @@ def get_indicators(indicators):
                                 new_indicator = ip_parser(new_indicator)
                             patterns_lists[value].append(new_indicator)
                             entries_dict[new_indicator] = stix_indicator
+        # Handle CVE
+        elif stix_indicator.get("description") == "cve cvss score":
+            new_indicator = stix_indicator.get("name")
+            if new_indicator:
+                patterns_lists["CVE CVSS Score"].append(new_indicator)
+                entries_dict[new_indicator] = stix_indicator
 
     regex = re.compile("(\\w.*?) = '(.*?)'")
     patterns_lists = {

--- a/Scripts/StixParser/StixParser_test.py
+++ b/Scripts/StixParser/StixParser_test.py
@@ -50,8 +50,8 @@ class TestGetIndicators:
         stix_input = stix_input.get("objects")
 
         output_dict, stix_objects = get_indicators(stix_input)
-        assert output_dict == expected_output[0]
-        assert stix_objects.get("8.8.8.8").get("pattern") == "[domain-name:value = 'ip-8-8-8-8']"
+        assert output_dict == expected_output[0], err
+        assert stix_objects.get("8.8.8.8").get("pattern") == "[domain-name:value = 'ip-8-8-8-8']", err
 
     def test_get_indicators_dict(self):
         from StixParser import get_indicators

--- a/Scripts/StixParser/StixParser_test.py
+++ b/Scripts/StixParser/StixParser_test.py
@@ -7,6 +7,25 @@ import demistomock as demisto
 """ helper functions """
 
 
+def _get_stix(
+        stix2="./TestData/stix2.json",
+        stix2_results="./TestData/stix2_results.json"):
+    with open(stix2) as f:
+        stix_input = json.load(f)
+
+    with open(stix2_results) as f:
+        expected_output = json.load(f)
+
+    return stix_input, expected_output
+
+
+def _get_stix_little():
+    return _get_stix(
+        "./TestData/little_stix2.json",
+        "./TestData/little_stix2_results.json"
+    )
+
+
 def _get_results_from_demisto(entry, func, mocker):
     mock_demisto(mocker)
     try:
@@ -23,38 +42,21 @@ def mock_demisto(mocker):
 
 
 class TestGetIndicators:
-    @staticmethod
-    def _get_stix(
-            stix2="./TestData/little_stix2.json",
-            stix2_results="./TestData/little_stix2_results.json"):
-        with open(stix2) as f:
-            stix_input = json.load(f)
-
-        with open(stix2_results) as f:
-            expected_output = json.load(f)
-
-        return stix_input, expected_output
-
-    def _get_stix_little(self):
-        return self._get_stix(
-            "./TestData/little_stix2.json",
-            "./TestData/little_stix2_results.json"
-        )
-
     def test_get_indicators(self):
+        err = "Output from Demisto didn't match the expected output"
         from StixParser import get_indicators
 
-        stix_input, expected_output = self._get_stix()
+        stix_input, expected_output = _get_stix()
+        stix_input = stix_input.get("objects")
 
         output_dict, stix_objects = get_indicators(stix_input)
-
-        assert (output_dict == expected_output[0]
-                and stix_objects == expected_output[1]), "Output from Demisto didn't match the expected output"
+        assert output_dict == expected_output[0]
+        assert stix_objects.get("8.8.8.8").get("pattern") == "[domain-name:value = 'ip-8-8-8-8']"
 
     def test_get_indicators_dict(self):
         from StixParser import get_indicators
 
-        stix_input, expected_output = self._get_stix_little()
+        stix_input, expected_output = _get_stix_little()
 
         output, _ = get_indicators(stix_input[0])
         output_url = output.get("URL")
@@ -67,24 +69,22 @@ class TestGetIndicators:
 class TestSTIX2ToDemisto:
     def test_stix2_to_demisto(self, mocker):
         from StixParser import stix2_to_demisto
-        with open("./TestData/stix2.json") as f:
-            js = json.load(f)
+        stix_input, expected_output = _get_stix()
         try:
-            d_results = _get_results_from_demisto(js, stix2_to_demisto, mocker)
+            d_results = _get_results_from_demisto(stix_input, stix2_to_demisto, mocker)
             d_results = json.loads(d_results)
             assert isinstance(d_results, list)
         except ValueError:
             pytest.fail(
                 "Couldn't parse output as JSON", pytrace=True
             )
-        with open("./TestData/stix2_results.json") as f:
-            results = json.load(f)
-            results_length = len(results)
-            result_counter = 0
-            for result in results:
-                for result_demisto in d_results:
-                    if result == result_demisto:
-                        result_counter += 1
+        expected_output = expected_output[2]
+        results_length = len(expected_output)
+        result_counter = 0
+        for result in expected_output:
+            for result_demisto in d_results:
+                if result == result_demisto:
+                    result_counter += 1
 
         assert result_counter == results_length, "Results from expected file are {} but got {} " \
                                                  "results from script.".format(results_length, result_counter)
@@ -97,17 +97,79 @@ class TestSTIX2ToDemisto:
 
 
 class TestHelperFunctions:
+    err_msg = "Expected output [{}] but got [{}]"
+
     def test_ip_parser(self):
         from StixParser import ip_parser
         ip = "IP-1-2-3-4"
         expected_ip = "1.2.3.4"
         result = ip_parser(ip)
-        assert result == expected_ip, "Expected ip [{}] but got [{}]".format(expected_ip, result)
+        assert result == expected_ip, self.err_msg.format(expected_ip, result)
 
     def test_ip_parser_not_ip(self):
         from StixParser import ip_parser
         not_ip = "trololololo"
         expected_value = not_ip
         result = ip_parser(expected_value)
-        assert result == expected_value, "Expected value [{}] but got [{}]".format(expected_value, result)
+        assert result == expected_value, self.err_msg.format(expected_value, result)
 
+    def test_convert_to_json(self):
+        from StixParser import convert_to_json
+        js = "[]"
+        expected = []
+        result = convert_to_json(js)
+        assert result == expected, self.err_msg.format(expected, result)
+
+    def test_convert_to_json_false(self):
+        from StixParser import convert_to_json
+        js = "notjsonable"
+        expected = None
+        result = convert_to_json(js)
+        assert result == expected, self.err_msg.format(expected, result)
+
+    def test_create_timestamp(self):
+        from StixParser import create_timestamp
+        timestamp = "2019-05-28T16:38:17.845Z"
+        result = create_timestamp(timestamp)
+        assert timestamp == result, self.err_msg.format(timestamp, result)
+
+    def test_create_timstamp_false(self):
+        from StixParser import create_timestamp
+        false_value = "nottimestamp"
+        result = create_timestamp(false_value)
+        assert result is None, self.err_msg.format(None, result)
+
+    def test_create_indicator_entry(self):
+        from StixParser import create_indicator_entry
+        expected = {'indicator_type': 'ip',
+                    'value': '8.8.8.8',
+                    'CustomFields': {
+                        'indicatorId': 'ind_id',
+                        'stixPackageId': 'pkg_id'
+                    },
+                    'source': 'stix2',
+                    'score': 0,
+                    'timestamp': None
+                    }
+        result = create_indicator_entry(
+            "ip",
+            "8.8.8.8",
+            "pkg_id",
+            "ind_id",
+            None,
+            "stix2",
+            0
+        )
+        assert result == expected, self.err_msg.format(expected, result)
+
+    def test_get_score(self):
+        from StixParser import get_score
+        score_field = "IMPACT:Low, This IP address is not used " \
+                      "for legitimate hosting so there should be no operational impact.\n\n"
+        result = get_score(score_field)
+        assert result == 2, self.err_msg.format(result, 2)
+
+    def test_get_score_false(self):
+        from StixParser import get_score
+        result = get_score("not a real score")
+        assert result == 0, self.err_msg.format(0, result)

--- a/Scripts/StixParser/StixParser_test.py
+++ b/Scripts/StixParser/StixParser_test.py
@@ -94,3 +94,20 @@ class TestSTIX2ToDemisto:
         # Empty case
         res = _get_results_from_demisto([], stix2_to_demisto, mocker)
         assert res, "Sent empty JSON but got a response"
+
+
+class TestHelperFunctions:
+    def test_ip_parser(self):
+        from StixParser import ip_parser
+        ip = "IP-1-2-3-4"
+        expected_ip = "1.2.3.4"
+        result = ip_parser(ip)
+        assert result == expected_ip, "Expected ip [{}] but got [{}]".format(expected_ip, result)
+
+    def test_ip_parser_not_ip(self):
+        from StixParser import ip_parser
+        not_ip = "trololololo"
+        expected_value = not_ip
+        result = ip_parser(expected_value)
+        assert result == expected_value, "Expected value [{}] but got [{}]".format(expected_value, result)
+

--- a/Scripts/StixParser/StixParser_test.py
+++ b/Scripts/StixParser/StixParser_test.py
@@ -141,16 +141,17 @@ class TestHelperFunctions:
 
     def test_create_indicator_entry(self):
         from StixParser import create_indicator_entry
-        expected = {'indicator_type': 'ip',
-                    'value': '8.8.8.8',
-                    'CustomFields': {
-                        'indicatorId': 'ind_id',
-                        'stixPackageId': 'pkg_id'
-                    },
-                    'source': 'stix2',
-                    'score': 0,
-                    'timestamp': None
-                    }
+        expected = {
+            'indicator_type': 'ip',
+            'value': '8.8.8.8',
+            'CustomFields': {
+                'indicatorId': 'ind_id',
+                'stixPackageId': 'pkg_id'
+            },
+            'source': 'stix2',
+            'score': 0,
+            'timestamp': None
+        }
         result = create_indicator_entry(
             "ip",
             "8.8.8.8",

--- a/Scripts/StixParser/TestData/little_stix2.json
+++ b/Scripts/StixParser/TestData/little_stix2.json
@@ -6,7 +6,7 @@
       "url"
     ],
     "modified": "2019-05-26T16:18:32.000Z",
-    "pattern": "[url:value = 'http://johnson.com']",
+    "pattern": "[url:value = 'http://demisto.com']",
     "score": "None",
     "source": "",
     "type": "indicator",

--- a/Scripts/StixParser/TestData/little_stix2_results.json
+++ b/Scripts/StixParser/TestData/little_stix2_results.json
@@ -7,7 +7,7 @@
     "Email": [
       "user@example.com"
     ],
-    "Registry Path Reputation": [],
+    "Registry Path Reputation": ["HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\RKey"],
     "URL": [
       "http://johnson.com"
     ]

--- a/Scripts/StixParser/TestData/little_stix2_results.json
+++ b/Scripts/StixParser/TestData/little_stix2_results.json
@@ -1,16 +1,20 @@
 [
   {
+    "CVE CVSS Score": [],
     "File": [],
     "IP": [],
     "Domain": [],
     "Email": [
       "user@example.com"
     ],
+    "Registry Path Reputation": [],
     "URL": [
       "http://johnson.com"
     ]
   },
   {
+    "CVE CVSS Score": [],
+    "Registry Path Reputation": [],
     "http://johnson.com": {
       "created": "2019-05-26T16:18:32.000Z",
       "id": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",

--- a/Scripts/StixParser/TestData/little_stix2_results.json
+++ b/Scripts/StixParser/TestData/little_stix2_results.json
@@ -9,20 +9,20 @@
     ],
     "Registry Path Reputation": ["HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\RKey"],
     "URL": [
-      "http://johnson.com"
+      "http://demisto.com"
     ]
   },
   {
     "CVE CVSS Score": [],
     "Registry Path Reputation": [],
-    "http://johnson.com": {
+    "http://demisto.com": {
       "created": "2019-05-26T16:18:32.000Z",
       "id": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
       "labels": [
         "url"
       ],
       "modified": "2019-05-26T16:18:32.000Z",
-      "pattern": "[url:value = 'http://johnson.com']",
+      "pattern": "[url:value = 'http://demisto.com']",
       "score": "None",
       "source": "",
       "type": "indicator",

--- a/Scripts/StixParser/TestData/stix2.json
+++ b/Scripts/StixParser/TestData/stix2.json
@@ -144,7 +144,7 @@
         "hostname"
       ],
       "modified": "2019-05-26T16:15:44.000Z",
-      "pattern": "[domain-name:value = '8.8.8.8']",
+      "pattern": "[domain-name:value = 'ip-8-8-8-8']",
       "score": "Not Specified",
       "source": "",
       "type": "indicator",

--- a/Scripts/StixParser/TestData/stix2.json
+++ b/Scripts/StixParser/TestData/stix2.json
@@ -23,7 +23,7 @@
         "url"
       ],
       "modified": "2019-05-26T16:18:32.000Z",
-      "pattern": "[url:value = 'http://johnson.com']",
+      "pattern": "[url:value = 'http://demisto.com']",
       "score": "None",
       "source": "",
       "type": "indicator",

--- a/Scripts/StixParser/TestData/stix2.json
+++ b/Scripts/StixParser/TestData/stix2.json
@@ -144,7 +144,7 @@
         "hostname"
       ],
       "modified": "2019-05-26T16:15:44.000Z",
-      "pattern": "[domain-name:value = 'ip-192-127-5-1']",
+      "pattern": "[domain-name:value = '8.8.8.8']",
       "score": "Not Specified",
       "source": "",
       "type": "indicator",

--- a/Scripts/StixParser/TestData/stix2_results.json
+++ b/Scripts/StixParser/TestData/stix2_results.json
@@ -21,8 +21,8 @@
     "URL": [
       "http://johnson.com"
     ],
-    "Registry Path Reputation": [],
-    "CVE CVSS Score": []
+    "Registry Path Reputation": ["HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\RKey"],
+    "CVE CVSS Score": ["CVE-2019-7312"]
   },
   {
     "http://johnson.com": {

--- a/Scripts/StixParser/TestData/stix2_results.json
+++ b/Scripts/StixParser/TestData/stix2_results.json
@@ -89,7 +89,7 @@
   },
   {
     "indicator_type": "Domain",
-    "value": "ip-192-127-5-1",
+    "value": "8.8.8.8",
     "CustomFields": {
       "indicatorId": "indicator--620f36bc-ab89-484d-8ff0-51dbd4cfe4b9",
       "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"

--- a/Scripts/StixParser/TestData/stix2_results.json
+++ b/Scripts/StixParser/TestData/stix2_results.json
@@ -1,123 +1,295 @@
 [
   {
-    "indicator_type": "File",
-    "value": "384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf",
-    "CustomFields": {
-      "indicatorId": "indicator--c38d5378-ff87-4412-aa05-9d0c72f5bdcf",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
-    },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:18:03.000Z"
+    "File": [
+      "4e0daff2b6a2db421e79fb64228943be",
+      "384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf",
+      "115f9ecff8fcd3f266184c32eae03296e0131567ada6094dd022aa771c66cc8e",
+      "d76dcf2ae966dae2839c3145c55342d9cb528bd803deb71cdc39cbab3f556f0b",
+      "d7a10a4b3fd245dc44c1bb143d1a7f12816cdef7"
+    ],
+    "IP": [
+      "9.9.9.9",
+      "8.3.3.3"
+    ],
+    "Domain": [
+      "demisto.com",
+      "8.8.8.8"
+    ],
+    "Email": [
+      "user@example.com"
+    ],
+    "URL": [
+      "http://johnson.com"
+    ],
+    "Registry Path Reputation": [],
+    "CVE CVSS Score": []
   },
   {
-    "indicator_type": "File",
-    "value": "115f9ecff8fcd3f266184c32eae03296e0131567ada6094dd022aa771c66cc8e",
-    "CustomFields": {
-      "indicatorId": "indicator--b484b083-a85e-49e0-84e4-d0ab13edeca5",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    "http://johnson.com": {
+      "created": "2019-05-26T16:18:32.000Z",
+      "id": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
+      "labels": [
+        "url"
+      ],
+      "modified": "2019-05-26T16:18:32.000Z",
+      "pattern": "[url:value = 'http://johnson.com']",
+      "score": "None",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.837119Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:15:14.000Z"
+    "4e0daff2b6a2db421e79fb64228943be": {
+      "created": "2019-05-26T16:12:18.000Z",
+      "id": "indicator--8be84046-032a-4556-be39-940a06440d81",
+      "labels": [
+        "file md5"
+      ],
+      "modified": "2019-05-26T16:12:18.000Z",
+      "pattern": "[file:hashes.md5 = '4e0daff2b6a2db421e79fb64228943be']",
+      "score": "None",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.83887Z"
+    },
+    "user@example.com": {
+      "created": "2019-05-26T16:11:08.000Z",
+      "id": "indicator--7ed80192-4b84-4954-8b41-6268290cd5c7",
+      "labels": [
+        "email"
+      ],
+      "modified": "2019-05-26T16:11:08.000Z",
+      "pattern": "[email-message:sender_ref.value = 'user@example.com']",
+      "score": "None",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.840274Z"
+    },
+    "demisto.com": {
+      "created": "2019-05-26T16:10:49.000Z",
+      "id": "indicator--62662049-2a64-4961-b493-4c932633a72f",
+      "labels": [
+        "domain"
+      ],
+      "modified": "2019-05-26T16:10:49.000Z",
+      "pattern": "[domain-name:value = 'demisto.com']",
+      "score": "None",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.841314Z"
+    },
+    "384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf": {
+      "created": "2019-05-26T16:18:03.000Z",
+      "id": "indicator--c38d5378-ff87-4412-aa05-9d0c72f5bdcf",
+      "labels": [
+        "ssdeep"
+      ],
+      "modified": "2019-05-26T16:18:03.000Z",
+      "pattern": "[file:hashes.ssdeep = '384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf']",
+      "score": "Not Specified",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.847309Z"
+    },
+    "9.9.9.9": {
+      "created": "2019-05-26T16:17:08.000Z",
+      "id": "indicator--cc6f097d-651d-462f-a4cf-a6065cfa2f26",
+      "labels": [
+        "ipv4"
+      ],
+      "modified": "2019-05-26T16:17:08.000Z",
+      "pattern": "[ipv4-addr:value = '9.9.9.9']",
+      "score": "Not Specified",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.850114Z"
+    },
+    "8.3.3.3": {
+      "created": "2019-05-26T16:16:19.000Z",
+      "id": "indicator--7fa7ad39-29c9-4cb1-9ee8-ce716d3e2ad7",
+      "labels": [
+        "ip"
+      ],
+      "modified": "2019-05-26T16:16:19.000Z",
+      "pattern": "[ipv4-addr:value = '8.3.3.3']",
+      "score": "Not Specified",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.851906Z"
+    },
+    "8.8.8.8": {
+      "created": "2019-05-26T16:15:44.000Z",
+      "id": "indicator--620f36bc-ab89-484d-8ff0-51dbd4cfe4b9",
+      "labels": [
+        "hostname"
+      ],
+      "modified": "2019-05-26T16:15:44.000Z",
+      "pattern": "[domain-name:value = '8.8.8.8']",
+      "score": "Not Specified",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.853086Z"
+    },
+    "115f9ecff8fcd3f266184c32eae03296e0131567ada6094dd022aa771c66cc8e": {
+      "created": "2019-05-26T16:15:14.000Z",
+      "id": "indicator--b484b083-a85e-49e0-84e4-d0ab13edeca5",
+      "labels": [
+        "file sha-256 v2"
+      ],
+      "modified": "2019-05-26T16:15:14.000Z",
+      "pattern": "[file:hashes.sha256 = '115f9ecff8fcd3f266184c32eae03296e0131567ada6094dd022aa771c66cc8e']",
+      "score": "None",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.854465Z"
+    },
+    "d76dcf2ae966dae2839c3145c55342d9cb528bd803deb71cdc39cbab3f556f0b": {
+      "created": "2019-05-26T16:13:33.000Z",
+      "id": "indicator--af539811-9383-4cdb-9a44-4a8985525302",
+      "labels": [
+        "file sha-256"
+      ],
+      "modified": "2019-05-26T16:13:33.000Z",
+      "pattern": "[file:hashes.sha256 = 'd76dcf2ae966dae2839c3145c55342d9cb528bd803deb71cdc39cbab3f556f0b']",
+      "score": "Not Specified",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.857271Z"
+    },
+    "d7a10a4b3fd245dc44c1bb143d1a7f12816cdef7": {
+      "created": "2019-05-26T16:13:00.000Z",
+      "id": "indicator--454c5435-fa71-4cf8-bcba-1336dbc20600",
+      "labels": [
+        "file sha-1"
+      ],
+      "modified": "2019-05-26T16:13:00.000Z",
+      "pattern": "[file:hashes.sha1 = 'd7a10a4b3fd245dc44c1bb143d1a7f12816cdef7']",
+      "score": "Medium",
+      "source": "",
+      "type": "indicator",
+      "valid_from": "2019-05-28T16:38:17.858716Z"
+    }
   },
-  {
-    "indicator_type": "File",
-    "value": "4e0daff2b6a2db421e79fb64228943be",
-    "CustomFields": {
-      "indicatorId": "indicator--8be84046-032a-4556-be39-940a06440d81",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+  [
+    {
+      "indicator_type": "File",
+      "value": "115f9ecff8fcd3f266184c32eae03296e0131567ada6094dd022aa771c66cc8e",
+      "CustomFields": {
+        "indicatorId": "indicator--b484b083-a85e-49e0-84e4-d0ab13edeca5",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:15:14.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:12:18.000Z"
-  },
-  {
-    "indicator_type": "File",
-    "value": "d7a10a4b3fd245dc44c1bb143d1a7f12816cdef7",
-    "CustomFields": {
-      "indicatorId": "indicator--454c5435-fa71-4cf8-bcba-1336dbc20600",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "File",
+      "value": "384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf",
+      "CustomFields": {
+        "indicatorId": "indicator--c38d5378-ff87-4412-aa05-9d0c72f5bdcf",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:18:03.000Z"
     },
-    "source": "indicator",
-    "score": 2,
-    "timestamp": "2019-05-26T16:13:00.000Z"
-  },
-  {
-    "indicator_type": "File",
-    "value": "d76dcf2ae966dae2839c3145c55342d9cb528bd803deb71cdc39cbab3f556f0b",
-    "CustomFields": {
-      "indicatorId": "indicator--af539811-9383-4cdb-9a44-4a8985525302",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "File",
+      "value": "d76dcf2ae966dae2839c3145c55342d9cb528bd803deb71cdc39cbab3f556f0b",
+      "CustomFields": {
+        "indicatorId": "indicator--af539811-9383-4cdb-9a44-4a8985525302",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:13:33.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:13:33.000Z"
-  },
-  {
-    "indicator_type": "IP",
-    "value": "9.9.9.9",
-    "CustomFields": {
-      "indicatorId": "indicator--cc6f097d-651d-462f-a4cf-a6065cfa2f26",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "File",
+      "value": "d7a10a4b3fd245dc44c1bb143d1a7f12816cdef7",
+      "CustomFields": {
+        "indicatorId": "indicator--454c5435-fa71-4cf8-bcba-1336dbc20600",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 2,
+      "timestamp": "2019-05-26T16:13:00.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:17:08.000Z"
-  },
-  {
-    "indicator_type": "IP",
-    "value": "8.3.3.3",
-    "CustomFields": {
-      "indicatorId": "indicator--7fa7ad39-29c9-4cb1-9ee8-ce716d3e2ad7",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "File",
+      "value": "4e0daff2b6a2db421e79fb64228943be",
+      "CustomFields": {
+        "indicatorId": "indicator--8be84046-032a-4556-be39-940a06440d81",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:12:18.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:16:19.000Z"
-  },
-  {
-    "indicator_type": "Domain",
-    "value": "demisto.com",
-    "CustomFields": {
-      "indicatorId": "indicator--62662049-2a64-4961-b493-4c932633a72f",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "IP",
+      "value": "9.9.9.9",
+      "CustomFields": {
+        "indicatorId": "indicator--cc6f097d-651d-462f-a4cf-a6065cfa2f26",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:17:08.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:10:49.000Z"
-  },
-  {
-    "indicator_type": "Domain",
-    "value": "8.8.8.8",
-    "CustomFields": {
-      "indicatorId": "indicator--620f36bc-ab89-484d-8ff0-51dbd4cfe4b9",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "IP",
+      "value": "8.3.3.3",
+      "CustomFields": {
+        "indicatorId": "indicator--7fa7ad39-29c9-4cb1-9ee8-ce716d3e2ad7",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:16:19.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:15:44.000Z"
-  },
-  {
-    "indicator_type": "Email",
-    "value": "user@example.com",
-    "CustomFields": {
-      "indicatorId": "indicator--7ed80192-4b84-4954-8b41-6268290cd5c7",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "Domain",
+      "value": "8.8.8.8",
+      "CustomFields": {
+        "indicatorId": "indicator--620f36bc-ab89-484d-8ff0-51dbd4cfe4b9",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:15:44.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:11:08.000Z"
-  },
-  {
-    "indicator_type": "URL",
-    "value": "http://johnson.com",
-    "CustomFields": {
-      "indicatorId": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
-      "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+    {
+      "indicator_type": "Domain",
+      "value": "demisto.com",
+      "CustomFields": {
+        "indicatorId": "indicator--62662049-2a64-4961-b493-4c932633a72f",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:10:49.000Z"
     },
-    "source": "indicator",
-    "score": 0,
-    "timestamp": "2019-05-26T16:18:32.000Z"
-  }
+    {
+      "indicator_type": "Email",
+      "value": "user@example.com",
+      "CustomFields": {
+        "indicatorId": "indicator--7ed80192-4b84-4954-8b41-6268290cd5c7",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:11:08.000Z"
+    },
+    {
+      "indicator_type": "URL",
+      "value": "http://johnson.com",
+      "CustomFields": {
+        "indicatorId": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
+        "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"
+      },
+      "source": "indicator",
+      "score": 0,
+      "timestamp": "2019-05-26T16:18:32.000Z"
+    }
+  ]
 ]

--- a/Scripts/StixParser/TestData/stix2_results.json
+++ b/Scripts/StixParser/TestData/stix2_results.json
@@ -19,20 +19,20 @@
       "user@example.com"
     ],
     "URL": [
-      "http://johnson.com"
+      "http://demisto.com"
     ],
     "Registry Path Reputation": ["HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\RKey"],
     "CVE CVSS Score": ["CVE-2019-7312"]
   },
   {
-    "http://johnson.com": {
+    "http://demisto.com": {
       "created": "2019-05-26T16:18:32.000Z",
       "id": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
       "labels": [
         "url"
       ],
       "modified": "2019-05-26T16:18:32.000Z",
-      "pattern": "[url:value = 'http://johnson.com']",
+      "pattern": "[url:value = 'http://demisto.com']",
       "score": "None",
       "source": "",
       "type": "indicator",
@@ -282,7 +282,7 @@
     },
     {
       "indicator_type": "URL",
-      "value": "http://johnson.com",
+      "value": "http://demisto.com",
       "CustomFields": {
         "indicatorId": "indicator--893eac0c-3232-4219-91bb-97f9a6b0de6c",
         "stixPackageId": "bundle--6ab84b67-f7a2-47b4-b7cd-097231cb7031"


### PR DESCRIPTION
## Status
Ready


## Description
Adds support for registry and CVE indicators. 
added unit tests
fixed bug with `ip-x-x-x-x` to `x.x.x.x` IP format

## Screenshots
Paste here any images that will help the reviewer

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Code Review

## Additional changes
Describe additional changes done, for example adding a function to common server.