### PR TITLE
extend retries in wait for server to be ready

### DIFF
--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -16,7 +16,7 @@ from Tests.test_utils import print_error, print_color, LOG_COLORS
 # Disable insecure warnings
 urllib3.disable_warnings()
 
-MAX_TRIES = 20
+MAX_TRIES = 30
 SLEEP_TIME = 45
 
 


### PR DESCRIPTION
## Status
Ready

## Description
nightly build fails because server is not ready until the end of the retries to connect to it.
so this one increases the retries by 50%

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests - this is the testing infra itself
- [ ] Code Review