### PR TITLE
Pack Metadata should be 1.0.0 as initial release.

### DIFF
--- a/Packs/Zabbix/pack_metadata.json
+++ b/Packs/Zabbix/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Allow integration with Zabbix api.",
     "support": "developer",
     "serverMinVersion": "4.5.0",
-    "currentVersion": "2.0.0",
+    "currentVersion": "1.0.0",
     "author": "Henrique Caires",
     "url": "https://github.com/HenriqueCaires",
     "email": "henrique@caires.net.br",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Pack Metadata should be 1.0.0 as initial release.
