### PR TITLE
SLA Test - avoid running on 4.0.0

### DIFF
--- a/TestPlaybooks/playbook-SLA_Scripts_-_Test.yml
+++ b/TestPlaybooks/playbook-SLA_Scripts_-_Test.yml
@@ -557,7 +557,7 @@ view: |-
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1785,
+        "height": 1780,
         "width": 1380,
         "x": -90,
         "y": -90

--- a/TestPlaybooks/playbook-SLA_Scripts_-_Test.yml
+++ b/TestPlaybooks/playbook-SLA_Scripts_-_Test.yml
@@ -557,7 +557,7 @@ view: |-
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1780,
+        "height": 1785,
         "width": 1380,
         "x": -90,
         "y": -90

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1353,7 +1353,8 @@
             "playbookID": "DUO Test Playbook"
         },
         {
-            "playbookID": "SLA Scripts - Test"
+            "playbookID": "SLA Scripts - Test",
+            "fromversion": "4.1.0"
         },
         {
             "playbookID": "PcapHTTPExtractor-Test"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: build https://circleci.com/gh/demisto/content/27835?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

## Description
SLA test fails to run on version 4.0.0 since it uses a builtin command `resetTimer`.
build fails only on "Two Before GA" which is 4.0.0. i couldn't find any build that run this test on that version.
failed build: https://circleci.com/gh/demisto/content/27855
after change build: https://circleci.com/gh/demisto/content/27856

## Screenshots
![image](https://user-images.githubusercontent.com/30797606/63546258-0be36780-c532-11e9-97b8-a8afa35223db.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Additional changes
it was merged before we run the build with multiple server versions.
no one changed it since then.
nightly runs on GA/master which doesn't have a problem running it.
couldn't find a "run all tests" build that run it on 4.0.0.
