### PR TITLE
New SplunkPy command !splunk-job-status

### DIFF
--- a/Integrations/SplunkPy/CHANGELOG.md
+++ b/Integrations/SplunkPy/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Added the ***splunk-job-status*** command, which checks the status of a job.
 - Added the **Replace with Underscore in Incident Fields** parameter key, which replaces problematic characters (e.g., ".") with underscores ("\_") in context keys.
 - Added ***First fetch timestamp*** parameter which indicates from which date and time should incidents be fetched.
 - Fixed an issue where ***splunk-search*** presented the table headers in alphabetical order instead of the query order.

--- a/Integrations/SplunkPy/SplunkPy.py
+++ b/Integrations/SplunkPy/SplunkPy.py
@@ -604,6 +604,32 @@ def splunk_edit_notable_event_command(proxy):
     demisto.results('Splunk ES Notable events: ' + response_info['message'])
 
 
+def splunk_job_status(service):
+    sid = demisto.args().get('sid')
+    try:
+        job = service.job(sid)
+    except HTTPError as error:
+        if error.message == 'HTTP 404 Not Found -- Unknown sid.':
+            demisto.results("Not found job for SID: {}".format(sid))
+        else:
+            return_error(error.message, error)
+    else:
+        status = job.state.content.get('dispatchState')
+        entry_context = {
+            'SID': sid,
+            'Status': status
+        }
+        context = {'Splunk.JobStatus(val.SID && val.SID === obj.SID)': entry_context}
+        human_readable = tableToMarkdown('Splunk Job Status', entry_context)
+        demisto.results({
+            "Type": entryTypes['note'],
+            "Contents": entry_context,
+            "ContentsFormat": formats["json"],
+            "EntryContext": context,
+            "HumanReadable": human_readable
+        })
+
+
 def splunk_parse_raw_command():
     raw = demisto.args().get('raw', '')
     rawDict = rawToDict(raw)
@@ -688,6 +714,8 @@ def main():
         splunk_parse_raw_command()
     if demisto.command() == 'splunk-submit-event-hec':
         splunk_submit_event_hec_command()
+    if demisto.command() == 'splunk-job-status':
+        splunk_job_status(service)
 
 
 if __name__ in ['__main__', '__builtin__', 'builtins']:

--- a/Integrations/SplunkPy/SplunkPy.yml
+++ b/Integrations/SplunkPy/SplunkPy.yml
@@ -358,6 +358,24 @@ script:
       JSON event protocol.
     execution: false
     name: splunk-submit-event-hec
+  - arguments:
+    - default: false
+      description: ID of the job for which to get the status.
+      isArray: false
+      name: sid
+      required: true
+      secret: false
+    deprecated: false
+    description: Returns the status of a job.
+    execution: false
+    name: splunk-job-status
+    outputs:
+    - contextPath: Splunk.JobStatus.SID
+      description: ID of the job.
+      type: String
+    - contextPath: Splunk.JobStatus.Status
+      description: Status of the job.
+      type: String
   dockerimage45: demisto/splunksdk:1.0
   dockerimage: demisto/splunksdk:1.0.0.6822
   feed: false

--- a/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
+++ b/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
@@ -1,14 +1,16 @@
 id: SplunkPy-Test-V2
 version: -1
+contentitemfields:
+  propagationLabels: []
 name: SplunkPy-Test-V2
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 85ee287c-4ebe-49ad-8507-5c2cff19c982
+    taskid: cf43cb85-c6a4-47c3-8ca3-d59b67debd06
     type: start
     task:
-      id: 85ee287c-4ebe-49ad-8507-5c2cff19c982
+      id: cf43cb85-c6a4-47c3-8ca3-d59b67debd06
       version: -1
       name: ""
       iscommand: false
@@ -27,14 +29,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "1":
     id: "1"
-    taskid: fb621622-fbc7-4c65-86e5-c6942e932a49
+    taskid: 2ecc6f75-4f57-48d2-8eab-0b7716a35e19
     type: regular
     task:
-      id: fb621622-fbc7-4c65-86e5-c6942e932a49
+      id: 2ecc6f75-4f57-48d2-8eab-0b7716a35e19
       version: -1
       name: Delete Context
       description: Delete field from context
@@ -64,14 +64,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "2":
     id: "2"
