### PR TITLE
cant skip test by instance so removing it completely. will be restore…

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -743,12 +743,6 @@
             "timeout": 500
         },
         {
-            "integrations": "McAfee ESM-v10",
-            "instance_names": "v11.1.3",
-            "playbookID": "McAfeeESMTest",
-            "timeout": 720
-        },
-        {
             "integrations": "GoogleSafeBrowsing",
             "playbookID": "Google Safe Browsing Test",
             "timeout": 240


### PR DESCRIPTION
… after instance maintenance

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
removing McAfee ESM test for version 11.1 until instance issues will be resolved.
https://github.com/demisto/etc/issues/19549

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review
