### PR TITLE
Stability fix for phishing tests

### DIFF
--- a/TestData/Inline_malicious_url.eml
+++ b/TestData/Inline_malicious_url.eml
@@ -81,7 +81,7 @@ Content-type: text/plain;
 	charset="UTF-8"
 Content-transfer-encoding: 7bit
 
-http://www.desktop-style.de/
+http://www.desktop-style.de
 
  
 
@@ -142,7 +142,7 @@ div.WordSection1
 </head>
 <body lang=3D"en-IL" link=3D"#0563C1" vlink=3D"#954F72">
 <div class=3D"WordSection1">
-<p class=3D"MsoNormal"><span lang=3D"en-IL"><a href=3D"http://www.desktop-style.de/">http://www.desktop-style.de/</a><o:p=
+<p class=3D"MsoNormal"><span lang=3D"en-IL"><a href=3D"http://www.desktop-style.de">http://www.desktop-style.de</a><o:p=
 ></o:p></span></p>
 <p class=3D"MsoNormal"><span lang=3D"en-IL"><o:p>&nbsp;</o:p></span></p>
 </div>

--- a/TestPlaybooks/NonCircleTests/playbook-Extract_Indicators_From_File_-_test.yml
+++ b/TestPlaybooks/NonCircleTests/playbook-Extract_Indicators_From_File_-_test.yml
@@ -149,7 +149,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: http://www.desktop-style.de/
+              simple: http://www.desktop-style.de
     view: |-
       {
         "position": {

--- a/TestPlaybooks/NonCircleTests/playbook-Phishing_test_-_Inline.yml
+++ b/TestPlaybooks/NonCircleTests/playbook-Phishing_test_-_Inline.yml
@@ -242,7 +242,7 @@ tasks:
       comment:
         simple: Malicious website for test
       indicator:
-        simple: http://www.desktop-style.de/
+        simple: http://www.desktop-style.de
       miner:
         simple: Malicious
     reputationcalc: 1

--- a/TestPlaybooks/NonCircleTests/playbook-Phishing_test_-_attachment.yml
+++ b/TestPlaybooks/NonCircleTests/playbook-Phishing_test_-_attachment.yml
@@ -235,7 +235,7 @@ tasks:
       comment:
         simple: Malicious website for test
       indicator:
-        simple: http://www.desktop-style.de/
+        simple: http://www.desktop-style.de
       miner:
         simple: Malicious
     reputationcalc: 1

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test.yml
@@ -150,7 +150,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: http://www.desktop-style.de/
+              simple: http://www.desktop-style.de
       - - operator: isExists
           left:
             value:

--- a/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test_4_5.yml
+++ b/TestPlaybooks/playbook-Extract_Indicators_From_File_-_Generic_v2_-_Test_4_5.yml
@@ -153,7 +153,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: http://www.desktop-style.de/
+              simple: http://www.desktop-style.de
       - - operator: isExists
           left:
             value:

--- a/TestPlaybooks/playbook-Phishing_v2_Test_-_Attachment.yml
+++ b/TestPlaybooks/playbook-Phishing_v2_Test_-_Attachment.yml
@@ -215,7 +215,7 @@ tasks:
       comment:
         simple: Malicious website for test
       indicator:
-        simple: http://www.desktop-style.de/
+        simple: http://www.desktop-style.de
       miner:
         simple: Malicious
     reputationcalc: 1

--- a/TestPlaybooks/playbook-Phishing_v2_Test_-_Inline.yml
+++ b/TestPlaybooks/playbook-Phishing_v2_Test_-_Inline.yml
@@ -215,7 +215,7 @@ tasks:
       comment:
         simple: Malicious website for test
       indicator:
-        simple: http://www.desktop-style.de/
+        simple: http://www.desktop-style.de
       miner:
         simple: Malicious
     reputationcalc: 1


### PR DESCRIPTION
## Status
Ready

## Description
Seems like the URL **sometimes** wasn't detected as malicious even though it was added to the miner right before being calculated. Although the build passed when the original URL was replaced with this one, it failed nightly. Attempting this fix now which works locally.

## Screenshots
![image](https://user-images.githubusercontent.com/43602124/70712664-f9618980-1cec-11ea-9f24-eb927cbb13da.png)


![image](https://user-images.githubusercontent.com/43602124/70712610-d0d98f80-1cec-11ea-98eb-4a0facd0b47f.png)


## Does it break backward compatibility?
   - No

