### PR TITLE
Skipping LogRhythmRest

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1716,7 +1716,7 @@
         }
     ],
     "skipped_tests": {
-        "LogRhythm-Test-Playbook": "A command's response doesnt match the expected results (issue #18385)",
+        "LogRhythm REST test": "A command's response doesnt match the expected results (issue #18385)",
         "search_endpoints_by_hash_-_tie_-_test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "McAfee-TIE Test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "CreatePhishingClassifierMLTest": "Test is unstable and fails with no reason from time to time (issue ##18349)",


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/18385

## Description
LogRhytemRest - A command doesn't return the expected results - I couldn't find a way to replicate the sought results neither through Demisto nor the UI. 

(made a mistake and skipped the playbook and not the test - so Im pushing again)
