### PR TITLE
[expanse-272] Add support for expanse-get-exposures command

### DIFF
--- a/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
+++ b/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- Added support for the ***expanse-get-exposures*** command.
 
 ## [20.4.1] - 2020-04-29
 Fixed an issue where incident polling did not behave as expected in some situations.

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -615,7 +615,6 @@ def get_expanse_exposure_context(data):
     }
 
 
-
 def fetch_events_incidents_command(start_date, end_date, token, next_=None):
     """
     retrieve active exposures from Expanse API and create incidents
@@ -911,6 +910,7 @@ def exposures_command():
     human_readable = tableToMarkdown("Expanse Exposure information for: {search}".format(search=search), expanse_exposure_context)
     expanse_exposure_context['Exposures'] = raw_exposures
     return_outputs(human_readable, ec, exposures)
+
 
 def arg_to_timestamp(arg, arg_name: str, required: bool = False):
     if arg is None:

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -568,6 +568,54 @@ def get_expanse_behavior_context(data):
     }
 
 
+def get_expanse_exposure_context(data):
+    """
+    provides custom context information from the Expanse Exposure API
+    """
+
+    def exposure_to_obj(exposure):
+        return {
+            "ExposureType": exposure['exposureType'],
+            "BusinessUnit": exposure['businessUnit']['name'],
+            "Ip": exposure['ip'],
+            "Port": exposure['port'],
+            "Severity": exposure['severity'],
+            "Certificate": exposure['certificate'],
+            "FirstObservsation": exposure['firstObservation'],
+            "LastObservsation": exposure['lastObservation'],
+            "Status": exposure['statuses'],
+            "Provider": exposure['provider']
+        }
+
+    def exposure_to_summary(exposure):
+        return "{exposureType} exposure on {ip}:{port}".format(**exposure)
+
+    def exposure_stats(exposures):
+        results = {
+            "CRITICAL": 0,
+            "WARNING": 0,
+            "ROUTINE": 0,
+            "UNKNOWN": 0
+        }
+        for exposure in exposures:
+            results[exposure['severity']] += 1
+
+        return results
+
+    counts = exposure_stats(data)
+    return {
+        "SearchTerm": data[0]['ip'],
+        "TotalExposureCount": len(data),
+        "CriticalExposureCount": counts['CRITICAL'],
+        "WarningExposureCount": counts['WARNING'],
+        "RoutineExposureCount": counts['ROUTINE'],
+        "UnknownExposureCount": counts['UNKNOWN'],
+        "ExposureSummaries": '\n'.join([exposure_to_summary(exposure) for exposure in data]),
+        "Exposures": [exposure_to_obj(exposure) for exposure in data]
+    }
+
+
+
 def fetch_events_incidents_command(start_date, end_date, token, next_=None):
     """
     retrieve active exposures from Expanse API and create incidents
@@ -824,11 +872,45 @@ def behavior_command():
         'Expanse.Behavior(val.SearchTerm == obj.SearchTerm)': expanse_behavior_context
     }
 
+    raw_flows = expanse_behavior_context['Flows']
     del expanse_behavior_context['Flows']  # Remove flow objects from human readable response
     human_readable = tableToMarkdown("Expanse Behavior information for: {search}".format(search=search), expanse_behavior_context)
-
+    expanse_behavior_context['Flows'] = raw_flows
     return_outputs(human_readable, ec, behaviors)
 