-    taskid: b04cac04-ea5a-478b-8392-a530870d02ff
+    taskid: 9b011c29-cff0-4e52-897c-f8f124a28e07
     type: regular
     task:
-      id: b04cac04-ea5a-478b-8392-a530870d02ff
+      id: 9b011c29-cff0-4e52-897c-f8f124a28e07
       version: -1
       name: Splunk search with app
       description: Searches Splunk for events.
@@ -105,14 +103,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "3":
     id: "3"
-    taskid: 3d52d7ff-5882-41cf-8d1d-8d55859a81ff
+    taskid: a6f922ca-8b92-4053-8911-7276b19c7080
     type: regular
     task:
-      id: 3d52d7ff-5882-41cf-8d1d-8d55859a81ff
+      id: a6f922ca-8b92-4053-8911-7276b19c7080
       version: -1
       name: Splunk search
       description: Searches Splunk for events.
@@ -144,14 +140,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "4":
     id: "4"
-    taskid: 15277270-d8cf-464a-8e13-0ddd93248a0d
+    taskid: 8b6a41d3-0496-403d-8458-5839174930e9
     type: condition
     task:
-      id: 15277270-d8cf-464a-8e13-0ddd93248a0d
+      id: 8b6a41d3-0496-403d-8458-5839174930e9
       version: -1
       name: 'Verify Context '
       type: condition
@@ -182,14 +176,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "5":
     id: "5"
-    taskid: 4b1c5a4a-b00e-4663-8c4a-2eac4cbc0e75
+    taskid: 18d36ca0-02af-449b-825a-338dc966165a
     type: condition
     task:
-      id: 4b1c5a4a-b00e-4663-8c4a-2eac4cbc0e75
+      id: 18d36ca0-02af-449b-825a-338dc966165a
       version: -1
       name: Verify Context
       type: condition
@@ -217,14 +209,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "6":
     id: "6"
-    taskid: a6d0cd9c-7c35-4e5d-88aa-90250dd5b3b5
+    taskid: 4b1fd2e7-d90d-4b68-8fae-de2d982e7e16
     type: regular
     task:
-      id: a6d0cd9c-7c35-4e5d-88aa-90250dd5b3b5
+      id: 4b1fd2e7-d90d-4b68-8fae-de2d982e7e16
       version: -1
       name: Get splunk indexes
       description: Prints all Splunk index names.
@@ -247,14 +237,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "7":
     id: "7"
-    taskid: b293116a-ee77-4fd8-8d6c-a5a5bbff8e7a
+    taskid: c1abf296-0101-4b7d-8445-30a94e570d45
     type: regular
     task:
-      id: b293116a-ee77-4fd8-8d6c-a5a5bbff8e7a
+      id: c1abf296-0101-4b7d-8445-30a94e570d45
       version: -1
       name: Splunk Create job
       description: Creates a new search job in Splunk.
@@ -264,7 +252,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "8"
+      - "17"
     scriptarguments:
       app: {}
       query:
@@ -280,14 +268,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "8":
     id: "8"
-    taskid: 4545519c-23bd-4787-86d4-4718dd9c803f
+    taskid: b71e43c9-6d14-40bf-8277-ca7306a895ce
     type: regular
     task:
-      id: 4545519c-23bd-4787-86d4-4718dd9c803f
+      id: b71e43c9-6d14-40bf-8277-ca7306a895ce
       version: -1
       name: Get job results
       description: Returns the results of a previous Splunk search. You can use this
@@ -307,20 +293,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 1200
+          "y": 1330
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "9":
     id: "9"
-    taskid: 2c688e19-58a4-4882-8064-110b9449d924
+    taskid: 8199bb00-8731-4489-8871-f3af2bdd64d2
     type: regular
     task:
-      id: 2c688e19-58a4-4882-8064-110b9449d924
+      id: 8199bb00-8731-4489-8871-f3af2bdd64d2
       version: -1
       name: Submit event
       description: Creates a new event in Splunk.
@@ -348,14 +332,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "10":
     id: "10"
-    taskid: 83a12924-c8ff-45d9-81a5-b46f3ea1b437
+    taskid: 36823bac-6e73-4bf9-8b52-4cc9e219309d
     type: regular
     task:
