### PR TITLE
[Fix] QRadar missing SEC header when trying to get offense types

### DIFF
--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.
-  - Fixed an issue in which the ***qradar-offense-by-id*** command failed when trying to get offense type with a missing SEC header.
+  - Fixed an issue in which the ***qradar-offense-by-id*** command failed if an SEC header was missing when trying to get an offense type.
 
 ## [19.8.2] - 2019-08-22
   - Fixed an issue in which users would receive an error message for missing SEC headers.

--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.
+  - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.
+  - Fixed an issue in which the ***qradar-offense-by-id*** command failed when trying to get offense type with a missing SEC header.
 
 ## [19.8.2] - 2019-08-22
   - Fixed an issue in which users would receive an error message for missing SEC headers.

--- a/Integrations/QRadar/QRadar.py
+++ b/Integrations/QRadar/QRadar.py
@@ -373,7 +373,7 @@ def get_offense_types():
     url = '{0}/api/siem/offense_types'.format(SERVER)
     # Due to a bug in QRadar, this functions does not work if username/password was not provided
     if USERNAME and PASSWORD:
-        return send_request('GET', url, headers=None)
+        return send_request('GET', url)
     return {}
 
 


### PR DESCRIPTION
## Status
Ready (validated with @yoavBenZion)

## Related Issues
leftover from: https://github.com/demisto/content/pull/4067

## Description
Fixed an issue in which the `qradar-offense-by-id` command failed when trying to get offense type with a missing SEC header.

## Does it break backward compatibility?
   - No