### PR TITLE
EDL - set app server host to handle ipv6

### DIFF
--- a/Packs/EDL/Integrations/EDL/CHANGELOG.md
+++ b/Packs/EDL/Integrations/EDL/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
   - Removed `Long Running Instance` from instance configuration.
+  - Set the listener host to 0.0.0.0 in order to handle IPv6.
 
 ## [20.4.1] - 2020-04-29
 Removed the default initial value for the **Listen Port** parameter.

--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -517,7 +517,7 @@ def run_long_running(params, is_test=False):
         else:
             demisto.debug('Starting HTTP Server')
 
-        server = WSGIServer(('', port), APP, **ssl_args, log=DEMISTO_LOGGER)
+        server = WSGIServer(('0.0.0.0', port), APP, **ssl_args, log=DEMISTO_LOGGER)
         if is_test:
             server_process = Process(target=server.serve_forever)
             server_process.start()


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/23728

## Description
Set app hostname to be `0.0.0.0` to hanlde IPv6

## Minimum version of Demisto
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No


