### PR TITLE
Microsoft Teams enhancements

### DIFF
--- a/Integrations/MicrosoftTeams/CHANGELOG.md
+++ b/Integrations/MicrosoftTeams/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased]
-Added argument channel_name to mirror-investigation to allow mirroring to a channel with custom channel name
-
-
+  - Added argument channel_name to mirror-investigation to allow mirroring to a channel with custom channel name
+  - Added a message to be sent to opened channel as part of mirror investigation process.
+  - Improved messages returned from the bot in direct messages.
+  
 ## [19.8.2] - 2019-08-22
 #### New Integration
 Send messages and notifications to your team members.

--- a/Integrations/MicrosoftTeams/CHANGELOG.md
+++ b/Integrations/MicrosoftTeams/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-  - Added argument channel_name to mirror-investigation to allow mirroring to a channel with custom channel name
-  - Added a message to be sent to opened channel as part of mirror investigation process.
+  - Added the *channel_name* argument to the ***mirror-investigation***, which enables mirroring to a channel with a custom channel name.
+  - Added a message that is sent to a channel that is opened as part of the mirror investigation process.
   - Improved messages returned from the bot in direct messages.
   
 ## [19.8.2] - 2019-08-22

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1001,8 +1001,19 @@ def mirror_investigation():
         demisto.results('Investigation mirror was updated successfully.')
     else:
         channel_name: str = demisto.args().get('channel_name', '') or f'incident-{investigation_id}'
-        channel_description = f'Channel to mirror incident {investigation_id}'
-        channel_id = create_channel(team_aad_id, channel_name, channel_description)
+        channel_description: str = f'Channel to mirror incident {investigation_id}'
+        channel_id: str = create_channel(team_aad_id, channel_name, channel_description)
+        service_url: str = integration_context.get('service_url', '')
+        server_links: dict = demisto.demistoUrls()
+        server_link: str = server_links.get('server', '')
+        warroom_link: str = f'{server_link}#/WarRoom/{investigation_id}'
+        conversation: dict = {
+            'type': 'message',
+            'text': f'This channel was created to mirror [incident {investigation_id}]({warroom_link}) '
+                    f'between Teams and Demisto. In order for your Teams messages to be mirrored in Demisto, '
+                    f'you need to mention the Demisto Bot in the message.'
+        }
+        send_message_request(service_url, channel_id, conversation)
         mirrored_channels.append({
             'channel_id': channel_id,
             'investigation_id': investigation_id,
@@ -1159,8 +1170,8 @@ def direct_message_handler(integration_context: dict, request_body: dict, conver
             formatted_message = urlify_hyperlinks(data)
     else:
         try:
-            return_card = True
             data = demisto.directMessage(message, username, user_email, allow_external_incidents_creation)
+            return_card = True
             if data.startswith('`'):  # We got a list of incidents/tasks:
                 data_by_line: list = data.replace('```', '').strip().split('\n')
                 return_card = True

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -1108,6 +1108,7 @@
       "384:mzawcK1gOUqJMpMhE5yOaF0O9TwFExCZkUf6H+PknKV+rXkrsH/CxEdubVAjMPW4:AiMVWcK9AhrDNEf"
     ],
     "emails": [
+      "johnnydepp@gmail.com",
       "2cbad0d78c624400ef83a5750534448g@thread.skype",
       "67pd3967e74g45f28d0c65f1689132bb@thread.skype",
       "67pd3967e74g45f28d0c65f1689132bo@thread.skype",


### PR DESCRIPTION
## Status
Ready

## Description
1. Added message to be sent on channel creation as part of mirror flow.
2. Fixed bug in which error returned from server are not sent in direct messages.

## Screenshots
![image](https://user-images.githubusercontent.com/31018228/63714757-20ce3c80-c84b-11e9-9f38-1edde1d06ddc.png)

Error returned from server when an external user tries to send `list my incidents` to the bot in direct message:

<img width="738" alt="Screen Shot 2019-08-26 at 21 48 28" src="https://user-images.githubusercontent.com/31018228/63714965-7d315c00-c84b-11e9-8c7b-4d907d71f197.png">


## Required version of Demisto
5.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Code Review

## Dependencies
- [x] MicrosoftTeamsAsk

