### PR TITLE
HTMLDocumenation commands fix

### DIFF
--- a/Scripts/HTMLDocsAutomation/CHANGELOG.md
+++ b/Scripts/HTMLDocsAutomation/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-
+- Fixed an issue where commands in the top part were in the format **name:name** instead of **description:name**.
+- Added links for the list of commands to each command.
 
 ## [19.10.0] - 2019-10-03
 Added support for commands that have only headlines and no text in the human readable output.

--- a/Scripts/HTMLDocsAutomation/HTMLDocsAutomation.py
+++ b/Scripts/HTMLDocsAutomation/HTMLDocsAutomation.py
@@ -167,7 +167,7 @@ GENERIC_RECORD: str = '''    <tr>
 def get_yaml_obj(entry_id):
     data = {}  # type: dict
     try:
-        yml_file_path = '../../Integrations/AttackIQFireDrill/AttackIQFireDrill.yml'# demisto.getFilePath(entry_id)['path']
+        yml_file_path = demisto.getFilePath(entry_id)['path']
         with open(yml_file_path, 'r') as yml_file:
             data = yaml.safe_load(yml_file)
         if not isinstance(data, dict):

--- a/Scripts/HTMLDocsAutomation/HTMLDocsAutomation.py
+++ b/Scripts/HTMLDocsAutomation/HTMLDocsAutomation.py
@@ -48,7 +48,7 @@ PERMISSIONS_HEADER: str = '''<h2>Permissions</h2>
     <li>permission 2</li>
 </ul>'''
 
-COMMAND_LIST: str = '  <li>{command_hr}: {command}</li>'
+COMMAND_LIST: str = '  <li><a href="#{command}" target="_self">{command_hr}: {command}</a></li>'
 
 PERMISSIONS_PER_COMMAND: str = '''
 <h5>Required Permissions</h5>
@@ -58,7 +58,7 @@ PERMISSIONS_PER_COMMAND: str = '''
     <li>permission 2</li>
 </ul>'''
 
-SINGLE_COMMAND: str = '''<h3>{index}. {command_hr}</h3>
+SINGLE_COMMAND: str = '''<h3 id="{command_hr}">{index}. {command_hr}</h3>
 <hr>
 <p>{command_description}</p>
 <h5>Base Command</h5>
@@ -167,7 +167,7 @@ GENERIC_RECORD: str = '''    <tr>
 def get_yaml_obj(entry_id):
     data = {}  # type: dict
     try:
-        yml_file_path = demisto.getFilePath(entry_id)['path']
+        yml_file_path = '../../Integrations/AttackIQFireDrill/AttackIQFireDrill.yml'# demisto.getFilePath(entry_id)['path']
         with open(yml_file_path, 'r') as yml_file:
             data = yaml.safe_load(yml_file)
         if not isinstance(data, dict):
@@ -369,7 +369,8 @@ def generate_commands_section(yaml_data, example_dict, should_include_permission
     command_sections: list = []
 
     commands = [cmd for cmd in yaml_data['script']['commands'] if not cmd.get('deprecated')]
-    command_list = [COMMAND_LIST.format(command_hr=cmd['name'], command=cmd['name']) for cmd in commands]
+    command_list = [COMMAND_LIST.format(command_hr=cmd['description'].rstrip('.'), command=cmd['name'])
+                    for cmd in commands]
 
     for i, cmd in enumerate(commands):
         cmd_section, cmd_errors = generate_single_command_section(i + 1, cmd, example_dict, should_include_permissions)
@@ -503,7 +504,7 @@ def generate_html_docs(args, yml_data, example_dict, errors):
 
 def main():
     args: dict = demisto.args()
-    yml_data: dict = get_yaml_obj(args['entryID'])
+    yml_data: dict = get_yaml_obj(args.get('entryID'))
     command_examples, errors = get_command_examples(args.get('commands'))
     example_dict, build_errors = build_example_dict(command_examples)
     errors.extend(build_errors)

--- a/Scripts/HTMLDocsAutomation/HTMLDocsAutomation_test.py
+++ b/Scripts/HTMLDocsAutomation/HTMLDocsAutomation_test.py
@@ -90,10 +90,13 @@ def test_generate_commands_section():
         'script': {
             'commands': [
                 {'deprecated': True,
-                 'name': 'deprecated-cmd'},
+                 'name': 'deprecated-cmd',
+                 'description': 'desc'},
                 {'deprecated': False,
-                 'name': 'non-deprecated-cmd'},
-                {'name': 'non-deprecated-cmd2'}
+                 'name': 'non-deprecated-cmd',
+                 'description': 'desc1'},
+                {'name': 'non-deprecated-cmd2',
+                 'description': 'desc2.'}
             ]
         }
     }
@@ -106,12 +109,12 @@ def test_generate_commands_section():
   After you successfully execute a command, a DBot message appears in the War Room with the command details.
 </p>
 <ol>
-  <li>non-deprecated-cmd: non-deprecated-cmd</li>
-  <li>non-deprecated-cmd2: non-deprecated-cmd2</li>
+  <li><a href="#non-deprecated-cmd" target="_self">desc1: non-deprecated-cmd</a></li>
+  <li><a href="#non-deprecated-cmd2" target="_self">desc2: non-deprecated-cmd2</a></li>
 </ol>
-<h3>1. non-deprecated-cmd</h3>
+<h3 id="non-deprecated-cmd">1. non-deprecated-cmd</h3>
 <hr>
-<p> </p>
+<p>desc1</p>
 <h5>Base Command</h5>
 <p>
   <code>non-deprecated-cmd</code>
@@ -144,9 +147,9 @@ There are no context output for this command.
  -->
 </p>
 
-<h3>2. non-deprecated-cmd2</h3>
+<h3 id="non-deprecated-cmd2">2. non-deprecated-cmd2</h3>
 <hr>
-<p> </p>
+<p>desc2.</p>
 <h5>Base Command</h5>
 <p>
   <code>non-deprecated-cmd2</code>


### PR DESCRIPTION
## Status
Ready

## Description
1. There was an issue where in the commands part it was command_name:command_name instead of description: name(i.e. List all assets: attackiq-list-assets)
2. i added a link to the part of the page where the command is detailed.
## Screenshots
![image](https://user-images.githubusercontent.com/50324325/66300643-51030380-e8fe-11e9-814b-7a16469c0773.png)

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)