### PR TITLE
Change the CA certificate field from short to long Text.

### DIFF
--- a/Integrations/integration-Kafka_V2.yml
+++ b/Integrations/integration-Kafka_V2.yml
@@ -28,7 +28,7 @@ configuration:
     CA certificate of Kafka server (.cer)
   name: ca_cert
   defaultvalue: ""
-  type: 0
+  type: 12
   required: false
 - display: Client certificate (.cer)
   name: client_cert


### PR DESCRIPTION
Using the Kafka v2 integration did not work with CA certificate. I had to copy it and modify the CA certificate field to long because as a short field it does not take the carriage return into account

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold(Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------


## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - Yes
       - Further details:
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.
