### PR TITLE
Address a Few RedCanary Integration Bugs

### DIFF
--- a/Packs/Legacy/Integrations/RedCanary/RedCanary.py
+++ b/Packs/Legacy/Integrations/RedCanary/RedCanary.py
@@ -1,3 +1,7 @@
+import demistomock as demisto	
+from CommonServerPython import *	
+from CommonServerUserPython import *	
+
 ''' IMPORTS '''
 import requests
 
@@ -62,12 +66,14 @@ def http_request(requests_func, url_suffix, **kwargs):
     params = kwargs.get('params')
     headers = kwargs.get('headers', {})
     data = kwargs.get('data', {})
+
     res = requests_func(BASE_URL + url_suffix,
                         verify=USE_SSL,
                         params=params,
                         headers=headers,
                         data=data
                         )
+
     if res.status_code == 403:
         raise Exception('API Key is incorrect')
 
@@ -156,7 +162,7 @@ def get_full_timeline(detection_id, per_page=100):
                            'per_page': per_page,
         })
 
-        if len(res['data']) == 0 or True:
+        if len(res['data']) == 0:
             done = True
 
         activities.extend(res['data'])

--- a/Packs/Legacy/Integrations/RedCanary/RedCanary.py
+++ b/Packs/Legacy/Integrations/RedCanary/RedCanary.py
@@ -1,6 +1,6 @@
-import demistomock as demisto	
-from CommonServerPython import *	
-from CommonServerUserPython import *	
+import demistomock as demisto
+from CommonServerPython import *
+from CommonServerUserPython import *
 
 ''' IMPORTS '''
 import requests


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description

Bug #1: No incidents are created due to a bug in the exclusion logic around acknowledgement of an incident in RedCanary. Looking at this [line](https://github.com/blakemotl/content/blob/master/Packs/Legacy/Integrations/RedCanary/RedCanary.py#L323) last_acknowledged_at and last_acknowledged_by are guaranteed to exist as confirmed by RedCanary directly, but default to null. As a result this line always evaluates to false.

Bug #2: There is a bug in the integration that results in the last incident in RedCanary, being repeatedly created in Demisto. If a new incident is created in RedCanary, the old incident will stop repeating and the new one starts repeating. I was not able to figure out exactly whats causing it, but it looks to be some kind of rounding error, since the integration cuts off the millisecond part of the timestamp. Additionally it is possible, but unlikely, that an incident can be skipped due to a timing error since the integration stores a timestamp that skips a second ahead to attempt to prevent duplication. However RedCanary already exposes a way to enforce uniqueness via the ID field. That field is unique per incident just like the incident ID in Demisto is unique. So the easiest way to fix this bug is to keep track of the latest ID that was created within Demisto and store that in addition to the time. That change starts [here](https://github.com/blakemotl/content/blob/master/Packs/Legacy/Integrations/RedCanary/RedCanary.py#L522).

## Minimum version of Demisto
- [ ] 4.5.0
- [X] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Testing
We have deployed this in our Demisto environment and both bugs above have been resolved.

