### PR TITLE
docxCriticalAndHighIncidentsReport - Fixed the capitalisation of the table's headers

### DIFF
--- a/Reports/report-docx-criticalAndHighIncidentsReport.json
+++ b/Reports/report-docx-criticalAndHighIncidentsReport.json
@@ -243,6 +243,15 @@
           "status",
           "dueDate"
         ],
+        "readableHeaders": {
+          "name": "Name",
+          "occurred": "Occurred",
+          "type": "Type",
+          "owner": "Owner",
+          "severity": "Severity",
+          "status": "Status",
+          "dueDate": "Due Date"
+        },
         "classes": "striped stackable small very compact",
         "i": "14558e70-005d-11e8-831f-e7429aff1c69",
         "rowPos": 6,

--- a/Reports/report-docx-criticalAndHighIncidentsReport_CHANGELOG.md
+++ b/Reports/report-docx-criticalAndHighIncidentsReport_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Capitalized the names of the table's columns.
 
 ## [19.9.0] - 2019-09-04
 Update status column display values.


### PR DESCRIPTION
## Status 
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19889

## Description
The headers of the table's column s in the report were not capitalised.
Now they are.

## Screenshots
Before (on my mac):
<img width="353" alt="Screen Shot 2019-11-26 at 17 51 06" src="https://user-images.githubusercontent.com/33782301/69649695-1869e580-1076-11ea-85f1-2a8db858b21b.png">

After (notice the problem is fixed):
<img width="353" alt="Screen Shot 2019-11-26 at 17 53 45" src="https://user-images.githubusercontent.com/33782301/69649736-27509800-1076-11ea-808f-ac7406c01732.png">

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review