### PR TITLE
FeedJSON handling flattened list inside a JSON object

### DIFF
--- a/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule.py
+++ b/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule.py
@@ -157,15 +157,14 @@ def fetch_indicators_command(client: Client, indicator_type: str, feedTags: list
     for result in client.build_iterator(**kwargs):
         for service_name, items in result.items():
             feed_config = client.feed_name_to_config.get(service_name, {})
-            indicator_field = feed_config.get('indicator', 'indicator')
+            indicator_field = feed_config.get('indicator') if feed_config.get('indicator') else 'indicator'
             indicator_type = feed_config.get('indicator_type', indicator_type)
             for item in items:
                 mapping = feed_config.get('mapping')
 
                 if isinstance(item, str):
-                    indicator_value = item
-                else:
-                    indicator_value = item.get(indicator_field)
+                    item = {indicator_field: item}
+                indicator_value = item.get(indicator_field)
 
                 current_indicator_type = indicator_type or auto_detect_indicator_type(indicator_value)
                 if not current_indicator_type:
@@ -221,9 +220,6 @@ def extract_all_fields_from_indicator(indicator, indicator_key):
         elif json_element and indicator_key not in json_element:
             for key, value in json_element:
                 insert_value_to_fields(key, value)
-
-    if not isinstance(indicator, dict):
-        return {}
 
     extract(indicator)
     return fields

--- a/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule.py
+++ b/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule.py
@@ -161,7 +161,12 @@ def fetch_indicators_command(client: Client, indicator_type: str, feedTags: list
             indicator_type = feed_config.get('indicator_type', indicator_type)
             for item in items:
                 mapping = feed_config.get('mapping')
-                indicator_value = item.get(indicator_field)
+
+                if isinstance(item, str):
+                    indicator_value = item
+                else:
+                    indicator_value = item.get(indicator_field)
+
                 current_indicator_type = indicator_type or auto_detect_indicator_type(indicator_value)
                 if not current_indicator_type:
                     continue
@@ -176,7 +181,7 @@ def fetch_indicators_command(client: Client, indicator_type: str, feedTags: list
                 if mapping:
                     for map_key in mapping:
                         if map_key in attributes:
-                            indicator['fields'][mapping[map_key]] = attributes.get(map_key)
+                            indicator['fields'][mapping[map_key]] = attributes.get(map_key)  # type: ignore
 
                 indicator['rawJSON'] = item
 
@@ -216,6 +221,9 @@ def extract_all_fields_from_indicator(indicator, indicator_key):
         elif json_element and indicator_key not in json_element:
             for key, value in json_element:
                 insert_value_to_fields(key, value)
+
+    if not isinstance(indicator, dict):
+        return {}
 
     extract(indicator)
     return fields

--- a/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule_test.py
+++ b/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule_test.py
@@ -84,3 +84,36 @@ def test_json_feed_with_config_mapping():
         custom_fields = indicator['fields']
         assert 'Region' in custom_fields
         assert 'region' in indicator['rawJSON']
+
+
+FLAT_LIST_OF_INDICATORS = '''{
+    "hooks": [
+    "1.1.1.1",
+    "2.2.2.2",
+    "3.3.3.3"
+    ]
+}'''
+
+
+def test_list_of_indicators_with_no_json_object():
+    feed_name_to_config = {
+        'AMAZON': {
+            'url': 'https://api.github.com/meta',
+            'extractor': "hooks",
+            'indicator': None
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get('https://api.github.com/meta', json=json.loads(FLAT_LIST_OF_INDICATORS))
+
+        client = Client(
+            url='https://api.github.com/meta',
+            feed_name_to_config=feed_name_to_config,
+            insecure=True
+        )
+
+        indicators = fetch_indicators_command(client=client, indicator_type=None, feedTags=['test'])
+        assert len(indicators) == 3
+        assert indicators[0].get('value') == '1.1.1.1'
+        assert indicators[0].get('type') == 'IP'

--- a/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule_test.py
+++ b/Packs/ApiModules/Scripts/JSONFeedApiModule/JSONFeedApiModule_test.py
@@ -97,7 +97,7 @@ FLAT_LIST_OF_INDICATORS = '''{
 
 def test_list_of_indicators_with_no_json_object():
     feed_name_to_config = {
-        'AMAZON': {
+        'Github': {
             'url': 'https://api.github.com/meta',
             'extractor': "hooks",
             'indicator': None
@@ -117,3 +117,4 @@ def test_list_of_indicators_with_no_json_object():
         assert len(indicators) == 3
         assert indicators[0].get('value') == '1.1.1.1'
         assert indicators[0].get('type') == 'IP'
+        assert indicators[1].get('rawJSON') == {'indicator': '2.2.2.2'}

--- a/Packs/FeedJSON/Integrations/FeedJSON/CHANGELOG.md
+++ b/Packs/FeedJSON/Integrations/FeedJSON/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed an issue where the integration failed to fetch indicators from a list within a JSON object.
+Fixed an issue where the integration failed to fetch indicators from lists within JSON objects.
 
 ## [20.4.0] - 2020-04-14
 Added the *Tags* parameter.

--- a/Packs/FeedJSON/Integrations/FeedJSON/CHANGELOG.md
+++ b/Packs/FeedJSON/Integrations/FeedJSON/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue where the integration failed to fetch indicators from a list within a JSON object.
 
 ## [20.4.0] - 2020-04-14
 Added the *Tags* parameter.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24461

## Description
Added handling for flattened list of indicators inside a JSON object.
Before it was treated as json objects that includes the value, now it also support a list of text indicators one after another. (you can see an example in the test)

## Must have
- [x] Tests
- [x] Documentation 

