### PR TITLE
IPv6 Indicator Type: update default mapping

### DIFF
--- a/Misc/reputation-ipv6.json
+++ b/Misc/reputation-ipv6.json
@@ -215,6 +215,20 @@
                     }
                 ]
             }
+        },
+        "tags": {
+            "simple": "",
+            "complex": {
+                "root": "IPv6",
+                "filters": [],
+                "accessor": "Tags",
+                "transformers": [
+                    {
+                        "operator": "uniq",
+                        "args": {}
+                    }
+                ]
+            }
         }
     },
     "manualMapping": null,


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Works towards https://github.com/demisto/etc/issues/21756

## Description
Update the default mapping of the IPv6 indicator type to include new indicator fields.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

