### PR TITLE
[Marketplace] - missing pack metadata load fix

### DIFF
--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -415,7 +415,7 @@ class TestImagesUpload:
         search_for_images_return_value = [{'display_name': integration_name,
                                            'image_path': f'/path/{temp_image_name}'}]
         mocker.patch("marketplace_services_test.Pack._search_for_images", return_value=search_for_images_return_value)
-        mocker.patch('builtins.open', mock_open(read_data="image_data"))
+        mocker.patch("builtins.open", mock_open(read_data="image_data"))
         mocker.patch("Tests.Marketplace.marketplace_services.print")
         dummy_storage_bucket = mocker.MagicMock()
         dummy_storage_bucket.blob.return_value.name = os.path.join(GCPConfig.STORAGE_BASE_PATH, "TestPack",
@@ -425,3 +425,20 @@ class TestImagesUpload:
         assert task_status
         assert len(expected_result) == len(integration_images)
         assert integration_images == expected_result
+
+
+class TestLoadUserMetadata:
+    @pytest.fixture(scope="class")
+    def dummy_pack(self):
+        """ dummy pack fixture
+        """
+        return Pack(pack_name="TestPack", pack_path="dummy_path")
+
+    def test_load_user_metadata_with_missing_file(self, mocker, dummy_pack):
+        mocker.patch("os.path.exists", return_value=False)
+        print_error_mock = mocker.patch("Tests.Marketplace.marketplace_services.print_error")
+        task_status, user_metadata = dummy_pack.load_user_metadata()
+
+        assert print_error_mock.call_count == 1
+        assert not task_status
+        assert user_metadata == {}

--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -435,6 +435,14 @@ class TestLoadUserMetadata:
         return Pack(pack_name="TestPack", pack_path="dummy_path")
 
     def test_load_user_metadata_with_missing_file(self, mocker, dummy_pack):
+        """
+           Given:
+               - Pack with missing pack metadata.
+           When:
+               - Pack is invalid.
+           Then:
+               - Task should not fail with referenced before assignment error.
+       """
         mocker.patch("os.path.exists", return_value=False)
         print_error_mock = mocker.patch("Tests.Marketplace.marketplace_services.print_error")
         task_status, user_metadata = dummy_pack.load_user_metadata()

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -808,13 +808,14 @@ class Pack(object):
 
         """
         task_status = False
+        user_metadata = {}
 
         try:
             user_metadata_path = os.path.join(self._pack_path, Pack.USER_METADATA)  # user metadata path before parsing
 
             if not os.path.exists(user_metadata_path):
                 print_error(f"{self._pack_name} pack is missing {Pack.USER_METADATA} file.")
-                return task_status
+                return task_status, user_metadata
 
             with open(user_metadata_path, "r") as user_metadata_file:
                 user_metadata = json.load(user_metadata_file)  # loading user metadata


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold 

## Description
- Fixed `local variable 'user_metadata' referenced before assignment` error when trying to load missing pack metadata (https://circleci.com/gh/demisto/content/52017).
-  Deleted `Okta_v2` folder, the real pack is `Okta`.