### PR TITLE
Secure private packs

### DIFF
--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -373,6 +373,7 @@ def main():
                   if os.path.exists(os.path.join(extract_destination_path, pack_name))]
 
     # Add private packs to the index
+    private_packs = []
     if private_index_path:
         try:
             private_packs = get_private_packs(private_index_path)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

In line 461, `private_packs` may be not defined if there is no private bucket provided. I defined it in the beginning of the code.