### PR TITLE
Content Creator Packs Support

### DIFF
--- a/content_creator.py
+++ b/content_creator.py
@@ -97,8 +97,8 @@ def add_tools_to_bundle(bundle):
 
 # modify incident fields file to contain only `incidentFields` field (array)
 # from { "incidentFields": [...]} to [...]
-def convert_incident_fields_to_array():
-    scan_files = glob.glob(os.path.join(INCIDENT_FIELDS_DIR, '*.json'))
+def convert_incident_fields_to_array(incident_fields_dir=INCIDENT_FIELDS_DIR):
+    scan_files = glob.glob(os.path.join(incident_fields_dir, '*.json'))
     for path in scan_files:
         with open(path, 'r+') as file_:
             data = json.load(file_)
@@ -110,10 +110,10 @@ def convert_incident_fields_to_array():
 
 
 def copy_yaml_post(path, out_path, yml_info):
-    dirname = os.path.dirname(path)
-    if dirname in DIR_TO_PREFIX.keys() and not os.path.basename(path).startswith('playbook-'):
+    parent_dir_name = os.path.basename(os.path.dirname(path))
+    if parent_dir_name in DIR_TO_PREFIX.keys() and not os.path.basename(path).startswith('playbook-'):
         script_obj = yml_info
-        if dirname != 'Scripts':
+        if parent_dir_name != 'Scripts':
             script_obj = yml_info['script']
         with io.open(path, mode='r', encoding='utf-8') as file_:
             yml_text = file_.read()
@@ -125,8 +125,8 @@ def copy_yaml_post(path, out_path, yml_info):
     shutil.copyfile(path, out_path)
 
 
-def copy_dir_yml(dir_name, bundle_post):
-    scan_files = glob.glob(os.path.join(dir_name, '*.yml'))
+def copy_dir_yml(dir_path, bundle_post):
+    scan_files = glob.glob(os.path.join(dir_path, '*.yml'))
     post_files = 0
     for path in scan_files:
         if len(os.path.basename(path)) >= MAX_FILE_NAME:
@@ -142,9 +142,10 @@ def copy_dir_yml(dir_name, bundle_post):
     print(f' - total files: {post_files}')
 
 
-def copy_dir_json(dir_name, bundle_post):
+def copy_dir_json(dir_path, bundle_post):
     # handle *.json files
-    scan_files = glob.glob(os.path.join(dir_name, '*.json'))
+    dir_name = os.path.basename(dir_path)
+    scan_files = glob.glob(os.path.join(dir_path, '*.json'))
     for path in scan_files:
         dpath = os.path.basename(path)
         # this part is a workaround because server doesn't support indicatorfield-*.json naming
@@ -167,9 +168,9 @@ def copy_dir_files(*args):
     copy_dir_yml(*args)
 
 
-def copy_test_files(bundle_test):
+def copy_test_files(bundle_test, test_playbooks_dir=TEST_PLAYBOOKS_DIR):
     print('Copying test files to test bundle')
-    scan_files = glob.glob(os.path.join(TEST_PLAYBOOKS_DIR, '*'))
+    scan_files = glob.glob(os.path.join(test_playbooks_dir, '*'))
     for path in scan_files:
         if os.path.isdir(path):
             non_circle_tests = glob.glob(os.path.join(path, '*'))

--- a/content_creator.py
+++ b/content_creator.py
@@ -193,27 +193,7 @@ def copy_test_files(bundle_test, test_playbooks_dir=TEST_PLAYBOOKS_DIR):
             shutil.copyfile(path, os.path.join(bundle_test, os.path.basename(path)))
 
 
