### PR TITLE
Domain Indicator Type: update default mapping

### DIFF
--- a/Misc/reputation-domain.json
+++ b/Misc/reputation-domain.json
@@ -348,6 +348,66 @@
           }
         ]
       }
+    },
+    "associations": {
+      "simple": "",
+      "complex": {
+        "root": "Domain",
+        "filters": [],
+        "accessor": "Associations",
+        "transformers": [{
+          "operator": "uniq",
+          "args": {}
+        }]
+      }
+    },
+    "reportedby": {
+      "simple": "",
+      "complex": {
+        "root": "Domain",
+        "filters": [],
+        "accessor": "ReportedBy",
+        "transformers": [{
+          "operator": "uniq",
+          "args": {}
+        }]
+      }
+    },
+    "threattypes": {
+      "simple": "",
+      "complex": {
+        "root": "Domain",
+        "filters": [],
+        "accessor": "ThreatTypes",
+        "transformers": [{
+          "operator": "uniq",
+          "args": {}
+        }]
+      }
+    },
+    "trafficlightprotocoltlp": {
+      "simple": "",
+      "complex": {
+        "root": "Domain",
+        "filters": [],
+        "accessor": "TrafficLightProtocol",
+        "transformers": [{
+          "operator": "uniq",
+          "args": {}
+        }]
+      }
+    },
+    "tags": {
+      "simple": "",
+      "complex": {
+        "root": "Domain",
+        "filters": [],
+        "accessor": "Tags",
+        "transformers": [{
+          "operator": "uniq",
+          "args": {}
+        }]
+      }
     }
   },
   "manualMapping": null,


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Works towards https://github.com/demisto/etc/issues/21756

## Description
Update the default mapping of the Domain indicator type to include new indicator fields.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

