### PR TITLE
ServiceNow - added validation to fetch_time parameter

### DIFF
--- a/Integrations/ServiceNow/CHANGELOG.md
+++ b/Integrations/ServiceNow/CHANGELOG.md
@@ -1,1 +1,5 @@
-Fixed an issue with the **servicenow-upload-file*** command when the uploaded file is an info file.
+## [Unreleased]
+  -
+
+## [19.10.0] - 2019-10-03
+  - Fixed an issue with the **servicenow-upload-file*** command when the uploaded file is an info file.

--- a/Integrations/ServiceNow/ServiceNow.py
+++ b/Integrations/ServiceNow/ServiceNow.py
@@ -1465,6 +1465,9 @@ def fetch_incidents():
 
 
 def test_module():
+    # Validate fetch_time parameter is valid (if not, parse_date_range will raise the error message)
+    parse_date_range(FETCH_TIME, '%Y-%m-%d %H:%M:%S')
+
     path = 'table/' + TICKET_TYPE + '?sysparm_limit=1'
     res = send_request(path, 'GET')
     if 'result' not in res:

--- a/Integrations/ServiceNow/ServiceNow.yml
+++ b/Integrations/ServiceNow/ServiceNow.yml
@@ -11,13 +11,13 @@ configuration:
   name: credentials
   required: false
   type: 9
-- defaultvalue: 'True'
+- defaultvalue: ''
   display: Use system proxy settings
   name: proxy
   required: false
   type: 8
 - defaultvalue: 'false'
-  display: Trust any certificate (unsecure)
+  display: Trust any certificate (not secure)
   name: insecure
   required: false
   type: 8


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: [https://github.com/demisto/etc/issues/19083](https://github.com/demisto/etc/issues/19083)

## Description
Added a test for fetch_time in test-module command

## Screenshots
![image](https://user-images.githubusercontent.com/38749041/66581096-2deb8480-eb88-11e9-8314-968ba2da36d3.png)

## Does it break backward compatibility?
   - No

## Additional changes
- Set the default value of proxy parameter to ''
- Fixed CHANGELOG format

## Technical writer review
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/ServiceNow_Bug/Integrations/ServiceNow/CHANGELOG.md)