### PR TITLE
changed handle proxy spot to be after the get token operation

### DIFF
--- a/Integrations/RSANetWitness_v11_1/CHANGELOG.md
+++ b/Integrations/RSANetWitness_v11_1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+  - Fixed an issue where environment proxy effects the integration when even though no proxy should be used.
 
 
 ## [19.11.0] - 2019-11-12

--- a/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1.py
+++ b/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1.py
@@ -968,10 +968,10 @@ EXECUTION
 
 def main():
     global TOKEN
-    TOKEN = get_token()
     command = demisto.command()
     try:
         handle_proxy(proxy_param_name='proxy', checkbox_default_value=False)
+        TOKEN = get_token()
         if command == 'test-module':
             demisto.results(test_module())
         elif command == 'fetch-incidents':


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/18744

## Description
Changed handle proxy spot to be after the get token operation

## Does it break backward compatibility?
   - No

## Dependencies
- RSA NetWitness v11.1

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/4d993465bdc5133c29b5430e592186a4fbbd9e50/Integrations/RSANetWitness_v11_1/CHANGELOG.md)