### PR TITLE
Add prismacloud playbook SG allows all traffic (#4471)

### DIFF
--- a/Playbooks/playbook-Prisma_Cloud_Remediation_-_AWS_Security_Groups_Allows_Internet_Traffic_To_TCP_Port.yml
+++ b/Playbooks/playbook-Prisma_Cloud_Remediation_-_AWS_Security_Groups_Allows_Internet_Traffic_To_TCP_Port.yml
@@ -1,0 +1,642 @@
+id: Prisma Cloud Remediation - AWS Security Groups Allows Internet Traffic To TCP
+version: -1
+name: Prisma Cloud Remediation - AWS Security Groups Allows Internet Traffic To TCP
+  Port
+description: "This playbook extracts the TCP public Security Groups rule and provides
+  manual/automatic options to have the rules revoked."
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 71d4aa73-20de-444e-8e36-37a1f01e8507
+    type: start
+    task:
+      id: 71d4aa73-20de-444e-8e36-37a1f01e8507
+      version: -1
+      name: ""
+      description: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 340
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: 1e14b68c-206f-4925-8be3-5614db1dbc1d
+    type: regular
+    task:
+      id: 1e14b68c-206f-4925-8be3-5614db1dbc1d
+      version: -1
+      name: Get TCP public Security Group rules from incident data
+      description: Get the TCP public security group rule which is recommended to
+        be removed/revoked. As EC2 integration is not fully setup, this task relies
+        on the incident data to provide the IpPermissions of the Security Group.
+      scriptName: AwsEC2GetPublicSGRules
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "12"
+    scriptarguments:
+      fromPort:
+        complex:
+          root: incident
+          accessor: labels.policy
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: name
+          - operator: RegexGroups
+            args:
+              groups:
+                value:
+                  simple: "0"
+              keys: {}
+              regex:
+                value:
+                  simple: \((\d+)\)\s?$
+      groupId:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: id
+      includeIPv6: {}
+      ipPermissions:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: data
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: ipPermissions
+      protocol:
+        simple: tcp
+      region:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: regionId
+      toPort:
+        complex:
+          root: incident
+          accessor: labels.policy
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: name
+          - operator: RegexGroups
+            args:
+              groups:
+                value:
+                  simple: "0"
+              keys: {}
+              regex:
+                value:
+                  simple: \((\d+)\)\s?$
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: 940ce5be-bfa7-4d57-8dd2-3ea599939d63
+    type: condition
+    task:
+      id: 940ce5be-bfa7-4d57-8dd2-3ea599939d63
+      version: -1
+      name: Run command to automatically revoke public Security Group rules?
+      description: Ask the analyst whether or not the public security group rules should be automatically revoked
+        using a command.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "12"
+      "YES":
+      - "19"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 1250
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    message:
+      to: null
+      subject: null
+      body:
+        simple: Run command to revoke public Security Group rules?
+      methods: []
+      format: ""
+      bcc: null
+      cc: null
+      timings:
+        retriescount: 2
+        retriesinterval: 360
+        completeafterreplies: 1
+      replyOptions:
+      - "YES"
+      - "NO"
+  "8":
+    id: "8"
+    taskid: 0686f462-5117-4462-879f-ad026bf49b94
+    type: condition
+    task:
+      id: 0686f462-5117-4462-879f-ad026bf49b94
+      version: -1
+      name: Is AWS - EC2 enabled?
+      description: Check to see if the EC2 integration is enabled. If EC2 integration
+        is not configured, automation cannot be performed.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "1"
+      "yes":
+      - "14"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: StringContainsArray
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: AWS - EC2
+                accessor: brand
+            iscontext: true
+          right:
+            value:
+              simple: AWS - EC2
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "10":
+    id: "10"
+    taskid: 02956e95-5454-4c2d-80b3-dbc064976db6
+    type: regular
+    task:
+      id: 02956e95-5454-4c2d-80b3-dbc064976db6
+      version: -1
+      name: Revoke public TCP ingress rules
+      description: Revoke TCP public security group rules
+      script: AWS - EC2|||aws-ec2-revoke-security-group-ingress-rule
+      type: regular
+      iscommand: true
+      brand: AWS - EC2
+    nexttasks:
+      '#none#':
+      - "20"
+    scriptarguments:
+      cidrIp:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.cidrIp}
+      fromPort:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.fromPort}
+      groupId:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.groupId}
+      ipProtocol:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.ipProtocol}
+      region:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.region}
+      roleArn: {}
+      roleSessionDuration: {}
+      roleSessionName: {}
+      sourceSecurityGroupName: {}
+      toPort:
+        simple: ${AWS.EC2.SecurityGroup.PublicRules.toPort}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 500,
+          "y": 1700
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "12":
+    id: "12"
+    taskid: 945e7ff2-80b9-4e1d-8d0f-9efb035b806c
+    type: regular
+    task:
+      id: 945e7ff2-80b9-4e1d-8d0f-9efb035b806c
+      version: -1
+      name: Manually remove public TCP ingress rules
+      description: Manually inspect and remove public ingress rules.
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "20"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1430
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "14":
+    id: "14"
+    taskid: 3d6f253d-bc63-4355-89a2-faf3e88ec2d9
+    type: regular
+    task:
+      id: 3d6f253d-bc63-4355-89a2-faf3e88ec2d9
+      version: -1
+      name: Get the latest Security Group IP permissions
+      description: 'Obtain the latest/current ipPermission to make sure that the automation
+        uses the latest ipPermissions. '
+      script: AWS - EC2|||aws-ec2-describe-security-groups
+      type: regular
+      iscommand: true
+      brand: AWS - EC2
+    nexttasks:
+      '#none#':
+      - "15"
+    scriptarguments:
+      filters: {}
+      groupIds:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: id
+      groupNames: {}
+      region:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: regionId
+      roleArn: {}
+      roleSessionDuration: {}
+      roleSessionName: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 490,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "15":
+    id: "15"
+    taskid: 08e30ab7-fc75-4a78-80e0-44cd5114cb91
+    type: regular
+    task:
+      id: 08e30ab7-fc75-4a78-80e0-44cd5114cb91
+      version: -1
+      name: Get TCP public Security Group Rules
+      description: Get TCP public security group rule which is recommended to
+        be removed/revoked
+      scriptName: AwsEC2GetPublicSGRules
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "22"
+    scriptarguments:
+      fromPort:
+        complex:
+          root: incident
+          accessor: labels.policy
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: name
+          - operator: RegexGroups
+            args:
+              groups:
+                value:
+                  simple: "0"
+              keys: {}
+              regex:
+                value:
+                  simple: \((\d+)\)\s?$
+      groupId:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: id
+      includeIPv6: {}
+      ipPermissions:
+        complex:
+          root: AWS
+          accessor: EC2.SecurityGroups.IpPermissions
+      protocol:
+        simple: tcp
+      region:
+        complex:
+          root: incident
+          accessor: labels.resource
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: regionId
+      toPort:
+        complex:
+          root: incident
+          accessor: labels.policy
+          transformers:
+          - operator: ParseJSON
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: name
+          - operator: RegexGroups
+            args:
+              groups:
+                value:
+                  simple: "0"
+              keys: {}
+              regex:
+                value:
+                  simple: \((\d+)\)\s?$
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 490,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "19":
+    id: "19"
+    taskid: f0353b92-bfa5-4bfb-8774-8005101f8542
+    type: condition
+    task:
+      id: f0353b92-bfa5-4bfb-8774-8005101f8542
+      version: -1
+      name: Are there any public rules?
+      description: Ensure that there is at least one public Security Group rule to
+        be revoked
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "20"
+      "yes":
+      - "10"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              complex:
+                root: AWS
+                accessor: EC2.SecurityGroup.PublicRules
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 500,
+          "y": 1430
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "20":
+    id: "20"
+    taskid: 990fecaa-6d51-472c-844b-c2a252387f89
+    type: regular
+    task:
+      id: 990fecaa-6d51-472c-844b-c2a252387f89
+      version: -1
+      name: Close investigation
+      description: commands.local.cmd.close.inv
+      script: Builtin|||closeInvestigation
+      type: regular
+      iscommand: true
+      brand: Builtin
+    nexttasks:
+      '#none#':
+      - "21"
+    scriptarguments:
+      assetid: {}
+      closeNotes: {}
+      closeReason: {}
+      id:
+        complex:
+          root: incident
+          accessor: id
+      mndadone: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 1870
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "21":
+    id: "21"
+    taskid: ebb9e96f-2401-4c4e-8567-c134b01e2438
+    type: title
+    task:
+      id: ebb9e96f-2401-4c4e-8567-c134b01e2438
+      version: -1
+      name: Done
+      description: ""
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 2050
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "22":
+    id: "22"
+    taskid: 4a844aab-0fd5-4ef0-8af9-4a1ea5c34958
+    type: condition
+    task:
+      id: 4a844aab-0fd5-4ef0-8af9-4a1ea5c34958
+      version: -1
+      name: Auto removal of public Security Group rules?
+      description: Allow automatic revocation of public security group rules based
+        on the playbook's input
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "3"
+      "yes":
+      - "19"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              complex:
+                root: inputs.AutoRevokeRule
+                transformers:
+                - operator: toLowerCase
+            iscontext: true
+          right:
+            value:
+              simple: "yes"
+    view: |-
+      {
+        "position": {
+          "x": 490,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {
+      "22_19_yes": 0.52,
+      "22_3_#default#": 0.59,
+      "3_12_#default#": 0.5,
+      "3_19_YES": 0.58
+    },
+    "paper": {
+      "dimensions": {
+        "height": 1775,
+        "width": 830,
+        "x": 50,
+        "y": 340
+      }
+    }
+  }
+inputs:
+- key: AutoRevokeRule
+  value:
+    simple: "no"
+  required: true
+  description: "If set to:\n- yes: public security group rules will be automatically
+    revoked\n- no: analyst will be prompted whether or not to allow automatic removal of
+    the rules. "
+outputs: []
+tests:
+  - No test
+fromversion: 5.0.0

--- a/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules.py
+++ b/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules.py
@@ -1,0 +1,130 @@
+import demistomock as demisto
+from CommonServerPython import *
+from CommonServerUserPython import *
+import json
+import copy
+
+
+def get_dict_value(data, key):
+    """ Returns dict value for a given key (case insensitive) """
+    for key_name in data.keys():
+        if key_name.lower() == key.lower():
+            return data[key_name]
+
+    return None
+
+
+def get_ec2_sg_public_rules(group_id, ip_permissions, checked_protocol=None, checked_from_port=None,
+                            checked_to_port=None, region=None, include_ipv6='no'):
+    """
+        Get the list of public
+        which can be passed on to the following command:
+        aws-ec2-revoke-security-group-ingress-rule
+    """
+    public_rules = []
+    for rule in ip_permissions:
+        # Check protocol
+        protocol = get_dict_value(rule, 'IpProtocol')
+        if protocol != '-1':
+            if checked_protocol.lower() != protocol.lower():
+                continue
+
+        bad_rule = {
+            'groupId': group_id,
+            'ipProtocol': protocol
+        }
+
+        if region:
+            bad_rule.update(region=region)
+
+        # Check the ports
+        from_port = get_dict_value(rule, 'FromPort')
+        to_port = get_dict_value(rule, 'ToPort')
+        if from_port and to_port:
+            if from_port < checked_from_port and to_port < checked_from_port:
+                continue
+            elif from_port > checked_to_port and to_port > checked_to_port:
+                continue
+
+            bad_rule.update({
+                'fromPort': from_port,
+                'toPort': to_port
+            })
+
+        # Process IPV4
+        ip_ranges = get_dict_value(rule, 'ipv4Ranges')
+        if not ip_ranges:
+            ip_ranges = get_dict_value(rule, 'IpRanges')
+
+        if ip_ranges:
+            for ip_range in ip_ranges:
+                cidr_ip = get_dict_value(ip_range, 'CidrIp')
+                if cidr_ip == '0.0.0.0/0':
+                    tmp = copy.copy(bad_rule)
+                    tmp['cidrIp'] = '0.0.0.0/0'
+                    public_rules.append(tmp)
+
+        # Process IPv6
+        if include_ipv6 == 'yes':
+            ip_ranges = get_dict_value(rule, 'Ipv6Ranges')
+            if ip_ranges:
+                for ip_range in ip_ranges:
+                    cidr_ip = get_dict_value(ip_range, 'CidrIpv6')
+                    if cidr_ip == '::/0':
+                        tmp = copy.copy(bad_rule)
+                        tmp['cidrIp'] = '::/0'
+                        public_rules.append(tmp)
+
+    return public_rules
+
+
+def main(args):
+    ip_perms = args.get('ipPermissions')
+
+    if isinstance(ip_perms, str):
+        try:
+            ip_perms = json.loads(ip_perms)
+        except json.JSONDecodeError:
+            return_error('Unable to parse ipPermissions. Invalid JSON string.')
+
+    # If checked from_port or to_port is not specified
+    # it will default to 0-65535 (all port)
+    if args.get('fromPort'):
+        from_port = int(args.get('fromPort'))
+    else:
+        from_port = 0
+
+    if args.get('toPort'):
+        to_port = int(args.get('toPort'))
+    else:
+        to_port = 65535
+
+    public_rules = get_ec2_sg_public_rules(
+        group_id=args.get('groupId'),
+        ip_permissions=ip_perms,
+        checked_protocol=args.get('protocol'),
+        checked_from_port=from_port,
+        checked_to_port=to_port,
+        region=args.get('region'),
+        include_ipv6=args.get('includeIPv6')
+    )
+
+    readable_output = tableToMarkdown('Public Security Group Rules', public_rules,
+                                      ['groupId', 'ipProtocol', 'fromPort', 'toPort', 'cidrIp', 'region']
+                                      )
+
+    context = {
+        'AWS': {
+            'EC2': {
+                'SecurityGroup': {
+                    'PublicRules': public_rules
+                }
+            }
+        }
+    }
+
+    return_outputs(readable_output, context, raw_response=public_rules)
+
+
+if __name__ in ('builtins', '__builtin__'):
+    main(demisto.args())

--- a/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules.yml
+++ b/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules.yml
@@ -1,0 +1,95 @@
+args:
+- default: false
+  description: Security Group ID (sg-xxxxxxxxx)
+  isArray: false
+  name: groupId
+  required: true
+  secret: false
+- default: false
+  description: JSON string of the ipPermissions. IpPermissions should have one or
+    more rules which are composed of IpProtocol, FromPort, ToPort, or IpRanges. Refer
+    to aws-ec2-describe-security-groups (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html)
+    for example/reference.
+  isArray: true
+  name: ipPermissions
+  required: true
+  secret: false
+- auto: PREDEFINED
+  default: false
+  description: Protocol to check. TCP/UDP/All(-1)
+  isArray: false
+  name: protocol
+  predefined:
+  - tcp
+  - udp
+  - '-1'
+  required: true
+  secret: false
+- default: false
+  description: Lower bound port range to be checked. If fromPort and toPort are not
+    specified, all ports will be included.
+  isArray: false
+  name: fromPort
+  required: false
+  secret: false
+- default: false
+  description: Upper bound port range to be checked. If fromPort and toPort are not
+    specified, all ports will be included.
+  isArray: false
+  name: toPort
+  required: false
+  secret: false
+- default: false
+  description: Security group region
+  isArray: false
+  name: region
+  required: false
+  secret: false
+- auto: PREDEFINED
+  default: true
+  defaultValue: 'no'
+  description: Include IPv6 in the result. By default, IPv6 is not included
+  isArray: false
+  name: includeIPv6
+  predefined:
+  - 'yes'
+  - 'no'
+  required: false
+  secret: false
+comment: Find Security Group rules which allows ::/0 (IPv4) or 0.0.0.0/0.
+commonfields:
+  id: AwsEC2GetPublicSGRules
+  version: -1
+enabled: true
+name: AwsEC2GetPublicSGRules
+outputs:
+- contextPath: AWS.EC2.SecurityGroup.PublicRules
+  description: List public Security Group rules
+  type: Unknown
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.groupId
+  description: Security Group ID
+  type: String
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.ipProtocol
+  description: IP Protocol (TCP/UDP/-1)
+  type: String
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.fromPort
+  description: Security Group rule's lower bound port range
+  type: Number
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.toPort
+  description: Security Group rule's upper bound port range
+  type: Number
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.cidrIp
+  description: Security Group rule's CIDR range
+  type: String
+- contextPath: AWS.EC2.SecurityGroup.PublicRules.region
+  description: Region of the security group
+  type: String
+script: '-'
+system: false
+tags:
+- Amazon Web Services
+timeout: '0'
+type: python
+dockerimage: demisto/python3:3.7.4.977
+runas: DBotWeakRole
+runonce: false

--- a/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules_test.py
+++ b/Scripts/AwsEC2GetPublicSGRules/AwsEC2GetPublicSGRules_test.py
@@ -1,0 +1,51 @@
+from AwsEC2GetPublicSGRules import get_ec2_sg_public_rules
+
+IPPERM = [{"IpProtocol": "-1", "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [],
+           "UserIdGroupPairs": []}, {"FromPort": 10, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [], "ToPort": 22,
+                                     "UserIdGroupPairs": []},
+          {"FromPort": 22, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+           "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [], "ToPort": 23, "UserIdGroupPairs": []},
+          {"FromPort": 55, "IpProtocol": "tcp", "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+           "PrefixListIds": [], "ToPort": 55, "UserIdGroupPairs": []}]
+
+
+def test_get_ec2_sg_public_rules():
+    expected1 = [{"groupId": "sg-12345", "ipProtocol": "tcp", "region": "us-east-1", "fromPort": 10, "toPort": 22,
+                  "cidrIp": "0.0.0.0/0"},
+                 {"groupId": "sg-12345", "ipProtocol": "tcp", "region": "us-east-1", "fromPort": 22, "toPort": 23,
+                  "cidrIp": "0.0.0.0/0"}]
+
+    expected2 = [{"cidrIp": "::/0", "groupId": "sg-12345", "ipProtocol": "-1", "region": "us-east-1"},
+                 {"cidrIp": "0.0.0.0/0", "fromPort": 10, "groupId": "sg-12345", "ipProtocol": "tcp",
+                  "region": "us-east-1", "toPort": 22},
+                 {"cidrIp": "::/0", "fromPort": 10, "groupId": "sg-12345", "ipProtocol": "tcp", "region": "us-east-1",
+                  "toPort": 22}, {"cidrIp": "0.0.0.0/0", "fromPort": 22, "groupId": "sg-12345", "ipProtocol": "tcp",
+                                  "region": "us-east-1", "toPort": 23},
+                 {"cidrIp": "::/0", "fromPort": 22, "groupId": "sg-12345", "ipProtocol": "tcp", "region": "us-east-1",
+                  "toPort": 23}]
+
+    expected3 = []
+
+    expected4 = [{"cidrIp": "::/0", "groupId": "sg-12345", "ipProtocol": "-1", "region": "us-east-1"}]
+
+    result1 = get_ec2_sg_public_rules(group_id='sg-12345', ip_permissions=IPPERM, checked_protocol='tcp',
+                                      checked_from_port=22, checked_to_port=22, region='us-east-1', include_ipv6='no'
+                                      )
+
+    result2 = get_ec2_sg_public_rules(group_id='sg-12345', ip_permissions=IPPERM, checked_protocol='tcp',
+                                      checked_from_port=22, checked_to_port=22, region='us-east-1', include_ipv6='yes'
+                                      )
+
+    result3 = get_ec2_sg_public_rules(group_id='sg-12345', ip_permissions=IPPERM, checked_protocol='udp',
+                                      checked_from_port=55, checked_to_port=60, region='us-east-1', include_ipv6='no'
+                                      )
+
+    result4 = get_ec2_sg_public_rules(group_id='sg-12345', ip_permissions=IPPERM, checked_protocol='udp',
+                                      checked_from_port=55, checked_to_port=60, region='us-east-1', include_ipv6='yes'
+                                      )
+
+    assert expected1 == result1
+    assert expected2 == result2
+    assert expected3 == result3
+    assert expected4 == result4

--- a/TestPlaybooks/playbook-AwsEC2GetPublicSGRules-Test.yml
+++ b/TestPlaybooks/playbook-AwsEC2GetPublicSGRules-Test.yml
@@ -1,0 +1,367 @@
+id: TestAwsEC2GetPublicSGRules-Test
+version: -1
+name: AwsEC2GetPublicSGRules-Test
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: ff1ca85b-aeb0-42a5-8c0e-561f52ac2ff4
+    type: start
+    task:
+      id: ff1ca85b-aeb0-42a5-8c0e-561f52ac2ff4
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: 8d3c4f9c-0f5a-4fb2-835a-9926af5a51c6
+    type: regular
+    task:
+      id: 8d3c4f9c-0f5a-4fb2-835a-9926af5a51c6
+      version: -1
+      name: Set
+      description: Sets a value in Context with the given Context key.
+      scriptName: Set
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      append: {}
+      key:
+        simple: ipPermissions
+      value:
+        simple: |-
+          [{"IpProtocol": "-1", "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [],
+                     "UserIdGroupPairs": []}, {"FromPort": 10, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                                               "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [], "ToPort": 22,
+                                               "UserIdGroupPairs": []},
+                    {"FromPort": 22, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}], "PrefixListIds": [], "ToPort": 23, "UserIdGroupPairs": []},
+                    {"FromPort": 55, "IpProtocol": "tcp", "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+                     "PrefixListIds": [], "ToPort": 55, "UserIdGroupPairs": []}]
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: 8be9f13f-6791-4bec-8700-5b8686674c40
+    type: regular
+    task:
+      id: 8be9f13f-6791-4bec-8700-5b8686674c40
+      version: -1
+      name: AwsEC2GetPublicSGRules
+      description: Find Security Group rules which allow ::/0 (IPv4) or 0.0.0.0/0.
+      scriptName: AwsEC2GetPublicSGRules
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      fromPort:
+        simple: "22"
+      groupId:
+        simple: sg-12345
+      includeIPv6: {}
+      ipPermissions:
+        simple: ${ipPermissions}
+      protocol:
+        simple: tcp
+      region:
+        simple: us-west-2
+      toPort:
+        simple: "22"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: f6308096-df58-45d5-853f-54793bc7248f
+    type: regular
+    task:
+      id: f6308096-df58-45d5-853f-54793bc7248f
+      version: -1
+      name: Delete Context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: a9bb9d31-dbd4-416e-802f-b587d9264de9
+    type: condition
+    task:
+      id: a9bb9d31-dbd4-416e-802f-b587d9264de9
+      version: -1
+      name: Check Result
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "6"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: hasLength
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules
+            iscontext: true
+          right:
+            value:
+              simple: "2"
+      - - operator: containsGeneral
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules.fromPort
+            iscontext: true
+          right:
+            value:
+              simple: "10"
+      - - operator: containsGeneral
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules.fromPort
+            iscontext: true
+          right:
+            value:
+              simple: "22"
+      - - operator: notContainsGeneral
+          left:
+            value:
+              complex:
+                root: AWS
+                accessor: EC2.SecurityGroup.PublicRules.fromPort
+            iscontext: true
+          right:
+            value:
+              simple: "55"
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: 1f425a5e-20f1-4c00-80c8-b8619204cf7c
+    type: title
+    task:
+      id: 1f425a5e-20f1-4c00-80c8-b8619204cf7c
+      version: -1
+      name: Test Completed
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1420
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "6":
+    id: "6"
+    taskid: 0fe0e0fa-a895-4a68-84bb-d7afd4944736
+    type: regular
+    task:
+      id: 0fe0e0fa-a895-4a68-84bb-d7afd4944736
+      version: -1
+      name: Delete Context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+    scriptarguments:
+      all: {}
+      index: {}
+      key:
+        simple: AWS
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "7":
+    id: "7"
+    taskid: 9005e094-4c9d-4299-8e55-4a70ae5c6a65
+    type: regular
+    task:
+      id: 9005e094-4c9d-4299-8e55-4a70ae5c6a65
+      version: -1
+      name: AwsEC2GetPublicSGRules
+      description: Find Security Group rules which allow ::/0 (IPv4) or 0.0.0.0/0.
+      scriptName: AwsEC2GetPublicSGRules
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      fromPort:
+        simple: "55"
+      groupId:
+        simple: sg-12345
+      includeIPv6:
+        simple: "yes"
+      ipPermissions:
+        simple: ${ipPermissions}
+      protocol:
+        simple: udp
+      region: {}
+      toPort:
+        simple: "60"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "8":
+    id: "8"
+    taskid: 134d7ac9-9a89-4324-88b1-7c3105fed802
+    type: condition
+    task:
+      id: 134d7ac9-9a89-4324-88b1-7c3105fed802
+      version: -1
+      name: Check Result
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "5"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: hasLength
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules
+            iscontext: true
+          right:
+            value:
+              simple: "1"
+      - - operator: containsGeneral
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules.ipProtocol
+            iscontext: true
+          right:
+            value:
+              simple: "-1"
+      - - operator: isNotExists
+          left:
+            value:
+              simple: AWS.EC2.SecurityGroup.PublicRules.fromPort
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1435,
+        "width": 380,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -90,6 +90,9 @@
             "playbookID": "SMB test"
         },
         {
+            "playbookID": "TestAwsEC2GetPublicSGRules-Test"
+        },
+        {
             "playbookID": "TestParseEmailHeaders"
         },
         {

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -287,6 +287,7 @@
       "pylint.readthedocs.io",
       "mypy.readthedocs.io",
       "i.ytimg.com",
+      "docs.aws.amazon.com",
       "http://docs.aws.amazon.com",
       "www.youtube.com",
       "cdn.zerofox.com",


### PR DESCRIPTION
* Add script AwsEC2GetPublicSGRules

* code cleanup

* fix type assignment

* set array to true for ipPermissions

* add test and change output to use return_output

* add test playbook TestAwsEC2GetPublicSGRules

* add playbook Prisma Cloud Remediation - AWS Security Groups Allows Internet Traffic To TCP

* 10/30/2019 changes:
- remove CHANGELOG.md,
- use return_error
- update script and test playbook ID

* changed playbook id to match playbook name

* add docs.aws.amazon.com to whitelist

* Updated texts

Updated description texts.

* Updated texts

Updated description texts.

* Updated texts

Updated description texts.