### PR TITLE
Timestamp Replacement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,9 +108,7 @@ jobs:
                 exit 0
             fi
 
-            python3 -m pytest ./Tests/scripts/infrastructure_tests/mock_unit_test.py -v
-            python3 -m pytest ./Tests/scripts/infrastructure_tests/release_notes_test.py -v
-            python3 -m pytest ./Tests/scripts/infrastructure_tests/test_configure_tests.py -v
+            python3 -m pytest ./Tests/scripts/infrastructure_tests/ -v
             python3 -m pytest ./Tests/Marketplace/Tests/marketplace_services_test.py -v
             python3 -m pytest ./Tests/Marketplace/Tests/upload_packs_test.py -v
             python3 -m pytest ./Tests/Marketplace/Tests/search_and_install_packs_test.py -v

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -1,12 +1,15 @@
 from __future__ import print_function
 import os
+import json
 import signal
 import string
 import time
 import unicodedata
 import urllib3
 import demisto_client.demisto_api
-from subprocess import call, Popen, PIPE, check_call, check_output
+from subprocess import call, Popen, PIPE, check_call, check_output, CalledProcessError
+from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
+    LOG_COLORS
 
 VALID_FILENAME_CHARS = '-_.() %s%s' % (string.ascii_letters, string.digits)
 PROXY_PROCESS_INIT_TIMEOUT = 20
@@ -249,6 +252,96 @@ class MITMProxy:
             self.ami.call(['mkdir', '--parents', dst_folder])
             self.ami.call(['mv', src_files, dst_folder])
 
