### PR TITLE
SumoLogic: do not exit early when fetching records

### DIFF
--- a/Integrations/integration-SumoLogic.yml
+++ b/Integrations/integration-SumoLogic.yml
@@ -260,9 +260,10 @@ script:
                 query = beforeHttp + url + afterWhitespace
             }
             var headers = 'headers' in args ? argToList(args.headers) : undefined;
+            var waitForSearchComplete = args.waitForSearchComplete == 'true';
             var s = search(query, args.from, args.to, a2i(args.limit, defaultLimit), a2i(args.offset, 0), args.timezone,
                 a2i(args.maxTimeToWaitForResults, defaultSearchTimeout) * 60, args.byReceiptTime, a2i(params.sleepBetweenChecks, defaultSleep),
-                args.waitForSearchComplete);
+                waitForSearchComplete);
             var md = '';
             var ec = {};
             if (s.messages && s.messages.length > 0) {

--- a/Integrations/integration-SumoLogic.yml
+++ b/Integrations/integration-SumoLogic.yml
@@ -133,7 +133,7 @@ script:
         return {body: result.Body, obj: obj, statusCode: result.StatusCode, cookies: result.Cookies};
     };
 
-    var search = function(query, from, to, limit, offset, timezone, maxTimeToWaitForResults, byReceiptTime, sleep, fetchRecords) {
+    var search = function(query, from, to, limit, offset, timezone, maxTimeToWaitForResults, byReceiptTime, sleep, waitForSearchComplete) {
         var p = {query: query};
         if (from) {
             p.from = from;
@@ -156,7 +156,7 @@ script:
             for (var i=0; i<maxTimeToWaitForResults / sleep; i++) {
                 wait(sleep);
                 stat = doReq('GET', 'search/jobs/' + res.obj.id, null, res.cookies);
-                if (stat.obj.state === 'DONE GATHERING RESULTS' || (!fetchRecords && stat.obj.messageCount > (offset + 1) * limit)) {
+                if (stat.obj.state === 'DONE GATHERING RESULTS' || (!waitForSearchComplete && stat.obj.messageCount > (offset + 1) * limit)) {
                     done = true;
                     break;
                 }
@@ -262,7 +262,7 @@ script:
             var headers = 'headers' in args ? argToList(args.headers) : undefined;
             var s = search(query, args.from, args.to, a2i(args.limit, defaultLimit), a2i(args.offset, 0), args.timezone,
                 a2i(args.maxTimeToWaitForResults, defaultSearchTimeout) * 60, args.byReceiptTime, a2i(params.sleepBetweenChecks, defaultSleep),
-                params.fetchRecords);
+                args.waitForSearchComplete);
             var md = '';
             var ec = {};
             if (s.messages && s.messages.length > 0) {
@@ -323,6 +323,14 @@ script:
       - "false"
       description: If "true", the search is executed using receipt time. Default is
         "false".
+      defaultValue: "false"
+    - name: waitForSearchComplete
+      auto: PREDEFINED
+      predefined:
+      - "true"
+      - "false"
+      description: If "true", the search will wait for the query to iterate over all messages before returning results.
+        This is useful when working with aggregate records, as otherwise the query may return partial values.
       defaultValue: "false"
     outputs:
     - contextPath: Search.Messages

--- a/Integrations/integration-SumoLogic.yml
+++ b/Integrations/integration-SumoLogic.yml
@@ -133,7 +133,7 @@ script:
         return {body: result.Body, obj: obj, statusCode: result.StatusCode, cookies: result.Cookies};
     };
 
-    var search = function(query, from, to, limit, offset, timezone, maxTimeToWaitForResults, byReceiptTime, sleep) {
+    var search = function(query, from, to, limit, offset, timezone, maxTimeToWaitForResults, byReceiptTime, sleep, fetchRecords) {
         var p = {query: query};
         if (from) {
             p.from = from;
@@ -156,7 +156,7 @@ script:
             for (var i=0; i<maxTimeToWaitForResults / sleep; i++) {
                 wait(sleep);
                 stat = doReq('GET', 'search/jobs/' + res.obj.id, null, res.cookies);
-                if (stat.obj.state === 'DONE GATHERING RESULTS' || stat.obj.messageCount > (offset + 1) * limit) {
+                if (stat.obj.state === 'DONE GATHERING RESULTS' || (!fetchRecords && stat.obj.messageCount > (offset + 1) * limit)) {
                     done = true;
                     break;
                 }
@@ -215,7 +215,7 @@ script:
             }
 
             var s = search(params.fetchQuery, lastRun.time, now, a2i(params.limit, defaultLimit), 0, params.timeZone, a2i(params.maxTimeout, 180), false,
-                a2i(params.sleepBetweenChecks, defaultSleep));
+                a2i(params.sleepBetweenChecks, defaultSleep), params.fetchRecords);
             var incidents = [];
 
             if (!params.fetchRecords && s.messages) {
@@ -261,7 +261,8 @@ script:
             }
             var headers = 'headers' in args ? argToList(args.headers) : undefined;
             var s = search(query, args.from, args.to, a2i(args.limit, defaultLimit), a2i(args.offset, 0), args.timezone,
-                a2i(args.maxTimeToWaitForResults, defaultSearchTimeout) * 60, args.byReceiptTime, a2i(params.sleepBetweenChecks, defaultSleep));
+                a2i(args.maxTimeToWaitForResults, defaultSearchTimeout) * 60, args.byReceiptTime, a2i(params.sleepBetweenChecks, defaultSleep),
+                params.fetchRecords);
             var md = '';
             var ec = {};
             if (s.messages && s.messages.length > 0) {

--- a/Integrations/integration-SumoLogic_CHANGELOG.md
+++ b/Integrations/integration-SumoLogic_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-  - Bug fix: wait for the query to complete when fetching records.
+  - Added the *waitForSearchComplete* parameter, which causes the search to wait for the query to iterate over all messages before returning results.
+  - Bug fix: wait for the query to complete when fetching incidents as aggregate records.
 
 ## [19.11.1] - 2019-11-26
   - Added the *fetchDelay* parameter, which defines the time between ***fetch-incidents*** executions.

--- a/Integrations/integration-SumoLogic_CHANGELOG.md
+++ b/Integrations/integration-SumoLogic_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+  - Bug fix: wait for the query to complete when fetching records.
 
 ## [19.11.1] - 2019-11-26
   - Added the *fetchDelay* parameter, which defines the time between ***fetch-incidents*** executions.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
This would cause incorrect results to be returned by the Sumo integration, based only on the subset of messages being scanned.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
   - [X] No

## Must have
- [X] Tests
- [X] Documentation 
