### PR TITLE
[Enhancement] QRadar qradar-get-note command

### DIFF
--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-  - Added new functionality to ***qradar-get-note*** command. note_id argument is no longer required, so when executed without it, the command will get all the offense's notes.
-  - Fixed an issue in which ***qradar-update-offense*** command, when trying to close an offense, would raise an error that the user didn't provide closing reason, even when they did.  
+  - The *note_id* argument is now optional in the ***qradar-get-note*** command. If the *note_id* argument is not specified, the command will return all notes for the the offense.
+  - Fixed an issue when closing an offense with the ***qradar-update-offense*** command, in which a user would specify a close reason, an error was returned specifying that there was no close reason.  
 
 ## [19.9.0] - 2019-09-04
   - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.

--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-  - Added new functionality to ***qradar-get-note*** command. note_id argument is no longer required, so when executed without it, the command will get all the offense's notes. 
+  - Added new functionality to ***qradar-get-note*** command. note_id argument is no longer required, so when executed without it, the command will get all the offense's notes.
+  - Fixed an issue in which ***qradar-update-offense*** command, when trying to close an offense, would raise an error that the user didn't provide closing reason, even when they did.  
 
 ## [19.9.0] - 2019-09-04
   - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.

--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - The *note_id* argument is now optional in the ***qradar-get-note*** command. If the *note_id* argument is not specified, the command will return all notes for the the offense.
-  - Fixed an issue when closing an offense with the ***qradar-update-offense*** command, in which a user would specify a close reason, an error was returned specifying that there was no close reason.  
+  - Fixed an issue when closing an offense with the ***qradar-update-offense*** command, in which a user would specify a close reason, but an error was returned specifying that there was no close reason.  
 
 ## [19.9.0] - 2019-09-04
   - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.

--- a/Integrations/QRadar/CHANGELOG.md
+++ b/Integrations/QRadar/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+  - Added new functionality to ***qradar-get-note*** command. note_id argument is no longer required, so when executed without it, the command will get all the offense's notes. 
 
 ## [19.9.0] - 2019-09-04
   - Fixed an issue in which the ***qradar-get-search-results*** command failed when the root of the result contained a non-ascii character.

--- a/Integrations/QRadar/QRadar.py
+++ b/Integrations/QRadar/QRadar.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 # disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
-
 ''' GLOBAL VARS '''
 SERVER = demisto.params()['server'][:-1] if demisto.params()['server'].endswith('/') else demisto.params()['server']
 CREDENTIALS = demisto.params().get('credentials')
@@ -209,7 +208,8 @@ def send_request(method, url, headers=AUTH_HEADERS, params=None):
         if TOKEN:
             res = requests.request(method, url, headers=headers, params=params, verify=USE_SSL)
         else:
-            res = requests.request(method, url, headers=headers, params=params, verify=USE_SSL, auth=(USERNAME, PASSWORD))
+            res = requests.request(method, url, headers=headers, params=params, verify=USE_SSL,
+                                   auth=(USERNAME, PASSWORD))
         res.raise_for_status()
     except HTTPError:
         err_json = res.json()
@@ -379,7 +379,10 @@ def get_offense_types():
 
 # Returns the result of a get note request
 def get_note(offense_id, note_id, fields):
-    url = '{0}/api/siem/offenses/{1}/notes/{2}'.format(SERVER, offense_id, note_id)
+    if note_id:
+        url = '{0}/api/siem/offenses/{1}/notes/{2}'.format(SERVER, offense_id, note_id)
+    else:
+        url = '{0}/api/siem/offenses/{1}/notes'.format(SERVER, offense_id)
     params = {'fields': fields} if fields else {}
     return send_request('GET', url, AUTH_HEADERS, params=params)
 
@@ -870,10 +873,14 @@ def get_note_command():
         'create_time': 'CreateTime',
         'username': 'CreatedBy'
     }
