### PR TITLE
Slack - Add incident labels

### DIFF
--- a/Integrations/Slack/CHANGELOG.md
+++ b/Integrations/Slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-Fixed an issue where mirrored investigations contained mismatched user names.
-Added reporter and reporter email as labels to incidents created by direct messages.
+  - Fixed an issue where mirrored investigations contained mismatched user names.
+  - Added reporter and reporter email as labels to incidents that are created by direct messages.
 
 ## [19.11.1] - 2019-11-26
 Added Slack API rate limit call handling.

--- a/Integrations/Slack/CHANGELOG.md
+++ b/Integrations/Slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 Fixed an issue where mirrored investigations contained mismatched user names.
+Added reporter and reporter email as labels to incidents created by direct messages.
 
 ## [19.11.1] - 2019-11-26
 Added Slack API rate limit call handling.

--- a/Integrations/Slack/Slack.py
+++ b/Integrations/Slack/Slack.py
@@ -238,8 +238,7 @@ def send_slack_request_sync(client: slack.WebClient, method: str, http_verb: str
                 if file_:
                     response = client.api_call(method, files={"file": file_}, data=body)
                 else:
-                    response = client.api_call(method,
-                                               json=body)
+                    response = client.api_call(method, json=body)
             else:
                 response = client.api_call(method, http_verb='GET', params=body)
         except SlackApiError as api_error:

--- a/Integrations/Slack/Slack.py
+++ b/Integrations/Slack/Slack.py
@@ -238,7 +238,8 @@ def send_slack_request_sync(client: slack.WebClient, method: str, http_verb: str
                 if file_:
                     response = client.api_call(method, files={"file": file_}, data=body)
                 else:
-                    response = client.api_call(method, json=body)
+                    response = client.api_call(method,
+                                               json=body)
             else:
                 response = client.api_call(method, http_verb='GET', params=body)
         except SlackApiError as api_error:
@@ -822,7 +823,8 @@ async def handle_dm(user: dict, text: str, client: slack.WebClient):
     if message.find('incident') != -1 and (message.find('create') != -1
                                            or message.find('open') != -1
                                            or message.find('new') != -1):
-        user_email = user.get('profile', {}).get('email')
+        user_email = user.get('profile', {}).get('email', '')
+        user_name = user.get('name', '')
         if user_email:
             demisto_user = demisto.findUser(email=user_email)
         else:
@@ -832,7 +834,7 @@ async def handle_dm(user: dict, text: str, client: slack.WebClient):
             data = 'You are not allowed to create incidents.'
         else:
             try:
-                data = await translate_create(demisto_user, text)
+                data = await translate_create(text, user_name, user_email, demisto_user)
             except Exception as e:
                 data = 'Failed creating incidents: {}'.format(str(e))
     else:
@@ -856,11 +858,13 @@ async def handle_dm(user: dict, text: str, client: slack.WebClient):
     await send_slack_request_async(client, 'chat.postMessage', body=body)
 
 
-async def translate_create(demisto_user: dict, message: str) -> str:
+async def translate_create(message: str, user_name: str, user_email: str, demisto_user: dict) -> str:
     """
     Processes an incident creation message
-    :param demisto_user: The Demisto user associated with the message (if exists)
     :param message: The creation message
+    :param user_name The name of the user in Slack
+    :param user_email The email of the user in Slack
+    :param demisto_user: The demisto user associated with the request (if exists)
     :return: Creation result
     """
     json_pattern = r'(?<=json=).*'
@@ -870,6 +874,10 @@ async def translate_create(demisto_user: dict, message: str) -> str:
     json_match = re.search(json_pattern, message)
     created_incident = None
     data = ''
+    user_demisto_id = ''
+    if demisto_user:
+        user_demisto_id = demisto_user.get('id', '')
+
     if json_match:
         if re.search(name_pattern, message) or re.search(type_pattern, message):
             data = 'No other properties other than json should be specified.'
@@ -878,7 +886,7 @@ async def translate_create(demisto_user: dict, message: str) -> str:
             incidents = json.loads(incidents_json.replace('“', '"').replace('”', '"'))
             if not isinstance(incidents, list):
                 incidents = [incidents]
-            created_incident = await create_incidents(demisto_user, incidents)
+            created_incident = await create_incidents(incidents, user_name, user_email, user_demisto_id)
 
             if not created_incident:
                 data = 'Failed creating incidents.'
@@ -900,7 +908,7 @@ async def translate_create(demisto_user: dict, message: str) -> str:
             if incident_type:
                 incident['type'] = incident_type
 
-            created_incident = await create_incidents(demisto_user, [incident])
+            created_incident = await create_incidents([incident], user_name, user_email, user_demisto_id)
             if not created_incident:
                 data = 'Failed creating incidents.'
 
@@ -915,15 +923,30 @@ async def translate_create(demisto_user: dict, message: str) -> str:
     return data
 
 
-async def create_incidents(demisto_user: dict, incidents: list) -> dict:
+async def create_incidents(incidents: list, user_name: str, user_email: str, user_demisto_id: str = '') -> dict:
     """
     Creates incidents according to a provided JSON object
-    :param demisto_user: The demisto user associated with the request (if exists)
     :param incidents: The incidents JSON
+    :param user_name The name of the user in Slack
+    :param user_email The email of the user in Slack
+    :param user_demisto_id: The id of demisto user associated with the request (if exists)
     :return: The creation result
     """
-    if demisto_user:
-        data = demisto.createIncidents(incidents, userID=demisto_user['id'])
+
+    for incident in incidents:
+        # Add relevant labels to context
+        labels = incident.get('labels', [])
+        keys = [l.get('type') for l in labels]
+        if 'Reporter' not in keys:
+            labels.append({'type': 'Reporter', 'value': user_name})
+        if 'ReporterEmail' not in keys:
+            labels.append({'type': 'ReporterEmail', 'value': user_email})
+        if 'Source' not in keys:
+            labels.append({'type': 'Source', 'value': 'Slack'})
+        incident['labels'] = labels
+
+    if user_demisto_id:
+        data = demisto.createIncidents(incidents, userID=user_demisto_id)
     else:
         data = demisto.createIncidents(incidents)
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20429

## Description
As in Slack v1, added Reporter, Reporter email and Source to the incidents labels created in direct messages.

## Does it break backward compatibility?
   - No

## Must have
- [X] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/compare/slack-fixes?expand=1#diff-2e92c7b68cd6a9f0e792c765a6ee5bec)