### PR TITLE
added getIndexHash to demistomock

### DIFF
--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -563,3 +563,6 @@ def createIndicators(indicators_batch):
 
 def findIndicators(fromdate = '', query = '', size = 100, page = 0, todate = '', value = ''):
     return {}
+
+def getIndexHash():
+    return ''


### PR DESCRIPTION
## Status
Ready

## Description
Added new demisto command getIndexHash to demistomock. The command returns the hash of the current tenant index.