### PR TITLE
 EclecticIQ - added compatibility with EclecticIQ Platform version 2.7

### DIFF
--- a/Integrations/EclecticIQ/EclecticIQ.py
+++ b/Integrations/EclecticIQ/EclecticIQ.py
@@ -4,6 +4,7 @@ from CommonServerPython import *
 from CommonServerUserPython import *
 import json
 import requests
+import re
 
 # Disable insecure warnings
 requests.packages.urllib3.disable_warnings()
@@ -135,18 +136,22 @@ def login():
     Logins to EclecticIQ API with given credentials and sets the returned token in the headers
 
     """
-
-    cmd_url = '/api/auth'
-    cmd_json = {
-        'password': PASSWORD,
-        'username': USERNAME
-    }
-    response = http_request('POST', cmd_url, cmd_json=cmd_json)
-    if 'token' in response:
-        token = response['token']
+    if (re.match('^[\dabcdef]{64}$', PASSWORD)) == None:
+        cmd_url = '/api/auth'
+        cmd_json = {
+            'password': PASSWORD,
+            'username': USERNAME
+        }
+        response = http_request('POST', cmd_url, cmd_json=cmd_json)
+        if 'token' in response:
+            token = response['token']
+            HEADERS['Authorization'] = 'Bearer {}'.format(token)
+        else:
+            return_error('Failed to retrieve token')
     else:
-        return_error('Failed to retrieve token')
-    HEADERS['Authorization'] = 'Bearer {}'.format(token)
+        HEADERS['Authorization'] = 'Bearer {}'.format(PASSWORD)
+        cmd_url = '/api'
+        response = http_request('GET', cmd_url)
 
 
 def ip_command():


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Added 2FA auth compatibility. Starting with EclecticIQ version 2.7 user can use either password or token for authentication.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

