### PR TITLE
jira-issue-upload-file with ASCII filenames

### DIFF
--- a/Integrations/JiraV2/CHANGELOG.md
+++ b/Integrations/JiraV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Added the _attachmentName_ parameter to the ___jira-issue-upload-file___ command, which sets the attachment name in Jira.
 
 ## [19.10.2] - 2019-10-29
 API token parameter is now encrypted.

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -194,6 +194,7 @@ def generate_md_context_get_issue(data):
         attachments = demisto.get(element, 'fields.attachment')
         if isinstance(attachments, list):
             md_obj['attachment'] = ','.join(attach.get('filename') for attach in attachments)
+            context_obj['attachment'] = ','.join(attach.get('filename') for attach in attachments)
 
         get_issue_obj['md'].append(md_obj)
         get_issue_obj['context'].append(context_obj)

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -483,29 +483,29 @@ def add_comment_command(issue_id, comment, visibility=''):
     return_outputs(readable_output=human_readable, outputs={}, raw_response=contents)
 
 
-def issue_upload_command(issue_id, upload):
-    j_res = upload_file(upload, issue_id)
+def issue_upload_command(issue_id, upload, attachment_name=None):
+    j_res = upload_file(upload, issue_id, attachment_name)
     md = generate_md_upload_issue(j_res, issue_id)
     human_readable = tableToMarkdown(demisto.command(), md, "")
     contents = j_res
     return_outputs(readable_output=human_readable, outputs={}, raw_response=contents)
 
 
-def upload_file(entry_id, issue_id):
+def upload_file(entry_id, issue_id, attachment_name=None):
     headers = {
         'X-Atlassian-Token': 'no-check',
     }
+    file_name, file_bytes = get_file(entry_id)
     res = requests.post(
         url=BASE_URL + f'rest/api/latest/issue/{issue_id}/attachments',
         headers=headers,
-        files={'file': get_file(entry_id)},
+        files={'file': (attachment_name or file_name, file_bytes)},
         auth=(USERNAME, API_TOKEN or PASSWORD),
         verify=USE_SSL
     )
 
     if not res.ok:
-        return_error(
-            f'Failed to execute request, status code:{res.status_code}\nBody: {res.text}')
+        return_error(f'Failed to execute request, status code:{res.status_code}\nBody: {res.text}')
 
     return res.json()
 

--- a/Integrations/JiraV2/JiraV2.yml
+++ b/Integrations/JiraV2/JiraV2.yml
@@ -199,6 +199,8 @@ script:
       description: The ID of the issue.
     - name: upload
       description: The entry ID to upload.
+    - name: attachmentName
+      description: The attachment name to be displayed in Jira (overrides original file name)
     description: Uploads a file attachment to an issue.
   - name: jira-issue-add-comment
     arguments:

--- a/TestPlaybooks/playbook-Jira-v2-Test.yml
+++ b/TestPlaybooks/playbook-Jira-v2-Test.yml
@@ -630,7 +630,7 @@ tasks:
       - - operator: isEqualString
           left:
             value:
-              simple: File.Name
+              simple: ${Ticket.attachment}
             iscontext: true
           right:
             value:

--- a/TestPlaybooks/playbook-Jira-v2-Test.yml
+++ b/TestPlaybooks/playbook-Jira-v2-Test.yml
@@ -1,14 +1,14 @@
 id: Jira-v2-Test
-version: 2
+version: -1
 name: Jira-v2-Test
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 3ef73c80-e9db-44e2-808f-b5a916d07c93
+    taskid: dba45c76-d4b8-423e-8507-da910a986a0a
     type: start
     task:
-      id: 3ef73c80-e9db-44e2-808f-b5a916d07c93
+      id: dba45c76-d4b8-423e-8507-da910a986a0a
       version: -1
       name: ""
       iscommand: false
@@ -26,12 +26,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "1":
     id: "1"
-    taskid: 0c58843c-f39a-49de-8173-4930079cba47
+    taskid: 9695f51e-d54f-4dda-89bd-c7216b24ed3f
     type: regular
     task:
-      id: 0c58843c-f39a-49de-8173-4930079cba47
+      id: 9695f51e-d54f-4dda-89bd-c7216b24ed3f
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -56,12 +57,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
-    taskid: e70bd6cd-8f16-4500-8b50-c1060f60ffd2
+    taskid: 29324ef0-6bcd-46f5-8329-5268f144e77f
     type: regular
     task:
