### PR TITLE
Kafka - fixed lz4 compression issue

### DIFF
--- a/Packs/Kafka_V2/Integrations/Kafka_V2/Pipfile
+++ b/Packs/Kafka_V2/Integrations/Kafka_V2/Pipfile
@@ -12,7 +12,7 @@ v = {version = "*",editable = true}
 flake8 = "*"
 
 [packages]
-pykafka = "*"
+pykafka = {git = "https://github.com/Parsely/pykafka.git", editable = true, ref = "master"}
 requests = "*"
 
 [requires]


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23942

## Description
Kafka currently fails with a "unable to decode lz4 compressed Kafka messages." error.
That problem is now fixed.

## Does it break backward compatibility?
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

