### PR TITLE
OpenLDAP - fixed authentication with engine 

### DIFF
--- a/Beta_Integrations/OpenLDAP/CHANGELOG.md
+++ b/Beta_Integrations/OpenLDAP/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## [Unreleased]
--
+Fixed Ldap authentication in case of running integration on engine.  

--- a/Beta_Integrations/OpenLDAP/CHANGELOG.md
+++ b/Beta_Integrations/OpenLDAP/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## [Unreleased]
-Fixed Ldap authentication in case of running integration on engine.  
+Fixed LDAP authentication when running the integration on an engine.  

--- a/Beta_Integrations/OpenLDAP/OpenLDAP.yml
+++ b/Beta_Integrations/OpenLDAP/OpenLDAP.yml
@@ -92,7 +92,7 @@ script:
           secret: true
       deprecated: false
       description: ''
-      execution: true
+      execution: false
       name: ad-authenticate
     - arguments:
         - default: false
@@ -103,7 +103,7 @@ script:
           secret: false
       deprecated: false
       description: ''
-      execution: true
+      execution: false
       name: ad-groups
     - arguments:
         - default: false
@@ -145,7 +145,7 @@ script:
           secret: false
       deprecated: false
       description: ''
-      execution: true
+      execution: false
       name: ad-authenticate-and-roles
   dockerimage: demisto/ldap:1.0.0.4710
   isfetch: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
OpenLDAP commands where marked as `Potentially harmful` (in order to prevent users from running it's command in playbooks), what caused failure on running scheduled commands (populate AD Roles Mapping) on engine with the following error: `Module OpenLDAP does not accept command: ad-groups (High privilege command ad-groups cannot be run automatically, please complete task manually (67))`. 
The fix is to remove `Potentially harmful` from integration commands.

## Screenshots
Paste here any images that will help the reviewer

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [x] Code Review

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [x] [CHANGELOG](https://github.com/demisto/content/blob/aee4047e4ba099aa77789be3e59b26717512545e/Beta_Integrations/OpenLDAP/CHANGELOG.md)