### PR TITLE
Changed the error message in 'getTimeFrame' method

### DIFF
--- a/Integrations/integration-LogRhythm.yml
+++ b/Integrations/integration-LogRhythm.yml
@@ -536,12 +536,8 @@ script:
             start.setDate(start.getDate()-30);
             break;
         case 'Custom':
-            if(!startArg){
-                throw 'start-date argument is missing';
-            }
-
-            if(!endArg){
-                throw 'end-date argument is missing';
+            if(!startArg || !endArg){
+                throw 'If time_frame argument is set to Custom, start-date and end-date argumetns should be specified';
             }
 
             start = new Date(startArg);

--- a/Integrations/integration-LogRhythm_CHANGELOG.md
+++ b/Integrations/integration-LogRhythm_CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+-  Fixed an issue with the error message in ***lr-get-alarms*** command

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -1972,7 +1972,9 @@
     "31:tCNnPn/K8BROQtLwu3Qs1Fz2TjDW+b7RiyfdRvmvCG+dGRQ08+3CN4i8QpLn2o4",
     "20:7yMOvCHfrNUNaJIus4SbwkpcSids8EscckQZzX/oGEwux6FJcH42uCQd9tNH8gmDkvPw",
     "LastVerbExecutionTime",
-    "JunkAddRecipientsToSafeSendersList"
+    "JunkAddRecipientsToSafeSendersList",
+    "<SOAP-ENV:Header>",
+    "</SOAP-ENV:Header>"
   ],
   "TrendMicroDDA": [
     "x-dtas"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20409

## Description
The error message in 'getTimeFrame' method was not clear and therefore has changed

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [X] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [X] [CHANGELOG](https://github.com/demisto/content/blob/LogRhythm-fixing_error_details/Integrations/integration-LogRhythm_CHANGELOG.md)