### PR TITLE
SymantecEndpointProtection test playbook fix

### DIFF
--- a/TestPlaybooks/playbook-SymantecEndpointProtection_Test.yml
+++ b/TestPlaybooks/playbook-SymantecEndpointProtection_Test.yml
@@ -718,7 +718,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: 192.168.1.17
+              simple: 192.168.1.12
     view: |-
       {
         "position": {


### PR DESCRIPTION

## Status
Ready

## Description
Test playbook for SymantecEndpointProtection searched for 192.168.1.17 while it got 192.168.1.12 in the response - failing the playbook
