### PR TITLE
Update BaseClient _http_request Function

### DIFF
--- a/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Scripts/CommonServerPython/CommonServerPython.py
@@ -2315,7 +2315,7 @@ if 'requests' in sys.modules:
             if not proxy:
                 self._session.trust_env = False
 
-        def _http_request(self, method, url_suffix, full_url=None, headers=None,
+        def _http_request(self, method, url_suffix='', full_url=None, headers=None,
                           auth=None, json_data=None, params=None, data=None, files=None,
                           timeout=10, resp_type='json', ok_codes=None, **kwargs):
             """A wrapper for requests lib to send our requests and handle requests and responses better.

--- a/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -907,6 +907,11 @@ class TestBaseClient:
         response.status_code = 400
         assert not self.client._is_status_code_valid(response)
 
+    def test_http_request_full_url_no_url_suffix(self, requests_mock):
+        requests_mock.get('http://fullurl.com/without/url/suffix', text=json.dumps(self.text))
+        res = self.client._http_request('get', full_url='http://fullurl.com/without/url/suffix')
+        assert res == self.text
+
 
 def test_parse_date_string():
     # test unconverted data remains: Z


### PR DESCRIPTION
## Status
Ready

## Description
Fixes the issue if the user wanted to provide a `full_url` instead of using the `base_url` together with a `url_suffix` when calling the BaseClient's `_http_request` method that the user still needed to provide a value for the `url_suffix` argument.

## Required version of Demisto
any

## Does it break backward compatibility?
   - No

## Must have
- [x] Tests
- [ ] Documentation (with link to it)
- [ ] Code Review

## Dependencies
Mention the dependencies of the entity you changed as given from the precommit hooks in checkboxes, and tick after tested them.
- [ ] Everything

## Additional changes
Added a unit-test first. You can see it fail in the first commit. Passes in the second.

## Technical writer review
Mention and link to the files that require a technical writer review.
- [ ] [YAML file](link)
- [ ] [CHANGELOG](link)