### PR TITLE
Phishing - Core - playbok + test fix

### DIFF
--- a/Playbooks/playbook-Phishing_-_Core.yml
+++ b/Playbooks/playbook-Phishing_-_Core.yml
@@ -203,6 +203,14 @@ tasks:
                       value:
                         simple: Rasterize
                     ignorecase: true
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
             iscontext: true
       - - operator: isEqualString
           left:

--- a/Playbooks/playbook-Phishing_-_Core_CHANGELOG.md
+++ b/Playbooks/playbook-Phishing_-_Core_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue where Rasterize would attempt to run even if inactive.
 
 ## [19.10.2] - 2019-10-29
 #### New Playbook

--- a/TestPlaybooks/playbook-Phishing_-_Core_-_Test.yml
+++ b/TestPlaybooks/playbook-Phishing_-_Core_-_Test.yml
@@ -84,10 +84,10 @@ tasks:
     ignoreworker: false
   "16":
     id: "16"
-    taskid: 8da75c1a-01b8-4ce4-8729-8198c1abc3a0
+    taskid: 312cbf88-1940-4449-8efa-692adda3c97e
     type: regular
     task:
-      id: 8da75c1a-01b8-4ce4-8729-8198c1abc3a0
+      id: 312cbf88-1940-4449-8efa-692adda3c97e
       version: -1
       name: Close manual review
       description: Closes the manual task to pass the test successfully. The task
@@ -101,12 +101,12 @@ tasks:
       - "3"
     scriptarguments:
       command:
-        simple: '!taskComplete id=manual parentPlaybookID=26'
+        simple: '!taskComplete id=manual parentPlaybookID=27'
       cron:
-        simple: '*/8 * * * *'
+        simple: '*/5 * * * *'
       endDate: {}
       times:
-        simple: "10"
+        simple: "15"
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -170,7 +170,7 @@ tasks:
     nexttasks:
       '#none#':
       - "16"
-      - "26"
+      - "27"
     scriptarguments:
       body: {}
       filename:
@@ -234,14 +234,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "26":
-    id: "26"
-    taskid: 94b22083-6d4b-4bca-82fd-8e0e384d5512
+  "27":
+    id: "27"
+    taskid: 1cb6933a-1d83-4f69-87de-e0e991a07e9c
     type: playbook
     task:
-      id: 94b22083-6d4b-4bca-82fd-8e0e384d5512
+      id: 1cb6933a-1d83-4f69-87de-e0e991a07e9c
       version: -1
-      name: Phishing - Simple_dev
+      name: Phishing - Core
       playbookName: Phishing - Core
       type: playbook
       iscommand: false
@@ -260,7 +260,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 480,
+          "x": 490,
           "y": 680
         }
       }
@@ -273,7 +273,7 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1150,
-        "width": 810,
+        "width": 820,
         "x": 50,
         "y": -190
       }

--- a/TestPlaybooks/playbook-Phishing_-_Core_-_Test.yml
+++ b/TestPlaybooks/playbook-Phishing_-_Core_-_Test.yml
@@ -103,7 +103,7 @@ tasks:
       command:
         simple: '!taskComplete id=manual parentPlaybookID=27'
       cron:
-        simple: '*/5 * * * *'
+        simple: '*/8 * * * *'
       endDate: {}
       times:
         simple: "15"

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1530,7 +1530,7 @@
                 "Rasterize"
             ],
             "fromversion": "4.5.0",
-            "timeout": 1200
+            "timeout": 1500
         },
         {
             "integrations": "McAfee Active Response",


### PR DESCRIPTION
## Status
Ready

## Related Issues
- fixes: https://github.com/demisto/etc/issues/20087
- fixes test failing issue as well (no issue opened)

## Description
- The test was failing because the scheduled command that should automatically complete the manual task in the `Phishing - Core` playbook, was referring to the wrong playbook ID (most likely due to changes in the test). I fixed the ID and increased the frequency and number of times that the manual task completion runs.

- I also spotted a small bug in the playbook in the Rasterize task - it would attempt to run even if inactive. Fixed as well.

## Required version of Demisto
4.5.0

## Does it break backward compatibility?
   - No