### PR TITLE
Email entry context fix

### DIFF
--- a/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- Change Email entry context
 
 ## [19.10.1] - 2019-10-15
  - Added ***is_debug_mode*** wrapper function for checking if **debug-mode** is enabled. 

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -1606,7 +1606,7 @@ outputPaths = {
     'url': 'URL(val.Data && val.Data == obj.Data)',
     'domain': 'Domain(val.Name && val.Name == obj.Name)',
     'cve': 'CVE(val.ID && val.ID == obj.ID)',
-    'email': 'Account.Email(val.Address && val.Address == obj.Address)',
+    'email': 'Email(val.Address && val.Address == obj.Address)',
     'dbotscore': 'DBotScore'
 }
 


### PR DESCRIPTION
Hi,
The entry context of Email in common server python doesn't up to date.
If we will fix it can break some Tests but it's required to do so, so people will use the right entry context for Email.