### PR TITLE
Updated TAXII Feed test and fixed a bug

### DIFF
--- a/Integrations/FeedTAXII/FeedTAXII.py
+++ b/Integrations/FeedTAXII/FeedTAXII.py
@@ -702,15 +702,16 @@ class TAXIIClient(object):
 
                                 for indicator in indicators:
                                     yield indicator
-
-                                if self.last_stix_package_ts is None or timestamp > self.last_stix_package_ts:
-                                    self.last_stix_package_ts = timestamp
+                                if timestamp:
+                                    if self.last_stix_package_ts is None or timestamp > self.last_stix_package_ts:
+                                        self.last_stix_package_ts = timestamp
 
                             elif c.tag.endswith('Timestamp_Label'):
                                 timestamp = Taxii11.parse_timestamp_label(c.text)
 
-                                if self.last_taxii_content_ts is None or timestamp > self.last_taxii_content_ts:
-                                    self.last_taxii_content_ts = timestamp
+                                if timestamp:
+                                    if self.last_taxii_content_ts is None or timestamp > self.last_taxii_content_ts:
+                                        self.last_taxii_content_ts = timestamp
 
                         element.clear()
 

--- a/TestPlaybooks/playbook-TAXII_Feed_Test.yml
+++ b/TestPlaybooks/playbook-TAXII_Feed_Test.yml
@@ -49,6 +49,8 @@ tasks:
     scriptarguments:
       limit:
         simple: "10"
+      initial_interval:
+        simple: "50 days"
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
## Status
Ready

## Description
Updated TAXII test playbook to fetch incidents from 50 days ago (to make sure indicators are fetched), and also fixed a bug encountered while using another TAXII server.

## Required version of Demisto
5.5.0

## Does it break backward compatibility?
   - No