### PR TITLE
New playbooks - Retrieve file by hash & generic

### DIFF
--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
@@ -14,6 +14,7 @@ tasks:
       id: cfa6c853-3dae-449f-810e-8a0303dda6b0
       version: -1
       name: ""
+      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -38,6 +39,7 @@ tasks:
       id: a23dc210-7967-4632-81a5-ca345c80f56b
       version: -1
       name: Is Cylance Protect v2 enabled?
+      description: ""
       type: condition
       iscommand: false
       brand: ""
@@ -92,6 +94,7 @@ tasks:
       id: d346aafe-2acb-49f6-81ae-dc461600d941
       version: -1
       name: Done
+      description: ""
       type: title
       iscommand: false
       brand: ""
@@ -114,6 +117,7 @@ tasks:
       id: d3cb43ee-f52d-4112-8a87-4202337b4d29
       version: -1
       name: Is there a file to download?
+      description: ""
       type: condition
       iscommand: false
       brand: ""

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
@@ -2,8 +2,8 @@ id: Get File Sample By Hash - Cylance Protect v2
 version: -1
 fromversion: 4.0.0
 name: Get File Sample By Hash - Cylance Protect v2
-description: This playbook returns a file sample to the war-room given the file'a
-  sha256, using Cylance Protect v2 integration.
+description: This playbook returns a file sample to the war-room given the file's
+  SHA256 hash, using Cylance Protect v2 integration.
 starttaskid: "0"
 tasks:
   "0":
@@ -211,7 +211,7 @@ inputs:
   value: {}
   required: false
   description: |-
