### PR TITLE
Add creds support for Github integration

### DIFF
--- a/Packs/Legacy/Integrations/GitHub/CHANGELOG.md
+++ b/Packs/Legacy/Integrations/GitHub/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## [Unreleased]
--
-
+- Added support for github bots
 
 ## [20.4.0] - 2020-04-14
 -

--- a/Packs/Legacy/Integrations/GitHub/CHANGELOG.md
+++ b/Packs/Legacy/Integrations/GitHub/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-- Added support for github bots
+Added support for GitHub bots.
 
 ## [20.4.0] - 2020-04-14
 -

--- a/Packs/Legacy/Integrations/GitHub/GitHub.py
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.py
@@ -1198,6 +1198,9 @@ if TOKEN == '' and PRIVATE_KEY != '':
     generated_jwt_token = create_jwt(PRIVATE_KEY, INTEGRATION_ID)
     TOKEN = get_installation_access_token(INSTALLATION_ID, generated_jwt_token)
 
+if TOKEN == '' and PRIVATE_KEY == '':
+    return_error("Insert api token or private key")
+
 HEADERS = {
     'Authorization': "Bearer " + TOKEN
 }

--- a/Packs/Legacy/Integrations/GitHub/GitHub.py
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.py
@@ -5,7 +5,6 @@ from CommonServerUserPython import *
 ''' IMPORTS '''
 
 import json
-import jwt
 import requests
 from typing import Union, Any
 from datetime import datetime
