### PR TITLE
Extract Indicators From File - Generic v2 - 3 bugfixes + additional formats

### DIFF
--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2.yml
@@ -9,22 +9,28 @@ description: |-
   - TXT
   - HTM, HTML
   - DOC, DOCX
-starttaskid: "0"
+  - PPT
+  - PPTX
+  - RTF
+  - XLS
+  - XLSX
+  - XML
+starttaskid: '0'
 tasks:
-  "0":
-    id: "0"
+  '0':
+    id: '0'
     taskid: 7820586b-f2e6-4673-8dd8-08caab0d1173
     type: start
     task:
       id: 7820586b-f2e6-4673-8dd8-08caab0d1173
       version: -1
-      description: Start
-      name: ""
+      name: ''
+      description: ''
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "1"
+      - '1'
     separatecontext: false
     view: |-
       {
@@ -36,8 +42,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "1":
-    id: "1"
+  '1':
+    id: '1'
     taskid: 7872ce6f-5e06-4c00-846b-6de0d54307b1
     type: condition
     task:
@@ -48,15 +54,15 @@ tasks:
         Checks if there is a file in the playbook input.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "10"
-      "yes":
-      - "2"
+      - '10'
+      'yes':
+      - '2'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -75,22 +81,22 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "2":
-    id: "2"
-    taskid: e06408f8-c0cb-4516-87c0-014108497f20
+  '2':
+    id: '2'
+    taskid: ae4c0ec9-1082-477b-8b41-dc412d1377e5
     type: regular
     task:
-      id: e06408f8-c0cb-4516-87c0-014108497f20
+      id: ae4c0ec9-1082-477b-8b41-dc412d1377e5
       version: -1
       name: Set file to local context
       description: Set the input file into local context.
       scriptName: Set
       type: regular
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "4"
+      - '4'
     scriptarguments:
       append: {}
       key:
@@ -98,6 +104,8 @@ tasks:
       value:
         complex:
           root: inputs.File
+          transformers:
+          - operator: uniq
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -110,46 +118,47 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "3":
-    id: "3"
+  '3':
+    id: '3'
     taskid: 832242ed-942e-4094-8cf4-003921e7ef7a
     type: title
     task:
       id: 832242ed-942e-4094-8cf4-003921e7ef7a
       version: -1
       name: Done
-      description: Done
+      description: ''
       type: title
       iscommand: false
-      brand: ""
+      brand: ''
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 510,
-          "y": 1680
+          "y": 1730
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "4":
-    id: "4"
+  '4':
+    id: '4'
     taskid: ab59c7dd-3e82-4efe-8e36-d3065d88a590
     type: title
     task:
       id: ab59c7dd-3e82-4efe-8e36-d3065d88a590
       version: -1
       name: Extract Indicators From Files
-      description: Extracts indicators from files
+      description: ''
       type: title
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "5"
-      - "7"
-      - "9"
+      - '5'
+      - '7'
+      - '9'
+      - '15'
     separatecontext: false
     view: |-
       {
@@ -161,27 +170,27 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "5":
-    id: "5"
-    taskid: 6bc85e4c-1f70-41b7-8bec-3c6410c9ad53
+  '5':
+    id: '5'
+    taskid: 1bb80350-a076-43ed-8d0a-af4d4cdc7b16
     type: condition
     task:
-      id: 6bc85e4c-1f70-41b7-8bec-3c6410c9ad53
+      id: 1bb80350-a076-43ed-8d0a-af4d4cdc7b16
       version: -1
       name: Is there a text-based file?
       description: Checks if there is a text-based file in context. Skips MSG and
         EML files.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "10"
-      "yes":
-      - "6"
+      - '10'
+      'yes':
+      - '6'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -246,6 +255,42 @@ tasks:
                     right:
                       value:
                         simple: message/rfc822
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: text/rtf
+                    ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: rtf
+                    ignorecase: true
+                - - operator: notContainsGeneral
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xml
+                    ignorecase: true
+                - - operator: notContainsGeneral
+                    left:
+                      value:
+                        simple: File.Type
+                      iscontext: true
+                    right:
+                      value:
+                        simple: text/rtf
+                    ignorecase: true
                 accessor: EntryID
                 transformers:
                 - operator: uniq
@@ -260,22 +305,22 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "6":
-    id: "6"
-    taskid: d2c83c31-2092-4c86-81ad-359fcf0ee1e6
+  '6':
+    id: '6'
+    taskid: 584508ae-71de-46a5-8c04-e5d45dfbb6d0
     type: regular
     task:
-      id: d2c83c31-2092-4c86-81ad-359fcf0ee1e6
+      id: 584508ae-71de-46a5-8c04-e5d45dfbb6d0
       version: -1
       name: Extract indicators from text-based file
       description: Extracts indicators from text-based files.
       scriptName: ExtractIndicatorsFromTextFile
       type: regular
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "3"
+      - '3'
     scriptarguments:
       entryID:
         complex:
@@ -338,6 +383,42 @@ tasks:
               right:
                 value:
                   simple: message/rfc822
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: text/rtf
+              ignorecase: true
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: rtf
+              ignorecase: true
+          - - operator: notContainsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: xml
+              ignorecase: true
+          - - operator: notContainsGeneral
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: text/rtf
+              ignorecase: true
           accessor: EntryID
           transformers:
           - operator: uniq
@@ -347,15 +428,15 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 82.5,
-          "y": 950
+          "x": 92.5,
+          "y": 1000
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "7":
-    id: "7"
+  '7':
+    id: '7'
     taskid: 79feacf1-749d-4213-85ce-9b87809c59cf
     type: condition
     task:
@@ -365,15 +446,15 @@ tasks:
       description: Checks if there is a PDF file in context.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "10"
-      "yes":
-      - "8"
+      - '10'
+      'yes':
+      - '8'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -413,8 +494,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "8":
-    id: "8"
+  '8':
+    id: '8'
     taskid: f954fb51-0ed0-44d2-837a-64f852f3dd9d
     type: regular
     task:
@@ -425,10 +506,10 @@ tasks:
       scriptName: ReadPDFFileV2
       type: regular
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "13"
+      - '13'
     scriptarguments:
       entryID:
         complex:
@@ -462,32 +543,32 @@ tasks:
       {
         "position": {
           "x": 930,
-          "y": 950
+          "y": 1000
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "9":
-    id: "9"
-    taskid: 596a82ed-b1a5-4a82-8eca-c351ae07e8c3
+  '9':
+    id: '9'
+    taskid: ea30b950-c393-43b3-8f33-1804d071bb4b
     type: condition
     task:
-      id: 596a82ed-b1a5-4a82-8eca-c351ae07e8c3
+      id: ea30b950-c393-43b3-8f33-1804d071bb4b
       version: -1
       name: Is there a Word file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "10"
-      "yes":
-      - "11"
+      - '10'
+      'yes':
+      - '11'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -511,6 +592,15 @@ tasks:
                     right:
                       value:
                         simple: Microsoft Word
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: docx
+                    ignorecase: true
                 - - operator: isNotEqualString
                     left:
                       value:
@@ -571,6 +661,24 @@ tasks:
                       value:
                         simple: Excel
                     ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: ppt
+                    ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: pptx
+                    ignorecase: true
                 accessor: EntryID
                 transformers:
                 - operator: uniq
@@ -585,48 +693,48 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "10":
-    id: "10"
+  '10':
+    id: '10'
     taskid: 371fb092-fd79-4550-8b2e-d3c945d2cc10
     type: title
     task:
       id: 371fb092-fd79-4550-8b2e-d3c945d2cc10
       version: -1
       name: No File To Parse
-      description: No File To Parse
+      description: ''
       type: title
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "3"
+      - '3'
     separatecontext: false
     view: |-
       {
         "position": {
           "x": -350,
-          "y": 900
+          "y": 950
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "11":
-    id: "11"
-    taskid: e08be4df-5efa-4f1a-834d-05a15f8fd63f
+  '11':
+    id: '11'
+    taskid: bccca988-5145-4391-8476-945618df7c72
     type: regular
     task:
-      id: e08be4df-5efa-4f1a-834d-05a15f8fd63f
+      id: bccca988-5145-4391-8476-945618df7c72
       version: -1
       name: Extract indicators from Word file
       description: Extracts indicators from word files (DOC, DOCX).
       scriptName: ExtractIndicatorsFromWordFile
       type: regular
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "3"
+      - '3'
     scriptarguments:
       entryID:
         complex:
@@ -648,6 +756,15 @@ tasks:
               right:
                 value:
                   simple: Microsoft Word
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: docx
+              ignorecase: true
           - - operator: isNotEqualString
               left:
                 value:
@@ -708,6 +825,23 @@ tasks:
                 value:
                   simple: Excel
               ignorecase: true
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: ppt
+              ignorecase: true
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: pptx
           accessor: EntryID
           transformers:
           - operator: uniq
@@ -717,14 +851,14 @@ tasks:
       {
         "position": {
           "x": 510,
-          "y": 950
+          "y": 1000
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "12":
-    id: "12"
+  '12':
+    id: '12'
     taskid: 01853d00-5297-4e59-83fa-1aec87f7b3aa
     type: condition
     task:
@@ -734,15 +868,15 @@ tasks:
       description: Checks whether images were extracted from PDF files.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "3"
-      "yes":
-      - "14"
+      - '3'
+      'yes':
+      - '14'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -793,14 +927,14 @@ tasks:
       {
         "position": {
           "x": 1180,
-          "y": 1310
+          "y": 1360
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "13":
-    id: "13"
+  '13':
+    id: '13'
     taskid: 60827e91-7450-4f79-8e82-863488b15371
     type: condition
     task:
@@ -811,15 +945,15 @@ tasks:
         enabled.
       type: condition
       iscommand: false
-      brand: ""
+      brand: ''
     nexttasks:
       '#default#':
-      - "3"
-      "yes":
-      - "12"
+      - '3'
+      'yes':
+      - '12'
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: 'yes'
       condition:
       - - operator: isExists
           left:
@@ -840,14 +974,14 @@ tasks:
       {
         "position": {
           "x": 1060,
-          "y": 1120
+          "y": 1170
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "14":
-    id: "14"
+  '14':
+    id: '14'
     taskid: 19fe4f88-c55b-4f13-814c-1ad0aae31cae
     type: regular
     task:
@@ -859,10 +993,10 @@ tasks:
       script: '|||image-ocr-extract-text'
       type: regular
       iscommand: true
-      brand: ""
+      brand: ''
     nexttasks:
       '#none#':
-      - "3"
+      - '3'
     scriptarguments:
       entryid:
         complex:
@@ -914,7 +1048,348 @@ tasks:
       {
         "position": {
           "x": 1300,
-          "y": 1490
+          "y": 1540
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  '15':
+    id: '15'
+    taskid: b7677e2a-e24c-42f2-845e-0a0b8138222c
+    type: condition
+    task:
+      id: b7677e2a-e24c-42f2-845e-0a0b8138222c
+      version: -1
+      name: Is there another supported document type?
+      description: |-
+        Checks if one of the following file types exists:
+        - PPT
+        - PPTX
+        - RTF
+        - XLS
+        - XLSX
+        - XML
+      type: condition
+      iscommand: false
+      brand: ''
+    nexttasks:
+      '#default#':
+      - '10'
+      'yes':
+      - '16'
+    separatecontext: false
+    conditions:
+    - label: 'yes'
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: File
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: ppt
+                    ignorecase: true
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: pptx
+                    ignorecase: true
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: rtf
+                    ignorecase: true
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xls
+                    ignorecase: true
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xlsx
+                    ignorecase: true
+                  - operator: containsGeneral
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xml
+                    ignorecase: true
+                  - operator: containsGeneral
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: vnd.ms-powerpoint
+                    ignorecase: true
+                  - operator: containsGeneral
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: vnd.ms-excel
+                    ignorecase: true
+                  - operator: containsGeneral
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: text/rtf
+                    ignorecase: true
+                accessor: EntryID
+                transformers:
+                - operator: uniq
+            iscontext: true
+          ignorecase: true
+    view: |-
+      {
+        "position": {
+          "x": 1520,
+          "y": 700
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  '16':
+    id: '16'
+    taskid: 8e1253c5-d43e-46fc-833c-733839e10dd4
+    type: regular
+    task:
+      id: 8e1253c5-d43e-46fc-833c-733839e10dd4
+      version: -1
+      name: Convert document to PDF
+      description: |-
+        Converts the following formats to PDF format:
+        - PPT
+        - PPTX
+        - RTF
+        - XLS
+        - XLSX
+        - XML
+      scriptName: ConvertFile
+      type: regular
+      iscommand: false
+      brand: ''
+    nexttasks:
+      '#none#':
+      - '17'
+    scriptarguments:
+      all_files:
+        simple: 'yes'
+      entry_id:
+        complex:
+          root: File
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: ppt
+              ignorecase: true
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: pptx
+              ignorecase: true
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: rtf
+              ignorecase: true
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: xls
+              ignorecase: true
+            - operator: isEqualString
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: xlsx
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: xml
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: vnd.ms-powerpoint
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: vnd.ms-excel
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: text/rtf
+              ignorecase: true
+          accessor: EntryID
+          transformers:
+          - operator: uniq
+      format: {}
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1600,
+          "y": 1015
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  '17':
+    id: '17'
+    taskid: 630c86cc-1ab5-4512-82e6-1326fe94beeb
+    type: regular
+    task:
+      id: 630c86cc-1ab5-4512-82e6-1326fe94beeb
+      version: -1
+      name: Extract indicators from document converted to PDF
+      description: |-
+        Extracts indicators from all other supported documents that have been converted to PDF beforehand. The formats are:
+        - PPT
+        - PPTX
+        - RTF
+        - XLS
+        - XLSX
+        - XML
+      scriptName: ReadPDFFileV2
+      type: regular
+      iscommand: false
+      brand: ''
+    nexttasks:
+      '#none#':
+      - '3'
+    scriptarguments:
+      entryID:
+        complex:
+          root: File
+          filters:
+          - - operator: notIn
+              left:
+                value:
+                  simple: EntryID
+                iscontext: true
+              right:
+                value:
+                  simple: inputs.File.EntryID
+                iscontext: true
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: application/pdf
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Type
+                iscontext: true
+              right:
+                value:
+                  simple: PDF document
+              ignorecase: true
+            - operator: containsGeneral
+              left:
+                value:
+                  simple: File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: application/pdf
+          transformers:
+          - operator: uniq
+          - operator: getField
+            args:
+              field:
+                value:
+                  simple: EntryID
+      maxImages: {}
+      userPassword: {}
+    reputationcalc: 2
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1810,
+          "y": 1240
         }
       }
     note: false
@@ -927,15 +1402,19 @@ view: |-
       "12_3_#default#": 0.34,
       "13_12_yes": 0.55,
       "13_3_#default#": 0.19,
+      "15_16_yes": 0.38,
       "1_10_#default#": 0.15,
-      "5_10_#default#": 0.25,
+      "5_10_#default#": 0.36,
+      "5_6_yes": 0.36,
       "7_10_#default#": 0.1,
-      "9_10_#default#": 0.16
+      "7_8_yes": 0.38,
+      "9_10_#default#": 0.21,
+      "9_11_yes": 0.35
     },
     "paper": {
       "dimensions": {
-        "height": 1765,
-        "width": 2030,
+        "height": 1815,
+        "width": 2540,
         "x": -350,
         "y": -20
       }
@@ -946,6 +1425,8 @@ inputs:
   value:
     complex:
       root: File
+      transformers:
+      - operator: uniq
   required: false
   description: The file from which to extract indicators.
 outputs:

--- a/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_CHANGELOG.md
+++ b/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_CHANGELOG.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+- Fixed an issue where the playbook would not always catch DOCX files
+- Fixed an issue where RTF was extracted as a plain text file
+- Fixed an issue where PPT files were extracted as Word documents
+- Added XLS, XLSX, PPT, PPTX, and XML file support.

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
@@ -9,14 +9,18 @@ description: |-
   TXT
   HTM, HTML
   DOC, DOCX
+  RTF
+  XLSX
+  PPTX
+  XML
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: acf29053-815f-4e96-8122-4781e4f967d7
+    taskid: 78bf33b4-ff2b-4983-8dce-f7378b58fbe3
     type: start
     task:
-      id: acf29053-815f-4e96-8122-4781e4f967d7
+      id: 78bf33b4-ff2b-4983-8dce-f7378b58fbe3
       version: -1
       name: ""
       iscommand: false
@@ -37,10 +41,10 @@ tasks:
     ignoreworker: false
   "1":
     id: "1"
-    taskid: 8d01fbd2-8fe8-49f3-89ea-1c412a1c53a1
+    taskid: 15c5130d-0e87-4e30-8e72-5a055ba0b5d7
     type: regular
     task:
-      id: 8d01fbd2-8fe8-49f3-89ea-1c412a1c53a1
+      id: 15c5130d-0e87-4e30-8e72-5a055ba0b5d7
       version: -1
       name: Download TXT file
       description: Downloads a TXT file using HTTP GET.
@@ -50,7 +54,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -80,10 +84,10 @@ tasks:
     ignoreworker: false
   "3":
     id: "3"
-    taskid: 36c14cb2-423d-4d53-8423-2f1a44f4875f
+    taskid: 00fdd3e6-d928-46cc-8ad4-b964c19d6cae
     type: condition
     task:
-      id: 36c14cb2-423d-4d53-8423-2f1a44f4875f
+      id: 00fdd3e6-d928-46cc-8ad4-b964c19d6cae
       version: -1
       name: Were the correct indicators extracted?
       description: Checks whether specific indicators were extracted from each one
@@ -190,10 +194,10 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 88666eac-de82-43cd-80e7-b7bcbd707c8b
+    taskid: 77036a8e-804e-4b68-8f43-bc45b6209dcb
     type: title
     task:
-      id: 88666eac-de82-43cd-80e7-b7bcbd707c8b
+      id: 77036a8e-804e-4b68-8f43-bc45b6209dcb
       version: -1
       name: Done
       type: title
@@ -212,10 +216,10 @@ tasks:
     ignoreworker: false
   "5":
     id: "5"
-    taskid: a7537367-cc86-4d5c-8179-eb9e3edbf463
+    taskid: b6d1b934-2c67-49cd-8a78-d38a5aeeb3cf
     type: regular
     task:
-      id: a7537367-cc86-4d5c-8179-eb9e3edbf463
+      id: b6d1b934-2c67-49cd-8a78-d38a5aeeb3cf
       version: -1
       name: Make test fail
       description: Causes the test playbook to fail if the correct email addresses
@@ -244,10 +248,10 @@ tasks:
     ignoreworker: false
   "7":
     id: "7"
-    taskid: 69f8a4ec-a422-4067-84d8-c09cf54de4a9
+    taskid: dc6fd48f-81c5-45b7-8591-ba1a1d61ec24
     type: title
     task:
-      id: 69f8a4ec-a422-4067-84d8-c09cf54de4a9
+      id: dc6fd48f-81c5-45b7-8591-ba1a1d61ec24
       version: -1
       name: Download Files
       type: title
@@ -262,6 +266,8 @@ tasks:
       - "15"
       - "18"
       - "20"
+      - "23"
+      - "25"
     separatecontext: false
     view: |-
       {
@@ -275,10 +281,10 @@ tasks:
     ignoreworker: false
   "8":
     id: "8"
-    taskid: d021722f-2461-4b45-863a-d17979a1988e
+    taskid: 96dce868-c3d3-4036-8796-161f10ef1ec2
     type: regular
     task:
-      id: d021722f-2461-4b45-863a-d17979a1988e
+      id: 96dce868-c3d3-4036-8796-161f10ef1ec2
       version: -1
       name: Download DOC file
       description: Downloads a DOC file using HTTP GET.
@@ -288,7 +294,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -318,10 +324,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: d79d8f9b-0d3d-479f-8fe1-1cf0902d8bf2
+    taskid: 9482b4f3-cfff-4572-8177-82425015af71
     type: regular
     task:
-      id: d79d8f9b-0d3d-479f-8fe1-1cf0902d8bf2
+      id: 9482b4f3-cfff-4572-8177-82425015af71
       version: -1
       name: Download DOCX file
       description: Downloads a DOCX file using HTTP GET.
@@ -331,7 +337,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -361,10 +367,10 @@ tasks:
     ignoreworker: false
   "11":
     id: "11"
-    taskid: 2c831b40-0b51-4868-8d07-3452279b8f0b
+    taskid: db1f5f75-c756-4d00-8bd4-316323b8f184
     type: regular
     task:
-      id: 2c831b40-0b51-4868-8d07-3452279b8f0b
+      id: db1f5f75-c756-4d00-8bd4-316323b8f184
       version: -1
       name: Download PDF file
       description: Downloads a PDF file using HTTP GET.
@@ -374,7 +380,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -404,10 +410,10 @@ tasks:
     ignoreworker: false
   "12":
     id: "12"
-    taskid: 77764bdf-2752-45c1-845b-9912d826761d
+    taskid: b184ff30-45c2-4ddd-8401-cade5152ff59
     type: regular
     task:
-      id: 77764bdf-2752-45c1-845b-9912d826761d
+      id: b184ff30-45c2-4ddd-8401-cade5152ff59
       version: -1
       name: Delete Context
       description: Delete the context of the incident to start with clear context.
@@ -439,10 +445,10 @@ tasks:
     ignoreworker: false
   "14":
     id: "14"
-    taskid: 6d32259d-a837-4547-82d0-cf883f087d8b
+    taskid: 31115798-08a0-4f95-8d45-51f88b87d1ca
     type: condition
     task:
-      id: 6d32259d-a837-4547-82d0-cf883f087d8b
+      id: 31115798-08a0-4f95-8d45-51f88b87d1ca
       version: -1
       name: Did the PDF file return outputs?
       description: |-
@@ -525,10 +531,10 @@ tasks:
     ignoreworker: false
   "15":
     id: "15"
-    taskid: 9ac7080d-c4dd-4b94-8fe0-4b182283c074
+    taskid: 79e7cd2d-b448-467f-8514-4869fd39a425
     type: regular
     task:
-      id: 9ac7080d-c4dd-4b94-8fe0-4b182283c074
+      id: 79e7cd2d-b448-467f-8514-4869fd39a425
       version: -1
       name: Download EML file
       description: Downloads an EML file using HTTP GET.
@@ -538,7 +544,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -568,10 +574,10 @@ tasks:
     ignoreworker: false
   "18":
     id: "18"
-    taskid: b24d3e5f-c9a5-4d2a-851a-2e7d7aea1877
+    taskid: 411b835a-4896-4f5a-821a-c317bfdf19c1
     type: regular
     task:
-      id: b24d3e5f-c9a5-4d2a-851a-2e7d7aea1877
+      id: 411b835a-4896-4f5a-821a-c317bfdf19c1
       version: -1
       name: Download XLSX file
       description: Downloads an XLSX file using HTTP GET.
@@ -581,7 +587,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -609,39 +615,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  "19":
-    id: "19"
-    taskid: aaea1865-4ee1-4738-8d3a-794c62b22d03
-    type: playbook
-    task:
-      id: aaea1865-4ee1-4738-8d3a-794c62b22d03
-      version: -1
-      name: Extract Indicators From File - Generic v2
-      playbookName: Extract Indicators From File - Generic v2
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "14"
-      - "3"
-    separatecontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 770
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
   "20":
     id: "20"
-    taskid: 3f9b5e0d-cf2f-4305-8983-856df49f1b50
+    taskid: 8e151e12-588e-4907-8554-e0cebb60daf4
     type: regular
     task:
-      id: 3f9b5e0d-cf2f-4305-8983-856df49f1b50
+      id: 8e151e12-588e-4907-8554-e0cebb60daf4
       version: -1
       name: Download RTF file
       description: Sends http request. Returns the response as json.
@@ -651,7 +630,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "19"
+      - "21"
     scriptarguments:
       body: {}
       filename: {}
@@ -678,6 +657,129 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+  "21":
+    id: "21"
+    taskid: 950f9080-f2b8-427e-8ede-0cec74bf04b8
+    type: playbook
+    task:
+      id: 950f9080-f2b8-427e-8ede-0cec74bf04b8
+      version: -1
+      name: Extract Indicators From File - Generic v2
+      playbookName: Extract Indicators From File - Generic v2
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "14"
+      - "3"
+    scriptarguments:
+      File:
+        complex:
+          root: File
+          transformers:
+          - operator: uniq
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 770
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "23":
+    id: "23"
+    taskid: e940c9e5-3236-42f9-823f-a5ada1ffc259
+    type: regular
+    task:
+      id: e940c9e5-3236-42f9-823f-a5ada1ffc259
+      version: -1
+      name: Download PPTX file
+      description: Downloads an PPTX file using HTTP GET.
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "21"
+    scriptarguments:
+      body: {}
+      filename: {}
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password: {}
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/test_pptx.pptx
+      username: {}
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 1940,
+          "y": 570
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "25":
+    id: "25"
+    taskid: 9b443dc6-bb8c-4eb4-8da3-f8eb91fd299e
+    type: regular
+    task:
+      id: 9b443dc6-bb8c-4eb4-8da3-f8eb91fd299e
+      version: -1
+      name: Download XML file
+      description: Downloads an XML file using HTTP GET.
+      scriptName: http
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "21"
+    scriptarguments:
+      body: {}
+      filename: {}
+      headers: {}
+      insecure: {}
+      method:
+        simple: GET
+      password: {}
+      proxy: {}
+      saveAsFile:
+        simple: "yes"
+      unsecure: {}
+      url:
+        simple: https://raw.githubusercontent.com/demisto/content/master/TestData/test_xml.xml
+      username: {}
+    reputationcalc: 1
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 2400,
+          "y": 570
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -687,7 +789,7 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1415,
-        "width": 3240,
+        "width": 4160,
         "x": -1380,
         "y": 50
       }


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20272
fixes: https://github.com/demisto/etc/issues/20246
fixes: https://github.com/demisto/etc/issues/20247
fixes: https://github.com/demisto/etc/issues/19446

## Description
- Fixed an issue where the playbook would not always catch DOCX files
- Fixed an issue where RTF was extracted as a plain text file
- Fixed an issue where PPT files were extracted as Word documents
- Added XLS, XLSX, PPT, PPTX, and XML file support.
- Improved synergy between the playbook filters and the (currently broken) HTTP GET method

## Required version of Demisto
4.1.0

## Does it break backward compatibility?
   - Yes
       - Further details: RTF is now converted to PDF and extracted properly. Probably won't cause any problems.

## Must have
- [x] Tests
- [ ] Documentation
- [ ] Code Review


## Additional changes
Unfortunately I found 4 content and 2 server bugs while working on this. This PR fixes 3 of them.
![Bugs I found when working on an ENHANCEMENT for Extract Indicators From File - Generic v2  There is another server issue that I didn't open because I cannot reproduce it](https://user-images.githubusercontent.com/43602124/69350057-8af75180-0c81-11ea-8b88-5630b5d22c14.PNG)



## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)