### PR TITLE
Spearmin10 panorama edit/create custom url category issue on panos 9 base

### DIFF
--- a/Integrations/Panorama/Panorama.py
+++ b/Integrations/Panorama/Panorama.py
@@ -1802,11 +1802,15 @@ def panorama_get_custom_url_category_command():
 
 @logger
 def panorama_create_custom_url_category(custom_url_category_name: str, sites, description: str = None):
+    if PANOS_VER == 8:
+        element = add_argument(description, 'description', False) + add_argument_list(sites, 'list', True)
+    else:
+        element = add_argument(description, 'description', False) + add_argument_list(sites, 'list', True) + add_argument("URL List", 'type', False)
     params = {
         'action': 'set',
         'type': 'config',
         'xpath': XPATH_OBJECTS + "profiles/custom-url-category/entry[@name='" + custom_url_category_name + "']",
-        'element': add_argument(description, 'description', False) + add_argument_list(sites, 'list', True),
+        'element': element,
         'key': API_KEY
     }
     result = http_request(

--- a/Integrations/Panorama/Panorama.yml
+++ b/Integrations/Panorama/Panorama.yml
@@ -1875,11 +1875,15 @@ script:
 
     @logger
     def panorama_create_custom_url_category(custom_url_category_name: str, sites, description: str = None):
+        if PANOS_VER == 8:
+            element = add_argument(description, 'description', False) + add_argument_list(sites, 'list', True)
+        else:
+            element = add_argument(description, 'description', False) + add_argument_list(sites, 'list', True) + add_argument("URL List", 'type', False)
         params = {
             'action': 'set',
             'type': 'config',
             'xpath': XPATH_OBJECTS + "profiles/custom-url-category/entry[@name='" + custom_url_category_name + "']",
-            'element': add_argument(description, 'description', False) + add_argument_list(sites, 'list', True),
+            'element': element,
             'key': API_KEY
         }
         result = http_request(


### PR DESCRIPTION
Fixed: !panorama-edit-custom-url-category doesn't work with PANOS 9.x
Error message:
With message: ["Demisto_Malicious_URLs -> list 'https://xxxx.com/yyyy' is invalid. custom-url-category entry has to be type specified", 'Demisto_Malicious_URLs -> list is invalid']

## Status
Ready

## Related Issues


## Description
Fixed: !panorama-edit-custom-url-category and !panorama-create-custom-url-category don't work with PANOS 9.x

## Screenshots
![image](https://user-images.githubusercontent.com/54964121/67147789-2720e800-f2d3-11e9-8f6a-3d8a4cd2c246.png)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Integration-BUG--Panorama |

## Required version of Demisto
5.0

## Does it break backward compatibility?
   - Yes

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)