### PR TITLE
unmock mysql - doesn't use http

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1896,6 +1896,7 @@
         "TruSTAR"
     ],
     "unmockable_integrations": {
+        "mysql": "Does not use http",
         "SlackV2": "Integration requires SSL",
         "Whois": "Mocks does not support sockets",
         "Panorama": "Exception: Proxy process took to long to go up. https://circleci.com/gh/demisto/content/24826",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
No need for mocking in mysql tests. It doesn't use http.

## Does it break backward compatibility?
   - No

