### PR TITLE
remove carbon black tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1829,9 +1829,6 @@
             "playbookID": "Get File Sample From Hash - Generic - Test"
         },
         {
-            "playbookID": "get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test"
-        },
-        {
             "playbookID": "get_file_sample_from_path_-_d2_-_test"
         },
         {
@@ -1843,9 +1840,6 @@
         },
         {
             "playbookID": "TestIsEmailAddressInternal"
-        },
-        {
-            "playbookID": "search_endpoints_by_hash_-_carbon_black_response_-_test"
         },
         {
             "integrations": "Google Cloud Compute",
@@ -2040,9 +2034,7 @@
         "5dc848e5-a649-4394-8300-386770d39d75": "Issue 19840",
         "Get File Sample By Hash - Generic - Test": "Issue 19841",
         "Get File Sample From Hash - Generic - Test": "Issue 19842",
-        "get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test": "Issue 19843",
         "get_file_sample_from_path_-_d2_-_test": "Issue 19844",
-        "search_endpoints_by_hash_-_carbon_black_response_-_test": "Issue 19852",
         "Cofense Triage Test": "Creds only works on demo4",
         "Test - Windows Defender Advanced Threat Protection": "Issue - #18552",
         "nexpose_test": "Issue 18694",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19843
https://github.com/demisto/etc/issues/19852

## Description
The tests: get_file_sample_by_hash_-_carbon_black_enterprise_Response_-_test and search_endpoints_by_hash_-_carbon_black_response_-_test uses the deprecated integration Carbon Black Enterprise Response(Go version).
