### PR TITLE
remove Get File Sample By Hash - Generic - Test

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1823,9 +1823,6 @@
             "playbookID": "efc817d2-6660-4d4f-890d-90513ca1e180"
         },
         {
-            "playbookID": "Get File Sample By Hash - Generic - Test"
-        },
-        {
             "playbookID": "Get File Sample From Hash - Generic - Test"
         },
         {
@@ -2038,7 +2035,6 @@
         "d66e5f86-e045-403f-819e-5058aa603c32": "pr 3220",
         "Carbon Black Enterprise Protection V2 Test": "Issue 19838",
         "5dc848e5-a649-4394-8300-386770d39d75": "Issue 19840",
-        "Get File Sample By Hash - Generic - Test": "Issue 19841",
         "Get File Sample From Hash - Generic - Test": "Issue 19842",
         "get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test": "Issue 19843",
         "get_file_sample_from_path_-_d2_-_test": "Issue 19844",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19841

## Description
The playbook `Get File Sample From Hash - Generic` use the playbook `Get File Sample By Hash` for the deprecated integration Carbon Black Enterprise Response(Go version) and for Cylance protect.

No need to test it in Carbon Black and for testing in Cylance Protect we have `Get File Sample By Hash - Cylance Protect - Test`