### PR TITLE
MineMeld treat properly non root server URLs

### DIFF
--- a/Integrations/PaloAlto_MineMeld/CHANGELOG.md
+++ b/Integrations/PaloAlto_MineMeld/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+  - Added support to non root URL structures.

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.py
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.py
@@ -9,7 +9,6 @@ import os.path
 import os
 import time
 import re
-from urlparse import urljoin  # type: ignore
 
 # globals and constants
 IPV4_CLASS = 'minemeld.ft.local.YamlIPv4FT'

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.py
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.py
@@ -63,7 +63,7 @@ class APIClient(object):
         if headers is None:
             headers = {}
 
-        api_url = urljoin(self.url, uri)
+        api_url = "".join([self.url, uri])
         api_request = urllib2.Request(api_url, headers=headers)
         basic_authorization = base64.b64encode('{}:{}'.format(self.username, self.password))
         api_request.add_header(

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -160,16 +160,16 @@ script:
     name: ip
     outputs:
     - contextPath: DBotScore.Indicator
-      description: The Indicator
+      description: STRING, The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: The Indicator type
+      description: STRING, The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: The DBot score vendor
+      description: STRING, Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: The DBot score
+      description: INT, The actual score.
       type: number
     - contextPath: IP.Malicious.Vendor
       description: For malicious IPs, the vendor that made the decision
@@ -235,16 +235,16 @@ script:
     name: file
     outputs:
     - contextPath: DBotScore.Indicator
-      description: The Indicator
+      description: STRING, The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: The Indicator type
+      description: STRING, The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: The DBot score vendor
+      description: STRING, Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: The DBot score
+      description: INT, The actual score.
       type: number
     - contextPath: File.Malicious.Vendor
       description: For malicious files, the vendor that made the decision
@@ -316,16 +316,16 @@ script:
     name: domain
     outputs:
     - contextPath: DBotScore.Indicator
-      description: The Indicator
+      description: STRING, The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: The Indicator type
+      description: STRING, The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: The DBot score vendor
+      description: STRING, Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: The DBot score
+      description: INT, The actual score.
       type: number
     - contextPath: Domain.Malicious.Vendor
       description: For malicious Domains, the vendor that made the decision
@@ -391,16 +391,16 @@ script:
     name: url
     outputs:
     - contextPath: DBotScore.Indicator
-      description: The Indicator
+      description: STRING, The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: The Indicator type
+      description: STRING, The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: The DBot score vendor
+      description: STRING, Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: The DBot score
+      description: INT, The actual score.
       type: number
     - contextPath: URL.Malicious.Vendor
       description: For malicious URLs, the vendor that made the decision

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -152,7 +152,7 @@ script:
       description: ip
       isArray: false
       name: ip
-      required: true
+      required: false
       secret: false
     deprecated: false
     description: Search for ip on miners
@@ -227,7 +227,7 @@ script:
       description: file
       isArray: false
       name: file
-      required: true
+      required: false
       secret: false
     deprecated: false
     description: Search for file on lists
@@ -308,7 +308,7 @@ script:
       description: domain
       isArray: false
       name: domain
-      required: true
+      required: false
       secret: false
     deprecated: false
     description: Search for domain on lists
@@ -383,7 +383,7 @@ script:
       description: url
       isArray: false
       name: url
-      required: true
+      required: false
       secret: false
     deprecated: false
     description: Search for url on lists

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -475,5 +475,6 @@ script:
   runonce: false
   script: '-'
   type: python
+  subtype: python2
 tests:
 - minemeld_test

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -152,7 +152,7 @@ script:
       description: ip
       isArray: false
       name: ip
-      required: false
+      required: true
       secret: false
     deprecated: false
     description: Search for ip on miners
@@ -227,7 +227,7 @@ script:
       description: file
       isArray: false
       name: file
-      required: false
+      required: true
       secret: false
     deprecated: false
     description: Search for file on lists
@@ -308,7 +308,7 @@ script:
       description: domain
       isArray: false
       name: domain
-      required: false
+      required: true
       secret: false
     deprecated: false
     description: Search for domain on lists
@@ -383,7 +383,7 @@ script:
       description: url
       isArray: false
       name: url
-      required: false
+      required: true
       secret: false
     deprecated: false
     description: Search for url on lists

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -160,16 +160,16 @@ script:
     name: ip
     outputs:
     - contextPath: DBotScore.Indicator
-      description: STRING, The indicator that was tested.
+      description: The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: STRING, The indicator type.
+      description: The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: STRING, Vendor used to calculate the score.
+      description: Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: INT, The actual score.
+      description: The actual score.
       type: number
     - contextPath: IP.Malicious.Vendor
       description: For malicious IPs, the vendor that made the decision
@@ -235,16 +235,16 @@ script:
     name: file
     outputs:
     - contextPath: DBotScore.Indicator
-      description: STRING, The indicator that was tested.
+      description: The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: STRING, The indicator type.
+      description: The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: STRING, Vendor used to calculate the score.
+      description: Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: INT, The actual score.
+      description: The actual score.
       type: number
     - contextPath: File.Malicious.Vendor
       description: For malicious files, the vendor that made the decision
@@ -316,16 +316,16 @@ script:
     name: domain
     outputs:
     - contextPath: DBotScore.Indicator
-      description: STRING, The indicator that was tested.
+      description: The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: STRING, The indicator type.
+      description: The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: STRING, Vendor used to calculate the score.
+      description: Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: INT, The actual score.
+      description: The actual score.
       type: number
     - contextPath: Domain.Malicious.Vendor
       description: For malicious Domains, the vendor that made the decision
@@ -391,16 +391,16 @@ script:
     name: url
     outputs:
     - contextPath: DBotScore.Indicator
-      description: STRING, The indicator that was tested.
+      description: The indicator that was tested.
       type: string
     - contextPath: DBotScore.Type
-      description: STRING, The indicator type.
+      description: The indicator type.
       type: string
     - contextPath: DBotScore.Vendor
-      description: STRING, Vendor used to calculate the score.
+      description: Vendor used to calculate the score.
       type: string
     - contextPath: DBotScore.Score
-      description: INT, The actual score.
+      description: The actual score.
       type: number
     - contextPath: URL.Malicious.Vendor
       description: For malicious URLs, the vendor that made the decision

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -84,9 +84,9 @@ class IntegrationValidator(object):
                         or (command_name == 'domain' and arg_name == 'domain')
                         or (command_name == 'url' and arg_name == 'url')
                         or (command_name == 'ip' and arg_name == 'ip')):
