### PR TITLE
[Enhancement] PagerDuty-get-users-on-call-now

### DIFF
--- a/Integrations/PagerDuty/CHANGELOG.md
+++ b/Integrations/PagerDuty/CHANGELOG.md
@@ -3,5 +3,4 @@
     - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
         policy IDs.
     - schedule_ids: Filters the results, showing only on-calls for the specified schedule
-        IDs. If null is provided, it includes permanent on-calls due to direct user
-        escalation targets.
+        IDs. 

--- a/Integrations/PagerDuty/CHANGELOG.md
+++ b/Integrations/PagerDuty/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-  - added new arguments to ***PagerDuty-get-users-on-call-now*** command:
+  - added new arguments to the ***PagerDuty-get-users-on-call-now*** command.
     - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
         policy IDs.
     - schedule_ids: Filters the results, showing only on-calls for the specified schedule

--- a/Integrations/PagerDuty/CHANGELOG.md
+++ b/Integrations/PagerDuty/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [Unreleased]
+  - added new arguments to ***PagerDuty-get-users-on-call-now*** command:
+    - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
+        policy IDs.
+    - schedule_ids: Filters the results, showing only on-calls for the specified schedule
+        IDs. If null is provided, it includes permanent on-calls due to direct user
+        escalation targets.

--- a/Integrations/PagerDuty/PagerDuty.yml
+++ b/Integrations/PagerDuty/PagerDuty.yml
@@ -1,52 +1,62 @@
+category: Messaging
 commonfields:
   id: PagerDuty v2
   version: -1
-name: PagerDuty v2
-display: PagerDuty v2
-category: Messaging
-description: Alert and notify users using PagerDuty
 configuration:
 - display: API Key
   name: APIKey
-  defaultvalue: ""
-  type: 4
   required: true
+  type: 4
 - display: Service Key (for triggering events only)
   name: ServiceKey
-  defaultvalue: ""
+  required: false
   type: 0
+- display: Trust any certificate (not secure)
+  name: insecure
   required: false
-- display: Use system proxy settings
-  name: proxy
-  defaultvalue: "true"
   type: 8
+- defaultvalue: ''
+  display: Use system proxy settings
+  name: proxy
   required: false
+  type: 8
 - display: Fetch incidents
   name: isFetch
-  defaultvalue: ""
-  type: 8
   required: false
+  type: 8
 - display: Incident type
   name: incidentType
-  defaultvalue: ""
+  required: false
   type: 13
-  required: false
-- display: Initial Fetch Interval(In minutes, used only for first fetch or after Reset last run)
+- defaultvalue: '1'
+  display: Initial Fetch Interval(In minutes, used only for first fetch or after Reset
+    last run)
   name: FetchInterval
-  defaultvalue: "1"
-  type: 0
   required: false
+  type: 0
+description: Alert and notify users using PagerDuty
+display: PagerDuty v2
+name: PagerDuty v2
 script:
-  script: ''
-  type: python
   commands:
-  - name: PagerDuty-get-all-schedules
-    arguments:
-    - name: query
+  - arguments:
+    - default: false
       description: Show only the schedules whose name matches the query
-    - name: limit
+      isArray: false
+      name: query
+      required: false
+      secret: false
+    - default: false
       description: The limit for the amount of schedules to receive(Default is 25,
         max value is 100)
+      isArray: false
+      name: limit
+      required: false
+      secret: false
+    deprecated: false
+    description: Receive all schedules from PagerDuty
+    execution: false
+    name: PagerDuty-get-all-schedules
     outputs:
     - contextPath: PagerDuty.Schedules.id
       description: The ID of the schedule
@@ -54,18 +64,31 @@ script:
     - contextPath: PagerDuty.Schedules.name
       description: The name of the schedule
       type: string
-    description: Receive all schedules from PagerDuty
-  - name: PagerDuty-get-users-on-call
-    arguments:
-    - name: scheduleID
-      required: true
-      default: true
+  - arguments:
+    - default: true
       description: (default and mandatory) The unique identifier of the schdule
