### PR TITLE
parse_date_range - fixed utc parameter condition and added unit-tests

### DIFF
--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1700,6 +1700,9 @@ def parse_date_range(date_range, date_format=None, to_timestamp=False, timezone=
       :type timezone: ``int``
       :param timezone: timezone should be passed in hours (e.g if +0300 then pass 3, if -0200 then pass -2).
 
+      :type timezone: ``bool``
+      :param utc: If set to True, utc time will be used, otherwise local time.
+
       :return: The parsed date range.
       :rtype: ``(datetime.datetime, datetime.datetime)`` or ``(int, int)`` or ``(str, str)``
     """

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1700,7 +1700,7 @@ def parse_date_range(date_range, date_format=None, to_timestamp=False, timezone=
       :type timezone: ``int``
       :param timezone: timezone should be passed in hours (e.g if +0300 then pass 3, if -0200 then pass -2).
 
-      :type timezone: ``bool``
+      :type utc: ``bool``
       :param utc: If set to True, utc time will be used, otherwise local time.
 
       :return: The parsed date range.

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1716,11 +1716,11 @@ def parse_date_range(date_range, date_format=None, to_timestamp=False, timezone=
         return_error('Invalid timezone "{}" - must be a number (of type int or float).'.format(timezone))
 
     if utc:
-        end_time = datetime.now() + timedelta(hours=timezone)
-        start_time = datetime.now() + timedelta(hours=timezone)
-    else:
         end_time = datetime.utcnow() + timedelta(hours=timezone)
         start_time = datetime.utcnow() + timedelta(hours=timezone)
+    else:
+        end_time = datetime.now() + timedelta(hours=timezone)
+        start_time = datetime.now() + timedelta(hours=timezone)
 
     unit = range_split[1]
     if 'minute' in unit:

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -630,7 +630,6 @@ def test_exception_in_return_error(mocker):
 
 
 def test_get_demisto_version(mocker):
-
     # verify expected server version and build returned in case Demisto class has attribute demistoVersion
     mocker.patch.object(
         demisto,
@@ -666,3 +665,17 @@ def test_parse_date_string():
     assert parse_date_string(
         '2019-09-17T06:16:39.4040+05:00', '%Y-%m-%dT%H:%M:%S+02:00'
     ) == datetime(2019, 9, 17, 6, 16, 39, 404000)
+
+
+def test_parse_date_range():
+    utc_now = datetime.utcnow()
+    utc_start_time, utc_end_time = parse_date_range('2 days', utc=True)
+    # testing UTC date time and range of 2 days
+    assert utc_now.replace(microsecond=0) == utc_end_time.replace(microsecond=0)
+    assert abs(utc_start_time - utc_end_time).days == 2
+
+    local_now = datetime.now()
+    local_start_time, local_end_time = parse_date_range('73 minutes', utc=False)
+    # testing local datetime and range of 73 minutes
+    assert local_now.replace(microsecond=0) == local_end_time.replace(microsecond=0)
+    assert abs(local_start_time - local_end_time).seconds / 60 == 73

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -3,7 +3,7 @@ import demistomock as demisto
 from CommonServerPython import xml2json, json2xml, entryTypes, formats, tableToMarkdown, underscoreToCamelCase, \
     flattenCell, date_to_timestamp, datetime, camelize, pascalToSpace, argToList, \
     remove_nulls_from_dictionary, is_error, get_error, hash_djb2, fileResult, is_ip_valid, get_demisto_version, \
-    IntegrationLogger, parse_date_string
+    IntegrationLogger, parse_date_string, parse_date_range
 
 import copy
 import os


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Switched the condition when `utc` parameter in `parse_date_range` function is set to True.

## Required version of Demisto
4.5.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] all tests