### PR TITLE
remove sixgill darkfeed test playbook - the old playbook was deleted 

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2412,11 +2412,6 @@
             "fromversion": "5.0.0"
         },
         {
-            "integrations": "Sixgill",
-            "playbookID": "Sixgill - Darkfeed - Indicators-Test",
-            "fromversion": "5.0.0"
-        },
-        {
             "integrations": "AutoFocus Feed",
             "playbookID": "playbook-FeedAutofocus_test",
             "fromversion": "5.5.0"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Removed the test playbook configuration because the test playbook not exist anymore , was deleted by the partner
