### PR TITLE
Zabbix - currentVersion from 2.0.0 to 1.0.0

### DIFF
--- a/Packs/Zabbix/pack_metadata.json
+++ b/Packs/Zabbix/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Allow integration with Zabbix api.",
     "support": "developer",
     "serverMinVersion": "4.5.0",
-    "currentVersion": "2.0.0",
+    "currentVersion": "1.0.0",
     "author": "Henrique Caires",
     "url": "https://github.com/HenriqueCaires",
     "email": "henrique@caires.net.br",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Changed `currentVersion` from `2.0.0` to `1.0.0`

## Does it break backward compatibility?
   - [x] No