### PR TITLE
Fix panorama-check-logs-status command to support GenericPolling

### DIFF
--- a/Integrations/Panorama/CHANGELOG.md
+++ b/Integrations/Panorama/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+Fixed ***panorama-check-logs-status*** to work with **GenericPolling** playbook.
 
 
 ## [19.9.1] - 2019-09-18

--- a/Integrations/Panorama/Panorama.py
+++ b/Integrations/Panorama/Panorama.py
@@ -3433,7 +3433,8 @@ def panorama_get_traffic_logs(job_id):
     return result
 
 
-def check_traffic_logs_status(job_id):
+def panorama_check_traffic_logs_status_command():
+    job_id = demisto.args().get('job_id')
     result = panorama_get_traffic_logs(job_id)
 
     if result['response']['@status'] == 'error':
@@ -3463,12 +3464,6 @@ def check_traffic_logs_status(job_id):
                                          removeNull=True),
         'EntryContext': {"Panorama.TrafficLogs(val.JobID == obj.JobID)": query_traffic_status_output}
     })
-
-
-def panorama_check_traffic_logs_status_batch_command():
-    job_ids = argToList(demisto.args().get('job_id'))
-    for job_id in job_ids:
-        check_traffic_logs_status(job_id)
 
 
 def prettify_traffic_logs(traffic_logs):
@@ -3721,11 +3716,16 @@ def panorama_query_logs_command():
     })
 
 
-def panorama_check_logs_status_command():
+def panorama_check_logs_status_batch_command():
+    job_ids = argToList(demisto.args().get('job_id'))
+    for job_id in job_ids:
+        panorama_check_logs_status(job_id)
+
+
+def panorama_check_logs_status(job_id):
     """
     Check query logs status
     """
-    job_id = demisto.args().get('job_id')
     result = panorama_get_traffic_logs(job_id)
 
     if result['response']['@status'] == 'error':
@@ -4078,7 +4078,7 @@ def main():
             panorama_query_traffic_logs_command()
 
         elif demisto.command() == 'panorama-check-traffic-logs-status':
-            panorama_check_traffic_logs_status_batch_command()
+            panorama_check_traffic_logs_status_command()
 
         elif demisto.command() == 'panorama-get-traffic-logs':
             panorama_get_traffic_logs_command()
@@ -4088,7 +4088,7 @@ def main():
             panorama_query_logs_command()
 
         elif demisto.command() == 'panorama-check-logs-status':
-            panorama_check_logs_status_command()
+            panorama_check_logs_status_batch_command()
 
         elif demisto.command() == 'panorama-get-logs':
             panorama_get_logs_command()

--- a/Integrations/Panorama/Panorama.py
+++ b/Integrations/Panorama/Panorama.py
@@ -3433,8 +3433,7 @@ def panorama_get_traffic_logs(job_id):
     return result
 
 
-def panorama_check_traffic_logs_status_command():
-    job_id = demisto.args().get('job_id')
+def check_traffic_logs_status(job_id):
     result = panorama_get_traffic_logs(job_id)
 
     if result['response']['@status'] == 'error':
@@ -3464,6 +3463,12 @@ def panorama_check_traffic_logs_status_command():
                                          removeNull=True),
         'EntryContext': {"Panorama.TrafficLogs(val.JobID == obj.JobID)": query_traffic_status_output}
     })
+
+
+def panorama_check_traffic_logs_status_batch_command():
+    job_ids = argToList(demisto.args().get('job_id'))
+    for job_id in job_ids:
+        check_traffic_logs_status(job_id)
 
 
 def prettify_traffic_logs(traffic_logs):
@@ -4073,7 +4078,7 @@ def main():
             panorama_query_traffic_logs_command()
 
         elif demisto.command() == 'panorama-check-traffic-logs-status':
-            panorama_check_traffic_logs_status_command()
+            panorama_check_traffic_logs_status_batch_command()
 
         elif demisto.command() == 'panorama-get-traffic-logs':
             panorama_get_traffic_logs_command()


### PR DESCRIPTION
## Status
In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/18773

## Description
Fix panorama-check-logs-status command to support GenericPolling by setting it to receive lists

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)