### PR TITLE
Marketplace - skipped temporary signing step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,7 +523,7 @@ jobs:
             PACK_ARTIFACTS=$CIRCLE_ARTIFACTS/content_packs.zip
             GCS_PATH=$(mktemp)
             echo $GCS_MARKET_KEY > $GCS_PATH
-            python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -b 'marketplace-dist' -s $GCS_PATH -n $CIRCLE_BUILD_NUM -k $PACK_SIGNING_KEY -p 'All' -pb 'marketplace-dist-private' -o
+            python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -b 'marketplace-dist' -s $GCS_PATH -n $CIRCLE_BUILD_NUM -p 'All' -pb 'marketplace-dist-private' -o
             rm $GCS_PATH
           when: on_success
       - store_artifacts:

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -399,6 +399,7 @@ def print_packs_summary(packs_list):
         print_error(f"Number of failed packs: {len(failed_packs)}")
         failed_packs_table = _build_summary_table(failed_packs)
         print_error(failed_packs_table)
+        sys.exit(1)
 
 
 def option_handler():


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description

- Skipped signing step in `upload_packs` until the issue is resolved. Currently all packs fail on signing step `b'Unable to read key file: /keyfile. Error: open /keyfile: no such file or directory\n'`

`--------------------------------------- Packs Upload Summary ---------------------------------------
Total number of packs: 76
Number of failed packs: 76
`

- Additionally from now, if at least one of pack fails in upload step, the build will fail after adding non zero exit status. 