### PR TITLE
EDL edl-update Command Description Typo Fix

### DIFF
--- a/Integrations/EDL/EDL.yml
+++ b/Integrations/EDL/EDL.yml
@@ -96,7 +96,7 @@ script:
       required: true
       secret: false
     deprecated: false
-    description: Updates values stored in the EDL (only avaialable On-Demand).
+    description: Updates values stored in the EDL (only available On-Demand).
     execution: false
     name: edl-update
   dockerimage: demisto/teams:1.0.0.6483


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixes a typo in the description of the `edl-update` command. `available` was misspelled as 'avaialable'.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/76970045-f00f3b00-6933-11ea-8bb8-2224f9fe3d60.png)


## Minimum version of Demisto
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No
