### PR TITLE
Replaced spaces with '%20' in the URL output

### DIFF
--- a/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/CHANGELOG.md
+++ b/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+-
 
 ## [20.5.0] - 2020-05-12
 Set the default value for the *bypass exclusion list* parameter to "true".

--- a/Packs/FeedMicrosoftIntune/ReleaseNotes/1_0_1.md
+++ b/Packs/FeedMicrosoftIntune/ReleaseNotes/1_0_1.md
@@ -1,0 +1,3 @@
+#### Integrations
+- __Microsoft Intune Feed__
+- Replaced spaces with '%20' in the url output

--- a/Packs/FeedMicrosoftIntune/pack_metadata.json
+++ b/Packs/FeedMicrosoftIntune/pack_metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "Microsoft Intune Feed",
-  "description": "Indicators feed from Microsoft Intune",
+  "description": "Indicator feed from Microsoft Intune",
   "support": "Cortex XSOAR",
-  "currentVersion": "1.0.0",
+  "currentVersion": "1.0.1",
   "author": "Cortex XSOAR",
   "url": "https://www.paloaltonetworks.com/cortex",
   "email": "",

--- a/Packs/PAN-OS/Integrations/Panorama/CHANGELOG.md
+++ b/Packs/PAN-OS/Integrations/Panorama/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Added the option to list predefined applications in PAN-OS 9.X in the ***panorama-get-applications*** command using the argument *predefined*.
 - Fixed an issue where listing custom applications in PAN-OS 9.X using the ***panorama-get-applications***  command did not work properly.
 - Fixed an issue where running the ***panorama-get-url-category*** command multiple times, displayed previous results in the war room.
-
+- Replaced the spaces in the URL context output of the **!panorama-create-edl** command to `%20`.   
 
 ## [20.5.0] - 2020-05-12
 - Fixed an issue where commands resulting with an empty list would raise an error instead of a warning.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -3368,7 +3368,7 @@ def panorama_create_edl_command():
     Create an edl object
     """
     edl_name = demisto.args().get('name')
-    url = demisto.args().get('url')
+    url = demisto.args().get('url').replace(' ', '%20')
     type_ = demisto.args().get('type')
     recurring = demisto.args().get('recurring')
     certificate_profile = demisto.args().get('certificate_profile')

--- a/Packs/PAN-OS/ReleaseNotes/1_0_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+- __Panorama__ Replaced the spaces in the URL context output of the **!panorama-create-edl** command to `%20`.   
+

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
   "name": "PAN-OS",
   "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
   "support": "xsoar",
-  "currentVersion": "1.0.0",
+  "currentVersion": "1.0.1",
   "author": "Cortex XSOAR",
   "url": "https://www.paloaltonetworks.com/cortex",
   "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: demisto/etc#24420

## Description
Replaced spaces with '%20' in the URL output

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 


