### PR TITLE
Microsoft Teams - single port support and integration health command

### DIFF
--- a/Integrations/MicrosoftTeams/CHANGELOG.md
+++ b/Integrations/MicrosoftTeams/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-  - Added single port mapping support.
-  - Added the command ***microsoft-teams-integration-health***.
+  - Added support for single port mapping.
+  - Added the ***microsoft-teams-integration-health*** command.
 
 ## [19.9.1] - 2019-09-18
   - Added verification for the authorization header signature.

--- a/Integrations/MicrosoftTeams/CHANGELOG.md
+++ b/Integrations/MicrosoftTeams/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Added single port mapping support.
 
 ## [19.9.1] - 2019-09-18
   - Added verification for the authorization header signature.

--- a/Integrations/MicrosoftTeams/CHANGELOG.md
+++ b/Integrations/MicrosoftTeams/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-Added single port mapping support.
+  - Added single port mapping support.
+  - Added the command ***microsoft-teams-integration-health***.
 
 ## [19.9.1] - 2019-09-18
   - Added verification for the authorization header signature.

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -432,7 +432,9 @@ def get_graph_access_token() -> str:
             return access_token
     tenant_id: str = integration_context.get('tenant_id', '')
     if not tenant_id:
-        raise ValueError('Tenant ID not found')
+        raise ValueError(
+            'Did not receive tenant ID from Microsoft Teams, verify the messaging endpoint is configured correctly.'
+        )
     url: str = f'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token'
     data: dict = {
         'grant_type': 'client_credentials',
@@ -525,6 +527,52 @@ def http_request(
         error_message = 'Proxy Error - if \'Use system proxy settings\' in the integration configuration has been ' \
                         'selected, try deselecting it.'
         raise ConnectionError(error_message)
+
+
+def integration_health():
+
+    bot_framework_api_health = 'Operational'
+    graph_api_health = 'Operational'
+
+    try:
+        get_bot_access_token()
+    except ValueError as e:
+        bot_framework_api_health = f'Non operational - {str(e)}'
+
+    try:
+        get_graph_access_token()
+    except ValueError as e:
+        graph_api_health = f'Non operational - {str(e)}'
+
+    api_health_output: list = [{
+        'Bot Framework API Health': bot_framework_api_health,
+        'Graph API Health': graph_api_health
+    }]
+
+    api_health_human_readble: str = tableToMarkdown('Microsoft API Health', api_health_output)
+
+    mirrored_channels_output = list()
+    integration_context: dict = demisto.getIntegrationContext()
+    teams: list = json.loads(integration_context.get('teams', '[]'))
+    for team in teams:
+        mirrored_channels: list = team.get('mirrored_channels', [])
+        for channel in mirrored_channels:
+            mirrored_channels_output.append({
+                'Team': team.get('team_name'),
+                'Channel': channel.get('channel_name'),
+                'Investigation ID': channel.get('investigation_id')
+            })
+
+    mirrored_channels_human_readable: str
+
+    if mirrored_channels_output:
+        mirrored_channels_human_readable = tableToMarkdown(
+            'Microsft Teams Mirrored Channels', mirrored_channels_output
+        )
+    else:
+        mirrored_channels_human_readable = 'No mirrored channels.'
+
+    demisto.results(api_health_human_readble + mirrored_channels_human_readable)
 
 
 def validate_auth_header(headers: dict) -> bool:
@@ -1438,7 +1486,8 @@ def main():
         'long-running-execution': long_running_loop,
         'send-notification': send_message,
         'mirror-investigation': mirror_investigation,
-        'close-channel': close_channel
+        'close-channel': close_channel,
+        'microsoft-teams-integration-health': integration_health
         # 'microsoft-teams-create-team': create_team,
         # 'microsoft-teams-send-file': send_file,
     }

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1432,7 +1432,7 @@ def long_running_loop():
         port: int
         if port_mapping:
             if ':' in port_mapping:
-                port = int(port_mapping.split(':')[0])
+                port = int(port_mapping.split(':')[1])
             else:
                 port = int(port_mapping)
         else:

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1376,18 +1376,23 @@ def long_running_loop():
     certificate: str = demisto.params().get('certificate', '')
     private_key: str = demisto.params().get('key', '')
 
+    certificate_path = str()
+    private_key_path = str()
+
     try:
         port_mapping: str = PARAMS.get('longRunningPort', '')
+        port: int
         if port_mapping:
-            port: int = int(port_mapping.split(':')[0])
+            if ':' in port_mapping:
+                port = int(port_mapping.split(':')[0])
+            else:
+                port = int(port_mapping)
         else:
             raise ValueError('No port mapping was provided')
         Thread(target=channel_mirror_loop, daemon=True).start()
         demisto.info('Started channel mirror loop thread')
 
         ssl_args = dict()
-        certificate_path = str()
-        private_key_path = str()
 
         if certificate and private_key:
             certificate_file = NamedTemporaryFile(delete=False)

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -54,7 +54,7 @@ configuration:
   name: longRunning
   required: false
   type: 8
-- display: Port mapping, e.g. <host port>:<docker port> (Required for investigation
+- display: Port mapping, e.g. <port> or <host port>:<docker port> (Required for investigation
     mirroring and direct messages)
   name: longRunningPort
   required: false

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -173,6 +173,10 @@ script:
     description: Deletes the specified Microsoft Teams channel.
     execution: false
     name: close-channel
+  - deprecated: false
+    description: Returns real-time and historical data on integration status.
+    execution: false
+    name: microsoft-teams-integration-health
   dockerimage: demisto/teams:1.0.0.1701
   isfetch: false
   longRunning: true
@@ -180,7 +184,6 @@ script:
   runonce: false
   script: '-'
   type: python
-  subtype: python3
 tests:
 - No test
 fromversion: 5.0.0

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -184,6 +184,7 @@ script:
   runonce: false
   script: '-'
   type: python
+  subtype: python3
 tests:
 - No test
 fromversion: 5.0.0

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -70,7 +70,7 @@ script:
   commands:
   - arguments:
     - default: false
-      description: Channel to which send messages.
+      description: The channel to which to send messages.
       isArray: false
       name: channel
       required: false
@@ -88,7 +88,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Team in which the specified channel exists. The team must already
+      description: The team in which the specified channel exists. The team must already
         exist, and this value will override the default channel configured in the
         integration parameters.
       isArray: false
@@ -145,7 +145,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Team in which to mirror the Demisto investigation. If not specified,
+      description: The team in which to mirror the Demisto investigation. If not specified,
         the default team configured in the integration parameters will be used.
       isArray: false
       name: team
@@ -164,7 +164,7 @@ script:
     name: mirror-investigation
   - arguments:
     - default: false
-      description: Name of the channel to close.
+      description: The name of the channel to close.
       isArray: false
       name: channel
       required: false
@@ -174,7 +174,7 @@ script:
     execution: false
     name: close-channel
   - deprecated: false
-    description: Returns real-time and historical data on integration status.
+    description: Returns real-time and historical data on the integration status.
     execution: false
     name: microsoft-teams-integration-health
   dockerimage: demisto/teams:1.0.0.1701

--- a/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -54,7 +54,7 @@ configuration:
   name: longRunning
   required: false
   type: 8
-- display: Port mapping, e.g. <port> or <host port>:<docker port> (Required for investigation
+- display: Listen port, e.g. 7000 (Required for investigation
     mirroring and direct messages)
   name: longRunningPort
   required: false

--- a/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -1251,3 +1251,24 @@ def test_error_parser():
     }
     graph_error_json_response = MockResponse(graph_error_json_response, 401)
     assert error_parser(graph_error_json_response) == f'{error_code}: {error_message}'
+
+
+def test_integration_health(mocker):
+    from MicrosoftTeams import integration_health
+    mocker.patch.object(demisto, 'results')
+    expected_results = """### Microsoft API Health
+|Bot Framework API Health|Graph API Health|
+|---|---|
+| Operational | Operational |
+### Microsft Teams Mirrored Channels
+|Channel|Investigation ID|Team|
+|---|---|---|
+| incident-10 | 10 | The-A-Team |
+| incident-2 | 2 | The-A-Team |
+| booya | 14 | The-A-Team |
+"""
+    integration_health()
+
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0] == expected_results


### PR DESCRIPTION
## Status
Ready

## Description
- Added support for single port mapping
- Added integration health command, which checks connectivity to Microsoft APIs and lists the mirrored channels

## Required version of Demisto
5.0

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation
- [ ] Code Review

## Dependencies
- [x] MicrosoftTeamsAsk

## Technical writer review
@kirbles19 please review:
- [ ] [YAML file](https://github.com/demisto/content/blob/bd2285bc9c3095dfe304395e6a01a493344b90d6/Integrations/MicrosoftTeams/MicrosoftTeams.yml)
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/bd2285bc9c3095dfe304395e6a01a493344b90d6/Integrations/MicrosoftTeams/CHANGELOG.md)