-    - name: since
+      isArray: false
+      name: scheduleID
+      required: true
+      secret: false
+    - default: false
       description: The start of the date range Using ISO 8601 Representation. E.g.
         !PagerDutyGetUsersOnCall since=2011-05-06T17:00Z
-    - name: until
+      isArray: false
+      name: since
+      required: false
+      secret: false
+    - default: false
       description: The end of the date range
+      isArray: false
+      name: until
+      required: false
+      secret: false
+    deprecated: false
+    description: Returns the names and details of on call users at a certain time
+      or by specific schedule
+    execution: false
+    name: PagerDuty-get-users-on-call
     outputs:
     - contextPath: PagerDutyUser.id
       description: User's ID
@@ -85,13 +108,33 @@ script:
     - contextPath: PagerDutyUser.TimeZone
       description: The time zone of the user
       type: string
-    description: Returns the names and details of on call users at a certain time
-      or by specific schedule
-  - name: PagerDuty-get-users-on-call-now
-    arguments:
-    - name: limit
+  - arguments:
+    - default: false
       description: The limit for the amount of users to receive(Default is 25, max
         value is 100)
+      isArray: false
+      name: limit
+      required: false
+      secret: false
+    - default: false
+      description: Filters the results, showing only on-calls for the specified escalation
+        policy IDs
+      isArray: true
+      name: escalation_policy_ids
+      required: false
+      secret: false
+    - default: false
+      description: Filters the results, showing only on-calls for the specified schedule
+        IDs. If null is provided, it includes permanent on-calls due to direct user
+        escalation targets
+      isArray: true
+      name: schedule_ids
+      required: false
+      secret: false
+    deprecated: false
+    description: Returns the names and details of current on call personnel
+    execution: false
+    name: PagerDuty-get-users-on-call-now
     outputs:
     - contextPath: PagerDutyUser.ID
       description: User's ID
@@ -111,27 +154,45 @@ script:
     - contextPath: PagerDutyUser.TimeZone
       description: The time zone of the user
       type: string
-    description: Returns the names and details of current on call personnel
-  - name: PagerDuty-incidents
-    arguments:
-    - name: status
-      auto: PREDEFINED
+  - arguments:
+    - auto: PREDEFINED
+      default: false
+      description: Returns only the incidents currently in the passed status(es).
+        Valid status options are triggered,acknowledged, and resolved. (Default values
+        are triggered,acknowledged)
+      isArray: false
+      name: status
       predefined:
       - triggered
       - acknowledged
       - resolved
-      description: Returns only the incidents currently in the passed status(es).
-        Valid status options are triggered,acknowledged, and resolved. (Default values
-        are triggered,acknowledged)
-    - name: since
+      required: false
+      secret: false
+    - default: false
       description: Beginning date and time. Using ISO 8601 Representation. E.g. PagerDutyIncidents
         since=2011-05-06T17:00Z (must be used with until argument)
-    - name: sortBy
+      isArray: false
+      name: since
+      required: false
+      secret: false
+    - default: false
       description: Used to specify both the field you wish to sort the results on,
         as well as the direction (ascending/descending) of the results.See more https://v2.developer.pagerduty.com/v2/page/api-reference#!/Incidents/get_incidents
-    - name: until
+      isArray: false
+      name: sortBy
+      required: false
+      secret: false
+    - default: false
       description: Last date and time.  Using ISO 8601 Representation. E.g. PagerDutyIncidents
         until=2016-05-06T13:00Z
+      isArray: false
+      name: until
+      required: false
+      secret: false
+    deprecated: false
+    description: Shows incidents in PagerDuty. Default status parameters are triggered,acknowledged
+    execution: false
+    name: PagerDuty-incidents
     outputs:
     - contextPath: PagerDuty.Incidents.ID
       description: Incident ID
@@ -196,49 +257,88 @@ script:
     - contextPath: PagerDuty.Incidents.acknowledgement.acknowledger
       description: The name of the acknowledger to the incident
       type: string
