### PR TITLE
IP Indicator Type: update default mapping

### DIFF
--- a/Misc/reputation-ip.json
+++ b/Misc/reputation-ip.json
@@ -182,7 +182,7 @@
             "complex": {
                 "root": "IP",
                 "filters": [],
-                "accessor": "Reported By",
+                "accessor": "ReportedBy",
                 "transformers": [
                     {
                         "operator": "uniq",
@@ -196,7 +196,7 @@
             "complex": {
                 "root": "IP",
                 "filters": [],
-                "accessor": "Threat Types",
+                "accessor": "ThreatTypes",
                 "transformers": [
                     {
                         "operator": "uniq",
@@ -210,7 +210,21 @@
             "complex": {
                 "root": "IP",
                 "filters": [],
-                "accessor": "Traffic Light Protocol (TLP)",
+                "accessor": "TrafficLightProtocol",
+                "transformers": [
+                    {
+                        "operator": "uniq",
+                        "args": {}
+                    }
+                ]
+            }
+        },
+        "tags": {
+            "simple": "",
+            "complex": {
+                "root": "IP",
+                "filters": [],
+                "accessor": "Tags",
                 "transformers": [
                     {
                         "operator": "uniq",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Works towards https://github.com/demisto/etc/issues/21756

## Description
Update the default mapping of the IP indicator type to include new indicator fields.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

