### PR TITLE
Added the "command" argument that is missing from the command that is…

### DIFF
--- a/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
+++ b/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
@@ -927,7 +927,10 @@ script:
       type: string
     description: Block one or more IP addresses using Checkpoint Firewall
   - name: checkpoint
-    arguments: []
+    arguments:
+      - name: command
+        required: true
+        description: The command to execute
     description: Use Check Point's Management API (requires management server R80
       or later). Specifying 'command'=<API command> is mandatory
   - name: checkpoint-delete-rule


### PR DESCRIPTION
… deemed as "mandatory"

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[24636](https://github.com/demisto/etc/issues/24636)

## Description
The generic command "checkpoint" allows execution of any API command using the "command" input as an argument. This argument is missing. I have added it.

## Screenshots
From this:
![image](https://user-images.githubusercontent.com/53576129/82205002-c0fa5300-98fd-11ea-9857-91b9ae45b029.png)

To this:
![image](https://user-images.githubusercontent.com/53576129/82204829-82fd2f00-98fd-11ea-96f8-981cb228f70e.png)


## Minimum version of Demisto
- [x] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
NA

## Demisto Partner?
NA

