### PR TITLE
updated conf.json to skip zerofox integration

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1871,6 +1871,7 @@
 
 
       "_comment": "~~~ INSTANCE ISSUES ~~~",
+        "ZeroFox": "No data (Alerts) in the product, which is required because record isn't working (issue 19161)",
         "Jask": "Returning 401 (issue 18879)",
         "SumoLogic": "No credentials (Issue 18441)",
         "Lastline": "Temporally moved to skipped in order to not fail nightly",


### PR DESCRIPTION
## Status
Ready

## Description
ZeroFox is missing data (alerts) and we can't generate it by ourselves, plus the record in the build isn't working due to proxy issues, Therefore the nightly breaks and we must skip the tests. An issue asks for data generation was opened - https://github.com/demisto/etc/issues/19161