### PR TITLE
MailSenderNew add support for custom headers (#3904)

### DIFF
--- a/Integrations/MailSenderNew/CHANGELOG.md
+++ b/Integrations/MailSenderNew/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+  - Added the ability to add custom headers to an email.

--- a/Integrations/MailSenderNew/CHANGELOG.md
+++ b/Integrations/MailSenderNew/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## [Unreleased]
-  - Added the ability to add custom headers to an email.
+Added the *additionalHeader* argument, which enables you to add custom headers to an email.

--- a/Integrations/MailSenderNew/MailSenderNew.py
+++ b/Integrations/MailSenderNew/MailSenderNew.py
@@ -223,6 +223,7 @@ def create_msg():
     to = argToList(demisto.getArg('to'))
     cc = argToList(demisto.getArg('cc'))
     bcc = argToList(demisto.getArg('bcc'))
+    additional_header = argToList(demisto.getArg('additionalHeader'))
     subject = demisto.getArg('subject') or ''
     body = demisto.getArg('body') or ''
     htmlBody = demisto.getArg('htmlBody') or ''
@@ -286,6 +287,10 @@ def create_msg():
         msg['To'] = header(','.join(to))
     if cc:
         msg['CC'] = header(','.join(cc))
+    if additional_header:
+        for h in additional_header:
+            header_name_and_value = h.split('=')
+            msg[header_name_and_value[0]] = header(header_name_and_value[1])
     # Notice we should not add BCC header since Python2 does not filter it
     return msg.as_string(), to, cc, bcc
 

--- a/Integrations/MailSenderNew/MailSenderNew.yml
+++ b/Integrations/MailSenderNew/MailSenderNew.yml
@@ -99,8 +99,7 @@ script:
         value", "key": "context key"}}. Each var name can either be provided with
         the value or a context key to retrieve the value from.'
     - name: additionalHeader
-      description: Additional header in the form headerName=headerValue. Multiple headers are supported as comma-separated
-        list. (e.g. headerName1=headerValue1,headerName2=headerValue2)
+      description: 'A CSV list of additional headers in the format: headerName=headerValue. For example: "headerName1=headerValue1,headerName2=headerValue2".'
       isArray: true
     description: Send an email
   runonce: false

--- a/Integrations/MailSenderNew/MailSenderNew.yml
+++ b/Integrations/MailSenderNew/MailSenderNew.yml
@@ -98,6 +98,10 @@ script:
         values are in the form of a JSON document like {"varname": {"value": "some
         value", "key": "context key"}}. Each var name can either be provided with
         the value or a context key to retrieve the value from.'
+    - name: additionalHeader
+      description: Additional header in the form headerName=headerValue. Multiple headers are supported as comma-separated
+        list. (e.g. headerName1=headerValue1,headerName2=headerValue2)
+      isArray: true
     description: Send an email
   runonce: false
 tests:

--- a/Integrations/MailSenderNew/MailSenderNew_test.py
+++ b/Integrations/MailSenderNew/MailSenderNew_test.py
@@ -4,20 +4,21 @@ import demistomock as demisto
 import pytest
 
 
-@pytest.mark.parametrize('subject,subj_include', [
-                        (u'testbefore\ntestafter', 'testafter'),
-                        ('testbefore\ntestafter', 'testafter'),
-                        ('\xd7\xa2\xd7\x91\xd7\xa8\xd7\x99\xd7\xaa', '=?utf-8?'),  # non-ascii char utf-8 encoded
-                        (u'עברית', '=?utf-8?')
+@pytest.mark.parametrize('subject,subj_include,headers', [
+                        (u'testbefore\ntestafter', 'testafter', 'foo=baz'),
+                        ('testbefore\ntestafter', 'testafter', 'foo=baz'),
+                        ('\xd7\xa2\xd7\x91\xd7\xa8\xd7\x99\xd7\xaa', '=?utf-8?', 'foo=baz'),  # non-ascii char utf-8 encoded
+                        (u'עברית', '=?utf-8?', 'foo=baz')
                         ])  # noqa: E124
-def test_create_msg(mocker, subject, subj_include):
+def test_create_msg(mocker, subject, subj_include, headers):
     mocker.patch.object(demisto, 'args', return_value={
         'to': 'test@test.com,test1@test.com',  # disable-secrets-detection
         'from': 'test@test.com',
         'bcc': 'bcc@test.com',  # disable-secrets-detection
         'cc': 'cc@test.com',  # disable-secrets-detection
         'subject': subject,
-        'body': 'this is the body'
+        'body': 'this is the body',
+        'additionalHeader': headers
     })
     mocker.patch.object(demisto, 'params', return_value={
         'from': 'test@test.com',
@@ -29,3 +30,4 @@ def test_create_msg(mocker, subject, subj_include):
     lines = msg.splitlines()
     subj = [x for x in lines if 'Subject' in x][0]
     assert subj_include in subj
+    assert 'foo' in msg


### PR DESCRIPTION
## Status
Ready

## Description
Adds the ability to add custom headers to an email.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/63030721-7a358380-bebb-11e9-8379-8a9d057094d8.png)


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
pingunaut:integration_mailsender_new_custom_headers | https://github.com/demisto/content/pull/3904

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] GDPR Breach Notification
- [ ] Send Investigation Summary Reports
- [ ] Phishing Investigation - Generic
- [ ] Send Investigation Summary Reports Job
- [ ] Phishing Investigation - Generic v2
