### PR TITLE
Splunk - Fixed the missing data of notable events bug

### DIFF
--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Added a new parameter to control which data is included in the labels of fetched incidents.
 
 ## [19.11.0] - 2019-11-12
 Increased the maximum fetch limit for Splunk.

--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -167,6 +167,15 @@ def notable_to_incident(event):
             rawDict = rawToDict(event['_raw'])
             for rawKey in rawDict:
                 labels.append({'type': rawKey, 'value': rawDict[rawKey]})
+    if demisto.args().get("relevant_data_for_labels", "Raw") == "All":
+        for field in event:
+            if isinstance(event[field], list):
+                # Transforming the value to a string, since labels cannot be lists.
+                list_to_string = ''.join(str(element) for element in event[field])
+                labels.append({'type': field, 'value': list_to_string})
+            # Avoiding replacing the current value of "_raw", which is parsed above using rawToDict.
+            elif field != "_raw":
+                labels.append({'type': field, 'value': event[field]})
     if demisto.get(event, 'security_domain'):
         labels.append({'type': 'security_domain', 'value': event["security_domain"]})
     incident['labels'] = labels

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -83,9 +83,15 @@ configuration:
   defaultvalue: ""
   type: 0
   required: false
-description: Run queries on Splunk servers.
-display: SplunkPy
-name: SplunkPy
+- display: Relevant data for labels (the data which will be added to the labels of
+    fetched events. Note - choosing "All" may slow down events fetching).
+  name: relevant_data_for_labels
+  defaultvalue: ""
+  type: 16
+  required: false
+  options:
+  - Raw
+  - All
 script:
   commands:
   - arguments:

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -2,6 +2,9 @@ category: Analytics & SIEM
 commonfields:
   id: SplunkPy
   version: -1
+description: Run queries on Splunk servers.
+display: SplunkPy
+name: SplunkPy
 configuration:
 - display: Host - ip (x.x.x.x)
   name: host


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20060

## Description
Whenever an event was fetched as an incident to Demisto, some of the fetched event's fields were missing from the labels.
I've added a parameter that will allow the user to have those fields added to the labels.
However, since this is a significant increase in each incident's size which might slow down fetching, the default remains only adding the raw data to the labels.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review