### PR TITLE
Remove slack threshold

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -234,8 +234,7 @@
             "integrations": "SlackV2",
             "playbookID": "Slack Test Playbook",
             "timeout" : 2400,
-            "fromversion": "5.0.0",
-            "pid_threshold": 30
+            "fromversion": "5.0.0"
         },
         {
             "integrations": "Cortex XDR - IR",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/22018

## Description
Removing the high threshold for slack PID in the build