### PR TITLE
Replaced deprecated searchincidents in ExtraHop - Ticket Tracking

### DIFF
--- a/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking.yml
+++ b/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking.yml
@@ -1,6 +1,5 @@
 id: ExtraHop - Ticket Tracking
 version: -1
-fromversion: 4.5.0
 name: ExtraHop - Ticket Tracking
 description: Links the Demisto incident back to the ExtraHop detection that created
   it for ticket tracking purposes.
@@ -14,9 +13,9 @@ tasks:
       id: 71394f2c-bc76-4885-8bab-b55ce0094789
       version: -1
       name: ""
-      description: ""
       iscommand: false
       brand: ""
+      description: ''
     nexttasks:
       '#none#':
       - "15"
@@ -90,10 +89,10 @@ tasks:
       id: f4953d89-2219-4d74-8acf-d819728d0ac9
       version: -1
       name: Done
-      description: ""
       type: title
       iscommand: false
       brand: ""
+      description: ''
     separatecontext: false
     view: |-
       {
@@ -245,15 +244,14 @@ tasks:
     ignoreworker: false
   "4":
     id: "4"
-    taskid: 8185a734-72c0-4461-83d4-774c4cc8652a
+    taskid: 695438ce-bf6a-43e8-8d73-3b314c1ea1e5
     type: regular
     task:
-      id: 8185a734-72c0-4461-83d4-774c4cc8652a
+      id: 695438ce-bf6a-43e8-8d73-3b314c1ea1e5
       version: -1
       name: Search for any untracked ExtraHop Detections
-      description: Searches Demisto incidents for any ExtraHop Detections that are
-        untracked.
-      scriptName: SearchIncidents
+      description: Searches Demisto incidents for any ExtraHop Detections that are untracked.
+      scriptName: SearchIncidentsV2
       type: regular
       iscommand: false
       brand: ""
@@ -736,9 +734,11 @@ view: |-
 inputs:
 - key: OnCall
   value:
-    simple: false
+    simple: "false"
   required: false
-  description: Set to true to assign only user that is currently on shift. Requires Cortex XSOAR v5.5 or later.
+  description: Set to true to assign only user that is currently on shift. Requires
+    Cortex XSOAR v5.5 or later.
 outputs: []
+fromversion: 4.5.0
 tests:
 - ExtraHop_v2-Test

--- a/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking_CHANGELOG.md
+++ b/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
--
+Searching incidents is now done using SearchIncidentsV2 instead of the deprecated SearchIncidents automation.
 
 ## [20.4.1] - 2020-04-29
 Added the *OnCall* input to assign only users that are on shift.

--- a/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking_README.md
+++ b/Packs/DeprecatedContent/Playbooks/playbook-ExtraHop_-_Ticket_Tracking_README.md
@@ -5,14 +5,14 @@ This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
 This playbook does not use any sub-playbooks.
-
+e
 ### Integrations
 * Builtin
 
 ### Scripts
 * AssignAnalystToIncident
 * Exists
-* SearchIncidents
+* SearchIncidentsV2
 
 ### Commands
 * extrahop-track-ticket


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24207

## Description
Replaced deprecated `SearchIncidents` with `SearchIncidentsV2` in `ExtraHop - Ticket Tracking`

## Minimum version of Demisto
4.5.0

## Does it break backward compatibility?
   - [x] No


