### PR TITLE
fix MISP is storing too much data on indicator

### DIFF
--- a/Integrations/MISP_V2/CHANGELOG.md
+++ b/Integrations/MISP_V2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed an issue where MISP indicators data was not filtered correctly by default
+Fixed an issue where MISP indicators data was not filtered correctly by default.
 
 ## [19.12.0] - 2019-12-10
 Added support to filter an event by attribute data fields.

--- a/Integrations/MISP_V2/CHANGELOG.md
+++ b/Integrations/MISP_V2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue where MISP indicators data was not filtered correctly by default
 
 ## [19.12.0] - 2019-12-10
 Added support to filter an event by attribute data fields.

--- a/Integrations/MISP_V2/MISP_V2.py
+++ b/Integrations/MISP_V2/MISP_V2.py
@@ -33,6 +33,9 @@ proxies = handle_proxy()  # type: ignore
 MISP_PATH = 'MISP.Event(obj.ID === val.ID)'
 MISP = ExpandedPyMISP(url=MISP_URL, key=MISP_KEY, ssl=USE_SSL, proxies=proxies)  # type: ExpandedPyMISP
 DATA_KEYS_TO_SAVE = demisto.params().get('context_select', [])
+if not DATA_KEYS_TO_SAVE:
+    DATA_KEYS_TO_SAVE = ['Value', 'Type', 'Comment', 'EventID', 'UUID', 'Timestamp', 'Category']
+
 """
 dict format :
     MISP key:DEMISTO key

--- a/Integrations/MISP_V2/MISP_V2.py
+++ b/Integrations/MISP_V2/MISP_V2.py
@@ -33,7 +33,6 @@ proxies = handle_proxy()  # type: ignore
 MISP_PATH = 'MISP.Event(obj.ID === val.ID)'
 MISP = ExpandedPyMISP(url=MISP_URL, key=MISP_KEY, ssl=USE_SSL, proxies=proxies)  # type: ExpandedPyMISP
 DATA_KEYS_TO_SAVE = demisto.params().get('context_select', [])
-
 """
 dict format :
     MISP key:DEMISTO key
@@ -242,13 +241,13 @@ def remove_unselected_context_keys(context_data):
 def arrange_context_according_to_user_selection(context_data):
     if not DATA_KEYS_TO_SAVE:
         return
+    for data in context_data:
+        # each event has it's own attributes
+        remove_unselected_context_keys(data)
 
-    # each event has it's own attributes
-    remove_unselected_context_keys(context_data[0])
-
-    # each related event has it's own attributes
-    for obj in context_data[0]['Object']:
-        remove_unselected_context_keys(obj)
+        # each related event has it's own attributes
+        for obj in data['Object']:
+            remove_unselected_context_keys(obj)
 
 
 def build_context(response: Union[dict, requests.Response]) -> dict:  # type: ignore

--- a/Integrations/MISP_V2/MISP_V2.yml
+++ b/Integrations/MISP_V2/MISP_V2.yml
@@ -21,7 +21,6 @@ configuration:
   type: 8
 - display: Select which attribute data fields of the event will be saved to context. Leave empty to select all attributes.
   name: context_select
-  defaultvalue: ID,Value
   options:
   - Category
   - Comment

--- a/Integrations/MISP_V2/MISP_V2.yml
+++ b/Integrations/MISP_V2/MISP_V2.yml
@@ -21,6 +21,7 @@ configuration:
   type: 8
 - display: Select which attribute data fields of the event will be saved to context. Leave empty to select all attributes.
   name: context_select
+  defaultvalue: ID,Value
   options:
   - Category
   - Comment


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [ ] Ready
- [x] In Hold - searching for the best default filtering to use, because it is expected to break BC

## Related Issues
fixes: https://github.com/demisto/etc/issues/20277

## Description
add defaults to `context_select` param. when there are no defaults it will put all of the data to the indicators which can crush the demisto client and slow down the server

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

