### PR TITLE
fix download links in test playbooks of test data

### DIFF
--- a/TestPlaybooks/NonCircleTests/playbook-TestParseEmailHeaders.yml
+++ b/TestPlaybooks/NonCircleTests/playbook-TestParseEmailHeaders.yml
@@ -199,7 +199,7 @@ tasks:
         simple: "yes"
       unsecure: {}
       url:
-        simple: https://github.com/demisto/content/raw/master/Scripts/ParseEmailFiles/test_data/utf_subject.msg
+        simple: https://github.com/demisto/content/raw/master/Packs/Legacy/Scripts/ParseEmailFiles/test_data/utf_subject.msg
       username: {}
     separatecontext: false
     view: |-

--- a/TestPlaybooks/playbook-CreateIndicatorFromSTIXTest.yml
+++ b/TestPlaybooks/playbook-CreateIndicatorFromSTIXTest.yml
@@ -59,7 +59,7 @@ tasks:
         simple: 'yes'
       unsecure: {}
       url:
-        simple: https://github.com/demisto/content/raw/master/Scripts/StixParser/TestData/stix1/file-stix-ioc.xml
+        simple: https://github.com/demisto/content/raw/master/Packs/Legacy/Scripts/StixParser/TestData/stix1/file-stix-ioc.xml
       username: {}
     separatecontext: false
     view: |-
@@ -103,7 +103,7 @@ tasks:
         simple: 'yes'
       unsecure: {}
       url:
-        simple: https://github.com/demisto/content/raw/master/Scripts/StixParser/TestData/stix2.json
+        simple: https://github.com/demisto/content/raw/master/Packs/Legacy/Scripts/StixParser/TestData/stix2.json
       username: {}
     separatecontext: false
     view: |-

--- a/TestPlaybooks/playbook-UnzipFile-Test.yml
+++ b/TestPlaybooks/playbook-UnzipFile-Test.yml
@@ -58,7 +58,7 @@ tasks:
         simple: "yes"
       unsecure: {}
       url:
-        simple: https://raw.githubusercontent.com/demisto/content/master/Scripts/UnzipFile/data_test/fix_unzip.png.zip
+        simple: https://github.com/demisto/content/raw/master/Packs/Legacy/Scripts/UnzipFile/data_test/fix_unzip.png.zip
       username: {}
     separatecontext: false
     view: |-


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
fix download links in test playbooks of test data.
after we moved the content items to Legact packs some link were broken

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

