### PR TITLE
Mail Sender new: ignore fqdn name which is empty or contains only whitespace

### DIFF
--- a/Integrations/MailSenderNew/CHANGELOG.md
+++ b/Integrations/MailSenderNew/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fix to ignore FQDN configuration parameter if empty or contains only white spaces.
 
 ## [19.9.0] - 2019-09-04
 Improved debug failure logging when testing the integration instance configuration.

--- a/Integrations/MailSenderNew/CHANGELOG.md
+++ b/Integrations/MailSenderNew/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fix to ignore FQDN configuration parameter if empty or contains only white spaces.
+The integration ignores the FQDN configuration parameter if it is empty or contains only white spaces.
 
 ## [19.9.0] - 2019-09-04
 Improved debug failure logging when testing the integration instance configuration.

--- a/Integrations/MailSenderNew/MailSenderNew.py
+++ b/Integrations/MailSenderNew/MailSenderNew.py
@@ -305,6 +305,7 @@ def main():
     global SERVER
     FROM = demisto.getParam('from')
     FQDN = demisto.params().get('fqdn')
+    FQDN = (FQDN and FQDN.strip()) or None
     stderr_org = smtplib.stderr  # type: ignore
     try:
         if demisto.command() == 'test-module':

--- a/Integrations/MailSenderNew/MailSenderNew.yml
+++ b/Integrations/MailSenderNew/MailSenderNew.yml
@@ -36,7 +36,7 @@ configuration:
   defaultvalue: "false"
   type: 8
   required: false
-- display: Do not validate server certificate (insecure)
+- display: Trust any certificate (not secure)
   name: insecure
   defaultvalue: "false"
   type: 8


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
Related: https://github.com/demisto/etc/issues/18994

## Description
An empty or blank fqdn can cause issues with some smtp servers. fix ignore an empty or blank configuration.

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/mail-sender-blank-fqdn/Integrations/MailSenderNew/CHANGELOG.md)