### PR TITLE
Changed type of memory threshold string to int

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2486,7 +2486,7 @@
             "integrations": "Feodo Tracker Hashes Feed",
             "playbookID": "playbook-feodoteackerhash_test",
             "fromversion": "5.5.0",
-            "memory_threshold": "130",
+            "memory_threshold": 130,
             "timeout": 600
         },
         {


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
`Feodo Tracker Hashes Feed` memory threshold was string instead of int which crashed the nightly build. FYI @roysagi 

