### PR TITLE
fix for panaroma-edit-rule with the behaviour option add  or remove

### DIFF
--- a/Integrations/Panorama/Panorama.py
+++ b/Integrations/Panorama/Panorama.py
@@ -2726,7 +2726,7 @@ def panorama_get_current_element(element_to_change: str, xpath: str) -> list:
     if 'list' in current_object:
         current_objects_items = argToList(current_object['list']['member'])
     elif 'member' in current_object:
-        current_objects_items = argToList(current_object.get('member'))
+        current_objects_items = [arg["#text"] for arg in current_object.get('member')]
 
     return current_objects_items
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
in the present integration, if we select the behavior as add or remove. first it fetches the current objects and ideally it  has to make a list of present IPs But, instead of making list of Just IPs the present integration is making list of some metadata as well. so edited the fucntion to return only list of present IPs

## Screenshots
![image](https://user-images.githubusercontent.com/24710601/75152204-85048700-572e-11ea-8590-db372bf955ee.png)
after editing:

![image](https://user-images.githubusercontent.com/24710601/75152584-62bf3900-572f-11ea-8a7a-5ed7c9421c93.png)



## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No


