### PR TITLE
[Fix] attackiq-run-all-tests-in-assessment missing on_demand_only arg

### DIFF
--- a/Integrations/AttackIQFireDrill/AttackIQFireDrill.py
+++ b/Integrations/AttackIQFireDrill/AttackIQFireDrill.py
@@ -516,7 +516,7 @@ def run_all_tests_in_assessment_command():
     ass_id = args.get('assessment_id')
     on_demand_only = args.get('on_demand_only')
     try:
-        params = {'on_demand_only': True} if on_demand_only else None
+        params = {'on_demand_only': on_demand_only == 'True'}
         raw_res = http_request('POST', f'/v1/assessments/{ass_id}/run_all_tests', params=params)
         hr = raw_res['message'] if 'message' in raw_res else \
             f'Request to run all tests for assessment {ass_id} was sent successfully.'

--- a/Integrations/AttackIQFireDrill/AttackIQFireDrill.py
+++ b/Integrations/AttackIQFireDrill/AttackIQFireDrill.py
@@ -514,8 +514,10 @@ def run_all_tests_in_assessment_command():
     """
     args = demisto.args()
     ass_id = args.get('assessment_id')
+    on_demand_only = args.get('on_demand_only')
     try:
-        raw_res = http_request('POST', f'/v1/assessments/{ass_id}/run_all_tests')
+        params = {'on_demand_only': True} if on_demand_only else None
+        raw_res = http_request('POST', f'/v1/assessments/{ass_id}/run_all_tests', params=params)
         hr = raw_res['message'] if 'message' in raw_res else \
             f'Request to run all tests for assessment {ass_id} was sent successfully.'
         demisto.results(hr)

--- a/Integrations/AttackIQFireDrill/AttackIQFireDrill.yml
+++ b/Integrations/AttackIQFireDrill/AttackIQFireDrill.yml
@@ -20,7 +20,7 @@ configuration:
   required: false
   type: 8
 description: An attack simulation platform that provides validations for security controls, responses, and remediation exercises.
-display: AttackIQ FireDrill
+display: AttackIQ Platform
 name: AttackIQFireDrill
 script:
   commands:

--- a/Integrations/AttackIQFireDrill/AttackIQFireDrill.yml
+++ b/Integrations/AttackIQFireDrill/AttackIQFireDrill.yml
@@ -225,6 +225,7 @@ script:
       required: true
       secret: false
     - default: false
+      auto: PREDEFINED
       description: Runs only on-demand tests in the assessment. True executes
         tests in the assessment that are not scheduled to run. False executes all
         tests in the assessment including scheduled tests. Default is false.
@@ -232,6 +233,9 @@ script:
       name: on_demand_only
       required: false
       secret: false
+      predefined:
+        - 'True'
+        - 'False'
     deprecated: false
     description: Runs all tests in the assessment.
     execution: false

--- a/Integrations/AttackIQFireDrill/CHANGELOG.md
+++ b/Integrations/AttackIQFireDrill/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-  - Changed display name from "AttackIQ FireDrill" to "AttackIQ Platform"
+  - Changed the integtration name from "AttackIQ FireDrill" to "AttackIQ Platform"
 
 
 ## [19.9.1] - 2019-09-18

--- a/Integrations/AttackIQFireDrill/CHANGELOG.md
+++ b/Integrations/AttackIQFireDrill/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+  - Changed display name from "AttackIQ FireDrill" to "AttackIQ Platform"
 
 
 ## [19.9.1] - 2019-09-18


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19353
documentation issue: https://github.com/demisto/etc/issues/19352

## Description
Added `on_demand_only` to `attackiq-run-all-tests-in-assessment` http request.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation (https://support.demisto.com/hc/en-us/articles/360036030353)
- [x] Code Review

## Additional changes
Changed display name of the integration to `AttackIQ Platform`

## Screenshots
### Without `on_demand_only`
![image](https://user-images.githubusercontent.com/20818773/65579042-9ed34f80-df7f-11e9-9db4-04c57ec86891.png)

### With `on_demand_only=True`
![image](https://user-images.githubusercontent.com/20818773/65579084-aeeb2f00-df7f-11e9-8af3-60fae91303bf.png)

### With `on_demand_only=False`
![image](https://user-images.githubusercontent.com/20818773/65579117-c4f8ef80-df7f-11e9-978d-345b050fede4.png)

## Technical writer review
Mention and link to the files that require a technical writer review.
- [x] [CHANGELOG](https://github.com/demisto/content/edit/attackiq-name-change/Integrations/AttackIQFireDrill/CHANGELOG.md?pr=%2Fdemisto%2Fcontent%2Fpull%2F4482)