### PR TITLE
Tests - print incident search response only in case of timeout

### DIFF
--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -585,9 +585,11 @@ def __create_incident_with_playbook(client, name, playbook_id, integrations, pri
     # inc_filter.query
     search_filter.filter = inc_filter
 
+    incident_search_responses = []
+
     try:
         incidents = client.search_incidents(filter=search_filter)
-        prints_manager.add_print_job('Incident search response: {}'.format(str(incidents)), print, thread_index)
+        incident_search_responses.append(incidents)
     except ApiException as err:
         prints_manager.add_print_job(err, print, thread_index)
         incidents = {'total': 0}
@@ -597,13 +599,16 @@ def __create_incident_with_playbook(client, name, playbook_id, integrations, pri
     while incidents['total'] < 1:
         try:
             incidents = client.search_incidents(filter=search_filter)
-            prints_manager.add_print_job('Incident search response: {}'.format(str(incidents)), print, thread_index)
+            incident_search_responses.append(incidents)
         except ApiException as err:
             prints_manager.add_print_job(err, print, thread_index)
         if time.time() > timeout:
             error_message = 'Got timeout for searching incident with id {}, ' \
                             'got {} incidents in the search'.format(inc_id, incidents['total'])
             prints_manager.add_print_job(error_message, print_error, thread_index)
+            prints_manager.add_print_job(
+                'Incident search responses: {}'.format(str(incident_search_responses)), print, thread_index
+            )
             return False, -1
 
         time.sleep(10)


### PR DESCRIPTION

## Status
- [x] Ready

## Description
Changed the logic to print the server incident search response only in case of timeout