### PR TITLE
Client change to use API key

### DIFF
--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -528,7 +528,7 @@ def execute_testing(server, server_ip, server_version, server_numeric_version, i
     password = secret_conf.get('userPassword')
     demisto_api_key = secret_conf.get('temp_apikey')
 
-    c = demisto_client.configure(base_url=server, username=username, password=password, verify_ssl=False)
+    c = demisto_client.configure(base_url=server, api_key=demisto_api_key, verify_ssl=False)
 
     default_test_timeout = conf.get('testTimeout', 30)
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -523,9 +523,6 @@ def execute_testing(server, server_ip, server_version, server_numeric_version, i
     build_name = options.buildName
 
     conf, secret_conf = load_conf_files(conf_path, secret_conf_path)
-
-    username = secret_conf.get('username')
-    password = secret_conf.get('userPassword')
     demisto_api_key = secret_conf.get('temp_apikey')
 
     c = demisto_client.configure(base_url=server, api_key=demisto_api_key, verify_ssl=False)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: a bug, probably creates others.

## Description
We used username and password while running the tests. By design, demisto-py creates a singular client. This client is then invoked multiple times throughout the testing process. After an undetermined amount of time, the session expires and renders the client invalid. We catch this error, but it takes down the build in the process.

We are changing the client to use the api-key which should address this issue.