### PR TITLE
add fromversion to test playbook

### DIFF
--- a/TestPlaybooks/playbook-SecurityAdvisor-Test.yml
+++ b/TestPlaybooks/playbook-SecurityAdvisor-Test.yml
@@ -1,6 +1,7 @@
 id: SecurityAdvisor-Test
 version: -1
 name: SecurityAdvisor-Test
+fromversion: 4.5.0
 description: Test Playbook for SecurityAdvisor integration. Tests coach-end-user command.
 starttaskid: "0"
 tasks:

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1929,7 +1929,8 @@
         },
         {
             "integrations": "SecurityAdvisor",
-            "playbookID": "SecurityAdvisor-Test"
+            "playbookID": "SecurityAdvisor-Test",
+            "fromversion": "4.5.0"
         },
         {
             "integrations": "Google Key Management Service",


### PR DESCRIPTION
## Status
Ready

## Description
fixes the build, the integration is from version 4.5.0 but the test has no fromversion, that is why the build fails on server with version prior than 4.5.0

## Related PRs
List related PRs against other branches:

## Does it break backward compatibility?
   - No

