### PR TITLE
Use handle_proxy() in all requests in SplunkPy integration.

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -161,7 +161,7 @@ def updateNotableEvents(sessionKey, baseurl, comment, status=None, urgency=None,
     args['output_mode'] = 'json'
 
     mod_notables = requests.post(baseurl + 'services/notable_update', data=args, headers=auth_header,
-                                 verify=VERIFY_CERTIFICATE,proxies=PROXIES)
+                                 verify=VERIFY_CERTIFICATE, proxies=PROXIES)
 
     return mod_notables.json()
 
@@ -546,7 +546,7 @@ def splunk_submit_event_hec(hec_token, baseurl, event, fields, host, index, sour
     }
 
     response = requests.post(baseurl + '/services/collector/event', data=json.dumps(args), headers=headers,
-                             verify=VERIFY_CERTIFICATE,proxies=PROXIES)
+                             verify=VERIFY_CERTIFICATE, proxies=PROXIES)
     return response
 
 
@@ -579,7 +579,7 @@ def splunk_edit_notable_event_command():
     password = demisto.params()['authentication']['password']
     auth_req = requests.post(baseurl + 'services/auth/login',
                              data={'username': username, 'password': password, 'output_mode': 'json'},
-                             verify=VERIFY_CERTIFICATE,proxies=PROXIES)
+                             verify=VERIFY_CERTIFICATE, proxies=PROXIES)
 
     sessionKey = auth_req.json()['sessionKey']
     eventIDs = None

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -573,7 +573,7 @@ def splunk_submit_event_hec_command():
         demisto.results('The event was sent successfully to Splunk.')
 
 
-def splunk_edit_notable_event_command(proxy):
+def splunk_edit_notable_event_command():
     baseurl = 'https://' + demisto.params()['host'] + ':' + demisto.params()['port'] + '/'
     username = demisto.params()['authentication']['identifier']
     password = demisto.params()['authentication']['password']
@@ -706,7 +706,7 @@ def main():
     if demisto.command() == 'splunk-submit-event':
         splunk_submit_event_command(service)
     if demisto.command() == 'splunk-notable-event-edit':
-        splunk_edit_notable_event_command(proxy)
+        splunk_edit_notable_event_command()
     if demisto.command() == 'splunk-parse-raw':
         splunk_parse_raw_command()
     if demisto.command() == 'splunk-submit-event-hec':

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -24,6 +24,7 @@ VERIFY_CERTIFICATE = not bool(params.get('unsecure'))
 FETCH_LIMIT = int(params.get('fetch_limit', 50))
 FETCH_LIMIT = max(min(200, FETCH_LIMIT), 1)
 PROBLEMATIC_CHARACTERS = ['.', '(', ')', '[', ']']
+PROXIES = handle_proxy()
 REPLACE_WITH = '_'
 REPLACE_FLAG = params.get('replaceKeys', False)
 FETCH_TIME = demisto.params().get('fetch_time')
@@ -160,7 +161,7 @@ def updateNotableEvents(sessionKey, baseurl, comment, status=None, urgency=None,
     args['output_mode'] = 'json'
 
     mod_notables = requests.post(baseurl + 'services/notable_update', data=args, headers=auth_header,
-                                 verify=VERIFY_CERTIFICATE)
+                                 verify=VERIFY_CERTIFICATE,proxies=PROXIES)
 
     return mod_notables.json()
 
@@ -545,7 +546,7 @@ def splunk_submit_event_hec(hec_token, baseurl, event, fields, host, index, sour
     }
 
     response = requests.post(baseurl + '/services/collector/event', data=json.dumps(args), headers=headers,
-                             verify=VERIFY_CERTIFICATE)
+                             verify=VERIFY_CERTIFICATE,proxies=PROXIES)
     return response
 
 
@@ -573,17 +574,12 @@ def splunk_submit_event_hec_command():
 
 
 def splunk_edit_notable_event_command(proxy):
-    if not proxy:
-        os.environ["HTTPS_PROXY"] = ""
-        os.environ["HTTP_PROXY"] = ""
-        os.environ["https_proxy"] = ""
-        os.environ["http_proxy"] = ""
     baseurl = 'https://' + demisto.params()['host'] + ':' + demisto.params()['port'] + '/'
     username = demisto.params()['authentication']['identifier']
     password = demisto.params()['authentication']['password']
     auth_req = requests.post(baseurl + 'services/auth/login',
                              data={'username': username, 'password': password, 'output_mode': 'json'},
-                             verify=VERIFY_CERTIFICATE)
+                             verify=VERIFY_CERTIFICATE,proxies=PROXIES)
 
     sessionKey = auth_req.json()['sessionKey']
     eventIDs = None

--- a/Packs/SplunkPy/ReleaseNotes/1_0_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Use handle_proxy() for all requests

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SplunkPy",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
It's a standard across integrations to use the common server method 'handle_proxy'. The SplunkPy integration has 3 requests.post call and it was relying on the older method of checking `if not proxy: then do this or that`. This PR sets a variable `PROXIES=handle_proxy()` in the beginning of the file and everywhere there is a requests call adds `proxies=PROXIES` to it.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

