### PR TITLE
CommonServerPython IntegrationLogger auto replace fix

### DIFF
--- a/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fix IntegrationLogger auto replace of sensitive strings.
+Fixed the IntegrationLogger auto-replace of sensitive strings.
 
 ## [19.10.1] - 2019-10-15
  - Added ***is_debug_mode*** wrapper function for checking if **debug-mode** is enabled. 

--- a/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fix IntegrationLogger auto replace of sensitive strings.
 
 ## [19.10.1] - 2019-10-15
  - Added ***is_debug_mode*** wrapper function for checking if **debug-mode** is enabled. 

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -610,16 +610,17 @@ class IntegrationLogger(object):
         # set the os env COMMON_SERVER_NO_AUTO_REPLACE_STRS. Either in CommonServerUserPython, or docker env
         if (not os.getenv('COMMON_SERVER_NO_AUTO_REPLACE_STRS') and hasattr(demisto, 'getParam')):
             # add common params
-            if isinstance(demisto.getParam('credentials'), dict) and demisto.getParam('credentials').get('password'):
-                pswrd = self.encode(demisto.getParam('credentials').get('password'))
-                self.add_replace_strs(pswrd, b64_encode(pswrd))
-            sensitive_params = ('key', 'private', 'password', 'secret', 'token')
+            sensitive_params = ('key', 'private', 'password', 'secret', 'token', 'credentials')
             if demisto.params():
                 for (k, v) in demisto.params().items():
                     k_lower = k.lower()
                     for p in sensitive_params:
-                        if p in k_lower and v:
-                            self.add_replace_strs(v, b64_encode(v))
+                        if p in k_lower:
+                            if isinstance(v, STRING_OBJ_TYPES):
+                                self.add_replace_strs(v, b64_encode(v))
+                            if isinstance(v, dict) and v.get('password'):  # credentials object case
+                                pswrd = v.get('password')
+                                self.add_replace_strs(pswrd, b64_encode(pswrd))
 
     def encode(self, message):
         try:

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -552,16 +552,18 @@ def test_logger_write(mocker):
 def test_logger_init_key_name(mocker):
     mocker.patch.object(demisto, 'params', return_value={
         'key': {'password': 'my_password'},
+        'secret': 'my_secret'
     })
     mocker.patch.object(demisto, 'info')
     ilog = IntegrationLogger()
-    ilog.write("This is a test with my_password")
+    ilog.write("This is a test with my_password and my_secret")
     ilog.print_log()
     # assert that the print doesn't contain my_password
     # call_args is tuple (args list, kwargs). we only need the args
     args = demisto.info.call_args[0]
     assert 'This is a test' in args[0]
     assert 'my_password' not in args[0]
+    assert 'my_secret' not in args[0]
     assert '<XX_REPLACED>' in args[0]
 
 

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -549,6 +549,22 @@ def test_logger_write(mocker):
     assert '<XX_REPLACED>' in args[0]
 
 
+def test_logger_init_key_name(mocker):
+    mocker.patch.object(demisto, 'params', return_value={
+        'key': {'password': 'my_password'},
+    })
+    mocker.patch.object(demisto, 'info')
+    ilog = IntegrationLogger()
+    ilog.write("This is a test with my_password")
+    ilog.print_log()
+    # assert that the print doesn't contain my_password
+    # call_args is tuple (args list, kwargs). we only need the args
+    args = demisto.info.call_args[0]
+    assert 'This is a test' in args[0]
+    assert 'my_password' not in args[0]
+    assert '<XX_REPLACED>' in args[0]
+
+
 def test_logger_replace_strs(mocker):
     mocker.patch.object(demisto, 'params', return_value={
         'apikey': 'my_apikey',


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: tbd

## Description
Credential object object named with one of the following strings: ‘key’, ‘private’, ‘password’, ‘secret’, ‘token’ would error.


## Does it break backward compatibility?
   - No

## Must have
- [x] Tests (unit)
- [x] Documentation (with link to it)
- [ ] Code Review


## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/common-auto-replace-fix/Scripts/CommonServerPython/CHANGELOG.md)