### PR TITLE
EWS v2 - fixed ews-get-contacts command

### DIFF
--- a/Integrations/EWSv2/CHANGELOG.md
+++ b/Integrations/EWSv2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-  - Improved ***ews-get-contacts*** command.
+Improved implementation of the ***ews-get-contacts*** command.
 
 
 ## [19.8.0] - 2019-08-06

--- a/Integrations/EWSv2/CHANGELOG.md
+++ b/Integrations/EWSv2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+  - Improved ***ews-get-contacts*** command.
 
 
 ## [19.8.0] - 2019-08-06

--- a/Integrations/EWSv2/EWSv2.py
+++ b/Integrations/EWSv2/EWSv2.py
@@ -19,7 +19,7 @@ from exchangelib.errors import ErrorItemNotFound, ResponseMessageError, Transpor
     ErrorInvalidIdMalformed, \
     ErrorFolderNotFound, ErrorToFolderNotFound, ErrorMailboxStoreUnavailable, ErrorMailboxMoveInProgress, \
     AutoDiscoverFailed, ErrorNameResolutionNoResults
-from exchangelib.items import Item, Message
+from exchangelib.items import Item, Message, Contact
 from exchangelib.services import EWSService, EWSAccountService
 from exchangelib.util import create_element, add_xml_child
 from exchangelib import IMPERSONATION, DELEGATE, Account, Credentials, \
@@ -1295,11 +1295,11 @@ def get_contacts(limit, target_mailbox=None):
         contact_dict = dict((k, v if not isinstance(v, EWSDateTime) else v.ewsformat())
                             for k, v in contact.__dict__.items()
                             if isinstance(v, basestring) or isinstance(v, EWSDateTime))
-        if contact.physical_addresses:
+        if isinstance(contact, Contact) and contact.physical_addresses:
             contact_dict['physical_addresses'] = map(parse_physical_address, contact.physical_addresses)
-        if contact.phone_numbers:
+        if isinstance(contact, Contact) and contact.phone_numbers:
             contact_dict['phone_numbers'] = map(parse_phone_number, contact.phone_numbers)
-        if contact.email_addresses and len(contact.email_addresses) > 0:
+        if isinstance(contact, Contact) and contact.email_addresses and len(contact.email_addresses) > 0:
             contact_dict['emailAddresses'] = map(lambda x: x.email, contact.email_addresses)
         contact_dict = keys_to_camel_case(contact_dict)
         contact_dict = dict((k, v) for k, v in contact_dict.items() if v)
@@ -1309,10 +1309,8 @@ def get_contacts(limit, target_mailbox=None):
 
     account = get_account(target_mailbox or ACCOUNT_EMAIL)
     contacts = []
-    count = 0
-    for contact in account.contacts.all():  # pylint: disable=E1101
-        if count >= limit:
-            break
+
+    for contact in account.contacts.all()[:int(limit)]:  # pylint: disable=E1101
         contacts.append(parse_contact(contact))
     return get_entry_for_object('Email contacts for %s' % target_mailbox,
                                 'Account.Email(val.Address == obj.originMailbox).EwsContacts',

--- a/Integrations/EWSv2/EWSv2.yml
+++ b/Integrations/EWSv2/EWSv2.yml
@@ -1077,6 +1077,7 @@ script:
   runonce: false
   script: '-'
   type: python
+  subtype: python2
 tests:
 - pyEWS_Test
 - EWS search-mailbox test

--- a/TestPlaybooks/playbook-pyEWS_Test.yml
+++ b/TestPlaybooks/playbook-pyEWS_Test.yml
@@ -230,7 +230,7 @@ tasks:
     scriptarguments:
       expectedValue: {}
       fields:
-        simple: phoneNumbers,displayName,emailAddresses
+        simple: displayName,id
       path:
         simple: Account.Email.EwsContacts
     separatecontext: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
In case of saving new contact as distribution list in target mailbox, `ews-get-contacts` will raise AttributeError. Added type checking in order separate between `Contact` and `DistributionList` objects. Additionally fixed the `limit` argument that had no impact on the results. 

## Required version of Demisto
4.5.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Playbooks:
- [x] Search And Delete Emails - Generic
- [x] Get Original Email - Generic
- [x] Phishing Investigation - Generic
- [x] Process Email - Generic
- [x] Office 365 Search and Delete
- [x] Search And Delete Emails - EWS
- [x] Process Email - EWS
- [x] Phishing Investigation - Generic v2
- [x] Get Original Email - EWS

Integrations:
- [x] EWS v2

Tests:
- [x] Phishing v2 Test - Inline
- [x] EWSv2_empty_attachment_test
- [x] EWS Public Folders Test
- [x] Phishing test - attachment
- [x] get_original_email_-_ews-_test
- [x] pyEWS_Test
- [x] Process Email - Generic for Rasterize
- [x] Phishing v2 Test - Attachment
- [x] EWS search-mailbox test
- [x] Phishing test - Inline
- [x] process_email_-_generic_-_test

## Additional changes
Describe additional changes done, for example adding a function to common server.
