### PR TITLE
Improved base client exception parsing

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CHANGELOG.md
+++ b/Packs/Base/Scripts/CommonServerPython/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
   - Added the argument *ignore_auto_extract* to the ***return_outputs*** command.
   - Added a default value to the indicator timeline field **Category** when a value is not provided in an entry's timeline data.
+  - Improved error message parsing of HTTP response in BaseClient.
+
 
 ## [20.3.4] - 2020-03-30
 - Added support for successful empty responses (status code 204) in the base client.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2567,8 +2567,9 @@ if 'requests' in sys.modules:
                         error_entry = res.json()
                         err_msg += '\n{}'.format(json.dumps(error_entry))
                         raise DemistoException(err_msg)
-                    except ValueError as exception:
-                        raise DemistoException(err_msg, exception)
+                    except ValueError:
+                        err_msg += '\n{}'.format(res.text)
+                        raise DemistoException(err_msg)
 
                 is_response_empty_and_successful = (res.status_code == 204)
                 if is_response_empty_and_successful and return_empty_response:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
When the base client gets a text error response- trying to get `res.json()` will cause ValueError and hide the true cause of the error which can be taken from `res.text`


