### PR TITLE
IBM Resilient - fixed NistAttackVector key error

### DIFF
--- a/Integrations/integration-IBM_Resilient_Systems.yml
+++ b/Integrations/integration-IBM_Resilient_Systems.yml
@@ -512,9 +512,9 @@ script:
             'Resilient.Incidents(val.Id && val.Id === obj.Id)': result_incident
         }
         hr_incident = result_incident[:]
-        if hr_incident[0]['NistAttackVectors']:
+        if hr_incident[0].get('NistAttackVectors'):
             nist_vectors_str = ''
-            for vector in hr_incident[0]['NistAttackVectors']:
+            for vector in hr_incident[0].get('NistAttackVectors', []):
                 nist_vectors_str += vector + '\n'
             hr_incident[0]['NistAttackVectors'] = nist_vectors_str
         title = 'IBM Resilient Systems incident ID ' + incident_id

--- a/Integrations/integration-IBM_Resilient_Systems_CHANGELOG.md
+++ b/Integrations/integration-IBM_Resilient_Systems_CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+Fixed an issue where the ***rs-get-incident*** command failed on key error.


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/20815

## Description
Changed to use `.get()` instead of direct key access to NistAttackVector

## Required version of Demisto
Any

## Does it break backward compatibility?
   - No

## Must have
- [ ] Code Review

## Dependencies
None

## Technical writer review
- [ ] [CHANGELOG](https://github.com/demisto/content/blob/fc8e3bca48c72f2e6920b89b0550677ebb7313db/Integrations/integration-IBM_Resilient_Systems_CHANGELOG.md)