### PR TITLE
Archer - fixed display of type 4 fields in search records

### DIFF
--- a/Packs/Legacy/Integrations/integration-ArcherRSA.yml
+++ b/Packs/Legacy/Integrations/integration-ArcherRSA.yml
@@ -1467,9 +1467,9 @@ script:
 
             var fields = verifyOrMakeArray(record.Field);
             fields.forEach(function (field) {
-                if (field['#text'] != null) {
+                if (field['#text'] !== null) {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
-                } else if (field.ListValues != null && field.ListValues['#text'] != null) {
+                } else if (field.ListValues !== null && field.ListValues['#text'] !== null) {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field.ListValues.ListValue['#text'];
                 } else {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = null;

--- a/Packs/Legacy/Integrations/integration-ArcherRSA.yml
+++ b/Packs/Legacy/Integrations/integration-ArcherRSA.yml
@@ -1470,7 +1470,7 @@ script:
                 if (field['#text'] != null) {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
                 } else if (field.ListValues != null && field.ListValues['#text'] != null) {
-                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field.ListValues['#text'];
+                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field.ListValues.ListValue['#text'];
                 } else {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = null;
                 }

--- a/Packs/Legacy/Integrations/integration-ArcherRSA.yml
+++ b/Packs/Legacy/Integrations/integration-ArcherRSA.yml
@@ -1467,7 +1467,13 @@ script:
 
             var fields = verifyOrMakeArray(record.Field);
             fields.forEach(function (field) {
-                toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
+                if (field['#text'] != null) {
+                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
+                } else if (field.ListValues != null && field.ListValues['#text'] != null) {
+                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field.ListValues['#text'];
+                } else {
+                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
+                }
             });
             outputs.push(toContext);
         });

--- a/Packs/Legacy/Integrations/integration-ArcherRSA.yml
+++ b/Packs/Legacy/Integrations/integration-ArcherRSA.yml
@@ -1472,7 +1472,7 @@ script:
                 } else if (field.ListValues != null && field.ListValues['#text'] != null) {
                     toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field.ListValues['#text'];
                 } else {
-                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = field['#text'];
+                    toContext.Fields[GLOBAL_MAPPING[field['-id']].Name] = null;
                 }
             });
             outputs.push(toContext);

--- a/Packs/Legacy/Integrations/integration-ArcherRSA_CHANGELOG.md
+++ b/Packs/Legacy/Integrations/integration-ArcherRSA_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
--
+Fixed a bug in searh which caused type 4 fields not to be displayed.
 
 
 ## [20.3.3] - 2020-03-18


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23125

## Description
Type 4 fields were not returned to context, nor shown in the human readable, when running the search records command.
This is now fixed.

## Does it break backward compatibility?
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

