### PR TITLE
PAN-OS integration - Dynamic User Groups - tagging and untagging

### DIFF
--- a/Integrations/Panorama/Panorama.py
+++ b/Integrations/Panorama/Panorama.py
@@ -3579,6 +3579,106 @@ def panorama_unregister_ip_tag_command():
     })
 
 
+''' User Tags '''
+
+
+@logger
+def panorama_register_user_tag(tag: str, users: List):
+    entry: str = ''
+    for user in users:
+        entry += f'<entry user=\"{user}\"><tag><member>{tag}</member></tag></entry>'
+
+    params = {
+        'type': 'user-id',
+        'cmd': '<uid-message><version>2.0</version><type>update</type><payload><register-user>' + entry
+               + '</register-user></payload></uid-message>',
+        'key': API_KEY
+    }
+
+    result = http_request(
+        URL,
+        'POST',
+        params=params,
+    )
+
+    return result
+
+
+def panorama_register_user_tag_command():
+    """
+    Register Users to a Tag
+    """
+    tag = demisto.args()['tag']
+    users = argToList(demisto.args()['Users'])
+
+    result = panorama_register_user_tag(tag, users)
+
+    registered_user: Dict[str, str] = {}
+
+    # get existing Users for this tag
+    context_users = demisto.dt(demisto.context(), 'Panorama.DynamicTags(val.Tag ==\"' + tag + '\").Users')
+
+    if context_users:
+        all_users = users + context_users
+    else:
+        all_users = users
+
+    registered_user = {
+        'Tag': tag,
+        'Users': all_users
+    }
+
+    demisto.results({
+        'Type': entryTypes['note'],
+        'ContentsFormat': formats['json'],
+        'Contents': result,
+        'ReadableContentsFormat': formats['text'],
+        'HumanReadable': 'Registered user-tag successfully',
+        'EntryContext': {
+            "Panorama.DynamicTags(val.Tag == obj.Tag)": registered_user
+        }
+    })
+
+
+@logger
+def panorama_unregister_user_tag(tag: str, users: list):
+    entry = ''
+    for user in users:
+        entry += '<entry user=\"' + user + '\"><tag><member>' + tag + '</member></tag></entry>'
+
+    params = {
+        'type': 'user-id',
+        'cmd': '<uid-message><version>2.0</version><type>update</type><payload><unregister-user>' + entry
+               + '</unregister-user></payload></uid-message>',
+        'key': API_KEY
+    }
+    result = http_request(
+        URL,
+        'POST',
+        params=params,
+    )
+
+    return result
+
+
+def panorama_unregister_user_tag_command():
+    """
+    Unregister Users from a Tag
+    """
+    tag = demisto.args()['tag']
+    users = argToList(demisto.args()['Users'])
+
+    result = panorama_unregister_user_tag(tag, users)
+
+    demisto.results({
+        'Type': entryTypes['note'],
+        'ContentsFormat': formats['json'],
+        'Contents': result,
+        'ReadableContentsFormat': formats['text'],
+        'HumanReadable': 'Unregistered user-tag successfully'
+    })
+
+
 ''' Traffic Logs '''
 
 
@@ -4705,6 +4805,13 @@ def main():
 
         elif demisto.command() == 'panorama-unregister-ip-tag':
             panorama_unregister_ip_tag_command()
+
+        # Registered Users
+        elif demisto.command() == 'panorama-register-user-tag':
+            panorama_register_user_tag_command()
+
+        elif demisto.command() == 'panorama-unregister-user-tag':
+            panorama_unregister_user_tag_command()
 
         # Security Rules Managing
         elif demisto.command() == 'panorama-list-rules':

--- a/Integrations/Panorama/Panorama.yml
+++ b/Integrations/Panorama/Panorama.yml
@@ -2377,6 +2377,47 @@ script:
     name: panorama-unregister-ip-tag
   - arguments:
     - default: false
+      description: Tag for which to register Users.
+      isArray: false
+      name: tag
+      required: true
+      secret: false
+    - default: false
+      description: Users to register.
+      isArray: true
+      name: Users
+      required: true
+      secret: false
+    deprecated: false
+    description: Registers Users to a tag.
+    execution: false
+    name: panorama-register-user-tag
+    outputs:
+    - contextPath: Panorama.DynamicTags.Tag
+      description: Name of the tag.
+      type: string
+    - contextPath: Panorama.DynamicTags.Users
+      description: Registered Users.
+      type: string
+  - arguments:
+    - default: false
+      description: Tag for which to unregister Users.
+      isArray: false
+      name: tag
+      required: true
+      secret: false
+    - default: false
+      description: Users to unregister.
+      isArray: true
+      name: Users
+      required: true
+      secret: false
+    deprecated: false
+    description: Unregisters Users from a tag.
+    execution: false
+    name: panorama-unregister-user-tag    
+  - arguments:
+    - default: false
       description: Specifies the match criteria for the logs. This is similar to the
         query provided in the web interface under the Monitor tab, when viewing the
         logs.

