### PR TITLE
update AbuseDB's indicator-related commands to return timeline data

### DIFF
--- a/Integrations/AbuseDB/AbuseDB.py
+++ b/Integrations/AbuseDB/AbuseDB.py
@@ -116,7 +116,7 @@ def analysis_to_entry(info, threshold=THRESHOLD, verbose=VERBOSE):
     if not isinstance(info, list):
         info = [info]
 
-    context_ip_generic, context_ip, human_readable, dbot_scores = [], [], [], []
+    context_ip_generic, context_ip, human_readable, dbot_scores, timeline = [], [], [], [], []
     for analysis in info:
         ip_ec = {
             "Address": analysis.get("ipAddress"),
@@ -155,7 +155,15 @@ def analysis_to_entry(info, threshold=THRESHOLD, verbose=VERBOSE):
         context_ip.append(abuse_ec)
         context_ip_generic.append(ip_ec)
 
-    return createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, title=ANALYSIS_TITLE)
+        ip_address = analysis.get('ipAddress')
+        ip_rep = scoreToReputation(dbot_score)
+        timeline.append({
+            'Value': ip_address,
+            'Message': 'AbuseIPDB marked the indicator "{}" as *{}*'.format(ip_address, ip_rep),
+            'Category': 'Indicator Enrichment'
+        })
+
+    return createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, timeline, title=ANALYSIS_TITLE)
 
 
 def blacklist_to_entry(data, saveToContext):
@@ -188,7 +196,7 @@ def getDBotScore(analysis, threshold=THRESHOLD):
     return dbot_score
 
 
-def createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, title):
+def createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, timeline, title):
     entry = {
         'ContentsFormat': formats['json'],
         'Type': entryTypes['note'],
@@ -199,7 +207,8 @@ def createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, tit
             'IP(val.Address && val.Address == obj.Address)': createContext(context_ip_generic, removeNull=True),
             'AbuseIPDB(val.IP.Address && val.IP.Address == obj.IP.Address)': createContext(context_ip, removeNull=True),
             'DBotScore': createContext(dbot_scores, removeNull=True)
-        }
+        },
+        'IndicatorTimeline': timeline
     }
     return entry
 

--- a/Integrations/AbuseDB/AbuseDB.py
+++ b/Integrations/AbuseDB/AbuseDB.py
@@ -160,7 +160,7 @@ def analysis_to_entry(info, threshold=THRESHOLD, verbose=VERBOSE):
         timeline.append({
             'Value': ip_address,
             'Message': 'AbuseIPDB marked the indicator "{}" as *{}*'.format(ip_address, ip_rep),
-            'Category': 'Indicator Enrichment'
+            'Category': 'Integration Update'
         })
 
     return createEntry(context_ip, context_ip_generic, human_readable, dbot_scores, timeline, title=ANALYSIS_TITLE)


### PR DESCRIPTION
## Status
Ready

## Related Issues
related to: https://github.com/demisto/content/pull/5404

## Description
Update a command that acts on an indicator to return timeline data to be used by server in updating the Indicator's timeline. An example command is needed by server-side to demo this feature.

## Required version of Demisto
5.5.5

## Does it break backward compatibility?
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)