### PR TITLE
add Exception object to return_error

### DIFF
--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1352,7 +1352,7 @@ def return_outputs(readable_output, outputs, raw_response=None):
     demisto.results(return_entry)
 
 
-def return_error(message, error='', outputs=None):
+def return_error(message, error='', outputs=None, exception_object=None):
     """
         Returns error entry with given message and exits the script
 
@@ -1365,12 +1365,17 @@ def return_error(message, error='', outputs=None):
         :type outputs: ``dict or None``
         :param outputs: the outputs that will be returned to playbook/investigation context (optional)
 
+        :type exception_object: ``Exception or None``
+        :param exception_object: the exception raised from code
+
         :return: Error entry object
         :rtype: ``dict``
     """
     LOG(message)
     if error:
         LOG(error)
+    if exception_object:
+        LOG(str(exception_object))
     LOG.print_log()
     demisto.results({
         'Type': entryTypes['error'],

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1352,30 +1352,25 @@ def return_outputs(readable_output, outputs, raw_response=None):
     demisto.results(return_entry)
 
 
-def return_error(message, error='', outputs=None, exception_object=None):
+def return_error(message, error='', outputs=None):
     """
         Returns error entry with given message and exits the script
 
         :type message: ``str``
         :param message: The message to return in the entry (required)
 
-        :type error: ``str``
+        :type error: ``str`` or Exception
         :param error: The raw error message to log (optional)
 
         :type outputs: ``dict or None``
         :param outputs: the outputs that will be returned to playbook/investigation context (optional)
-
-        :type exception_object: ``Exception or None``
-        :param exception_object: the exception raised from code
 
         :return: Error entry object
         :rtype: ``dict``
     """
     LOG(message)
     if error:
-        LOG(error)
-    if exception_object:
-        LOG(str(exception_object))
+        LOG(str(error))
     LOG.print_log()
     demisto.results({
         'Type': entryTypes['error'],

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from mock import patch
+
 import demistomock as demisto
 from CommonServerPython import xml2json, json2xml, entryTypes, formats, tableToMarkdown, underscoreToCamelCase, \
     flattenCell, date_to_timestamp, datetime, camelize, pascalToSpace, argToList, \
@@ -439,10 +441,10 @@ def test_get_error_need_raise_error_on_non_error_input():
 
 
 @pytest.mark.parametrize('data,data_expected', [
-                        ("this is a test", b"this is a test"),
-                        (u"עברית", u"עברית".encode('utf-8')),
-                        (b"binary data\x15\x00", b"binary data\x15\x00"),
-                        ])  # noqa: E124
+    ("this is a test", b"this is a test"),
+    (u"עברית", u"עברית".encode('utf-8')),
+    (b"binary data\x15\x00", b"binary data\x15\x00"),
+])  # noqa: E124
 def test_fileResult(mocker, request, data, data_expected):
     mocker.patch.object(demisto, 'uniqueFile', return_value="test_file_result")
     mocker.patch.object(demisto, 'investigation', return_value={'id': '1'})
@@ -480,5 +482,16 @@ def test_is_mac_address():
     mac_address_false = 'AA:BB:CC:00:11'
     mac_address_true = 'AA:BB:CC:00:11:22'
 
-    assert(is_mac_address(mac_address_false) is False)
-    assert(is_mac_address(mac_address_true))
+    assert (is_mac_address(mac_address_false) is False)
+    assert (is_mac_address(mac_address_true))
+
+
+def test_exception_in_return_error(mocker):
+    from CommonServerPython import return_error, IntegrationLogger
+
+    expected = {'EntryContext': None, 'Type': 4, 'ContentsFormat': 'text', 'Contents': 'Message'}
+    mocker.patch.object(demisto, 'results')
+    with pytest.raises(SystemExit, match='0'):
+        return_error("Message", exception_object=ValueError("Error!"))
+    results = demisto.results.call_args[0][0]
+    assert expected == results

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -491,7 +491,10 @@ def test_exception_in_return_error(mocker):
 
     expected = {'EntryContext': None, 'Type': 4, 'ContentsFormat': 'text', 'Contents': 'Message'}
     mocker.patch.object(demisto, 'results')
+    mocker.patch.object(IntegrationLogger, '__call__')
     with pytest.raises(SystemExit, match='0'):
         return_error("Message", exception_object=ValueError("Error!"))
     results = demisto.results.call_args[0][0]
     assert expected == results
+    # IntegrationLogger = LOG (2 times if exception supplied)
+    assert IntegrationLogger.__call__.call_count == 2

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -493,7 +493,7 @@ def test_exception_in_return_error(mocker):
     mocker.patch.object(demisto, 'results')
     mocker.patch.object(IntegrationLogger, '__call__')
     with pytest.raises(SystemExit, match='0'):
-        return_error("Message", exception_object=ValueError("Error!"))
+        return_error("Message", error=ValueError("Error!"))
     results = demisto.results.call_args[0][0]
     assert expected == results
     # IntegrationLogger = LOG (2 times if exception supplied)

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from mock import patch
 
 import demistomock as demisto
 from CommonServerPython import xml2json, json2xml, entryTypes, formats, tableToMarkdown, underscoreToCamelCase, \


### PR DESCRIPTION
## Status
Ready

## Description
Added the option to a raised error to return_error so we can log the Error and not depend on the user.

## Screenshots
![image](https://user-images.githubusercontent.com/11165655/62711066-19accf00-ba01-11e9-8e33-2f9b114f069c.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review

