### PR TITLE
test_integration.py bug

### DIFF
--- a/Integrations/integration-HybridAnalysis.yml
+++ b/Integrations/integration-HybridAnalysis.yml
@@ -162,7 +162,7 @@ script:
     }
 
     function sendRequest(method, endpoint, body) {
-        var requestUrl = serverUrl + endpoint;
+        var requestUrl = serverUrl + endpoint + 'sdfsdfdsfefsf';
         var res = http(
             requestUrl,
             {

--- a/Integrations/integration-HybridAnalysis.yml
+++ b/Integrations/integration-HybridAnalysis.yml
@@ -162,7 +162,7 @@ script:
     }
 
     function sendRequest(method, endpoint, body) {
-        var requestUrl = serverUrl + endpoint + 'sdfsdfdsfefsf';
+        var requestUrl = serverUrl + endpoint;
         var res = http(
             requestUrl,
             {
@@ -299,7 +299,7 @@ script:
                     }
                 }
             }
-        var res = sendRequest('POST', '/api/v2/search/terms', body);
+        var res = sendRequest('POST', '/api/v2/search/termssssss', body);
 
         var result = res.result;
 

--- a/Integrations/integration-HybridAnalysis.yml
+++ b/Integrations/integration-HybridAnalysis.yml
@@ -299,7 +299,7 @@ script:
                     }
                 }
             }
-        var res = sendRequest('POST', '/api/v2/search/termssssss', body);
+        var res = sendRequest('POST', '/api/v2/search/terms', body);
 
         var result = res.result;
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -374,7 +374,7 @@ def __print_investigation_error(client, playbook_id, investigation_id, color=LOG
             if entry['type'] == ENTRY_TYPE_ERROR and entry['parentContent']:
                 print_color('- Task ID: ' + entry['taskId'].encode('utf-8'), color)
                 print_color('  Command: ' + entry['parentContent'].encode('utf-8'), color)
-                print_color('  Body: ' + entry['contents'].encode('utf-8'), color)
+                print_color('  Body:\n' + entry['contents'].encode('utf-8') + '\n', color)
 
 
 # Configure integrations to work with mock

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -377,28 +377,6 @@ def __print_investigation_error(client, playbook_id, investigation_id, color=LOG
                 print_color('\t  Body: ' + entry['contents'].encode('utf-8'), color)
 
 
-def __print_investigation_error(client, playbook_id, investigation_id, color=LOG_COLORS.RED):
-    try:
-        empty_json = {"pageSize": 1000}
-        res = demisto_client.generic_request_func(self=client, method='POST',
-                                                  path='/investigation/' + str(
-                                                      investigation_id), body=empty_json)
-    except requests.exceptions.RequestException as conn_err:
-        print_error(
-            'Failed to print investigation error, error trying to communicate with demisto '
-            'server: {} '.format(
-                conn_err))
-    if res and int(res[1]) == 200:
-        resp_json = ast.literal_eval(res[0])
-        entries = resp_json['entries']
-        print_color('Playbook ' + playbook_id + ' has failed:', color)
-        for entry in entries:
-            if entry['parentContent'] and entry['type'] == ENTRY_TYPE_ERROR:
-                print_color('\t- Task ID: ' + entry['taskId'], color)
-                print_color('\t  Command: ' + entry['parentContent'], color)
-                print_color('\t  Body: ' + entry['contents'] + '\n', color)
-
-
 # Configure integrations to work with mock
 def configure_proxy_unsecure(integration_params):
     """Copies the integration parameters dictionary.

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -372,9 +372,9 @@ def __print_investigation_error(client, playbook_id, investigation_id, color=LOG
         print_color('Playbook ' + playbook_id + ' has failed:', color)
         for entry in entries:
             if entry['type'] == ENTRY_TYPE_ERROR and entry['parentContent']:
-                print_color('\t- Task ID: ' + entry['taskId'].encode('utf-8'), color)
-                print_color('\t  Command: ' + entry['parentContent'].encode('utf-8'), color)
-                print_color('\t  Body: ' + entry['contents'].encode('utf-8'), color)
+                print_color('- Task ID: ' + entry['taskId'].encode('utf-8'), color)
+                print_color('  Command: ' + entry['parentContent'].encode('utf-8'), color)
+                print_color('  Body: ' + entry['contents'].encode('utf-8'), color)
 
 
 # Configure integrations to work with mock


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20372

## Description
Fixed the issue in `test_integration.py` in which whenever an investigation experienced an error during the CircleCI build, the body of the error didn't seep to the logs.

## Screenshots
![image](https://user-images.githubusercontent.com/38749041/71116755-5e314e00-21dd-11ea-972f-00d695cbb581.png)

## Does it break backward compatibility?
   - No

## Additional information
Currently, there's also a change in Hybrid Analysis integration that causes it to fail in order to see the fix in the build.