### PR TITLE
[expanse-272]  Adding support for minimum severity incident filtering

### DIFF
--- a/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
+++ b/Packs/Expanse/Integrations/Expanse/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Added support for filtering incident creation by Expanse Exposure severity level.
 - Added support for the ***expanse-get-exposures*** command.
 
 ## [20.4.1] - 2020-04-29

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -24,6 +24,7 @@ SERVER = 'https://expander.expanse.co'
 VERIFY_CERTIFICATES = not demisto.params().get('insecure')
 PROXY = demisto.params().get('proxy')
 BEHAVIOR_ENABLED = demisto.params().get('behavior', False)
+MINIMUM_SEVERITY = demisto.params().get('minimum_severity', 'WARNING')
 BASE_URL = SERVER
 EXPOSURE_EVENT_TYPES = "ON_PREM_EXPOSURE_APPEARANCE,ON_PREM_EXPOSURE_REAPPEARANCE"
 API_ENDPOINTS = {
@@ -166,22 +167,23 @@ def parse_events(events):
     """
     incidents = []
     for event in events['data']:
-        incident = {
-            'name': "{type} on {ip}:{port}/{protocol}".format(
-                type=event['payload']['exposureType'],
-                ip=event['payload']['ip'],
-                protocol=event['payload']['portProtocol'],
-                port=event['payload']['port']
-            ),
-            'occurred': event['eventTime'],
-            'rawJSON': json.dumps(event),
-            'type': 'Expanse Appearance',
-            'CustomFields': {
-                'expanserawjsonevent': json.dumps(event)
-            },
-            'severity': EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']]
-        }
-        incidents.append(incident)
+        if EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']] >= EXPOSURE_SEVERITY_MAPPING[MINIMUM_SEVERITY]:
+            incident = {
+                'name': "{type} on {ip}:{port}/{protocol}".format(
+                    type=event['payload']['exposureType'],
+                    ip=event['payload']['ip'],
+                    protocol=event['payload']['portProtocol'],
+                    port=event['payload']['port']
+                ),
+                'occurred': event['eventTime'],
+                'rawJSON': json.dumps(event),
+                'type': 'Expanse Appearance',
+                'CustomFields': {
+                    'expanserawjsonevent': json.dumps(event)
+                },
+                'severity': EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']]
+            }
+            incidents.append(incident)
     return incidents
 
 

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -167,7 +167,6 @@ def parse_events(events):
     """
     incidents = []
     for event in events['data']:
-        print(EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']], EXPOSURE_SEVERITY_MAPPING[MINIMUM_SEVERITY])
         if EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']] >= EXPOSURE_SEVERITY_MAPPING[MINIMUM_SEVERITY]:
             incident = {
                 'name': "{type} on {ip}:{port}/{protocol}".format(

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -167,6 +167,7 @@ def parse_events(events):
     """
     incidents = []
     for event in events['data']:
+        print(EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']], EXPOSURE_SEVERITY_MAPPING[MINIMUM_SEVERITY])
         if EXPOSURE_SEVERITY_MAPPING[event['payload']['severity']] >= EXPOSURE_SEVERITY_MAPPING[MINIMUM_SEVERITY]:
             incident = {
                 'name': "{type} on {ip}:{port}/{protocol}".format(

--- a/Packs/Expanse/Integrations/Expanse/Expanse.yml
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.yml
@@ -40,9 +40,18 @@ configuration:
   name: first_run
   required: false
   type: 0
+- display: Minimum severity of Expanse Exposure to create an incident for
+  hidden: false
+  name: minimum_severity
+  required: false
+  type: 15
+  options:
+  - ROUTINE
+  - WARNING
+  - CRITICAL
 description: The Expanse App for Demisto leverages the Expander API to retrieve network
-  exposures and create incidents in Demisto.  This application also allows for IP
-  and Domain enrichment, retrieving assets and exposures information drawn from Expanse’s
+  exposures and risky flows to create incidents in Demisto.  This application also allows for IP,
+  Domain, Certificate, Behavior, and Exposure enrichment, retrieving assets and exposures information drawn from Expanse’s
   unparalleled view of the Internet.
 display: Expanse
 name: Expanse

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -54,6 +54,7 @@ def test_fetch_incidents(mocker):
     assert r[0]['name'] == "NTP_SERVER on 203.215.173.113:123/UDP"
     assert r[0]['severity'] == 1
 
+
 def test_fetch_incidents_severity(mocker):
     mocker.patch.object(demisto, 'params', return_value={
         'api_key': TEST_API_KEY,
@@ -751,7 +752,7 @@ MOCK_EVENTS = {
                         }
                     }
                 },
-                'severity': 'ROUTINE',
+                'severity': 'WARNING',
                 'tags': {
                     'ipRange': ['untagged']
                 },

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -55,15 +55,6 @@ def test_fetch_incidents(mocker):
     assert r[0]['severity'] == 2
 
 
-def test_fetch_incidents_severity(mocker):
-    mocker.patch.object(demisto, 'params', return_value={
-        'api_key': TEST_API_KEY,
-        'first_run': '7',
-        'minimum_severity': 'CRITICAL'
-    })
-    assert len(parse_events(MOCK_EVENTS)) == 0
-
-
 def test_fetch_incidents_with_behavior(mocker):
     mocker.patch.object(demisto, 'params', return_value={
         'api_key': TEST_API_KEY,

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -54,6 +54,20 @@ def test_fetch_incidents(mocker):
     assert r[0]['name'] == "NTP_SERVER on 203.215.173.113:123/UDP"
     assert r[0]['severity'] == 1
 
+def test_fetch_incidents_severity(mocker):
+    mocker.patch.object(demisto, 'params', return_value={
+        'api_key': TEST_API_KEY,
+        'first_run': '7',
+        'minimum_severity': 'CRITICAL'
+    })
+    mocker.patch('Expanse.http_request', side_effect=http_request_mock)
+    mocker.patch.object(demisto, 'command', return_value='fetch-incidents')
+    mocker.patch.object(demisto, 'results')
+    main()
+    results = demisto.results.call_args[0]
+    r = json.loads(results[0]['Contents'])
+    assert len(r) == 0, 'Should not return any incidents'
+
 
 def test_fetch_incidents_with_behavior(mocker):
     mocker.patch.object(demisto, 'params', return_value={

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -1,4 +1,4 @@
-from Expanse import main, parse_events
+from Expanse import main
 import demistomock as demisto
 import json
 

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -1,4 +1,4 @@
-from Expanse import main
+from Expanse import main, parse_events
 import demistomock as demisto
 import json
 
@@ -52,7 +52,7 @@ def test_fetch_incidents(mocker):
     results = demisto.results.call_args[0]
     r = json.loads(results[0]['Contents'])
     assert r[0]['name'] == "NTP_SERVER on 203.215.173.113:123/UDP"
-    assert r[0]['severity'] == 1
+    assert r[0]['severity'] == 2
 
 
 def test_fetch_incidents_severity(mocker):
@@ -61,13 +61,7 @@ def test_fetch_incidents_severity(mocker):
         'first_run': '7',
         'minimum_severity': 'CRITICAL'
     })
-    mocker.patch('Expanse.http_request', side_effect=http_request_mock)
-    mocker.patch.object(demisto, 'command', return_value='fetch-incidents')
-    mocker.patch.object(demisto, 'results')
-    main()
-    results = demisto.results.call_args[0]
-    r = json.loads(results[0]['Contents'])
-    assert len(r) == 0, 'Should not return any incidents'
+    assert len(parse_events(MOCK_EVENTS)) == 0
 
 
 def test_fetch_incidents_with_behavior(mocker):
@@ -83,7 +77,7 @@ def test_fetch_incidents_with_behavior(mocker):
     results = demisto.results.call_args[0]
     r = json.loads(results[0]['Contents'])
     assert r[0]['name'] == "NTP_SERVER on 203.215.173.113:123/UDP"
-    assert r[0]['severity'] == 1
+    assert r[0]['severity'] == 2
 
 
 def test_ip(mocker):

--- a/Packs/Expanse/Integrations/Expanse/README.md
+++ b/Packs/Expanse/Integrations/Expanse/README.md
@@ -22,6 +22,7 @@ This integration was integrated and tested with Expanse Events API v1, Assets AP
     * __Use system proxy settings__
     * __How many events to pull from Expander per run__
     * __How many days to pull past events on first run__
+    * __Minimum severity of Expanse Exposure to create an incident for__
 4. Click __Test__ to validate the URLs, token, and connection.
 ## Fetched Incidents Data
 ---


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
We've received a custom request to do severity filtering on new incidents during ingest, rather than allow customers to utilize playbook filtering to auto-close low-severity incidents. This change adds support for a new `minimum_severity` app param to choose `ROUTINE`, `WARNING`, or `CRITICAL` as the minimum Expanse severity level they'd like to ingest. `WARNING` is default. 

## Screenshots

## Minimum version of Demisto
- [ ] 4.5.0
- [x] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

## Demisto Partner?
- [x] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

