### PR TITLE
support for skipping py2 setup in bootstrap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             echo "Parameters: NIGHTLY: $NIGHTLY, NON_AMI_RUN: $NON_AMI_RUN, SERVER_BRANCH_NAME: $SERVER_BRANCH_NAME, INSTANCE_TESTS: $INSTANCE_TESTS"
             if [ ! -e "venv" ]; then
               echo "installing venv"
-              NO_HOOKS=1 .hooks/bootstrap
+              NO_HOOKS=1 SETUP_PY2=yes .hooks/bootstrap
               source ./venv/bin/activate
               pip install -r .circleci/build-requirements.txt
               pip3 install -r .circleci/build-requirements.txt

--- a/.hooks/bootstrap
+++ b/.hooks/bootstrap
@@ -4,29 +4,38 @@
 set -e
 
 #
-# Bootstraps a development environment. 
-# 
+# Bootstraps a development environment.
+#
 # This includes:
 # * install pre-commit hooks
-# * setup virtualenv 
+# * setup virtualenv
 
 if [ "$1" == "-h" -o "$1" == "--help" ]; then
     cat << EOF
-Setup development environment:
+Setup development environment (run with no arguments):
 * install pre-commit hooks (set NO_HOOKS=1 to skip)
 * setup venv virtualenv (set NO_VENV=1 to skip)
+
+To update python packages run: $0 -u
+
 EOF
 exit 0
 fi
 
 if [ "$1" == "-u" -o "$1" == "--update" ]; then
-    echo "Updating python dependencies..."
-    if [ ! -f "venv/bin/pip2" ]; then
+    if [ ! -f "venv/bin/pip2" -a ! -f "venv/bin/pip3" ]; then
         echo "ERROR: It seems that venv hasn't been setup. Run $0 to fully setup the venv without the [$1] option."
         exit 1
     fi
-    venv/bin/pip2 install -r dev-requirements-py2.txt
-    venv/bin/pip3 install -r dev-requirements-py3.txt
+    if [ -f "venv/bin/pip2" ]; then
+        echo "Updating python 2 dependencies ..."
+        venv/bin/pip2 install -r dev-requirements-py2.txt
+    fi
+    if [ -f "venv/bin/pip3" ]; then
+        echo "Updating python 3 dependencies ..."
+        venv/bin/pip3 install -r dev-requirements-py3.txt
+    fi
+    echo "Done updating dependencies"
     exit 0
 fi
 
@@ -46,9 +55,9 @@ else
     if [ ! -e "${GIT_HOOKS_DIR}/pre-commit" ]; then
         echo "Installing 'pre-commit' hooks"
         ln -s "${HOOKS_DIR}/pre-commit" "${GIT_HOOKS_DIR}/pre-commit"
-    else        
+    else
         echo "Skipping install of pre-commit hook as it already exists."
-        echo "If you want to re-install: 'rm ${GIT_HOOKS_DIR}/pre-commit' and then run this script again."        
+        echo "If you want to re-install: 'rm ${GIT_HOOKS_DIR}/pre-commit' and then run this script again."
     fi
 fi
 
@@ -63,9 +72,16 @@ else
             echo "ERROR: virtualenv is missing. Please install using: pip install virtualenv" 1>&2
             exit 1
         fi
-        if ! command -v python2 >/dev/null 2>&1; then
-            echo "ERROR: python2 is missing. Please make sure you have Python 2 installed on your system" 1>&2
-            exit 1
+        SETUP_PY2=${SETUP_PY2:-auto}
+        if [ "$SETUP_PY2" == "auto" ]; then
+            # we only setup PY2 if our remote origin is pointing to the demisto content repo (not a fork)
+            if git remote get-url origin | grep -E 'github.com:demisto/content.git$' >/dev/null 2>&1; then
+                echo "Will setup python 2 venv as detected content repo as remote"
+                echo "If you wish to skip python 2 setup, set environment variable SETUP_PY2=no"
+                SETUP_PY2=yes
+            else
+                INCLUDE_PY2_NOTE=yes
+            fi
         fi
         PY3CMD="python3"
         if command -v python3.8 >/dev/null 2>&1; then
@@ -82,20 +98,35 @@ else
             echo "ERROR: python 3.7 or above version validation failed. Please make sure you have Python 3.7 (and above) installed on your system" 1>&2
             exit 1
         fi
+        if [ "$SETUP_PY2" == "yes" ]; then
+            if ! command -v python2 >/dev/null 2>&1; then
+                echo "ERROR: python2 is missing. Please make sure you have Python 2 installed on your system" 1>&2
+                exit 1
+            fi
+        fi
         virtualenv -p $PY3CMD venv
-        virtualenv -p python2 venv
+        if [ "$SETUP_PY2" == "yes" ]; then
+            virtualenv -p python2 venv
+        fi
         echo "# set PIPENV_IGNORE_VIRTUALENVS=1 so when setting up pipenv environments it doesn't use this one" >> venv/bin/activate
         echo "export PIPENV_IGNORE_VIRTUALENVS=1" >> venv/bin/activate
-        echo "Done setting up python2/3 virtual env. Installing dependencies..."
-        venv/bin/pip2 install -r dev-requirements-py2.txt
+        echo "Done setting up python virtual env. Installing dependencies..."
+        if [ "$SETUP_PY2" == "yes" ]; then
+            venv/bin/pip2 install -r dev-requirements-py2.txt
+        fi
         venv/bin/pip3 install -r dev-requirements-py3.txt
+        if [ "$INCLUDE_PY2_NOTE" == "yes" ]; then
+            echo "=========================="
+            echo "Note: python 2 is NOT setup. If you require python 2 for your scripts/integrations run this command again"
+            echo "with the environment variable set: SETUP_PY2=yes"
+        fi
         echo "=========================="
         echo "Done setting up virtualenv at directory 'venv'"
         echo "Activate the venv by running: . ./venv/bin/activate"
-        echo "Deactivate by running: deactivate"        
+        echo "Deactivate by running: deactivate"
     else
         echo "Skipping virtual env setup as directory ${PWD}/venv exists."
-        echo "If you want to re-install: 'rm -r ${PWD}/venv' and then run this script again." 
+        echo "If you want to re-install: 'rm -r ${PWD}/venv' and then run this script again."
     fi
 fi
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/22604

## Description
Skip setup of py2 when working on a fork
 

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 