@@ -1195,6 +1194,11 @@ COMMANDS = {
 '''EXECUTION'''
 
 if TOKEN == '' and PRIVATE_KEY != '':
+    try:
+        import jwt
+    except Exception:
+        return_error("You need to update the docket image so that the jwt package could be used")
+
     generated_jwt_token = create_jwt(PRIVATE_KEY, INTEGRATION_ID)
     TOKEN = get_installation_access_token(INSTALLATION_ID, generated_jwt_token)
 

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -42,11 +42,11 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- display: Integration id
+- display: Github app integration id
   name: integration_id
   required: false
   type: 0
-- display: Installation id
+- display: Github app installation id
   name: installation_id
   required: false
   type: 0

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -9,8 +9,12 @@ configuration:
   type: 8
 - display: API Token
   name: token
-  required: true
+  required: false
   type: 4
+- display: Credentials
+  name: credentials
+  required: false
+  type: 9
 - display: 'Username of the repository owner, for example: github.com/repos/{_owner_}/{repo}/issues'
   name: user
   required: false
@@ -39,6 +43,14 @@ configuration:
   name: incidentType
   required: false
   type: 13
+- display: Integration id
+  name: integration_id
+  required: false
+  type: 0
+- display: Installation id
+  name: installation_id
+  required: false
+  type: 0
 description: Integration to GitHub API
 display: GitHub
 name: GitHub
@@ -2575,7 +2587,7 @@ script:
     - contextPath: GitHub.PR.ChangedFiles
       description: The number of changed files in the pull request.
       type: Number
-  dockerimage: demisto/python3:3.7.3.286
+  dockerimage: demisto/pyjwt3:1.0.0.4946
   subtype: python3
   isfetch: true
   longRunning: false

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -38,8 +38,7 @@ configuration:
   name: insecure
   required: false
   type: 8
-- defaultvalue: ""
-  display: Incident type
+- display: Incident type
   name: incidentType
   required: false
   type: 13

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -42,11 +42,11 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- display: Github app integration id
+- display: GitJub app integration ID
   name: integration_id
   required: false
   type: 0
-- display: Github app installation id
+- display: GitHub app installation ID
   name: installation_id
   required: false
   type: 0

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -42,7 +42,7 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- display: GitJub app integration ID
+- display: GitHub app integration ID
   name: integration_id
   required: false
   type: 0

--- a/Packs/Legacy/Integrations/GitHub/GitHub.yml
+++ b/Packs/Legacy/Integrations/GitHub/GitHub.yml
@@ -146,7 +146,7 @@ script:
       description: The state of the closed issue.
       type: String
     - contextPath: GitHub.Issue.Labels
-      description: Labels spplied to the issue.
+      description: Labels applied to the issue.
       type: String
     - contextPath: GitHub.Issue.Assignees
       description: Users assigned to the issue.
@@ -155,7 +155,7 @@ script:
       description: Date when the issue was created.
       type: Date
     - contextPath: GitHub.Issue.Updated_at
-      description: Date when the issue was last updated
+      description: Date when the issue was last updated.
       type: Date
     - contextPath: GitHub.Issue.Closed_at
       description: Date when the issue was closed.

--- a/Packs/Legacy/Integrations/GitHub/README.md
+++ b/Packs/Legacy/Integrations/GitHub/README.md
@@ -22,6 +22,12 @@
 <li>Click<span> </span><strong>Test</strong><span> </span>to validate the URLs, token, and connection.</li>
 </ol>
 *Use API token to authenticate as a user and credentials to authenticate as a bot.
+<h2>Authenticating</h2>
+The integration provides 2 methods of authentication: API token and private key. The API token method is used
+to authenticate as a Github user, and take actions on behalf of a certain Github user. On the other hand, the second 
+method uses private key to generate a JWT token to create the API token. This method is required when authenticating as
+a bot, a.k.a. Github apps.
+
 <h2>Commands</h2>
 <p>You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook. After you successfully execute a command, a DBot message appears in the War Room with the command details.</p>
 <ol>

--- a/Packs/Legacy/Integrations/GitHub/README.md
+++ b/Packs/Legacy/Integrations/GitHub/README.md
@@ -10,6 +10,7 @@
 <strong>Name</strong>: a textual name for the integration instance.</li>
 <li><strong>Fetch incidents</strong></li>
 <li><strong>API Token</strong></li>
+<li><strong>Credentials (for Github bots)/strong></li>
 <li><strong>Username of the repository owner, for example: github.com/repos/{<em>owner</em>}/{repo}/issues</strong></li>
 <li><strong>The name of the requested repository.</strong></li>
 <li><strong>First fetch timestamp, in days.</strong></li>
@@ -20,6 +21,7 @@
 </li>
 <li>Click<span> </span><strong>Test</strong><span> </span>to validate the URLs, token, and connection.</li>
 </ol>
+*Use API token to authenticate as a user and credentials to authenticate as a bot.
 <h2>Commands</h2>
 <p>You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook. After you successfully execute a command, a DBot message appears in the War Room with the command details.</p>
 <ol>

--- a/Packs/Legacy/Integrations/GitHub/README.md
+++ b/Packs/Legacy/Integrations/GitHub/README.md
@@ -10,7 +10,7 @@
 <strong>Name</strong>: a textual name for the integration instance.</li>
 <li><strong>Fetch incidents</strong></li>
 <li><strong>API Token</strong></li>
-<li><strong>Credentials (for Github bots)/strong></li>
+<li><strong>Credentials (for GitHub bots)/strong></li>
 <li><strong>Username of the repository owner, for example: github.com/repos/{<em>owner</em>}/{repo}/issues</strong></li>
 <li><strong>The name of the requested repository.</strong></li>
 <li><strong>First fetch timestamp, in days.</strong></li>
@@ -24,9 +24,9 @@
 *Use API token to authenticate as a user and credentials to authenticate as a bot.
 <h2>Authenticating</h2>
 The integration provides 2 methods of authentication: API token and private key. The API token method is used
-to authenticate as a Github user, and take actions on behalf of a certain Github user. On the other hand, the second 
+to authenticate as a GitHub user, and take actions on behalf of a certain GitHub user. On the other hand, the second 
 method uses private key to generate a JWT token to create the API token. This method is required when authenticating as
-a bot, a.k.a. Github apps.
+a bot, a.k.a. GitHub apps.
 
 <h2>Commands</h2>
 <p>You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook. After you successfully execute a command, a DBot message appears in the War Room with the command details.</p>


### PR DESCRIPTION
## Status
- [x] In Progress

## Description
Add support for authenticating using creds for Github bots.
The flow doesn't replace the existing one with API key, it just operates one step before by generating the API key using the creds. I also wrapped it using 
`if TOKEN == '' and PRIVATE_KEY != ''` to not break backward compatibility. 