-      id: e70bd6cd-8f16-4500-8b50-c1060f60ffd2
+      id: 29324ef0-6bcd-46f5-8329-5268f144e77f
       version: -1
       name: jira-create-issue
       description: Create a new issue on Jira
@@ -102,12 +104,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "3":
     id: "3"
-    taskid: d3f8d2e2-ee51-46d3-8bc5-32599e15ca6c
+    taskid: 3a4230e7-07e9-4b79-8c77-e6e2bbd3f2fa
     type: regular
     task:
-      id: d3f8d2e2-ee51-46d3-8bc5-32599e15ca6c
+      id: 3a4230e7-07e9-4b79-8c77-e6e2bbd3f2fa
       version: -1
       name: jira-get-issue
       description: Fetch issue from Jira
@@ -135,12 +138,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "4":
     id: "4"
-    taskid: 1fbdf37b-40bd-467e-84c4-8603602e7393
+    taskid: 53c14246-24ff-44cb-8431-7b2ba6befcc7
     type: regular
     task:
-      id: 1fbdf37b-40bd-467e-84c4-8603602e7393
+      id: 53c14246-24ff-44cb-8431-7b2ba6befcc7
       version: -1
       name: VerifyContextFields
       scriptName: VerifyContextFields
@@ -173,12 +177,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
-    taskid: 151e43fb-aabc-4a0c-8c08-0cf36be38050
+    taskid: 4bd14937-933b-4514-81ad-f2a01e46214d
     type: regular
     task:
-      id: 151e43fb-aabc-4a0c-8c08-0cf36be38050
+      id: 4bd14937-933b-4514-81ad-f2a01e46214d
       version: -1
       name: jira-issue-add-comment
       description: Add new comment to existing Jira issue
@@ -205,12 +210,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "6":
     id: "6"
-    taskid: 1ea23c8c-dcff-4701-86bd-e2e800d38188
+    taskid: a866d23d-1c6e-4e40-8516-f609a705fe8b
     type: regular
     task:
-      id: 1ea23c8c-dcff-4701-86bd-e2e800d38188
+      id: a866d23d-1c6e-4e40-8516-f609a705fe8b
       version: -1
       name: jira-issue-add-link
       description: Creates (or updates) issue link
@@ -241,12 +247,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "9":
     id: "9"
-    taskid: 04b162b7-a79d-4b52-8761-af7f3cb9fa42
+    taskid: 92ac5ce5-d7d8-4e2e-8cc6-cd472a33f756
     type: regular
     task:
-      id: 04b162b7-a79d-4b52-8761-af7f3cb9fa42
+      id: 92ac5ce5-d7d8-4e2e-8cc6-cd472a33f756
       version: -1
       name: jira-issue-upload-file
       description: Upload a file attachments to an issue
@@ -258,6 +265,8 @@ tasks:
       '#none#':
       - "12"
     scriptarguments:
+      attachmentName:
+        simple: testfile.txt
       issueId:
         simple: ${Ticket.Id}
       upload:
@@ -272,12 +281,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "11":
     id: "11"
-    taskid: 9296772d-7030-4bc5-8e68-16ac20a836fd
+    taskid: 7dfb63bd-0b64-4085-89f9-02b5f14681d8
     type: regular
     task:
-      id: 9296772d-7030-4bc5-8e68-16ac20a836fd
+      id: 7dfb63bd-0b64-4085-89f9-02b5f14681d8
       version: -1
       name: VerifyContextFields
       scriptName: VerifyContextFields
@@ -310,12 +320,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "12":
     id: "12"
-    taskid: 3f691c22-fcc9-4463-8769-539ebdab6161
+    taskid: 6c20a65d-722a-4780-85e0-29387a4b1cbc
     type: regular
     task:
-      id: 3f691c22-fcc9-4463-8769-539ebdab6161
+      id: 6c20a65d-722a-4780-85e0-29387a4b1cbc
       version: -1
       name: jira-issue-query
       description: Query Jira issues
@@ -342,12 +353,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "13":
     id: "13"
-    taskid: df0a90a2-4410-44ce-8d89-07e75a55c40f
+    taskid: 2f0b1862-ae7e-4998-8113-860f61bcfa54
     type: regular
     task:
-      id: df0a90a2-4410-44ce-8d89-07e75a55c40f
+      id: 2f0b1862-ae7e-4998-8113-860f61bcfa54
       version: -1
       name: FileCreateAndUpload
       description: |
@@ -374,12 +386,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "14":
     id: "14"
-    taskid: 75002cc4-453f-4dc7-80e2-883358efaba9
+    taskid: ee7d30df-0f17-4dae-8a32-764321ec87fb
     type: regular
     task:
