### PR TITLE
Fix typos in AlienVault

### DIFF
--- a/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/CHANGELOG.md
+++ b/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [Unreleased]
+-

--- a/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/FeedAlienVaultOTXTaxii.yml
+++ b/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/FeedAlienVaultOTXTaxii.yml
@@ -100,7 +100,7 @@ script:
       required: true
       secret: false
     deprecated: false
-    description: Gets the indicators from AlientVault OTX.
+    description: Gets the indicators from AlienVault OTX.
     execution: false
     name: alienvaultotx-get-indicators
   dockerimage: demisto/taxii:1.0.0.6243

--- a/Packs/FeedAlienVault/Integrations/FeedAlienVaultReputation/README.md
+++ b/Packs/FeedAlienVault/Integrations/FeedAlienVaultReputation/README.md
@@ -8,7 +8,7 @@ Use the AlienVault Reputation feed integration to fetch indicators from the feed
 3. Click __Add instance__ to create and configure a new integration instance.
    | Parameter | Description | Example |
    | --- | --- | ---| 
-   | Name | A meaningful name for the integration instance. | alientvault_domain |
+   | Name | A meaningful name for the integration instance. | alienvault_domain |
    | Fetch indicators | Select this check box to fetch indicators. | N/A |
    | Indicator Reputation | The reputation applied to indicators from this integration instance. The default value is Bad. | N/A |
    | Source Reliability | Reliability of the source providing the intelligence data. The default value is C - Fairly reliable | N/A |

--- a/Packs/FeedAlienVault/pack_metadata.json
+++ b/Packs/FeedAlienVault/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "AlientVault Feed",
+    "name": "AlienVault Feed",
     "description": "Indicators feed from AlienVault",
     "support": "Cortex XSOAR",
     "serverMinVersion": "5.5.0",
@@ -17,7 +17,7 @@
     "deprecated": false,
     "certification": "certified",
     "useCases": [],
-    "keywords": ["AlientVault", "Feed"],
+    "keywords": ["AlienVault", "Feed"],
     "price": 0,
     "dependencies": {
         "Base": {


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

Is it just me or the `t` comes naturally after `alien`?