-    note = replace_keys(raw_note, note_names_map)
-    if 'CreateTime' in note:
-        note['CreateTime'] = epoch_to_ISO(note['CreateTime'])
-    return get_entry_for_object('QRadar note created successfully', note, raw_note, demisto.args().get('headers'),
+    notes = replace_keys(raw_note, note_names_map)
+    if not isinstance(notes, list):
+        notes = [notes]
+    for note in notes:
+        if 'CreateTime' in note:
+            note['CreateTime'] = epoch_to_ISO(note['CreateTime'])
+    return get_entry_for_object('QRadar note for offense: {0}'.format(str(demisto.args().get('offense_id'))), notes,
+                                raw_note, demisto.args().get('headers'),
                                 'QRadar.Note(val.ID === "{0}")'.format(demisto.args().get('note_id')))
 
 

--- a/Integrations/QRadar/QRadar.py
+++ b/Integrations/QRadar/QRadar.py
@@ -677,7 +677,7 @@ def update_offense_command():
     args = demisto.args()
     if 'closing_reason_name' in args:
         args['closing_reason_id'] = convert_closing_reason_name_to_id(args.get('closing_reason_name'))
-    elif 'CLOSED' == args.get('status') and not args.get('closing_reasond_id'):
+    elif 'CLOSED' == args.get('status') and not args.get('closing_reason_id'):
         raise ValueError(
             'Invalid input - must provide closing reason name or id (may use "qradar-get-closing-reasons" command to '
             'get them) to close offense')

--- a/Integrations/QRadar/QRadar.yml
+++ b/Integrations/QRadar/QRadar.yml
@@ -1047,7 +1047,7 @@ script:
       description: The note ID
       isArray: false
       name: note_id
-      required: true
+      required: false
       secret: false
     - default: false
       description: 'If used, will filter all fields except for the specified ones.
@@ -1458,48 +1458,50 @@ script:
     execution: false
     name: qradar-get-domain-by-id
     outputs:
-      - contextPath: QRadar.Domains.AssetScannerIDs
-        description: Array of Asset Scanner IDs.
-        type: Number
-      - contextPath: QRadar.Domains.CustomProperties
-        description: Custom properties of the domain.
-        type: String
-      - contextPath: QRadar.Domains.Deleted
-        description: Indicates if the domain is deleted.
-        type: Boolean
-      - contextPath: QRadar.Domains.Description
-        description: Description of the domain.
-        type: String
-      - contextPath: QRadar.Domains.EventCollectorIDs
-        description: Array of Event Collector IDs.
-        type: Number
-      - contextPath: QRadar.Domains.FlowCollectorIDs
-        description: Array of Flow Collector IDs.
-        type: Number
-      - contextPath: QRadar.Domains.FlowSourceIDs
-        description: Array of Flow Source IDs.
-        type: Number
-      - contextPath: QRadar.Domains.ID
-        description: ID of the domain.
-        type: Number
-      - contextPath: QRadar.Domains.LogSourceGroupIDs
-        description: Array of Log Source Group IDs.
-        type: Number
-      - contextPath: QRadar.Domains.LogSourceIDs
-        description: Array of Log Source IDs.
-        type: Number
-      - contextPath: QRadar.Domains.Name
-        description: Name of the Domain.
-        type: String
-      - contextPath: QRadar.Domains.QVMScannerIDs
-        description: Array of QVM Scanner IDs.
-        type: Number
-      - contextPath: QRadar.Domains.TenantID
-        description: ID of the Domain tenant.
-        type: Number
+    - contextPath: QRadar.Domains.AssetScannerIDs
+      description: Array of Asset Scanner IDs.
+      type: Number
+    - contextPath: QRadar.Domains.CustomProperties
+      description: Custom properties of the domain.
+      type: String
+    - contextPath: QRadar.Domains.Deleted
+      description: Indicates if the domain is deleted.
+      type: Boolean
+    - contextPath: QRadar.Domains.Description
+      description: Description of the domain.
+      type: String
+    - contextPath: QRadar.Domains.EventCollectorIDs
+      description: Array of Event Collector IDs.
+      type: Number
+    - contextPath: QRadar.Domains.FlowCollectorIDs
+      description: Array of Flow Collector IDs.
+      type: Number
+    - contextPath: QRadar.Domains.FlowSourceIDs
+      description: Array of Flow Source IDs.
+      type: Number
+    - contextPath: QRadar.Domains.ID
+      description: ID of the domain.
+      type: Number
+    - contextPath: QRadar.Domains.LogSourceGroupIDs
+      description: Array of Log Source Group IDs.
+      type: Number
+    - contextPath: QRadar.Domains.LogSourceIDs
+      description: Array of Log Source IDs.
+      type: Number
+    - contextPath: QRadar.Domains.Name
+      description: Name of the Domain.
+      type: String
+    - contextPath: QRadar.Domains.QVMScannerIDs
+      description: Array of QVM Scanner IDs.
+      type: Number
+    - contextPath: QRadar.Domains.TenantID
+      description: ID of the Domain tenant.
+      type: Number
   isfetch: true
+  longRunning: false
+  longRunningPort: false
   runonce: false
-  script: ''
+  script: '-'
   type: python
   subtype: python2
 image: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHMAAAAfCAYAAADUdfLHAAAHgElEQVR4Ae3YA6xlWRaA4VW2bdu2bVdbZbRt27a7y7Zt27ZtvFrzJ1mT7Nnpvnicmb6VfPXeuzzJn3P2OltC+bd0z8eJUB4P4RcswVGcwXGsxCA8hRpIComIX/4DvsRohUmIgoZoIW5HCkhEwscsgjHQGFiIqpCIhIvZBsegnrOYg0/wKHriQbyLKTgB9VxCb0hE/MfsBfUcwXPICDFJkB6pICY5emAn1PMGJCL+YnaGen51IubBs1iPS1DcxHGMQUskNm/76yyehMS9SMzSOAU1t/AYBCnwnj2mOIc1mIl52A81W1EPgs64BDU30BQStyIxx0IdT0CQA8uhGIYq3rSbCIIi+AO3vPd3ch5TrEQySNyIxOwCdXwPQWZsxToUg6AAvsMOnMERzMM9EFTGASieguBpqOMRSNyIxJwKNXuQDYJBmI8UELwIxXnMxB9YgstQbEJRFMJRKOpBsAhqNiI5JHZFYlaFOl6CoCW2IysE7yEKPf0QSOGEPm4xW0IxE4JuUEdDSPRFvDSgW2bkRSqI2JCj5jQKQDAYAyDoiGOoCEEZe349FqEXBO2hWADBcCdcImyDmm8h0RYJ2RYd0Bh3orTYpVLNdAjyYS7SQDADfSGoj5V4Cb3sOcVvELwFRWs0h+IjCL6EmqUQIy/07ZKIA6qPtmgdQBs0Q05IPMuL9miNdsgCSQDVLWQztEBLdBVnUlV8DEFLDIOgPOYhERJjEKpCHH9A0R0FnCEqGxSzIOgDNfuX7fskLQTyYr+uyTigTdAQncMolIbEkx5QR2NIArgHRdAfr6M56oq3bfckBD3wKQSdLIygFt6GeGpCMQiCPViCJDiEzRC0hpqzy/Z+kgMCeaFPFydmWI6iAiQePPBfErMD6qAp6qIV2oi3UTAAgr74AILbnICN8DDEUwSKcRBsxCokwi7sgKAB1FwgYj4I5HkvptmAJVjm2A31zP+HxUyD+9AM+dETzcTuE9U8DUFXfAtBIydsPrwM8bSE4gVkgWI00uIqlkHQDmrOcHnNDoGwZvoxb6EixJMUz0Ad11HqnxLTpEZL3IcK/55mF0PN5xBUwTAIstjjiSG4G2UgjjKYhGwYCMXDKA/FHxAMgJq9REzjrZlBY5rk2AJ1NII4kqAWHsfn+Alf4RV0RnqIz9TGi/gMb6EdBPcFiZkSzfE8vsKP+BzPoZk9L45KaGbKQZABd+ML9ICExGL+DDWzIUiCH5ENgifQGoJkRowf9SJOISNehqI3BN9BzQKICSumWQx11IGYPBgHDWArakAcafADFL4ReDJAzCpYAQ1gLgpAzCyoGYp8WAM1U8KNOdBdx1AcgsfRF4LceC2EXZuyOIiByIGz9nc6sw9qPvuPmP3/MmYFCHwZsR9qziCPE2SZ9zlbsQC7oI69yAwxw6Dee68gCoqT9pgfsyAOQ80NrMNC93Ez2Y9ppmKe/9pwY5bDDah5B4Ls+BwpIciCFJAg0iA1JnoT8n1QRw3vJvivYrZDXhQ1RVAJg6COX7yxXR3vQEwiDIY6GkLQDerYg07Ii6qYCTV+zB+hjnsgJgOWQM1VFIMfMwqKG9iIlfg8rJj8JzasqDmCAhC0Qh9ImArhNGZAkBproWYVEgeKaa7hiueWdwYMQlqI6YllmIvJyAlx3A51tIJghve9leEPHBv+Zp3+DIsxH0OQCuL40L/i+DHNKbSGmEQIO2YrqGMYxJRCEkiYiiA3BG9DHQ9AgsYMbjcqQYJIheyojgVQRzMk8S6HMyDwvRLiNJsIaZAbzbEtxJi9Ib6wYlrQ36GOtyCxoBfUMQ8CP2ao95lHoI5LqAF/2u2CP7EUe3ER6rMg2XAZal6AwNcoQMwM6ItRWIWDuAo1wWJeRpHYilkA+6H++hkD/REFNedRLUjMYNNsGvwKdYyHmNxYAfXcwC7MgR8kJ65CzRMQ+Or+TcwaOAD1XMN6rAsh5kGki5WYFrQJrkIdU1AAEobM+BXq6QGJSUxT1DuT9iI1BEOhju9RCwUgaAt1NEUanIGaHyHw3Q11NIBgjbeB8TIqIw8Eb4YQcx/SxFpMC9oRV6COc/gKJb3BxZcfr+Mo1HEd90NiKab/2nPIijQ4GmTt6wd1tIB4Z89+ZIR4hkAdtZEH16DmDYjn6/iPaWxDfTvUcw3rMQTv4xW8g9+xApeg8I1HVwv6AHrg3uX7PkkPAdt5YW8azIaaK8iP9N4ZNiHI+9xp9l2o41sk9ja3/TWwFgojCmqegTiyYHvCxDR2n/kNoqAxdAvqucoGezF/oz2MmD9CTRTKQrDeW7M+QifcbXHV0xaCnDgEdazEdxiPS1BPPaTGcag5jefREX2wAuqpGC8xfTaw/IBz0Njix3wh/JjPQh13QHAnNICd3hnWA2Lae2uxb6wXtREE70B9Jgr+cNQIfswDSBtXMf2oedAd72EU5mFZNK3EAiLmdWIm4Xt+xgLMwcwgo3pdLMIsLMVzEHO7PXcCZ3AcK/AcimA05mIpHoI4qmMEDuAMTmEN+qI4pmMOFqISBEnxONbhFM7gMObhXtTHPMzGErSF4ENvsyElJLr+BYNjupf20vh5AAAAAElFTkSuQmCC


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/17548
fixes: https://github.com/demisto/etc/issues/18597

## Description
Added new functionality to `qradar-get-note` command. `note_id` argument is no longer required, so when executed without it, the command will get all the offense's notes.

## Does it break backward compatibility?
   - No

## Screenshots:
### qradar-get-note from offense with multiple notes:
![image](https://user-images.githubusercontent.com/20818773/64671573-8c322400-d471-11e9-9bd9-7b2f63c177b6.png)

### qradar-get-note from offense with single note:
![image](https://user-images.githubusercontent.com/20818773/64671641-bf74b300-d471-11e9-8211-38a479c85837.png)

### qradar-get-note from offense with no note:
![image](https://user-images.githubusercontent.com/20818773/64671684-dd421800-d471-11e9-8ef1-0884c1a9a79e.png)

## Must have
- [x] Tests (No instance)
- [x] Documentation (will be reworked following the PR)
- [x] Code Review

## Additional changes:
Fixed a bug that prevented closing offenses.