### PR TITLE
[trustar-150] Phishing Triage API changes

### DIFF
--- a/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
+++ b/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- Updated Phishing Triage calls
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
@@ -71,30 +71,21 @@ def translate_indicators(ts_indicators, context_path=''):
     ec = {}
     if file_context:
         ec['{}File(val.Name && val.Name === obj.Name)'.format(context_path)] = file_context
-        ec['File(val.Name && val.Name === obj.Name)'] = file_context
     if url_context:
         ec['{}URL(val.Address && val.Address === obj.Address)'.format(context_path)] = url_context
-        ec['URL(val.Address && val.Address === obj.Address)'] = url_context
     if ip_context:
         ec['{}IP(val.Address && val.Address === obj.Address)'.format(context_path)] = ip_context
-        ec['IP(val.Address && val.Address === obj.Address)'] = ip_context
     if email_context:
         ec['{}Account.Email(val.Address && val.Address === obj.Address)'.format(context_path)] = email_context
-        ec['Account.Email(val.Address && val.Address === obj.Address)'] = email_context
     if key_context:
         ec['{}RegistryKey(val.Path && val.Path === obj.Path)'.format(context_path)] = key_context
-        ec['RegistryKey(val.Path && val.Path === obj.Path)'] = key_context
     if cve_context:
         ec['{}CVE(val.ID && val.ID === obj.ID)'.format(context_path)] = cve_context
-        ec['CVE(val.ID && val.ID === obj.ID)'] = cve_context
     return indicators, ec
 
 
 def translate_triage_submission(submissions):
     submission_dicts = [s.to_dict(remove_nones=True) for s in submissions]
-    for submission in submission_dicts:
-        indicators = [c.to_dict(remove_nones=True) for c in submission.get('context')]
-        submission['context'] = indicators
     ec = {'TruSTAR.PhishingSubmission(val.submissionId == obj.submissionId)': submission_dicts}
     return submission_dicts, ec
 
@@ -661,14 +652,14 @@ def get_enclaves():
     return entry
 
 
-def get_all_phishing_indicators(normalized_triage_score,
-                                normalized_source_score,
+def get_all_phishing_indicators(priority_event_score,
+                                normalized_indicator_score,
                                 from_time,
                                 to_time,
                                 status):
     cursor = encode_cursor(1000, 0)
-    args = {'normalized_triage_score': normalized_triage_score,
-            'normalized_source_score': normalized_source_score,
+    args = {'priority_event_score': priority_event_score,
+            'normalized_indicator_score': normalized_indicator_score,
             'status': status,
             'cursor': cursor,
             'from_time': date_to_unix(from_time) if from_time else None,
@@ -689,12 +680,12 @@ def get_all_phishing_indicators(normalized_triage_score,
     return 'No phishing indicators were found.'
 
 
-def get_phishing_submissions(normalized_triage_score,
+def get_phishing_submissions(priority_event_score,
                              from_time,
                              to_time,
                              status):
     cursor = encode_cursor(1000, 0)
-    args = {'normalized_triage_score': normalized_triage_score,
+    args = {'priority_event_score': priority_event_score,
             'status': status,
             'cursor': cursor,
             'from_time': date_to_unix(from_time) if from_time else None,
@@ -820,15 +811,15 @@ try:
                                                  ('Domain', 'URL',), create_domain_ec))
 
     elif demisto.command() == 'trustar-get-phishing-indicators':
-        nts = argToList(demisto.args().get('normalized_triage_score'))
-        nss = argToList(demisto.args().get('normalized_source_score'))
+        nts = argToList(demisto.args().get('priority_event_score'))
+        nss = argToList(demisto.args().get('normalized_indicator_score'))
         ft = demisto.args().get('from_time')
         tt = demisto.args().get('to_time')
         st = argToList(demisto.args().get('status'))
         demisto.results(get_all_phishing_indicators(nts, nss, ft, tt, st))
 
     elif demisto.command() == 'trustar-get-phishing-submissions':
-        nts = argToList(demisto.args().get('normalized_triage_score'))
+        nts = argToList(demisto.args().get('priority_event_score'))
         ft = demisto.args().get('from_time')
         tt = demisto.args().get('to_time')
         st = argToList(demisto.args().get('status'))

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
@@ -626,7 +626,7 @@ script:
     description: Check Domain reputation on TruStar
   - name: trustar-get-phishing-submissions
     arguments:
-    - name: normalized_triage_score
+    - name: priority_event_score
       description: Score of email submission
       isArray: true
       defaultValue: 0,1,2,3
@@ -652,7 +652,7 @@ script:
     - contextPath: TruSTAR.PhishingSubmission.title
       description: Submission title
       type: string
-    - contextPath: TruSTAR.PhishingSubmission.normalizedTriageScore
+    - contextPath: TruSTAR.PhishingSubmission.priorityEventScore
       description: Submission triage score
       type: number
     - contextPath: TruSTAR.PhishingSubmission.context.indicatorType
@@ -661,7 +661,7 @@ script:
     - contextPath: TruSTAR.PhishingSubmission.context.sourceKey
       description: Indicator source
       type: string
-    - contextPath: TruSTAR.PhishingSubmission.context.normalizedSourceScore
+    - contextPath: TruSTAR.PhishingSubmission.context.normalizedIndicatorScore
       description: Indicator score
       type: number
     description: Fetches all phishing submissions that fit the given criteria
@@ -681,11 +681,11 @@ script:
       tags
   - name: trustar-get-phishing-indicators
     arguments:
-    - name: normalized_source_score
+    - name: normalized_indicator_score
       description: Intel score of the indicator
       isArray: true
       defaultValue: 0,1,2,3
-    - name: normalized_triage_score
+    - name: priority_event_score
       description: Score of email submission
       isArray: true
       defaultValue: 0,1,2,3
@@ -733,6 +733,6 @@ script:
       description: CVE ID
       type: string
     description: Get phishing indicators that match the given criteria.
-  dockerimage: demisto/trustar:latest
+  dockerimage: demisto/trustar:20.1.0.8039
   runonce: false
   subtype: python2


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Changes in TruSTAR Phishing Triage API

## Description
Some names and contracts changed in our API the last couple of weeks prior to GA of Phishing Triage.

## Screenshots
This is how the phishing triage commands will look like now:

![image (5)](https://user-images.githubusercontent.com/5058599/82069825-42f23e00-96aa-11ea-8641-7170cd832fe8.png)
![image (6)](https://user-images.githubusercontent.com/5058599/82069826-44236b00-96aa-11ea-9a4d-ec4e2e8eae64.png)


## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [X] Yes
       - Further details: We changed parts of the contract of our Phishing Triage API. This has an impact in some commands that we recently added. Given that we are making Phishing Triage GA after May 18 we needed to replicate it in the integration. Although from an implementation perspective this are breaking changes, we are safe because there are no users using these features yet.
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [X] The title must be in the following format: **[YOUR_PARTNER_ID] short description**



