### PR TITLE
set default encoding to utf-8 in Intsights

### DIFF
--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,1 +1,1 @@
-set integration dockerimage to python3:3.7.4.977
+set default encoding to utf-8

--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,0 +1,1 @@
+set integration dockerimage to python3:3.7.4.977

--- a/Integrations/IntSight/IntSight.py
+++ b/Integrations/IntSight/IntSight.py
@@ -1,3 +1,6 @@
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *

--- a/Integrations/IntSight/IntSight.py
+++ b/Integrations/IntSight/IntSight.py
@@ -7,7 +7,7 @@ import base64
 import sys
 from datetime import datetime
 reload(sys)
-sys.setdefaultencoding('utf-8')
+sys.setdefaultencoding('utf-8')  # pylint: disable=E1101
 
 requests.packages.urllib3.disable_warnings()
 

--- a/Integrations/IntSight/IntSight.py
+++ b/Integrations/IntSight/IntSight.py
@@ -1,13 +1,13 @@
-import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
 import requests
 import json
 import base64
+import sys
 from datetime import datetime
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 requests.packages.urllib3.disable_warnings()
 

--- a/Integrations/IntSight/IntSight.yml
+++ b/Integrations/IntSight/IntSight.yml
@@ -789,7 +789,5 @@ script:
     description: Get all mssp sub accounts
   isfetch: true
   runonce: false
-  subtype: python3
-  dockerimage: demisto/python3:3.7.4.977
 tests:
   - IntSights Test

--- a/Integrations/IntSight/IntSight.yml
+++ b/Integrations/IntSight/IntSight.yml
@@ -789,5 +789,7 @@ script:
     description: Get all mssp sub accounts
   isfetch: true
   runonce: false
+  subtype: python3
+  dockerimage: demisto/python3:3.7.4.977
 tests:
   - IntSights Test


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/18055

## Description
the integration crashed when the extracting alerts tags with different encoding, set default encoding to utf-8 fix that

