### PR TITLE
remove Get File Sample From Hash - Generic - Test

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1826,9 +1826,6 @@
             "playbookID": "Get File Sample By Hash - Generic - Test"
         },
         {
-            "playbookID": "Get File Sample From Hash - Generic - Test"
-        },
-        {
             "playbookID": "get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test"
         },
         {
@@ -2039,7 +2036,6 @@
         "Carbon Black Enterprise Protection V2 Test": "Issue 19838",
         "5dc848e5-a649-4394-8300-386770d39d75": "Issue 19840",
         "Get File Sample By Hash - Generic - Test": "Issue 19841",
-        "Get File Sample From Hash - Generic - Test": "Issue 19842",
         "get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test": "Issue 19843",
         "get_file_sample_from_path_-_d2_-_test": "Issue 19844",
         "search_endpoints_by_hash_-_carbon_black_response_-_test": "Issue 19852",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19842

## Description
The playbook `Get File Sample From Hash - Generic` use the integrations Cylance Protect and Carbon Black Enterprise Response(Go version) both of them are deprecated.
