### PR TITLE
[expanse-272] Expanse Expander - Fixing incident polling bug

### DIFF
--- a/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
+++ b/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-  - Added bug fix for incident polling missing behavior data in some situations.
+Fixed an issue where incident polling did not behave as expected in some situations.
 
 ## [20.4.0] - 2020-04-14
   - Added support for pulling behavior data to create new incidents.

--- a/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
+++ b/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+  - Added bug fix for incident polling missing behavior data in some situations.
 
 ## [20.4.0] - 2020-04-14
   - Added support for pulling behavior data to create new incidents.

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -69,7 +69,7 @@ def make_headers(endpoint, token):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'User-Agent': 'Expanse_Demisto/1.1.0'
+        'User-Agent': 'Expanse_Demisto/1.1.1'
     }
     if endpoint == "IdToken":
         headers['Authorization'] = 'Bearer ' + token
@@ -638,6 +638,7 @@ def fetch_incidents_command():
 
     if last_run.get('complete_for_today') is True and last_run.get('start_time') == yesterday:
         # wait until tomorrow to try again
+        demisto.incidents([])
         return
 
     # Refresh JWT

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -627,7 +627,6 @@ def fetch_incidents_command():
 
     # Check if it's been run
     now = datetime.today()
-    today = datetime.strftime(now, "%Y-%m-%d")
     yesterday = datetime.strftime(now - timedelta(days=1), "%Y-%m-%d")
     last_run = demisto.getLastRun()
     start_date = yesterday
@@ -637,7 +636,7 @@ def fetch_incidents_command():
         # first time integration is running
         start_date = datetime.strftime(now - timedelta(days=FIRST_RUN), "%Y-%m-%d")
 
-    if last_run.get('complete_for_today') is True and last_run.get('start_time') == today:
+    if last_run.get('complete_for_today') is True and last_run.get('start_time') == yesterday:
         # wait until tomorrow to try again
         return
 
@@ -647,12 +646,13 @@ def fetch_incidents_command():
     # Fetch Events
     more_events = True
     page_token = None
+    incidents = []
 
     while more_events:
         event_incidents, page_token = fetch_events_incidents_command(start_date, end_date, token, page_token)
         for incident in event_incidents:
             demisto.debug("Adding event incident name={name}, type={type}, severity={severity}".format(**incident))
-        demisto.incidents(event_incidents)
+        incidents += event_incidents
         if page_token is None:
             more_events = False
 
@@ -665,9 +665,12 @@ def fetch_incidents_command():
             behavior_incidents, next_offset = fetch_behavior_incidents_command(start_date, token, next_offset)
             for incident in behavior_incidents:
                 demisto.debug("Adding behavior incident name={name}, type={type}, severity={severity}".format(**incident))
-            demisto.incidents(behavior_incidents)
+            incidents += behavior_incidents
             if next_offset is None:
                 more_behavior = False
+
+    # Send all Incidents
+    demisto.incidents(incidents)
 
     # Save last_run
     demisto.setLastRun({

--- a/Packs/Expanse/pack_metadata.json
+++ b/Packs/Expanse/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "The Expanse App for Demisto leverages the Expander API to retrieve network exposures and create incidents in Demisto.",
     "support": "partner",
     "serverMinVersion": "4.5.0",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Expanse",
     "url": "https://www.expanse.co/",
     "email": "help@expanseinc.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.
Incident ingest was not including behavior data _seemingly_ because `demisto.incidents()` was called more than once. There was also an issue where our logic of whether to check for new events was off by 1 day, so it was duplicating events. 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [x] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [x] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

