### PR TITLE
Update Devo_v2 README for https links

### DIFF
--- a/Integrations/Devo_v2/README.md
+++ b/Integrations/Devo_v2/README.md
@@ -378,7 +378,7 @@ N/A
 ## Additional Information
 ---
 #### Youtube Video Demo (Click Image, Will redirect to youtube)
-[![Devo-Demisto Plugin Demo](http://img.youtube.com/vi/jyUqEcWOXfU/0.jpg)](http://www.youtube.com/watch?v=jyUqEcWOXfU "Devo Demisto Demo")
+[![Devo-Demisto Plugin Demo](https://img.youtube.com/vi/jyUqEcWOXfU/0.jpg)](https://www.youtube.com/watch?v=jyUqEcWOXfU "Devo Demisto Demo")
 
 ## Known Limitations
 ---


### PR DESCRIPTION
Update Devo_v2 README.md to point to https URLs for youtube instead of http

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
Updated README.md to point to https URLs in Youtube instead of HTTP

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 