-def main(circle_artifacts):
-    print('Starting to create content artifact...')
-
-    print('creating dir for bundles...')
-    for bundle_dir in [BUNDLE_POST, BUNDLE_TEST, PACKS_BUNDLE]:
-        os.mkdir(bundle_dir)
-
-    add_tools_to_bundle(BUNDLE_POST)
-
-    for package_dir in DIR_TO_PREFIX:
-        # handles nested package directories
-        create_unifieds_and_copy(package_dir)
-
-    for content_dir in CONTENT_DIRS:
-        print(f'Copying dir {content_dir} to bundles...')
-        copy_dir_files(content_dir, BUNDLE_POST)
-
-    copy_test_files(BUNDLE_TEST)
-
-    # handle copying packs content to content_new.zip and content_test.zip
-    packs = get_child_directories(PACKS_DIR)
+def copy_packs_content_to_old_bundles(packs):
     for pack in packs:
         # each pack directory has it's own content subdirs, 'Integrations', 'Scripts', 'TestPlaybooks', 'Layouts' etc.
         sub_dirs_paths = get_child_directories(pack)
@@ -229,7 +209,8 @@ def main(circle_artifacts):
                     # handle nested packages
                     create_unifieds_and_copy(sub_dir_path)
 
-    # handle copying packs content to packs_bundle for zipping to `content_packs.zip`
+
+def copy_packs_content_to_packs_bundle(packs):
     for pack in packs:
         pack_name = os.path.basename(pack)
         pack_dst = os.path.join(PACKS_BUNDLE, pack_name)
@@ -261,6 +242,33 @@ def main(circle_artifacts):
                         shutil.copyfile(md_file_path, os.path.join(dest_dir, md_out_name))
             else:
                 copy_dir_files(content_dir, dest_dir)
+
+
+def main(circle_artifacts):
+    print('Starting to create content artifact...')
+
+    print('creating dir for bundles...')
+    for bundle_dir in [BUNDLE_POST, BUNDLE_TEST, PACKS_BUNDLE]:
+        os.mkdir(bundle_dir)
+
+    add_tools_to_bundle(BUNDLE_POST)
+
+    for package_dir in DIR_TO_PREFIX:
+        # handles nested package directories
+        create_unifieds_and_copy(package_dir)
+
+    for content_dir in CONTENT_DIRS:
+        print(f'Copying dir {content_dir} to bundles...')
+        copy_dir_files(content_dir, BUNDLE_POST)
+
+    copy_test_files(BUNDLE_TEST)
+
+    # handle copying packs content to bundles for zipping to content_new.zip and content_test.zip
+    packs = get_child_directories(PACKS_DIR)
+    copy_packs_content_to_old_bundles(packs)
+
+    # handle copying packs content to packs_bundle for zipping to `content_packs.zip`
+    copy_packs_content_to_packs_bundle(packs)
 
     print('Copying content descriptor to bundles')
     for bundle_dir in [BUNDLE_POST, BUNDLE_TEST]:

--- a/content_creator.py
+++ b/content_creator.py
@@ -61,6 +61,15 @@ def get_child_directories(directory):
     return child_directories
 
 
+def get_child_files(directory):
+    '''Return a list of paths of immediate child files of the 'directory' argument'''
+    child_files = [
+        os.path.join(directory, path) for
+        path in os.listdir(directory) if os.path.isfile(os.path.join(directory, path))
+    ]
+    return child_files
+
+
 def create_unifieds_and_copy(package_dir, dest_dir=BUNDLE_POST, skip_dest_dir=BUNDLE_TEST):
     '''
     For directories that have packages, aka subdirectories for each integration/script

--- a/content_creator.py
+++ b/content_creator.py
@@ -87,14 +87,15 @@ def create_unifieds_and_copy(package_dir, dest_dir=BUNDLE_POST, skip_dest_dir=BU
             case the package is part of the skipped list
     '''
     scanned_packages = glob.glob(os.path.join(package_dir, '*/'))
+    package_dir_name = os.path.basename(package_dir)
     for package in scanned_packages:
         if any(package_to_skip in package for package_to_skip in PACKAGES_TO_SKIP):
             # there are some packages that we don't want to include in the content zip
             # for example HelloWorld integration
