### PR TITLE
Jira integration: add support for remote application links (#3854)

### DIFF
--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -519,7 +519,7 @@ def get_file(entry_id):
     return file_name, file_bytes
 
 
-def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None):
+def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None, application_type=None, application_name=None):
     req_url = f'rest/api/latest/issue/{issue_id}/remotelink'
     link = {
         "object": {
@@ -534,6 +534,12 @@ def add_link_command(issue_id, title, url, summary=None, global_id=None, relatio
         link['globalId'] = global_id
     if relationship:
         link['relationship'] = relationship
+    if application_type or application_name:
+        link['application'] = {}
+    if application_type:
+        link['application']['type'] = application_type
+    if application_type:
+        link['application']['name'] = application_name
 
     result = jira_req('POST', req_url, json.dumps(link))
     data = result.json()

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -519,7 +519,8 @@ def get_file(entry_id):
     return file_name, file_bytes
 
 
-def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None, application_type=None, application_name=None):
+def add_link_command(issue_id, title, url, summary=None, global_id=None, relationship=None,
+                     application_type=None, application_name=None):
     req_url = f'rest/api/latest/issue/{issue_id}/remotelink'
     link = {
         "object": {

--- a/Integrations/JiraV2/JiraV2.yml
+++ b/Integrations/JiraV2/JiraV2.yml
@@ -230,6 +230,10 @@ script:
     - name: issueId
       required: true
       description: The ID of the issue.
+    - name: applicationType
+      description: The application type of the linked remote application. E.g "com.atlassian.confluence".
+    - name: applicationName
+      description: The application name of the linked remote application. E.g "My Confluence Instance".
     description: Creates (or updates) an issue link.
   - name: jira-edit-issue
     arguments:

--- a/Releases/LatestRelease/JiraV2.md
+++ b/Releases/LatestRelease/JiraV2.md
@@ -1,0 +1,1 @@
+- Add support for remote application links.


### PR DESCRIPTION
* Jira integration: add support for remote application links

* Fix edit issue (remove empty 'project' object)

* fix formatting -.-

* Revert "Fix edit issue (remove empty 'project' object)"

Will be handled in a separate PR

This reverts commit d29e16de69712819a9ea15adcb7d677839879ebb.

## Status
Ready

## Description
Adds support for remote application links.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
pingunaut:jira-confluence-remote-link | https://github.com/demisto/content/pull/3854

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] Jira-v2-Test
- [x] Jira-Test
- [x] JiraCreateIssue-example-test