### PR TITLE
fixing dev-requirements-py3 demisto-sdk download

### DIFF
--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,5 +1,5 @@
 flake8==3.7.8
-demisto-sdk==0.1.6
+demisto-sdk>0.1.2, <1.0.0
 demisto-py==2.0.6
 pytest==5.2.1
 pytest-mock==1.11.1


### PR DESCRIPTION

## Description
dev-requirements-py3 will now install up to but not including demisto-sdk version 1.0.0
