### PR TITLE
Update Tanium V2 to support question text with parameters

### DIFF
--- a/Integrations/Tanium_v2/CHANGELOG.md
+++ b/Integrations/Tanium_v2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-
+- Support questions text with parameters instead of using the parameters argument in ***tn-ask-question*** command.
+- Fixed an issue where ***tn-get-question-result*** command returned a list in single column result.
 
 ## [19.12.1] - 2019-12-25
 Fixed an issue where ***tn-get-question-result*** command returned empty results.

--- a/Integrations/Tanium_v2/CHANGELOG.md
+++ b/Integrations/Tanium_v2/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-- Support questions text with parameters instead of using the parameters argument in ***tn-ask-question*** command.
-- Fixed an issue where ***tn-get-question-result*** command returned a list in single column result.
+  - Added support for question text with parameters instead of using the parameters argument in the ***tn-ask-question*** command.
+  - Fixed an issue where the ***tn-get-question-result*** command returned a list in a single-column result.
 
 ## [19.12.1] - 2019-12-25
 Fixed an issue where ***tn-get-question-result*** command returned empty results.

--- a/Integrations/Tanium_v2/Tanium_v2.py
+++ b/Integrations/Tanium_v2/Tanium_v2.py
@@ -649,7 +649,6 @@ def ask_question(client, data_args):
     parameters = data_args.get('parameters')
 
     body = client.parse_question(question_text, parameters)
-    print(body)
     id_, res = client.create_question(body)
     context = {'ID': id_}
     context = createContext(context, removeNull=True)

--- a/Integrations/Tanium_v2/Tanium_v2.py
+++ b/Integrations/Tanium_v2/Tanium_v2.py
@@ -111,14 +111,14 @@ class Client(BaseClient):
             res = self.do_request('POST', 'parse_question', {'text': text}).get('data')[0]
         else:
             # if there are no parameters argument - try to gets the sensors from parse question api
-            text_without_params = re.sub('\[(.*?)\]', '', text)
+            text_without_params = re.sub(r'\[(.*?)\]', '', text)
             res = self.do_request('POST', 'parse_question', {'text': text_without_params}).get('data')[0]
 
             # call sensors/by-name/ for each sensor in the response and update parameters_condition
             # with the correct parameters
             for item in res.get('selects'):
                 sensor = item.get('sensor').get('name')
-                search_results = re.search(f'{sensor}\[(.*?)\]', text)
+                search_results = re.search(rf'{sensor}\[(.*?)\]', text)
                 if search_results:
                     parameters_str = search_results.group(1)
                     parameters = parameters_str.split(',')

--- a/Integrations/Tanium_v2/Tanium_v2.yml
+++ b/Integrations/Tanium_v2/Tanium_v2.yml
@@ -1,6 +1,6 @@
 category: Endpoint
 commonfields:
-  id: Tanium v2
+  id: Tanium v22
   version: -1
 configuration:
 - display: Hostname, IP address, or server URL.
@@ -24,8 +24,8 @@ configuration:
   required: false
   type: 8
 description: Tanium endpoint security and systems management
-display: Tanium v2
-name: Tanium v2
+display: Tanium v22
+name: Tanium v22
 script:
   commands:
   - arguments:

--- a/Integrations/Tanium_v2/Tanium_v2.yml
+++ b/Integrations/Tanium_v2/Tanium_v2.yml
@@ -1,6 +1,6 @@
 category: Endpoint
 commonfields:
-  id: Tanium v22
+  id: Tanium v2
   version: -1
 configuration:
 - display: Hostname, IP address, or server URL.
@@ -24,8 +24,8 @@ configuration:
   required: false
   type: 8
 description: Tanium endpoint security and systems management
-display: Tanium v22
-name: Tanium v22
+display: Tanium v2
+name: Tanium v2
 script:
   commands:
   - arguments:

--- a/Integrations/Tanium_v2/Tanium_v2_test.py
+++ b/Integrations/Tanium_v2/Tanium_v2_test.py
@@ -61,6 +61,55 @@ parse_question_res = {
     ]
 }
 
+parse_question_Folder_Contents_res = {
+    "data": [
+        {
+            "from_canonical_text": 0,
+            "question_text": "Get Folder-Contents from all machines",
+            "selects": [
+                {
+                    "sensor": {
+                        "hash": 3881863289,
+                        "name": "Folder-Contents"
+                    }
+                }
+            ],
+            "sensor_references": [
+                {
+                    "name": "Folder-Contents",
+                    "real_ms_avg": 53,
+                    "start_char": "4"
+                }
+            ]
+        },
+        {
+            "from_canonical_text": 0,
+            "question_text": "Get Tanium File Contents from all machines",
+            "selects": [
+                {
+                    "sensor": {
+                        "hash": 4070262781,
+                        "name": "Tanium File Contents"
+                    }
+                }
+            ],
+            "sensor_references": [
+                {
+                    "name": "Folder-Contents",
+                    "real_ms_avg": 53,
+                    "start_char": "4"
+                }
+            ]
+        }
+    ]
+}
+
+sensor_res = {
+    "data": {
+        "parameter_definition": "{\"parameters\":[{\"key\":\"folderPath\"}]}"
+        }
+}
+
 CREATE_ACTION_BY_TARGET_GROUP_RES = {
     'package_spec': {'source_id': 12345},
     'name': 'action-name via Demisto API',
@@ -237,3 +286,15 @@ def test_parse_question_results():
     client = Client(BASE_URL, 'username', 'password', 'domain')
     results = client.parse_question_results(QUESTION_RESULTS_RAW)
     assert results == QUESTION_RESULTS
+
+
+def test_parse_question(requests_mock):
+    client = Client(BASE_URL, 'username', 'password', 'domain')
+    requests_mock.get(BASE_URL + 'session/login', json={'data': {'session': 'session-id'}})
+    requests_mock.post(BASE_URL + 'parse_question', json=parse_question_Folder_Contents_res)
+    requests_mock.get(BASE_URL + 'sensors/by-name/Folder-Contents', json=sensor_res)
+
+    results = client.parse_question('Get Folder-Contents[c:\] from all machines', '')
+    assert results['selects'][0]['sensor']['name'] == 'Folder-Contents'
+    assert results['selects'][0]['sensor']['parameters'][0]['key'] == '||folderPath||'
+    assert results['selects'][0]['sensor']['parameters'][0]['value'] == 'c:\\'

--- a/Integrations/Tanium_v2/Tanium_v2_test.py
+++ b/Integrations/Tanium_v2/Tanium_v2_test.py
@@ -106,8 +106,7 @@ parse_question_Folder_Contents_res = {
 
 sensor_res = {
     "data": {
-        "parameter_definition": "{\"parameters\":[{\"key\":\"folderPath\"}]}"
-        }
+        "parameter_definition": "{\"parameters\":[{\"key\":\"folderPath\"}]}"}
 }
 
 CREATE_ACTION_BY_TARGET_GROUP_RES = {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/22492

## Description
- Update parse_question method to support question text with parameters instead of using the `parameters` argument in `tn-ask-question` command, which means that now its possible to call this command:
`!tn-ask-question question-text="Get Folder Contents[c:\] from all machines"`

instead of this:
`!tn-ask-question question-text="Get Folder Contents from all machines" parameters="Folder Contents{folderPath=c:\}"`

- Fix parse_question_results method to support list in single column result.

## Screenshots
![image](https://user-images.githubusercontent.com/46249224/77088371-0806bd80-6a0d-11ea-82eb-74a035db7ad0.png)
