### PR TITLE
Fix jira-edit-issue command (#4062)

### DIFF
--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -305,7 +305,7 @@ def get_issue_fields(issue_creating=False, **issue_args):
     if issue_args.get('summary'):
         issue['fields']['summary'] = issue_args['summary']
 
-    if not issue['fields'].get('project'):
+    if not issue['fields'].get('project') and (issue_args.get('projectKey') or issue_args.get('projectName')):
         issue['fields']['project'] = {}
 
     if issue_args.get('projectKey'):


### PR DESCRIPTION
## Status
Ready

## Description
Fixes the `jira-edit-issue` command which would fail if the empty `project` field was included in the body.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
pingunaut:edit-jira-empty-projects | https://github.com/demisto/content/pull/4062

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [x] Documentation (with link to it) - N/A
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] JiraCreateIssue-example-test
- [x] Jira-Test
- [x] Jira-v2-Test
