### PR TITLE
removed autoextract from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1739,7 +1739,6 @@
         "search_endpoints_by_hash_-_tie_-_test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "McAfee-TIE Test": "Test is unstable - from time to time fails to create an instance (issue #18350)",
         "CreatePhishingClassifierMLTest": "Test is unstable and fails with no reason from time to time (issue ##18349)",
-        "Autoextract - Test": "See issue #18343 for further information",
         "rsa_packets_and_logs_test": "A command searches for a session ID which doesn't exist on our local server - asked RSA to help (issue #18332)",
         "TestUptycs": "There is not enough data in uptycs instance in order the test to pass. Data need to be generated like open connections",
         "LogRhythmRest": "Unstable environment Adi is checking",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1394,7 +1394,8 @@
             "nightly": true
         },
         {
-            "playbookID": "Autoextract - Test"
+            "playbookID": "Autoextract - Test",
+            "fromversion": "4.1.0"
         },
         {
             "playbookID": "FilterByList - Test",


### PR DESCRIPTION
## Status
Ready

## Related Issues
Fixed in: https://github.com/demisto/server/pull/13269
Original issue: https://github.com/demisto/etc/issues/18343

## Description
Test was moved to skipped originally because of a server bug, since this bug was fixed, the test can be unskipped.