### PR TITLE
Marketplace - Skipped zipping of old format reputation files

### DIFF
--- a/Tests/store_packs.py
+++ b/Tests/store_packs.py
@@ -8,6 +8,7 @@ import uuid
 import yaml
 import enum
 import prettytable
+import fnmatch
 import google.auth
 from google.cloud import storage
 from distutils.util import strtobool
@@ -236,6 +237,16 @@ class Pack(object):
                     dirs[:] = [d for d in dirs if d not in Pack.EXCLUDE_DIRECTORIES]
 
                     for f in files:
+                        if f.startswith('.'):
+                            print_warning(f"Skipping zipping {f} for {self._pack_name} pack")
+                            continue
+
+                        current_directory = root.split(os.path.sep)[-1]
+
+                        if current_directory == 'Misc' and not fnmatch.fnmatch(f, 'reputation-*.json'):
+                            # reputation in old format aren't supported in 6.0.0 server version
+                            print_warning(f"Skipped zipping {f} for {self._pack_name} pack")
+
                         full_file_path = os.path.join(root, f)
                         relative_file_path = os.path.relpath(full_file_path, self._pack_path)
                         pack_zip.write(filename=full_file_path, arcname=relative_file_path)

--- a/Tests/store_packs.py
+++ b/Tests/store_packs.py
@@ -249,6 +249,7 @@ class Pack(object):
                         if current_directory == 'Misc' and not fnmatch.fnmatch(f, 'reputation-*.json'):
                             # reputation in old format aren't supported in 6.0.0 server version
                             print_warning(f"Skipped zipping {f} for {self._pack_name} pack")
+                            continue
 
                         full_file_path = os.path.join(root, f)
                         relative_file_path = os.path.relpath(full_file_path, self._pack_path)

--- a/Tests/store_packs.py
+++ b/Tests/store_packs.py
@@ -76,6 +76,7 @@ class Pack(object):
         USER_METADATA (str); user metadata file name, the one that located in content repo.
         INDEX_NAME (str): pack's index name, may be changed in the future.
         EXCLUDE_DIRECTORIES (list): list of directories to excluded before uploading pack zip to storage.
+        AUTHOR_IMAGE_NAME (str): author image file name.
 
     """
     PACK_INITIAL_VERSION = "1.0.0"

--- a/Tests/store_packs.py
+++ b/Tests/store_packs.py
@@ -85,6 +85,7 @@ class Pack(object):
     README = "README.md"
     USER_METADATA = "pack_metadata.json"
     METADATA = "metadata.json"
+    AUTHOR_IMAGE_NAME = "Author_image.png"
     INDEX_NAME = "index"
     EXCLUDE_DIRECTORIES = ["TestPlaybooks"]
 
@@ -237,7 +238,8 @@ class Pack(object):
                     dirs[:] = [d for d in dirs if d not in Pack.EXCLUDE_DIRECTORIES]
 
                     for f in files:
-                        if f.startswith('.'):
+                        # skipping unzipping of unwanted files
+                        if f.startswith('.') or f in [Pack.AUTHOR_IMAGE_NAME, Pack.USER_METADATA]:
                             print_warning(f"Skipping zipping {f} for {self._pack_name} pack")
                             continue
 

--- a/Tests/store_packs.py
+++ b/Tests/store_packs.py
@@ -239,7 +239,7 @@ class Pack(object):
                     dirs[:] = [d for d in dirs if d not in Pack.EXCLUDE_DIRECTORIES]
 
                     for f in files:
-                        # skipping unzipping of unwanted files
+                        # skipping zipping of unwanted files
                         if f.startswith('.') or f in [Pack.AUTHOR_IMAGE_NAME, Pack.USER_METADATA]:
                             print_warning(f"Skipping zipping {f} for {self._pack_name} pack")
                             continue


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Server version 6.0.0 will not support old format reputation json files. Skipped it while zipping and additionally removed zipping of not necessary files that were used for debugging (pack_metadata.json). 

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No