+
+def exposures_command():
+    """
+    searches by ip for exposure data from Expanse
+    """
+    search = demisto.args()['ip']
+
+    params = {
+        "inet": search,
+        "activityStatus": "active"
+    }
+    token = do_auth()
+    results = http_request('GET', 'exposures/ip-ports', params, token=token)
+    try:
+        exposures = results['data']
+        if len(exposures) == 0:
+            demisto.results("No data found")
+            return
+    except Exception:
+        demisto.results("No data found")
+        return
+
+    expanse_exposure_context = get_expanse_exposure_context(exposures)
+
+    ec = {
+        'Expanse.Exposures(val.SearchTerm == obj.SearchTerm)': expanse_exposure_context
+    }
+
+    raw_exposures = expanse_exposure_context['Exposures']
+    del expanse_exposure_context['Exposures']  # Remove exposure objects from human readable response
+    human_readable = tableToMarkdown("Expanse Exposure information for: {search}".format(search=search), expanse_exposure_context)
+    expanse_exposure_context['Exposures'] = raw_exposures
+    return_outputs(human_readable, ec, exposures)
 
 def arg_to_timestamp(arg, arg_name: str, required: bool = False):
     if arg is None:
@@ -892,6 +974,9 @@ def main():
 
         elif active_command == 'expanse-get-behavior':
             behavior_command()
+
+        elif active_command == 'expanse-get-exposures':
+            exposures_command()
 
     # Log exceptions
     except Exception as e:

--- a/Packs/Expanse/Integrations/Expanse/Expanse.yml
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.yml
@@ -646,7 +646,7 @@ script:
     - contextPath: Expanse.Exposures.Exposures.Provider
       description: Provider details of the Exposure
       type: Unknown
-  dockerimage: demisto/python3:3.7.4.2245
+  dockerimage: demisto/python3:3.8.2.6981
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Expanse/Integrations/Expanse/Expanse.yml
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.yml
@@ -549,7 +549,7 @@ script:
       type: String
     - contextPath: Expanse.Behavior.Flows
       description: Array of flow objects.
-      type: String
+      type: Unknown
     - contextPath: Expanse.Behavior.Flows.InternalAddress
       description: Internal IP address for flow
       type: String
@@ -580,6 +580,72 @@ script:
     - contextPath: Expanse.Behavior.Flows.RiskRule
       description: Risk rule violated by the flow.
       type: String
+  - arguments:
+    - default: true
+      description: The ip to search.
+      isArray: true
+      name: ip
+      required: true
+      secret: false
+    deprecated: false
+    description: Returns exposure information about the ip.
+    execution: false
+    name: expanse-get-exposures
+    outputs:
+    - contextPath: Expanse.Exposures.SearchTerm
+      description: The ip that was searched.
+      type: String
+    - contextPath: Expanse.Exposures.TotalExposureCount
+      description: The total count of exposures for the IP
+      type: Number
+    - contextPath: Expanse.Exposures.CriticalExposureCount
+      description: The total count of CRITICAL exposures for the IP
+      type: Number
+    - contextPath: Expanse.Exposures.WarningExposureCount
+      description: The total count of WARNING exposures for the IP
+      type: Number
+    - contextPath: Expanse.Exposures.RoutineExposureCount
+      description: The total count of ROUTINE exposures for the IP
+      type: Number
+    - contextPath: Expanse.Exposures.UnknownExposureCount
+      description: The total count of UNKNOWN exposures for the IP
+      type: Number
+    - contextPath: Expanse.Exposures.ExposureSummaries
+      description: Summaries of exposures for the IP address
+      type: String
+    - contextPath: Expanse.Exposures.Exposures
+      description: Array of Exposures for the IP address
+      type: Unknown
+    - contextPath: Expanse.Exposures.Exposures.ExposureType
+      description: Exposure type of the Exposure
+      type: String
+    - contextPath: Expanse.Exposures.Exposures.BusinessUnit
+      description: Business Unit of the Exposure
+      type: String
+    - contextPath: Expanse.Exposures.Exposures.Ip
+      description: IP Address the Exposure was found on
+      type: String
+    - contextPath: Expanse.Exposures.Exposures.Port
+      description: Port the Exposure was found on
+      type: String
+    - contextPath: Expanse.Exposures.Exposures.Severity
+      description: Severity of the Exposure
+      type: String
+    - contextPath: Expanse.Exposures.Exposures.Certificate
+      description: Certificate details associated with Exposure
+      type: Unknown
+    - contextPath: Expanse.Exposures.Exposures.FirstObservsation
+      description: First Observation of the Exposure
+      type: Unknown
+    - contextPath: Expanse.Exposures.Exposures.LastObservsation
+      description: Last Observation of the Exposure
+      type: Unknown
+    - contextPath: Expanse.Exposures.Exposures.Status
+      description: Status details of the Exposure
+      type: Unknown
+    - contextPath: Expanse.Exposures.Exposures.Provider
+      description: Provider details of the Exposure
+      type: Unknown
   dockerimage: demisto/python3:3.7.4.2245
   feed: false
   isfetch: true

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -2,7 +2,7 @@ from Expanse import main
 import demistomock as demisto
 import json
 
