### PR TITLE
Fix default demisto version in test_content.py

### DIFF
--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -630,7 +630,7 @@ def get_and_print_server_numeric_version(tests_settings):
         image_data = [line for line in image_data_file if line.startswith(tests_settings.serverVersion)]
         if len(image_data) != 1:
             print('Did not get one image data for server version, got {}'.format(image_data))
-            return '0.0.0'
+            return '99.99.98'  # latest
         else:
             server_numeric_version = re.findall(r'Demisto-Circle-CI-Content-[\w-]+-([\d.]+)-[\d]{5}', image_data[0])
             if server_numeric_version:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
in case of a problem, we should assume latest demisto version
fixes:
![image](https://user-images.githubusercontent.com/30797606/74102411-e849c300-4b4b-11ea-9a80-688df1172183.png)


## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

