### PR TITLE
Added new params and changed fetch incidents to use them

### DIFF
--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Added two new parameters for the names of the earliest and latest times to fetch fields.
 
 
 ## [19.9.1] - 2019-09-18

--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -342,8 +342,11 @@ if demisto.command() == 'fetch-incidents':
         t = t - timedelta(minutes=10)
         lastRun = t.strftime(SPLUNK_TIME_FORMAT)
 
-    kwargs_oneshot = {"index_earliest": lastRun,
-                      "index_latest": now, "count": FETCH_LIMIT, 'offset': search_offset}
+    earliest_fetch_time_fieldname = demisto.params().get("earliest_fetch_time_fieldname", "index_earliest")
+    latest_fetch_time_fieldname = demisto.params().get("latest_fetch_time_fieldname", "index_latest")
+
+    kwargs_oneshot = {earliest_fetch_time_fieldname: lastRun,
+                      latest_fetch_time_fieldname: now, "count": FETCH_LIMIT, 'offset': search_offset}
 
     searchquery_oneshot = demisto.params()['fetchQuery']
 

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -37,10 +37,10 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- display: 'Proxy - in format: 127.0.0.1:8080'
+- display: Use system proxy settings
   name: proxy
   required: false
-  type: 0
+  type: 8
 - display: Timezone of the Splunk server, in minutes. For example, GMT is gmt +3, set +180 (set only
     if different than Demisto server). Relevant only for fetching notable events.
   name: timezone
@@ -61,11 +61,23 @@ configuration:
   name: useSplunkTime
   required: false
   type: 8
-- defaultvalue: 'true'
-  display: Trust any certificate (unsecure)
+- defaultvalue: ''
+  display: Trust any certificate (not secure)
   name: unsecure
   required: false
   type: 8
+- display: Earliest time to fetch field name (the name of the field to define the
+    earliest time of the query by)
+  name: earliest_fetch_time_fieldname
+  defaultvalue: index_earliest
+  type: 0
+  required: false
+- display: Latest time to fetch field name (the name of the field to define the latest
+    time of the query by)
+  name: latest_fetch_time_fieldname
+  defaultvalue: index_latest
+  type: 0
+  required: false
 description: Run queries on Splunk servers.
 display: SplunkPy
 name: SplunkPy

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -66,14 +66,14 @@ configuration:
   name: unsecure
   required: false
   type: 8
-- display: Earliest time to fetch field name (the name of the field to define the
-    earliest time of the query by)
+- display: Earliest time to fetch (the name of the Splunk field whose value defines the query's
+    earliest time to fetch)
   name: earliest_fetch_time_fieldname
   defaultvalue: index_earliest
   type: 0
   required: false
-- display: Latest time to fetch field name (the name of the field to define the latest
-    time of the query by)
+- display: Latest time to fetch (the name of the Splunk field whose value defines the query's
+    latest time to fetch)
   name: latest_fetch_time_fieldname
   defaultvalue: index_latest
   type: 0


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19347

## Description
Added two new parameters that allow the user to control the names of the earliest fetch time and latest fetch time fields.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review