### PR TITLE
Request debugging test fix

### DIFF
--- a/TestPlaybooks/script-SimpleRequest.yml
+++ b/TestPlaybooks/script-SimpleRequest.yml
@@ -4,6 +4,10 @@ commonfields:
 name: SimpleRequest
 script: |-
   import requests
+  from urllib3 import disable_warnings
+
+  # disable insecure warnings
+  disable_warnings()
 
   resp = requests.get('https://www.demisto.com', verify=False)
 

--- a/TestPlaybooks/script-SimpleRequestExecutor.yml
+++ b/TestPlaybooks/script-SimpleRequestExecutor.yml
@@ -3,6 +3,11 @@ commonfields:
   version: -1
 name: SimpleRequestExecutor
 script: |-
+  from urllib3 import disable_warnings
+
+  # disable insecure warnings
+  disable_warnings()
+
   res = []
 
   cmd_args = {'debug-mode': 'True'}

--- a/TestPlaybooks/script-SimpleRequestGetter.yml
+++ b/TestPlaybooks/script-SimpleRequestGetter.yml
@@ -3,6 +3,11 @@ commonfields:
   version: -1
 name: SimpleRequestGetter
 script: |-
+  from urllib3 import disable_warnings
+
+  # disable insecure warnings
+  disable_warnings()
+  
   entries = demisto.executeCommand("getEntries", {})
   req_log_entries = []
   for entry in entries:

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1985,7 +1985,6 @@
         "Test-Detonate URL - Crowdstrike": "Issue 19439",
         "Git_Integration-Test": "Issue 20029",
         "Symantec Data Loss Prevention - Test": "Issue 20134",
-        "Request Debugging - Test": "Issue 20337",
         "Extract Indicators From File - Generic v2": "Issue 20143",
         "PAN-OS Create Or Edit Rule Test":"Issue 20037",
         "NetWitness Endpoint Test": "Issue 19878",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20337

## Description
Add disable_warnings to `SimpleRequest`, `SimpleRequestExecutor`,  and `SimpleRequestGetter` scripts because the warning was failing the task in the playbook.

## Required version of Demisto
5.0.0

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)