-      id: 83a12924-c8ff-45d9-81a5-b46f3ea1b437
+      id: 36823bac-6e73-4bf9-8b52-4cc9e219309d
       version: -1
       name: Parse raw
       description: Parses the raw part of the event.
@@ -373,20 +355,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 1400
+          "y": 1500
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "11":
     id: "11"
-    taskid: 9c29640f-4bf6-43ce-8c82-57bda30ba17b
+    taskid: 9d6b200d-62ca-4580-8f9d-64525a772e79
     type: condition
     task:
-      id: 9c29640f-4bf6-43ce-8c82-57bda30ba17b
+      id: 9d6b200d-62ca-4580-8f9d-64525a772e79
       version: -1
       name: Verify Context
       type: condition
@@ -408,20 +388,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 1590
+          "y": 1650
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "12":
     id: "12"
-    taskid: dfa984f1-dd31-4e52-81f2-76d07bd74a6a
+    taskid: 5ed27c3d-45ea-423a-8012-11a2f988fe01
     type: regular
     task:
-      id: dfa984f1-dd31-4e52-81f2-76d07bd74a6a
+      id: 5ed27c3d-45ea-423a-8012-11a2f988fe01
       version: -1
       name: Add raw data
       description: Sets a value into the context with the given context key
@@ -451,20 +429,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 1770
+          "y": 1830
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "13":
     id: "13"
-    taskid: 1e8197c1-754d-4fd0-884f-4147425bce1c
+    taskid: 9b51ecd3-7440-4497-8bb1-3acb82256ca6
     type: regular
     task:
-      id: 1e8197c1-754d-4fd0-884f-4147425bce1c
+      id: 9b51ecd3-7440-4497-8bb1-3acb82256ca6
       version: -1
       name: Parse raw example
       description: Parses the raw part of the event.
@@ -483,20 +459,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 1940
+          "y": 1990
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "14":
     id: "14"
-    taskid: 7606bb7c-da62-4811-834a-9ab0d3b22ffc
+    taskid: 73fccbae-ceee-4eb7-81a4-70ebe47c8061
     type: condition
     task:
-      id: 7606bb7c-da62-4811-834a-9ab0d3b22ffc
+      id: 73fccbae-ceee-4eb7-81a4-70ebe47c8061
       version: -1
       name: Is the raw parsed?
       description: Check whether the values provided in arguments are equal. If either
@@ -522,20 +496,18 @@ tasks:
       {
         "position": {
           "x": 60,
-          "y": 2120
+          "y": 2150
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "15":
     id: "15"
-    taskid: cc2ee6f4-c5f9-4ad8-8e52-5fa3221abcea
+    taskid: 641ad311-a14c-4a1c-8579-9dc7775ed074
     type: title
     task:
-      id: cc2ee6f4-c5f9-4ad8-8e52-5fa3221abcea
+      id: 641ad311-a14c-4a1c-8579-9dc7775ed074
       version: -1
       name: Success!
       type: title
@@ -552,14 +524,12 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
   "16":
     id: "16"
-    taskid: c3bfeed2-77c3-4613-88c7-b39bf598c2d2
+    taskid: 8104d1ee-f3c5-4bd7-8058-4dd8289f6b83
     type: regular
     task:
-      id: c3bfeed2-77c3-4613-88c7-b39bf598c2d2
+      id: 8104d1ee-f3c5-4bd7-8058-4dd8289f6b83
       version: -1
       name: Oh No
       description: Prints text to war room (Markdown supported)
@@ -581,8 +551,36 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
+  "17":
+    id: "17"
+    taskid: 5660134d-1820-4aeb-8f7d-d7682a31a81c
+    type: regular
+    task:
+      id: 5660134d-1820-4aeb-8f7d-d7682a31a81c
+      version: -1
+      name: splunk-job-status
+      description: checking the status of a job
+      script: SplunkPy|||splunk-job-status
+      type: regular
+      iscommand: true
+      brand: SplunkPy
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      sid:
+        simple: ${Splunk.Job}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 1165
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
 view: |-
   {
     "linkLabelsPosition": {},


### PR DESCRIPTION
replacing: https://github.com/demisto/content/pull/6104

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/22345

## Description
Add a new command to SplunkPy integration for checking the status of a job in Splunk

## Does it break backward compatibility?
   - [x] No