### PR TITLE
Fixed array handling in Splunk notable to incident

### DIFF
--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-Improved handling of the *app context* parameter.
+- Improved handling of the *app context* parameter.
+- Fixed handling of arrays when converting notable to incidents.
 
 ## [19.10.1] - 2019-10-15
 - Added the *app* parameter, which is the app context of the namespace.

--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-- Improved handling of the *app context* parameter.
-- Fixed handling of arrays when converting notable to incidents.
+  - Improved handling of the *app context* parameter.
+  - Fixed handling of arrays when converting notable events to incidents.
 
 ## [19.10.1] - 2019-10-15
 - Added the *app* parameter, which is the app context of the namespace.

--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -153,7 +153,7 @@ def notable_to_incident(event):
         rule_title = event['rule_title']
     if demisto.get(event, 'rule_name'):
         rule_name = event['rule_name']
-    incident["name"] = rule_title + ' : ' + rule_name
+    incident["name"] = "{} : {}".format(rule_title, rule_name)
     if demisto.get(event, 'urgency'):
         incident["severity"] = severity_to_level(event['urgency'])
     if demisto.get(event, 'rule_description'):


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19572

## Description
Splunk was producing an error  when the rule name was an array.
This case in now handled correctly.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review