### PR TITLE
Increased maximal fetch limit

### DIFF
--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Increased Splunk maximal fetch limit.
+Increased the maximum fetch limit for Splunk.
 
 ## [19.10.2] - 2019-10-29
   - Improved handling of the *app context* parameter.

--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Increased Splunk maximal fetch limit.
 
 ## [19.10.2] - 2019-10-29
   - Improved handling of the *app context* parameter.

--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -19,7 +19,7 @@ sys.setdefaultencoding('utf8')  # pylint: disable=maybe-no-member
 SPLUNK_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 VERIFY_CERTIFICATE = not bool(demisto.params().get('unsecure'))
 FETCH_LIMIT = int(demisto.params().get('fetch_limit', 50))
-FETCH_LIMIT = max(min(50, FETCH_LIMIT), 1)
+FETCH_LIMIT = max(min(200, FETCH_LIMIT), 1)
 
 
 def get_current_splunk_time(splunk_service):

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -25,7 +25,7 @@ configuration:
   required: false
   type: 0
 - defaultvalue: '50'
-  display: Fetch Limit (No more than 200, preferably under 50)
+  display: Fetch Limit (Max.- 200, Recommended less than 50)
   name: fetch_limit
   required: false
   type: 0

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -25,7 +25,7 @@ configuration:
   required: false
   type: 0
 - defaultvalue: '50'
-  display: Fetch Limit (No more than 50)
+  display: Fetch Limit (No more than 200, preferably under 50)
   name: fetch_limit
   required: false
   type: 0


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20012

## Description
The limit on Splunk's fetch incidents was too low and caused slow ingestion.
The problem should be fixed by this increase.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

