### PR TITLE
PANW AutoFocus V2 indicators context outputs - Support for version 5.0

### DIFF
--- a/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Integrations/AutofocusV2/AutofocusV2.py
@@ -73,7 +73,14 @@ API_PARAM_DICT = {
         'Malware Family': 'malware_family'
 
     },
-
+    'file_indicators': {
+        'Size': 'Size',
+        'SHA1': 'SHA1',
+        'SHA256': 'SHA256',
+        'FileType': 'Type',
+        'Tags': 'Tags',
+        'FileName': 'Name'
+    },
     'search_results': {
         'sha1': 'SHA1',
         'sha256': 'SHA256',
@@ -522,6 +529,24 @@ def print_hr_by_category(category_name, category_data):
             })
 
 
+def get_file_context_indicators(results):
+    files = []
+    for result in results:
+        raw_file = get_fields_from_hit_object(result, 'file_indicators')
+        file = get_relevant_fields(raw_file, 'file_indicators')
+        files.append(file)
+    return files
+
+
+def get_relevant_fields(result_object, response_dict_name):
+    af_params_dict = API_PARAM_DICT.get(response_dict_name)
+    new_object = {}
+    for key in result_object.keys():
+        if key in af_params_dict.values():
+            new_object[key] = result_object.get(key)
+    return new_object
+
+
 ''' COMMANDS'''
 
 
@@ -583,6 +608,7 @@ def samples_search_results_command():
     args = demisto.args()
     af_cookie = args.get('af_cookie')
     results, status = get_search_results('samples', af_cookie)
+    files = get_file_context_indicators(results)
     if len(results) < 1:
         md = results = 'No entries found that match the query'
     else:
@@ -593,7 +619,8 @@ def samples_search_results_command():
         'Contents': results,
         'EntryContext': {'AutoFocus.SamplesResults(val.ID == obj.ID)': results,
                          'AutoFocus.SamplesSearch(val.AFCookie == obj.AFCookie)': {'Status': status,
-                                                                                   'AFCookie': af_cookie}},
+                                                                                   'AFCookie': af_cookie},
+                         outputPaths['file']: files},
         'HumanReadable': md
     })
 
@@ -602,6 +629,7 @@ def sessions_search_results_command():
     args = demisto.args()
     af_cookie = args.get('af_cookie')
     results, status = get_search_results('sessions', af_cookie)
+    files = get_file_context_indicators(results)
     if len(results) < 1:
         md = results = 'No entries found that match the query'
     else:
@@ -612,7 +640,8 @@ def sessions_search_results_command():
         'Contents': results,
         'EntryContext': {'AutoFocus.SessionsResults(val.ID == obj.ID)': results,
                          'AutoFocus.SessionsSearch(val.AFCookie == obj.AFCookie)': {'Status': status,
-                                                                                    'AFCookie': af_cookie}},
+                                                                                    'AFCookie': af_cookie},
+                         outputPaths['file']: files},
         'HumanReadable': md
     })
 

--- a/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Integrations/AutofocusV2/AutofocusV2.py
@@ -541,9 +541,10 @@ def get_file_context_indicators(results):
 def get_relevant_fields(result_object, response_dict_name):
     af_params_dict = API_PARAM_DICT.get(response_dict_name)
     new_object = {}
-    for key in result_object.keys():
-        if key in af_params_dict.values():
-            new_object[key] = result_object.get(key)
+    if af_params_dict:
+        for key in result_object.keys():
+            if key in af_params_dict.values():
+                new_object[key] = result_object.get(key)
     return new_object
 
 