-TEST_IP = "74.142.119.130"
+TEST_IP = "12.4.49.74"
 TEST_API_KEY = "123456789123456789"
 TEST_DOMAIN = "base2.pets.com"
 
@@ -27,6 +27,9 @@ def http_request_mock(method, endpoint, params=None, token=False):
 
     elif endpoint == 'assets/certificates':
         r = MOCK_CERTIFICATE_RESPONSE
+
+    elif endpoint == 'exposures/ip-ports':
+        r = MOCK_EXPOSURES_RESPONSE
 
     return r
 
@@ -125,6 +128,18 @@ def test_behavior(mocker):
     assert results[0]['EntryContext']['Expanse.Behavior(val.SearchTerm == obj.SearchTerm)']['SearchTerm'] == TEST_IP
     assert results[0]['EntryContext']['Expanse.Behavior(val.SearchTerm == obj.SearchTerm)']['ExternalAddresses'] \
         == '169.255.204.27'
+
+
+def test_exposures(mocker):
+    mocker.patch.object(demisto, 'args', return_value={'ip': TEST_IP})
+    mocker.patch('Expanse.http_request', side_effect=http_request_mock)
+    mocker.patch.object(demisto, 'command', return_value='expanse-get-exposures')
+    mocker.patch.object(demisto, 'results')
+    main()
+    results = demisto.results.call_args[0]
+    assert results[0]['EntryContext']['Expanse.Exposures(val.SearchTerm == obj.SearchTerm)']['SearchTerm'] == TEST_IP
+    assert results[0]['EntryContext']['Expanse.Exposures(val.SearchTerm == obj.SearchTerm)']['WarningExposureCount'] \
+        == 1
 
 
 MOCK_TOKEN_RESPONSE = {
@@ -319,7 +334,7 @@ MOCK_IP_RESPONSE = {
             ],
             "locationInformation": [
                 {
-                    "ip": "74.142.119.130",
+                    "ip": "12.4.49.74",
                     "geolocation": {
                         "latitude": 41.0433,
                         "longitude": -81.5239,
@@ -532,7 +547,7 @@ MOCK_IP_EMPTY_RESPONSE = {
             ],
             "locationInformation": [
                 {
-                    "ip": "74.142.119.130",
+                    "ip": "12.4.49.74",
                     "geolocation": {
                         "city": "AKRON",
                         "regionCode": "OH",
@@ -758,7 +773,7 @@ MOCK_BEHAVIOR = {
                     Iran, Iraq, Liberia, North Korea, South Sudan, Sudan, Syria, Zimbabwe)",
                 "additionalDataFields": "[]"
             },
-            "internalAddress": "74.142.119.130",
+            "internalAddress": "12.4.49.74",
             "internalPort": 443,
             "externalAddress": "169.255.204.27",
             "externalPort": 43624,
@@ -871,6 +886,223 @@ MOCK_CERTIFICATE_RESPONSE = {
         "details": {
             "recentIps": [],
             "cloudResources": []
+        }
+    }]
+}
+
+MOCK_EXPOSURES_RESPONSE = {
+    "data": [{
+        "id": "1bb22f55-673e-3156-bb73-991dc1a8d197",
+        "exposureType": "LONG_EXPIRATION_CERTIFICATE_ADVERTISEMENT",
+        "businessUnit": {
+            "id": "6b73ef6c-b230-3797-b321-c4a340169eb7",
+            "name": "Acme Latex Supply",
+            "tenantId": "04b5140e-bbe2-3e9c-9318-a39a3b547ed5"
+        },
+        "ip": "12.4.49.74",
+        "port": "443",
+        "portNumber": 443,
+        "portProtocol": "TCP",
+        "provider": None,
+        "tags": {
+            "ipRange": [
+                "untagged"
+            ]
+        },
+        "severity": "WARNING",
+        "certificate": {
+            "id": "Vw6RoQXvVxlCtbCBO5EMoA==",
+            "issuer": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL \
+            (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+            "issuerAlternativeNames": "",
+            "issuerCountry": "US",
+            "issuerEmail": "",
+            "issuerLocality": "Sunnyvale",
+            "issuerName": "192.168.168.168",
+            "issuerOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+            "issuerOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+            "issuerState": "California",
+            "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5akohpdNcWTsjtYeOoR2KqN577kz\
+            C2tPrD9Nl4hgunmMoc8xMA2wXLhWCEMFD6loaYH2gOIrRhytbRa3XB3stiGT5NVjWMyxWJk3dLFZ2fZLpRG\
+            upJhoFv7IE3pB71AXcgZG+25FPjEPV+Z8SRQI3Bd3IBZfoGASmRbCg7YNWdAIRdb3e8Rb99uBTDstYs5\
+            ucWnXZI6+IDTpJVsVjoS9olYq26Q1FbC7x9dmYD74ATwcdAmbcbINlUrrptafjRuAfyaLQxt0OUkA\
+            Hm65EYliqqsS+88BIW4fIxD87X5MLY/tNOBGjKUXE0+iK1jbrVrrUoA0nLnOeDquFq72MixkwwIDAQAB",
+            "publicKeyAlgorithm": "RSA",
+            "publicKeyRsaExponent": 65537,
+            "signatureAlgorithm": "SHA1withRSA",
+            "subject": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL \
+            (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+            "subjectAlternativeNames": "",
+            "subjectCountry": "US",
+            "subjectEmail": "",
+            "subjectLocality": "Sunnyvale",
+            "subjectName": "192.168.168.168",
+            "subjectOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+            "subjectOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+            "subjectState": "California",
+            "serialNumber": "1533615873",
+            "validNotBefore": "1970-01-01T00:00:01Z",
+            "validNotAfter": "2038-01-19T03:14:07Z",
+            "version": "3",
+            "isSelfSigned": True,
+            "isWildcard": False,
+            "isDomainControlValidated": False,
+            "publicKeyBits": 2048,
+            "numCertificateObservations": 0,
+            "numKeyObservations": 0
+        },
+        "firstObservation": {
+            "id": "05cbdfc6-48fa-3c6d-80ac-4ad39d5ece88",
+            "ip": "12.4.49.74",
+            "scanned": "2019-09-04T14:23:38Z",
+            "hostname": None,
+            "portNumber": 443,
+            "geolocation": {
+                "city": "WESTSACRAMENTO",
+                "latitude": 38.5921,
+                "longitude": -121.5456,
+                "regionCode": "CA",
+                "countryCode": "US"
+            },
+            "qrispTaskId": 29825013,
+            "portProtocol": "TCP",
+            "configuration": {
+                "certificate": {
+                    "id": "570e91a1-05ef-3719-82b5-b0813b910ca0",
+                    "issuer": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL\
+                    (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+                    "md5Hash": "Vw6RoQXvVxlCtbCBO5EMoA==",
+                    "pemSha1": "GkB2d6a9Us_urkxp14wwAkp1VqM=",
+                    "subject": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL\
+                    (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+                    "version": "3",
+                    "issuerOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "pemSha256": "uuAMf7Q_qEaStP_lU-j-m6CflNqkoZsHysSrHLhwy78=",
+                    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5akohpdNcWTsjtYeOoR2KqN577kzC2tPrD9\
+                    Nl4hgunmMoc8xMA2wXLhWCEMFD6loaYH2gOIrRhytbRa3XB3stiGT5NVjWMyxWJk3dLFZ2fZLpRGupJhoFv7IE3pB7\
+                    1AXcgZG+25FPjEPV+Z8SRQI3Bd3IBZfoGASmRbCg7YNWdAIRdb3e8Rb99uBTDstYs5ucWnXZI6+IDTpJVsVjoS9\
+                    olYq26Q1FbC7x9dmYD74ATwcdAmbcbINlUrrptafjRuAfyaLQxt0OUkAHm65EYliqqsS+88BIW4fIxD87X5M\
+                    LY/tNOBGjKUXE0+iK1jbrVrrUoA0nLnOeDquFq72MixkwwIDAQAB",
+                    "isWildcard": False,
+                    "issuerName": "192.168.168.168",
+                    "subjectOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "issuerEmail": "",
+                    "issuerState": "California",
+                    "subjectName": "192.168.168.168",
+                    "isSelfSigned": True,
+                    "serialNumber": "1533615873",
+                    "subjectEmail": "",
+                    "subjectState": "California",
+                    "issuerCountry": "US",
+                    "issuerOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "publicKeyBits": 2048,
+                    "publicKeySpki": "pVo0cfjizXqevMzNgJD2nnEZKTwbpEgJYY7cwQuYK_o=",
+                    "validNotAfter": "2038-01-19T03:14:07Z",
+                    "issuerLocality": "Sunnyvale",
+                    "subjectCountry": "US",
+                    "subjectOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "validNotBefore": "1970-01-01T00:00:01Z",
+                    "subjectLocality": "Sunnyvale",
+                    "publicKeyModulus": "e5a92886974d7164ec8ed61e3a84762aa379efb9330b6b4fac3f4d978860ba798ca1cf31\
+                    300db05cb8560843050fa9686981f680e22b461cad6d16b75c1decb62193e4d56358ccb158993774b159d9f64b\
+                    a511aea4986816fec8137a41ef5017720646fb6e453e310f57e67c491408dc177720165fa060129916c283b\
+                    60d59d00845d6f77bc45bf7db814c3b2d62ce6e7169d7648ebe2034e9255b158e84bda2562adba43515b\
+                    0bbc7d766603ef8013c1c74099b71b20d954aeba6d69f8d1b807f268b431b743949001e6eb9118962\
+                    aaab12fbcf01216e1f2310fced7e4c2d8fed34e0468ca517134fa22b58dbad5aeb5280349cb9c\
+                    e783aae16aef6322c64c3",
+                    "publicKeyAlgorithm": "RSA",
+                    "signatureAlgorithm": "SHA1withRSA",
+                    "publicKeyRsaExponent": 65537,
+                    "issuerAlternativeNames": "",
+                    "subjectAlternativeNames": "",
+                    "isDomainControlValidated": False
+                },
+                "validWhenScanned": True
+            }
+        },
+        "lastObservation": {
+            "id": "747e01c9-2ea6-34ac-90d9-0704c4fe32b1",
+            "ip": "12.4.49.74",
+            "scanned": "2020-04-21T03:04:32Z",
+            "hostname": None,
+            "portNumber": 443,
+            "geolocation": {
+                "city": "WESTSACRAMENTO",
+                "latitude": 38.5921,
+                "longitude": -121.5456,
+                "regionCode": "CA",
+                "countryCode": "US"
+            },
+            "qrispTaskId": 41034108,
+            "portProtocol": "TCP",
+            "configuration": {
+                "certificate": {
+                    "id": "570e91a1-05ef-3719-82b5-b0813b910ca0",
+                    "issuer": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL \
+                    (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+                    "md5Hash": "Vw6RoQXvVxlCtbCBO5EMoA==",
+                    "pemSha1": "GkB2d6a9Us_urkxp14wwAkp1VqM=",
+                    "subject": "C=US,ST=California,L=Sunnyvale,O=HTTPS Management Certificate for SonicWALL \
+                    (self-signed),OU=HTTPS Management Certificate for SonicWALL (self-signed),CN=192.168.168.168",
+                    "version": "3",
+                    "issuerOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "pemSha256": "uuAMf7Q_qEaStP_lU-j-m6CflNqkoZsHysSrHLhwy78=",
+                    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5akohpdNcWTsjtYeOoR2KqN577kzC2tPr\
+                    D9Nl4hgunmMoc8xMA2wXLhWCEMFD6loaYH2gOIrRhytbRa3XB3stiGT5NVjWMyxWJk3dLFZ2fZLpRGupJhoFv7IE3pB7\
+                    1AXcgZG+25FPjEPV+Z8SRQI3Bd3IBZfoGASmRbCg7YNWdAIRdb3e8Rb99uBTDstYs5ucWnXZI6+IDTpJVsVjoS9olYq26\
+                    Q1FbC7x9dmYD74ATwcdAmbcbINlUrrptafjRuAfyaLQxt0OUkAHm65EYliqqsS+88BIW4fIxD87X5MLY/tNOBGjKUXE0+iK\
+                    1jbrVrrUoA0nLnOeDquFq72MixkwwIDAQAB",
+                    "isWildcard": False,
+                    "issuerName": "192.168.168.168",
+                    "subjectOrg": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "issuerEmail": "",
+                    "issuerState": "California",
+                    "subjectName": "192.168.168.168",
+                    "isSelfSigned": True,
+                    "serialNumber": "1533615873",
+                    "subjectEmail": "",
+                    "subjectState": "California",
+                    "issuerCountry": "US",
+                    "issuerOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "publicKeyBits": 2048,
+                    "publicKeySpki": "pVo0cfjizXqevMzNgJD2nnEZKTwbpEgJYY7cwQuYK_o=",
+                    "validNotAfter": "2038-01-19T03:14:07Z",
+                    "issuerLocality": "Sunnyvale",
+                    "subjectCountry": "US",
+                    "subjectOrgUnit": "HTTPS Management Certificate for SonicWALL (self-signed)",
+                    "validNotBefore": "1970-01-01T00:00:01Z",
+                    "subjectLocality": "Sunnyvale",
+                    "publicKeyModulus": "e5a92886974d7164ec8ed61e3a84762aa379efb9330b6b4fac3f4d978860ba798ca1cf\
+                    31300db05cb8560843050fa9686981f680e22b461cad6d16b75c1decb62193e4d56358ccb158993774b159d9f64b\
+                    a511aea4986816fec8137a41ef5017720646fb6e453e310f57e67c491408dc177720165fa060129916c283b60d59\
+                    d00845d6f77bc45bf7db814c3b2d62ce6e7169d7648ebe2034e9255b158e84bda2562adba43515b0bbc7d766603ef\
+                    8013c1c74099b71b20d954aeba6d69f8d1b807f268b431b743949001e6eb9118962aaab12fbcf01216e1f2310fced7\
+                    e4c2d8fed34e0468ca517134fa22b58dbad5aeb5280349cb9ce783aae16aef6322c64c3",
+                    "publicKeyAlgorithm": "RSA",
+                    "signatureAlgorithm": "SHA1withRSA",
+                    "publicKeyRsaExponent": 65537,
+                    "issuerAlternativeNames": "",
+                    "subjectAlternativeNames": "",
+                    "isDomainControlValidated": False
+                },
+                "validWhenScanned": True
+            }
+        },
+        "statuses": {
+            "remediation": [
+                {
+                    "id": "7b379428-4d12-4fbd-9b3f-15a04d7e4e11",
+                    "comment": "Reached out to device owner",
+                    "created": "2020-04-08T19:17:31.514017Z",
+                    "modified": "2020-04-08T19:17:31.514536Z",
+                    "stage": 100,
+                    "user": "60709972-10f2-4a22-8a9a-978b264f964d",
+                    "exposureId": "1bb22f55-673e-3156-bb73-991dc1a8d197",
+                    "provider": None,
+                    "username": "beta+vandelay@expanseinc.com"
+                }
+            ],
+            "snooze": []
         }
     }]
 }

--- a/Packs/Expanse/Integrations/Expanse/README.md
+++ b/Packs/Expanse/Integrations/Expanse/README.md
@@ -140,6 +140,7 @@ After you successfully execute a command, a DBot message appears in the War Room
 2. domain
 3. expanse-get-certificate
 4. expanse-get-behavior
+5. expanse-get-exposures
 
 ### 1. ip
 ---
@@ -690,6 +691,169 @@ expanse-get-behavior command
 |BusinessUnit|ExternalAddresses|FlowSummaries|InternalAddress|InternalCountryCode|InternalDomains|InternalExposureTypes|InternalIPRanges|SearchTerm|
 |---|---|---|---|---|---|---|---|---|
 | VanDelay Industries | 66.110.49.36,66.110.49.72 | 74.142.119.130:57475 (US) -> 66.110.49.72:443 (CA) TCP violates Outbound Flows from Servers at 2020-04-05T21:18:56.889Z<br />74.142.119.130:61694 (US) -> 66.110.49.36:443 (CA) TCP violates Outbound Flows from Servers at 2020-04-05T21:03:50.867Z | 74.142.119.130 | US |  | HttpServer |  | 74.142.119.130 |
+
+
+### 4. expanse-get-exposures
+---
+expanse-get-exposures command
+##### Required Permissions
+**none**
+##### Base Command
+
+`expanse-get-exposures`
+##### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| ip | ip to search| Required |
+
+
+##### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Expanse.Exposures.SearchTerm | string | IP used to search |
+| Expanse.Exposures.TotalExposureCount | number | The total count of exposures for the IP |
+| Expanse.Exposures.CriticalExposureCount | number | The total count of CRITICAL exposures for the IP |
+| Expanse.Exposures.WarningExposureCount | number | The total count of WARNING exposures for the IP |
+| Expanse.Exposures.RoutineExposureCount | number | The total count of ROUTINE exposures for the IP |
+| Expanse.Exposures.UnknownExposureCount | number | The total count of UNKNOWN exposures for the IP |
+| Expanse.Exposures.ExposureSummaries | string | Summaries of exposures for the IP address |
+| Expanse.Exposures.Exposures | unknown | Array of Exposures for the IP address |
+| Expanse.Exposures.Exposures.ExposureType | string | Exposure type of the Exposure |
+| Expanse.Exposures.Exposures.BusinessUnit | string | Business Unit of the Exposure |
+| Expanse.Exposures.Exposures.Ip | string | IP Address the Exposure was found on |
+| Expanse.Exposures.Exposures.Port | string | Port the Exposure was found on |
+| Expanse.Exposures.Exposures.Severity | string | Severity of the Exposure |
+| Expanse.Exposures.Exposures.Certificate | unknown | Certificate details associated with Exposure |
+| Expanse.Exposures.Exposures.FirstObservsation | unknown | First Observation of the Exposure |
+| Expanse.Exposures.Exposures.LastObservsation | unknown | Last Observation of the Exposure |
+| Expanse.Exposures.Exposures.Status | unknown | Status details of the Exposure |
+| Expanse.Exposures.Exposures.Provider | unknown | Provider details of the Exposure |
+
+
+##### Command Example
+```!expanse-get-exposures ip=33.2.243.123```
+
+##### Context Example
+```
+{
+    "CriticalExposureCount": 0,
+    "ExposureSummaries": "NTP_SERVER exposure on 33.2.243.123:UDP123",
+    "Exposures": [
+        {
+            "BusinessUnit": "VanDelay Industries",
+            "Certificate": null,
+            "ExposureType": "NTP_SERVER",
+            "FirstObservsation": {
+                "configuration": {
+                    "certificate": null,
+                    "response": {
+                        "ntp": {
+                            "delay": 0,
+                            "dispersion": 65537,
+                            "extentionData": null,
+                            "keyIdentifier": null,
+                            "leapIndicator": 3,
+                            "messageDigest": null,
+                            "mode": 4,
+                            "originateTime": "2004-11-24T15:12:11.444Z",
+                            "poll": 4,
+                            "precision": -18,
+                            "receiveTime": "2019-02-01T00:32:17.693Z",
+                            "reference": {
+                                "ref_str": {
+                                    "reference": ""
+                                }
+                            },
+                            "stratum": 0,
+                            "transmitTime": "2019-02-01T00:32:17.693Z",
+                            "updateTime": "2036-02-07T06:28:16Z",
+                            "version": 4
+                        }
+                    }
+                },
+                "geolocation": {
+                    "city": "VICTOR",
+                    "countryCode": "US",
+                    "latitude": 42.982,
+                    "longitude": -77.4245,
+                    "regionCode": "NY"
+                },
+                "hostname": null,
+                "id": "2d349139-1111-3c92-a168-557d34729bf8",
+                "ip": "33.2.243.123",
+                "portNumber": 123,
+                "portProtocol": "UDP",
+                "qrispTaskId": 21716146,
+                "scanned": "2019-02-01T00:19:16Z"
+            },
+            "Ip": "33.2.243.123",
+            "LastObservsation": {
+                "configuration": {
+                    "certificate": null,
+                    "response": {
+                        "ntp": {
+                            "delay": 0,
+                            "dispersion": 65537,
+                            "extentionData": null,
+                            "keyIdentifier": null,
+                            "leapIndicator": 3,
+                            "messageDigest": null,
+                            "mode": 4,
+                            "originateTime": "2004-11-24T15:12:11.444Z",
+                            "poll": 4,
+                            "precision": -18,
+                            "receiveTime": "2020-05-05T16:05:36.606Z",
+                            "reference": {
+                                "ref_str": {
+                                    "reference": ""
+                                }
+                            },
+                            "stratum": 0,
+                            "transmitTime": "2020-05-05T16:05:36.606Z",
+                            "updateTime": "2036-02-07T06:28:16Z",
+                            "version": 4
+                        }
+                    }
+                },
+                "geolocation": {
+                    "city": "VICTOR",
+                    "countryCode": "US",
+                    "latitude": 42.982,
+                    "longitude": -77.4245,
+                    "regionCode": "NY"
+                },
+                "hostname": null,
+                "id": "69a0159b-facc-3c55-b71d-3e6b8ae9252b",
+                "ip": "33.2.243.123",
+                "portNumber": 123,
+                "portProtocol": "UDP",
+                "qrispTaskId": 41755001,
+                "scanned": "2020-05-05T16:03:30Z"
+            },
+            "Port": "UDP123",
+            "Provider": null,
+            "Severity": "ROUTINE",
+            "Status": {
+                "remediation": [],
+                "snooze": []
+            }
+        }
+    ],
+    "RoutineExposureCount": 1,
+    "SearchTerm": "33.2.243.123",
+    "TotalExposureCount": 1,
+    "UnknownExposureCount": 0,
+    "WarningExposureCount": 0
+}
+```
+
+##### Human Readable Output
+### Expanse Exposure information for: 33.2.243.123
+|CriticalExposureCount|ExposureSummaries|RoutineExposureCount|SearchTerm|TotalExposureCount|UnknownExposureCount|WarningExposureCount|
+|---|---|---|---|---|---|---|
+| 0 | NTP_SERVER exposure on 33.2.243.123:UDP123 | 1 | 33.2.243.123 | 1 | 0 | 0 |
 
 
 ## Additional Information


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Adds support for new *expanse-get-exposures* command.

## Screenshots
<img width="1516" alt="Screen Shot 2020-05-07 at 12 50 49 PM" src="https://user-images.githubusercontent.com/61566898/81338402-6f320d00-9061-11ea-85cc-3a30000d112a.png">

## Minimum version of Demisto
- [ ] 4.5.0
- [x] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

## Demisto Partner?
- [x] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

