### PR TITLE
Unskipping PAN-OS

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1949,7 +1949,6 @@
     "skipped_tests": {
         "Create Phishing Classifier V2 ML Test": "Issue 20174",
         "Extract Indicators From File - Generic v2": "Issue 20143",
-        "PAN-OS Create Or Edit Rule Test":"Issue 20037",
         "NetWitness Endpoint Test": "Issue 19878",
         "SentinelOne V2 - test": "Issue 19361",
         "CuckooTest": "Issue 19425",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20156
fixes: https://github.com/demisto/etc/issues/20037

## Description
don't see any reason to change the SELinux permissions as the tests passes.

## Does it break backward compatibility?
   - No