### PR TITLE
[JiraV2] Fix setting up incident due date

### DIFF
--- a/Integrations/JiraV2/CHANGELOG.md
+++ b/Integrations/JiraV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed an issue in ***jira-create-issue*** and ***jira-edit-issue*** where due date was not set correctly.
+Fixed an issue in the ***jira-create-issue*** and ***jira-edit-issue*** commands where the due date was not set correctly.
 
 ## [20.2.0] - 2020-02-04
 Fixed an issue in ***jira-get-issue*** where trying to get the attachment of the issue would fail.

--- a/Integrations/JiraV2/CHANGELOG.md
+++ b/Integrations/JiraV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue in ***jira-create-issue*** and ***jira-edit-issue*** where due date was not set correctly.
 
 ## [20.2.0] - 2020-02-04
 Fixed an issue in ***jira-get-issue*** where trying to get the attachment of the issue would fail.

--- a/Integrations/JiraV2/JiraV2.py
+++ b/Integrations/JiraV2/JiraV2.py
@@ -371,8 +371,9 @@ def get_issue_fields(issue_creating=False, **issue_args):
             issue['fields']['priority'] = {}
         issue['fields']['priority']['name'] = issue_args['priority']
 
-    if issue_args.get('duedate'):
-        issue['fields']['duedate'] = issue_args['duedate']
+    duedate = issue_args.get('duedate') or issue_args.get('dueDate')
+    if duedate:
+        issue['fields']['duedate'] = duedate
 
     if issue_args.get('assignee'):
         if not issue['fields'].get('assignee'):

--- a/Integrations/JiraV2/JiraV2.yml
+++ b/Integrations/JiraV2/JiraV2.yml
@@ -70,12 +70,10 @@ configuration:
   required: false
 - display: Fetch incidents
   name: isFetch
-  defaultvalue: ""
   type: 8
   required: false
 - display: Incident type
   name: incidentType
-  defaultvalue: ""
   type: 13
   required: false
 - display: Use created field to fetch incidents

--- a/Integrations/JiraV2/JiraV2.yml
+++ b/Integrations/JiraV2/JiraV2.yml
@@ -2,7 +2,7 @@ commonfields:
   id: jira-v2
   version: -1
 name: jira-v2
-display: Atlassian Jira (v2)
+display: Atlassian Jira v2
 fromversion: 5.0.0
 category: Case Management
 description: Use the Jira integration to manage issues and create Demisto incidents from projects.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Fixed an issue in ***jira-create-issue*** and ***jira-edit-issue*** where the due date was not set correctly.

I'm pretty certain that changing just the `issue_args["duedate"]` to `issue_args["dueDate"]` would be sufficient, but leaning to the defensive programming here.

## Screenshots

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
