### PR TITLE
Fix first fetch default value

### DIFF
--- a/Integrations/GitHub/CHANGELOG.md
+++ b/Integrations/GitHub/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Improved implementation of the default value for the fetch time parameter.
 
 ## [19.10.0] - 2019-10-03
 -

--- a/Integrations/GitHub/GitHub.py
+++ b/Integrations/GitHub/GitHub.py
@@ -19,7 +19,7 @@ TOKEN = demisto.params().get('token', '')
 BASE_URL = 'https://api.github.com'
 REPOSITORY = demisto.params().get('repository')
 USE_SSL = not demisto.params().get('insecure', False)
-FETCH_TIME = demisto.params().get('fetch_time', '30 days')
+FETCH_TIME = demisto.params().get('fetch_time', '3')
 
 USER_SUFFIX = '/repos/{}/{}'.format(USER, REPOSITORY)
 ISSUE_SUFFIX = USER_SUFFIX + '/issues'

--- a/Integrations/GitHub/GitHub.yml
+++ b/Integrations/GitHub/GitHub.yml
@@ -20,7 +20,7 @@ configuration:
   required: false
   type: 0
 - defaultvalue: 3
-  display: First fetch interval in days
+  display: First fetch interval (in days)
   name: fetch_time
   required: false
   type: 0

--- a/Integrations/GitHub/GitHub.yml
+++ b/Integrations/GitHub/GitHub.yml
@@ -19,8 +19,8 @@ configuration:
   name: repository
   required: false
   type: 0
-- defaultvalue: 3 days
-  display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)
+- defaultvalue: 3
+  display: First fetch interval in days
   name: fetch_time
   required: false
   type: 0


### PR DESCRIPTION
## Status
Ready

## Description
the default fetch time was in text format, while it should be a number (the integration code converts it to int: `start_time = datetime.now() - timedelta(days=int(FETCH_TIME))`

## Does it break backward compatibility?
   - No, if someone used the previous default value it would break fetch flow

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](https://github.com/demisto/content/edit/fix-github-default-fetch/Integrations/GitHub/GitHub.yml?pr=%2Fdemisto%2Fcontent%2Fpull%2F4486)
- [ ] [CHANGELOG](https://github.com/demisto/content/edit/fix-github-default-fetch/Integrations/GitHub/CHANGELOG.md?pr=%2Fdemisto%2Fcontent%2Fpull%2F4486)