### PR TITLE
[Fix] Changed Indicator Fields IDs

### DIFF
--- a/IndicatorFields/incidentfield-description.json
+++ b/IndicatorFields/incidentfield-description.json
@@ -5,7 +5,7 @@
   "neverSetAsRequired": false,
   "threshold": 72,
   "defaultRows": null,
-  "id": "incident_description",
+  "id": "indicator_description",
   "validatedError": "",
   "group": 2,
   "script": "",

--- a/IndicatorFields/incidentfield-description_CHANGELOG.md
+++ b/IndicatorFields/incidentfield-description_CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+-

--- a/IndicatorFields/incidentfield-osversion.json
+++ b/IndicatorFields/incidentfield-osversion.json
@@ -5,7 +5,7 @@
   "neverSetAsRequired": false,
   "threshold": 72,
   "defaultRows": null,
-  "id": "incident_osversion",
+  "id": "indicator_osversion",
   "validatedError": "",
   "group": 2,
   "script": "",

--- a/IndicatorFields/incidentfield-osversion_CHANGELOG.md
+++ b/IndicatorFields/incidentfield-osversion_CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+-


### PR DESCRIPTION
## Status
Ready

## Description
Changed id for indicators that did not match expected id name (was: `incident_*` should've been `indicator_*`)

## Screenshots
### Before fix: 
![image](https://user-images.githubusercontent.com/20818773/62948260-b64de300-bdec-11e9-9545-621817591c9a.png)

### After fix (to be uploaded after artifact is read):
Os version and description successfully installed:
![image](https://user-images.githubusercontent.com/20818773/63005127-9407a400-be84-11e9-8704-cd088eabfa20.png)

![image](https://user-images.githubusercontent.com/20818773/63004999-560a8000-be84-11e9-80ad-859d5a14fef3.png)

## Required version of Demisto
5.0.0

## Does it break backward compatibility?
   - No