### PR TITLE
CommonServerPowerShell accept inner context as an object

### DIFF
--- a/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.ps1
+++ b/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.ps1
@@ -44,7 +44,12 @@ class DemistoObject {
     hidden [hashtable] $ContextArgs
 
     DemistoObject () {
-        $context = $global:InnerContext | ConvertFrom-Json -AsHashtable
+        if($global:InnerContext.GetType().Name -eq 'String') {
+            $context = $global:InnerContext | ConvertFrom-Json -AsHashtable
+        }
+        else {
+            $context = $global:InnerContext
+        }
         $this.ServerEntry = $context
         $this.ContextArgs = $context.args
         $this.IsDebug = $context.IsDebug


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Optimise so $demisto object will initialise from global:InnerContext also if it is an object. Save on the server side the overhead to convert to a string. Server PR will follow once this is merged.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
