### PR TITLE
Change Version Number in IAM Test Playbook

### DIFF
--- a/Integrations/AWS-IAM/AWS-IAM.yml
+++ b/Integrations/AWS-IAM/AWS-IAM.yml
@@ -1393,4 +1393,4 @@ script:
   runonce: false
   subtype: python2
 tests:
-- AWS - IAM Test Playbook
+- d5cb69b1-c81c-4f27-8a40-3106c0cb2620

--- a/TestPlaybooks/playbook-AWS-IAM-Test.yml
+++ b/TestPlaybooks/playbook-AWS-IAM-Test.yml
@@ -1,5 +1,5 @@
 id: AWS - IAM Test Playbook
-version: 16
+version: -1
 name: AWS - IAM Test Playbook
 starttaskid: "0"
 tasks:

--- a/TestPlaybooks/playbook-AWS-IAM-Test.yml
+++ b/TestPlaybooks/playbook-AWS-IAM-Test.yml
@@ -1,4 +1,4 @@
-id: AWS - IAM Test Playbook
+id: d5cb69b1-c81c-4f27-8a40-3106c0cb2620
 version: -1
 name: AWS - IAM Test Playbook
 starttaskid: "0"

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1133,7 +1133,7 @@
         },
         {
             "integrations": "AWS - IAM",
-            "playbookID": "AWS - IAM Test Playbook"
+            "playbookID": "d5cb69b1-c81c-4f27-8a40-3106c0cb2620"
         },
         {
             "integrations": "McAfee Active Response",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: master

## Description
Old AWS playbooks were using hardcoded version. Switched IAM test playbook to -1