-    description: Shows incidents in PagerDuty. Default status parameters are triggered,acknowledged
-  - name: PagerDuty-submit-event
-    arguments:
-    - name: source
-      required: true
+  - arguments:
+    - default: false
       description: Specific human-readable unique identifier, such as a hostname,
         for the system having the problem.
-    - name: summary
+      isArray: false
+      name: source
       required: true
-      description: "\t A high-level, text summary message of the event. Will be used
-        to construct an alert's description."
-    - name: severity
+      secret: false
+    - default: false
+      description: "\t A high-level, text summary message of the event. Will be used\
+        \ to construct an alert's description."
+      isArray: false
+      name: summary
       required: true
-      auto: PREDEFINED
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: The severity of the event
+      isArray: false
+      name: severity
       predefined:
       - critical
       - error
       - warning
       - info
-      description: The severity of the event
-    - name: action
       required: true
-      auto: PREDEFINED
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: The action to be executed
+      isArray: false
+      name: action
       predefined:
       - trigger
       - acknowledge
       - resolve
-      description: The action to be executed
-    - name: description
+      required: true
+      secret: false
+    - default: false
       description: A short description of the problem
-    - name: group
+      isArray: false
+      name: description
+      required: false
+      secret: false
+    - default: false
       description: 'A cluster or grouping of sources. For example, sources “prod-datapipe-02”
         and “prod-datapipe-03” might both be part of “prod-datapipe”. Example: "prod-datapipe"
         "www"'
-    - name: event_class
+      isArray: false
+      name: group
+      required: false
+      secret: false
+    - default: false
       description: 'The class/type of the event. Example: "High CPU" "Latency"'
-    - name: component
+      isArray: false
+      name: event_class
+      required: false
+      secret: false
+    - default: false
       description: 'The part or component of the affected system that is broken. Example:
         "keepalive" "webping"'
-    - name: incident_key
+      isArray: false
+      name: component
+      required: false
+      secret: false
+    - default: false
       description: Incident key, used to acknowledge/resolve specific event
-    - name: serviceKey
+      isArray: false
+      name: incident_key
+      required: false
+      secret: false
+    - default: false
       description: Service key for the integration
+      isArray: false
+      name: serviceKey
+      required: false
+      secret: false
+    deprecated: false
+    description: Creates a new event/incident in PagerDuty(In order to use this command
+      you have to enter the Service Key in the integration settings)
+    execution: false
+    name: PagerDuty-submit-event
     outputs:
     - contextPath: PagerDuty.Event.Status
       description: Status of the action on the event
@@ -246,13 +346,17 @@ script:
     - contextPath: PagerDuty.Event.incident_key
       description: Incident key
       type: string
-    description: Creates a new event/incident in PagerDuty(In order to use this command
-      you have to enter the Service Key in the integration settings)
-  - name: PagerDuty-get-contact-methods
-    arguments:
-    - name: UserID
-      required: true
+  - arguments:
+    - default: false
       description: 'ID of the wanted user '
+      isArray: false
+      name: UserID
+      required: true
+      secret: false
+    deprecated: false
+    description: Get the contact methods of a given user
+    execution: false
+    name: PagerDuty-get-contact-methods
     outputs:
     - contextPath: PagerDuty.Contact_methods.phone
       description: The phone number of the user
@@ -266,12 +370,17 @@ script:
     - contextPath: PagerDuty.Contact_methods.email
       description: The email of the user
       type: string
-    description: Get the contact methods of a given user
-  - name: PagerDuty-get-users-notification
-    arguments:
-    - name: UserID
-      required: true
+  - arguments:
+    - default: false
       description: ID of the wanted user
+      isArray: false
+      name: UserID
+      required: true
+      secret: false
+    deprecated: false
+    description: Get the users notification rules
+    execution: false
+    name: PagerDuty-get-users-notification
     outputs:
     - contextPath: PagerDuty.Notification_rules.start_delay_in_minutes
       description: The delay time for notifying the user
