### PR TITLE
Replaced SendEmail with send-mail in Phishing v2

### DIFF
--- a/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2.yml
+++ b/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2.yml
@@ -245,35 +245,37 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-  '16':
-    id: '16'
-    taskid: 417da9df-5b58-4530-8dae-8591592a06df
+  "16":
+    id: "16"
+    taskid: b2b37a86-85e8-4385-811c-004dd3b0b215
     type: regular
     task:
-      id: 417da9df-5b58-4530-8dae-8591592a06df
+      id: b2b37a86-85e8-4385-811c-004dd3b0b215
       version: -1
       name: Update  the user that the reported email is safe
-      description: Send an email to the user explaining that the email they reported
-        is safe.
-      scriptName: SendEmail
+      description: Send an email to the user explaining that the email they reported is safe.
+      script: '|||send-mail'
       type: regular
-      iscommand: false
-      brand: ''
+      iscommand: true
+      brand: ""
     nexttasks:
       '#none#':
-      - '8'
+      - "8"
     scriptarguments:
+      attachCIDs: {}
       attachIDs: {}
+      attachNames: {}
       bcc: {}
       body:
-        simple: "Hi ${.=val.Account.DisplayName && val.Email.Address === val.incident.labels['Email/from']\
-          \ ? val.Account.DisplayName : val.incident.labels['Email/from']},\nWe've\
-          \ concluded that the email you forwarded to us is safe.\nThank you for your\
-          \ alertness and your participation in keeping our organization secure.\n\
-          \nCordially,\n  Your security team"
+        simple: |-
+          Hi ${.=val.Account.DisplayName && val.Email.Address === val.incident.labels['Email/from'] ? val.Account.DisplayName : val.incident.labels['Email/from']},
+          We've concluded that the email you forwarded to us is safe.
+          Thank you for your alertness and your participation in keeping our organization secure.
+
+          Cordially,
+            Your security team
       cc: {}
       htmlBody: {}
-      noteEntryID: {}
       replyTo: {}
       subject:
         simple: 'Re: Phishing Investigation - ${incident.name}'
@@ -281,7 +283,13 @@ tasks:
         simple: ${incident.labels.Email/from}
     reputationcalc: 1
     separatecontext: false
-    view: "{\n  \"position\": {\n    \"x\": 130,\n    \"y\": 3930\n  }\n}"
+    view: |-
+      {
+        "position": {
+          "x": 130,
+          "y": 3930
+        }
+      }
     note: false
     timertriggers:
     - fieldname: detectionsla

--- a/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2_CHANGELOG.md
+++ b/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2_CHANGELOG.md
@@ -1,8 +1,6 @@
 ## [Unreleased]
--
-
-## [20.5.0] - 2020-05-12
-The playbook now uses Block Indicators - Generic v2 to block malicious indicators (off by default).
+- The playbook now uses Block Indicators - Generic v2 to block malicious indicators (off by default).
+- Replaced the deprecated SendEmail automation with the send-mail command. 
 
 ## [20.4.1] - 2020-04-29
 - Added the *OnCall* input to assign only users that are on shift.

--- a/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2_README.md
+++ b/Packs/Phishing/Playbooks/Phishing_Investigation_-_Generic_v2_README.md
@@ -24,7 +24,6 @@ This playbook uses the following sub-playbooks, integrations, and scripts.
 ### Scripts
 * DBotPredictPhishingWords
 * AssignAnalystToIncident
-* SendEmail
 * CheckEmailAuthenticity
 * Set
 
@@ -53,4 +52,4 @@ There are no outputs for this playbook.
 
 ## Playbook Image
 ---
-![Phishing_Investigation_Generic_v2](https://raw.githubusercontent.com/demisto/content/7a20daa4d3560df3be0d2f3f41c00d43ac1a1e23/Packs/Phishing/doc_files/Phishing_Investigation_Generic_v2.png)
+![Phishing_Investigation_Generic_v2](https://raw.githubusercontent.com/demisto/content/master/docs/images/playbooks/Phishing_Investigation_Generic_v2.png)


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24202

## Description
Replaced the deprecated `SendEmail` script with the `send-mail` command.

## Minimum version of Demisto
4.5.0

## Does it break backward compatibility?
No


