### PR TITLE
Update script-MatchRegex.yml

### DIFF
--- a/Scripts/script-MatchRegex.yml
+++ b/Scripts/script-MatchRegex.yml
@@ -61,3 +61,4 @@ outputs:
   description: List of Regex matches
   type: string
 scripttarget: 0
+dockerimage: demisto/python3:latest


### PR DESCRIPTION
Specified the docker container to utilize python3 due to python2.7 (default container) not support ASCII text (Ex: Ïº).

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold(Reason for hold)
Ready

## Related Issues
fixes: Issue with RegexGroups not supporting ASCII characters due to Python 2.7.

## Description
Python 2.7 does not support ASCII characters as a string input into the regex matches demisto function. 