### PR TITLE
fixed integration/script code files regex

### DIFF
--- a/Tests/scripts/constants.py
+++ b/Tests/scripts/constants.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 # dirs
 INTEGRATIONS_DIR = "Integrations"
@@ -24,13 +25,13 @@ DESCRIPTION_REGEX = r".*\.md"
 CONF_REGEX = "Tests/conf.json"
 SCHEMA_REGEX = "Tests/schemas/.*.yml"
 SCRIPT_TYPE_REGEX = ".*script-.*.yml"
-SCRIPT_PY_REGEX = r"{}.*\.py$".format(SCRIPTS_DIR)
-SCRIPT_JS_REGEX = r"{}.*\.js$".format(SCRIPTS_DIR)
+SCRIPT_PY_REGEX = os.path.join(SCRIPTS_DIR, '(.+)', r'\1.py')
+SCRIPT_JS_REGEX = os.path.join(SCRIPTS_DIR, '(.+)', r'\1.js')
 SCRIPT_YML_REGEX = r"{}.*\.yml$".format(SCRIPTS_DIR)
 TEST_SCRIPT_REGEX = r"{}.*script-.*\.yml$".format(TEST_PLAYBOOKS_DIR)
 SCRIPT_REGEX = r"{}.*script-.*\.yml$".format(SCRIPTS_DIR)
-INTEGRATION_PY_REGEX = r"{}.*\.py$".format(INTEGRATIONS_DIR)
-INTEGRATION_JS_REGEX = r"{}.*\.js$".format(INTEGRATIONS_DIR)
+INTEGRATION_PY_REGEX = os.path.join(INTEGRATIONS_DIR, '(.+)', r'\1.py')
+INTEGRATION_JS_REGEX = os.path.join(INTEGRATIONS_DIR, '(.+)', r'\1.js')
 INTEGRATION_YML_REGEX = r"{}.*\.yml$".format(INTEGRATIONS_DIR)
 INTEGRATION_REGEX = r"{}.*integration-.*\.yml$".format(INTEGRATIONS_DIR)
 PLAYBOOK_REGEX = r"(?!Test){}.*playbook-.*\.yml$".format(PLAYBOOKS_DIR)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
related: https://circleci.com/gh/demisto/content/29036
@DeanArbel FYI

## Description
fixed regex for code files in integration/script packages.
this regex will only catch code files in the package directories (excluding the unit test files).

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Additional changes
as a followup to this fix, i opened dev task to validate the rest of the regex in that file:
https://github.com/demisto/etc/issues/19073