### PR TITLE
Backward compatibility check won't fail builds

### DIFF
--- a/Tests/scripts/validate_files.py
+++ b/Tests/scripts/validate_files.py
@@ -376,7 +376,7 @@ class FilesValidator(object):
             if not prev_ver:
                 # validate against master if no version was provided
                 prev_ver = 'master'
-            self.validate_against_previous_version(branch_name, prev_ver)
+            self.validate_against_previous_version(branch_name, prev_ver, no_error=True)
         else:
             self.validate_against_previous_version(branch_name, prev_ver, no_error=True)
             # validates all of Content repo directories according to their schemas


### PR DESCRIPTION
## Status
Ready

## Description
When backward compatibility check run, it won't fail the build even if the check failed.