--- a/Playbooks/NetSec_-_Palo_Alto_Networks_DUG_-_Tag_User.yml
+++ b/Playbooks/NetSec_-_Palo_Alto_Networks_DUG_-_Tag_User.yml
@@ -1,0 +1,260 @@
+id: NetSec - Palo Alto Networks DUG - Tag User
+version: -1
+name: NetSec - Palo Alto Networks DUG - Tag User
+description: 'Block a user by tagging it  in the Palo Alto Networks NGFW. This requires
+  PAN-OS 9.1+. If the user is in the Demisto List with the name stated in playbook
+  inputs, the user will not be auto blocked but will first  require manager approval.
+  The list contents should be comma-separated (example contents: "user1,nam\jsmith")'
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: e075a102-f806-43e4-85ce-a1aca534406e
+    type: start
+    task:
+      id: e075a102-f806-43e4-85ce-a1aca534406e
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "10"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 550,
+          "y": -165
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "1":
+    id: "1"
+    taskid: 2b0f9a00-495e-45d1-8a07-df0818217a83
+    type: regular
+    task:
+      id: 2b0f9a00-495e-45d1-8a07-df0818217a83
+      version: -1
+      name: Panorama - Tag User
+      script: '|||panorama-register-user-tag'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "9"
+    scriptarguments:
+      Users:
+        simple: ${inputs.username}
+      tag:
+        simple: ${inputs.tagname}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 740
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "5":
+    id: "5"
+    taskid: 5d60dd32-6e84-48be-8a7a-6e7334530c31
+    type: condition
+    task:
+      id: 5d60dd32-6e84-48be-8a7a-6e7334530c31
+      version: -1
+      name: Is user in VIP list excluded from automated containment?
+      description: Check whether the values provided in arguments are equal. If either
+        of the arguments are missing, no is returned.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "1"
+      "yes":
+      - "6"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: inList
+          left:
+            value:
+              simple: inputs.username
+            iscontext: true
+          right:
+            value:
+              complex:
+                root: VIPUsers
+                transformers:
+                - operator: splitAndTrim
+                  args:
+                    delimiter:
+                      value:
+                        simple: ','
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 300
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "6":
+    id: "6"
+    taskid: 7056a53e-acb5-417c-804b-28def00eb058
+    type: condition
+    task:
+      id: 7056a53e-acb5-417c-804b-28def00eb058
+      version: -1
+      name: Escalate - Manager approves quarantine for VIP user?
+      description: Escalate - Manager approves quarantine for VIP user?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "no":
+      - "9"
+      "yes":
+      - "1"
+    separatecontext: false
+    sla:
+      hours: 1
+      days: 0
+      weeks: 0
+    defaultassigneecomplex:
+      simple: admin
+    restrictedcompletion: true
+    view: |-
+      {
+        "position": {
+          "x": 70,
+          "y": 550
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "9":
+    id: "9"
+    taskid: 5d58bd45-6dc5-489a-84e5-bfe0d642343f
+    type: title
+    task:
+      id: 5d58bd45-6dc5-489a-84e5-bfe0d642343f
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 260,
+          "y": 1000
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "10":
+    id: "10"
+    taskid: a0c6678d-898f-43d8-8aeb-4a8c6fd83122
+    type: condition
+    task:
+      id: a0c6678d-898f-43d8-8aeb-4a8c6fd83122
+      version: -1
+      name: Is there a VIP username list to check?
+      description: Check if list exist in demisto lists.
+      scriptName: IsListExist
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "1"
+      "yes":
+      - "11"
+    scriptarguments:
+      listName:
+        simple: ${inputs.VIPListName}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 550,
+          "y": -30
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "11":
+    id: "11"
+    taskid: cada2e5b-96b5-4d58-8e89-0385c9f03656
+    type: regular
+    task:
+      id: cada2e5b-96b5-4d58-8e89-0385c9f03656
+      version: -1
+      name: Get VIP user list
+      description: commands.local.cmd.list.get
+      script: Builtin|||getList
+      type: regular
+      iscommand: true
+      brand: Builtin
+    nexttasks:
+      '#none#':
+      - "5"
+    scriptarguments:
+      extend-context:
+        simple: VIPUsers=.
+      listName:
+        simple: ${inputs.VIPListName}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 140
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1230,
+        "width": 870,
+        "x": 60,
+        "y": -165
+      }
+    }
+  }
+inputs:
+- key: tagname
+  value: {}
+  required: true
+  description: ""
+- key: username
+  value: {}
+  required: true
+  description: ""
+- key: VIPListName
+  value:
+    simple: VIP_Users
+  required: false
+  description: Name of the list that contains VIP users who can only be blocked after manager approval.
+outputs: []

