### PR TITLE
Mimecast v2 fix

### DIFF
--- a/Integrations/MimecastV2/MimecastV2.py
+++ b/Integrations/MimecastV2/MimecastV2.py
@@ -219,6 +219,8 @@ def parse_query_args(args):
 
 
 def test_module():
+    if not ACCESS_KEY:
+        return_error('Cannot test valid connection without the Access Key parameter.')
     list_managed_url()
 
 
@@ -1482,7 +1484,8 @@ def download_attachment_request(attachment_id):
 LOG('command is %s' % (demisto.command(),))
 
 # Check if token needs to be refresh, if it does and relevant params are set, refresh.
-auto_refresh_token()
+if ACCESS_KEY:
+    auto_refresh_token()
 
 try:
     if demisto.command() == 'test-module':


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress - waiting first for packigify to merge into master
Fixes issue when not having access_key configured blocks the integration from running any command due to auto token refresh that needs it.

Fix: If there is no access key, won't run auto token refresh since it won't work anyway.
Also reflects in test error in case access key is not provided, that it cannot actually test the integration.