+    def clean_mock_file(self, playbook_id, path=None, thread_index=0, prints_manager=None):
+        prints_manager.add_print_job(f'clean_mock_file was called for test "{playbook_id}"', print, thread_index)
+        path = path or self.current_folder
+        problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
+        prints_manager.add_print_job(f'problem_keys_filepath="{problem_keys_filepath}"', print, thread_index)
+        problem_key_file_exists = ["[", "-f", problem_keys_filepath, "]"]
+        if not self.ami.call(problem_key_file_exists) == 0:
+            err_msg = 'Error: The problematic_keys.json file was not written to the file path' \
+                      ' "{}" when recording the "{}" test playbook'.format(problem_keys_filepath, playbook_id)
+            prints_manager.add_print_job(err_msg, print_error, thread_index)
+            return
+        problem_keys = json.loads(self.ami.check_output(['cat', problem_keys_filepath]))
+        prints_manager.add_print_job(
+            f'Test "{playbook_id}" problem_keys: \n{json.dumps(problem_keys, indent=4)}',
+            print,
+            thread_index
+        )
+
+        # is there data in problematic_keys.json that needs whitewashing?
+        prints_manager.add_print_job('checking if there is data to whitewash', print, thread_index)
+        needs_whitewashing = False
+        for val in problem_keys.values():
+            if val:
+                needs_whitewashing = True
+                break
+
+        if problem_keys and needs_whitewashing:
+            mock_file_path = os.path.join(path, get_mock_file_path(playbook_id))
+            cleaned_mock_filepath = mock_file_path.strip('.mock') + '_cleaned.mock'
+            # rewrite mock file with problematic key values replaced
+            command = 'mitmdump -ns ~/timestamp_replacer.py '
+            log_file = os.path.join(path, get_log_file_path(playbook_id, record=True))
+            # Handle proxy log output
+            debug_opt = f' >>{log_file} 2>&1' if not self.debug else ''
+            options = f'--set script_mode=clean --set keys_filepath={problem_keys_filepath}'
+            if options.strip():
+                command += options
+            command += ' -r {} -w {}{}'.format(mock_file_path, cleaned_mock_filepath, debug_opt)
+            command = "source .bash_profile && {}".format(command)
+            prints_manager.add_print_job(f'command to clean mockfile:\n\t{command}', print, thread_index)
+            split_command = command.split()
+            prints_manager.add_print_job('Let\'s try and clean the mockfile from timestamp data!', print, thread_index)
+            try:
+                clean_cmd_output = check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'))
+                prints_manager.add_print_job(
+                    f'clean_cmd_output.decode()={clean_cmd_output.decode()}',
+                    print,
+                    thread_index
+                )
+            except CalledProcessError as e:
+                cleaning_err_msg = 'There may have been a problem when filtering timestamp data from the mock file.'
+                prints_manager.add_print_job(cleaning_err_msg, print_error, thread_index)
+                err_msg = f'command `{command}` exited with return code [{e.returncode}]'
+                err_msg = f'{err_msg} and the output of "{e.output}"' if e.output else err_msg
+                prints_manager.add_print_job(err_msg, print_error, thread_index)
+            else:
+                prints_manager.add_print_job('Success!', print_color, thread_index, LOG_COLORS.GREEN)
+
+            # verify cleaned mock is different than original
+            verify_diff_start_msg = 'verifying cleaned mock file is different than the original mock file'
+            prints_manager.add_print_job(verify_diff_start_msg, print, thread_index)
+            diff_cmd = 'diff -sq {} {}'.format(cleaned_mock_filepath, mock_file_path)
+            try:
+                diff_cmd_output = self.ami.check_output(diff_cmd.split()).decode().strip()
+                prints_manager.add_print_job(f'diff_cmd_output={diff_cmd_output}', print, thread_index)
+                if diff_cmd_output.endswith('are identical'):
+                    identical_msg = 'cleaned mock file and original mock file are identical... ' \
+                                    'uh oh looks like cleaning didn\'t work properly'
+                    prints_manager.add_print_job(identical_msg, print_warning, thread_index)
+                else:
+                    prints_manager.add_print_job(
+                        'looks like the cleaning process did something!',
+                        print_color,
+                        thread_index,
+                        LOG_COLORS.GREEN
+                    )
+
+            except CalledProcessError as e:
+                err_msg = 'command `{}` exited with return code [{}]'.format(diff_cmd, e.returncode)
+                err_msg = '{} and the output of "{}"'.format(err_msg, e.output) if e.output else err_msg
+                prints_manager.add_print_job(err_msg, print_error, thread_index)
+
+            prints_manager.add_print_job('Replace old mock with cleaned one.', print, thread_index)
+            mv_cmd = 'mv {} {}'.format(cleaned_mock_filepath, mock_file_path)
+            self.ami.call(mv_cmd.split())
+        else:
+            empty_msg = '"problematic_keys.json" dictionary values were empty - ' \
+                        'no data to whitewash from the mock file.'
+            prints_manager.add_print_job(empty_msg, print, thread_index)
+
     def start(self, playbook_id, path=None, record=False, thread_index=0, prints_manager=None):
         """Start the proxy process and direct traffic through it.
 
@@ -267,15 +360,47 @@ class MITMProxy:
         # Create mock files directory
         silence_output(self.ami.call, ['mkdir', os.path.join(path, get_folder_path(playbook_id))], stderr='null')
 
-        # Configure proxy server
-        actions = '--server-replay-kill-extra --server-replay' if not record else '--save-stream-file'
-        command = "mitmdump --ssl-insecure --verbose --listen-port {} {}".format(self.PROXY_PORT, actions).split()
-        command.append(os.path.join(path, get_mock_file_path(playbook_id)))
+        repo_problem_keys_filepath = os.path.join(
+            self.repo_folder, get_folder_path(playbook_id), 'problematic_keys.json'
+        )
+        prints_manager.add_print_job(f'repo_problem_keys_filepath={repo_problem_keys_filepath}', print, thread_index)
+        current_problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
+        prints_manager.add_print_job(
+            f'current_problem_keys_filepath={current_problem_keys_filepath}', print, thread_index
+        )
 
+        script_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'timestamp_replacer.py')
+        prints_manager.add_print_job(f'script_filepath={script_filepath}', print, thread_index)
+        remote_script_path = self.ami.copy_file(script_filepath)
+        prints_manager.add_print_job(f'remote_script_path={remote_script_path}', print, thread_index)
+
+        # if recording
+        # record with detect_timestamps and then rewrite mock file
+        if record:
+            actions = '-s {} '.format(remote_script_path)
+            actions += '--set script_mode=record '
+            actions += '--set detect_timestamps=true --set keys_filepath={} --save-stream-file'.format(
+                current_problem_keys_filepath
+            )
+        else:
+            actions = '-s {} '.format(remote_script_path)
+            actions += '--set script_mode=playback '
+            actions += '--set keys_filepath={} --server-replay-kill-extra --server-replay'.format(
+                repo_problem_keys_filepath
+            )
+
+        log_file = os.path.join(path, get_log_file_path(playbook_id, record))
         # Handle proxy log output
-        if not self.debug:
-            log_file = os.path.join(path, get_log_file_path(playbook_id, record))
-            command.extend(['>{}'.format(log_file), '2>&1'])
+        debug_opt = " >{} 2>&1".format(log_file) if not self.debug else ''
+
+        # all mitmproxy/mitmdump commands should have the 'source .bash_profile && ' prefix to ensure the PATH
+        # is correct when executing the command over ssh
+        # Configure proxy server
+        command = "source .bash_profile && mitmdump --ssl-insecure --verbose --listen-port {} {} {}{}".format(
+            self.PROXY_PORT, actions, os.path.join(path, get_mock_file_path(playbook_id)), debug_opt
+        )
+        prints_manager.add_print_job(f'mitm command: "{command}"', print, thread_index)
+        command = command.split()
 
         # Start proxy server
         self.process = Popen(self.ami.add_ssh_prefix(command, "-t"), stdout=PIPE, stderr=PIPE)
@@ -297,17 +422,18 @@ class MITMProxy:
         proxy_up_message = 'Proxy process up and running. Took {} seconds'.format(seconds_since_init)
         prints_manager.add_print_job(proxy_up_message, print, thread_index)
 
-    def stop(self):
+    def stop(self, thread_index=0, prints_manager=None):
         if not self.process:
             raise Exception("Cannot stop proxy - not running.")
 
+        prints_manager.add_print_job('proxy.stop() was called', print, thread_index)
         self.process.send_signal(signal.SIGINT)  # Terminate proxy process
         self.ami.call(["rm", "-rf", "/tmp/_MEI*"])  # Clean up temp files
 
         # Handle logs
         if self.debug:
-            print("proxy outputs:")
-            print(self.process.stdout.read())
-            print(self.process.stderr.read())
+            prints_manager.add_print_job('proxy outputs:', print, thread_index)
+            prints_manager.add_print_job(f'{self.process.stdout.read()}', print, thread_index)
+            prints_manager.add_print_job(f'{self.process.stderr.read()}', print, thread_index)
 
         self.process = None

--- a/Tests/scripts/ami_mock_dependencies_setup.sh
+++ b/Tests/scripts/ami_mock_dependencies_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+echo "Starting mitmproxy dependencies setup"
+echo "-------------------------------------"
+
+sudo yum -y install python3
+python3 -m pip install --user pipx
+# disable-secrets-detection-start
+echo "
+export PATH=$HOME/.local/bin:$PATH" >> ~/.bash_profile
+# disable-secrets-detection-end
+source ~/.bash_profile
+pipx install mitmproxy
+pipx inject mitmproxy python-dateutil
+
+echo "'mitmproxy' installed and 'python-dateutil' dependency injected"
+echo "mitmproxy dependencies setup completed"
+echo "--------------------------------------"

--- a/Tests/scripts/copy_content_data.sh
+++ b/Tests/scripts/copy_content_data.sh
@@ -9,6 +9,9 @@ USER="ec2-user"
 echo "[`date`] ${PUBLIC_IP}: add instance to known hosts"
 ssh-keyscan -H ${PUBLIC_IP} >> ~/.ssh/known_hosts
 
+MOCKS_SETUP_DEPS_COMMAND=`cat ./Tests/scripts/ami_mock_dependencies_setup.sh`
+ssh ${USER}@${PUBLIC_IP} "eval ${MOCKS_SETUP_DEPS_COMMAND}" &>/dev/null
+
 echo "[`date`] ${PUBLIC_IP}: start server"
 
 START_SERVER_COMMAND="sudo systemctl start demisto"

--- a/Tests/timestamp_replacer.py
+++ b/Tests/timestamp_replacer.py
@@ -1,0 +1,465 @@
+import json
+import functools
+import urllib
+from collections import OrderedDict
+from os import path
+from copy import deepcopy
+from typing import List, Union
+from mitmproxy import ctx, flow
+from mitmproxy.http import HTTPRequest
+from mitmproxy.script import concurrent
+from mitmproxy.addons.serverplayback import ServerPlayback
+from time import ctime
+from dateutil.parser import parse
+
+
+def record_concurrently(replaying: bool = False):
+    '''
+    A decorator to return a decorator that just executes the function it decorates normally if 'replaying' is true,
+    (AKA mitmdump is executing in server-replay mode or reading in a mock file and cleaning it and saving the cleaned
+    mock to a new file), otherwise pass the 'concurrant' decorater so that when mitmdump is executing in recording
+    mode, that requests will be processed concurrently and not be blocking which can cause proxy errors during
+    recording if multiple requests are made in a short timespan.
+
+    Arguments:
+        replaying (bool): True if timestamp replacer script is running in server playback mode or cleaning a mock file
+
+    Returns:
+        (function): decorator
+    '''
+    print(f'replaying={replaying}')
+    if replaying:
+        def nonconcurrent_decorator(func):
+            @functools.wraps(func)
+            def passthrough_wrapper(*args, **kwargs):
+                value = func(*args, **kwargs)
+                return value
+            return passthrough_wrapper
+        return nonconcurrent_decorator
+    else:
+        return concurrent
+
+
+class TimestampReplacer:
+    def __init__(self):
+        self.count = 0
+        self.constant = 'constant_value'
+        self.json_keys = set()
+        self.form_keys = set()
+        self.query_keys = set()
+        self.bad_keys_filepath = ''
+        self.detect_timestamps = False
+
+    def load(self, loader):
+        loader.add_option(
+            name='detect_timestamps',
+            typespec=bool,
+            default=False,
+            help='''
+            Set to True only if recording a mock file. Used to determine which keys need to be replaced in incoming
+            request bodies during a mock playback.
+            '''
+        )
+        loader.add_option(
+            name='keys_filepath',
+            typespec=str,
+            default='problematic_keys.json',  # disable-secrets-detection
+            help='''
+            The path to the file that contains the problematic keys for the test playbook recording that resides
+            in the same directory.
+            '''
+        )
+        loader.add_option(
+            name='script_mode',
+            typespec=str,
+            default='playback',
+            help='''
+            The mode that timestamp_replacer.py is being executed in. The options are 'record', 'clean', and
+            'playback'. If no option is provided, defaults to 'playback'.
+            '''
+        )
+        loader.add_option(
+            name='debug',
+            typespec=bool,
+            default=False,
+            help='''
+            Set to True to print out additional information for each request that comes in.
+            '''
+        )
+
+    def running(self):
+        if ctx.options.debug:
+            print(f'ctx.options={ctx.options}')
+
+        self.bad_keys_filepath = ctx.options.keys_filepath
+        if ctx.options.detect_timestamps:
+            print('Detecting Timestamp Fields')
+            self.detect_timestamps = True
+        self.load_problematic_keys()
+
+    def _debug_request(self, flow: flow.Flow) -> None:
+        '''Print details of the request'''
+        req = flow.request
+        print(f'{req.method} {req.pretty_url}')
+        _, _, path, _, query, _ = urllib.parse.urlparse(req.url)
+        queriesArray = urllib.parse.parse_qsl(query, keep_blank_values=True)
+        print(f'queriesArray={queriesArray}')
+        if req.multipart_form:
+            print(f'multipart_form data = {req.multipart_form.items()}')
+        if req.urlencoded_form:
+            print(f'urlencoded_form data = {req.urlencoded_form.items()}')
+        print(f'hashed_data={ServerPlayback._hash(self, flow)}')
+
+    # @record_concurrently(
+    #     replaying=bool(
+    #         ctx.options.server_replay or (ctx.options.rfile and ctx.options.save_stream_file)
+    #     )
+    # )
+    def request(self, flow: flow.Flow) -> None:
+        self.count += 1
+        if ctx.options.debug:
+            self._debug_request(flow)
+        req = flow.request
+        if ctx.options.script_mode == 'record':
+            if ctx.options.detect_timestamps:
+                self.run_all_key_detections(req)
+                print('updating problem_keys file at "{}"'.format(self.bad_keys_filepath))
+                self.update_problem_keys_file()
+        elif ctx.options.script_mode in {'clean', 'playback'}:
+            print(f'mode={ctx.options.script_mode} cleaning problematic key values from the request')
+            self.clean_bad_keys(req)
+
+    def clean_bad_keys(self, req: HTTPRequest) -> None:
+        '''Modify the request so that values of problematic keys are constant data
+
+        Args:
+            req (HTTPRequest): The request to modify
+        '''
+        self.clean_url_query(req)
+        self.clean_urlencoded_form(req)
+        self.clean_multipart_form(req)
+        self.clean_json_body(req)
+
+    def clean_url_query(self, req: HTTPRequest) -> None:
+        '''Replace any problematic values of query parameters with constant data
+
+        Args:
+            req (HTTPRequest): The request to modify
+        '''
+        query_data = req._get_query()
+        print('fetched query_data: {}'.format(query_data))
+        updated_query_data = []
+        if query_data and self.query_keys:
+            for key, val in query_data:
+                if key in self.query_keys:
+                    updated_query_data.append((key, self.constant))
+                else:
+                    updated_query_data.append((key, val))
+            req._set_query(updated_query_data)
+            print(f'updated query_data: {req._get_query()}')
+
+    def clean_urlencoded_form(self, req: HTTPRequest) -> None:
+        '''Replace any problematic values of urlencoded form keys with constant data
+
+        Args:
+            req (HTTPRequest): The request to modify
+        '''
+        if req.urlencoded_form and self.form_keys:
+            updated_urlencoded_form_data = []
+            for key, val in req.urlencoded_form.items(multi=True):
+                if key in self.form_keys:
+                    updated_urlencoded_form_data.append((key, self.constant))
+                else:
+                    updated_urlencoded_form_data.append((key, val))
+            req._set_urlencoded_form(updated_urlencoded_form_data)
+
+    def clean_multipart_form(self, req: HTTPRequest) -> None:
+        '''Replace any problematic values of multipart form keys with constant data
+
+        Args:
+            req (HTTPRequest): The request to modify
+        '''
+        if req.multipart_form and self.form_keys:
+            updated_multipart_form_data = []
+            for key, val in req.multipart_form.items(multi=True):
+                if key in self.form_keys:
+                    updated_multipart_form_data.append((key, self.constant))
+                else:
+                    updated_multipart_form_data.append((key, val))
+            req._set_multipart_form(updated_multipart_form_data)
+
+    def clean_json_body(self, req: HTTPRequest) -> None:
+        '''Replace any problematic values of keys in the request's json body (if it has one)
+
+        Args:
+            req (HTTPRequest): The request to modify
+        '''
+        if req.method == 'POST':
+            raw_content = req.raw_content
+            if raw_content is not None:
+                content = req.raw_content.decode()
+            else:
+                content = ''
+            json_data = content.startswith('{')
+            if json_data:
+                content = json.loads(content, object_pairs_hook=OrderedDict)
+                self.modify_json_body(req, content)
+
+    def modify_json_body(self, req: HTTPRequest, json_body: dict) -> None:
+        '''Modify the json body of a request by replacing any timestamp data with constant data
+
+        Args:
+            req (HTTPRequest): The request whose json body will be modified.
+            json_body (dict): The request body to modify.
+        '''
+        original_content = deepcopy(json_body)
+        body = json_body
+        modified = False
+        keys_to_replace = self.json_keys
+        print('{}'.format(keys_to_replace))
+        for key_path in keys_to_replace:
+            body = json_body
+            keys = key_path.split('.')
+            print('keypath parts: {}'.format(keys))
+            lastkey = keys[-1]
+            print('lastkey: {}'.format(lastkey))
+            skip_key = False
+            for k in keys[:-1]:
+                if k in body:
+                    body = body[k]
+                elif isinstance(body, list) and k.isdigit():
+                    if int(k) > len(body) - 1:
+                        skip_key = True
+                        break
+                    body = body[int(k)]
+                else:
+                    skip_key = True
+                    break
+            if not skip_key:
+                if lastkey in body:
+                    print('modifying request to "{}"'.format(req.pretty_url))
+                    body[lastkey] = self.constant
+                    modified = True
+                elif isinstance(body, list) and lastkey.isdigit() and int(lastkey) <= len(body) - 1:
+                    print('modifying request to "{}"'.format(req.pretty_url))
+                    body[int(lastkey)] = self.constant
+                    modified = True
+        if modified:
+            print('original request body:\n{}'.format(json.dumps(original_content, indent=4)))
+            print('modified request body:\n{}'.format(json.dumps(json_body, indent=4)))
+            req.set_content(json.dumps(json_body).encode())
+
+    def run_all_key_detections(self, req: HTTPRequest) -> None:
+        '''Used to detect problematic keys in
+        1. request query parameters
+        2. urlencoded forms parameters and multipart forms parameters
+        3. json request body
+
+        Args:
+            req (HTTPRequest): The request to inspect for problematic keys
+        '''
+        self.handle_url_query(req)
+        self.handle_urlencoded_form(req)
+        self.handle_multipart_form(req)
+        self.handle_json_body(req)
+
+    def handle_url_query(self, req: HTTPRequest) -> None:
+        query_data = req._get_query()
+        print('query_data: {}'.format(query_data))
+        for key, val in query_data:
+            # don't bother trying to interpret an argument less than 4 characters as some type of timestamp
+            if len(val) > 4:
+                try:
+                    parse(val)
+                    self.query_keys.add(key)
+                except ValueError:
+                    pass
+
+    def handle_multipart_form(self, req: HTTPRequest) -> None:
+        '''Used when detecting what keys in a multipart form to replace with constants.
+
+        Args:
+            req (HTTPRequest): The request to inspect
+        '''
+        if req.multipart_form:
+            for key, val in req.multipart_form.items(multi=True):
+                # don't bother trying to interpret an argument less than 4 characters as some type of timestamp
+                if len(val) > 4:
+                    try:
+                        parse(val)
+                        self.form_keys.add(key)
+                    except ValueError:
+                        pass
+
+    def handle_urlencoded_form(self, req: HTTPRequest) -> None:
+        '''Used when detecting what keys in an url encoded parameters to replace with constants.
+
+        Args:
+            req (HTTPRequest): The request to inspect
+        '''
+        if req.urlencoded_form:
+            for key, val in req.urlencoded_form.items(multi=True):
+                # don't bother trying to interpret an argument less than 4 characters as some type of timestamp
+                if len(val) > 4:
+                    try:
+                        parse(val)
+                        self.form_keys.add(key)
+                    except ValueError:
+                        pass
+
+    def handle_json_body(self, req: HTTPRequest) -> None:
+        '''Used when detecting what keys in a request's json body to replace with constants.
+
+        Args:
+            req (HTTPRequest): The request to inspect
+        '''
+        if req.method == 'POST':
+            raw_content = req.raw_content
+            if raw_content is not None:
+                content = req.raw_content.decode()
+            else:
+                content = ''
+            json_data = content.startswith('{')
+            if json_data:
+                content = json.loads(content, object_pairs_hook=OrderedDict)
+                json_keys = self.determine_problematic_keys(content)
+                self.json_keys.update(json_keys)
+
+    def determine_problematic_keys(self, content: dict) -> List[str]:
+        '''Given a json request body, return the keys (in dot notation) whose values are potentially timestamp data.
+
+        Args:
+            content (dict): The json request body to iterate through and find problematic timestamp data.
+
+        Returns:
+            List[str]: A list of keys (in dot notation, e.g. 'query.filter.time' is an example of what could be one
+                problematic key) whose values are potentially timestamp data.
+        '''
+        def travel_dict(obj: Union[dict, list], key_path='') -> List[str]:
+            bad_key_paths = []
+            if isinstance(obj, dict):
+                for key, val in obj.items():
+                    sub_key_path = '{}.{}'.format(key_path, key) if key_path else key
+                    if isinstance(val, (list, dict)):
+                        bad_key_paths.extend(travel_dict(val, sub_key_path))
+                    else:
+                        is_string = isinstance(val, str) and len(val) > 4
+                        possible_timestamp = isinstance(val, (int, float)) and len(str(val)) >= 8
+                        try:
+                            if is_string or possible_timestamp:
+                                for_eval = val
+                                if possible_timestamp:
+                                    if isinstance(for_eval, float):
+                                        digits = str(val).split('.')
+                                        for_eval = digits[0]
+                                    if len(str(for_eval)) < 13:
+                                        parse(ctime(val))
+                                    else:
+                                        parse(ctime(val / 1000.0))
+                                else:
+                                    parse(val)
+                                # if it continues to the next line that means it successfully parsed the object
+                                # and it's some sort of time-related object
+                                bad_key_paths.append(sub_key_path)
+                        except (ValueError, OverflowError):
+                            pass
+            elif isinstance(obj, list):
+                for i, val in enumerate(obj):
+                    sub_key_path = '{}.{}'.format(key_path, i) if key_path else i
+                    if isinstance(val, (list, dict)):
+                        bad_key_paths.extend(travel_dict(val, sub_key_path))
+                    else:
+                        is_string = isinstance(val, str) and len(val) > 4
+                        possible_timestamp = isinstance(val, (int, float)) and len(str(val)) >= 8
+                        try:
+                            if is_string or possible_timestamp:
+                                for_eval = val
+                                if possible_timestamp:
+                                    if isinstance(for_eval, float):
+                                        digits = str(val).split('.')
+                                        for_eval = digits[0]
+                                    if len(str(for_eval)) < 13:
+                                        parse(ctime(val))
+                                    else:
+                                        parse(ctime(val / 1000.0))
+                                else:
+                                    parse(val)
+                                # if it continues to the next line that means it successfully parsed the object
+                                # and it's some sort of time-related object
+                                bad_key_paths.append(sub_key_path)
+                        except (ValueError, OverflowError):
+                            pass
+            return bad_key_paths
+        bad_keys = travel_dict(content)
+        return bad_keys
+
+    def update_problem_keys_file(self):
+        '''Update the problem keys dictionary at the keys_filepath with new problematic keys'''
+        existing_problem_keys = self.read_in_problematic_keys()
+        for key, val in existing_problem_keys.items():
+            if key == 'keys_to_replace':
+                existing_problem_keys[key] = ' '.join(set(val.split()).union(self.json_keys))
+            elif key == 'server_replay_ignore_payload_params':
+                existing_problem_keys[key] = ' '.join(set(val.split()).union(self.form_keys))
+            elif key == 'server_replay_ignore_params':
+                existing_problem_keys[key] = ' '.join(set(val.split()).union(self.query_keys))
+        self.write_out_problematic_keys(existing_problem_keys)
+
+    def read_in_problematic_keys(self):
+        '''Load problematic keys dictionary from the keys_filepath argument filepath in content-test-data repo
+        if it exists. Otherwise, return the dictionary with empty values.
+        '''
+        print('executing "read_in_problematic_keys" method')
+        repo_bad_keys_filepath = self.bad_keys_filepath.replace('/tmp/Mocks', 'content-test-data')
+        print('reading in problematic keys data from "{}"'.format(repo_bad_keys_filepath))
+        if not path.exists(self.bad_keys_filepath) and path.exists(repo_bad_keys_filepath):
+            with open(repo_bad_keys_filepath, 'r') as fp:
+                problem_keys = json.load(fp)
+        elif path.exists(self.bad_keys_filepath):
+            with open(self.bad_keys_filepath, 'r') as fp:
+                problem_keys = json.load(fp)
+        else:
+            problem_keys = {
+                'keys_to_replace': '',
+                'server_replay_ignore_params': '',
+                'server_replay_ignore_payload_params': ''
+            }
+        return problem_keys
+
+    def write_out_problematic_keys(self, problem_keys: dict):
+        '''Write updated problematic keys dictionary back to the file at the keys_filepath argument
+
+        Args:
+            problem_keys (dict): Updated dictionary of problematic keys
+        '''
+        with open(self.bad_keys_filepath, 'w') as bad_keys_file:
+            bad_keys_file.write(json.dumps(problem_keys, indent=4))
+
+    def load_problematic_keys(self):
+        '''Load problematic keys from the keys_filepath argument filepath if it exists. Only necessary when running
+        mitmdump in playback mode. Resets command line options with the key value pairs from the loaded dictionary.
+        '''
+        print('executing "load_problematic_keys" method')
+        if path.exists(self.bad_keys_filepath):
+            print('"{}" path exists - loading bad keys'.format(self.bad_keys_filepath))
+
+            problem_keys = json.load(open(self.bad_keys_filepath, 'r'))
+
+            query_keys = problem_keys.get('server_replay_ignore_params')
+            self.query_keys.update(query_keys.split() if isinstance(query_keys, str) else query_keys)
+            form_keys = problem_keys.get('server_replay_ignore_payload_params')
+            self.form_keys.update(form_keys.split() if isinstance(form_keys, str) else form_keys)
+            json_keys = problem_keys.get('keys_to_replace')
+            self.json_keys.update(json_keys.split() if isinstance(json_keys, str) else json_keys)
+
+            print('bad keys loaded\n---------------')
+            print(f'self.query_keys={self.query_keys}')
+            print(f'self.form_keys={self.form_keys}')
+            print(f'self.json_keys={self.json_keys}')
+        else:
+            print('"{}" path doesn\'t exist - no bad keys to set'.format(self.bad_keys_filepath))
+            print('not setting bad keys from file')
+
+
+# mitmproxy picks up the contents of the addons global list and loads what it finds into the addons mechanism.
+addons = [TimestampReplacer()]


### PR DESCRIPTION
## Status
- [x] Ready.

## Description
Implements timestamp replacement script that is executed by `mitmdump`. After recording a mock file, the file is edited to replace timestamp data with constant values. The next time that a test playbook is executed against that mock, the requests are modified as they are made to replace the same timestamp data that was replaced in the mock file with the same constant values so that the requests being made by the test playbook match the requests in the edited mock file.

## Minimum version of Demisto
- [x] 4.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