-    Specifies wherther the downloaded file will be unnziped. The command default is 'no'.
+    Specifies whether the downloaded file will be unzipped. The command default is 'no'.
     Yes - unzip automatically
     No - will not unzip
 outputs: []

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Cylance_Protect_v2.yml
@@ -1,0 +1,215 @@
+id: Get File Sample By Hash - Cylance Protect v2
+version: -1
+fromversion: 4.0.0
+name: Get File Sample By Hash - Cylance Protect v2
+description: This playbook returns a file sample to the war-room given the file'a
+  sha256, using Cylance Protect v2 integration.
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: cfa6c853-3dae-449f-810e-8a0303dda6b0
+    type: start
+    task:
+      id: cfa6c853-3dae-449f-810e-8a0303dda6b0
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: a23dc210-7967-4632-81a5-ca345c80f56b
+    type: condition
+    task:
+      id: a23dc210-7967-4632-81a5-ca345c80f56b
+      version: -1
+      name: Is Cylance Protect v2 enabled?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "3"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Cylance Protect v2
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+                accessor: brand
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: d346aafe-2acb-49f6-81ae-dc461600d941
+    type: title
+    task:
+      id: d346aafe-2acb-49f6-81ae-dc461600d941
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 710
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: d3cb43ee-f52d-4112-8a87-4202337b4d29
+    type: condition
+    task:
+      id: d3cb43ee-f52d-4112-8a87-4202337b4d29
+      version: -1
+      name: Is there a file to download?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "4"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              complex:
+                root: inputs.SHA256
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 320,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: dfadf1e2-5822-4eb8-8050-a244ba71ee6f
+    type: regular
+    task:
+      id: dfadf1e2-5822-4eb8-8050-a244ba71ee6f
+      version: -1
+      name: Cylance Protect - download threat
+      description: Downloads the threat (file) attached to a specific SHA256 hash.
+      script: Cylance Protect v2|||cylance-protect-download-threat
+      type: regular
+      iscommand: true
+      brand: Cylance Protect v2
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      sha256:
+        complex:
+          root: inputs.SHA256
+      threshold: {}
+      unzip:
+        complex:
+          root: inputs.unzip
+          transformers:
+          - operator: toLowerCase
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 700,
+          "y": 540
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {
+      "1_2_#default#": 0.28,
+      "3_2_#default#": 0.35,
+      "3_4_yes": 0.55
+    },
+    "paper": {
+      "dimensions": {
+        "height": 725,
+        "width": 1030,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: SHA256
+  value:
+    complex:
+      root: File
+      accessor: SHA256
+  required: false
+  description: ""
+- key: unzip
+  value: {}
+  required: false
+  description: |-
+    Specifies wherther the downloaded file will be unnziped. The command default is 'no'.
+    Yes - unzip automatically
+    No - will not unzip
+outputs: []
+tests:
+  - No test

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
@@ -3,7 +3,7 @@ version: -1
 name: Get File Sample By Hash - Generic v2
 fromversion: 4.0.0
 description: |-
-  This playbook returns a file sample correlating from a hash to the war-room using the following sub-playbooks:
+  This playbook returns a file sample correlating to a hash in the war-room using the following sub-playbooks:
   - Get File Sample By Hash - Carbon Black Enterprise Response
   - Get File Sample By Hash - Cylance Protect v2
 starttaskid: "0"
@@ -101,8 +101,8 @@ tasks:
       id: 5989c92e-a48a-4546-8fab-5a879606db38
       version: -1
       name: Get File Sample By Hash - Cylance Protect v2
-      description: This playbook returns a file sample to the war-room given the file'a
-        sha256, using Cylance Protect v2 integration.
+      description: This playbook returns a file sample to the war-room given the file's
+        SHA256 hash, using Cylance Protect v2 integration.
       playbookName: Get File Sample By Hash - Cylance Protect v2
       type: playbook
       iscommand: false

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
@@ -16,6 +16,7 @@ tasks:
       id: 0131a1f1-22f0-489d-8c41-ec4a0e89369d
       version: -1
       name: ""
+      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -77,6 +78,7 @@ tasks:
       id: 905fca17-4fc2-4efb-8db3-322ff915dee8
       version: -1
       name: Done
+      description: ""
       type: title
       iscommand: false
       brand: ""

--- a/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
+++ b/Playbooks/playbook-Get_File_Sample_By_Hash_-_Generic_v2.yml
@@ -1,0 +1,163 @@
+id: Get File Sample By Hash - Generic v2
+version: -1
+name: Get File Sample By Hash - Generic v2
+fromversion: 4.0.0
+description: |-
+  This playbook returns a file sample correlating from a hash to the war-room using the following sub-playbooks:
+  - Get File Sample By Hash - Carbon Black Enterprise Response
+  - Get File Sample By Hash - Cylance Protect v2
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 0131a1f1-22f0-489d-8c41-ec4a0e89369d
+    type: start
+    task:
+      id: 0131a1f1-22f0-489d-8c41-ec4a0e89369d
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+      - "5"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: 1da5490c-6904-40e5-8acf-94035fb926c1
+    type: playbook
+    task:
+      id: 1da5490c-6904-40e5-8acf-94035fb926c1
+      version: -1
+      name: Get File Sample By Hash - Carbon Black Enterprise Response
+      description: Returns to the war-room a file sample correlating to MD5 hashes
+        in the input using Carbon Black Enterprise Response integration
+      playbookName: Get File Sample By Hash - Carbon Black Enterprise Response
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      MD5:
+        complex:
+          root: inputs.MD5
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: 905fca17-4fc2-4efb-8db3-322ff915dee8
+    type: title
+    task:
+      id: 905fca17-4fc2-4efb-8db3-322ff915dee8
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: 5989c92e-a48a-4546-8fab-5a879606db38
+    type: playbook
+    task:
+      id: 5989c92e-a48a-4546-8fab-5a879606db38
+      version: -1
+      name: Get File Sample By Hash - Cylance Protect v2
+      description: This playbook returns a file sample to the war-room given the file'a
+        sha256, using Cylance Protect v2 integration.
+      playbookName: Get File Sample By Hash - Cylance Protect v2
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      SHA256:
+        complex:
+          root: inputs.SHA256
+      unzip: {}
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 385,
+        "width": 810,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: MD5
+  value:
+    complex:
+      root: File
+      accessor: MD5
+  required: false
+  description: Get file sample from MD5 input
+- key: SHA256
+  value:
+    complex:
+      root: File
+      accessor: SHA256
+  required: false
+  description: Get file sample from SHA256 input
+outputs:
+- contextPath: File
+  description: File sample object
+  type: unknown
+tests:
+  - No test

--- a/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
+++ b/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
@@ -16,6 +16,7 @@ tasks:
       id: aafd2bad-97ae-4462-85cb-8ef1cad54fc5
       version: -1
       name: ""
+      description: ""
       iscommand: false
       brand: ""
     nexttasks:
@@ -86,6 +87,7 @@ tasks:
       id: 21df4e3f-565e-48ca-8937-7106ed312e6e
       version: -1
       name: Done
+      description: ""
       type: title
       iscommand: false
       brand: ""

--- a/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
+++ b/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
@@ -1,0 +1,200 @@
+id: Retrieve File from Endpoint - Generic
+version: -1
+name: Retrieve File from Endpoint - Generic
+fromversion: 4.0.0
+description: |-
+  This playbook retrieves a file sample from an endpoint using the following playbooks:
+  - Get File Sample From Path - Generic
+  - Get File Sample By Hash - Generic v2
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: aafd2bad-97ae-4462-85cb-8ef1cad54fc5
+    type: start
+    task:
+      id: aafd2bad-97ae-4462-85cb-8ef1cad54fc5
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+      - "4"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "2":
+    id: "2"
+    taskid: 91b91a1f-227c-433f-8fa0-80fd671e1a1d
+    type: playbook
+    task:
+      id: 91b91a1f-227c-433f-8fa0-80fd671e1a1d
+      version: -1
+      name: Get File Sample From Path - Generic
+      description: |-
+        Returns a file sample to the war-room from a path on an endpoint using one or more integrations
+
+        inputs:
+        * UseD2 - if "True", use Demisto Dissolvable Agent (D2) to return the file (default: False)
+      playbookName: Get File Sample From Path - Generic
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      Hostname:
+        complex:
+          root: inputs.Hostname
+      Path:
+        complex:
+          root: inputs.Path
+      UseD2:
+        complex:
+          root: inputs.UseD2
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "3":
+    id: "3"
+    taskid: 21df4e3f-565e-48ca-8937-7106ed312e6e
+    type: title
+    task:
+      id: 21df4e3f-565e-48ca-8937-7106ed312e6e
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "4":
+    id: "4"
+    taskid: e6fa1361-9097-4532-8d10-e0c53b74aee7
+    type: playbook
+    task:
+      id: e6fa1361-9097-4532-8d10-e0c53b74aee7
+      version: -1
+      name: Get File Sample By Hash - Generic v2
+      description: |-
+        This playbook returns a file sample correlating from a hash to the war-room using the following sub-playbooks:
+        - Get File Sample By Hash - Carbon Black Enterprise Response
+        - Get File Sample By Hash - Cylance Protect v2
+      playbookName: Get File Sample By Hash - Generic v2
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      MD5:
+        complex:
+          root: inputs.MD5
+      SHA256:
+        complex:
+          root: inputs.SHA256
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 385,
+        "width": 810,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs:
+- key: MD5
+  value:
+    complex:
+      root: File
+      accessor: MD5
+      transformers:
+      - operator: uniq
+  required: false
+  description: Get file sample from MD5 input.
+- key: SHA256
+  value:
+    complex:
+      root: File
+      accessor: SHA256
+      transformers:
+      - operator: uniq
+  required: false
+  description: Get file sample from SHA256 input.
+- key: Hostname
+  value:
+    complex:
+      root: Endpoint
+      accessor: Hostname
+      transformers:
+      - operator: uniq
+  required: false
+  description: Hostname of the host the file is located on.
+- key: Path
+  value:
+    complex:
+      root: File
+      accessor: Path
+  required: false
+  description: File path.
+- key: UseD2
+  value:
+    simple: "no"
+  required: false
+  description: |-
+    This value specifies whether there will be use of D2 to retrieve the file.
+    Default is no.
+outputs: []
+tests:
+  - No test

--- a/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
+++ b/Playbooks/playbook-Retrieve_File_from_Endpoint_-_Generic.yml
@@ -111,7 +111,7 @@ tasks:
       version: -1
       name: Get File Sample By Hash - Generic v2
       description: |-
-        This playbook returns a file sample correlating from a hash to the war-room using the following sub-playbooks:
+        This playbook returns a file sample correlating to a hash from the war-room using the following sub-playbooks:
         - Get File Sample By Hash - Carbon Black Enterprise Response
         - Get File Sample By Hash - Cylance Protect v2
       playbookName: Get File Sample By Hash - Generic v2
@@ -182,7 +182,7 @@ inputs:
       transformers:
       - operator: uniq
   required: false
-  description: Hostname of the host the file is located on.
+  description: Hostname of the machine on which the file is located.
 - key: Path
   value:
     complex:
@@ -195,7 +195,7 @@ inputs:
     simple: "no"
   required: false
   description: |-
-    This value specifies whether there will be use of D2 to retrieve the file.
+    Determines whether a D2 agent will be used to retrieve the file.
     Default is no.
 outputs: []
 tests:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19748

## Description
New playbooks: 
1) Get File Sample By Hash - Cylance Protect v2
2) Get File Sample By Hash - Generic v2
3) Retrieve File from Endpoint - Generic

## Required version of Demisto
4.0.0

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review


## Technical writer review
Mention and link to the files that require a technical writer review.
- [x] [YAML file](link)
- [ ] [CHANGELOG](link)