### PR TITLE
Defunct processes

### DIFF
--- a/Integrations/rasterize/CHANGELOG.md
+++ b/Integrations/rasterize/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue in ***rasterize*** command in which child processes were defuncted.
 
 ## [19.11.0] - 2019-11-12
 Added support for the *px* suffix in the _width_ and _height_ parameters.

--- a/Integrations/rasterize/CHANGELOG.md
+++ b/Integrations/rasterize/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed an issue in ***rasterize*** command in which child processes were defuncted.
+Fixed an issue with the ***rasterize*** command in which child processes were defunct.
 
 ## [19.11.0] - 2019-11-12
 Added support for the *px* suffix in the _width_ and _height_ parameters.

--- a/Integrations/rasterize/rasterize.yml
+++ b/Integrations/rasterize/rasterize.yml
@@ -152,7 +152,7 @@ script:
     description: Converts a PDF file to an image file.
     execution: false
     name: rasterize-pdf
-  dockerimage: demisto/chromium:1.0.0.2889
+  dockerimage: demisto/chromium:1.0.0.4968
   isfetch: false
   runonce: false
   script: '-'

--- a/Integrations/rasterize/rasterize_test.py
+++ b/Integrations/rasterize/rasterize_test.py
@@ -1,30 +1,49 @@
 from rasterize import *
 from tempfile import NamedTemporaryFile
+from subprocess import *
 import os
 
 
-def test_rasterize_email_image():
+def test_rasterize_email_image(caplog):
     with NamedTemporaryFile('w+') as f:
         f.write('<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">'
                 '</head><body><br>---------- TEST FILE ----------<br></body></html>')
         path = os.path.realpath(f.name)
         f.flush()
         rasterize(path=f'file://{path}', width=250, height=250, r_type='png')
+        caplog.clear()
 
 
-def test_rasterize_email_pdf():
+def test_rasterize_email_pdf(caplog):
     with NamedTemporaryFile('w+') as f:
         f.write('<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">'
                 '</head><body><br>---------- TEST FILE ----------<br></body></html>')
         path = os.path.realpath(f.name)
         f.flush()
         rasterize(path=f'file://{path}', width=250, height=250, r_type='pdf', offline_mode=False)
+        caplog.clear()
 
 
-def test_rasterize_email_pdf_offline():
+def test_rasterize_email_pdf_offline(caplog):
     with NamedTemporaryFile('w+') as f:
         f.write('<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">'
                 '</head><body><br>---------- TEST FILE ----------<br></body></html>')
         path = os.path.realpath(f.name)
         f.flush()
         rasterize(path=f'file://{path}', width=250, height=250, r_type='pdf', offline_mode=True)
+        caplog.clear()
+
+
+def test_rasterize_no_defunct_processes(caplog):
+    with NamedTemporaryFile('w+') as f:
+        f.write('<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">'
+                '</head><body><br>---------- TEST FILE ----------<br></body></html>')
+        path = os.path.realpath(f.name)
+        f.flush()
+        rasterize(path=f'file://{path}', width=250, height=250, r_type='pdf', offline_mode=False)
+        process = Popen(['ps', '-aux'], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        processes_str, _ = process.communicate()
+        processes = processes_str.split('\n')
+        defunct_process_list = [process for process in processes if 'defunct' in process]
+        assert not defunct_process_list
+        caplog.clear()


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20702

## Description
Implemented a function that closes the driver & reaps all the child process that are defunct.

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [x] Code Review

## Dependencies
- [x] Phishing v2 Test - Inline
- [x] RasterizeImageTest
- [x] process_email_-_generic_-_test
- [ ] URL Enrichment - Generic v2 - Test
- [x] Rasterize Test
- [x] Impossible Traveler - Test
- [x] Process Email - Generic for Rasterize
- [x] Phishing v2 Test - Attachment
- [x] EWS Mail Sender Test 2
- [ ] Phishing - Core - Test


## Technical writer review
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/9cd4c8ac0ee83bbca22ca91dcd19ec2ab78a4ed1/Integrations/rasterize/CHANGELOG.md)