### PR TITLE
IOC Reputation Command Args isArray Validation

### DIFF
--- a/Tests/scripts/constants.py
+++ b/Tests/scripts/constants.py
@@ -331,3 +331,4 @@ INTEGRATION_CATEGORIES = ['Analytics & SIEM', 'Utilities', 'Messaging', 'Endpoin
                           'Deception', 'Email Gateway']
 
 EXTERNAL_PR_REGEX = r'^pull/(\d+)$'
+REPUTATION_COMMANDS = {'file', 'email', 'domain', 'url', 'ip'}

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -1,4 +1,4 @@
-from Tests.scripts.constants import PYTHON_SUBTYPES, INTEGRATION_CATEGORIES
+from Tests.scripts.constants import PYTHON_SUBTYPES, INTEGRATION_CATEGORIES, REPUTATION_COMMANDS
 from Tests.test_utils import print_error, get_yaml, print_warning, get_remote_file, server_version_compare, \
     get_dockerimage45
 
@@ -13,8 +13,6 @@ class IntegrationValidator(object):
        current_integration (dict): Json representation of the current integration from the branch.
        old_integration (dict): Json representation of the current integration from master.
     """
-
-    reputation_commands = ['file', 'email', 'domain', 'url', 'ip']
 
     def __init__(self, file_path, check_git=True, old_file_path=None, old_git_branch='master'):
         self._is_valid = True
@@ -145,7 +143,7 @@ class IntegrationValidator(object):
         commands = self.current_integration.get('script', {}).get('commands', [])
         for command in commands:
             command_name = command.get('name')
-            if command_name in self.reputation_commands:
+            if command_name in REPUTATION_COMMANDS:
                 for arg in command.get('arguments', []):
                     arg_name = arg.get('name')
                     if arg_name == command_name:

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -46,6 +46,7 @@ class IntegrationValidator(object):
         """Check whether the Integration is valid or not, update the _is_valid field to determine that"""
         self.is_valid_subtype()
         self.is_default_arguments()
+        self.is_isarray_arguments()
         self.is_proxy_configured_correctly()
         self.is_insecure_configured_correctly()
         self.is_valid_category()
@@ -131,6 +132,29 @@ class IntegrationValidator(object):
                                     .format(arg_name, command_name))
 
         return self._is_valid
+
+
+    def is_isarray_arguments(self):
+        """Check if a reputation command's (domain/email/file/ip/url)
+            argument of the same name has the 'isArray' attribute set to True
+
+        Returns:
+            bool. Whether 'isArray' is True
+        """
+        reputation_commands = ['file', 'email', 'domain', 'url', 'ip']
+        commands = self.current_integration.get('script', {}).get('commands', [])
+        for command in commands:
+            command_name = command.get('name')
+            if command_name in reputation_commands:
+                for arg in command.get('arguments', []):
+                    arg_name = arg.get('name')
+                    if arg_name == command_name:
+                        if arg.get('isArray') is False:
+                            self._is_valid = False
+                            print_error("The argument '{}' of the command '{}' is not configured with 'isArray' set to True"
+                                        .format(arg_name, command_name))
+        return self._is_valid
+
 
     def is_outputs_for_reputations_commands_valid(self):
         """Check if a reputation command (domain/email/file/ip/url)

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -14,6 +14,8 @@ class IntegrationValidator(object):
        old_integration (dict): Json representation of the current integration from master.
     """
 
+    reputation_commands = ['file', 'email', 'domain', 'url', 'ip']
+
     def __init__(self, file_path, check_git=True, old_file_path=None, old_git_branch='master'):
         self._is_valid = True
 
@@ -140,11 +142,10 @@ class IntegrationValidator(object):
         Returns:
             bool. Whether 'isArray' is True
         """
-        reputation_commands = ['file', 'email', 'domain', 'url', 'ip']
         commands = self.current_integration.get('script', {}).get('commands', [])
         for command in commands:
             command_name = command.get('name')
-            if command_name in reputation_commands:
+            if command_name in self.reputation_commands:
                 for arg in command.get('arguments', []):
                     arg_name = arg.get('name')
                     if arg_name == command_name:

--- a/Tests/scripts/hook_validations/integration.py
+++ b/Tests/scripts/hook_validations/integration.py
@@ -133,7 +133,6 @@ class IntegrationValidator(object):
 
         return self._is_valid
 
-
     def is_isarray_arguments(self):
         """Check if a reputation command's (domain/email/file/ip/url)
             argument of the same name has the 'isArray' attribute set to True
@@ -154,7 +153,6 @@ class IntegrationValidator(object):
                             print_error("The argument '{}' of the command '{}' is not configured with 'isArray' set to True"
                                         .format(arg_name, command_name))
         return self._is_valid
-
 
     def is_outputs_for_reputations_commands_valid(self):
         """Check if a reputation command (domain/email/file/ip/url)

