### PR TITLE
fixed output paths in ZipFile

### DIFF
--- a/Scripts/ZipFile/CHANGELOG.md
+++ b/Scripts/ZipFile/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## [Unreleased]
- -
+Added output to match output paths.

--- a/Scripts/ZipFile/CHANGELOG.md
+++ b/Scripts/ZipFile/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## [Unreleased]
-Added output to match output paths.
+Fixed an issue where the output mismatched the output paths.

--- a/Scripts/ZipFile/ZipFile.py
+++ b/Scripts/ZipFile/ZipFile.py
@@ -91,6 +91,7 @@ results = [
         'Contents': {'ZippedFiles': zipName},
         'EntryContext': {
             'ZippedFiles': zipName,
+            'ZipFile.ZippedFile': zipName,
             'File(val.EntryID=="' + fileEntryID + '").zipped': True
         },
         'ReadableContentsFormat': formats['markdown'],


### PR DESCRIPTION
## Status
Ready

## Description
The output path in the playbook was wrong. added the output in the script.

## Does it break backward compatibility?
   - No

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/compare/fix-zipfile-output?expand=1#diff-28e05782ee053247478fdcdaba8fc2bf)