-            merge_script_package_to_yml(package, package_dir, BUNDLE_TEST)
+            merge_script_package_to_yml(package, package_dir_name, BUNDLE_TEST)
             print('skipping {}'.format(package))
         else:
-            merge_script_package_to_yml(package, package_dir, BUNDLE_POST)
+            merge_script_package_to_yml(package, package_dir_name, BUNDLE_POST)
 
 
 def add_tools_to_bundle(bundle):

--- a/content_creator.py
+++ b/content_creator.py
@@ -52,24 +52,12 @@ MAX_FILE_NAME = 85
 LONG_FILE_NAMES = []
 
 
-def get_parent_directory(path):
-    pass
-
-
 def get_child_directories(directory):
     '''Return a list of paths of immediate child directories of the 'directory' argument'''
     child_directories = [
         os.path.join(directory, path) for
         path in os.listdir(directory) if os.path.isdir(os.path.join(directory, path))
     ]
-    # # make sure that directory paths end in '/'
-    # directories = []
-    # for directory in child_directories:
-    #     if not directory.endswith('/'):
-    #         directories.append(directory + '/')
-    #     else:
-    #         directories.append(directory)
-    # return directories
     return child_directories
 
 
@@ -280,7 +268,8 @@ def main(circle_artifacts):
                     package_dir_name = os.path.basename(package_dir)
                     dest_package_dir = os.path.join(dest_dir, package_dir_name)
                     os.mkdir(dest_package_dir)
-                    merge_script_package_to_yml(package_dir, dir_name, dest_path=dest_package_dir)
+                    package_dir_with_slash = package_dir + '/'
+                    merge_script_package_to_yml(package_dir_with_slash, dir_name, dest_path=dest_package_dir)
 
                     # also copy CHANGELOG markdown files over
                     package_files = get_child_files(package_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -52,12 +52,24 @@ MAX_FILE_NAME = 85
 LONG_FILE_NAMES = []
 
 
+def get_parent_directory(path):
+    pass
+
+
 def get_child_directories(directory):
     '''Return a list of paths of immediate child directories of the 'directory' argument'''
     child_directories = [
         os.path.join(directory, path) for
         path in os.listdir(directory) if os.path.isdir(os.path.join(directory, path))
     ]
+    # # make sure that directory paths end in '/'
+    # directories = []
+    # for directory in child_directories:
+    #     if not directory.endswith('/'):
+    #         directories.append(directory + '/')
+    #     else:
+    #         directories.append(directory)
+    # return directories
     return child_directories
 
 
@@ -277,7 +289,7 @@ def main(circle_artifacts):
                         for file_path in package_files if ('CHANGELOG' in file_path and file_path.endswith('.md'))
                     ]
                     for md_file_path in changelog_files:
