### PR TITLE
update docker hardening to provide full error entry

### DIFF
--- a/Scripts/DockerHardeningCheck/CHANGELOG.md
+++ b/Scripts/DockerHardeningCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Updated error entry to contain detailed reason for failure.
+Updated the error entry with a detailed explanation of the failure.
 
 ## [20.1.0] - 2020-01-07
 -

--- a/Scripts/DockerHardeningCheck/CHANGELOG.md
+++ b/Scripts/DockerHardeningCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Updated error entry to contain detailed reason for failure.
 
 ## [20.1.0] - 2020-01-07
 -

--- a/Scripts/DockerHardeningCheck/DockerHardeningCheck.py
+++ b/Scripts/DockerHardeningCheck/DockerHardeningCheck.py
@@ -149,15 +149,17 @@ def main():
         },
     ]
     failed = False
+    failed_msg = ''
     for v in res:
         if v[status] != success:
             failed = True
             v[status] = "Failed: " + v[status]
+            failed_msg += f'* {v[status]}\n'
     table = tableToMarkdown("Docker Hardening Results Check", res, [check, status])
     return_outputs(table)
     if failed:
-        return_error("Failed verifying docker hardening. "
-                     "More details at: https://support.demisto.com/hc/en-us/articles/360040922194")
+        return_error(f'Failed verifying docker hardening:\n{failed_msg}'
+                     'More details at: https://support.demisto.com/hc/en-us/articles/360040922194')
 
 
 # python2 uses __builtin__ python3 uses builtins

--- a/Scripts/DockerHardeningCheck/DockerHardeningCheck.yml
+++ b/Scripts/DockerHardeningCheck/DockerHardeningCheck.yml
@@ -29,6 +29,6 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.7.5.4583
+dockerimage: demisto/python3:3.8.1.5734
 runas: DBotWeakRole
 fromversion: 5.0.0


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
Update docker hardening script to include also in error entry the full details why the error happened. This helps if we get just the error entry form a customer without the entry with the table results.


## Screenshots
![image](https://user-images.githubusercontent.com/1395797/74569707-e3ac5280-4f2f-11ea-8ec4-2283476c92c4.png)


## Minimum version of Demisto
- [ ] 4.5.0
- [x] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

