### PR TITLE
fix for bootstrap to detect python 3.7 and above (needed by demisto-sdk)

### DIFF
--- a/.hooks/bootstrap
+++ b/.hooks/bootstrap
@@ -67,11 +67,22 @@ else
             echo "ERROR: python2 is missing. Please make sure you have Python 2 installed on your system" 1>&2
             exit 1
         fi
-        if ! command -v python3 >/dev/null 2>&1; then
+        PY3CMD="python3"
+        if command -v python3.8 >/dev/null 2>&1; then
+            PY3CMD="python3.8"
+        elif command -v python3.7 >/dev/null 2>&1; then
+            PY3CMD="python3.7"
+        fi
+        if ! command -v $PY3CMD >/dev/null 2>&1; then
             echo "ERROR: python3 is missing. Please make sure you have Python 3 installed on your system" 1>&2
             exit 1
         fi
-        virtualenv -p python3 venv
+        echo "Using python 3 command: `command -v $PY3CMD`"
+        if ! $PY3CMD -c 'import sys;assert sys.version_info.major == 3 and sys.version_info.minor >= 7, "python version check failed for: {}".format(sys.version_info)'; then
+            echo "ERROR: python 3.7 or above version validation failed. Please make sure you have Python 3.7 (and above) installed on your system" 1>&2
+            exit 1
+        fi
+        virtualenv -p $PY3CMD venv
         virtualenv -p python2 venv
         echo "# set PIPENV_IGNORE_VIRTUALENVS=1 so when setting up pipenv environments it doesn't use this one" >> venv/bin/activate
         echo "export PIPENV_IGNORE_VIRTUALENVS=1" >> venv/bin/activate


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Check to find that python3 is 3.7 or above. Fix after test on Ubuntu by @aburt-demisto 