--- a/Playbooks/playbook-Block_Account_-_Generic.yml
+++ b/Playbooks/playbook-Block_Account_-_Generic.yml
@@ -28,10 +28,12 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 50
+          "y": 20
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "2":
     id: "2"
     taskid: 1808d949-f921-4957-8796-7bbedd822ad9
@@ -48,11 +50,13 @@ tasks:
     view: |-
       {
         "position": {
-          "x": -90,
-          "y": 870
+          "x": 0,
+          "y": 1180
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "5":
     id: "5"
     taskid: 0b958771-7e06-4239-899f-f7d133be6938
@@ -61,22 +65,24 @@ tasks:
       id: 0b958771-7e06-4239-899f-f7d133be6938
       version: -1
       name: Block accounts
-      description: ""
       type: title
       iscommand: false
       brand: ""
     nexttasks:
       '#none#':
       - "12"
+      - "14"
     separatecontext: false
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 380
+          "x": 250,
+          "y": 360
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "8":
     id: "8"
     taskid: 2c5a17dd-e019-4e20-8f5b-4333678a26e0
@@ -108,10 +114,12 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 195
+          "y": 165
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "12":
     id: "12"
     taskid: 5da07472-33bb-451d-8562-365e05f456ec
@@ -164,11 +172,13 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
-          "y": 515
+          "x": 230,
+          "y": 505
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
   "13":
     id: "13"
     taskid: c8b9285e-4d21-4070-89b6-33c611531812
@@ -194,20 +204,157 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 275,
-          "y": 690
+          "x": 320,
+          "y": 730
         }
       }
     note: false
+    timertriggers: []
+    ignoreworker: false
+  "14":
+    id: "14"
+    taskid: 7b9a0521-f530-41f2-8e6c-06df1f72ad87
+    type: condition
+    task:
+      id: 7b9a0521-f530-41f2-8e6c-06df1f72ad87
+      version: -1
+      name: Is PAN-OS enabled?
+      description: |
+        Verify that there is a valid instance of PAN-OS enabled.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "16"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: panorama
+                    ignorecase: true
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+                    ignorecase: true
+                accessor: brand
+            iscontext: true
+          ignorecase: true
+    view: |-
+      {
+        "position": {
+          "x": 770,
+          "y": 505
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "15":
+    id: "15"
+    taskid: 9da1c44c-5522-421f-8f84-a70123600e4a
+    type: regular
+    task:
+      id: 9da1c44c-5522-421f-8f84-a70123600e4a
+      version: -1
+      name: PAN-OS - Register Tag to User
+      description: Registers Users to a tag.
+      script: '|||panorama-register-user-tag'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      Users:
+        simple: ${inputs.Username}
+      tag:
+        simple: ${inputs.tagname}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 900,
+          "y": 1000
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+  "16":
+    id: "16"
+    taskid: 06dfb070-8751-4cbc-8dcd-b7ffd39ca2cc
+    type: condition
+    task:
+      id: 06dfb070-8751-4cbc-8dcd-b7ffd39ca2cc
+      version: -1
+      name: Is there a Tag name to register?
+      description: Verify that the playbook input includes at least one username to
+        block.
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "2"
+      "yes":
+      - "15"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              simple: inputs.tagname
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 900,
+          "y": 730
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
-    "linkLabelsPosition": {},
+    "linkLabelsPosition": {
+      "12_2_#default#": 0.1,
+      "14_16_yes": 0.6,
+      "14_2_#default#": 0.1,
+      "16_15_yes": 0.71,
+      "16_2_#default#": 0.1,
+      "8_2_#default#": 0.16
+    },
     "paper": {
       "dimensions": {
-        "height": 885,
-        "width": 745,
-        "x": -90,
-        "y": 50
+        "height": 1225,
+        "width": 1280,
+        "x": 0,
+        "y": 20
       }
     }
   }
@@ -216,6 +363,10 @@ inputs:
   value: {}
   required: false
   description: Array of malicious usernames to block.
+- key: Tag
+  value: {}
+  required: false
+  description: PAN-OS Tag name to register to the username in order to block it.
 outputs: []
 tests:
   - block_indicators_-_generic_-_test


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/19049

## Description
Added 2 commands to PAN-OS to support registering and unregistering user tags.
Added the command to Block Account generic playbook.
Added another playbook showcasing this capability which can be further customized.

Tested working with PAN-OS 9.1.0

## Screenshots
![NetSec_-_Palo_Alto_Networks_DUG_-_Tag_User](https://user-images.githubusercontent.com/3792355/73605088-c1d5c780-454e-11ea-9048-86a0a8f64d41.png)


## Minimum version of Demisto
- [x] 5.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

