### PR TITLE
Parseemailfiles lower nonetype fix

### DIFF
--- a/Scripts/ParseEmailFiles/CHANGELOG.md
+++ b/Scripts/ParseEmailFiles/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Added handling for rare case when an attachment lacks both the 'DisplayName' and 'AttachName' properties.
+Added handling for cases where an attachment has neither the *DisplayName* nor the *AttachName* properties.
 
 ## [19.12.0] - 2019-12-10
 Fixed an issue with handling smime signed files with no attachments.

--- a/Scripts/ParseEmailFiles/CHANGELOG.md
+++ b/Scripts/ParseEmailFiles/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Added handling for cases where an attachment has neither the *DisplayName* nor the *AttachName* properties.
+Added handling for cases where an attachment has neither the *DisplayName* nor the *AttachFilename* properties.
 
 ## [19.12.0] - 2019-12-10
 Fixed an issue with handling smime signed files with no attachments.

--- a/Scripts/ParseEmailFiles/CHANGELOG.md
+++ b/Scripts/ParseEmailFiles/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Added handling for rare case when an attachment lacks both the 'DisplayName' and 'AttachName' properties.
 
 ## [19.12.0] - 2019-12-10
 Fixed an issue with handling smime signed files with no attachments.

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3293,6 +3293,7 @@ def save_attachments(attachments, root_email_file_name, max_depth):
     for attachment in attachments:
         if attachment.data is not None:
             display_name = attachment.DisplayName if attachment.DisplayName else attachment.AttachFilename
+            display_name = display_name if display_name else ''
             demisto.results(fileResult(display_name, attachment.data))
             name_lower = display_name.lower()
             if max_depth > 0 and (name_lower.endswith(".eml") or name_lower.endswith('.p7m')):
@@ -3639,7 +3640,7 @@ def main():
         if is_error(result):
             return_error(get_error(result))
 
-        file_type = result[0]['FileMetadata']['info']
+        file_type = result[0]['FileMetadata'].get('info', '')
 
     except Exception as ex:
         return_error(
@@ -3664,14 +3665,14 @@ def main():
                 with open(file_path, 'rb') as f:
                     file_contents = f.read()
 
-                if 'Content-Type:'.lower() in file_contents.lower():
+                if file_contents and 'Content-Type:'.lower() in file_contents.lower():
                     email_data, attached_emails = handle_eml(file_path, b64=False, file_name=file_name,
                                                              parse_only_headers=parse_only_headers, max_depth=max_depth)
                     output = create_email_output(email_data, attached_emails)
                 else:
                     # Try a base64 decode
                     b64decode(file_contents)
-                    if 'Content-Type:'.lower() in file_contents.lower():
+                    if file_contents and 'Content-Type:'.lower() in file_contents.lower():
                         email_data, attached_emails = handle_eml(file_path, b64=True, file_name=file_name,
                                                                  parse_only_headers=parse_only_headers,
                                                                  max_depth=max_depth)

--- a/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3293,7 +3293,6 @@ def save_attachments(attachments, root_email_file_name, max_depth):
     for attachment in attachments:
         if attachment.data is not None:
             display_name = attachment.DisplayName if attachment.DisplayName else attachment.AttachFilename
-            display_name = display_name if display_name else ''
             demisto.results(fileResult(display_name, attachment.data))
             name_lower = display_name.lower()
             if max_depth > 0 and (name_lower.endswith(".eml") or name_lower.endswith('.p7m')):
@@ -3640,7 +3639,7 @@ def main():
         if is_error(result):
             return_error(get_error(result))
 
-        file_type = result[0]['FileMetadata'].get('info', '')
+        file_type = result[0]['FileMetadata']['info']
 
     except Exception as ex:
         return_error(
@@ -3665,14 +3664,14 @@ def main():
                 with open(file_path, 'rb') as f:
                     file_contents = f.read()
 
-                if file_contents and 'Content-Type:'.lower() in file_contents.lower():
+                if 'Content-Type:'.lower() in file_contents.lower():
                     email_data, attached_emails = handle_eml(file_path, b64=False, file_name=file_name,
                                                              parse_only_headers=parse_only_headers, max_depth=max_depth)
                     output = create_email_output(email_data, attached_emails)
                 else:
                     # Try a base64 decode
                     b64decode(file_contents)
-                    if file_contents and 'Content-Type:'.lower() in file_contents.lower():
+                    if 'Content-Type:'.lower() in file_contents.lower():
                         email_data, attached_emails = handle_eml(file_path, b64=True, file_name=file_name,
                                                                  parse_only_headers=parse_only_headers,
                                                                  max_depth=max_depth)


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20683

## Description
Won't break when attachment has neither `DisplayName` nor `AttachName`.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- ~~[ ] Tests~~ - couldn't create an .msg file for a unittest
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Process Email - Core
- [ ] Phishing Investigation - Generic
- [ ] Process Email - Generic
- [ ] Phishing - Core
- [ ] Process Email
- [ ] Phishing Playbook - Automated
- [ ] Phishing Investigation - Generic v2  

Tests
- [ ] Phishing v2 Test - Inline
- [ ] process_email_-_generic_-_test
- [ ] playbook-checkEmailAuthenticity-test
- [ ] Process Email - Generic for Rasterize
- [ ] Phishing v2 Test - Attachment
- [ ] TestParseEmailFile-deprecated-script
- [ ] ParseEmailFiles-test
- [ ] Phishing - Core - Test


## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [CHANGELOG](link)