### PR TITLE
CommonServer - comment about DBot Score object

### DIFF
--- a/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+-
 
 ## [19.11.1] - 2019-11-26
 BaseClient now uses the session function to maintain an open session with the server.

--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -76,6 +76,7 @@ thresholds = {
     'vtPositives': 10,
     'vtPositiveUrlsForIP': 30
 }
+# The dictionary below does not represent DBot Scores correctly, and should not be used
 dbotscores = {
     'Critical': 4,
     'High': 3,

--- a/Scripts/script-CommonServer.yml
+++ b/Scripts/script-CommonServer.yml
@@ -652,6 +652,7 @@ script: |-
 
   var entryTypes = {note: 1, downloadAgent: 2, file: 3, error: 4, pinned: 5, userManagement: 6, image: 7, plagroundError: 8, playgroundError: 8, entryInfoFile: 9, map: 15, widget: 17};
   var formats = {html: 'html', table: 'table', json: 'json', text: 'text', dbotResponse: 'dbotCommandResponse', markdown: 'markdown'};
+  // The object below does not represent DBot Scores correctly, and should not be used
   var dbotscores = {critical : 4, high: 3, medium: 2, low: 1, informational: 0.5, unknown: 0};
 
   /**

--- a/Scripts/script-CommonServer_CHANGELOG.md
+++ b/Scripts/script-CommonServer_CHANGELOG.md
@@ -1,2 +1,5 @@
 ## [Unreleased]
+-
+
+## [19.10.0] - 2019-10-03
 Added spaces between cells in the output of the ***tableToMarkdown*** function output, which prevents auto-extract over multiple cells.


### PR DESCRIPTION

## Status
Ready

## Description
The current `dbotscores` object does not actually represent DBot Scores and is misleading, so added a comment about that

## Required version of Demisto
Any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review

## Dependencies
None