@@ -282,31 +391,23 @@ script:
     - contextPath: PagerDuty.Notification_rules.id
       description: The id of the notification rule
       type: string
-    description: Get the users notification rules
-  - name: PagerDuty-resolve-event
-    arguments:
-    - name: incident_key
-      required: true
+  - arguments:
+    - default: false
       description: Incident key
-    - name: serviceKey
+      isArray: false
+      name: incident_key
       required: true
+      secret: false
+    - default: false
       description: Service key for the integration
-    outputs:
-    - contextPath: PagerDuty.Event.Status
-      description: Status of the action on the event
-      type: string
-    - contextPath: PagerDuty.Event.incident_key
-      description: Incident key
-      type: string
+      isArray: false
+      name: serviceKey
+      required: true
+      secret: false
+    deprecated: false
     description: Resolves an existing event in PagerDuty
-  - name: PagerDuty-acknowledge-event
-    arguments:
-    - name: incident_key
-      required: true
-      description: Incident key
-    - name: serviceKey
-      required: true
-      description: Service key for the integration
+    execution: false
+    name: PagerDuty-resolve-event
     outputs:
     - contextPath: PagerDuty.Event.Status
       description: Status of the action on the event
@@ -314,12 +415,41 @@ script:
     - contextPath: PagerDuty.Event.incident_key
       description: Incident key
       type: string
-    description: Acknowledges an existing event in PagerDuty
-  - name: PagerDuty-get-incident-data
-    arguments:
-    - name: incident_id
+  - arguments:
+    - default: false
+      description: Incident key
+      isArray: false
+      name: incident_key
       required: true
+      secret: false
+    - default: false
+      description: Service key for the integration
+      isArray: false
+      name: serviceKey
+      required: true
+      secret: false
+    deprecated: false
+    description: Acknowledges an existing event in PagerDuty
+    execution: false
+    name: PagerDuty-acknowledge-event
+    outputs:
+    - contextPath: PagerDuty.Event.Status
+      description: Status of the action on the event
+      type: string
+    - contextPath: PagerDuty.Event.incident_key
+      description: Incident key
+      type: string
+  - arguments:
+    - default: false
       description: ID of the incident to get information for.
+      isArray: false
+      name: incident_id
+      required: true
+      secret: false
+    deprecated: false
+    description: Get data about a incident from PagerDuty
+    execution: false
+    name: PagerDuty-get-incident-data
     outputs:
     - contextPath: PagerDuty.Incidents.ID
       description: Incident ID
@@ -384,9 +514,11 @@ script:
     - contextPath: PagerDuty.Incidents.acknowledgement.acknowledger
       description: The name of the acknowledger to the incident
       type: string
-    description: Get data about a incident from PagerDuty
-  - name: PagerDuty-get-service-keys
-    arguments: []
+  - deprecated: false
+    description: Get Service keys for each of the services configured in the PagerDuty
+      instance
+    execution: false
+    name: PagerDuty-get-service-keys
     outputs:
     - contextPath: PagerDuty.Service.ID
       description: The ID of the service connected to PagerDuty
@@ -404,15 +536,19 @@ script:
       description: The name of the integration used with the service
       type: string
     - contextPath: PagerDuty.Service.Integration.Vendor
