### PR TITLE
Marketplace - changed contentItems report section

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -584,7 +584,7 @@ class Pack(object):
                 PackFolders.INCIDENT_TYPES.value: "incidenttype",
                 PackFolders.DASHBOARDS.value: "dashboard",
                 PackFolders.INDICATOR_FIELDS.value: "indicatorfield",
-                PackFolders.REPORTS.value: "reports",
+                PackFolders.REPORTS.value: "report",
                 PackFolders.MISC.value: "reputation"
             }
 
@@ -676,15 +676,10 @@ class Pack(object):
                             'type': content_item.get('type', ""),
                             'description': content_item.get('description', "")
                         })
-                    elif current_directory == PackFolders.REPORTS.value:  # todo finalize this part with server side
-                        dash_board_section = content_item.get('dashboard', {})
-
+                    elif current_directory == PackFolders.REPORTS.value:
                         folder_collected_items.append({
                             'name': content_item.get('name', ""),
-                            'fromDate': dash_board_section.get('fromDate', ""),
-                            'toDate': dash_board_section.get('toDate', ""),
-                            'period': dash_board_section.get('period', {}),
-                            'fromDateLicense': dash_board_section.get('fromDateLicense', "")
+                            'description': content_item.get('description', "")
                         })
                     elif current_directory == PackFolders.MISC.value:
                         folder_collected_items.append({


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

# Related Issues
fixes: https://github.com/demisto/etc/issues/23844

## Description
Changed `contentItems` `report` section dictionary according to @asafshen request.
Example of parsed report item:
```
            {
                "name": "Last 30 days incidents",
                "description": "Last 30 days summary of incidents statistics, followed by a list of all current open incidents."
            }
```