### PR TITLE
Remove newlines in markdown header

### DIFF
--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -303,7 +303,7 @@ def build_search_human_readable(args, parsed_search_results):
         if not isinstance(parsed_search_results[0], dict):
             headers = "results"
 
-    human_readable = tableToMarkdown("Splunk Search results \n\n Results for query: {}".format(args['query']),
+    human_readable = tableToMarkdown("Splunk Search results for query: {}".format(args['query']),
                                      parsed_search_results, headers)
     return human_readable
 


### PR DESCRIPTION
The Demisto entry resulting from a Splunk search may not be properly
formatted when the search string contains special characters like pipe,
backticks etc. Removing newlines from the markdown header resolves this
issue and allows for the resulting Entry/Note/Evidence to be converted
to HTML using the built-in mdToHtml regardless of the presence of special
characters in the query string.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold(Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Required version of Demisto
x.x.x

## Does it break backward compatibility?
   - Yes
       - Further details:
   - No

## Must have
- [ ] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Dependency 1
- [ ] Dependency 2
- [ ] Dependency 3

## Additional changes
Describe additional changes done, for example adding a function to common server.

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)