### PR TITLE
Schedule Trigger instances_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,3 +578,17 @@ workflows:
   commit:
     jobs:
       - build
+  instances_testing:
+    # for details of triggered builds see https://circleci.com/docs/2.0/workflows/#nightly-example
+    # for details of cron syntax see https://www.unix.com/man-page/POSIX/1posix/crontab/ disable-secrets-detection
+    triggers:
+      - schedule:
+          # should trigger every day at 2 AM UTC (5 AM Israel Time)
+          cron: "0 2 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: instances_test_env


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
Moves configuration of a scheduled build to the circleci config file.

## Description
Triggers the scheduled instances test build from the circleci config file itself.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation

