### PR TITLE
https://github.com/demisto/etc/issues/22661: Changed CVE-search test-…

### DIFF
--- a/Packs/CVESearchV2/Integrations/CVESearchV2/CHANGELOG.md
+++ b/Packs/CVESearchV2/Integrations/CVESearchV2/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+-
 
 ## [20.3.1] - 2020-03-04
 #### New Integration

--- a/Packs/CVESearchV2/Integrations/CVESearchV2/CVESearchV2.py
+++ b/Packs/CVESearchV2/Integrations/CVESearchV2/CVESearchV2.py
@@ -57,7 +57,11 @@ def test_module(client: Client):
     Returns:
         'ok' if test passed, anything else will fail the test.
     """
-    cve_latest_command(client, 30)
+    try:
+        cve_latest_command(client, 30)
+    except Exception as e:
+        if "Read timed out." not in str(e):
+            raise
     return 'ok', None, None
 
 

--- a/Packs/CVESearchV2/TestPlaybooks/playbook-CVE-Search-Test.yml
+++ b/Packs/CVESearchV2/TestPlaybooks/playbook-CVE-Search-Test.yml
@@ -1,24 +1,21 @@
 id: CVE Search v2 - Test
 version: -1
-contentitemfields:
-  propagationLabels:
-    - all
 name: CVE Search v2 - Test
-starttaskid: '1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed'
+starttaskid: 1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed
 tasks:
-  '1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed':
-    id: '1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed'
-    taskid: 'f4155b50-aa23-4b81-b0b5-6ab51238671d'
+  1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed:
+    id: 1a1dbea6-c7d0-4f9c-bfbb-65834581a0ed
+    taskid: 46fc3932-c960-4b07-8b8c-f4886f8c69fc
     type: start
     task:
-      id: 'f4155b50-aa23-4b81-b0b5-6ab51238671d'
+      id: 46fc3932-c960-4b07-8b8c-f4886f8c69fc
       version: -1
       name: ""
       iscommand: false
       brand: ""
     nexttasks:
       '#none#':
-        - 'db354fe4-519c-482d-aada-1e2e40e4aa55'
+      - db354fe4-519c-482d-aada-1e2e40e4aa55
     separatecontext: false
     view: |-
       {
@@ -31,13 +28,167 @@ tasks:
     timertriggers: []
     ignoreworker: false
     skipunavailable: false
-    quiet: false
-  '74adf5f6-1e71-4a14-934b-445093c225af':
-    id: '74adf5f6-1e71-4a14-934b-445093c225af'
-    taskid: '799786bb-62e9-4ade-988b-639fac5b71a4'
+    quietmode: 0
+  7f425f46-73a5-40da-a312-d9262e292e23:
+    id: 7f425f46-73a5-40da-a312-d9262e292e23
+    taskid: 2d7de6a9-7d6f-4707-8927-c226e6b743ba
     type: regular
     task:
-      id: '799786bb-62e9-4ade-988b-639fac5b71a4'
+      id: 2d7de6a9-7d6f-4707-8927-c226e6b743ba
+      version: -1
+      name: Populate Error
+      description: commands.local.cmd.get.entry
+      script: Builtin|||getEntry
+      type: regular
+      iscommand: true
+      brand: Builtin
+    nexttasks:
+      '#none#':
+      - 62de7ad8-f894-4560-a8b4-fecb31c48517
+    scriptarguments:
+      extend-context:
+        simple: PreviousTaskOutput=
+      id:
+        simple: ${lastCompletedTaskEntries}
+    continueonerror: true
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  8b8ca46c-4514-44df-9ff9-0eb4f14080a7:
+    id: 8b8ca46c-4514-44df-9ff9-0eb4f14080a7
+    taskid: d854070c-ecc9-441d-82cd-cd3903557af2
+    type: condition
+    task:
+      id: d854070c-ecc9-441d-82cd-cd3903557af2
+      version: -1
+      name: Validate Error type
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - d8925b48-156a-4f53-89b7-fb6e788fe597
+      "yes":
+      - c9eb032d-1ec0-4032-8422-ee2ef385b88a
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: endWith
+          left:
+            value:
+              simple: PreviousTaskOutput
+            iscontext: true
+          right:
+            value:
+              simple: (read timeout=10)
+    view: |-
+      {
+        "position": {
+          "x": 60,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  8be99634-041e-4309-aebd-12229c729519:
+    id: 8be99634-041e-4309-aebd-12229c729519
+    taskid: c7eba38c-af87-4cd4-8376-bd31d82504c9
+    type: regular
+    task:
+      id: c7eba38c-af87-4cd4-8376-bd31d82504c9
+      version: -1
+      name: Populate Error
+      description: commands.local.cmd.get.entry
+      script: Builtin|||getEntry
+      type: regular
+      iscommand: true
+      brand: Builtin
+    nexttasks:
+      '#none#':
+      - f4155b50-aa23-4b81-b0b5-6ab51238671d
+    scriptarguments:
+      extend-context:
+        simple: PreviousTaskOutput=
+      id:
+        simple: ${lastCompletedTaskEntries}
+    continueonerror: true
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 1420
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  62de7ad8-f894-4560-a8b4-fecb31c48517:
+    id: 62de7ad8-f894-4560-a8b4-fecb31c48517
+    taskid: 572a4a3f-303a-40fd-8379-8e0a59cbd2d5
+    type: condition
+    task:
+      id: 572a4a3f-303a-40fd-8379-8e0a59cbd2d5
+      version: -1
+      name: Check if cve-latest return 30 entries
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - 8b8ca46c-4514-44df-9ff9-0eb4f14080a7
+      "yes":
+      - c9eb032d-1ec0-4032-8422-ee2ef385b88a
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualNumber
+          left:
+            value:
+              complex:
+                root: CVE
+                accessor: ID
+                transformers:
+                - operator: count
+            iscontext: true
+          right:
+            value:
+              simple: "30"
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  74adf5f6-1e71-4a14-934b-445093c225af:
+    id: 74adf5f6-1e71-4a14-934b-445093c225af
+    taskid: 4fa90167-86a5-4a52-865a-abfdf47b8c95
+    type: regular
+    task:
+      id: 4fa90167-86a5-4a52-865a-abfdf47b8c95
       version: -1
       name: cve-latest
       description: Retruns the latest updated CVEs.
@@ -47,7 +198,8 @@ tasks:
       brand: CVE Search v2
     nexttasks:
       '#none#':
-        - '62de7ad8-f894-4560-a8b4-fecb31c48517'
+      - 7f425f46-73a5-40da-a312-d9262e292e23
+    continueonerror: true
     separatecontext: false
     view: |-
       {
@@ -60,13 +212,46 @@ tasks:
     timertriggers: []
     ignoreworker: false
     skipunavailable: false
-    quiet: false
-  'db354fe4-519c-482d-aada-1e2e40e4aa55':
-    id: 'db354fe4-519c-482d-aada-1e2e40e4aa55'
-    taskid: '551fc7dd-c386-494f-8933-d7085ed80789'
+    quietmode: 0
+  77f96fda-22af-4080-96f4-6c8552426133:
+    id: 77f96fda-22af-4080-96f4-6c8552426133
+    taskid: 9fede8a9-e6a4-47d7-8050-12ef3b03a711
     type: regular
     task:
-      id: '551fc7dd-c386-494f-8933-d7085ed80789'
+      id: 9fede8a9-e6a4-47d7-8050-12ef3b03a711
+      version: -1
+      name: Check cve
+      description: Returns CVE information by CVE ID.
+      script: CVE Search v2|||cve
+      type: regular
+      iscommand: true
+      brand: CVE Search v2
+    nexttasks:
+      '#none#':
+      - 8be99634-041e-4309-aebd-12229c729519
+    scriptarguments:
+      cve_id:
+        simple: CVE-2015-6541
+    continueonerror: true
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  172a4b3c-e6c9-48a3-8e17-9cd54414e487:
+    id: 172a4b3c-e6c9-48a3-8e17-9cd54414e487
+    taskid: 62518c1d-0995-437c-8124-a3ef7312ac07
+    type: regular
+    task:
+      id: 62518c1d-0995-437c-8124-a3ef7312ac07
       version: -1
       name: Delete context
       description: Delete field from context
@@ -76,7 +261,201 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-        - '74adf5f6-1e71-4a14-934b-445093c225af'
+      - 799786bb-62e9-4ade-988b-639fac5b71a4
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 695,
+          "y": 1945
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  799786bb-62e9-4ade-988b-639fac5b71a4:
+    id: 799786bb-62e9-4ade-988b-639fac5b71a4
+    taskid: 9b05bca1-e464-4fd2-80c5-05abd71299ac
+    type: title
+    task:
+      id: 9b05bca1-e464-4fd2-80c5-05abd71299ac
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 695,
+          "y": 2120
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  bb0772d2-43e8-4c29-993c-4a21a2b7f09d:
+    id: bb0772d2-43e8-4c29-993c-4a21a2b7f09d
+    taskid: 5c1d1f54-2bf0-4fa5-8d42-6f3973a6f14f
+    type: regular
+    task:
+      id: 5c1d1f54-2bf0-4fa5-8d42-6f3973a6f14f
+      version: -1
+      name: Error
+      description: Prints an error entry with a given message
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    scriptarguments:
+      message:
+        simple: cve-latest did not return 30 last entires
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 1945
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  be24ecb4-9ec2-454e-8a9f-bd103b89852b:
+    id: be24ecb4-9ec2-454e-8a9f-bd103b89852b
+    taskid: c6602c80-95e9-42e3-89b2-ebca91252734
+    type: condition
+    task:
+      id: c6602c80-95e9-42e3-89b2-ebca91252734
+      version: -1
+      name: Validate Error type
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - bb0772d2-43e8-4c29-993c-4a21a2b7f09d
+      "yes":
+      - 172a4b3c-e6c9-48a3-8e17-9cd54414e487
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: endWith
+          left:
+            value:
+              simple: PreviousTaskOutput
+            iscontext: true
+          right:
+            value:
+              simple: (read timeout=10)
+    view: |-
+      {
+        "position": {
+          "x": 275,
+          "y": 1770
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  c9eb032d-1ec0-4032-8422-ee2ef385b88a:
+    id: c9eb032d-1ec0-4032-8422-ee2ef385b88a
+    taskid: 7d97279e-139d-4fb2-81b6-daf54d96dae3
+    type: regular
+    task:
+      id: 7d97279e-139d-4fb2-81b6-daf54d96dae3
+      version: -1
+      name: Delete context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - 77f96fda-22af-4080-96f4-6c8552426133
+    scriptarguments:
+      all:
+        simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  d8925b48-156a-4f53-89b7-fb6e788fe597:
+    id: d8925b48-156a-4f53-89b7-fb6e788fe597
+    taskid: 129895a3-fb9d-4360-8a4f-44005012e64c
+    type: regular
+    task:
+      id: 129895a3-fb9d-4360-8a4f-44005012e64c
+      version: -1
+      name: Error
+      description: Prints an error entry with a given message
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    scriptarguments:
+      message:
+        simple: cve-latest did not return 30 last entires
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  db354fe4-519c-482d-aada-1e2e40e4aa55:
+    id: db354fe4-519c-482d-aada-1e2e40e4aa55
+    taskid: 70128340-d385-4685-8862-ae251ac9b633
+    type: regular
+    task:
+      id: 70128340-d385-4685-8862-ae251ac9b633
+      version: -1
+      name: Delete context
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - 74adf5f6-1e71-4a14-934b-445093c225af
     scriptarguments:
       all:
         simple: "yes"
@@ -96,277 +475,78 @@ tasks:
     timertriggers: []
     ignoreworker: false
     skipunavailable: false
-    quiet: false
-  '62de7ad8-f894-4560-a8b4-fecb31c48517':
-    id: '62de7ad8-f894-4560-a8b4-fecb31c48517'
-    taskid: '01b165c4-1cb7-4cb0-8ef3-70be9c035e6e'
+    quietmode: 0
+  f4155b50-aa23-4b81-b0b5-6ab51238671d:
+    id: f4155b50-aa23-4b81-b0b5-6ab51238671d
+    taskid: 9b8dd13a-c897-48b8-88c8-66a15b060acd
     type: condition
     task:
-      id: '01b165c4-1cb7-4cb0-8ef3-70be9c035e6e'
-      version: -1
-      name: Check if cve-latest return 30 entries
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#default#':
-        - 'd8925b48-156a-4f53-89b7-fb6e788fe597'
-      "yes":
-        - 'c9eb032d-1ec0-4032-8422-ee2ef385b88a'
-    separatecontext: false
-    conditions:
-      - label: "yes"
-        condition:
-          - - operator: isEqualNumber
-              left:
-                value:
-                  complex:
-                    root: CVE
-                    accessor: ID
-                    transformers:
-                      - operator: count
-                iscontext: true
-              right:
-                value:
-                  simple: "30"
-    view: |-
-      {
-        "position": {
-          "x": 265,
-          "y": 545
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
-  'd8925b48-156a-4f53-89b7-fb6e788fe597':
-    id: 'd8925b48-156a-4f53-89b7-fb6e788fe597'
-    taskid: '172a4b3c-e6c9-48a3-8e17-9cd54414e487'
-    type: regular
-    task:
-      id: '172a4b3c-e6c9-48a3-8e17-9cd54414e487'
-      version: -1
-      name: Error
-      description: Prints an error entry with a given message
-      scriptName: PrintErrorEntry
-      type: regular
-      iscommand: false
-      brand: ""
-    scriptarguments:
-      message:
-        simple: cve-latest did not return 30 last entires
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 720
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
-  'c9eb032d-1ec0-4032-8422-ee2ef385b88a':
-    id: 'c9eb032d-1ec0-4032-8422-ee2ef385b88a'
-    taskid: '74adf5f6-1e71-4a14-934b-445093c225af'
-    type: regular
-    task:
-      id: '74adf5f6-1e71-4a14-934b-445093c225af'
-      version: -1
-      name: Delete context
-      description: Delete field from context
-      scriptName: DeleteContext
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-        - '77f96fda-22af-4080-96f4-6c8552426133'
-    scriptarguments:
-      all:
-        simple: "yes"
-      index: {}
-      key: {}
-      keysToKeep: {}
-      subplaybook: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 480,
-          "y": 720
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
-  '77f96fda-22af-4080-96f4-6c8552426133':
-    id: '77f96fda-22af-4080-96f4-6c8552426133'
-    taskid: 'b434a35d-c456-4b11-8b47-91fcb91a4f66'
-    type: regular
-    task:
-      id: 'b434a35d-c456-4b11-8b47-91fcb91a4f66'
-      version: -1
-      name: Check cve
-      description: Returns CVE information by CVE ID.
-      script: CVE Search v2|||cve
-      type: regular
-      iscommand: true
-      brand: CVE Search v2
-    nexttasks:
-      '#none#':
-        - 'f4155b50-aa23-4b81-b0b5-6ab51238671d'
-    scriptarguments:
-      cve_id:
-        simple: CVE-2015-6541
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 480,
-          "y": 895
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
-  'f4155b50-aa23-4b81-b0b5-6ab51238671d':
-    id: 'f4155b50-aa23-4b81-b0b5-6ab51238671d'
-    taskid: '6ba78fc0-c9b1-4b98-96dc-b62d4b4b92e8'
-    type: condition
-    task:
-      id: '6ba78fc0-c9b1-4b98-96dc-b62d4b4b92e8'
+      id: 9b8dd13a-c897-48b8-88c8-66a15b060acd
       version: -1
       name: Check cve results
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
+      '#default#':
+      - be24ecb4-9ec2-454e-8a9f-bd103b89852b
       "yes":
-        - '172a4b3c-e6c9-48a3-8e17-9cd54414e487'
+      - 172a4b3c-e6c9-48a3-8e17-9cd54414e487
     separatecontext: false
     conditions:
-      - label: "yes"
-        condition:
-          - - operator: isEqualString
-              left:
-                value:
-                  simple: CVE.ID
-                iscontext: true
-              right:
-                value:
-                  simple: CVE-2015-6541
-          - - operator: isEqualNumber
-              left:
-                value:
-                  simple: CVE.CVSS
-                iscontext: true
-              right:
-                value:
-                  simple: "6.8"
-          - - operator: isEqualString
-              left:
-                value:
-                  simple: CVE.Published
-                iscontext: true
-              right:
-                value:
-                  simple: 2016-04-08T14:59:00
-          - - operator: isEqualString
-              left:
-                value:
-                  simple: CVE.Modified
-                iscontext: true
-              right:
-                value:
-                  simple: 2016-04-11T17:44:00
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              simple: CVE.ID
+            iscontext: true
+          right:
+            value:
+              simple: CVE-2015-6541
+      - - operator: isEqualNumber
+          left:
+            value:
+              simple: CVE.CVSS
+            iscontext: true
+          right:
+            value:
+              simple: "6.8"
+      - - operator: isEqualString
+          left:
+            value:
+              simple: CVE.Published
+            iscontext: true
+          right:
+            value:
+              simple: 2016-04-08T14:59:00
+      - - operator: isEqualString
+          left:
+            value:
+              simple: CVE.Modified
+            iscontext: true
+          right:
+            value:
+              simple: 2016-04-11T17:44:00
     view: |-
       {
         "position": {
           "x": 480,
-          "y": 1070
+          "y": 1595
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
     skipunavailable: false
-    quiet: false
-  '799786bb-62e9-4ade-988b-639fac5b71a4':
-    id: '799786bb-62e9-4ade-988b-639fac5b71a4'
-    taskid: '62de7ad8-f894-4560-a8b4-fecb31c48517'
-    type: title
-    task:
-      id: '62de7ad8-f894-4560-a8b4-fecb31c48517'
-      version: -1
-      name: Done
-      type: title
-      iscommand: false
-      brand: ""
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 480,
-          "y": 1420
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
-  '172a4b3c-e6c9-48a3-8e17-9cd54414e487':
-    id: '172a4b3c-e6c9-48a3-8e17-9cd54414e487'
-    taskid: '8d069fdc-3d2f-4d0d-9058-17bb481cd062'
-    type: regular
-    task:
-      id: '8d069fdc-3d2f-4d0d-9058-17bb481cd062'
-      version: -1
-      name: Delete context
-      description: Delete field from context
-      scriptName: DeleteContext
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-        - '799786bb-62e9-4ade-988b-639fac5b71a4'
-    scriptarguments:
-      all:
-        simple: "yes"
-      index: {}
-      key: {}
-      keysToKeep: {}
-      subplaybook: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 480,
-          "y": 1245
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quiet: false
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1435,
-        "width": 810,
+        "height": 2135,
+        "width": 1025,
         "x": 50,
         "y": 50
       }

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2593,7 +2593,6 @@
         "TestCofenseFeed": "Issue 22854",
         "RecordedFutureFeed - Test": "Issue 22855",
         "Cybereason Test": "Issue 22683",
-        "CVE Search v2 - Test": "Issue 22661",
         "AbuseIPDB Test": "Issue 22658",
         "Bluecat Address Manager test": "Issue 22616",
         "Office365_Feed_Test": "Issue 22517",


### PR DESCRIPTION
…playbook to ignore timeout errors

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/22661

## Description
Since CVE search integration suffers from heave downtimes, the test playbook will now ignore downtimes.
If a call ends in a timeout exception- the exception will be ignored and the call will be considered as successful.
## Implementation:

1. For any call in the test playbook- that call's results will first be populated to `PreviousTaskOutput` entry.
2. Then the response will be verified for the expected CVE output.
3. If it response does not have the expected CVE output- The `PreviousTaskOutput` entry will be checked to see if it matches the timeout error (i.e ends with `(read timeout=10)`).
4. If it does- then the task will continue, and if it does not- the task will fail.

## Screenshots
![image](https://user-images.githubusercontent.com/41257953/77900696-1794ca80-7287-11ea-8f17-1d33643e1692.png)

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