-                    if arg.get('default') is False or arg.get('required') is True:
+                    if arg.get('default') is False:
                         self._is_valid = False
-                        print_error("The argument '{}' of the command '{}' is either non default or required"
+                        print_error("The argument '{}' of the command '{}' is not configured as default"
                                     .format(arg_name, command_name))
         return self._is_valid
 

--- a/Tests/scripts/hook_validations/tests/integration_test.py
+++ b/Tests/scripts/hook_validations/tests/integration_test.py
@@ -649,33 +649,6 @@ def test_is_default_arguments_non_default():
         "The integration validator did not find invalid arg (needed to be default and not required)"
 
 
-def test_is_default_arguments_is_required():
-    validator = IntegrationValidator("temp_file", check_git=False)
-    validator.current_integration = {
-        "script": {
-            "commands": [
-                {
-                    "name": "domain",
-                    "arguments": [
-                        {
-                            "name": "domain",
-                            "required": True,
-                            "default": True
-                        },
-                        {
-                            "name": "verbose"
-                        }
-                    ]
-                }
-            ]
-        }
-    }
-    validator.old_integration = None
-
-    assert validator.is_default_arguments() is False, \
-        "The integration validator did not find invalid arg (need not to be required)"
-
-
 def test_is_default_arguments_ok():
     validator = IntegrationValidator("temp_file", check_git=False)
     validator.current_integration = {


### PR DESCRIPTION
Also changed descriptions of DBOTSCORE output paths according to our new standards.

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/18898

## Description
weird behavior of urllib2, was omitting the subdomain from URLs on join operations (concat server root + api path) for instances that were installed on non root paths in server.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Code Review