### PR TITLE
Add get_demisto_version to CommonServerPython CHANGELOG

### DIFF
--- a/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+  - Added support for IPv6 in the ***is_ip_valid*** command.
+  - Added function ***get_demisto_version*** which return the Demisto server version and build number.
 
 
 ## [19.8.2] - 2019-08-22

--- a/Scripts/CommonServerPython/CommonServerPython.md
+++ b/Scripts/CommonServerPython/CommonServerPython.md
@@ -1,3 +1,0 @@
-## [Unreleased]
-  - Added support for IPv6 in the ***is_ip_valid*** command.
-  - Added function ***get_demisto_version*** which return the Demisto server version and build number.

--- a/Scripts/CommonServerPython/CommonServerPython.md
+++ b/Scripts/CommonServerPython/CommonServerPython.md
@@ -1,2 +1,3 @@
 ## [Unreleased]
-Added support for IPv6 in the ***is_ip_valid*** command.
+  - Added support for IPv6 in the ***is_ip_valid*** command.
+  - Added function ***get_demisto_version*** which return the Demisto server version and build number.


### PR DESCRIPTION


## Status
Ready


## Description
Added release notes to common server python.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Dependencies
None
