### PR TITLE
Update sane-doc-reports

### DIFF
--- a/Scripts/SaneDocReport/CHANGELOG.md
+++ b/Scripts/SaneDocReport/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-  - Makes the line chart x-axis more readable (padded)
-  - Fixes graphs width
+  - Fixed an issue where the line chart x-axis was not readable.
+  - Fixed an issue with graphs width.
 
 ## [19.11.0] - 2019-11-12
   - Fixed table and list functions.

--- a/Scripts/SaneDocReport/CHANGELOG.md
+++ b/Scripts/SaneDocReport/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue where the line chart x-axis was not readable.
-  - Fixed an issue with graphs width.
+  - Fixed an issue with graph width.
 
 ## [19.11.0] - 2019-11-12
   - Fixed table and list functions.

--- a/Scripts/SaneDocReport/CHANGELOG.md
+++ b/Scripts/SaneDocReport/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue where the line chart x-axis was not readable.
-  - Fixed an issue with graphs width.
+  - Fixed an issue with the graphs width.
 
 ## [19.11.0] - 2019-11-12
   - Fixed table and list functions.

--- a/Scripts/SaneDocReport/CHANGELOG.md
+++ b/Scripts/SaneDocReport/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue where the line chart x-axis was not readable.
-  - Fixed an issue with graph width.
+  - Fixed an issue with graphs width.
 
 ## [19.11.0] - 2019-11-12
   - Fixed table and list functions.

--- a/Scripts/SaneDocReport/CHANGELOG.md
+++ b/Scripts/SaneDocReport/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-
+  - Makes the line chart x-axis more readable (padded)
+  - Fixes graphs width
 
 ## [19.11.0] - 2019-11-12
   - Fixed table and list functions.

--- a/Scripts/SaneDocReport/SaneDocReport.yml
+++ b/Scripts/SaneDocReport/SaneDocReport.yml
@@ -33,7 +33,7 @@ tags:
 - docx
 timeout: '0'
 type: python
-dockerimage: demisto/sane-doc-reports:1.0.0.3374
+dockerimage: demisto/sane-doc-reports:1.0.0.4202
 runas: DBotWeakRole
 runonce: false
 tests:


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/sane-doc-reports/pull/59
https://github.com/demisto/dockerfiles/pull/912

https://github.com/demisto/etc/issues/19553
https://github.com/demisto/etc/issues/18586

## Description
Updating the `sane-doc-reports` tag.
Docx reports fixes for: graph size, and labels readability.

## Required version of Demisto
5.0.0

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [X] Code Review

## Additional changes

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](Scripts/SaneDocReport/CHANGELOG.md)