### PR TITLE
Taxii Feed Fix

### DIFF
--- a/Integrations/FeedTAXII/CHANGELOG.md
+++ b/Integrations/FeedTAXII/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fix uninitialized instance variables.
 
 ## [20.3.3] - 2020-03-18
 You can now use the API header and API key in the credentials fields when configuring an integration instance.

--- a/Integrations/FeedTAXII/FeedTAXII.py
+++ b/Integrations/FeedTAXII/FeedTAXII.py
@@ -503,16 +503,19 @@ class TAXIIClient(object):
         self.collection = collection
 
         # authentication
-        if credentials:
-            if '_header:' in credentials.get('identifier', None):
-                self.api_header = credentials.get('identifier', None).split('_header:')[1]
-                self.api_key = credentials.get('password', None)
-            else:
-                self.username = credentials.get('identifier', None)
-                self.password = credentials.get('password', None)
+        if not credentials:
+            credentials = {}
+        self.api_head, self.api_key, self.username, self.password = '', '', '', ''
+
+        if '_header:' in credentials.get('identifier', ''):
+            self.api_header = credentials.get('identifier', '').split('_header:')[1]
+            self.api_key = credentials.get('password', '')
+        else:
+            self.username = credentials.get('identifier', '')
+            self.password = credentials.get('password', '')
 
     def _send_request(self, url, headers, data, stream=False):
-        if self.api_key is not None and self.api_header is not None:
+        if self.api_key and self.api_header:
             headers[self.api_header] = self.api_key
 
         rkwargs = dict(
@@ -523,7 +526,7 @@ class TAXIIClient(object):
             data=data
         )
 
-        if self.username is not None and self.password is not None:
+        if self.username and self.password:
             rkwargs['auth'] = (self.username, self.password)
 
         r = requests.post(

--- a/Integrations/FeedTAXII/FeedTAXII_test.py
+++ b/Integrations/FeedTAXII/FeedTAXII_test.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import requests_mock
 
 """ helper functions """
 
@@ -95,3 +96,13 @@ class TestCommands:
             with open('FeedTAXII_test/TestCommands/indicators_results.json', 'r') as exp_f:
                 expected = json.load(exp_f)
                 assert res == expected
+
+
+class TestTaxiiClient:
+    # verify that unassigned instance variables are still instantiated
+    def test_send_request(self):
+        from FeedTAXII import TAXIIClient
+        client = TAXIIClient()
+        with requests_mock.Mocker() as m:
+            m.post('http://www.example.com', text='response does not matter')
+            client._send_request('http://www.example.com', {}, {})


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixes a problem where instance variables were uninitialized in the `init` method of the `TAXIIClient` class, causing an `AttributeError` to be raised when making requests.

## Minimum version of Demisto
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation

