### PR TITLE
Fixes oversight in Palo Alto Networks MineMeld integration

### DIFF
--- a/Integrations/PaloAlto_MineMeld/CHANGELOG.md
+++ b/Integrations/PaloAlto_MineMeld/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
-Exposed *type* in the list of arguments for `minemeld-add-to-miner` and `minemeld-remove-from-miner` commands.
+Added the *type* argument, which specifies the indicator type, to the following commands.
+  - ***minemeld-add-to-miner***
+  - ***minemeld-remove-from-miner***
 
 ## [19.10.2] - 2019-10-29
 Fixed lowercase hash types in the outputs.

--- a/Integrations/PaloAlto_MineMeld/CHANGELOG.md
+++ b/Integrations/PaloAlto_MineMeld/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Exposed *type* in the list of arguments for `minemeld-add-to-miner` and `minemeld-remove-from-miner` commands.
 
 ## [19.10.2] - 2019-10-29
 Fixed lowercase hash types in the outputs.

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -68,13 +68,13 @@ script:
       required: true
       secret: false
     - default: false
-      description: The value of the indicator  to remove.
+      description: The value of the indicator to remove.
       isArray: false
       name: indicator
       required: true
       secret: false
     - default: false
-      description: The type of the indicator  to remove.
+      description: The type of the indicator to remove.
       isArray: false
       name: type
       required: false

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -44,6 +44,12 @@ script:
       required: true
       secret: false
     - default: false
+      description: The type of the indicator to add.
+      isArray: false
+      name: type
+      required: false
+      secret: false
+    - default: false
       description: Comment for the indicator.
       isArray: false
       name: comment
@@ -66,6 +72,12 @@ script:
       isArray: false
       name: indicator
       required: true
+      secret: false
+    - default: false
+      description: The type of the indicator  to remove.
+      isArray: false
+      name: type
+      required: false
       secret: false
     deprecated: false
     description: Remove an indicator from a miner.

--- a/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
+++ b/Integrations/PaloAlto_MineMeld/PaloAlto_MineMeld.yml
@@ -44,7 +44,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: The type of the indicator to add.
+      description: The type of the indicator to add to the miner.
       isArray: false
       name: type
       required: false
@@ -56,7 +56,7 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: Add indicator to a miner.
+    description: Add an indicator to a miner.
     execution: false
     name: minemeld-add-to-miner
   - arguments:
@@ -74,13 +74,13 @@ script:
       required: true
       secret: false
     - default: false
-      description: The type of the indicator to remove.
+      description: The type of the indicator to remove from the miner.
       isArray: false
       name: type
       required: false
       secret: false
     deprecated: false
-    description: Remove an indicator from a miner.
+    description: Removes an indicator from a miner.
     execution: false
     name: minemeld-remove-from-miner
   - arguments:


### PR DESCRIPTION
## Description
Type argument to commands `minemeld-add-to-miner` and `minemeld-remove-from-miner` was. supported in the code but not exposed in the integration YAML file.

## Changes
- Exposed *type* argument in `minemeld-add-to-miner` command in the YAML file
- Exposed *type* argument in `minemeld-remove-from-miner` command in the YAML file
- Updated CHANGELOG.md 

## Does it break backward compatibility?
No. The *type* argument is **not** required and if not specified the behavior is the same as before.

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)