### PR TITLE
Test Fix SentinelOne V2

### DIFF
--- a/TestPlaybooks/playbook-SentinelOne-Beta-Test.yml
+++ b/TestPlaybooks/playbook-SentinelOne-Beta-Test.yml
@@ -954,7 +954,7 @@ tasks:
       - "15"
     scriptarguments:
       seconds:
-        simple: "2"
+        simple: "30"
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Changing the sleep to 30 seconds, since we got an error `query is still in process`

## Does it break backward compatibility?
   - No
