### PR TITLE
Change Created Credential Names to be Unique

### DIFF
--- a/Integrations/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.py
+++ b/Integrations/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.py
@@ -404,7 +404,7 @@ def fetch_credentials():
         credentials.append({
             'user': account_name,
             'password': password,
-            'name': system_name
+            'name': system_name + '_' + account_name
         })
 
     if identifier:

--- a/Integrations/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.yml
+++ b/Integrations/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.yml
@@ -326,5 +326,6 @@ script:
   runonce: false
   script: '-'
   type: python
+  subtype: python3
 tests:
 - BeyondTrust-Test

--- a/Integrations/BeyondTrust_Password_Safe/CHANGELOG.md
+++ b/Integrations/BeyondTrust_Password_Safe/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+Fixed an issue where stored credentials were using a non-unique identifier.


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19565

## Description
Credentials created and stored by this integration into Demisto did not have unique names preventing users from using the stored credentials with duplicate names when configuring integrations. Changed the names given to stored credentials so as to be more unique.

## Required version of Demisto
any

## Does it break backward compatibility?
   - Yes

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [x] BeyondTrust-Test

## Additional changes
Added python subtype to the integration yaml.

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/edit/beyondtrust-credentials-fix/Integrations/BeyondTrust_Password_Safe/CHANGELOG.md?pr=%2Fdemisto%2Fcontent%2Fpull%2F4673)