### PR TITLE
Moving Redlock out of skipped

### DIFF
--- a/TestPlaybooks/playbook-RedLockTest.yml
+++ b/TestPlaybooks/playbook-RedLockTest.yml
@@ -1,5 +1,6 @@
 id: RedLockTest
 version: -1
+fromversion: 5.0.0
 name: RedLockTest
 starttaskid: "0"
 tasks:

--- a/TestPlaybooks/playbook-RedLockTest.yml
+++ b/TestPlaybooks/playbook-RedLockTest.yml
@@ -1,6 +1,5 @@
 id: RedLockTest
 version: -1
-fromversion: 5.0.0
 name: RedLockTest
 starttaskid: "0"
 tasks:

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1089,7 +1089,6 @@
         {
             "integrations": "RedLock",
             "playbookID": "RedLockTest",
-            "fromversion": "5.0.0",
             "nightly": true
         },
         {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2119,6 +2119,6 @@
         "MicrosoftGraphMail": "Test direct access to oproxy",
         "Microsoft Graph User": "Test direct access to oproxy",
         "Windows Defender Advanced Threat Protection": "Test direct access to oproxy",
-        "Redlock": "SSL Issues"
+        "RedLock": "SSL Issues"
     }
 }

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1089,6 +1089,7 @@
         {
             "integrations": "RedLock",
             "playbookID": "RedLockTest",
+            "fromversion": "5.0.0",
             "nightly": true
         },
         {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2118,6 +2118,7 @@
         "Microsoft Graph": "Test direct access to oproxy",
         "MicrosoftGraphMail": "Test direct access to oproxy",
         "Microsoft Graph User": "Test direct access to oproxy",
-        "Windows Defender Advanced Threat Protection": "Test direct access to oproxy"
+        "Windows Defender Advanced Threat Protection": "Test direct access to oproxy",
+        "Redlock": "SSL Issues"
     }
 }

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2041,7 +2041,6 @@
         "Check Point Sandblast": "Issue 15948",
         "Remedy AR": "getting 'Not Found' in test button",
         "XFE": "License expired",
-        "RedLock": "Issue 15493",
         "Salesforce": "Issue 15901",
         "Zscaler": "Issue 17784",
         "RedCanary": "License expired",


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/15493

## Description
Fixed Redlock's test with new creds, and now removing it from skipped.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Code Review