-      description: The name of the vendor for the integration used with the service.(A value of 'Missing Vendor
-        information' will appear once no information could be found)
+      description: The name of the vendor for the integration used with the service.(A
+        value of 'Missing Vendor information' will appear once no information could
+        be found)
       type: string
     - contextPath: PagerDuty.Service.Integration.Key
       description: The key used to control events with the integration
       type: string
-    description: Get Service keys for each of the services configured in the PagerDuty
-      instance
   isfetch: true
+  longRunning: false
+  longRunningPort: false
   runonce: false
+  script: '-'
+  type: python
+  subtype: python3
 tests:
-  - PagerDuty Test
+- PagerDuty Test

--- a/Integrations/PagerDuty/PagerDuty.yml
+++ b/Integrations/PagerDuty/PagerDuty.yml
@@ -117,16 +117,16 @@ script:
       required: false
       secret: false
     - default: false
-      description: Filters the results, showing only on-calls for the specified escalation
-        policy IDs
+      description: Filters the results, showing only on-call users for the specified escalation
+        policy IDs.
       isArray: true
       name: escalation_policy_ids
       required: false
       secret: false
     - default: false
-      description: Filters the results, showing only on-calls for the specified schedule
-        IDs. If null is provided, it includes permanent on-calls due to direct user
-        escalation targets
+      description: Filters the results, showing only on-call users for the specified schedule
+        IDs. If the value is null, permanent on-call user are included due to direct user
+        escalation policy targets.
       isArray: true
       name: schedule_ids
       required: false

--- a/Scripts/script-PagerDutyAssignOnCallUser.yml
+++ b/Scripts/script-PagerDutyAssignOnCallUser.yml
@@ -1,23 +1,34 @@
 commonfields:
   id: PagerDutyAssignOnCallUser
   version: -1
-name: PagerDutyAssignOnCallUser
+name: PagerDutyAssignOnCallUser_dev
 script: |-
-  var res = executeCommand('PagerDuty-get-users-on-call-now', {});
+  var res = executeCommand('PagerDuty-get-users-on-call-now',
+      {
+          escalation_policy_ids: args.escalation_policy_ids,
+          schedule_ids: args.schedule_ids
+      });
+
   if (res[0].Type == entryTypes.error) {
       return res[0]
   }
-  var usersOnCall = res[0].Contents;
-  var selectedUser = usersOnCall[0];
+
+  var usersOnCall = res[0].Contents.oncalls;
+  var selectedUser = usersOnCall[0].user;
+
   if (selectedUser === null) {
       return 'error : could not find user from PagerDuty OnCall now!';
   }
-  res = executeCommand('getUserByEmail', {userEmail: selectedUser.Email});
+
+  res = executeCommand('getUserByEmail', {userEmail: selectedUser.email});
+
   if (res[0].Type == entryTypes.error) {
       return res[0];
   }
+
   var userId = res[0].Contents.id;
   setOwner(userId);
+
   return 'User ' + userId + ' was set as owner to incidents of this investigation';
 type: javascript
 tags:
@@ -25,9 +36,15 @@ tags:
 - communication
 comment: By default assigns the first on-call user to an investigation (all incidents
   in the investigation will be owned by the on call user)
-system: true
+enabled: true
+args:
+- name: escalation_policy_ids
+  description: comma separated escalation policy ids to choose the oncall from
+- name: schedule_ids
+  description: comma separated schedules to choose oncall from
 scripttarget: 0
 dependson:
   must:
   - PagerDuty-get-users-on-call-now
-timeout: 0s
+runonce: false
+runas: DBotWeakRole

--- a/Scripts/script-PagerDutyAssignOnCallUser.yml
+++ b/Scripts/script-PagerDutyAssignOnCallUser.yml
@@ -39,9 +39,9 @@ comment: By default assigns the first on-call user to an investigation (all inci
 enabled: true
 args:
 - name: escalation_policy_ids
-  description: comma separated escalation policy ids to choose the oncall from
+  description: Comma separated escalation policy IDs from which choose the oncall user.
 - name: schedule_ids
-  description: comma separated schedules to choose oncall from
+  description: Comma separated schedule IDs from which to choose the oncall.
 scripttarget: 0
 dependson:
   must:

--- a/Scripts/script-PagerDutyAssignOnCallUser.yml
+++ b/Scripts/script-PagerDutyAssignOnCallUser.yml
@@ -1,7 +1,7 @@
 commonfields:
   id: PagerDutyAssignOnCallUser
   version: -1
-name: PagerDutyAssignOnCallUser_dev
+name: PagerDutyAssignOnCallUser
 script: |-
   var res = executeCommand('PagerDuty-get-users-on-call-now',
       {
@@ -48,3 +48,5 @@ dependson:
   - PagerDuty-get-users-on-call-now
 runonce: false
 runas: DBotWeakRole
+tests:
+  - No tests

--- a/Scripts/script-PagerDutyAssignOnCallUser_CHANGELOG.md
+++ b/Scripts/script-PagerDutyAssignOnCallUser_CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [Unreleased]
-  - added new arguments to ***PagerDutyAssignOnCallUser*** script:
+  - Added new arguments to the ***PagerDutyAssignOnCallUser*** script.
     - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
         policy IDs.
     - schedule_ids: Filters the results, showing only on-calls for the specified schedule
-        IDs. If null is provided, it includes permanent on-calls due to direct user
-        escalation targets.
-  - fix TypeError exception
+        IDs. 
+  - Fixed an error in the PagerDuty script.

--- a/Scripts/script-PagerDutyAssignOnCallUser_CHANGELOG.md
+++ b/Scripts/script-PagerDutyAssignOnCallUser_CHANGELOG.md
@@ -1,0 +1,8 @@
+## [Unreleased]
+  - added new arguments to ***PagerDutyAssignOnCallUser*** script:
+    - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
+        policy IDs.
+    - schedule_ids: Filters the results, showing only on-calls for the specified schedule
+        IDs. If null is provided, it includes permanent on-calls due to direct user
+        escalation targets.
+  - fix TypeError exception

--- a/TestPlaybooks/playbook-PagerDuty_Test.yml
+++ b/TestPlaybooks/playbook-PagerDuty_Test.yml
@@ -5,10 +5,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 73dd87a5-8f99-4e67-8715-4d063cb59496
+    taskid: 7d81fe1a-b9e7-4b39-8781-1cd41d351394
     type: start
     task:
-      id: 73dd87a5-8f99-4e67-8715-4d063cb59496
+      id: 7d81fe1a-b9e7-4b39-8781-1cd41d351394
       version: -1
       name: ""
       iscommand: false
@@ -20,17 +20,19 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 480,
+          "x": 50,
           "y": 50
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "1":
     id: "1"
-    taskid: 17bdd88c-b6ef-401b-8e13-7b5fd0a6ec76
+    taskid: 0fa77151-6efb-4c01-8b2e-e038eef5f707
     type: regular
     task:
-      id: 17bdd88c-b6ef-401b-8e13-7b5fd0a6ec76
+      id: 0fa77151-6efb-4c01-8b2e-e038eef5f707
       version: -1
       name: Get on call users
       script: '|||PagerDuty-get-users-on-call-now'
@@ -46,23 +48,28 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 480,
-          "y": 340
+          "x": 50,
+          "y": 865
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
-    taskid: da501822-f46a-4e6f-8a8e-c9a46e34b4f0
+    taskid: eb6f57a1-02fa-4d90-8fad-b6fe878fbad4
     type: regular
     task:
-      id: da501822-f46a-4e6f-8a8e-c9a46e34b4f0
+      id: eb6f57a1-02fa-4d90-8fad-b6fe878fbad4
       version: -1
       name: Verify context
       scriptName: VerifyContext
       type: regular
       iscommand: false
       brand: ""
+    nexttasks:
+      '#none#':
+      - "11"
     scriptarguments:
       expectedValue: {}
       fields: {}
@@ -72,17 +79,19 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 480,
-          "y": 515
+          "x": 50,
+          "y": 1040
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
-    taskid: fb9acaf6-e92d-4cc5-892d-6a460a572c10
+    taskid: 4da31dfb-f411-4ff4-861c-316ce63b5501
     type: regular
     task:
-      id: fb9acaf6-e92d-4cc5-892d-6a460a572c10
+      id: 4da31dfb-f411-4ff4-861c-316ce63b5501
       version: -1
       name: Get schedules
       script: '|||PagerDuty-get-all-schedules'
@@ -104,18 +113,23 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "4":
     id: "4"
-    taskid: 27632f44-ee8f-4a36-8f7e-f6ab5c0a8f6b
+    taskid: 71eff7d1-30a4-441e-898f-d96fff862dfc
     type: regular
     task:
-      id: 27632f44-ee8f-4a36-8f7e-f6ab5c0a8f6b
+      id: 71eff7d1-30a4-441e-898f-d96fff862dfc
       version: -1
       name: Verify Context
       scriptName: VerifyContext
       type: regular
       iscommand: false
       brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
     scriptarguments:
       expectedValue: {}
       fields: {}
@@ -130,12 +144,14 @@ tasks:
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
-    taskid: 530b5c9c-731e-4818-89bd-c48ce52c28e1
+    taskid: 12579f84-18d9-4b55-8d05-a0e6d184f312
     type: regular
     task:
-      id: 530b5c9c-731e-4818-89bd-c48ce52c28e1
+      id: 12579f84-18d9-4b55-8d05-a0e6d184f312
       version: -1
       name: 'Get Incidents '
       script: '|||PagerDuty-incidents'
@@ -144,7 +160,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "9"
+      - "1"
     scriptarguments:
       since: {}
       sortBy: {}
@@ -154,18 +170,19 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 910,
-          "y": 340
+          "x": 50,
+          "y": 690
         }
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "7":
     id: "7"
-    taskid: 7fdf0e18-3eb6-46b6-8da3-d99fbdee35a9
+    taskid: c58f7088-121c-4c60-8898-3b21d4f05a0b
     type: title
     task:
-      id: 7fdf0e18-3eb6-46b6-8da3-d99fbdee35a9
+      id: c58f7088-121c-4c60-8898-3b21d4f05a0b
       version: -1
       name: PagerDuty Commands
       type: title
@@ -174,24 +191,23 @@ tasks:
     nexttasks:
       '#none#':
       - "3"
-      - "1"
-      - "5"
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 480,
+          "x": 50,
           "y": 195
         }
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "9":
     id: "9"
-    taskid: 7a2c4ce5-a31d-41e7-8f9f-69a13d13d277
+    taskid: f023b851-5819-4d83-8d96-82b7b48e0cb2
     type: title
     task:
-      id: ef319398-78f9-4c70-8e3a-d846929cb16d
+      id: f023b851-5819-4d83-8d96-82b7b48e0cb2
       version: -1
       name: End of test
       type: title
@@ -201,18 +217,351 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 910,
-          "y": 530
+          "x": 50,
+          "y": 2790
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
+  "10":
+    id: "10"
+    taskid: 6d293021-89d8-4f74-89ea-38fae70b9bab
+    type: regular
+    task:
+      id: 6d293021-89d8-4f74-89ea-38fae70b9bab
+      version: -1
+      name: Get on call users- schedule_ids
+      script: '|||PagerDuty-get-users-on-call-now'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "12"
+    scriptarguments:
+      escalation_policy_ids: {}
+      limit: {}
+      query: {}
+      schedule_ids:
+        simple: PFE1I5O,PO93R76
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1390
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "11":
+    id: "11"
+    taskid: 93dc62a3-0833-4e0c-860f-268133e69889
+    type: regular
+    task:
+      id: 93dc62a3-0833-4e0c-860f-268133e69889
+      version: -1
+      name: Clear context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "10"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1215
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "12":
+    id: "12"
+    taskid: 7353e653-17ad-4303-8f3b-20dc69a94fd6
+    type: condition
+    task:
+      id: 7353e653-17ad-4303-8f3b-20dc69a94fd6
+      version: -1
+      name: Verify context
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "13"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: PagerDutyUser
+                accessor: Email
+            iscontext: true
+          right:
+            value:
+              simple: meir@demisto.com
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: PagerDutyUser
+                accessor: Email
+            iscontext: true
+          right:
+            value:
+              simple: rony@demisto.com
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1565
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "13":
+    id: "13"
+    taskid: 6a306912-cbf5-4b8d-86cc-355ea5cf6f0e
+    type: regular
+    task:
+      id: 6a306912-cbf5-4b8d-86cc-355ea5cf6f0e
+      version: -1
+      name: Get on call users-escalation_policy_ids
+      description: Returns the names and details of current on call personnel
+      script: '|||PagerDuty-get-users-on-call-now'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "14"
+    scriptarguments:
+      escalation_policy_ids:
+        simple: PJUYEWG
+      limit: {}
+      schedule_ids: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1740
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "14":
+    id: "14"
+    taskid: 7d024e4e-695f-4c6e-8a08-f5a89dc46db7
+    type: condition
+    task:
+      id: 7d024e4e-695f-4c6e-8a08-f5a89dc46db7
+      version: -1
+      name: Verify context
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "15"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: PagerDutyUser
+                accessor: Email
+            iscontext: true
+          right:
+            value:
+              simple: dan@demisto.com
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1915
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "15":
+    id: "15"
+    taskid: b3b8304a-969a-4a94-86b9-32db986aa37d
+    type: regular
+    task:
+      id: b3b8304a-969a-4a94-86b9-32db986aa37d
+      version: -1
+      name: Clear context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "16"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2090
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "16":
+    id: "16"
+    taskid: 50ac163a-041f-4c84-8abd-138acec6c853
+    type: regular
+    task:
+      id: 50ac163a-041f-4c84-8abd-138acec6c853
+      version: -1
+      name: Set escalation_policy_ids in context
+      description: Sets a value into the context with the given context key
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "17"
+    scriptarguments:
+      append: {}
+      key:
+        simple: escalation_policy_ids
+      value:
+        simple: '["P4J5L11","PJUYEWG"]'
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2265
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "17":
+    id: "17"
+    taskid: 361cd2e3-89e6-4c51-804c-7b5db7d6188b
+    type: regular
+    task:
+      id: 361cd2e3-89e6-4c51-804c-7b5db7d6188b
+      version: -1
+      name: Get on call users-escalation_policy_ids
+      description: Returns the names and details of current on call personnel
+      script: '|||PagerDuty-get-users-on-call-now'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "18"
+    scriptarguments:
+      escalation_policy_ids:
+        simple: ${escalation_policy_ids}
+      limit: {}
+      schedule_ids: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2440
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "18":
+    id: "18"
+    taskid: 04f312ce-bcbc-4010-8f90-694fec5ed81d
+    type: condition
+    task:
+      id: 04f312ce-bcbc-4010-8f90-694fec5ed81d
+      version: -1
+      name: Verify context
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "9"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: PagerDutyUser
+                accessor: Email
+            iscontext: true
+          right:
+            value:
+              simple: dan@demisto.com
+      - - operator: containsGeneral
+          left:
+            value:
+              complex:
+                root: PagerDutyUser
+                accessor: Email
+            iscontext: true
+          right:
+            value:
+              simple: meir@demisto.com
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2615
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 560,
-        "width": 1240,
+        "height": 2805,
+        "width": 380,
         "x": 50,
         "y": 50
       }


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/18842

## Description
  - added new arguments to ***PagerDuty-get-users-on-call-now*** command:
    - escalation_policy_ids: Filters the results, showing only on-calls for the specified escalation
        policy IDs.
    - schedule_ids: Filters the results, showing only on-calls for the specified schedule
        IDs. If null is provided, it includes permanent on-calls due to direct user
        escalation targets.

## Screenshots
![image](https://user-images.githubusercontent.com/36194510/65253042-a370b180-db02-11e9-83c4-8e8f400f38d6.png)

## Does it break backward compatibility?
  - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] PagerDutyAssignOnCallUser.yml


## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](https://github.com/demisto/content/edit/pagerduty-enhance/Integrations/PagerDuty/PagerDuty.yml?pr=%2Fdemisto%2Fcontent%2Fpull%2F4441)
- [ ] [CHANGELOG](https://github.com/demisto/content/edit/pagerduty-enhance/Integrations/PagerDuty/CHANGELOG.md?pr=%2Fdemisto%2Fcontent%2Fpull%2F4441)