### PR TITLE
added memory threshold to recorded future feed on build

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2428,7 +2428,7 @@
             "playbookID": "RecordedFutureFeed - Test",
             "timeout": 1000,
             "fromversion": "5.5.0",
-            "memory_threshold": 85
+            "memory_threshold": 86
         },
         {
             "integrations": "Expanse",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2428,7 +2428,7 @@
             "playbookID": "RecordedFutureFeed - Test",
             "timeout": 1000,
             "fromversion": "5.5.0",
-            "memory_threshold": 80
+            "memory_threshold": 85
         },
         {
             "integrations": "Expanse",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Test failed on nightly due to memory threshold 

