### PR TITLE
fix GetIndicatorDBotScore test

### DIFF
--- a/TestPlaybooks/playbook-GetIndicatorDBotScore_Test.yml
+++ b/TestPlaybooks/playbook-GetIndicatorDBotScore_Test.yml
@@ -84,7 +84,7 @@ tasks:
         simple: Test Indicator
       sourceTimeStamp: {}
       type:
-        simple: SHA1
+        simple: File
       value:
         simple: e1112134b6dcc8bed54e0e34d8ac272795e73d74
     separatecontext: false


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
There is no `SHA1` indicator type anymore in 5.5. Now it is only `File`

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [x] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