--- a/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Integrations/AutofocusV2/AutofocusV2.py
@@ -576,7 +576,6 @@ def filter_object_entries_by_dict_values(result_object, response_dict_name):
     :param response_dict_name: a dictionary which it's values are the relevant fields (filters)
     :return: the result_object filtered by the relevant fields
     """
-    print(result_object)
     af_params_dict = API_PARAM_DICT.get(response_dict_name)
     result_object_filtered = {}
     if af_params_dict:
@@ -653,8 +652,8 @@ def samples_search_results_command():
     else:
         md = tableToMarkdown(f'Search Samples Results is {status}', results)
     context = {
-        'AutoFocus.SamplesResults(val.ID == obj.ID)': results,
-        'AutoFocus.SamplesSearch(val.AFCookie == obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
+        'AutoFocus.SamplesResults(val.ID === obj.ID)': results,
+        'AutoFocus.SamplesSearch(val.AFCookie ==== obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
         outputPaths['file']: files
     }
     demisto.results({
@@ -676,8 +675,8 @@ def sessions_search_results_command():
     else:
         md = tableToMarkdown(f'Search Samples Results is {status}', results)
     context = {
-        'AutoFocus.SessionsResults(val.ID == obj.ID)': results,
-        'AutoFocus.SessionsSearch(val.AFCookie == obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
+        'AutoFocus.SessionsResults(val.ID === obj.ID)': results,
+        'AutoFocus.SessionsSearch(val.AFCookie === obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
         outputPaths['file']: files
     }
     demisto.results({
@@ -696,7 +695,7 @@ def get_session_details_command():
     files = get_files_data_from_results(result)
     md = tableToMarkdown(f'Session {session_id}:', result)
     context = {
-        'AutoFocus.Sessions(val.ID == obj.ID)': result,
+        'AutoFocus.Sessions(val.ID === obj.ID)': result,
         outputPaths['file']: files
     }
     demisto.results({

--- a/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Integrations/AutofocusV2/AutofocusV2.py
@@ -529,23 +529,61 @@ def print_hr_by_category(category_name, category_data):
             })
 
 
-def get_file_context_indicators(results):
+def get_files_data_from_results(results):
+    """
+    Gets a list of results and for each result returns a file object includes all relevant file indicators exists
+    in that result
+    :param results: a list of dictionaries
+    :return: a list of file objects
+    """
     files = []
     for result in results:
         raw_file = get_fields_from_hit_object(result, 'file_indicators')
-        file = get_relevant_fields(raw_file, 'file_indicators')
-        files.append(file)
+        file_data = filter_object_entries_by_dict_values(raw_file, 'file_indicators')
+        files.append(file_data)
     return files
 
 
-def get_relevant_fields(result_object, response_dict_name):
+def filter_object_entries_by_dict_values(result_object, response_dict_name):
+    """
+    Gets a dictionary (result_object) and filters it's keys by the values of another
+    dictionary (response_dict_name)
+    input: response_dict_name = 'file_indicators' - see API_PARAM_DICT above
+           result_object = {
+                              "app": "web-browsing",
+                              "vsys": 1,
+                              "SHA256": "18c9acd34a3aea09121f027857e0004a3ea33a372b213a8361e8a978330f0dc8",
+                              "UploadSource": "Firewall",
+                              "src_port": 80,
+                              "device_serial": "007051000050926",
+                              "Seen": "2019-07-24T09:37:04",
+                              "Name": "wildfire-test-pe-file.exe",
+                              "user_id": "unknown",
+                              "src_country": "United States",
+                              "src_countrycode": "US",
+                              "dst_port": 65168,
+                              "device_countrycode": "US",
+                              "Industry": "High Tech",
+                              "Region": "us",
+                              "device_country": "United States",
+                              "ID": "179972200903"
+                            }
+    output: {
+                "SHA256": "18c9acd34a3aea09121f027857e0004a3ea33a372b213a8361e8a978330f0dc8",
+                "Name": "wildfire-test-pe-file.exe"
+            }
+    :param result_object: a dictionary representing an object
+    :param response_dict_name: a dictionary which it's values are the relevant fields (filters)
+    :return: the result_object filtered by the relevant fields
+    """
+    print(result_object)
     af_params_dict = API_PARAM_DICT.get(response_dict_name)
-    new_object = {}
+    result_object_filtered = {}
     if af_params_dict:
         for key in result_object.keys():
             if key in af_params_dict.values():
-                new_object[key] = result_object.get(key)
-    return new_object
+                result_object_filtered[key] = result_object.get(key)
+    return result_object_filtered
 
 
 ''' COMMANDS'''
@@ -609,19 +647,21 @@ def samples_search_results_command():
     args = demisto.args()
     af_cookie = args.get('af_cookie')
     results, status = get_search_results('samples', af_cookie)
-    files = get_file_context_indicators(results)
+    files = get_files_data_from_results(results)
     if len(results) < 1:
         md = results = 'No entries found that match the query'
     else:
         md = tableToMarkdown(f'Search Samples Results is {status}', results)
+    context = {
+        'AutoFocus.SamplesResults(val.ID == obj.ID)': results,
+        'AutoFocus.SamplesSearch(val.AFCookie == obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
+        outputPaths['file']: files
+    }
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['text'],
         'Contents': results,
-        'EntryContext': {'AutoFocus.SamplesResults(val.ID == obj.ID)': results,
-                         'AutoFocus.SamplesSearch(val.AFCookie == obj.AFCookie)': {'Status': status,
-                                                                                   'AFCookie': af_cookie},
-                         outputPaths['file']: files},
+        'EntryContext': context,
         'HumanReadable': md
     })
 
@@ -630,19 +670,21 @@ def sessions_search_results_command():
     args = demisto.args()
     af_cookie = args.get('af_cookie')
     results, status = get_search_results('sessions', af_cookie)
-    files = get_file_context_indicators(results)
+    files = get_files_data_from_results(results)
     if len(results) < 1:
         md = results = 'No entries found that match the query'
     else:
         md = tableToMarkdown(f'Search Samples Results is {status}', results)
+    context = {
+        'AutoFocus.SessionsResults(val.ID == obj.ID)': results,
+        'AutoFocus.SessionsSearch(val.AFCookie == obj.AFCookie)': {'Status': status, 'AFCookie': af_cookie},
+        outputPaths['file']: files
+    }
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['text'],
         'Contents': results,
-        'EntryContext': {'AutoFocus.SessionsResults(val.ID == obj.ID)': results,
-                         'AutoFocus.SessionsSearch(val.AFCookie == obj.AFCookie)': {'Status': status,
-                                                                                    'AFCookie': af_cookie},
-                         outputPaths['file']: files},
+        'EntryContext': context,
         'HumanReadable': md
     })
 
@@ -651,14 +693,17 @@ def get_session_details_command():
     args = demisto.args()
     session_id = args.get('session_id')
     result = get_session_details(session_id)
-    file = get_file_context_indicators(result)
+    files = get_files_data_from_results(result)
     md = tableToMarkdown(f'Session {session_id}:', result)
+    context = {
+        'AutoFocus.Sessions(val.ID == obj.ID)': result,
+        outputPaths['file']: files
+    }
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['text'],
         'Contents': result,
-        'EntryContext': {'AutoFocus.Sessions(val.ID == obj.ID)': result,
-                         outputPaths['file']: file},
+        'EntryContext': context,
         'HumanReadable': md
     })
 

--- a/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Integrations/AutofocusV2/AutofocusV2.py
@@ -650,12 +650,14 @@ def get_session_details_command():
     args = demisto.args()
     session_id = args.get('session_id')
     result = get_session_details(session_id)
+    file = get_file_context_indicators(result)
     md = tableToMarkdown(f'Session {session_id}:', result)
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['text'],
         'Contents': result,
-        'EntryContext': {'AutoFocus.Sessions(val.ID == obj.ID)': result},
+        'EntryContext': {'AutoFocus.Sessions(val.ID == obj.ID)': result,
+                         outputPaths['file']: file},
         'HumanReadable': md
     })
 

--- a/Integrations/AutofocusV2/AutofocusV2.yml
+++ b/Integrations/AutofocusV2/AutofocusV2.yml
@@ -1,42 +1,47 @@
+category: Data Enrichment & Threat Intelligence
 commonfields:
   id: AutoFocus V2
   version: -1
-name: AutoFocus V2
-display: Palo Alto Networks AutoFocus V2
-category: Data Enrichment & Threat Intelligence
-description: Use the Palo Alto Networks AutoFocus integration to distinguish the most important threats from everyday commodity attacks.
 configuration:
 - display: API Key
   name: api_key
-  defaultvalue: ""
-  type: 4
   required: true
-- display: Trust any certificate (insecure)
+  type: 4
+- defaultvalue: 'false'
+  display: Trust any certificate (insecure)
   name: insecure
-  defaultvalue: "false"
-  type: 8
   required: false
+  type: 8
 - display: Use system proxy
   name: proxy
-  defaultvalue: ""
-  type: 8
   required: false
+  type: 8
+description: Use the Palo Alto Networks AutoFocus integration to distinguish the most
+  important threats from everyday commodity attacks.
+display: Palo Alto Networks AutoFocus V2
+name: AutoFocus V2
 script:
-  script: '-'
-  subtype: python3
-  type: python
   commands:
-  - name: autofocus-search-samples
-    arguments:
-    - name: query
+  - arguments:
+    - default: false
+      description: The query for which to retrieve samples. For additional information
+        on how to build your query using the AF GUI, see the detailed description.
+      isArray: false
+      name: query
       required: true
-      description: The query for which to retrieve samples. For additional information on how to build your query using the
-        AF GUI, see the detailed description.
-    - name: max_results
+      secret: false
+    - default: false
+      defaultValue: '30'
       description: Number of results to return.
-      defaultValue: "30"
-    - name: sort
-      auto: PREDEFINED
+      isArray: false
+      name: max_results
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: The field by which to sort the results.
+      isArray: false
+      name: sort
       predefined:
       - App Name
       - App Packagename
@@ -49,21 +54,35 @@ script:
       - SHA1
       - SHA256
       - Ssdeep Fuzzy Hash
-      description: The field by which to sort the results.
-    - name: order
-      auto: PREDEFINED
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: Result order ("Ascending" or "Descending").
+      isArray: false
+      name: order
       predefined:
       - Ascending
       - Descending
-      description: Result order ("Ascending" or "Descending").
-    - name: scope
-      required: true
-      auto: PREDEFINED
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: ' Scope of the search. Can be "Private", "Public", or "Global".'
+      isArray: false
+      name: scope
       predefined:
       - Private
       - Public
       - Global
-      description: ' Scope of the search. Can be "Private", "Public", or "Global".'
+      required: true
+      secret: false
+    deprecated: false
+    description: Search for samples. To view results run the autofocus-samples-search-results
+      command with the returned Af Cookie. The AF Cookie expires 120 seconds after
+      the search completes.
+    execution: false
+    name: autofocus-search-samples
     outputs:
     - contextPath: AutoFocus.SamplesSearch.AFCookie
       description: AutoFocus search ID. Use this ID to get search results. The AF
@@ -72,20 +91,26 @@ script:
     - contextPath: AutoFocus.SamplesSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: 'Search for samples. To view results run the autofocus-samples-search-results command
-      with the returned Af Cookie. The AF Cookie expires 120 seconds after the
-      search completes.'
-  - name: autofocus-search-sessions
-    arguments:
-    - name: query
+  - arguments:
+    - default: false
+      description: The query for which to retrieve samples. For additional information
+        on how to build your query using the AF GUI, see the detailed description.
+      isArray: false
+      name: query
       required: true
-      description: The query for which to retrieve samples. For additional information on how to build your query using the
-        AF GUI, see the detailed description.
-    - name: max_results
+      secret: false
+    - default: false
+      defaultValue: '30'
       description: Maximum number of results to return. Default is 30.
-      defaultValue: "30"
-    - name: sort
-      auto: PREDEFINED
+      isArray: false
+      name: max_results
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: Field to sort by
+      isArray: false
+      name: sort
       predefined:
       - Application
       - Device Country
@@ -106,13 +131,24 @@ script:
       - SHA256
       - Time
       - Upload source
-      description: Field to sort by
-    - name: order
-      auto: PREDEFINED
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: Order of sort
+      isArray: false
+      name: order
       predefined:
       - Ascending
       - Descending
-      description: Order of sort
+      required: false
+      secret: false
+    deprecated: false
+    description: Search for sessions. To view results run the autofocus-sessions-search-results
+      command with the returned AF Cookie. The AF Cookie expires 120 seconds after
+      the search completes.
+    execution: false
+    name: autofocus-search-sessions
     outputs:
     - contextPath: AutoFocus.SessionsSearch.AFCookie
       description: AutoFocus search ID. Use this ID to get search results. The AF
@@ -121,14 +157,18 @@ script:
     - contextPath: AutoFocus.SessionsSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: 'Search for sessions. To view results run the autofocus-sessions-search-results command
-      with the returned AF Cookie. The AF Cookie expires 120 seconds after the
-      search completes.'
-  - name: autofocus-samples-search-results
-    arguments:
-    - name: af_cookie
+  - arguments:
+    - default: false
+      description: The AF Cookie for retrieving results of previous searches. The
+        AF Cookie expires 120 seconds after the search completes.
+      isArray: false
+      name: af_cookie
       required: true
-      description: 'The AF Cookie for retrieving results of previous searches. The AF Cookie expires 120 seconds after the search completes.'
+      secret: false
+    deprecated: false
+    description: Returns results of a previous samples search.
+    execution: false
+    name: autofocus-samples-search-results
     outputs:
     - contextPath: AutoFocus.SamplesResults.Size
       description: File size in bytes.
@@ -163,12 +203,18 @@ script:
     - contextPath: AutoFocus.SamplesSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: Returns results of a previous samples search.
-  - name: autofocus-sessions-search-results
-    arguments:
-    - name: af_cookie
+  - arguments:
+    - default: false
+      description: The AF Cookie for retrieving the results of a previous search.
+        The AF Cookie expires 120 seconds after the search completes.
+      isArray: false
+      name: af_cookie
       required: true
-      description: 'The AF Cookie for retrieving the results of a previous search. The AF Cookie expires 120 seconds after the search completes.'
+      secret: false
+    deprecated: false
+    description: Returns results of a previous sessions search.
+    execution: false
+    name: autofocus-sessions-search-results
     outputs:
     - contextPath: AutoFocus.SessionsResults.FileName
       description: File name.
@@ -200,12 +246,26 @@ script:
     - contextPath: AutoFocus.SessionsSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: Returns results of a previous sessions search.
-  - name: autofocus-get-session-details
-    arguments:
-    - name: session_id
-      required: true
+    - contextPath: File.Name
+      description: The full file name (including file extension).
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA256 hash of the file.
+      type: String
+    - contextPath: File.Tags
+      description: Tags of the file.
+      type: String
+  - arguments:
+    - default: false
       description: The session ID.
+      isArray: false
+      name: session_id
+      required: true
+      secret: false
+    deprecated: false
+    description: Get session details by session ID
+    execution: false
+    name: autofocus-get-session-details
     outputs:
     - contextPath: AutoFocus.Sessions.FileName
       description: File name.
@@ -228,14 +288,18 @@ script:
     - contextPath: AutoFocus.Sessions.UploadSource
       description: Source that uploaded the sample.
       type: String
-    description: Get session details by session ID
-  - name: autofocus-sample-analysis
-    arguments:
-    - name: sample_id
-      required: true
+  - arguments:
+    - default: false
       description: SHA256 hash of the sample to analyze.
-    - name: os
-      auto: PREDEFINED
+      isArray: false
+      name: sample_id
+      required: true
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: Analysis environment.
+      isArray: false
+      name: os
       predefined:
       - win7
       - winxp
@@ -243,15 +307,27 @@ script:
       - static_analyzer
       - mac
       - bare_metal
-      description: Analysis environment.
-    - name: filter_data
-      auto: PREDEFINED
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'True'
+      description: If "False", the data returned will not be smartly filtered, and
+        will significantly reduce integration performance. We recommend setting this
+        to "True".
+      isArray: false
+      name: filter_data
       predefined:
-      - "True"
-      - "False"
-      description: 'If "False", the data returned will not be smartly filtered, and will significantly reduce integration performance.
-        We recommend setting this to "True".'
-      defaultValue: "True"
+      - 'True'
+      - 'False'
+      required: false
+      secret: false
+    deprecated: false
+    description: Returns properties, behaviors, and activities observed for a sample.
+      Run the command a single time to get the fields and operating systems under
+      HTTP, Coverage, Behavior, Registry, Files, Processes, Connections, and DNS.
+    execution: false
+    name: autofocus-sample-analysis
     outputs:
     - contextPath: AutoFocus.SampleAnalysis.Analysis.Http
       description: HTTP requests made when the sample was executed.
@@ -280,16 +356,21 @@ script:
       description: DNS activity observed when the sample was executed.
       type: Unknown
     - contextPath: AutoFocus.SampleAnalysis.Analysis.Mutex
-      description: The mutex created when the programs start is listed with the parent process if the sample generates other program threads when
-        executed in the analysis environment.
+      description: The mutex created when the programs start is listed with the parent
+        process if the sample generates other program threads when executed in the
+        analysis environment.
       type: Unknown
-    description: Returns properties, behaviors, and activities observed for a sample.
-      Run the command a single time to get the fields and operating systems under HTTP, Coverage, Behavior, Registry, Files, Processes, Connections, and DNS.
-  - name: autofocus-tag-details
-    arguments:
-    - name: tag_name
-      required: true
+  - arguments:
+    - default: false
       description: The public tag name. Can be retrieved from the top-tags command.
+      isArray: false
+      name: tag_name
+      required: true
+      secret: false
+    deprecated: false
+    description: Get details on a given tag
+    execution: false
+    name: autofocus-tag-details
     outputs:
     - contextPath: AutoFocus.Tag.TagName
       description: Tag simple name.
@@ -310,39 +391,34 @@ script:
       description: Organization that created the tag.
       type: String
     - contextPath: AutoFocus.Tag.Source
-      description: Organization or individual that discovered the threat that is defined in
-        the tag.
+      description: Organization or individual that discovered the threat that is defined
+        in the tag.
       type: String
     - contextPath: AutoFocus.Tag.TagClass
       description: Tag classification.
       type: String
     - contextPath: AutoFocus.Tag.TagDefinitionStatus
-      description: Status of the tag definition ("enabled", "disabled", "removing", or "rescoping").
+      description: Status of the tag definition ("enabled", "disabled", "removing",
+        or "rescoping").
       type: String
     - contextPath: AutoFocus.Tag.TagGroup
       description: Tag group of the tag.
       type: String
-    description: Get details on a given tag
-  - name: autofocus-top-tags-search
-    arguments:
-    - name: scope
-      required: true
-      auto: PREDEFINED
+  - arguments:
+    - auto: PREDEFINED
+      default: false
+      description: Scope of the search.
+      isArray: false
+      name: scope
       predefined:
       - industry
       - organization
       - all
       - global
-      description: Scope of the search.
-    - name: class
       required: true
-      auto: PREDEFINED
-      predefined:
-      - Actor
-      - Campaign
-      - Exploit
-      - Malicious Behavior
-      - Malware Family
+      secret: false
+    - auto: PREDEFINED
+      default: false
       description: |-
         Tag class.
         - Malware Family: group of malware that have shared properties or common functions.
@@ -351,34 +427,64 @@ script:
         - Exploit: an attack, which takes advantage
         of a software or network weakness, bug, or vulnerability to manipulate the behavior of the system.
         - Malicious Behavior: behavior that is not specific to a malware family or campaign, but indicates that your system has been compromised.
-    - name: private
-      auto: PREDEFINED
+      isArray: false
+      name: class
       predefined:
-      - "True"
-      - "False"
+      - Actor
+      - Campaign
+      - Exploit
+      - Malicious Behavior
+      - Malware Family
+      required: true
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'False'
       description: If "True", the tag scope is private. Default is "False".
-      defaultValue: "False"
-    - name: public
-      auto: PREDEFINED
+      isArray: false
+      name: private
       predefined:
-      - "True"
-      - "False"
+      - 'True'
+      - 'False'
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'False'
       description: If "True", the tag scope is public. Default is "False".
-      defaultValue: "False"
-    - name: commodity
-      auto: PREDEFINED
+      isArray: false
+      name: public
       predefined:
-      - "True"
-      - "False"
+      - 'True'
+      - 'False'
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'False'
       description: If "True", the tag scope is commodity. Default is "False".
-      defaultValue: "False"
-    - name: unit42
-      auto: PREDEFINED
+      isArray: false
+      name: commodity
       predefined:
-      - "True"
-      - "False"
+      - 'True'
+      - 'False'
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'False'
       description: If "True", the tag scope is unit42. Default is "False".
-      defaultValue: "False"
+      isArray: false
+      name: unit42
+      predefined:
+      - 'True'
+      - 'False'
+      required: false
+      secret: false
+    deprecated: false
+    description: Performs a search to identify the most popular tags.
+    execution: false
+    name: autofocus-top-tags-search
     outputs:
     - contextPath: AutoFocus.TopTagsSearch.AFCookie
       description: AutoFocus search ID. Use this ID to get search results. The AF
@@ -387,13 +493,18 @@ script:
     - contextPath: AutoFocus.TopTagsSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: Performs a search to identify the most popular tags.
-  - name: autofocus-top-tags-results
-    arguments:
-    - name: af_cookie
-      required: true
+  - arguments:
+    - default: false
       description: 'The AF Cookie for retrieving results of previous search. Note:
         The AF Cookie expires 120 seconds after the search completes.'
+      isArray: false
+      name: af_cookie
+      required: true
+      secret: false
+    deprecated: false
+    description: Returns the results of a previous top tags search.
+    execution: false
+    name: autofocus-top-tags-results
     outputs:
     - contextPath: AutoFocus.TopTagsResults.Count
       description: Number of samples that matched this tag.
@@ -410,8 +521,13 @@ script:
     - contextPath: AutoFocus.TopTagsSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
-    description: Returns the results of a previous top tags search.
   dockerimage: demisto/python3:3.7.2.214
+  isfetch: false
+  longRunning: false
+  longRunningPort: false
   runonce: false
+  script: '-'
+  type: python
+  subtype: python3
 tests:
-  - AutoFocus V2 test
+- AutoFocus V2 test

--- a/Integrations/AutofocusV2/AutofocusV2.yml
+++ b/Integrations/AutofocusV2/AutofocusV2.yml
@@ -288,6 +288,12 @@ script:
     - contextPath: AutoFocus.Sessions.UploadSource
       description: Source that uploaded the sample.
       type: String
+    - contextPath: File.Name
+      description: The full file name (including file extension).
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA256 hash of the file.
+      type: String
   - arguments:
     - default: false
       description: SHA256 hash of the sample to analyze.

--- a/Integrations/AutofocusV2/AutofocusV2.yml
+++ b/Integrations/AutofocusV2/AutofocusV2.yml
@@ -203,6 +203,22 @@ script:
     - contextPath: AutoFocus.SamplesSearch.Status
       description: Search status ("in progress" or "complete").
       type: String
+    - contextPath: File.Size
+      description: The size of the file in bytes.
+      type: Number
+    - contextPath: File.SHA1
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA256 hash of the file.
+      type: String
+    - contextPath: File.Type
+      description: The file type, as determined by libmagic (same as displayed in
+        file entries).
+      type: String
+    - contextPath: File.Tags
+      description: Tags of the file.
+      type: String
   - arguments:
     - default: false
       description: The AF Cookie for retrieving the results of a previous search.

--- a/Integrations/AutofocusV2/CHANGELOG.md
+++ b/Integrations/AutofocusV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+  - Updated Cisco-umbrella Indicators context outputs to support version 5.0.
 
 ## [19.8.2] - 2019-08-22
   - Added *tagGroups* output to ***autofocus-samples-search-results*** command.

--- a/Integrations/AutofocusV2/CHANGELOG.md
+++ b/Integrations/AutofocusV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-  - Updated Cisco-umbrella Indicators context outputs to support version 5.0.
+  - Updated Palo Alto Networks AutoFocus V2 Indicators context outputs to support version 5.0.
 
 ## [19.8.2] - 2019-08-22
   - Added *tagGroups* output to ***autofocus-samples-search-results*** command.

--- a/TestPlaybooks/playbook-AutoFocus_V2_test.yml
+++ b/TestPlaybooks/playbook-AutoFocus_V2_test.yml
@@ -1,14 +1,14 @@
 id: AutoFocus V2 test
-version: -1
+version: 3
 name: AutoFocus V2 test
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 34b3687a-c2ff-44ef-8c0b-8e7ce506f533
+    taskid: 886cb64b-d1ff-417b-8daf-8c5ff71cfd18
     type: start
     task:
-      id: 34b3687a-c2ff-44ef-8c0b-8e7ce506f533
+      id: 886cb64b-d1ff-417b-8daf-8c5ff71cfd18
       version: -1
       name: ""
       iscommand: false
@@ -29,10 +29,10 @@ tasks:
     ignoreworker: false
   "1":
     id: "1"
-    taskid: 69792646-65fd-436e-8545-f0ec4b0a0c3a
+    taskid: eaf48c16-443d-432b-8fb6-811b3b2a26b0
     type: regular
     task:
-      id: 69792646-65fd-436e-8545-f0ec4b0a0c3a
+      id: eaf48c16-443d-432b-8fb6-811b3b2a26b0
       version: -1
       name: autofocus-search-samples
       description: 'Search for samples. To view results run autofocus-samples-search-results
@@ -69,10 +69,10 @@ tasks:
     ignoreworker: false
   "2":
     id: "2"
-    taskid: dcf2d97a-a25b-4468-825f-66fc8ab93573
+    taskid: a51bf59b-5f54-4d7b-8946-7008d2d10dd1
     type: regular
     task:
-      id: dcf2d97a-a25b-4468-825f-66fc8ab93573
+      id: a51bf59b-5f54-4d7b-8946-7008d2d10dd1
       version: -1
       name: autofocus-search-sessions
       description: 'Search for sessions. To view results run autofocus-sessions-search-results
@@ -107,10 +107,10 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: 163e4521-f5d7-4e8f-820b-f6fe3487c67f
+    taskid: 52156ec1-e4a9-41e8-8030-0d3520407495
     type: condition
     task:
-      id: 163e4521-f5d7-4e8f-820b-f6fe3487c67f
+      id: 52156ec1-e4a9-41e8-8030-0d3520407495
       version: -1
       name: Verify context
       type: condition
@@ -145,10 +145,10 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 66cbffa1-d5ab-498c-8c1f-072926c7ef83
+    taskid: 1b5a7307-da56-4af6-8648-b6f1a25b185b
     type: condition
     task:
-      id: 66cbffa1-d5ab-498c-8c1f-072926c7ef83
+      id: 1b5a7307-da56-4af6-8648-b6f1a25b185b
       version: -1
       name: Verify context
       type: condition
@@ -183,10 +183,10 @@ tasks:
     ignoreworker: false
   "5":
     id: "5"
-    taskid: d9e24b69-7551-4d64-81c2-8160a9eac410
+    taskid: cb45299a-b28a-4304-8235-124645286b76
     type: regular
     task:
-      id: d9e24b69-7551-4d64-81c2-8160a9eac410
+      id: cb45299a-b28a-4304-8235-124645286b76
       version: -1
       name: autofocus-samples-search-results
       description: Get results of a previous samples search
@@ -213,10 +213,10 @@ tasks:
     ignoreworker: false
   "6":
     id: "6"
-    taskid: 249ad525-3762-4865-84a7-daed04f70f26
+    taskid: b862ecd8-4de8-4016-852e-94280da764d3
     type: regular
     task:
-      id: 249ad525-3762-4865-84a7-daed04f70f26
+      id: b862ecd8-4de8-4016-852e-94280da764d3
       version: -1
       name: autofocus-sessions-search-results
       description: Get results of a previous sessions search
@@ -243,10 +243,10 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 4a79a648-e386-4e7e-8549-325a0305c1c9
+    taskid: ee5f5263-aa7f-4b00-8fd2-017726a03397
     type: condition
     task:
-      id: 4a79a648-e386-4e7e-8549-325a0305c1c9
+      id: ee5f5263-aa7f-4b00-8fd2-017726a03397
       version: -1
       name: Verify context
       type: condition
@@ -297,6 +297,41 @@ tasks:
           right:
             value:
               simple: in progress,complete
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Size
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: SHA1
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: SHA256
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Type
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Tags
+            iscontext: true
     view: |-
       {
         "position": {
@@ -309,10 +344,10 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: 300aedd7-c486-4bc7-80b8-f5275acebd9b
+    taskid: 91149c6a-3238-4464-89d5-ee3546e8b8b8
     type: condition
     task:
-      id: 300aedd7-c486-4bc7-80b8-f5275acebd9b
+      id: 91149c6a-3238-4464-89d5-ee3546e8b8b8
       version: -1
       name: Verify context
       type: condition
@@ -363,6 +398,27 @@ tasks:
           right:
             value:
               simple: in progress,complete
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Name
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: SHA256
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Tags
+            iscontext: true
     view: |-
       {
         "position": {
@@ -375,10 +431,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: 462154ec-45fe-4085-87fb-adb065db1c66
+    taskid: 833bc1c7-ce76-49b3-8c2b-fd8331e04653
     type: regular
     task:
-      id: 462154ec-45fe-4085-87fb-adb065db1c66
+      id: 833bc1c7-ce76-49b3-8c2b-fd8331e04653
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -410,10 +466,10 @@ tasks:
     ignoreworker: false
   "10":
     id: "10"
-    taskid: e3b8ba25-3ed9-4ae6-8e7e-6c9813aa82e6
+    taskid: dc56ebd7-b777-4946-869f-510a5066d453
     type: regular
     task:
-      id: e3b8ba25-3ed9-4ae6-8e7e-6c9813aa82e6
+      id: dc56ebd7-b777-4946-869f-510a5066d453
       version: -1
       name: autofocus-sample-analysis
       description: |-
@@ -448,10 +504,10 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 3ffef267-a964-4bf9-8fcb-c913907744a0
+    taskid: fbbfabb7-0afe-4340-8b0c-6628fbe7c3ff
     type: regular
     task:
-      id: 3ffef267-a964-4bf9-8fcb-c913907744a0
+      id: fbbfabb7-0afe-4340-8b0c-6628fbe7c3ff
       version: -1
       name: autofocus-get-session-details
       description: Get session details by session ID
@@ -486,10 +542,10 @@ tasks:
     ignoreworker: false
   "12":
     id: "12"
-    taskid: b99fe8d2-6cd6-4adc-8311-89453dcaf9f4
+    taskid: 60033ff3-276c-41c0-8c15-28220f162383
     type: condition
     task:
-      id: b99fe8d2-6cd6-4adc-8311-89453dcaf9f4
+      id: 60033ff3-276c-41c0-8c15-28220f162383
       version: -1
       name: Verify context
       type: condition
@@ -544,10 +600,10 @@ tasks:
     ignoreworker: false
   "14":
     id: "14"
-    taskid: 005fc680-2529-4a3d-8b1c-73c7e5632cb0
+    taskid: 848c4c05-5ca8-4a29-83c8-e76b5fb4561f
     type: condition
     task:
-      id: 005fc680-2529-4a3d-8b1c-73c7e5632cb0
+      id: 848c4c05-5ca8-4a29-83c8-e76b5fb4561f
       version: -1
       name: Verify context
       type: condition
@@ -595,6 +651,20 @@ tasks:
             value:
               simple: AutoFocus.Sessions.UploadSource
             iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: Name
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                accessor: SHA256
+            iscontext: true
     view: |-
       {
         "position": {
@@ -607,10 +677,10 @@ tasks:
     ignoreworker: false
   "15":
     id: "15"
-    taskid: 7732c835-7066-49b5-8898-416b0e07e27d
+    taskid: 437e01a2-1ee3-42ee-8200-de785ebbf38c
     type: regular
     task:
-      id: 7732c835-7066-49b5-8898-416b0e07e27d
+      id: 437e01a2-1ee3-42ee-8200-de785ebbf38c
       version: -1
       name: autofocus-top-tags-search
       description: Perform a search to Identify the most popular tags
@@ -645,10 +715,10 @@ tasks:
     ignoreworker: false
   "16":
     id: "16"
-    taskid: 5675f6d3-8a84-4ac2-87cd-c916359e38f5
+    taskid: 2dd10e45-2b26-4879-8ae8-d7ff3500152a
     type: regular
     task:
-      id: 5675f6d3-8a84-4ac2-87cd-c916359e38f5
+      id: 2dd10e45-2b26-4879-8ae8-d7ff3500152a
       version: -1
       name: autofocus-top-tags-results
       description: Get the results of a previous top tags search
@@ -675,10 +745,10 @@ tasks:
     ignoreworker: false
   "17":
     id: "17"
-    taskid: 973fcf53-2019-42c7-8316-9358fef2e36e
+    taskid: f720675d-b725-43bf-8d42-93605118c5a5
     type: regular
     task:
-      id: 973fcf53-2019-42c7-8316-9358fef2e36e
+      id: f720675d-b725-43bf-8d42-93605118c5a5
       version: -1
       name: autofocus-tag-details
       description: Get details on a given tag
@@ -713,10 +783,10 @@ tasks:
     ignoreworker: false
   "18":
     id: "18"
-    taskid: 915bd015-bb1d-4fb5-844b-f720ffa085c3
+    taskid: 9fa5f749-4919-4200-82ef-0814074219cf
     type: condition
     task:
-      id: 915bd015-bb1d-4fb5-844b-f720ffa085c3
+      id: 9fa5f749-4919-4200-82ef-0814074219cf
       version: -1
       name: Verify context
       type: condition
@@ -751,10 +821,10 @@ tasks:
     ignoreworker: false
   "19":
     id: "19"
-    taskid: 26ebc4ac-1072-445c-85cd-3e4e14cd5c4d
+    taskid: 412f126c-a1c6-48c2-8684-2f5ed34a4a3b
     type: condition
     task:
-      id: 26ebc4ac-1072-445c-85cd-3e4e14cd5c4d
+      id: 412f126c-a1c6-48c2-8684-2f5ed34a4a3b
       version: -1
       name: Verify context
       type: condition
@@ -799,10 +869,10 @@ tasks:
     ignoreworker: false
   "20":
     id: "20"
-    taskid: 489cd799-70f9-4fe7-892d-3a760410ce4d
+    taskid: 362587b3-66ce-401c-88d6-ec68eeefd631
     type: condition
     task:
-      id: 489cd799-70f9-4fe7-892d-3a760410ce4d
+      id: 362587b3-66ce-401c-88d6-ec68eeefd631
       version: -1
       name: Verify context
       type: condition
@@ -872,10 +942,10 @@ tasks:
     ignoreworker: false
   "21":
     id: "21"
-    taskid: 37fc6e8c-9bb0-452b-86ae-c962a2076cc9
+    taskid: 8ef0008a-1714-46f4-8c71-2ea2169f73ec
     type: title
     task:
-      id: 37fc6e8c-9bb0-452b-86ae-c962a2076cc9
+      id: 8ef0008a-1714-46f4-8c71-2ea2169f73ec
       version: -1
       name: DONE
       type: title
@@ -894,10 +964,10 @@ tasks:
     ignoreworker: false
   "22":
     id: "22"
-    taskid: a34daeea-b042-481c-8f3b-42c536c3ca3b
+    taskid: 380d10e3-9070-41e6-86ec-2c1cd4eee6b0
     type: regular
     task:
-      id: a34daeea-b042-481c-8f3b-42c536c3ca3b
+      id: 380d10e3-9070-41e6-86ec-2c1cd4eee6b0
       version: -1
       name: Sleep
       description: Sleep for X seconds
@@ -924,10 +994,10 @@ tasks:
     ignoreworker: false
   "23":
     id: "23"
-    taskid: 61a8556b-dc45-400e-8a1f-c311f88477f8
+    taskid: b22fd857-a674-4638-8a4e-ed30a6ea3ca9
     type: regular
     task:
-      id: 61a8556b-dc45-400e-8a1f-c311f88477f8
+      id: b22fd857-a674-4638-8a4e-ed30a6ea3ca9
       version: -1
       name: Sleep
       description: Sleep for X seconds
@@ -954,10 +1024,10 @@ tasks:
     ignoreworker: false
   "24":
     id: "24"
-    taskid: 7e8fbce8-268e-4ace-8a91-4beaeec3c9c4
+    taskid: c2e02f5c-f308-4c2d-8259-ba70dd20735d
     type: regular
     task:
-      id: 7e8fbce8-268e-4ace-8a91-4beaeec3c9c4
+      id: c2e02f5c-f308-4c2d-8259-ba70dd20735d
       version: -1
       name: Sleep
       description: Sleep for X seconds


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17949

## Description
Updated Palo Alto Networks AutoFocus V2 Indicators context outputs to support version 5.0.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review