### PR TITLE
Marketplace - update index fix

### DIFF
--- a/Tests/Marketplace/Tests/upload_packs_test.py
+++ b/Tests/Marketplace/Tests/upload_packs_test.py
@@ -70,6 +70,7 @@ class TestUpdateIndex:
         mocker.patch('os.path.isdir', return_value=True)
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])
@@ -125,6 +126,7 @@ class TestUpdateIndex:
         mocker.patch('os.listdir', return_value=[])
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])
@@ -177,6 +179,7 @@ class TestUpdateIndex:
         mocker.patch('os.path.isdir', return_value=True)
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])
@@ -236,6 +239,7 @@ class TestUpdateIndex:
         mocker.patch('os.path.isdir', return_value=True)
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])
@@ -292,6 +296,7 @@ class TestUpdateIndex:
         mocker.patch('os.path.isdir', return_value=True)
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])
@@ -348,6 +353,7 @@ class TestUpdateIndex:
         mocker.patch('os.path.isdir', return_value=True)
         mocker.patch('os.remove')
         mocker.patch('shutil.copy')
+        mocker.patch('os.path.exists')
         pack_dirs = scan_dir([('HelloWorld/metadata.json', 'metadata.json'),
                               ('HelloWorld/changelog.json', 'changelog.json'),
                               ('HelloWorld/README.md', 'README.md')])

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -184,6 +184,10 @@ def update_index_folder(index_folder_path, pack_name, pack_path, pack_version=''
 
         # Copy new files and add metadata for latest version
         for d in os.scandir(pack_path):
+            if not os.path.exists(index_pack_path):
+                os.mkdir(index_pack_path)
+                print(f"Created {pack_name} pack folder in {GCPConfig.INDEX_NAME}")
+
             shutil.copy(d.path, index_pack_path)
             if pack_version and Pack.METADATA == d.name:
                 shutil.copy(d.path, new_metadata_path)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

## Description
In case that new pack is uploaded, need to create new pack folder in index. `shutill.copy` doesn't handle it. Received error: [Errno 20] Not a directory: `/tmp/tmp.ZbcYkPjdus/index/MicrosoftGraphCalendar/metadata-1.0.0.json`

https://circleci.com/gh/demisto/content/49515#artifacts/containers/0