### PR TITLE
fix - xdr-update-incident should not execute with empty arguments

### DIFF
--- a/Scripts/XDRSyncScript/CHANGELOG.md
+++ b/Scripts/XDRSyncScript/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed bug - XDRSyncScript initiated xdr-update-incident with empty arguments
+Fixed an issue where the **XDRSyncScript** script executed the ***xdr-update-incident*** command when required arguments were empty.
 
 ## [19.10.2] - 2019-10-29
 The **XDRSyncScript** now works as expected.

--- a/Scripts/XDRSyncScript/CHANGELOG.md
+++ b/Scripts/XDRSyncScript/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed bug - XDRSyncScript initiated xdr-update-incident with empty arguments
 
 ## [19.10.2] - 2019-10-29
 The **XDRSyncScript** now works as expected.


### PR DESCRIPTION
## Status
Ready

## Description
fix - xdr-update-incident should not execute with empty arguments

## Does it break backward compatibility?
   - No

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/xdrsync-fix/Scripts/XDRSyncScript/CHANGELOG.md)