### PR TITLE
Fix intsights-get-alert-image and intsights-get-alert-takedown-status commands

### DIFF
--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
-Fix intsights-get-alert-image and intsights-get-alert-takedown-status commands
+Improved implementation of the following commands.
+  - ***intsights-get-alert-image***
+  - ***intsights-get-alert-takedown-status commands***
 
 ## [19.9.1] - 2019-09-18
 Improved the error message in cases where the URL address is incorrect.

--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 Improved implementation of the following commands.
   - ***intsights-get-alert-image***
-  - ***intsights-get-alert-takedown-status commands***
+  - ***intsights-get-alert-takedown-status***
 
 ## [19.9.1] - 2019-09-18
 Improved the error message in cases where the URL address is incorrect.

--- a/Integrations/IntSight/CHANGELOG.md
+++ b/Integrations/IntSight/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fix intsights-get-alert-image and intsights-get-alert-takedown-status commands
 
 ## [19.9.1] - 2019-09-18
 Improved the error message in cases where the URL address is incorrect.

--- a/Integrations/IntSight/IntSight.py
+++ b/Integrations/IntSight/IntSight.py
@@ -69,7 +69,7 @@ def req(method, path, json_data=None, params=None, json_response=False):
         except ValueError:
             return_error('Error in API call to IntSights service - check your configured URL address')
 
-    return r.text
+    return r
 
 
 def convert_iso_string_to_python_date(date_in_iso_format):


### PR DESCRIPTION
## Status
Ready

## Description
Updating req function to return the response instead of response text.
fixes: https://github.com/demisto/etc/issues/19507

## Screenshots
![image](https://user-images.githubusercontent.com/46249224/66043697-8687a580-e528-11e9-9b19-7a696dc4a9f5.png)


## Related PRs
https://github.com/demisto/content/pull/4278
