### PR TITLE
Remove integration strings from BaseClient

### DIFF
--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1882,7 +1882,7 @@ def parse_date_string(date_string, date_format='%Y-%m-%dT%H:%M:%S'):
         >>> parse_date_string('2019-09-17T06:16:39.4040+05:00', '%Y-%m-%dT%H:%M:%S+02:00')
         datetime.datetime(2019, 9, 17, 6, 16, 39, 404000)
 
-        :type date_string: ``str``
+\        :type date_string: ``str``
         :param date_string: The date string to parse. (required)
 
         :type date_format: ``str``
@@ -2058,28 +2058,10 @@ H || val.SSDeep && val.SSDeep == obj.SSDeep)': {'Malicious': {'Vendor': 'Vendor'
 # Will add only if 'requests' module imported
 if 'requests' in sys.modules:
     class BaseClient(object):
-        def __init__(self, integration_name, integration_command_name, integration_context_name, server, base_suffix,
-                     verify=True, proxy=False, ok_codes=tuple(), headers=None, auth=None):
-            """Wrapper of BaseClient with added _http_request functionality
-
-            :type integration_name: ``str``
-            :param integration_name:
-                Name of the integration as shown in the integration UI, for example: Microsoft Graph User.
-
-            :type integration_command_name: ``str``
-                :param integration_command_name:
-                Command names should be written in all lower-case letters,
-                and each word separated with a hyphen, for example: msgraph-user.
-
-            :type integration_context_name: ``str``
-            :param integration_context_name:
-
-            Context output names should be written in camel case, for example: MSGraphUser.
-            :type server: ``str``
-            :param server: Base server address, for example: https://example.com.
-
-            :type base_suffix: ``str``
-            :param base_suffix: Suffix appended to the base URI of the API, for example: /api/v2/
+        def __init__(self, base_url, verify=True, proxy=False, ok_codes=tuple(), headers=None, auth=None):
+            """Client to use in integrations with powerful _http_request
+            :type base_url: ``str``
+            :param base_url: Base server address with suffix, for example: https://example.com/api/v2/.
 
             :type verify: ``bool``
             :param verify: Whether the request should verify the SSL certificate.
@@ -2105,12 +2087,8 @@ if 'requests' in sys.modules:
             :return: No data returned
             :rtype: ``None``
             """
-            self._integration_name = str(integration_name)
-            self._integration_command_name = str(integration_command_name)
-            self._integration_context_name = str(integration_context_name)
-            self._server = server.rstrip('/')
+            self._base_url = base_url
             self._verify = verify
-            self._base_url = '{}{}'.format(self._server, base_suffix)
             self._ok_codes = ok_codes
             self._headers = headers
             self._auth = auth
@@ -2119,32 +2097,8 @@ if 'requests' in sys.modules:
             else:
                 self._proxies = None
 
-        @property
-        def integration_name(self):  # pragma: no cover
-            """Property of integration name
-            return: Integration command name.
-            :rtype: ``str``
-            """
-            return self._integration_name
-
-        @property
-        def integration_context_name(self):  # pragma: no cover
-            """Property of integration name context
-            return: Integration command name
-            :rtype: ``str``
-            """
-            return self._integration_context_name
-
-        @property
-        def integration_command_name(self):  # pragma: no cover
-            """Property of integration name command
-            return: Integration command name
-            :rtype: ``str``
-            """
-            return self._integration_command_name
-
         def _http_request(self, method, url_suffix, full_url=None, headers=None,
-                          auth=None, params=None, data=None, files=None,
+                          auth=None, json_data=None, params=None, data=None, files=None,
                           timeout=10, resp_type='json', ok_codes=None, **kwargs):
             """A wrapper for requests lib to send our requests and handle requests and responses better.
 
@@ -2173,6 +2127,9 @@ if 'requests' in sys.modules:
 
             :type data: ``dict``
             :param data: The data to send in a 'POST' request.
+
+            :type json_data: ``dict``
+            :param json_data: The json to send in a 'POST' request.
 
             :type files: ``dict``
             :param files: The file data to send in a 'POST' request.
@@ -2208,6 +2165,7 @@ if 'requests' in sys.modules:
                     verify=self._verify,
                     params=params,
                     data=data,
+                    json=json_data,
                     files=files,
                     headers=headers,
                     auth=auth,
@@ -2217,8 +2175,8 @@ if 'requests' in sys.modules:
                 )
                 # Handle error responses gracefully
                 if not self._is_status_code_valid(res, ok_codes):
-                    err_msg = 'Error in {} API call [{}] - {}' \
-                        .format(self._integration_name, res.status_code, res.reason)
+                    err_msg = 'Error in API call [{}] - {}' \
+                        .format(res.status_code, res.reason)
                     try:
                         # Try to parse json error response
                         error_entry = res.json()

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -2058,35 +2058,35 @@ H || val.SSDeep && val.SSDeep == obj.SSDeep)': {'Malicious': {'Vendor': 'Vendor'
 # Will add only if 'requests' module imported
 if 'requests' in sys.modules:
     class BaseClient(object):
