### PR TITLE
fix upload-file command when the file is summary report

### DIFF
--- a/Integrations/ServiceNow/CHANGELOG.md
+++ b/Integrations/ServiceNow/CHANGELOG.md
@@ -1,1 +1,1 @@
-Fix `servicenow-upload-file` command when the file is info file.
+Fixed an issue with the **servicenow-upload-file*** command when the uploaded file is an info file.

--- a/Integrations/ServiceNow/CHANGELOG.md
+++ b/Integrations/ServiceNow/CHANGELOG.md
@@ -1,1 +1,1 @@
-fix servicenow-upload-file command when the file is summary report
+Fix `servicenow-upload-file` command when the file is summary info file.

--- a/Integrations/ServiceNow/CHANGELOG.md
+++ b/Integrations/ServiceNow/CHANGELOG.md
@@ -1,0 +1,1 @@
+fix servicenow-upload-file command when the file is summary report

--- a/Integrations/ServiceNow/CHANGELOG.md
+++ b/Integrations/ServiceNow/CHANGELOG.md
@@ -1,1 +1,1 @@
-Fix `servicenow-upload-file` command when the file is summary info file.
+Fix `servicenow-upload-file` command when the file is info file.

--- a/Integrations/ServiceNow/ServiceNow.py
+++ b/Integrations/ServiceNow/ServiceNow.py
@@ -982,6 +982,11 @@ def upload_file_command():
     ticket_id = args['id']
     file_id = args['file_id']
     file_name = args.get('file_name', demisto.dt(demisto.context(), "File(val.EntryID=='" + file_id + "').Name"))
+
+    # in case of info file
+    if file_id and not file_name:
+        file_name = demisto.dt(demisto.context(), "InfoFile(val.EntryID=='" + file_id + "').Name")
+
     file_name = file_name[0] if isinstance(file_name, list) else file_name
 
     res = upload_file(ticket_id, file_id, file_name, ticket_type)

--- a/Integrations/ServiceNow/ServiceNow.py
+++ b/Integrations/ServiceNow/ServiceNow.py
@@ -984,8 +984,11 @@ def upload_file_command():
     file_name = args.get('file_name', demisto.dt(demisto.context(), "File(val.EntryID=='" + file_id + "').Name"))
 
     # in case of info file
-    if file_id and not file_name:
+    if not file_name:
         file_name = demisto.dt(demisto.context(), "InfoFile(val.EntryID=='" + file_id + "').Name")
+
+    if not file_name:
+        return_error('Could not find the file')
 
     file_name = file_name[0] if isinstance(file_name, list) else file_name
 

--- a/Integrations/ServiceNow/ServiceNow.yml
+++ b/Integrations/ServiceNow/ServiceNow.yml
@@ -4142,5 +4142,6 @@ script:
   runonce: false
   script: '-'
   type: python
+  subtype: python2
 tests:
 - No test - Hibernating instance


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17758

## Description
The command servicenow-upload-file failed when using the file generated with generateSummaryReport script.