-                        shutil.copyfile(md_file_path, dest_package_dir)
+                        shutil.copyfile(md_file_path, os.path.join(dest_package_dir, os.path.basename(md_file_path)))
             else:
                 if dir_name == INCIDENT_FIELDS_DIR:
                     convert_incident_fields_to_array(content_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -109,20 +109,6 @@ def add_tools_to_bundle(bundle):
         zipf.close()
 
 
-# modify incident fields file to contain only `incidentFields` field (array)
-# from { "incidentFields": [...]} to [...]
-def convert_incident_fields_to_array(incident_fields_dir=INCIDENT_FIELDS_DIR):
-    scan_files = glob.glob(os.path.join(incident_fields_dir, '*.json'))
-    for path in scan_files:
-        with open(path, 'r+') as file_:
-            data = json.load(file_)
-            incident_fields = data.get('incidentFields')
-            if incident_fields is not None:
-                file_.seek(0)
-                json.dump(incident_fields, file_, indent=2)
-                file_.truncate()
-
-
 def copy_playbook_yml(path, out_path, *args):
     '''Add "playbook-" prefix to playbook file's copy destination filename if it wasn't already present'''
     dest_dir_path = os.path.dirname(out_path)
@@ -218,8 +204,6 @@ def main(circle_artifacts):
 
     add_tools_to_bundle(BUNDLE_POST)
 
-    convert_incident_fields_to_array()
-
     for package_dir in DIR_TO_PREFIX:
         # handles nested package directories
         create_unifieds_and_copy(package_dir)
@@ -279,8 +263,6 @@ def main(circle_artifacts):
                         md_out_name = DIR_TO_PREFIX.get(dir_name) + '-' + package_dir_name + '_CHANGELOG.md'
                         shutil.copyfile(md_file_path, os.path.join(dest_dir, md_out_name))
             else:
-                if dir_name == INCIDENT_FIELDS_DIR:
-                    convert_incident_fields_to_array(content_dir)
                 copy_dir_files(content_dir, dest_dir)
 
     print('Copying content descriptor to bundles')

--- a/content_creator.py
+++ b/content_creator.py
@@ -122,6 +122,16 @@ def convert_incident_fields_to_array(incident_fields_dir=INCIDENT_FIELDS_DIR):
                 file_.truncate()
 
 
+def copy_playbook_yml(path, out_path, *args):
+    '''Add "playbook-" prefix to playbook file's copy destination filename if it wasn't already present'''
+    dest_dir_path = os.path.dirname(out_path)
+    dest_file_name = os.path.basename(out_path)
+    if not dest_file_name.startswith('playbook-'):
+        new_name = '{}{}'.format('playbook-', dest_file_name)
+        out_path = os.path.join(dest_dir_path, new_name)
+    shutil.copyfile(path, out_path)
+
+
 def copy_yaml_post(path, out_path, yml_info):
     parent_dir_name = os.path.basename(os.path.dirname(path))
     if parent_dir_name in DIR_TO_PREFIX.keys() and not os.path.basename(path).startswith('playbook-'):
@@ -141,6 +151,8 @@ def copy_yaml_post(path, out_path, yml_info):
 def copy_dir_yml(dir_path, bundle_post):
     scan_files = glob.glob(os.path.join(dir_path, '*.yml'))
     post_files = 0
+    dir_name = os.path.basename(dir_path)
+    copy_func = copy_playbook_yml if dir_name in ['Playbooks', 'TestPlaybooks'] else copy_yaml_post
     for path in scan_files:
         if len(os.path.basename(path)) >= MAX_FILE_NAME:
             LONG_FILE_NAMES.append(path)
@@ -150,7 +162,7 @@ def copy_dir_yml(dir_path, bundle_post):
 
         ver = yml_info.get('fromversion', '0')
         print(f' - processing: {ver} ({path})')
-        copy_yaml_post(path, os.path.join(bundle_post, os.path.basename(path)), yml_info)
+        copy_func(path, os.path.join(bundle_post, os.path.basename(path)), yml_info)
         post_files += 1
     print(f' - total files: {post_files}')
 

--- a/content_creator.py
+++ b/content_creator.py
@@ -248,8 +248,7 @@ def main(circle_artifacts):
                 packages_dirs = get_child_directories(content_dir)
                 for package_dir in packages_dirs:
                     package_dir_name = os.path.basename(package_dir)
-                    package_dir_with_slash = package_dir + '/'
-                    merge_script_package_to_yml(package_dir_with_slash, dir_name, dest_path=dest_dir)
+                    merge_script_package_to_yml(package_dir, dir_name, dest_path=dest_dir)
 
                     # also copy CHANGELOG markdown files over (should only be one per package)
                     package_files = get_child_files(package_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -266,19 +266,18 @@ def main(circle_artifacts):
                 packages_dirs = get_child_directories(content_dir)
                 for package_dir in packages_dirs:
                     package_dir_name = os.path.basename(package_dir)
-                    dest_package_dir = os.path.join(dest_dir, package_dir_name)
-                    os.mkdir(dest_package_dir)
                     package_dir_with_slash = package_dir + '/'
-                    merge_script_package_to_yml(package_dir_with_slash, dir_name, dest_path=dest_package_dir)
+                    merge_script_package_to_yml(package_dir_with_slash, dir_name, dest_path=dest_dir)
 
-                    # also copy CHANGELOG markdown files over
+                    # also copy CHANGELOG markdown files over (should only be one per package)
                     package_files = get_child_files(package_dir)
                     changelog_files = [
                         file_path
                         for file_path in package_files if ('CHANGELOG' in file_path and file_path.endswith('.md'))
                     ]
                     for md_file_path in changelog_files:
-                        shutil.copyfile(md_file_path, os.path.join(dest_package_dir, os.path.basename(md_file_path)))
+                        md_out_name = DIR_TO_PREFIX.get(dir_name) + '-' + package_dir_name + '_CHANGELOG.md'
+                        shutil.copyfile(md_file_path, os.path.join(dest_dir, md_out_name))
             else:
                 if dir_name == INCIDENT_FIELDS_DIR:
                     convert_incident_fields_to_array(content_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -255,10 +255,10 @@ def main(circle_artifacts):
                     package_files = get_child_files(package_dir)
                     changelog_files = [
                         file_path
-                        for file_path in package_files if ('CHANGELOG' in file_path and file_path.endswith('.md'))
+                        for file_path in package_files if 'CHANGELOG.md' in file_path
                     ]
                     for md_file_path in changelog_files:
-                        md_out_name = DIR_TO_PREFIX.get(dir_name) + '-' + package_dir_name + '_CHANGELOG.md'
+                        md_out_name = '{}-{}_CHANGELOG.md'.format(DIR_TO_PREFIX.get(dir_name), package_dir_name)
                         shutil.copyfile(md_file_path, os.path.join(dest_dir, md_out_name))
             else:
                 copy_dir_files(content_dir, dest_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -9,7 +9,7 @@ import yaml
 
 from Tests.scripts.constants import INTEGRATIONS_DIR, MISC_DIR, PLAYBOOKS_DIR, REPORTS_DIR, DASHBOARDS_DIR, \
     WIDGETS_DIR, SCRIPTS_DIR, INCIDENT_FIELDS_DIR, CLASSIFIERS_DIR, LAYOUTS_DIR, CONNECTIONS_DIR, \
-    BETA_INTEGRATIONS_DIR, INDICATOR_FIELDS_DIR, INCIDENT_TYPES_DIR, TEST_PLAYBOOKS_DIR
+    BETA_INTEGRATIONS_DIR, INDICATOR_FIELDS_DIR, INCIDENT_TYPES_DIR, TEST_PLAYBOOKS_DIR, PACKS_DIR
 from Tests.test_utils import print_error
 from package_creator import DIR_TO_PREFIX, merge_script_package_to_yml, write_yaml_with_docker
 
@@ -35,8 +35,6 @@ PACKAGES_TO_SKIP = [
     'HelloWorldSimple',
     'HelloWorldScript'
 ]
-
-PACKS_DIR = 'Packs'
 
 # temp folder names
 BUNDLE_POST = 'bundle_post'
@@ -121,7 +119,7 @@ def copy_playbook_yml(path, out_path, *args):
 
 def copy_yaml_post(path, out_path, yml_info):
     parent_dir_name = os.path.basename(os.path.dirname(path))
-    if parent_dir_name in DIR_TO_PREFIX.keys() and not os.path.basename(path).startswith('playbook-'):
+    if parent_dir_name in DIR_TO_PREFIX and not os.path.basename(path).startswith('playbook-'):
         script_obj = yml_info
         if parent_dir_name != 'Scripts':
             script_obj = yml_info['script']
@@ -226,7 +224,7 @@ def main(circle_artifacts):
             else:
                 # handle one-level deep content
                 copy_dir_files(sub_dir_path, BUNDLE_POST)
-                if dir_name in DIR_TO_PREFIX.keys():
+                if dir_name in DIR_TO_PREFIX:
                     # then it's a directory with nested packages that need to be handled
                     # handle nested packages
                     create_unifieds_and_copy(sub_dir_path)
@@ -246,7 +244,7 @@ def main(circle_artifacts):
             dir_name = os.path.basename(content_dir)
             dest_dir = os.path.join(pack_dst, dir_name)
             os.mkdir(dest_dir)
-            if dir_name in DIR_TO_PREFIX.keys():
+            if dir_name in DIR_TO_PREFIX:
                 packages_dirs = get_child_directories(content_dir)
                 for package_dir in packages_dirs:
                     package_dir_name = os.path.basename(package_dir)

--- a/content_creator.py
+++ b/content_creator.py
@@ -48,6 +48,42 @@ MAX_FILE_NAME = 85
 LONG_FILE_NAMES = []
 
 
+def get_child_directories(directory):
+    '''Return a list of paths of immediate child directories of the 'directory' argument'''
+    child_directories = [
+        os.path.join(directory, path) for
+        path in os.listdir(directory) if os.path.isdir(os.path.join(directory, path))
+    ]
+    return child_directories
+
+
+def create_unifieds_and_copy(package_dir, dest_dir=BUNDLE_POST, skip_dest_dir=BUNDLE_TEST):
+    '''
+    For directories that have packages, aka subdirectories for each integration/script
+    e.g. "Integrations", "Beta_Integrations", "Scripts". Creates a unified yml and writes
+    it to the dest_dir
+
+    Arguments:
+        package_dir: (str)
+            Path to directory in which there are package subdirectories. e.g. "Integrations",
+            "Beta_Integrations", "Scripts"
+        dest_dir: (str)
+            Path to destination directory to which the unified yml for a package should be written
+        skip_dest_dir: (str)
+            Path to the directory to which the unified yml for a package should be written in the
+            case the package is part of the skipped list
+    '''
+    scanned_packages = glob.glob(os.path.join(package_dir, '*/'))
+    for package in scanned_packages:
+        if any(package_to_skip in package for package_to_skip in PACKAGES_TO_SKIP):
+            # there are some packages that we don't want to include in the content zip
+            # for example HelloWorld integration
+            merge_script_package_to_yml(package, package_dir, BUNDLE_TEST)
+            print('skipping {}'.format(package))
+        else:
+            merge_script_package_to_yml(package, package_dir, BUNDLE_POST)
+
+
 def add_tools_to_bundle(bundle):
     for directory in glob.glob(os.path.join('Tools', '*')):
         zipf = zipfile.ZipFile(os.path.join(bundle, f'tools-{os.path.basename(directory)}.zip'), 'w',

--- a/content_creator.py
+++ b/content_creator.py
@@ -36,12 +36,16 @@ PACKAGES_TO_SKIP = [
     'HelloWorldScript'
 ]
 
+PACKS_DIR = 'Packs'
+
 # temp folder names
 BUNDLE_POST = 'bundle_post'
 BUNDLE_TEST = 'bundle_test'
+PACKS_BUNDLE = 'packs_bundle'
 # zip files names (the extension will be added later - shutil demands file name without extension)
 ZIP_POST = 'content_new'
 ZIP_TEST = 'content_test'
+ZIP_PACKS = 'content_packs'
 
 # server can't handle long file names
 MAX_FILE_NAME = 85

--- a/package_creator.py
+++ b/package_creator.py
@@ -102,16 +102,7 @@ def merge_script_package_to_yml(package_path, dir_name, dest_path=""):
     else:
         output_path = os.path.join(dir_name, output_filename)
 
-    yml_paths = glob.glob(os.path.join(package_path, '*.yml'))
-    yml_path = yml_paths[0]
-    for path in yml_paths:
-        # The plugin creates a unified YML file for the package.
-        # In case this script runs locally and there is a unified YML file in the package we need to ignore it.
-        # Also,
-        # we don't take the unified file by default because there might be packages that were not created by the plugin.
-        if 'unified' not in path:
-            yml_path = path
-            break
+    yml_path = '{}/{}.yml'.format(package_path, package_dir_name)
 
     with open(yml_path, 'r') as yml_file:
         yml_data = yaml.safe_load(yml_file)

--- a/package_creator.py
+++ b/package_creator.py
@@ -174,7 +174,7 @@ def insert_description_to_yml(dir_name, package_path, yml_data, yml_text):
 
 
 def get_data(dir_name, package_path, extension):
-    data_path = glob.glob(package_path + extension)
+    data_path = glob.glob(os.path.join(package_path, extension))
     data = None
     found_data_path = None
     if dir_name in ('Integrations', 'Beta_Integrations') and data_path:

--- a/package_creator.py
+++ b/package_creator.py
@@ -93,7 +93,10 @@ def merge_script_package_to_yml(package_path, dir_name, dest_path=""):
         output path, script path, image path
     """
     print("Merging package: {}".format(package_path))
-    output_filename = '{}-{}.yml'.format(DIR_TO_PREFIX[dir_name], os.path.basename(os.path.dirname(package_path)))
+    if package_path.endswith('/'):
+        package_path = package_path.rstrip('/')
+    package_dir_name = os.path.basename(package_path)
+    output_filename = '{}-{}.yml'.format(DIR_TO_PREFIX[dir_name], package_dir_name)
     if dest_path:
         output_path = os.path.join(dest_path, output_filename)
     else:

--- a/package_creator.py
+++ b/package_creator.py
@@ -99,7 +99,7 @@ def merge_script_package_to_yml(package_path, dir_name, dest_path=""):
     else:
         output_path = os.path.join(dir_name, output_filename)
 
-    yml_paths = glob.glob(package_path + '*.yml')
+    yml_paths = glob.glob(os.path.join(package_path, '*.yml'))
     yml_path = yml_paths[0]
     for path in yml_paths:
         # The plugin creates a unified YML file for the package.

--- a/package_creator.py
+++ b/package_creator.py
@@ -102,7 +102,16 @@ def merge_script_package_to_yml(package_path, dir_name, dest_path=""):
     else:
         output_path = os.path.join(dir_name, output_filename)
 
-    yml_path = '{}/{}.yml'.format(package_path, package_dir_name)
+    yml_paths = glob.glob(os.path.join(package_path, '*.yml'))
+    yml_path = yml_paths[0]
+    for path in yml_paths:
+        # The plugin creates a unified YML file for the package.
+        # In case this script runs locally and there is a unified YML file in the package we need to ignore it.
+        # Also,
+        # we don't take the unified file by default because there might be packages that were not created by the plugin.
+        if 'unified' not in path:
+            yml_path = path
+            break
 
     with open(yml_path, 'r') as yml_file:
         yml_data = yaml.safe_load(yml_file)


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19885

## Description
Add packs support to `content_creator.py`.
Look at this [build](https://circleci.com/gh/demisto/content/34471?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) to see these changes operating on a branch in which the files in the CortexXDR pack have been changed so as not to be duplicates of files already existing in content. Can look at the `Create Content Artifacts` build step and also inspect the zip files created by the build -
[content_new.zip](https://34471-60525392-gh.circle-artifacts.com/0/artifacts/content_new.zip)
[content_test.zip](https://34471-60525392-gh.circle-artifacts.com/0/artifacts/content_test.zip)
[content_packs.zip](https://34471-60525392-gh.circle-artifacts.com/0/artifacts/content_packs.zip)

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review