### PR TITLE
Skipped "attachment" phishing test (inline will still run)

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2057,6 +2057,7 @@
         "Test - Windows Defender Advanced Threat Protection": "Issue - #18552",
         "nexpose_test": "Issue 18694",
         "Recorded Future Test": "Issue 18922",
+        "Phishing v2 Test - Attachment": "Need to create new testdata (new MSG or EML file) with the URL that is used in the inline phishing test",
         "IntSights Mssp Test": "Issue #16351",
         "CheckPhish-Test": "Issue 19188",
         "fd93f620-9a2d-4fb6-85d1-151a6a72e46d": "Issue 19854",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2057,7 +2057,7 @@
         "Test - Windows Defender Advanced Threat Protection": "Issue - #18552",
         "nexpose_test": "Issue 18694",
         "Recorded Future Test": "Issue 18922",
-        "Phishing v2 Test - Attachment": "Need to create new testdata (new MSG or EML file) with the URL that is used in the inline phishing test",
+        "Phishing v2 Test - Attachment": "Issue 20867",
         "IntSights Mssp Test": "Issue #16351",
         "CheckPhish-Test": "Issue 19188",
         "fd93f620-9a2d-4fb6-85d1-151a6a72e46d": "Issue 19854",


### PR DESCRIPTION
## Status
Ready

## Description
Phishing v2 attachment test is still running on the old URL which is currently not flagged as malicious - and makes builds fail on timeout.

## Does it break backward compatibility?
   - No
