### PR TITLE
Fix netwitness-get-incident for NetWitness 11.4

### DIFF
--- a/Integrations/RSANetWitness_v11_1/CHANGELOG.md
+++ b/Integrations/RSANetWitness_v11_1/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- Fixed an issue with ***get-incident*** when the returned sources attribute is set to "[null]" in NetWitness 11.4
 
 ## [20.2.3] - 2020-02-18
 - Fixed an issue with ***fetch-incidents*** where setting a *Fetch Limit* would drop older incidents if the number of the fetched incidents was greater than the limit.

--- a/Integrations/RSANetWitness_v11_1/CHANGELOG.md
+++ b/Integrations/RSANetWitness_v11_1/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-- Fixed an issue with ***get-incident*** when the returned sources attribute is set to "[null]" in NetWitness 11.4
+Fixed an issue with the ***get-incident*** command when the returned sources attribute is set to "[null]". Applicable to NetWitness 11.4.
 
 ## [20.2.3] - 2020-02-18
 - Fixed an issue with ***fetch-incidents*** where setting a *Fetch Limit* would drop older incidents if the number of the fetched incidents was greater than the limit.

--- a/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1.py
+++ b/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1.py
@@ -788,7 +788,7 @@ def create_incident_md_table(incident):
     # if source fields exists and not empty - update incident entry 'source' field with a short string
     # representation of the source-list as value
     source_list = incident.get('sources')
-    if source_list:
+    if source_list and source_list[0]:
         incident_entry['sources'] = ', '.join(source_list)
     else:
         incident_entry['sources'] = ''

--- a/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1_test.py
+++ b/Integrations/RSANetWitness_v11_1/RSANetWitness_v11_1_test.py
@@ -9,7 +9,7 @@ INCIDENT_NEW = {
         },
         "openRemediationTaskCount": 0,
         "sources": [
-            "NetWitness Investigate"
+            None
         ],
         "id": "INC-3",
         "journalEntries": None,
@@ -240,3 +240,21 @@ def test_fetch_incidents_fetch_with_last_fetched_id(mocker):
     # assert fetch
     assert len(fetched_inc) == 1
     assert fetched_inc[0]['labels'][0]['value'] == '"{}"'.format(INCIDENT_NEW['items'][0]['id'])
+
+
+def test_get_incident(mocker):
+    def mock_demisto():
+        mock_args = {
+            'incidentId': 'INC-3'
+        }
+        mocker.patch.object(demisto, 'args', return_value=mock_args)
+        mocker.patch.object(demisto, 'results')
+        mocker.patch('RSANetWitness_v11_1.get_incident_request', return_value=INCIDENT_NEW['items'][0])
+
+    mock_demisto()
+    from RSANetWitness_v11_1 import get_incident
+
+    get_incident()
+    results = demisto.results.call_args[0]
+    # assert results
+    assert "INC-3" in results[0]['HumanReadable']


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
NetWitness 11.4 changed the incident JSON format. If no sources have been defined, they now display as `[null]` in the JSON:
```
{"id":"INC-46269","title":"My incident","summary":null,"priority":"Critical","riskScore":90,"status":"New","alertCount":2,"averageAlertRiskScore":90,"sealed":true,"totalRemediationTaskCount":0,"openRemediationTaskCount":0,"created":"2020-02-20T15:38:51.710Z","lastUpdated":"2020-02-20T15:38:51.710Z","lastUpdatedBy":null,"assignee":null,"sources":[null],"ruleId":"5d2d850417efd403bae12e70","firstAlertTime":"2020-02-20T15:38:48.370Z","categories":[],"journalEntries":null,"createdBy":"My incident","deletedAlertCount":0,"eventCount":2,"alertMeta":{"SourceIp":[],"DestinationIp":[]}}
```
This causes the integration to crash with this error:
```
!netwitness-get-incident incidentId="INC-46269"

Error from RSA NetWitness v11.1 is : Script failed to run:
Error: [Traceback (most recent call last):
   File "/tmp/pyrunner/_script_docker_python_loop.py", line 459, in <module>
    exec(code, sub_globals, sub_globals)
   File "<string>", line 1044, in <module>
   File "<string>", line 227, in get_incident
   File "<string>", line 792, in create_incident_md_table
TypeError: sequence item 0: expected string, NoneType found
] (2604) (2603)
```

## Description
Allow `netwitness-get-incident`  to work with NetWitness 11.4

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [x] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

