### PR TITLE
Find similar incident deprecated args

### DIFF
--- a/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
+++ b/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Deprecated arguments: similarCustomFields, similarIncidentKeys. You should use similarIncidentFields instead.
+Deprecated arguments: similarCustomFields, similarIncidentKeys. Use ***similarIncidentFields*** instead.
 
 
 ## [20.3.3] - 2020-03-18

--- a/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
+++ b/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+Deprecated arguments: similarCustomFields, similarIncidentKeys. You should use similarIncidentFields instead.
 
 
 ## [20.3.3] - 2020-03-18

--- a/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
+++ b/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
@@ -15,6 +15,7 @@ args:
   name: similarLabelsKeys
   required: false
   secret: false
+  deprecated: true
 - default: false
   description: A comma-separated list of similar context keys. Also supports allowing
     X different words between values (see the labels description).
@@ -29,6 +30,7 @@ args:
   name: similarCustomFields
   required: false
   secret: false
+  deprecated: true
 - auto: PREDEFINED
   default: false
   defaultValue: 'yes'


### PR DESCRIPTION
- [x] Ready

Just release notes - those arguments should be deprecated long ago, probably missed 