### PR TITLE
Pack metadata fixes

### DIFF
--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T14:47:00Z",
     "updated": "2020-03-09T14:47:00Z",
     "beta": false,

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Utilities"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-08T09:36:23Z",
     "updated": "2020-03-08T09:36:23Z",
     "beta": false,

--- a/Packs/CVESearchV2/pack_metadata.json
+++ b/Packs/CVESearchV2/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Vulnerability Management"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/CalculateGeoDistance/pack_metadata.json
+++ b/Packs/CalculateGeoDistance/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Utilities"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T15:04:49Z",
     "updated": "2020-03-09T15:04:49Z",
     "beta": false,

--- a/Packs/CalculateTimeDifference/pack_metadata.json
+++ b/Packs/CalculateTimeDifference/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Utilities"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/Expanse/pack_metadata.json
+++ b/Packs/Expanse/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/ExportIndicators/pack_metadata.json
+++ b/Packs/ExportIndicators/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedAWS/pack_metadata.json
+++ b/Packs/FeedAWS/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedAlienVault/pack_metadata.json
+++ b/Packs/FeedAlienVault/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedAutofocus/pack_metadata.json
+++ b/Packs/FeedAutofocus/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedAzure/pack_metadata.json
+++ b/Packs/FeedAzure/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedBambenekConsulting/pack_metadata.json
+++ b/Packs/FeedBambenekConsulting/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedBlocklist_de/pack_metadata.json
+++ b/Packs/FeedBlocklist_de/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedBruteForceBlocker/pack_metadata.json
+++ b/Packs/FeedBruteForceBlocker/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedCSV/pack_metadata.json
+++ b/Packs/FeedCSV/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedCloudflare/pack_metadata.json
+++ b/Packs/FeedCloudflare/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedCofense/pack_metadata.json
+++ b/Packs/FeedCofense/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedDShield/pack_metadata.json
+++ b/Packs/FeedDShield/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedElasticsearch/pack_metadata.json
+++ b/Packs/FeedElasticsearch/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedFastly/pack_metadata.json
+++ b/Packs/FeedFastly/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedFeodoTracker/pack_metadata.json
+++ b/Packs/FeedFeodoTracker/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedMalwareDomainList/pack_metadata.json
+++ b/Packs/FeedMalwareDomainList/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:04:45Z",
     "updated": "2020-03-09T16:04:45Z",
     "beta": false,

--- a/Packs/FeedOffice365/pack_metadata.json
+++ b/Packs/FeedOffice365/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FeedPlainText/pack_metadata.json
+++ b/Packs/FeedPlainText/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FeedProofpoint/pack_metadata.json
+++ b/Packs/FeedProofpoint/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FeedSpamhaus/pack_metadata.json
+++ b/Packs/FeedSpamhaus/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FeedTorExitAddresses/pack_metadata.json
+++ b/Packs/FeedTorExitAddresses/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/Feedsslabusech/pack_metadata.json
+++ b/Packs/Feedsslabusech/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
       "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/FetchIndicatorsFromFile/pack_metadata.json
+++ b/Packs/FetchIndicatorsFromFile/pack_metadata.json
@@ -9,9 +9,7 @@
     "email": "",
     "categories": [
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/ImpossibleTraveler/pack_metadata.json
+++ b/Packs/ImpossibleTraveler/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Forensics & Malware Analysis"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T17:08:23Z",
     "updated": "2020-03-09T17:08:23Z",
     "beta": false,

--- a/Packs/Ipstack/pack_metadata.json
+++ b/Packs/Ipstack/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:35:16Z",
     "updated": "2020-03-09T16:35:16Z",
     "beta": false,

--- a/Packs/ipinfo/pack_metadata.json
+++ b/Packs/ipinfo/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-11T09:36:20Z",
     "updated": "2020-03-11T09:36:20Z",
     "beta": false,

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -10,9 +10,7 @@
     "categories": [
         "Utilities"
     ],
-    "tags": [
-        ""
-    ],
+    "tags": [],
     "created": "2020-03-09T16:54:23Z",
     "updated": "2020-03-09T16:54:23Z",
     "beta": false,


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
We should never add empty string as tag in `pack_metadata.json`. Need to add validation for it in later step, it causes the server to display empty data as tags in UI.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No