### PR TITLE
Sentinelone v2 fetch fix

### DIFF
--- a/Integrations/SentinelOne-V2/CHANGELOG.md
+++ b/Integrations/SentinelOne-V2/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+  - Fixed an issue in the ***Fetch incidents*** function.
+  - Fixed bug in the ***sentinelone-get-threats*** command.
 
 
 ## [19.10.0] - 2019-10-03

--- a/Integrations/SentinelOne-V2/CHANGELOG.md
+++ b/Integrations/SentinelOne-V2/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue in the ***Fetch incidents*** function.
-  - Fixed bug in the ***sentinelone-get-threats*** command.
+  - Fixed an issue in the ***sentinelone-get-threats*** command.
 
 
 ## [19.10.0] - 2019-10-03

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -11,10 +11,16 @@ from distutils.util import strtobool
 # Disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
-TOKEN, SERVER, FETCH_TIME, BASE_URL = '', '', '', ''
-FETCH_THREAT_RANK, FETCH_LIMIT = 0, 0
-USE_SSL = False
-HEADERS: dict = {}
+''' GLOBALS '''
+
+TOKEN: str
+SERVER: str
+FETCH_TIME: str
+BASE_URL: str
+FETCH_THREAT_RANK: int
+FETCH_LIMIT: int
+USE_SSL: bool
+HEADERS: dict
 
 ''' HELPER FUNCTIONS '''
 

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -18,7 +18,7 @@ SERVER = demisto.params()['url'][:-1] if (demisto.params()['url'] and demisto.pa
     else demisto.params()['url']
 USE_SSL = not demisto.params().get('insecure', False)
 FETCH_TIME = demisto.params().get('fetch_time', '3 days')
-FETCH_THREAT_RANK = int(demisto.params().get('fetch_threshold', 5))
+FETCH_THREAT_RANK = int(demisto.params().get('fetch_threat_rank', 5))
 FETCH_LIMIT = int(demisto.params().get('fetch_limit', 10))
 BASE_URL = SERVER + '/web/api/v2.0/'
 HEADERS = {

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -448,7 +448,7 @@ def get_threats_request(content_hash=None, mitigation_status=None, created_befor
 
     params = {
         'contentHash': content_hash,
-        'mitigationStatus': mitigation_status,
+        'mitigationStatuses': mitigation_status,
         'createdAt__lt': created_before,
         'createdAt__gt': created_after,
         'createdAt__lte': created_until,

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -389,7 +389,12 @@ def get_threats_command():
     # Parse response into context & content entries
     if threats:
         for threat in threats:
-            if not rank or (rank and threat.get('rank') >= rank):
+            threat_rank = threat.get('rank')
+            try:
+                threat_rank = int(threat_rank)
+            except TypeError:
+                threat_rank = 0
+            if not rank or (rank and threat_rank >= rank):
                 contents.append({
                     'ID': threat.get('id'),
                     'Agent Computer Name': threat.get('agentComputerName'),

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -11,21 +11,10 @@ from distutils.util import strtobool
 # Disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
-''' GLOBALS/PARAMS '''
-
-TOKEN = demisto.params().get('token')
-SERVER = demisto.params()['url'][:-1] if (demisto.params()['url'] and demisto.params()['url'].endswith('/')) \
-    else demisto.params()['url']
-USE_SSL = not demisto.params().get('insecure', False)
-FETCH_TIME = demisto.params().get('fetch_time', '3 days')
-FETCH_THREAT_RANK = int(demisto.params().get('fetch_threat_rank', 0))
-FETCH_LIMIT = int(demisto.params().get('fetch_limit', 10))
-BASE_URL = SERVER + '/web/api/v2.0/'
-HEADERS = {
-    'Authorization': 'ApiToken ' + TOKEN,
-    'Content-Type': 'application/json',
-    'Accept': 'application/json'
-}
+TOKEN, SERVER, FETCH_TIME, BASE_URL = '', '', '', ''
+FETCH_THREAT_RANK, FETCH_LIMIT = 0, 0
+USE_SSL = False
+HEADERS: dict = {}
 
 ''' HELPER FUNCTIONS '''
 
@@ -1781,74 +1770,99 @@ def threat_to_incident(threat):
     return incident
 
 
-''' COMMANDS MANAGER / SWITCH PANEL '''
+def main():
+    ''' PARSE INTEGRATION PARAMETERS '''
 
-LOG('command is %s' % (demisto.command()))
+    global TOKEN, SERVER, USE_SSL, FETCH_TIME
+    global FETCH_THREAT_RANK, FETCH_LIMIT, BASE_URL, HEADERS
 
-try:
-    handle_proxy()
-    if demisto.command() == 'test-module':
-        # This is the call made when pressing the integration test button.
-        test_module()
-        demisto.results('ok')
-    elif demisto.command() == 'fetch-incidents':
-        fetch_incidents()
-    elif demisto.command() == 'sentinelone-get-activities':
-        get_activities_command()
-    elif demisto.command() == 'sentinelone-get-threats':
-        get_threats_command()
-    elif demisto.command() == 'sentinelone-mark-as-threat':
-        mark_as_threat_command()
-    elif demisto.command() == 'sentinelone-mitigate-threat':
-        mitigate_threat_command()
-    elif demisto.command() == 'sentinelone-resolve-threat':
-        resolve_threat_command()
-    elif demisto.command() == 'sentinelone-threat-summary':
-        get_threat_summary_command()
-    elif demisto.command() == 'sentinelone-get-hash':
-        get_hash_command()
-    elif demisto.command() == 'sentinelone-get-white-list':
-        get_white_list_command()
-    elif demisto.command() == 'sentinelone-create-white-list-item':
-        create_white_item_command()
-    elif demisto.command() == 'sentinelone-get-sites':
-        get_sites_command()
-    elif demisto.command() == 'sentinelone-get-site':
-        get_site_command()
-    elif demisto.command() == 'sentinelone-reactivate-site':
-        reactivate_site_command()
-    elif demisto.command() == 'sentinelone-list-agents':
-        list_agents_command()
-    elif demisto.command() == 'sentinelone-get-agent':
-        get_agent_command()
-    elif demisto.command() == 'sentinelone-get-groups':
-        get_groups_command()
-    elif demisto.command() == 'sentinelone-move-agent':
-        move_agent_to_group_command()
-    elif demisto.command() == 'sentinelone-delete-group':
-        delete_group()
-    elif demisto.command() == 'sentinelone-agent-processes':
-        get_agent_processes()
-    elif demisto.command() == 'sentinelone-connect-agent':
-        connect_agent_to_network()
-    elif demisto.command() == 'sentinelone-disconnect-agent':
-        disconnect_agent_from_network()
-    elif demisto.command() == 'sentinelone-broadcast-message':
-        broadcast_message()
-    elif demisto.command() == 'sentinelone-get-events':
-        get_events()
-    elif demisto.command() == 'sentinelone-create-query':
-        create_query()
-    elif demisto.command() == 'sentinelone-get-processes':
-        get_processes()
-    elif demisto.command() == 'sentinelone-shutdown-agent':
-        shutdown_agents()
-    elif demisto.command() == 'sentinelone-uninstall-agent':
-        uninstall_agent()
+    TOKEN = demisto.params().get('token')
+    SERVER = demisto.params().get('url')[:-1] if (demisto.params().get('url')
+                                                  and demisto.params().get('url').endswith('/')) \
+        else demisto.params().get('url')
+    USE_SSL = not demisto.params().get('insecure', False)
+    FETCH_TIME = demisto.params().get('fetch_time', '3 days')
+    FETCH_THREAT_RANK = int(demisto.params().get('fetch_threat_rank', 0))
+    FETCH_LIMIT = int(demisto.params().get('fetch_limit', 10))
+    BASE_URL = SERVER + '/web/api/v2.0/'
+    HEADERS = {
+        'Authorization': 'ApiToken ' + TOKEN if TOKEN else 'ApiToken',
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
 
-except Exception as e:
-    if demisto.command() == 'fetch-incidents':
-        LOG(str(e))
-        raise
-    else:
-        return_error(e)
+    ''' COMMANDS MANAGER / SWITCH PANEL '''
+
+    LOG('command is %s' % (demisto.command()))
+
+    try:
+        handle_proxy()
+        if demisto.command() == 'test-module':
+            # This is the call made when pressing the integration test button.
+            test_module()
+            demisto.results('ok')
+        elif demisto.command() == 'fetch-incidents':
+            fetch_incidents()
+        elif demisto.command() == 'sentinelone-get-activities':
+            get_activities_command()
+        elif demisto.command() == 'sentinelone-get-threats':
+            get_threats_command()
+        elif demisto.command() == 'sentinelone-mark-as-threat':
+            mark_as_threat_command()
+        elif demisto.command() == 'sentinelone-mitigate-threat':
+            mitigate_threat_command()
+        elif demisto.command() == 'sentinelone-resolve-threat':
+            resolve_threat_command()
+        elif demisto.command() == 'sentinelone-threat-summary':
+            get_threat_summary_command()
+        elif demisto.command() == 'sentinelone-get-hash':
+            get_hash_command()
+        elif demisto.command() == 'sentinelone-get-white-list':
+            get_white_list_command()
+        elif demisto.command() == 'sentinelone-create-white-list-item':
+            create_white_item_command()
+        elif demisto.command() == 'sentinelone-get-sites':
+            get_sites_command()
+        elif demisto.command() == 'sentinelone-get-site':
+            get_site_command()
+        elif demisto.command() == 'sentinelone-reactivate-site':
+            reactivate_site_command()
+        elif demisto.command() == 'sentinelone-list-agents':
+            list_agents_command()
+        elif demisto.command() == 'sentinelone-get-agent':
+            get_agent_command()
+        elif demisto.command() == 'sentinelone-get-groups':
+            get_groups_command()
+        elif demisto.command() == 'sentinelone-move-agent':
+            move_agent_to_group_command()
+        elif demisto.command() == 'sentinelone-delete-group':
+            delete_group()
+        elif demisto.command() == 'sentinelone-agent-processes':
+            get_agent_processes()
+        elif demisto.command() == 'sentinelone-connect-agent':
+            connect_agent_to_network()
+        elif demisto.command() == 'sentinelone-disconnect-agent':
+            disconnect_agent_from_network()
+        elif demisto.command() == 'sentinelone-broadcast-message':
+            broadcast_message()
+        elif demisto.command() == 'sentinelone-get-events':
+            get_events()
+        elif demisto.command() == 'sentinelone-create-query':
+            create_query()
+        elif demisto.command() == 'sentinelone-get-processes':
+            get_processes()
+        elif demisto.command() == 'sentinelone-shutdown-agent':
+            shutdown_agents()
+        elif demisto.command() == 'sentinelone-uninstall-agent':
+            uninstall_agent()
+
+    except Exception as e:
+        if demisto.command() == 'fetch-incidents':
+            LOG(str(e))
+            raise
+        else:
+            return_error(e)
+
+
+if __name__ in ['__main__', 'builtin', 'builtins']:
+    main()

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -436,7 +436,7 @@ def get_threats_command():
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['json'],
-        'Contents': contents,
+        'Contents': threats,
         'ReadableContentsFormat': formats['markdown'],
         'HumanReadable': tableToMarkdown('Sentinel One - Getting Threat List \n' + 'Provides summary information and '
                                                                                    'details for all the threats that '

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -18,7 +18,7 @@ SERVER = demisto.params()['url'][:-1] if (demisto.params()['url'] and demisto.pa
     else demisto.params()['url']
 USE_SSL = not demisto.params().get('insecure', False)
 FETCH_TIME = demisto.params().get('fetch_time', '3 days')
-FETCH_THREAT_RANK = int(demisto.params().get('fetch_threat_rank', 5))
+FETCH_THREAT_RANK = int(demisto.params().get('fetch_threat_rank', 0))
 FETCH_LIMIT = int(demisto.params().get('fetch_limit', 10))
 BASE_URL = SERVER + '/web/api/v2.0/'
 HEADERS = {

--- a/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -1754,7 +1754,7 @@ def fetch_incidents():
         except TypeError:
             rank = 0
         # If no fetch threat rank is provided, bring everything, else only fetch above the threshold
-        if FETCH_THREAT_RANK and rank >= FETCH_THREAT_RANK:
+        if rank >= FETCH_THREAT_RANK:
             incident = threat_to_incident(threat)
             incident_date = date_to_timestamp(incident['occurred'], '%Y-%m-%dT%H:%M:%S.%fZ')
             # update last run

--- a/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
@@ -45,31 +45,31 @@ INCIDENTS_FOR_FETCH = [
         "previousRoles": None,
         "rawCategory": "",
         "rawCloseReason": "",
-        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
-                   "\"EC2AMAZ-AJ0KANC\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123595\", "
-                   "\"agentInfected\": False, \"agentIp\": \"3.122.240.42\", \"agentIsActive\": True, "
+        "rawJSON": "{\"accountId\": \"412243337337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"EC2AMAZ-AJ0KDDD\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123596\", "
+                   "\"agentInfected\": False, \"agentIp\": \"3.136.231.41\", \"agentIsActive\": True, "
                    "\"agentIsDecommissioned\": False, \"agentMachineType\": \"server\", \"agentNetworkStatus\": "
-                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.2.3.37\", \"annotation\": "
                    "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
                    "\"Malware\", \"classificationSource\": \"Static\", \"classifierName\": \"STATIC\", "
-                   "\"cloudVerdict\": \"provider_unknown\", \"collectionId\": \"715789430041423401\", \"createdAt\": "
+                   "\"cloudVerdict\": \"provider_unknown\", \"collectionId\": \"715789430041423412\", \"createdAt\": "
                    "\"2019-09-15T14:25:49.944443Z\", \"createdDate\": \"2019-09-15T14:25:48.988000Z\", "
                    "\"description\": \"malware detected - not mitigated yet (static engine)\", \"engines\": ["
-                   "\"pre_execution\"], \"fileContentHash\": \"3e7704f5668bc4330c686ccce2dd6f9969686a2c\", "
+                   "\"pre_execution\"], \"fileContentHash\": \"3e7704f5668bc4330c686ccce2dd6f99696863bd\", "
                    "\"fileCreatedDate\": None, \"fileDisplayName\": \"Ncat Netcat Portable - CHIP-Installer.exe\", "
                    "\"fileExtensionType\": \"Executable\", \"fileIsDotNet\": None, \"fileIsExecutable\": False, "
-                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"43A5D890AC420FEC\", "
+                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"43A5D890AC420DKC\", "
                    "\"filePath\": \"\\\\Device\\\\HarddiskVolume1\\\\Users\\\\Administrator\\\\Downloads\\\\Ncat "
                    "Netcat Portable - CHIP-Installer.exe\", \"fileSha256\": None, \"fileVerificationType\": "
-                   "\"PathNotFound\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"715789434420276790\", "
+                   "\"PathNotFound\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"715789434420276799\", "
                    "\"indicators\": [25, 24, 23, 6], \"isCertValid\": False, \"isInteractiveSession\": False, "
-                   "\"isPartialStory\": False, \"maliciousGroupId\": \"B9343BEED7D7713D\", "
+                   "\"isPartialStory\": False, \"maliciousGroupId\": \"B9343BEED7D7713C\", "
                    "\"maliciousProcessArguments\": None, \"markedAsBenign\": None, \"mitigationMode\": \"protect\", "
                    "\"mitigationReport\": {\"kill\": {\"status\": \"success\"}, \"network_quarantine\": {\"status\": "
                    "None}, \"quarantine\": {\"status\": \"success\"}, \"remediate\": {\"status\": None}, "
                    "\"rollback\": {\"status\": None}}, \"mitigationStatus\": \"mitigated\", \"publisher\": \"\", "
-                   "\"rank\": 0, \"resolved\": False, \"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", "
-                   "\"threatAgentVersion\": \"3.1.3.38\", \"threatName\": \"Ncat Netcat Portable - "
+                   "\"rank\": 0, \"resolved\": False, \"siteId\": \"475482421366727777\", \"siteName\": \"demisto\", "
+                   "\"threatAgentVersion\": \"3.2.3.37\", \"threatName\": \"Ncat Netcat Portable - "
                    "CHIP-Installer.exe\", \"updatedAt\": \"2019-09-15T14:25:50.181148Z\", \"username\": \"\", "
                    "\"whiteningOptions\": [\"hash\", \"path\"]}",
         "rawName": "",
@@ -125,32 +125,32 @@ INCIDENTS_FOR_FETCH = [
         "previousRoles": None,
         "rawCategory": "",
         "rawCloseReason": "",
-        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
-                   "\"EC2AMAZ-AJ0KANC\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123595\", "
-                   "\"agentInfected\": False, \"agentIp\": \"3.122.240.42\", \"agentIsActive\": True, "
+        "rawJSON": "{\"accountId\": \"412243337337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"EC2AMAZ-AJ0KDDD\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123596\", "
+                   "\"agentInfected\": False, \"agentIp\": \"3.136.231.41\", \"agentIsActive\": True, "
                    "\"agentIsDecommissioned\": False, \"agentMachineType\": \"server\", \"agentNetworkStatus\": "
-                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.2.3.37\", \"annotation\": "
                    "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
                    "\"Malware\", \"classificationSource\": \"Engine\", \"classifierName\": \"STATIC\", "
-                   "\"cloudVerdict\": \"black\", \"collectionId\": \"433377870883088367\", \"createdAt\": "
+                   "\"cloudVerdict\": \"black\", \"collectionId\": \"433377888883088367\", \"createdAt\": "
                    "\"2019-09-16T09:36:02.411027Z\", \"createdDate\": \"2019-09-16T09:36:02.331000Z\", "
                    "\"description\": \"malware detected - not mitigated yet (static engine)\", \"engines\": ["
-                   "\"reputation\"], \"fileContentHash\": \"3395856ce81f2b7382dee72602f798b642f14140\", "
+                   "\"reputation\"], \"fileContentHash\": \"3395856ce81f2b7382dee72602f798b642f14444\", "
                    "\"fileCreatedDate\": None, \"fileDisplayName\": \"Unconfirmed 742374.crdownload\", "
                    "\"fileExtensionType\": \"Unknown\", \"fileIsDotNet\": None, \"fileIsExecutable\": False, "
-                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"A19CF2DDC726C178\", "
+                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"A19CF2DDC726C111\", "
                    "\"filePath\": \"\\\\Device\\\\HarddiskVolume1\\\\Users\\\\Administrator\\\\Downloads"
                    "\\\\Unconfirmed 742374.crdownload\", \"fileSha256\": None, \"fileVerificationType\": "
-                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"716368352944665294\", "
+                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"716368352944665999\", "
                    "\"indicators\": [], \"isCertValid\": False, \"isInteractiveSession\": False, \"isPartialStory\": "
-                   "False, \"maliciousGroupId\": \"FAF42748C2B397AD\", \"maliciousProcessArguments\": None, "
+                   "False, \"maliciousGroupId\": \"FAF42748C2B39DDD\", \"maliciousProcessArguments\": None, "
                    "\"markedAsBenign\": None, \"mitigationMode\": \"protect\", \"mitigationReport\": {\"kill\": {"
                    "\"status\": \"success\"}, \"network_quarantine\": {\"status\": None}, \"quarantine\": {"
                    "\"status\": \"success\"}, \"remediate\": {\"status\": None}, \"rollback\": {\"status\": None}}, "
                    "\"mitigationStatus\": \"mitigated\", \"publisher\": \"\", \"rank\": 7, \"resolved\": False, "
-                   "\"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
-                   "\"3.1.3.38\", \"threatName\": \"Unconfirmed 742374.crdownload\", \"updatedAt\": "
-                   "\"2019-09-16T09:36:02.636239Z\", \"username\": \"EC2AMAZ-AJ0KANC\\\\Administrator\", "
+                   "\"siteId\": \"475482421366727777\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
+                   "\"3.2.3.37\", \"threatName\": \"Unconfirmed 742374.crdownload\", \"updatedAt\": "
+                   "\"2019-09-16T09:36:02.636239Z\", \"username\": \"EC2AMAZ-AJ0KDDD\\\\Administrator\", "
                    "\"whiteningOptions\": [\"hash\"]}",
         "rawName": "",
         "rawPhase": "",
@@ -205,34 +205,34 @@ INCIDENTS_FOR_FETCH = [
         "previousRoles": None,
         "rawCategory": "",
         "rawCloseReason": "",
-        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
-                   "\"TLVWIN9131Q1V\", \"agentDomain\": \"PALOALTONETWORK\", \"agentId\": \"657738871640371668\", "
-                   "\"agentInfected\": False, \"agentIp\": \"77.125.26.141\", \"agentIsActive\": True, "
+        "rawJSON": "{\"accountId\": \"412243337337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"TLVWIN9131VVV\", \"agentDomain\": \"PALOALTONETWORK\", \"agentId\": \"657738871640371666\", "
+                   "\"agentInfected\": False, \"agentIp\": \"77.125.26.100\", \"agentIsActive\": True, "
                    "\"agentIsDecommissioned\": False, \"agentMachineType\": \"laptop\", \"agentNetworkStatus\": "
-                   "\"connected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "\"connected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.2.3.37\", \"annotation\": "
                    "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
                    "\"Malware\", \"classificationSource\": \"Static\", \"classifierName\": \"LOGIC\", "
-                   "\"cloudVerdict\": None, \"collectionId\": \"736969199281920523\", \"createdAt\": "
+                   "\"cloudVerdict\": None, \"collectionId\": \"736969199281920555\", \"createdAt\": "
                    "\"2019-10-14T19:46:14.666494Z\", \"createdDate\": \"2019-10-14T19:44:24.647000Z\", "
                    "\"description\": \"malware detected - not mitigated yet\", \"engines\": [\"data_files\"], "
                    "\"fileContentHash\": \"ffffffffffffffffffffffffffffffffffffffff\", \"fileCreatedDate\": None, "
                    "\"fileDisplayName\": \"19.152.0801.0008\", \"fileExtensionType\": \"Unknown\", \"fileIsDotNet\": "
                    "None, \"fileIsExecutable\": False, \"fileIsSystem\": False, \"fileMaliciousContent\": None, "
-                   "\"fileObjectId\": \"DC1471176A586CA6\", \"filePath\": "
-                   "\"\\\\Device\\\\HarddiskVolume4\\\\Users\\\\mgoldberg\\\\AppData\\\\Local\\\\Microsoft"
+                   "\"fileObjectId\": \"DC1471176A586CAA\", \"filePath\": "
+                   "\"\\\\Device\\\\HarddiskVolume4\\\\Users\\\\ooooooooo\\\\AppData\\\\Local\\\\Microsoft"
                    "\\\\OneDrive\\\\19.152.0801.0008\", \"fileSha256\": None, \"fileVerificationType\": "
-                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"736969199273531914\", "
+                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"736969199273531999\", "
                    "\"indicators\": [83], \"isCertValid\": False, \"isInteractiveSession\": False, "
-                   "\"isPartialStory\": False, \"maliciousGroupId\": \"CA1BD9CFD7148278\", "
+                   "\"isPartialStory\": False, \"maliciousGroupId\": \"CA1BD9CFD7148222\", "
                    "\"maliciousProcessArguments\": \"/q /c rmdir /s /q "
-                   "\\\"C:\\\\Users\\\\mgoldberg\\\\AppData\\\\Local\\\\Microsoft\\\\OneDrive\\\\19.152.0801.0008"
+                   "\\\"C:\\\\Users\\\\ooooooooo\\\\AppData\\\\Local\\\\Microsoft\\\\OneDrive\\\\19.152.0801.0008"
                    "\\\"\", \"markedAsBenign\": None, \"mitigationMode\": \"protect\", \"mitigationReport\": {"
                    "\"kill\": {\"status\": \"success\"}, \"network_quarantine\": {\"status\": None}, \"quarantine\": "
                    "{\"status\": \"success\"}, \"remediate\": {\"status\": None}, \"rollback\": {\"status\": None}}, "
                    "\"mitigationStatus\": \"mitigated\", \"publisher\": \"\", \"rank\": None, \"resolved\": False, "
-                   "\"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
-                   "\"3.1.3.38\", \"threatName\": \"19.152.0801.0008\", \"updatedAt\": "
-                   "\"2019-10-14T19:46:15.271542Z\", \"username\": \"PALOALTONETWORK\\\\mgoldberg\", "
+                   "\"siteId\": \"475482421366727777\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
+                   "\"3.2.3.37\", \"threatName\": \"19.152.0801.0008\", \"updatedAt\": "
+                   "\"2019-10-14T19:46:15.271542Z\", \"username\": \"PALOALTONETWORK\\\\ooooooooo\", "
                    "\"whiteningOptions\": [\"file_type\", \"path\"]}",
         "rawName": "",
         "rawPhase": "",
@@ -255,19 +255,19 @@ INCIDENTS_FOR_FETCH = [
 RAW_THREATS_RESPONSE = {
     "data": [
         {
-            "accountId": "433241117337583618",
+            "accountId": "412243337337583618",
             "accountName": "SentinelOne",
-            "agentComputerName": "TLVWIN9131Q1V",
+            "agentComputerName": "TLVWIN9131VVV",
             "agentDomain": "PALOALTONETWORK",
-            "agentId": "657738871640371668",
+            "agentId": "657738871640371666",
             "agentInfected": False,
-            "agentIp": "77.125.26.141",
+            "agentIp": "77.125.26.100",
             "agentIsActive": True,
             "agentIsDecommissioned": False,
             "agentMachineType": "laptop",
             "agentNetworkStatus": "connected",
             "agentOsType": "windows",
-            "agentVersion": "3.1.3.38",
+            "agentVersion": "3.2.3.37",
             "annotation": None,
             "annotationUrl": None,
             "browserType": None,
@@ -276,7 +276,7 @@ RAW_THREATS_RESPONSE = {
             "classificationSource": "Static",
             "classifierName": "LOGIC",
             "cloudVerdict": None,
-            "collectionId": "736969199281920523",
+            "collectionId": "736969199281920555",
             "createdAt": "2019-10-14T19:46:14.666494Z",
             "createdDate": "2019-10-14T19:44:24.647000Z",
             "description": "malware detected - not mitigated yet",
@@ -289,20 +289,20 @@ RAW_THREATS_RESPONSE = {
             "fileIsExecutable": False,
             "fileIsSystem": False,
             "fileMaliciousContent": None,
-            "fileObjectId": "DC1471176A586CA6",
-            "filePath": "\\Device\\HarddiskVolume4\\Users\\mgoldberg\\AppData\\Local\\Microsoft\\OneDrive\\19.152.0801"
+            "fileObjectId": "DC1471176A586CAA",
+            "filePath": "\\Device\\HarddiskVolume4\\Users\\ooooooooo\\AppData\\Local\\Microsoft\\OneDrive\\19.152.0801"
                         ".0008",
             "fileSha256": None,
             "fileVerificationType": "NotSigned",
             "fromCloud": False,
             "fromScan": False,
-            "id": "736969199273531914",
+            "id": "736969199273531999",
             "indicators": [83],
             "isCertValid": False,
             "isInteractiveSession": False,
             "isPartialStory": False,
-            "maliciousGroupId": "CA1BD9CFD7148278",
-            "maliciousProcessArguments": "/q /c rmdir /s /q \"C:\\Users\\mgoldberg\\AppData\\Local\\Microsoft\\OneDrive"
+            "maliciousGroupId": "CA1BD9CFD7148222",
+            "maliciousProcessArguments": "/q /c rmdir /s /q \"C:\\Users\\ooooooooo\\AppData\\Local\\Microsoft\\OneDrive"
                                          "\\19.152.0801.0008\"",
             "markedAsBenign": None,
             "mitigationMode": "protect",
@@ -327,28 +327,28 @@ RAW_THREATS_RESPONSE = {
             "publisher": "",
             "rank": None,
             "resolved": False,
-            "siteId": "475482421366727779",
+            "siteId": "475482421366727777",
             "siteName": "demisto",
-            "threatAgentVersion": "3.1.3.38",
+            "threatAgentVersion": "3.2.3.37",
             "threatName": "19.152.0801.0008",
             "updatedAt": "2019-10-14T19:46:15.271542Z",
-            "username": "PALOALTONETWORK\\mgoldberg",
+            "username": "PALOALTONETWORK\\ooooooooo",
             "whiteningOptions": ["file_type", "path"]
         },
         {
-            "accountId": "433241117337583618",
+            "accountId": "412243337337583618",
             "accountName": "SentinelOne",
-            "agentComputerName": "EC2AMAZ-AJ0KANC",
+            "agentComputerName": "EC2AMAZ-AJ0KDDD",
             "agentDomain": "WORKGROUP",
-            "agentId": "657613730168123595",
+            "agentId": "657613730168123596",
             "agentInfected": False,
-            "agentIp": "3.122.240.42",
+            "agentIp": "3.136.231.41",
             "agentIsActive": True,
             "agentIsDecommissioned": False,
             "agentMachineType": "server",
             "agentNetworkStatus": "disconnected",
             "agentOsType": "windows",
-            "agentVersion": "3.1.3.38",
+            "agentVersion": "3.2.3.37",
             "annotation": None,
             "annotationUrl": None,
             "browserType": None,
@@ -357,12 +357,12 @@ RAW_THREATS_RESPONSE = {
             "classificationSource": "Engine",
             "classifierName": "STATIC",
             "cloudVerdict": "black",
-            "collectionId": "433377870883088367",
+            "collectionId": "433377888883088367",
             "createdAt": "2019-09-16T09:36:02.411027Z",
             "createdDate": "2019-09-16T09:36:02.331000Z",
             "description": "malware detected - not mitigated yet (static engine)",
             "engines": ["reputation"],
-            "fileContentHash": "3395856ce81f2b7382dee72602f798b642f14140",
+            "fileContentHash": "3395856ce81f2b7382dee72602f798b642f14444",
             "fileCreatedDate": None,
             "fileDisplayName": "Unconfirmed 742374.crdownload",
             "fileExtensionType": "Unknown",
@@ -370,18 +370,18 @@ RAW_THREATS_RESPONSE = {
             "fileIsExecutable": False,
             "fileIsSystem": False,
             "fileMaliciousContent": None,
-            "fileObjectId": "A19CF2DDC726C178",
+            "fileObjectId": "A19CF2DDC726C111",
             "filePath": "\\Device\\HarddiskVolume1\\Users\\Administrator\\Downloads\\Unconfirmed 742374.crdownload",
             "fileSha256": None,
             "fileVerificationType": "NotSigned",
             "fromCloud": False,
             "fromScan": False,
-            "id": "716368352944665294",
+            "id": "716368352944665999",
             "indicators": [],
             "isCertValid": False,
             "isInteractiveSession": False,
             "isPartialStory": False,
-            "maliciousGroupId": "FAF42748C2B397AD",
+            "maliciousGroupId": "FAF42748C2B39DDD",
             "maliciousProcessArguments": None,
             "markedAsBenign": None,
             "mitigationMode": "protect",
@@ -406,28 +406,28 @@ RAW_THREATS_RESPONSE = {
             "publisher": "",
             "rank": 7,
             "resolved": False,
-            "siteId": "475482421366727779",
+            "siteId": "475482421366727777",
             "siteName": "demisto",
-            "threatAgentVersion": "3.1.3.38",
+            "threatAgentVersion": "3.2.3.37",
             "threatName": "Unconfirmed 742374.crdownload",
             "updatedAt": "2019-09-16T09:36:02.636239Z",
-            "username": "EC2AMAZ-AJ0KANC\\Administrator",
+            "username": "EC2AMAZ-AJ0KDDD\\Administrator",
             "whiteningOptions": ["hash"]
         },
         {
-            "accountId": "433241117337583618",
+            "accountId": "412243337337583618",
             "accountName": "SentinelOne",
-            "agentComputerName": "EC2AMAZ-AJ0KANC",
+            "agentComputerName": "EC2AMAZ-AJ0KDDD",
             "agentDomain": "WORKGROUP",
-            "agentId": "657613730168123595",
+            "agentId": "657613730168123596",
             "agentInfected": False,
-            "agentIp": "3.122.240.42",
+            "agentIp": "3.136.231.41",
             "agentIsActive": True,
             "agentIsDecommissioned": False,
             "agentMachineType": "server",
             "agentNetworkStatus": "disconnected",
             "agentOsType": "windows",
-            "agentVersion": "3.1.3.38",
+            "agentVersion": "3.2.3.37",
             "annotation": None,
             "annotationUrl": None,
             "browserType": None,
@@ -436,12 +436,12 @@ RAW_THREATS_RESPONSE = {
             "classificationSource": "Static",
             "classifierName": "STATIC",
             "cloudVerdict": "provider_unknown",
-            "collectionId": "715789430041423401",
+            "collectionId": "715789430041423412",
             "createdAt": "2019-09-15T14:25:49.944443Z",
             "createdDate": "2019-09-15T14:25:48.988000Z",
             "description": "malware detected - not mitigated yet (static engine)",
             "engines": ["pre_execution"],
-            "fileContentHash": "3e7704f5668bc4330c686ccce2dd6f9969686a2c",
+            "fileContentHash": "3e7704f5668bc4330c686ccce2dd6f99696863bd",
             "fileCreatedDate": None,
             "fileDisplayName": "Ncat Netcat Portable - CHIP-Installer.exe",
             "fileExtensionType": "Executable",
@@ -449,19 +449,19 @@ RAW_THREATS_RESPONSE = {
             "fileIsExecutable": False,
             "fileIsSystem": False,
             "fileMaliciousContent": None,
-            "fileObjectId": "43A5D890AC420FEC",
+            "fileObjectId": "43A5D890AC420DKC",
             "filePath": "\\Device\\HarddiskVolume1\\Users\\Administrator\\Downloads\\Ncat Netcat Portable - "
                         "CHIP-Installer.exe",
             "fileSha256": None,
             "fileVerificationType": "PathNotFound",
             "fromCloud": False,
             "fromScan": False,
-            "id": "715789434420276790",
+            "id": "715789434420276799",
             "indicators": [25, 24, 23, 6],
             "isCertValid": False,
             "isInteractiveSession": False,
             "isPartialStory": False,
-            "maliciousGroupId": "B9343BEED7D7713D",
+            "maliciousGroupId": "B9343BEED7D7713C",
             "maliciousProcessArguments": None,
             "markedAsBenign": None,
             "mitigationMode": "protect",
@@ -486,9 +486,9 @@ RAW_THREATS_RESPONSE = {
             "publisher": "",
             "rank": 0,
             "resolved": False,
-            "siteId": "475482421366727779",
+            "siteId": "475482421366727777",
             "siteName": "demisto",
-            "threatAgentVersion": "3.1.3.38",
+            "threatAgentVersion": "3.2.3.37",
             "threatName": "Ncat Netcat Portable - CHIP-Installer.exe",
             "updatedAt": "2019-09-15T14:25:50.181148Z",
             "username": "",

--- a/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
+++ b/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
@@ -1,0 +1,548 @@
+import demistomock as demisto
+from importlib import import_module
+
+
+sentinelone_v2 = import_module('SentinelOne-V2')
+fetch_incidents = sentinelone_v2.fetch_incidents
+main = sentinelone_v2.main
+
+# disable-secrets-detection-start
+INCIDENTS_FOR_FETCH = [
+    {
+        "CustomFields": None,
+        "ShardID": 0,
+        "account": "",
+        "activated": "0001-01-01T00:00:00Z",
+        "attachment": None,
+        "autime": 0,
+        "canvases": None,
+        "category": "",
+        "closeNotes": "",
+        "closeReason": "",
+        "closed": "0001-01-01T00:00:00Z",
+        "closingUserId": "",
+        "created": "0001-01-01T00:00:00Z",
+        "details": "",
+        "droppedCount": 0,
+        "dueDate": "0001-01-01T00:00:00Z",
+        "hasRole": False,
+        "id": "",
+        "investigationId": "",
+        "isPlayground": False,
+        "labels": None,
+        "lastOpen": "0001-01-01T00:00:00Z",
+        "linkedCount": 0,
+        "linkedIncidents": None,
+        "modified": "0001-01-01T00:00:00Z",
+        "name": "Sentinel One Threat: Malware",
+        "notifyTime": "0001-01-01T00:00:00Z",
+        "occurred": "2019-09-15T14:25:48.988Z",
+        "openDuration": 0,
+        "owner": "",
+        "parent": "",
+        "phase": "",
+        "playbookId": "",
+        "previousRoles": None,
+        "rawCategory": "",
+        "rawCloseReason": "",
+        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"EC2AMAZ-AJ0KANC\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123595\", "
+                   "\"agentInfected\": False, \"agentIp\": \"3.122.240.42\", \"agentIsActive\": True, "
+                   "\"agentIsDecommissioned\": False, \"agentMachineType\": \"server\", \"agentNetworkStatus\": "
+                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
+                   "\"Malware\", \"classificationSource\": \"Static\", \"classifierName\": \"STATIC\", "
+                   "\"cloudVerdict\": \"provider_unknown\", \"collectionId\": \"715789430041423401\", \"createdAt\": "
+                   "\"2019-09-15T14:25:49.944443Z\", \"createdDate\": \"2019-09-15T14:25:48.988000Z\", "
+                   "\"description\": \"malware detected - not mitigated yet (static engine)\", \"engines\": ["
+                   "\"pre_execution\"], \"fileContentHash\": \"3e7704f5668bc4330c686ccce2dd6f9969686a2c\", "
+                   "\"fileCreatedDate\": None, \"fileDisplayName\": \"Ncat Netcat Portable - CHIP-Installer.exe\", "
+                   "\"fileExtensionType\": \"Executable\", \"fileIsDotNet\": None, \"fileIsExecutable\": False, "
+                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"43A5D890AC420FEC\", "
+                   "\"filePath\": \"\\\\Device\\\\HarddiskVolume1\\\\Users\\\\Administrator\\\\Downloads\\\\Ncat "
+                   "Netcat Portable - CHIP-Installer.exe\", \"fileSha256\": None, \"fileVerificationType\": "
+                   "\"PathNotFound\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"715789434420276790\", "
+                   "\"indicators\": [25, 24, 23, 6], \"isCertValid\": False, \"isInteractiveSession\": False, "
+                   "\"isPartialStory\": False, \"maliciousGroupId\": \"B9343BEED7D7713D\", "
+                   "\"maliciousProcessArguments\": None, \"markedAsBenign\": None, \"mitigationMode\": \"protect\", "
+                   "\"mitigationReport\": {\"kill\": {\"status\": \"success\"}, \"network_quarantine\": {\"status\": "
+                   "None}, \"quarantine\": {\"status\": \"success\"}, \"remediate\": {\"status\": None}, "
+                   "\"rollback\": {\"status\": None}}, \"mitigationStatus\": \"mitigated\", \"publisher\": \"\", "
+                   "\"rank\": 0, \"resolved\": False, \"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", "
+                   "\"threatAgentVersion\": \"3.1.3.38\", \"threatName\": \"Ncat Netcat Portable - "
+                   "CHIP-Installer.exe\", \"updatedAt\": \"2019-09-15T14:25:50.181148Z\", \"username\": \"\", "
+                   "\"whiteningOptions\": [\"hash\", \"path\"]}",
+        "rawName": "",
+        "rawPhase": "",
+        "rawType": "",
+        "reason": "",
+        "reminder": "0001-01-01T00:00:00Z",
+        "roles": None,
+        "runStatus": "",
+        "severity": 0,
+        "sla": 0,
+        "sortValues": None,
+        "sourceBrand": "",
+        "sourceInstance": "",
+        "status": 0,
+        "type": "",
+        "version": 0
+    },
+    {
+        "CustomFields": None,
+        "ShardID": 0,
+        "account": "",
+        "activated": "0001-01-01T00:00:00Z",
+        "attachment": None,
+        "autime": 0,
+        "canvases": None,
+        "category": "",
+        "closeNotes": "",
+        "closeReason": "",
+        "closed": "0001-01-01T00:00:00Z",
+        "closingUserId": "",
+        "created": "0001-01-01T00:00:00Z",
+        "details": "",
+        "droppedCount": 0,
+        "dueDate": "0001-01-01T00:00:00Z",
+        "hasRole": False,
+        "id": "",
+        "investigationId": "",
+        "isPlayground": False,
+        "labels": None,
+        "lastOpen": "0001-01-01T00:00:00Z",
+        "linkedCount": 0,
+        "linkedIncidents": None,
+        "modified": "0001-01-01T00:00:00Z",
+        "name": "Sentinel One Threat: Malware",
+        "notifyTime": "0001-01-01T00:00:00Z",
+        "occurred": "2019-09-16T09:36:02.331Z",
+        "openDuration": 0,
+        "owner": "",
+        "parent": "",
+        "phase": "",
+        "playbookId": "",
+        "previousRoles": None,
+        "rawCategory": "",
+        "rawCloseReason": "",
+        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"EC2AMAZ-AJ0KANC\", \"agentDomain\": \"WORKGROUP\", \"agentId\": \"657613730168123595\", "
+                   "\"agentInfected\": False, \"agentIp\": \"3.122.240.42\", \"agentIsActive\": True, "
+                   "\"agentIsDecommissioned\": False, \"agentMachineType\": \"server\", \"agentNetworkStatus\": "
+                   "\"disconnected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
+                   "\"Malware\", \"classificationSource\": \"Engine\", \"classifierName\": \"STATIC\", "
+                   "\"cloudVerdict\": \"black\", \"collectionId\": \"433377870883088367\", \"createdAt\": "
+                   "\"2019-09-16T09:36:02.411027Z\", \"createdDate\": \"2019-09-16T09:36:02.331000Z\", "
+                   "\"description\": \"malware detected - not mitigated yet (static engine)\", \"engines\": ["
+                   "\"reputation\"], \"fileContentHash\": \"3395856ce81f2b7382dee72602f798b642f14140\", "
+                   "\"fileCreatedDate\": None, \"fileDisplayName\": \"Unconfirmed 742374.crdownload\", "
+                   "\"fileExtensionType\": \"Unknown\", \"fileIsDotNet\": None, \"fileIsExecutable\": False, "
+                   "\"fileIsSystem\": False, \"fileMaliciousContent\": None, \"fileObjectId\": \"A19CF2DDC726C178\", "
+                   "\"filePath\": \"\\\\Device\\\\HarddiskVolume1\\\\Users\\\\Administrator\\\\Downloads"
+                   "\\\\Unconfirmed 742374.crdownload\", \"fileSha256\": None, \"fileVerificationType\": "
+                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"716368352944665294\", "
+                   "\"indicators\": [], \"isCertValid\": False, \"isInteractiveSession\": False, \"isPartialStory\": "
+                   "False, \"maliciousGroupId\": \"FAF42748C2B397AD\", \"maliciousProcessArguments\": None, "
+                   "\"markedAsBenign\": None, \"mitigationMode\": \"protect\", \"mitigationReport\": {\"kill\": {"
+                   "\"status\": \"success\"}, \"network_quarantine\": {\"status\": None}, \"quarantine\": {"
+                   "\"status\": \"success\"}, \"remediate\": {\"status\": None}, \"rollback\": {\"status\": None}}, "
+                   "\"mitigationStatus\": \"mitigated\", \"publisher\": \"\", \"rank\": 7, \"resolved\": False, "
+                   "\"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
+                   "\"3.1.3.38\", \"threatName\": \"Unconfirmed 742374.crdownload\", \"updatedAt\": "
+                   "\"2019-09-16T09:36:02.636239Z\", \"username\": \"EC2AMAZ-AJ0KANC\\\\Administrator\", "
+                   "\"whiteningOptions\": [\"hash\"]}",
+        "rawName": "",
+        "rawPhase": "",
+        "rawType": "",
+        "reason": "",
+        "reminder": "0001-01-01T00:00:00Z",
+        "roles": None,
+        "runStatus": "",
+        "severity": 0,
+        "sla": 0,
+        "sortValues": None,
+        "sourceBrand": "",
+        "sourceInstance": "",
+        "status": 0,
+        "type": "",
+        "version": 0
+    },
+    {
+        "CustomFields": None,
+        "ShardID": 0,
+        "account": "",
+        "activated": "0001-01-01T00:00:00Z",
+        "attachment": None,
+        "autime": 0,
+        "canvases": None,
+        "category": "",
+        "closeNotes": "",
+        "closeReason": "",
+        "closed": "0001-01-01T00:00:00Z",
+        "closingUserId": "",
+        "created": "0001-01-01T00:00:00Z",
+        "details": "",
+        "droppedCount": 0,
+        "dueDate": "0001-01-01T00:00:00Z",
+        "hasRole": False,
+        "id": "",
+        "investigationId": "",
+        "isPlayground": False,
+        "labels": None,
+        "lastOpen": "0001-01-01T00:00:00Z",
+        "linkedCount": 0,
+        "linkedIncidents": None,
+        "modified": "0001-01-01T00:00:00Z",
+        "name": "Sentinel One Threat: Malware",
+        "notifyTime": "0001-01-01T00:00:00Z",
+        "occurred": "2019-10-14T19:44:24.647Z",
+        "openDuration": 0,
+        "owner": "",
+        "parent": "",
+        "phase": "",
+        "playbookId": "",
+        "previousRoles": None,
+        "rawCategory": "",
+        "rawCloseReason": "",
+        "rawJSON": "{\"accountId\": \"433241117337583618\", \"accountName\": \"SentinelOne\", \"agentComputerName\": "
+                   "\"TLVWIN9131Q1V\", \"agentDomain\": \"PALOALTONETWORK\", \"agentId\": \"657738871640371668\", "
+                   "\"agentInfected\": False, \"agentIp\": \"77.125.26.141\", \"agentIsActive\": True, "
+                   "\"agentIsDecommissioned\": False, \"agentMachineType\": \"laptop\", \"agentNetworkStatus\": "
+                   "\"connected\", \"agentOsType\": \"windows\", \"agentVersion\": \"3.1.3.38\", \"annotation\": "
+                   "None, \"annotationUrl\": None, \"browserType\": None, \"certId\": \"\", \"classification\": "
+                   "\"Malware\", \"classificationSource\": \"Static\", \"classifierName\": \"LOGIC\", "
+                   "\"cloudVerdict\": None, \"collectionId\": \"736969199281920523\", \"createdAt\": "
+                   "\"2019-10-14T19:46:14.666494Z\", \"createdDate\": \"2019-10-14T19:44:24.647000Z\", "
+                   "\"description\": \"malware detected - not mitigated yet\", \"engines\": [\"data_files\"], "
+                   "\"fileContentHash\": \"ffffffffffffffffffffffffffffffffffffffff\", \"fileCreatedDate\": None, "
+                   "\"fileDisplayName\": \"19.152.0801.0008\", \"fileExtensionType\": \"Unknown\", \"fileIsDotNet\": "
+                   "None, \"fileIsExecutable\": False, \"fileIsSystem\": False, \"fileMaliciousContent\": None, "
+                   "\"fileObjectId\": \"DC1471176A586CA6\", \"filePath\": "
+                   "\"\\\\Device\\\\HarddiskVolume4\\\\Users\\\\mgoldberg\\\\AppData\\\\Local\\\\Microsoft"
+                   "\\\\OneDrive\\\\19.152.0801.0008\", \"fileSha256\": None, \"fileVerificationType\": "
+                   "\"NotSigned\", \"fromCloud\": False, \"fromScan\": False, \"id\": \"736969199273531914\", "
+                   "\"indicators\": [83], \"isCertValid\": False, \"isInteractiveSession\": False, "
+                   "\"isPartialStory\": False, \"maliciousGroupId\": \"CA1BD9CFD7148278\", "
+                   "\"maliciousProcessArguments\": \"/q /c rmdir /s /q "
+                   "\\\"C:\\\\Users\\\\mgoldberg\\\\AppData\\\\Local\\\\Microsoft\\\\OneDrive\\\\19.152.0801.0008"
+                   "\\\"\", \"markedAsBenign\": None, \"mitigationMode\": \"protect\", \"mitigationReport\": {"
+                   "\"kill\": {\"status\": \"success\"}, \"network_quarantine\": {\"status\": None}, \"quarantine\": "
+                   "{\"status\": \"success\"}, \"remediate\": {\"status\": None}, \"rollback\": {\"status\": None}}, "
+                   "\"mitigationStatus\": \"mitigated\", \"publisher\": \"\", \"rank\": None, \"resolved\": False, "
+                   "\"siteId\": \"475482421366727779\", \"siteName\": \"demisto\", \"threatAgentVersion\": "
+                   "\"3.1.3.38\", \"threatName\": \"19.152.0801.0008\", \"updatedAt\": "
+                   "\"2019-10-14T19:46:15.271542Z\", \"username\": \"PALOALTONETWORK\\\\mgoldberg\", "
+                   "\"whiteningOptions\": [\"file_type\", \"path\"]}",
+        "rawName": "",
+        "rawPhase": "",
+        "rawType": "",
+        "reason": "",
+        "reminder": "0001-01-01T00:00:00Z",
+        "roles": None,
+        "runStatus": "",
+        "severity": 0,
+        "sla": 0,
+        "sortValues": None,
+        "sourceBrand": "",
+        "sourceInstance": "",
+        "status": 0,
+        "type": "",
+        "version": 0
+    }
+]
+
+RAW_THREATS_RESPONSE = {
+    "data": [
+        {
+            "accountId": "433241117337583618",
+            "accountName": "SentinelOne",
+            "agentComputerName": "TLVWIN9131Q1V",
+            "agentDomain": "PALOALTONETWORK",
+            "agentId": "657738871640371668",
+            "agentInfected": False,
+            "agentIp": "77.125.26.141",
+            "agentIsActive": True,
+            "agentIsDecommissioned": False,
+            "agentMachineType": "laptop",
+            "agentNetworkStatus": "connected",
+            "agentOsType": "windows",
+            "agentVersion": "3.1.3.38",
+            "annotation": None,
+            "annotationUrl": None,
+            "browserType": None,
+            "certId": "",
+            "classification": "Malware",
+            "classificationSource": "Static",
+            "classifierName": "LOGIC",
+            "cloudVerdict": None,
+            "collectionId": "736969199281920523",
+            "createdAt": "2019-10-14T19:46:14.666494Z",
+            "createdDate": "2019-10-14T19:44:24.647000Z",
+            "description": "malware detected - not mitigated yet",
+            "engines": ["data_files"],
+            "fileContentHash": "ffffffffffffffffffffffffffffffffffffffff",
+            "fileCreatedDate": None,
+            "fileDisplayName": "19.152.0801.0008",
+            "fileExtensionType": "Unknown",
+            "fileIsDotNet": None,
+            "fileIsExecutable": False,
+            "fileIsSystem": False,
+            "fileMaliciousContent": None,
+            "fileObjectId": "DC1471176A586CA6",
+            "filePath": "\\Device\\HarddiskVolume4\\Users\\mgoldberg\\AppData\\Local\\Microsoft\\OneDrive\\19.152.0801"
+                        ".0008",
+            "fileSha256": None,
+            "fileVerificationType": "NotSigned",
+            "fromCloud": False,
+            "fromScan": False,
+            "id": "736969199273531914",
+            "indicators": [83],
+            "isCertValid": False,
+            "isInteractiveSession": False,
+            "isPartialStory": False,
+            "maliciousGroupId": "CA1BD9CFD7148278",
+            "maliciousProcessArguments": "/q /c rmdir /s /q \"C:\\Users\\mgoldberg\\AppData\\Local\\Microsoft\\OneDrive"
+                                         "\\19.152.0801.0008\"",
+            "markedAsBenign": None,
+            "mitigationMode": "protect",
+            "mitigationReport": {
+                "kill": {
+                    "status": "success"
+                },
+                "network_quarantine": {
+                    "status": None
+                },
+                "quarantine": {
+                    "status": "success"
+                },
+                "remediate": {
+                    "status": None
+                },
+                "rollback": {
+                    "status": None
+                }
+            },
+            "mitigationStatus": "mitigated",
+            "publisher": "",
+            "rank": None,
+            "resolved": False,
+            "siteId": "475482421366727779",
+            "siteName": "demisto",
+            "threatAgentVersion": "3.1.3.38",
+            "threatName": "19.152.0801.0008",
+            "updatedAt": "2019-10-14T19:46:15.271542Z",
+            "username": "PALOALTONETWORK\\mgoldberg",
+            "whiteningOptions": ["file_type", "path"]
+        },
+        {
+            "accountId": "433241117337583618",
+            "accountName": "SentinelOne",
+            "agentComputerName": "EC2AMAZ-AJ0KANC",
+            "agentDomain": "WORKGROUP",
+            "agentId": "657613730168123595",
+            "agentInfected": False,
+            "agentIp": "3.122.240.42",
+            "agentIsActive": True,
+            "agentIsDecommissioned": False,
+            "agentMachineType": "server",
+            "agentNetworkStatus": "disconnected",
+            "agentOsType": "windows",
+            "agentVersion": "3.1.3.38",
+            "annotation": None,
+            "annotationUrl": None,
+            "browserType": None,
+            "certId": "",
+            "classification": "Malware",
+            "classificationSource": "Engine",
+            "classifierName": "STATIC",
+            "cloudVerdict": "black",
+            "collectionId": "433377870883088367",
+            "createdAt": "2019-09-16T09:36:02.411027Z",
+            "createdDate": "2019-09-16T09:36:02.331000Z",
+            "description": "malware detected - not mitigated yet (static engine)",
+            "engines": ["reputation"],
+            "fileContentHash": "3395856ce81f2b7382dee72602f798b642f14140",
+            "fileCreatedDate": None,
+            "fileDisplayName": "Unconfirmed 742374.crdownload",
+            "fileExtensionType": "Unknown",
+            "fileIsDotNet": None,
+            "fileIsExecutable": False,
+            "fileIsSystem": False,
+            "fileMaliciousContent": None,
+            "fileObjectId": "A19CF2DDC726C178",
+            "filePath": "\\Device\\HarddiskVolume1\\Users\\Administrator\\Downloads\\Unconfirmed 742374.crdownload",
+            "fileSha256": None,
+            "fileVerificationType": "NotSigned",
+            "fromCloud": False,
+            "fromScan": False,
+            "id": "716368352944665294",
+            "indicators": [],
+            "isCertValid": False,
+            "isInteractiveSession": False,
+            "isPartialStory": False,
+            "maliciousGroupId": "FAF42748C2B397AD",
+            "maliciousProcessArguments": None,
+            "markedAsBenign": None,
+            "mitigationMode": "protect",
+            "mitigationReport": {
+                "kill": {
+                    "status": "success"
+                },
+                "network_quarantine": {
+                    "status": None
+                },
+                "quarantine": {
+                    "status": "success"
+                },
+                "remediate": {
+                    "status": None
+                },
+                "rollback": {
+                    "status": None
+                }
+            },
+            "mitigationStatus": "mitigated",
+            "publisher": "",
+            "rank": 7,
+            "resolved": False,
+            "siteId": "475482421366727779",
+            "siteName": "demisto",
+            "threatAgentVersion": "3.1.3.38",
+            "threatName": "Unconfirmed 742374.crdownload",
+            "updatedAt": "2019-09-16T09:36:02.636239Z",
+            "username": "EC2AMAZ-AJ0KANC\\Administrator",
+            "whiteningOptions": ["hash"]
+        },
+        {
+            "accountId": "433241117337583618",
+            "accountName": "SentinelOne",
+            "agentComputerName": "EC2AMAZ-AJ0KANC",
+            "agentDomain": "WORKGROUP",
+            "agentId": "657613730168123595",
+            "agentInfected": False,
+            "agentIp": "3.122.240.42",
+            "agentIsActive": True,
+            "agentIsDecommissioned": False,
+            "agentMachineType": "server",
+            "agentNetworkStatus": "disconnected",
+            "agentOsType": "windows",
+            "agentVersion": "3.1.3.38",
+            "annotation": None,
+            "annotationUrl": None,
+            "browserType": None,
+            "certId": "",
+            "classification": "Malware",
+            "classificationSource": "Static",
+            "classifierName": "STATIC",
+            "cloudVerdict": "provider_unknown",
+            "collectionId": "715789430041423401",
+            "createdAt": "2019-09-15T14:25:49.944443Z",
+            "createdDate": "2019-09-15T14:25:48.988000Z",
+            "description": "malware detected - not mitigated yet (static engine)",
+            "engines": ["pre_execution"],
+            "fileContentHash": "3e7704f5668bc4330c686ccce2dd6f9969686a2c",
+            "fileCreatedDate": None,
+            "fileDisplayName": "Ncat Netcat Portable - CHIP-Installer.exe",
+            "fileExtensionType": "Executable",
+            "fileIsDotNet": None,
+            "fileIsExecutable": False,
+            "fileIsSystem": False,
+            "fileMaliciousContent": None,
+            "fileObjectId": "43A5D890AC420FEC",
+            "filePath": "\\Device\\HarddiskVolume1\\Users\\Administrator\\Downloads\\Ncat Netcat Portable - "
+                        "CHIP-Installer.exe",
+            "fileSha256": None,
+            "fileVerificationType": "PathNotFound",
+            "fromCloud": False,
+            "fromScan": False,
+            "id": "715789434420276790",
+            "indicators": [25, 24, 23, 6],
+            "isCertValid": False,
+            "isInteractiveSession": False,
+            "isPartialStory": False,
+            "maliciousGroupId": "B9343BEED7D7713D",
+            "maliciousProcessArguments": None,
+            "markedAsBenign": None,
+            "mitigationMode": "protect",
+            "mitigationReport": {
+                "kill": {
+                    "status": "success"
+                },
+                "network_quarantine": {
+                    "status": None
+                },
+                "quarantine": {
+                    "status": "success"
+                },
+                "remediate": {
+                    "status": None
+                },
+                "rollback": {
+                    "status": None
+                }
+            },
+            "mitigationStatus": "mitigated",
+            "publisher": "",
+            "rank": 0,
+            "resolved": False,
+            "siteId": "475482421366727779",
+            "siteName": "demisto",
+            "threatAgentVersion": "3.1.3.38",
+            "threatName": "Ncat Netcat Portable - CHIP-Installer.exe",
+            "updatedAt": "2019-09-15T14:25:50.181148Z",
+            "username": "",
+            "whiteningOptions": ["hash", "path"]
+        }
+    ]
+}
+# disable-secrets-detection-end
+
+
+def test_fetch_incidents_filtered_by_rank(mocker, requests_mock):
+    mocker.patch.object(demisto, 'params', return_value={
+        'url': 'https://usea1.sentinelone.net',
+        'fetch_time': '3 years',
+        'fetch_threat_rank': '5'
+    })
+    mocker.patch.object(demisto, 'getLastRun', return_value={'time': 1284629762000})
+    mocker.patch.object(demisto, 'setLastRun')
+    mocker.patch.object(demisto, 'incidents')
+    requests_mock.get('https://usea1.sentinelone.net/web/api/v2.0/threats', json=RAW_THREATS_RESPONSE)
+    main()
+    fetch_incidents()
+
+    assert demisto.incidents.call_count == 1
+    # call_args is tuple (args list, kwargs). we only need the first one
+    incidents = demisto.incidents.call_args[0][0]
+    # with 'fetch_threat_rank' equal to 5 only one of the 3 incidents from INCIDENTS_FOR_FETCH should be returned
+    # in this case the one with a rank of 7
+    assert len(incidents) == 1
+    threat_incident = incidents[0]
+    assert threat_incident.get('occurred', '') == '2019-09-16T09:36:02.331000Z'
+
+
+def test_fetch_incidents_all_inclusive(mocker, requests_mock):
+    mocker.patch.object(demisto, 'params', return_value={
+        'url': 'https://usea1.sentinelone.net',
+        'fetch_time': '3 years',
+        'fetch_threat_rank': '0'
+    })
+    mocker.patch.object(demisto, 'getLastRun', return_value={'time': 1284629762000})
+    mocker.patch.object(demisto, 'setLastRun')
+    mocker.patch.object(demisto, 'incidents')
+    requests_mock.get('https://usea1.sentinelone.net/web/api/v2.0/threats', json=RAW_THREATS_RESPONSE)
+    main()
+    fetch_incidents()
+
+    assert demisto.incidents.call_count == 1
+    # call_args is tuple (args list, kwargs). we only need the first one
+    incidents = demisto.incidents.call_args[0][0]
+    # with 'fetch_threat_rank' equal to 0 all 3 incidents from INCIDENTS_FOR_FETCH should be returned
+    assert len(incidents) == 3
+    threat_incident = incidents[0]
+    assert threat_incident.get('occurred', '') == '2019-10-14T19:44:24.647000Z'
+    threat_incident = incidents[1]
+    assert threat_incident.get('occurred', '') == '2019-09-16T09:36:02.331000Z'
+    threat_incident = incidents[2]
+    assert threat_incident.get('occurred', '') == '2019-09-15T14:25:48.988000Z'


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19630

## Description
Fix issue where not all threats were getting fetched into Demisto as incidents properly.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Documentation (with link to it)
- [x] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] SentinelOne V2 - test

## Additional changes
Fixed bug of comparisons with a Nonetype operand in the `get_threats_command` function.

## Technical writer review
Mention and link to the files that require a technical writer review.
- [x] [CHANGELOG](https://github.com/demisto/content/edit/sentinelone-v2-fetch-fix/Integrations/SentinelOne-V2/CHANGELOG.md?pr=%2Fdemisto%2Fcontent%2Fpull%2F4654)