### PR TITLE
FortiSIEM - Too many sessions bug

### DIFF
--- a/Integrations/FortiSIEM/CHANGELOG.md
+++ b/Integrations/FortiSIEM/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+Keeping the integration instance enabled will no longer create too many connections.

--- a/Integrations/FortiSIEM/FortiSIEM.yml
+++ b/Integrations/FortiSIEM/FortiSIEM.yml
@@ -26,7 +26,7 @@ configuration:
   defaultvalue: ""
   type: 9
   required: true
-- display: Trust any certificate (unsecure)
+- display: Trust any certificate (not secure)
   name: unsecure
   defaultvalue: ""
   type: 8
@@ -39,6 +39,7 @@ configuration:
 script:
   script: '-'
   type: python
+  subtype: python2
   commands:
   - name: fortisiem-get-events-by-incident
     arguments:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
fixes: [https://github.com/demisto/etc/issues/18577](https://github.com/demisto/etc/issues/18577)

## Description
Keeping the integration instance enabled creates too many connections. Logging out from the server in each execution of the integration should fix this issue.

## Does it break backward compatibility?
   - No

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)