### PR TITLE
Archer - Fixed retrieval of app IDs for applications with reverse field mapping. 

### DIFF
--- a/Integrations/integration-ArcherRSA.yml
+++ b/Integrations/integration-ArcherRSA.yml
@@ -2754,6 +2754,18 @@ script:
         };
     }
 
+
+    function getFieldIdInReverseMapping(idToNameMapping, fieldNameToSearch) {
+        for (var fieldID in idToNameMapping) {
+            var currentFieldData = idToNameMapping[fieldID];
+            if ("Name" in currentFieldData && currentFieldData["Name"] === fieldNameToSearch) {
+                return fieldID;
+            }
+        }
+        return '';
+    }
+
+
     function searchRecords(command, dataArgs) {
         /* corresponds to 'archer-search-records' command. Returns records from Archer who matches the user's
            search criteria. Looks for incident ids from Archer and then gets each one of them in getSearchRecords
@@ -2817,12 +2829,20 @@ script:
         var fieldIdToSearchOn;
         var fieldNameToSearchOn;
         if (fieldToSearchOn && searchValue) { // the user entered search parameters
-            fieldIdToSearchOn = nameToFieldMapping[fieldToSearchOn] ? nameToFieldMapping[fieldToSearchOn].Id : '';
+            isFieldNameInMapping = nameToFieldMapping[fieldToSearchOn] && typeof nameToFieldMapping[fieldToSearchOn] !== 'undefined';
+            fieldIdToSearchOn = isFieldNameInMapping ? nameToFieldMapping[fieldToSearchOn].Id : '';
+            if (fieldIdToSearchOn === '') {
+                fieldIdToSearchOn = getFieldIdInReverseMapping(nameToFieldMapping, fieldToSearchOn)
+            }
+            throw fieldIdToSearchOn;
             fieldNameToSearchOn = fieldToSearchOn;
         }else{ // performing a general search
             fieldNameToSearchOn = "Date Created";
             isFieldNameInMapping = nameToFieldMapping[fieldNameToSearchOn] && typeof nameToFieldMapping[fieldNameToSearchOn] !== 'undefined';
             fieldIdToSearchOn = isFieldNameInMapping? JSON.stringify(nameToFieldMapping[fieldNameToSearchOn].Id) : '';
+            if (fieldIdToSearchOn === '') {
+                fieldIdToSearchOn = getFieldIdInReverseMapping(nameToFieldMapping, fieldNameToSearchOn)
+            }
             dateOperator = "GreaterThan";
             var day = 60 * 1000 * 60 * 24;
             searchValue = toDateArcherString(new Date(new Date().getTime() - (day * 31)));

--- a/Integrations/integration-ArcherRSA.yml
+++ b/Integrations/integration-ArcherRSA.yml
@@ -2834,7 +2834,6 @@ script:
             if (fieldIdToSearchOn === '') {
                 fieldIdToSearchOn = getFieldIdInReverseMapping(nameToFieldMapping, fieldToSearchOn)
             }
-            throw fieldIdToSearchOn;
             fieldNameToSearchOn = fieldToSearchOn;
         }else{ // performing a general search
             fieldNameToSearchOn = "Date Created";

--- a/Integrations/integration-ArcherRSA_CHANGELOG.md
+++ b/Integrations/integration-ArcherRSA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-Fixed an issue with the presentation of users display names.
+- Fixed an issue with the presentation of users display names.
+- Fixed retrieval of app IDs for applications with reverse field mapping. 
 
 ## [19.11.0] - 2019-11-12
 - Fixed an issue in the Archer fetch incidents offset.

--- a/Integrations/integration-ArcherRSA_CHANGELOG.md
+++ b/Integrations/integration-ArcherRSA_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 - Fixed an issue with the presentation of users display names.
-- Fixed retrieval of app IDs for applications with reverse field mapping. 
+- Fixed an issue with the retrieval of app IDs for applications with reverse field mapping. 
 
 ## [19.11.0] - 2019-11-12
 - Fixed an issue in the Archer fetch incidents offset.


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19721

## Description
For several app IDs, such as 411, the field mapping which returns from Archer is reversed (the field ID is mapped to the field name instead of vice versa).
These cases used to cause an error, and are now handled.

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review