### PR TITLE
remove mem threshold for send notification test so it uses the default

### DIFF
--- a/TestPlaybooks/playbook-Send_Investigation_Summary_Reports_Test.yml
+++ b/TestPlaybooks/playbook-Send_Investigation_Summary_Reports_Test.yml
@@ -1,5 +1,5 @@
 id: Send Investigation Summary Reports - Test
-version: 1
+version: -1
 name: Send Investigation Summary Reports - Test
 description: 'Playbook should be run as a scheduled job at a recommended interval
   of once every 15 minutes. Playbook simply calls sub playbook: "Send Investigation

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2061,8 +2061,7 @@
         {
             "playbookID": "Send Investigation Summary Reports - Test",
             "integrations": "EWS Mail Sender",
-            "fromversion": "4.1.0",
-            "memory_threshold": 60
+            "fromversion": "4.1.0"            
         },
         {
             "integrations": "Anomali ThreatStream v2",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/22299

## Description
Use default mem threshold (75MB)

