### PR TITLE
mention -v option when failing

### DIFF
--- a/Tests/scripts/pkg_dev_test_tasks.py
+++ b/Tests/scripts/pkg_dev_test_tasks.py
@@ -314,7 +314,7 @@ Will lookup up what docker image to use and will setup the dev dependencies and 
         except subprocess.CalledProcessError as ex:
             sys.stderr.write("[FAILED {}] Error: {}\n".format(project_dir, str(ex)))
             if not LOG_VERBOSE:
-                sys.stderr.write("Need a more detailed log?" 
+                sys.stderr.write("Need a more detailed log?"
                                  " try running with the -v options as so: \n{} -v\n".format(" ".join(sys.argv[:])))
             return 2
         finally:

--- a/Tests/scripts/pkg_dev_test_tasks.py
+++ b/Tests/scripts/pkg_dev_test_tasks.py
@@ -312,7 +312,10 @@ Will lookup up what docker image to use and will setup the dev dependencies and 
                 docker_image_created = docker_image_create(docker, requirements)
                 docker_run(project_dir, docker_image_created, args.no_test, args.no_pylint, args.keep_container, args.root)
         except subprocess.CalledProcessError as ex:
-            sys.stderr.write("[FAILED {}] Error: {}.\nOutput:\n{}\n".format(project_dir, str(ex), ex.output))
+            sys.stderr.write("[FAILED {}] Error: {}\n".format(project_dir, str(ex)))
+            if not LOG_VERBOSE:
+                sys.stderr.write("Need a more detailed log?" 
+                                 " try running with the -v options as so: \n{} -v\n".format(" ".join(sys.argv[:])))
             return 2
         finally:
             sys.stdout.flush()


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
ex.output is None because of the way we run subprocesses in non verbose mode. Simply added a printout suggesting to run in verbose mode if failing. Should make life easier when encountering failures.
