### PR TITLE
fix to support array in "fp-add-address-to-category" command

### DIFF
--- a/Packs/Forcepoint/Integrations/integration-Forcepoint.yml
+++ b/Packs/Forcepoint/Integrations/integration-Forcepoint.yml
@@ -282,8 +282,12 @@ script:
         if (!args.categoryID && !args.categoryName) {
             throw "Please provide either the category name or it's ID.";
         }
-        var urls = args.urls ? args.urls.split(',') : undefined;
-        var ips = args.ips ? args.ips.split(',') : undefined;
+        if (args.urls){
+            var urls = Array.isArray(args.urls) ? args.urls: args.urls.split(',');
+        }
+        if (args.ips){
+            var ips = Array.isArray(args.ips) ? args.ips: args.ips.split(',');
+        }
         var res = args.categoryID ? editAddressRequest(urls, ips, parseInt(args.categoryID)) : editAddressRequest(urls, ips, undefined, args.categoryName);
         var title = 'Forcepoint Category Details';
         var data = [
@@ -515,8 +519,10 @@ script:
     arguments:
     - name: urls
       description: 'Comma separated list of URL addresses to add. '
+      isArray: true
     - name: ips
       description: 'Comma separated list of IP address to add. '
+      isArray: true
     - name: categoryID
       description: The category ID. Leave blank if category name is provided.
     - name: categoryName


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/23320

## Description
fix to support array in "fp-add-address-to-category" command.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 