### PR TITLE
unzipped test_content not in artifacts folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,9 +173,9 @@ jobs:
             demisto-sdk create -a $CIRCLE_ARTIFACTS
             # create zip with contents of content_new.zip and content_test.zip for use in updating content on instances
             cp "$CIRCLE_ARTIFACTS/content_new.zip" "$CIRCLE_ARTIFACTS/all_content.zip"
-            unzip -q "$CIRCLE_ARTIFACTS/content_test.zip" -d "$CIRCLE_ARTIFACTS/test_content"
-            zip -j "$CIRCLE_ARTIFACTS/all_content.zip" $CIRCLE_ARTIFACTS/test_content/*
-            rm -r $CIRCLE_ARTIFACTS/test_content
+            unzip -q "$CIRCLE_ARTIFACTS/content_test.zip" -d "test_content_dir"
+            zip -j "$CIRCLE_ARTIFACTS/all_content.zip" test_content_dir/*
+            rm -r test_content_dir
       - store_artifacts:
           path: artifacts
           destination: artifacts


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/content/pull/5213#discussion_r360155250

## Description
Changes the location of the unzipped content_test.zip so that it won't end up in the artifacts directory should the build step unexpectedly fail before the extracted contents are deleted.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review