### PR TITLE
[CircleCi] Don't Trigger Sample Tests If Tests Were Provided

### DIFF
--- a/Tests/scripts/configure_tests.py
+++ b/Tests/scripts/configure_tests.py
@@ -966,6 +966,7 @@ def get_test_list(files_string, branch_name, two_before_ga_ver='0', conf=None, i
         tests = tests.union(get_test_from_conf(branch_name, conf))
 
     if not tests:
+        tests = get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver)
         if changed_common:
             print_warning('Adding 3 random tests due to: {}'.format(','.join(changed_common)))
         elif sample_tests:  # Choosing 3 random tests for infrastructure testing
@@ -974,8 +975,6 @@ def get_test_list(files_string, branch_name, two_before_ga_ver='0', conf=None, i
             print_warning("Running Sanity check only")
             tests.add('DocumentationTest')  # test with integration configured
             tests.add('TestCommonPython')  # test with no integration configured
-        tests = tests.union(
-            get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver))
 
     if changed_common:
         tests.add('TestCommonPython')

--- a/Tests/scripts/configure_tests.py
+++ b/Tests/scripts/configure_tests.py
@@ -968,18 +968,14 @@ def get_test_list(files_string, branch_name, two_before_ga_ver='0', conf=None, i
     if not tests:
         if changed_common:
             print_warning('Adding 3 random tests due to: {}'.format(','.join(changed_common)))
-            tests = tests.union(get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set,
-                                                 server_version=two_before_ga_ver))
         elif sample_tests:  # Choosing 3 random tests for infrastructure testing
             print_warning('Collecting sample tests due to: {}'.format(','.join(sample_tests)))
-            tests = tests.union(
-                get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver))
         else:
             print_warning("Running Sanity check only")
-            tests = get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set,
-                                     server_version=two_before_ga_ver)
             tests.add('DocumentationTest')  # test with integration configured
             tests.add('TestCommonPython')  # test with no integration configured
+        tests = tests.union(
+            get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver))
 
     if changed_common:
         tests.add('TestCommonPython')

--- a/Tests/scripts/configure_tests.py
+++ b/Tests/scripts/configure_tests.py
@@ -965,16 +965,15 @@ def get_test_list(files_string, branch_name, two_before_ga_ver='0', conf=None, i
     if is_conf_json:
         tests = tests.union(get_test_from_conf(branch_name, conf))
 
-    if sample_tests:  # Choosing 3 random tests for infrastructure testing
-        print_warning('Collecting sample tests due to: {}'.format(','.join(sample_tests)))
-        tests = tests.union(
-            get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver))
-
     if not tests:
         if changed_common:
             print_warning('Adding 3 random tests due to: {}'.format(','.join(changed_common)))
             tests = tests.union(get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set,
                                                  server_version=two_before_ga_ver))
+        elif sample_tests:  # Choosing 3 random tests for infrastructure testing
+            print_warning('Collecting sample tests due to: {}'.format(','.join(sample_tests)))
+            tests = tests.union(
+                get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set, server_version=two_before_ga_ver))
         else:
             print_warning("Running Sanity check only")
             tests = get_random_tests(tests_num=RANDOM_TESTS_NUM, conf=conf, id_set=id_set,

--- a/Tests/scripts/infrastructure_tests/test_configure_tests.py
+++ b/Tests/scripts/infrastructure_tests/test_configure_tests.py
@@ -352,6 +352,23 @@ class TestSampleTesting:
 
         assert len(filterd_tests) == RANDOM_TESTS_NUM
 
+    def test_sample_tests__with_test(self, mocker):
+        """
+        Given:
+            - Sample tests is non empty
+            - Modified test equals 1 test
+        When:
+            - Calling get_modified_files
+        Then:
+            - Test filter should return 1 test
+        """
+        test_path = 'Tests/scripts/infrastructure_tests/tests_data/mock_test_playbooks/past_test_playbook_2.yml'
+        get_modified_files_ret = create_get_modified_files_ret(modified_tests_list=[test_path],
+                                                               sample_tests=['test'])
+        filterd_tests = get_mock_test_list(mocker=mocker, git_diff_ret=self.GIT_DIFF_RET,
+                                           get_modified_files_ret=get_modified_files_ret)
+        assert len(filterd_tests) == 1
+
 
 class TestChangedCommonTesting:
     TEST_ID = 'TestCommonPython'


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24015

## Description
Moved `sample_test` collection after `is empty tests` condition. Test samples shouldn't be triggered when tests were provided.