### PR TITLE
fix zscaler-undo-blacklist naming bug

### DIFF
--- a/Integrations/integration-Zscaler.yml
+++ b/Integrations/integration-Zscaler.yml
@@ -198,7 +198,7 @@ script:
         blacklist_urls = url.split(',')
         cmd_url = '/security/advanced/blacklist_urls?action=REMOVE_FROM_LIST'
         # Check if given URLs is blacklisted
-        blacklist_urls = get_blacklist()['blacklist_urls']
+        blacklist_urls = get_blacklist()['blacklistUrls']
         if len(blacklist_urls) == 1:  # Given only one URL to blacklist
             if blacklist_urls[0] not in blacklist_urls:
                 raise Exception('Given URL is not blacklisted')


### PR DESCRIPTION
## Status
Ready

## Description
Undo blacklist entries not fails due to wrong dict key name.

## Screenshots
![image](https://user-images.githubusercontent.com/1359917/66649027-5d080180-ec2d-11e9-980f-3647a4d9cdb3.png)

## Required version of Demisto
5.0.0

## Does it break backward compatibility?
   - No

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)