--- a/Tests/scripts/hook_validations/tests/integration_test.py
+++ b/Tests/scripts/hook_validations/tests/integration_test.py
@@ -676,6 +676,62 @@ def test_is_default_arguments_ok():
         "The integration validator found an invalid command arg while it is valid"
 
 
+def test_is_isarray_arguments_valid():
+    validator = IntegrationValidator("temp_file", check_git=False)
+    validator.current_integration = {
+        "script": {
+            "commands": [
+                {
+                    "name": "email",
+                    "arguments": [
+                        {
+                            "name": "email",
+                            "required": True,
+                            "default": True,
+                            "isArray": True
+                        },
+                        {
+                            "name": "verbose"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    validator.old_integration = None
+
+    assert validator.is_isarray_arguments() is True, \
+        "The integration validator found an invalid command arg configuration while it is valid"
+
+
+def test_is_isarray_arguments_invalid():
+    validator = IntegrationValidator("temp_file", check_git=False)
+    validator.current_integration = {
+        "script": {
+            "commands": [
+                {
+                    "name": "file",
+                    "arguments": [
+                        {
+                            "name": "file",
+                            "required": True,
+                            "default": True,
+                            "isArray": False
+                        },
+                        {
+                            "name": "verbose"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    validator.old_integration = None
+
+    assert validator.is_isarray_arguments() is False, \
+        "The integration validator did not find invalid arg configuration (needed to be isArray)"
+
+
 def test_is_outputs_for_reputations_commands_valid():
     validator = IntegrationValidator("temp_file", check_git=False)
     validator.current_integration = {

--- a/docs/code_conventions/README.MD
+++ b/docs/code_conventions/README.MD
@@ -220,6 +220,8 @@ There are two implementation requirements for reputation commands (aka `!file`, 
 - The reputation command's argument of the same name must have `default` set to `True`.
 - The reputation command's argument of the same name must have `isArray` set to `True`.
 
+For more details on these two command argument properties look at the [yaml-file-integration/README.md](../../docs/yaml-file-integration/README.MD#commands) in our `docs` folder.
+
 
 ## test-module
 - When users click the **Test** button, the `test-module` will execute when the **Test** button pressed in the integration instance setting page.

--- a/docs/code_conventions/README.MD
+++ b/docs/code_conventions/README.MD
@@ -152,7 +152,7 @@ class Client(BaseClient):
 ## Command Functions
 These are the best practices for defining the command functions.
 - Each integration command should have a corresponding `_command` function.
-- Eeach **_command** function should use `Client` class functions.
+- Each **_command** function should use `Client` class functions.
 - Each **_command** function should be unit testable. This means you should avoid using global functions, such as `demisto.results()`, `return_error()`, or `return_outputs()`.
 - The **_command** function will receive `client` instance and `args` (`demisto.args()` dictionary).
 - The **_command** function will return 3 variables: readable_output, outputs, raw_response
@@ -213,6 +213,13 @@ def main():
     except Exception as e:
         return_error(f'Failed to execute {demisto.command()} command. Error: {str(e)}')
 ```
+
+
+## IOC Reputation Commands
+There are two implementation requirements for reputation commands (aka `!file`, `!email`, `!domain`, `!url`, and `!ip`) that are enforced by checks in the [hook_validations](../../Tests/scripts/hook_validations/integration.py).
+- The reputation command's argument of the same name must have `default` set to `True`.
+- The reputation command's argument of the same name must have `isArray` set to `True`.
+
 
 ## test-module
 - When users click the **Test** button, the `test-module` will execute when the **Test** button pressed in the integration instance setting page.

--- a/docs/yaml-file-integration/README.MD
+++ b/docs/yaml-file-integration/README.MD
@@ -109,6 +109,8 @@ The command section tells Demisto what arguments are required for your command a
     arguments:
     - name: command-argument
       required: true
+      default: false
+      isArray: false
       description: This is a description for the argument
     outputs:
     - contextPath: Example.Sample.Name
@@ -127,6 +129,8 @@ An explanation of these fields is as follows:
 | **name** | The name of the command |
 | **arguments: name** | The name of the argument |
 | **arguments: required** | Boolean for if the argument is required |
+| **arguments: default** | Boolean for if the argument is the one chosen when argument values are passed to a command without specifying the command argument's name. Note that only one command argument can be set as the default per command |
+| **arguments: isArray** | Boolean for if the argument accepts a CSV list of input values |
 | **arguments: description** | A description of the argument |
 | **outputs: contextPath** | The dot notation representation of the context |
 | **outputs: description** | Description of the context item |


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19803

## Description
IOC reputation commands will be required to support batched indicators. Therefore implement validations check that args are marked as `isArray`.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.

## Technical writer review
- [ ] [docs/code_conventions/README.md](https://github.com/demisto/content/blob/91ff9002599aafda465cebf820827f6e2364100c/docs/code_conventions/README.MD)
- [ ] [docs/yaml-file-integration/README.md](https://github.com/demisto/content/edit/ioc-args-isarray-validation/docs/yaml-file-integration/README.MD?pr=%2Fdemisto%2Fcontent%2Fpull%2F4738)