### PR TITLE
Fix intsights bug when URL is wrong

### DIFF
--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,1 +1,1 @@
-set default encoding to utf-8
+Fixed an issue with Intsights integration when the server URL is wrong.

--- a/Integrations/IntSight/IntSight.py
+++ b/Integrations/IntSight/IntSight.py
@@ -53,8 +53,8 @@ SEVERITY_LEVEL = {
 def is_json(myjson):
     demisto.info('walla')
     try:
-        json_object = json.loads(myjson)
-    except ValueError as e:
+        json.loads(myjson)
+    except ValueError:
         return False
     return True
 

--- a/Integrations/IntSight/IntSight.yml
+++ b/Integrations/IntSight/IntSight.yml
@@ -61,6 +61,7 @@ configuration:
 script:
   script: ''
   type: python
+  subtype: python2
   commands:
   - name: intsights-get-alert-image
     arguments:


### PR DESCRIPTION

## Status
Ready
## Related Issues
fixes: https://github.com/demisto/etc/issues/18055

## Description
When the url parameter is different than `https://api.intsights.com/`, the commands crash with the error : 

> No JSON object could be decoded

## Screenshots
![64049784-d094fa00-cb2a-11e9-92b9-73fd3a6bc4ce](https://user-images.githubusercontent.com/46249224/64079821-1b626d80-ccf5-11e9-9eb1-742056f6a011.png)