-      id: 75002cc4-453f-4dc7-80e2-883358efaba9
+      id: ee7d30df-0f17-4dae-8a32-764321ec87fb
       version: -1
       name: jira-edit-issue
       script: '|||jira-edit-issue'
@@ -412,12 +425,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "18":
     id: "18"
-    taskid: 5a40beb6-f9af-43c5-8b56-d15d2a4ecc98
+    taskid: bb6875d7-2c53-41df-8a62-81ffdfc5f91b
     type: regular
     task:
-      id: 5a40beb6-f9af-43c5-8b56-d15d2a4ecc98
+      id: bb6875d7-2c53-41df-8a62-81ffdfc5f91b
       version: -1
       name: VerifyContext - Summary
       scriptName: VerifyContext
@@ -443,12 +457,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "21":
     id: "21"
-    taskid: 52962537-8a8c-45fa-836b-df9a2a5c9b14
+    taskid: e47265e7-2bdf-4a09-8f95-9f1e5c82fbe5
     type: regular
     task:
-      id: 52962537-8a8c-45fa-836b-df9a2a5c9b14
+      id: e47265e7-2bdf-4a09-8f95-9f1e5c82fbe5
       version: -1
       name: VerifyContext - Status
       scriptName: VerifyContext
@@ -474,12 +489,13 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "22":
     id: "22"
-    taskid: e6b8c279-faab-4b6c-8b2c-dbcefde06a6a
+    taskid: a539b38b-c417-4011-853e-98b5d24f5c4a
     type: regular
     task:
-      id: e6b8c279-faab-4b6c-8b2c-dbcefde06a6a
+      id: a539b38b-c417-4011-853e-98b5d24f5c4a
       version: -1
       name: jira-get-comments
       script: '|||jira-get-comments'
@@ -497,17 +513,18 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 2645
+          "y": 2820
         }
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "23":
     id: "23"
-    taskid: 8d40873a-dc3d-4421-8131-cf241914412a
+    taskid: 2d740c9c-5416-449d-821b-5853cb147503
     type: regular
     task:
-      id: 8d40873a-dc3d-4421-8131-cf241914412a
+      id: 2d740c9c-5416-449d-821b-5853cb147503
       version: -1
       name: VerifyContext - comment
       scriptName: VerifyContext
@@ -528,17 +545,18 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 2820
+          "y": 2995
         }
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "24":
     id: "24"
-    taskid: 4851d018-28df-44db-8dee-b5506fc03a20
+    taskid: 664772b5-0b10-4651-88bf-fd003f309c6d
     type: regular
     task:
-      id: 4851d018-28df-44db-8dee-b5506fc03a20
+      id: 664772b5-0b10-4651-88bf-fd003f309c6d
       version: -1
       name: delete-issue
       script: '|||jira-delete-issue'
@@ -553,17 +571,18 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 2995
+          "y": 3170
         }
       }
     note: false
     timertriggers: []
+    ignoreworker: false
   "25":
     id: "25"
-    taskid: 0c7ebbec-bbc5-46cc-8de8-72c73f11ffe8
+    taskid: 0cb252db-9391-4295-8436-f2d85d71c72e
     type: regular
     task:
-      id: 0c7ebbec-bbc5-46cc-8de8-72c73f11ffe8
+      id: 0cb252db-9391-4295-8436-f2d85d71c72e
       version: -1
       name: jira-get-issue with getAttachments
       script: '|||jira-get-issue'
@@ -572,7 +591,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "22"
+      - "26"
     scriptarguments:
       getAttachments:
         simple: '"true"'
@@ -589,12 +608,49 @@ tasks:
       }
     note: false
     timertriggers: []
+    ignoreworker: false
+  "26":
+    id: "26"
+    taskid: 6dfdac4d-b9f0-4bf7-855f-9de512952a96
+    type: condition
+    task:
+      id: 6dfdac4d-b9f0-4bf7-855f-9de512952a96
+      version: -1
+      name: check attachment name
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "22"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              simple: File.Name
+            iscontext: true
+          right:
+            value:
+              simple: testfile.txt
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2645
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 3040,
+        "height": 3215,
         "width": 380,
         "x": 50,
         "y": 50


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19707

## Description
`jira-issue-upload-file` fails with error 500 if the file to be uploaded contains special (non-ASCII). added a new argument **attachmentName** that will override the original filename when trying to upload.

## Does it break backward compatibility?
   - No

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)