### PR TITLE
Remedy On Demand - remove trailing slash from login url

### DIFF
--- a/Integrations/integration-Remedy-On-Demand.yml
+++ b/Integrations/integration-Remedy-On-Demand.yml
@@ -117,7 +117,7 @@ script:
     };
 
     var login = function() {
-        var url = baseUrl + '/api/jwt/login/';
+        var url = baseUrl + '/api/jwt/login';
 
         var body = {
             username: params.credentials.identifier,

--- a/Integrations/integration-Remedy-On-Demand_CHANGELOG.md
+++ b/Integrations/integration-Remedy-On-Demand_CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+Removed trailing slash from login URL, which caused bad request response.


### PR DESCRIPTION
## Status
Ready

## Description
Removed trailing slash from login URL, since it caused bad request response returned from remedy.

## Required version of Demisto
Any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Code Review

## Dependencies
None

