### PR TITLE
Increased default docker memory usage threshold and additional tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -942,7 +942,8 @@
         {
             "integrations": "EWS v2",
             "playbookID": "EWS Public Folders Test",
-            "instance_names": "ewv2_regular"
+            "instance_names": "ewv2_regular",
+            "memory_threshold": 100
         },
         {
             "playbookID": "TestWordFileToIOC",
@@ -960,7 +961,8 @@
         {
             "playbookID": "process_email_-_generic_-_test",
             "integrations": "Rasterize",
-            "timeout": 240
+            "timeout": 240,
+            "pid_threshold": 6
         },
         {
             "integrations": "activedir",
@@ -1054,7 +1056,7 @@
         {
             "integrations": "SplunkPy",
             "playbookID": "SplunkPySearch_Test",
-            "memory_threshold": 150
+            "memory_threshold": 200
         },
         {
             "integrations": "McAfee NSM",
@@ -2190,7 +2192,8 @@
         },
         {
             "integrations": "GoogleCloudTranslate",
-            "playbookID": "GoogleCloudTranslate-Test"
+            "playbookID": "GoogleCloudTranslate-Test",
+            "pid_threshold": 8
         },
         {
             "integrations": "Infoblox",

--- a/Tests/test_utils.py
+++ b/Tests/test_utils.py
@@ -355,7 +355,7 @@ class Docker:
     MEMORY_USAGE = 'MemUsage'
     PIDS_USAGE = 'PIDs'
     CONTAINER_NAME = 'Name'
-    DEFAULT_CONTAINER_MEMORY_USAGE = 50
+    DEFAULT_CONTAINER_MEMORY_USAGE = 75
     DEFAULT_CONTAINER_PIDS_USAGE = 3
     REMOTE_MACHINE_USER = 'ec2-user'
     SSH_OPTIONS = 'ssh -o StrictHostKeyChecking=no'


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related to: https://github.com/demisto/etc/issues/20719

## Description
Increased default docker memory usage threshold from 50 to 75 MB and increased threshold for additional tests.