### PR TITLE
demisto/etc#24229: Adding QueryResult output to indicate whether the …

### DIFF
--- a/Packs/Whois/Integrations/Whois/CHANGELOG.md
+++ b/Packs/Whois/Integrations/Whois/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Added the *Domain.Whois.QueryResult* output, which tells whether the query found a matching result.
 
 ## [20.4.1] - 2020-04-29
  - Fixed an issue where duplicate fields were created by the ***domain*** and ***whois*** commands outputs.

--- a/Packs/Whois/Integrations/Whois/Whois.py
+++ b/Packs/Whois/Integrations/Whois/Whois.py
@@ -8270,7 +8270,8 @@ def get_domain_from_query(query):
 
 def create_outputs(whois_result, domain, query=None):
     md = {'Name': domain}
-    ec = {'Name': domain}
+    ec = {'Name': domain,
+          'QueryResult': 'NOT FOUND' not in str(whois_result.get('raw', 'NOT FOUND'))}
     standard_ec = {}  # type:dict
     standard_ec['WHOIS'] = {}
     if 'status' in whois_result:

--- a/Packs/Whois/Integrations/Whois/Whois.yml
+++ b/Packs/Whois/Integrations/Whois/Whois.yml
@@ -166,6 +166,9 @@ script:
     - contextPath: Domain.Whois.QueryValue
       description: The query requested by the user.
       type: string
+    - contextPath: Domain.Whois.QueryResult
+      description: Whether the query found a matching result.
+      type: Boolean
   - arguments:
     - default: true
       description: The domain to enrich.
@@ -313,6 +316,9 @@ script:
     - contextPath: Domain.Whois.QueryStatus
       description: The result of the command ("Success" or "Failed").
       type: string
+    - contextPath: Domain.Whois.QueryResult
+      description: Whether the query found a matching result.
+      type: Boolean
   dockerimage: demisto/ippysocks:1.0.0.7353
   isfetch: false
   runonce: false

--- a/Packs/Whois/Integrations/Whois/Whois_test.py
+++ b/Packs/Whois/Integrations/Whois/Whois_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 import Whois
 import demistomock as demisto
 import pytest
@@ -64,3 +66,73 @@ def test_socks_proxy(mocker, request):
     assert_results_ok()
     tmp.seek(0)
     assert 'connected to' in tmp.read()  # make sure we went through microsocks
+
+
+TEST_QUERY_RESULT_INPUT = [
+    (
+        {'contacts': {'admin': None, 'billing': None, 'registrant': None, 'tech': None},
+         'raw': ['NOT FOUND\n>>> Last update of WHOIS database: 2020-05-07T13:55:34Z <<<']},
+        'rsqupuo.info',
+        False
+    ),
+    (
+        {'status': ['clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)'],
+         'updated_date': [datetime.datetime(2019, 9, 9, 8, 39, 4)],
+         'contacts': {'admin': {'country': 'US', 'state': 'CA', 'name': 'Google LLC'},
+                      'tech': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'},
+                      'registrant': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'}, 'billing': None},
+         'nameservers': ['ns1.google.com', 'ns4.google.com', 'ns3.google.com', 'ns2.google.com'],
+         'expiration_date': [datetime.datetime(2028, 9, 13, 0, 0), datetime.datetime(2028, 9, 13, 0, 0)],
+         'emails': ['abusecomplaints@markmonitor.com', 'whoisrequest@markmonitor.com'],
+         'raw': ['Domain Name: google.com\nRegistry Domain ID: 2138514_DOMAIN_COM-VRSN'],
+         'creation_date': [datetime.datetime(1997, 9, 15, 0, 0)], 'id': ['2138514_DOMAIN_COM-VRSN']},
+        'google.com',
+        True
+    ),
+    (
+        {'contacts': {'admin': None, 'billing': None, 'registrant': None, 'tech': None}},
+        'rsqupuo.info',
+        False
+    ),
+    (
+        {'status': ['clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)'],
+         'updated_date': [datetime.datetime(2019, 9, 9, 8, 39, 4)],
+         'contacts': {'admin': {'country': 'US', 'state': 'CA', 'name': 'Google LLC'},
+                      'tech': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'},
+                      'registrant': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'}, 'billing': None},
+         'nameservers': ['ns1.google.com', 'ns4.google.com', 'ns3.google.com', 'ns2.google.com'],
+         'expiration_date': [datetime.datetime(2028, 9, 13, 0, 0), datetime.datetime(2028, 9, 13, 0, 0)],
+         'emails': ['abusecomplaints@markmonitor.com', 'whoisrequest@markmonitor.com'],
+         'raw': 'Domain Name: google.com\nRegistry Domain ID: 2138514_DOMAIN_COM-VRSN',
+         'creation_date': [datetime.datetime(1997, 9, 15, 0, 0)], 'id': ['2138514_DOMAIN_COM-VRSN']},
+        'google.com',
+        True
+    ),
+    (
+        {'status': ['clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)'],
+         'updated_date': [datetime.datetime(2019, 9, 9, 8, 39, 4)],
+         'contacts': {'admin': {'country': 'US', 'state': 'CA', 'name': 'Google LLC'},
+                      'tech': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'},
+                      'registrant': {'organization': 'Google LLC', 'state': 'CA', 'country': 'US'}, 'billing': None},
+         'nameservers': ['ns1.google.com', 'ns4.google.com', 'ns3.google.com', 'ns2.google.com'],
+         'expiration_date': [datetime.datetime(2028, 9, 13, 0, 0), datetime.datetime(2028, 9, 13, 0, 0)],
+         'emails': ['abusecomplaints@markmonitor.com', 'whoisrequest@markmonitor.com'],
+         'raw': {'data': 'Domain Name: google.com\nRegistry Domain ID: 2138514_DOMAIN_COM-VRSN'},
+         'creation_date': [datetime.datetime(1997, 9, 15, 0, 0)], 'id': ['2138514_DOMAIN_COM-VRSN']},
+        'google.com',
+        True
+    ),
+    (
+        {'contacts': {'admin': None, 'billing': None, 'registrant': None, 'tech': None},
+         'raw': {'data': 'Domain Name: google.com\nRegistry Domain ID: 2138514_DOMAIN_COM-VRSN'}},
+        'rsqupuo.info',
+        True
+    ),
+]
+
+
+@pytest.mark.parametrize('whois_result, domain, expected', TEST_QUERY_RESULT_INPUT)
+def test_query_result(whois_result, domain, expected):
+    from Whois import create_outputs
+    md, standard_ec, dbot_score = create_outputs(whois_result, domain)
+    assert standard_ec['Whois']['QueryResult'] == expected


### PR DESCRIPTION
…query found a result

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24229

## Description
added output to context path under Domain.Whois.QueryResult to better show if the query found a result

## Minimum version of Demisto
- [x] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 