+        """Client to use in integrations with powerful _http_request
+        :type base_url: ``str``
+        :param base_url: Base server address with suffix, for example: https://example.com/api/v2/.
+
+        :type verify: ``bool``
+        :param verify: Whether the request should verify the SSL certificate.
+
+        :type proxy: ``bool``
+        :param proxy: Whether to run the integration using the system proxy.
+
+        :type ok_codes: ``tuple``
+        :param ok_codes:
+            The request codes to accept as OK, for example: (200, 201, 204).
+            If you specify "None", will use requests.Response.ok
+
+        :type headers: ``dict``
+        :param headers:
+            The request headers, for example: {'Accept`: `application/json`}.
+            Can be None.
+
+        :type auth: ``dict`` or ``tuple``
+        :param auth:
+            The request authorization, for example: (username, password).
+            Can be None.
+
+        :return: No data returned
+        :rtype: ``None``
+        """
         def __init__(self, base_url, verify=True, proxy=False, ok_codes=tuple(), headers=None, auth=None):
-            """Client to use in integrations with powerful _http_request
-            :type base_url: ``str``
-            :param base_url: Base server address with suffix, for example: https://example.com/api/v2/.
-
-            :type verify: ``bool``
-            :param verify: Whether the request should verify the SSL certificate.
-
-            :type proxy: ``bool``
-            :param proxy: Whether to run the integration using the system proxy.
-
-            :type ok_codes: ``tuple``
-            :param ok_codes:
-                The request codes to accept as OK, for example: (200, 201, 204).
-                If you specify "None", will use requests.Response.ok
-
-            :type headers: ``dict``
-            :param headers:
-                The request headers, for example: {'Accept`: `application/json`}.
-                Can be None.
-
-            :type auth: ``dict`` or ``tuple``
-            :param auth:
-                The request authorization, for example: (username, password).
-                Can be None.
-
-            :return: No data returned
-            :rtype: ``None``
-            """
             self._base_url = base_url
             self._verify = verify
             self._ok_codes = ok_codes

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -2129,7 +2129,7 @@ if 'requests' in sys.modules:
             :param data: The data to send in a 'POST' request.
 
             :type json_data: ``dict``
-            :param json_data: The json to send in a 'POST' request.
+            :param json_data: The dictionary to send in a 'POST' request.
 
             :type files: ``dict``
             :param files: The file data to send in a 'POST' request.

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1882,7 +1882,7 @@ def parse_date_string(date_string, date_format='%Y-%m-%dT%H:%M:%S'):
         >>> parse_date_string('2019-09-17T06:16:39.4040+05:00', '%Y-%m-%dT%H:%M:%S+02:00')
         datetime.datetime(2019, 9, 17, 6, 16, 39, 404000)
 
-\        :type date_string: ``str``
+        :type date_string: ``str``
         :param date_string: The date string to parse. (required)
 
         :type date_format: ``str``

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -736,10 +736,10 @@ class TestBuildDBotEntry(object):
         }
 
 
-class TestBaseClient(object):
+class TestBaseClient:
     from CommonServerPython import BaseClient
     text = {"status": "ok"}
-    client = BaseClient('Name', 'name', 'name', 'http://example.com', '/api/v2/', ok_codes=(200, 201))
+    client = BaseClient('http://example.com/api/v2/', ok_codes=(200, 201))
 
     def test_http_request_json(self, requests_mock):
         requests_mock.get('http://example.com/api/v2/event', text=json.dumps(self.text))

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -781,7 +781,7 @@ class TestBaseClient:
     def test_http_request_not_ok_with_json(self, requests_mock):
         from CommonServerPython import DemistoException
         requests_mock.get('http://example.com/api/v2/event', status_code=500, content=str.encode(json.dumps(self.text)))
-        with raises(DemistoException, match="Error in Name API"):
+        with raises(DemistoException, match="Error in API cal"):
             self.client._http_request('get', 'event')
 
     def test_http_request_timeout(self, requests_mock):
@@ -811,7 +811,7 @@ class TestBaseClient:
     def test_is_valid_ok_codes_empty(self):
         from requests import Response
         from CommonServerPython import BaseClient
-        new_client = BaseClient('Name', 'name', 'name', 'http://example.com', '/api/v2/')
+        new_client = BaseClient('http://example.com/api/v2/')
         response = Response()
         response.status_code = 200
         assert new_client._is_status_code_valid(response, None)

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -781,7 +781,7 @@ class TestBaseClient:
     def test_http_request_not_ok_with_json(self, requests_mock):
         from CommonServerPython import DemistoException
         requests_mock.get('http://example.com/api/v2/event', status_code=500, content=str.encode(json.dumps(self.text)))
-        with raises(DemistoException, match="Error in API cal"):
+        with raises(DemistoException, match="Error in API call"):
             self.client._http_request('get', 'event')
 
     def test_http_request_timeout(self, requests_mock):


### PR DESCRIPTION
## Status
Ready

## Description
removed integration_name, integration_context_name and integreation_command_name from BaseClient.
unified server and base suffix params into base_url.


## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review