### PR TITLE
SplunkPy - correct the usage of fields for hec submit event command

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -528,11 +528,18 @@ def splunk_submit_event_hec(hec_token, baseurl, event, fields, host, index, sour
 
     if hec_token is None:
         raise Exception('The HEC Token was not provided')
+    
+    parsed_fields = None
+    if fields:
+        try:
+            parsed_fields = json.loads(fields)
+        except:
+            parsed_fields = {'fields': fields}
 
     args = assign_params(
         event=event,
         host=host,
-        fields=json.loads(fields) if fields else None,
+        fields=parsed_fields,
         index=index,
         sourcetype=source_type,
         source=source,

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -532,7 +532,7 @@ def splunk_submit_event_hec(hec_token, baseurl, event, fields, host, index, sour
     args = assign_params(
         event=event,
         host=host,
-        fields={'fields': fields} if fields else None,
+        fields=json.loads(fields) if fields else None,
         index=index,
         sourcetype=source_type,
         source=source,

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -318,7 +318,7 @@ script:
       secret: false
     - default: false
       description: Fields for indexing that do not occur in the event payload itself.
-        Accepts json string of key value pairs.
+        Accepts json string of key value pairs or comma seperated values.
       isArray: false
       name: fields
       required: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -3,398 +3,379 @@ commonfields:
   id: SplunkPy
   version: -1
 configuration:
-  - display: Host - ip (x.x.x.x)
-    name: host
-    required: true
-    type: 0
-  - display: Username
-    name: authentication
-    required: true
-    type: 9
-  - defaultvalue: "8089"
-    display: Port
-    name: port
-    required: true
-    type: 0
-  - defaultvalue:
-      search index=notable | eval rule_name=if(isnull(rule_name),source,rule_name)
-      | eval rule_title=if(isnull(rule_title),rule_name,rule_title) | `get_urgency`
-      | `risk_correlation` | eval rule_description=if(isnull(rule_description),source,rule_description)
-      | eval security_domain=if(isnull(security_domain),source,security_domain)
-    display: Fetch notable events ES query
-    name: fetchQuery
-    required: false
-    type: 0
-  - defaultvalue: "50"
-    display: Fetch Limit (Max.- 200, Recommended less than 50)
-    name: fetch_limit
-    required: false
-    type: 0
-  - display: Fetch incidents
-    name: isFetch
-    required: false
-    type: 8
-  - display: Incident type
-    name: incidentType
-    required: false
-    type: 13
-  - display: Use system proxy settings
-    name: proxy
-    required: false
-    type: 8
-  - display:
-      Timezone of the Splunk server, in minutes. For example, GMT is gmt +3,
-      set +180 (set only if different than Demisto server). Relevant only for fetching
-      notable events.
-    name: timezone
-    required: false
-    type: 0
-  - defaultvalue: "false"
-    display: Parse Raw part of notable events
-    name: parseNotableEventsRaw
-    required: false
-    type: 8
-  - defaultvalue: false
-    display: Replace with Underscore in Incident Fields
-    name: replaceKeys
-    required: false
-    type: 8
-  - display: Extract Fields - CSV fields that will be parsed out of _raw notable events
-    name: extractFields
-    required: false
-    type: 12
-  - defaultvalue: "false"
-    display: Use Splunk Clock Time For Fetch
-    name: useSplunkTime
-    required: false
-    type: 8
-  - display: Trust any certificate (not secure)
-    name: unsecure
-    required: false
-    type: 8
-  - defaultvalue: index_earliest
-    display:
-      Earliest time to fetch (the name of the Splunk field whose value defines
-      the query's earliest time to fetch)
-    name: earliest_fetch_time_fieldname
-    required: false
-    type: 0
-  - defaultvalue: index_latest
-    display:
-      Latest time to fetch (the name of the Splunk field whose value defines
-      the query's latest time to fetch)
-    name: latest_fetch_time_fieldname
-    required: false
-    type: 0
-  - display: The app context of the namespace
-    name: app
-    required: false
-    type: 0
-  - display: HEC Token (HTTP Event Collector)
-    name: hec_token
-    required: false
-    type: 4
-  - display: "HEC URL (e.g: https://localhost:8088)."
-    name: hec_url
-    required: false
-    type: 0
-  - defaultvalue: 10 minutes
-    display:
-      First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3
-      months, 1 year)
-    hidden: false
-    name: fetch_time
-    required: false
-    type: 0
+- display: Host - ip (x.x.x.x)
+  name: host
+  required: true
+  type: 0
+- display: Username
+  name: authentication
+  required: true
+  type: 9
+- defaultvalue: '8089'
+  display: Port
+  name: port
+  required: true
+  type: 0
+- defaultvalue: search index=notable | eval rule_name=if(isnull(rule_name),source,rule_name)
+    | eval rule_title=if(isnull(rule_title),rule_name,rule_title) | `get_urgency`
+    | `risk_correlation` | eval rule_description=if(isnull(rule_description),source,rule_description)
+    | eval security_domain=if(isnull(security_domain),source,security_domain)
+  display: Fetch notable events ES query
+  name: fetchQuery
+  required: false
+  type: 0
+- defaultvalue: '50'
+  display: Fetch Limit (Max.- 200, Recommended less than 50)
+  name: fetch_limit
+  required: false
+  type: 0
+- display: Fetch incidents
+  name: isFetch
+  required: false
+  type: 8
+- display: Incident type
+  name: incidentType
+  required: false
+  type: 13
+- display: Use system proxy settings
+  name: proxy
+  required: false
+  type: 8
+- display: Timezone of the Splunk server, in minutes. For example, GMT is gmt +3,
+    set +180 (set only if different than Demisto server). Relevant only for fetching
+    notable events.
+  name: timezone
+  required: false
+  type: 0
+- defaultvalue: 'false'
+  display: Parse Raw part of notable events
+  name: parseNotableEventsRaw
+  required: false
+  type: 8
+- defaultvalue: false
+  display: Replace with Underscore in Incident Fields
+  name: replaceKeys
+  required: false
+  type: 8
+- display: Extract Fields - CSV fields that will be parsed out of _raw notable events
+  name: extractFields
+  required: false
+  type: 12
+- defaultvalue: 'false'
+  display: Use Splunk Clock Time For Fetch
+  name: useSplunkTime
+  required: false
+  type: 8
+- display: Trust any certificate (not secure)
+  name: unsecure
+  required: false
+  type: 8
+- defaultvalue: index_earliest
+  display: Earliest time to fetch (the name of the Splunk field whose value defines
+    the query's earliest time to fetch)
+  name: earliest_fetch_time_fieldname
+  required: false
+  type: 0
+- defaultvalue: index_latest
+  display: Latest time to fetch (the name of the Splunk field whose value defines
+    the query's latest time to fetch)
+  name: latest_fetch_time_fieldname
+  required: false
+  type: 0
+- display: The app context of the namespace
+  name: app
+  required: false
+  type: 0
+- display: HEC Token (HTTP Event Collector)
+  name: hec_token
+  required: false
+  type: 4
+- display: 'HEC URL (e.g: https://localhost:8088).'
+  name: hec_url
+  required: false
+  type: 0
+- defaultvalue: 10 minutes
+  display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3
+    months, 1 year)
+  hidden: false
+  name: fetch_time
+  required: false
+  type: 0
 description: Run queries on Splunk servers.
 display: SplunkPy
 name: SplunkPy
 script:
   commands:
-    - arguments:
-        - default: true
-          description: ID of the search for which to return results.
-          isArray: false
-          name: sid
-          required: true
-          secret: false
-      deprecated: false
-      description:
-        Returns the results of a previous Splunk search. You can use this
-        command in conjunction with the splunk-job-create command.
-      execution: false
-      name: splunk-results
-    - arguments:
-        - default: true
-          description:
-            'The Splunk search language string to execute. For example: "index=*
-            | head 3". '
-          isArray: false
-          name: query
-          required: true
-          secret: false
-        - default: false
-          description:
-            'Specifies the earliest time in the time range to search. The time
-            string can be a UTC time (with fractional seconds), a relative time specifier
-            (to now), or a formatted time string. Default is 1 week ago, in the format
-            "-7d". You can also specify time in the format: 2014-06-19T12:00:00.000-07:00"'
-          isArray: false
-          name: earliest_time
-          required: false
-          secret: false
-        - default: false
-          description:
-            ' Specifies the latest time in the time range to search. The time
-            string can be a UTC time (with fractional seconds), a relative time specifier
-            (to now), or a formatted time string. For example: "2014-06-19T12:00:00.000-07:00"
-            or "-3d" (for time 3 days before now)'
-          isArray: false
-          name: latest_time
-          required: false
-          secret: false
-        - default: false
-          description:
-            Maximum number of events to return. Default is 100. If "0", all
-            results are returned.
-          isArray: false
-          name: event_limit
-          required: false
-          secret: false
-        - default: false
-          defaultValue: "25000"
-          description:
-            The maximum number of returned results to  process at a time. For
-            example, if 100 results are returned, and you specify a batch_limit of 10,
-            the results will be processed 10 at a time over 10 iterations. This does not
-            effect the search or the context and outputs returned. In some cases, specifying
-            a batch_size enhances search performance. If you think that the search execution
-            is suboptimal, we recommend trying several batch_size values to determine
-            which works best for your search. Default is 25,000.
-          isArray: false
-          name: batch_limit
-          required: false
-          secret: false
-        - auto: PREDEFINED
-          default: false
-          defaultValue: "true"
-          description: Determines whether the results will be entered into the context.
-          isArray: false
-          name: update_context
-          predefined:
-            - "true"
-            - "false"
-          required: false
-          secret: false
-        - default: false
-          description:
-            A string that contains the application namespace in which to restrict
-            searches.
-          isArray: false
-          name: app
-          required: false
-          secret: false
-      deprecated: false
-      description: Searches Splunk for events.
-      execution: false
-      name: splunk-search
-      outputs:
-        - contextPath: Splunk.Result
-          description:
-            The results of the Splunk search. The results are a JSON array,
-            in which each item is a Splunk event.
-          type: Unknown
-    - arguments:
-        - default: false
-          description:
-            Splunk index to which to push data. Run the splunk-get-indexes
-            command to get all indexes.
-          isArray: false
-          name: index
-          required: true
-          secret: false
-        - default: true
-          description: The new event data to push, can be any string.
-          isArray: false
-          name: data
-          required: true
-          secret: false
-        - default: false
-          description: Event source type.
-          isArray: false
-          name: sourcetype
-          required: true
-          secret: false
-        - default: false
-          description: Event host. Can be "Local" or "120.0.0.1".
-          isArray: false
-          name: host
-          required: true
-          secret: false
-      deprecated: false
-      description: Creates a new event in Splunk.
-      execution: false
-      name: splunk-submit-event
-    - deprecated: false
-      description: Prints all Splunk index names.
-      execution: false
-      name: splunk-get-indexes
-    - arguments:
-        - default: false
-          description: A comma-separated list of event IDs of notable events.
-          isArray: false
-          name: eventIDs
-          required: true
-          secret: false
-        - default: false
-          description: A Splunk user to assign to the notable event.
-          isArray: false
-          name: owner
-          required: false
-          secret: false
-        - default: false
-          description: Comment to add to the notable event.
-          isArray: false
-          name: comment
-          required: true
-          secret: false
-        - auto: PREDEFINED
-          default: false
-          description: Notable event urgency.
-          isArray: false
-          name: urgency
-          predefined:
-            - critical
-            - high
-            - medium
-            - low
-            - informational
-          required: false
-          secret: false
-        - default: false
-          description:
-            Notable event status. 0 - Unassigned, 1 - Assigned, 2 - In Progress,
-            3 - Pending, 4 - Resolved, 5 - Closed.
-          isArray: false
-          name: status
-          required: false
-          secret: false
-      deprecated: false
-      description: Update an existing Notable event in Splunk ES
-      execution: true
-      name: splunk-notable-event-edit
-    - arguments:
-        - default: false
-          description:
-            The Splunk search language string to execute. For example :"index=*
-            | head 3".
-          isArray: false
-          name: query
-          required: true
-          secret: false
-        - default: false
-          description:
-            A string that contains the application namespace in which to restrict
-            searches.
-          isArray: false
-          name: app
-          required: false
-          secret: false
-      deprecated: false
-      description: Creates a new search job in Splunk.
-      execution: false
-      name: splunk-job-create
-      outputs:
-        - contextPath: Splunk.Job
-          description: The SID of the created job.
-          type: Unknown
-    - arguments:
-        - default: true
-          defaultValue: ${Splunk.Result._raw}
-          description: The raw data of the Splunk event (string).
-          isArray: false
-          name: raw
-          required: false
-          secret: false
-      deprecated: false
-      description: Parses the raw part of the event.
-      execution: false
-      name: splunk-parse-raw
-      outputs:
-        - contextPath: Splunk.Raw.Parsed
-          description: The raw event data (parsed).
-          type: unknown
-    - arguments:
-        - default: false
-          description: |-
-            Event payload key-value.
-            String example: "event": "Access log test message."
-          isArray: false
-          name: event
-          required: true
-          secret: false
-        - default: false
-          description:
-            Fields for indexing that do not occur in the event payload itself.
-            Accepts a json string of key value pairs.
-          isArray: false
-          name: fields
-          required: false
-          secret: false
-        - default: false
-          description: The index name.
-          isArray: false
-          name: index
-          required: false
-          secret: false
-        - default: false
-          description: The hostname.
-          isArray: false
-          name: host
-          required: false
-          secret: false
-        - default: false
-          description: User-defined event source type.
-          isArray: false
-          name: source_type
-          required: false
-          secret: false
-        - default: false
-          description: User-defined event source.
-          isArray: false
-          name: source
-          required: false
-          secret: false
-        - default: false
-          description: Epoch-formatted time
-          isArray: false
-          name: time
-          required: false
-          secret: false
-      deprecated: false
-      description:
-        Sends events to an HTTP Event Collector using the Splunk platform
-        JSON event protocol.
-      execution: false
-      name: splunk-submit-event-hec
-    - arguments:
-        - default: false
-          description: ID of the job for which to get the status.
-          isArray: false
-          name: sid
-          required: true
-          secret: false
-      deprecated: false
-      description: Returns the status of a job.
-      execution: false
-      name: splunk-job-status
-      outputs:
-        - contextPath: Splunk.JobStatus.SID
-          description: ID of the job.
-          type: String
-        - contextPath: Splunk.JobStatus.Status
-          description: Status of the job.
-          type: String
+  - arguments:
+    - default: true
+      description: ID of the search for which to return results.
+      isArray: false
+      name: sid
+      required: true
+      secret: false
+    deprecated: false
+    description: Returns the results of a previous Splunk search. You can use this
+      command in conjunction with the splunk-job-create command.
+    execution: false
+    name: splunk-results
+  - arguments:
+    - default: true
+      description: 'The Splunk search language string to execute. For example: "index=*
+        | head 3". '
+      isArray: false
+      name: query
+      required: true
+      secret: false
+    - default: false
+      description: 'Specifies the earliest time in the time range to search. The time
+        string can be a UTC time (with fractional seconds), a relative time specifier
+        (to now), or a formatted time string. Default is 1 week ago, in the format
+        "-7d". You can also specify time in the format: 2014-06-19T12:00:00.000-07:00"'
+      isArray: false
+      name: earliest_time
+      required: false
+      secret: false
+    - default: false
+      description: ' Specifies the latest time in the time range to search. The time
+        string can be a UTC time (with fractional seconds), a relative time specifier
+        (to now), or a formatted time string. For example: "2014-06-19T12:00:00.000-07:00"
+        or "-3d" (for time 3 days before now)'
+      isArray: false
+      name: latest_time
+      required: false
+      secret: false
+    - default: false
+      description: Maximum number of events to return. Default is 100. If "0", all
+        results are returned.
+      isArray: false
+      name: event_limit
+      required: false
+      secret: false
+    - default: false
+      defaultValue: '25000'
+      description: The maximum number of returned results to  process at a time. For
+        example, if 100 results are returned, and you specify a batch_limit of 10,
+        the results will be processed 10 at a time over 10 iterations. This does not
+        effect the search or the context and outputs returned. In some cases, specifying
+        a batch_size enhances search performance. If you think that the search execution
+        is suboptimal, we recommend trying several batch_size values to determine
+        which works best for your search. Default is 25,000.
+      isArray: false
+      name: batch_limit
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'true'
+      description: Determines whether the results will be entered into the context.
+      isArray: false
+      name: update_context
+      predefined:
+      - 'true'
+      - 'false'
+      required: false
+      secret: false
+    - default: false
+      description: A string that contains the application namespace in which to restrict
+        searches.
+      isArray: false
+      name: app
+      required: false
+      secret: false
+    deprecated: false
+    description: Searches Splunk for events.
+    execution: false
+    name: splunk-search
+    outputs:
+    - contextPath: Splunk.Result
+      description: The results of the Splunk search. The results are a JSON array,
+        in which each item is a Splunk event.
+      type: Unknown
+  - arguments:
+    - default: false
+      description: Splunk index to which to push data. Run the splunk-get-indexes
+        command to get all indexes.
+      isArray: false
+      name: index
+      required: true
+      secret: false
+    - default: true
+      description: The new event data to push, can be any string.
+      isArray: false
+      name: data
+      required: true
+      secret: false
+    - default: false
+      description: Event source type.
+      isArray: false
+      name: sourcetype
+      required: true
+      secret: false
+    - default: false
+      description: Event host. Can be "Local" or "120.0.0.1".
+      isArray: false
+      name: host
+      required: true
+      secret: false
+    deprecated: false
+    description: Creates a new event in Splunk.
+    execution: false
+    name: splunk-submit-event
+  - deprecated: false
+    description: Prints all Splunk index names.
+    execution: false
+    name: splunk-get-indexes
+  - arguments:
+    - default: false
+      description: A comma-separated list of event IDs of notable events.
+      isArray: false
+      name: eventIDs
+      required: true
+      secret: false
+    - default: false
+      description: A Splunk user to assign to the notable event.
+      isArray: false
+      name: owner
+      required: false
+      secret: false
+    - default: false
+      description: Comment to add to the notable event.
+      isArray: false
+      name: comment
+      required: true
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      description: Notable event urgency.
+      isArray: false
+      name: urgency
+      predefined:
+      - critical
+      - high
+      - medium
+      - low
+      - informational
+      required: false
+      secret: false
+    - default: false
+      description: Notable event status. 0 - Unassigned, 1 - Assigned, 2 - In Progress,
+        3 - Pending, 4 - Resolved, 5 - Closed.
+      isArray: false
+      name: status
+      required: false
+      secret: false
+    deprecated: false
+    description: Update an existing Notable event in Splunk ES
+    execution: true
+    name: splunk-notable-event-edit
+  - arguments:
+    - default: false
+      description: The Splunk search language string to execute. For example :"index=*
+        | head 3".
+      isArray: false
+      name: query
+      required: true
+      secret: false
+    - default: false
+      description: A string that contains the application namespace in which to restrict
+        searches.
+      isArray: false
+      name: app
+      required: false
+      secret: false
+    deprecated: false
+    description: Creates a new search job in Splunk.
+    execution: false
+    name: splunk-job-create
+    outputs:
+    - contextPath: Splunk.Job
+      description: The SID of the created job.
+      type: Unknown
+  - arguments:
+    - default: true
+      defaultValue: ${Splunk.Result._raw}
+      description: The raw data of the Splunk event (string).
+      isArray: false
+      name: raw
+      required: false
+      secret: false
+    deprecated: false
+    description: Parses the raw part of the event.
+    execution: false
+    name: splunk-parse-raw
+    outputs:
+    - contextPath: Splunk.Raw.Parsed
+      description: The raw event data (parsed).
+      type: unknown
+  - arguments:
+    - default: false
+      description: |-
+        Event payload key-value.
+        String example: "event": "Access log test message."
+      isArray: false
+      name: event
+      required: true
+      secret: false
+    - default: false
+      description: Fields for indexing that do not occur in the event payload itself.
+        Accepts multiple comma separated fields.
+      isArray: false
+      name: fields
+      required: false
+      secret: false
+    - default: false
+      description: The index name.
+      isArray: false
+      name: index
+      required: false
+      secret: false
+    - default: false
+      description: The hostname.
+      isArray: false
+      name: host
+      required: false
+      secret: false
+    - default: false
+      description: User-defined event source type.
+      isArray: false
+      name: source_type
+      required: false
+      secret: false
+    - default: false
+      description: User-defined event source.
+      isArray: false
+      name: source
+      required: false
+      secret: false
+    - default: false
+      description: Epoch-formatted time
+      isArray: false
+      name: time
+      required: false
+      secret: false
+    deprecated: false
+    description: Sends events to an HTTP Event Collector using the Splunk platform
+      JSON event protocol.
+    execution: false
+    name: splunk-submit-event-hec
+  - arguments:
+    - default: false
+      description: ID of the job for which to get the status.
+      isArray: false
+      name: sid
+      required: true
+      secret: false
+    deprecated: false
+    description: Returns the status of a job.
+    execution: false
+    name: splunk-job-status
+    outputs:
+    - contextPath: Splunk.JobStatus.SID
+      description: ID of the job.
+      type: String
+    - contextPath: Splunk.JobStatus.Status
+      description: Status of the job.
+      type: String
   dockerimage45: demisto/splunksdk:1.0
   dockerimage: demisto/splunksdk:1.0.0.6822
   feed: false
@@ -402,8 +383,8 @@ script:
   longRunning: false
   longRunningPort: false
   runonce: false
-  script: "-"
+  script: '-'
   subtype: python2
   type: python
 tests:
-  - SplunkPy-Test-V2
+- SplunkPy-Test-V2

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -3,379 +3,398 @@ commonfields:
   id: SplunkPy
   version: -1
 configuration:
-- display: Host - ip (x.x.x.x)
-  name: host
-  required: true
-  type: 0
-- display: Username
-  name: authentication
-  required: true
-  type: 9
-- defaultvalue: '8089'
-  display: Port
-  name: port
-  required: true
-  type: 0
-- defaultvalue: search index=notable | eval rule_name=if(isnull(rule_name),source,rule_name)
-    | eval rule_title=if(isnull(rule_title),rule_name,rule_title) | `get_urgency`
-    | `risk_correlation` | eval rule_description=if(isnull(rule_description),source,rule_description)
-    | eval security_domain=if(isnull(security_domain),source,security_domain)
-  display: Fetch notable events ES query
-  name: fetchQuery
-  required: false
-  type: 0
-- defaultvalue: '50'
-  display: Fetch Limit (Max.- 200, Recommended less than 50)
-  name: fetch_limit
-  required: false
-  type: 0
-- display: Fetch incidents
-  name: isFetch
-  required: false
-  type: 8
-- display: Incident type
-  name: incidentType
-  required: false
-  type: 13
-- display: Use system proxy settings
-  name: proxy
-  required: false
-  type: 8
-- display: Timezone of the Splunk server, in minutes. For example, GMT is gmt +3,
-    set +180 (set only if different than Demisto server). Relevant only for fetching
-    notable events.
-  name: timezone
-  required: false
-  type: 0
-- defaultvalue: 'false'
-  display: Parse Raw part of notable events
-  name: parseNotableEventsRaw
-  required: false
-  type: 8
-- defaultvalue: false
-  display: Replace with Underscore in Incident Fields
-  name: replaceKeys
-  required: false
-  type: 8
-- display: Extract Fields - CSV fields that will be parsed out of _raw notable events
-  name: extractFields
-  required: false
-  type: 12
-- defaultvalue: 'false'
-  display: Use Splunk Clock Time For Fetch
-  name: useSplunkTime
-  required: false
-  type: 8
-- display: Trust any certificate (not secure)
-  name: unsecure
-  required: false
-  type: 8
-- defaultvalue: index_earliest
-  display: Earliest time to fetch (the name of the Splunk field whose value defines
-    the query's earliest time to fetch)
-  name: earliest_fetch_time_fieldname
-  required: false
-  type: 0
-- defaultvalue: index_latest
-  display: Latest time to fetch (the name of the Splunk field whose value defines
-    the query's latest time to fetch)
-  name: latest_fetch_time_fieldname
-  required: false
-  type: 0
-- display: The app context of the namespace
-  name: app
-  required: false
-  type: 0
-- display: HEC Token (HTTP Event Collector)
-  name: hec_token
-  required: false
-  type: 4
-- display: 'HEC URL (e.g: https://localhost:8088).'
-  name: hec_url
-  required: false
-  type: 0
-- defaultvalue: 10 minutes
-  display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3
-    months, 1 year)
-  hidden: false
-  name: fetch_time
-  required: false
-  type: 0
+  - display: Host - ip (x.x.x.x)
+    name: host
+    required: true
+    type: 0
+  - display: Username
+    name: authentication
+    required: true
+    type: 9
+  - defaultvalue: "8089"
+    display: Port
+    name: port
+    required: true
+    type: 0
+  - defaultvalue:
+      search index=notable | eval rule_name=if(isnull(rule_name),source,rule_name)
+      | eval rule_title=if(isnull(rule_title),rule_name,rule_title) | `get_urgency`
+      | `risk_correlation` | eval rule_description=if(isnull(rule_description),source,rule_description)
+      | eval security_domain=if(isnull(security_domain),source,security_domain)
+    display: Fetch notable events ES query
+    name: fetchQuery
+    required: false
+    type: 0
+  - defaultvalue: "50"
+    display: Fetch Limit (Max.- 200, Recommended less than 50)
+    name: fetch_limit
+    required: false
+    type: 0
+  - display: Fetch incidents
+    name: isFetch
+    required: false
+    type: 8
+  - display: Incident type
+    name: incidentType
+    required: false
+    type: 13
+  - display: Use system proxy settings
+    name: proxy
+    required: false
+    type: 8
+  - display:
+      Timezone of the Splunk server, in minutes. For example, GMT is gmt +3,
+      set +180 (set only if different than Demisto server). Relevant only for fetching
+      notable events.
+    name: timezone
+    required: false
+    type: 0
+  - defaultvalue: "false"
+    display: Parse Raw part of notable events
+    name: parseNotableEventsRaw
+    required: false
+    type: 8
+  - defaultvalue: false
+    display: Replace with Underscore in Incident Fields
+    name: replaceKeys
+    required: false
+    type: 8
+  - display: Extract Fields - CSV fields that will be parsed out of _raw notable events
+    name: extractFields
+    required: false
+    type: 12
+  - defaultvalue: "false"
+    display: Use Splunk Clock Time For Fetch
+    name: useSplunkTime
+    required: false
+    type: 8
+  - display: Trust any certificate (not secure)
+    name: unsecure
+    required: false
+    type: 8
+  - defaultvalue: index_earliest
+    display:
+      Earliest time to fetch (the name of the Splunk field whose value defines
+      the query's earliest time to fetch)
+    name: earliest_fetch_time_fieldname
+    required: false
+    type: 0
+  - defaultvalue: index_latest
+    display:
+      Latest time to fetch (the name of the Splunk field whose value defines
+      the query's latest time to fetch)
+    name: latest_fetch_time_fieldname
+    required: false
+    type: 0
+  - display: The app context of the namespace
+    name: app
+    required: false
+    type: 0
+  - display: HEC Token (HTTP Event Collector)
+    name: hec_token
+    required: false
+    type: 4
+  - display: "HEC URL (e.g: https://localhost:8088)."
+    name: hec_url
+    required: false
+    type: 0
+  - defaultvalue: 10 minutes
+    display:
+      First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3
+      months, 1 year)
+    hidden: false
+    name: fetch_time
+    required: false
+    type: 0
 description: Run queries on Splunk servers.
 display: SplunkPy
 name: SplunkPy
 script:
   commands:
-  - arguments:
-    - default: true
-      description: ID of the search for which to return results.
-      isArray: false
-      name: sid
-      required: true
-      secret: false
-    deprecated: false
-    description: Returns the results of a previous Splunk search. You can use this
-      command in conjunction with the splunk-job-create command.
-    execution: false
-    name: splunk-results
-  - arguments:
-    - default: true
-      description: 'The Splunk search language string to execute. For example: "index=*
-        | head 3". '
-      isArray: false
-      name: query
-      required: true
-      secret: false
-    - default: false
-      description: 'Specifies the earliest time in the time range to search. The time
-        string can be a UTC time (with fractional seconds), a relative time specifier
-        (to now), or a formatted time string. Default is 1 week ago, in the format
-        "-7d". You can also specify time in the format: 2014-06-19T12:00:00.000-07:00"'
-      isArray: false
-      name: earliest_time
-      required: false
-      secret: false
-    - default: false
-      description: ' Specifies the latest time in the time range to search. The time
-        string can be a UTC time (with fractional seconds), a relative time specifier
-        (to now), or a formatted time string. For example: "2014-06-19T12:00:00.000-07:00"
-        or "-3d" (for time 3 days before now)'
-      isArray: false
-      name: latest_time
-      required: false
-      secret: false
-    - default: false
-      description: Maximum number of events to return. Default is 100. If "0", all
-        results are returned.
-      isArray: false
-      name: event_limit
-      required: false
-      secret: false
-    - default: false
-      defaultValue: '25000'
-      description: The maximum number of returned results to  process at a time. For
-        example, if 100 results are returned, and you specify a batch_limit of 10,
-        the results will be processed 10 at a time over 10 iterations. This does not
-        effect the search or the context and outputs returned. In some cases, specifying
-        a batch_size enhances search performance. If you think that the search execution
-        is suboptimal, we recommend trying several batch_size values to determine
-        which works best for your search. Default is 25,000.
-      isArray: false
-      name: batch_limit
-      required: false
-      secret: false
-    - auto: PREDEFINED
-      default: false
-      defaultValue: 'true'
-      description: Determines whether the results will be entered into the context.
-      isArray: false
-      name: update_context
-      predefined:
-      - 'true'
-      - 'false'
-      required: false
-      secret: false
-    - default: false
-      description: A string that contains the application namespace in which to restrict
-        searches.
-      isArray: false
-      name: app
-      required: false
-      secret: false
-    deprecated: false
-    description: Searches Splunk for events.
-    execution: false
-    name: splunk-search
-    outputs:
-    - contextPath: Splunk.Result
-      description: The results of the Splunk search. The results are a JSON array,
-        in which each item is a Splunk event.
-      type: Unknown
-  - arguments:
-    - default: false
-      description: Splunk index to which to push data. Run the splunk-get-indexes
-        command to get all indexes.
-      isArray: false
-      name: index
-      required: true
-      secret: false
-    - default: true
-      description: The new event data to push, can be any string.
-      isArray: false
-      name: data
-      required: true
-      secret: false
-    - default: false
-      description: Event source type.
-      isArray: false
-      name: sourcetype
-      required: true
-      secret: false
-    - default: false
-      description: Event host. Can be "Local" or "120.0.0.1".
-      isArray: false
-      name: host
-      required: true
-      secret: false
-    deprecated: false
-    description: Creates a new event in Splunk.
-    execution: false
-    name: splunk-submit-event
-  - deprecated: false
-    description: Prints all Splunk index names.
-    execution: false
-    name: splunk-get-indexes
-  - arguments:
-    - default: false
-      description: A comma-separated list of event IDs of notable events.
-      isArray: false
-      name: eventIDs
-      required: true
-      secret: false
-    - default: false
-      description: A Splunk user to assign to the notable event.
-      isArray: false
-      name: owner
-      required: false
-      secret: false
-    - default: false
-      description: Comment to add to the notable event.
-      isArray: false
-      name: comment
-      required: true
-      secret: false
-    - auto: PREDEFINED
-      default: false
-      description: Notable event urgency.
-      isArray: false
-      name: urgency
-      predefined:
-      - critical
-      - high
-      - medium
-      - low
-      - informational
-      required: false
-      secret: false
-    - default: false
-      description: Notable event status. 0 - Unassigned, 1 - Assigned, 2 - In Progress,
-        3 - Pending, 4 - Resolved, 5 - Closed.
-      isArray: false
-      name: status
-      required: false
-      secret: false
-    deprecated: false
-    description: Update an existing Notable event in Splunk ES
-    execution: true
-    name: splunk-notable-event-edit
-  - arguments:
-    - default: false
-      description: The Splunk search language string to execute. For example :"index=*
-        | head 3".
-      isArray: false
-      name: query
-      required: true
-      secret: false
-    - default: false
-      description: A string that contains the application namespace in which to restrict
-        searches.
-      isArray: false
-      name: app
-      required: false
-      secret: false
-    deprecated: false
-    description: Creates a new search job in Splunk.
-    execution: false
-    name: splunk-job-create
-    outputs:
-    - contextPath: Splunk.Job
-      description: The SID of the created job.
-      type: Unknown
-  - arguments:
-    - default: true
-      defaultValue: ${Splunk.Result._raw}
-      description: The raw data of the Splunk event (string).
-      isArray: false
-      name: raw
-      required: false
-      secret: false
-    deprecated: false
-    description: Parses the raw part of the event.
-    execution: false
-    name: splunk-parse-raw
-    outputs:
-    - contextPath: Splunk.Raw.Parsed
-      description: The raw event data (parsed).
-      type: unknown
-  - arguments:
-    - default: false
-      description: |-
-        Event payload key-value.
-        String example: "event": "Access log test message."
-      isArray: false
-      name: event
-      required: true
-      secret: false
-    - default: false
-      description: Fields for indexing that do not occur in the event payload itself.
-        Accepts multiple comma separated fields.
-      isArray: false
-      name: fields
-      required: false
-      secret: false
-    - default: false
-      description: The index name.
-      isArray: false
-      name: index
-      required: false
-      secret: false
-    - default: false
-      description: The hostname.
-      isArray: false
-      name: host
-      required: false
-      secret: false
-    - default: false
-      description: User-defined event source type.
-      isArray: false
-      name: source_type
-      required: false
-      secret: false
-    - default: false
-      description: User-defined event source.
-      isArray: false
-      name: source
-      required: false
-      secret: false
-    - default: false
-      description: Epoch-formatted time
-      isArray: false
-      name: time
-      required: false
-      secret: false
-    deprecated: false
-    description: Sends events to an HTTP Event Collector using the Splunk platform
-      JSON event protocol.
-    execution: false
-    name: splunk-submit-event-hec
-  - arguments:
-    - default: false
-      description: ID of the job for which to get the status.
-      isArray: false
-      name: sid
-      required: true
-      secret: false
-    deprecated: false
-    description: Returns the status of a job.
-    execution: false
-    name: splunk-job-status
-    outputs:
-    - contextPath: Splunk.JobStatus.SID
-      description: ID of the job.
-      type: String
-    - contextPath: Splunk.JobStatus.Status
-      description: Status of the job.
-      type: String
+    - arguments:
+        - default: true
+          description: ID of the search for which to return results.
+          isArray: false
+          name: sid
+          required: true
+          secret: false
+      deprecated: false
+      description:
+        Returns the results of a previous Splunk search. You can use this
+        command in conjunction with the splunk-job-create command.
+      execution: false
+      name: splunk-results
+    - arguments:
+        - default: true
+          description:
+            'The Splunk search language string to execute. For example: "index=*
+            | head 3". '
+          isArray: false
+          name: query
+          required: true
+          secret: false
+        - default: false
+          description:
+            'Specifies the earliest time in the time range to search. The time
+            string can be a UTC time (with fractional seconds), a relative time specifier
+            (to now), or a formatted time string. Default is 1 week ago, in the format
+            "-7d". You can also specify time in the format: 2014-06-19T12:00:00.000-07:00"'
+          isArray: false
+          name: earliest_time
+          required: false
+          secret: false
+        - default: false
+          description:
+            ' Specifies the latest time in the time range to search. The time
+            string can be a UTC time (with fractional seconds), a relative time specifier
+            (to now), or a formatted time string. For example: "2014-06-19T12:00:00.000-07:00"
+            or "-3d" (for time 3 days before now)'
+          isArray: false
+          name: latest_time
+          required: false
+          secret: false
+        - default: false
+          description:
+            Maximum number of events to return. Default is 100. If "0", all
+            results are returned.
+          isArray: false
+          name: event_limit
+          required: false
+          secret: false
+        - default: false
+          defaultValue: "25000"
+          description:
+            The maximum number of returned results to  process at a time. For
+            example, if 100 results are returned, and you specify a batch_limit of 10,
+            the results will be processed 10 at a time over 10 iterations. This does not
+            effect the search or the context and outputs returned. In some cases, specifying
+            a batch_size enhances search performance. If you think that the search execution
+            is suboptimal, we recommend trying several batch_size values to determine
+            which works best for your search. Default is 25,000.
+          isArray: false
+          name: batch_limit
+          required: false
+          secret: false
+        - auto: PREDEFINED
+          default: false
+          defaultValue: "true"
+          description: Determines whether the results will be entered into the context.
+          isArray: false
+          name: update_context
+          predefined:
+            - "true"
+            - "false"
+          required: false
+          secret: false
+        - default: false
+          description:
+            A string that contains the application namespace in which to restrict
+            searches.
+          isArray: false
+          name: app
+          required: false
+          secret: false
+      deprecated: false
+      description: Searches Splunk for events.
+      execution: false
+      name: splunk-search
+      outputs:
+        - contextPath: Splunk.Result
+          description:
+            The results of the Splunk search. The results are a JSON array,
+            in which each item is a Splunk event.
+          type: Unknown
+    - arguments:
+        - default: false
+          description:
+            Splunk index to which to push data. Run the splunk-get-indexes
+            command to get all indexes.
+          isArray: false
+          name: index
+          required: true
+          secret: false
+        - default: true
+          description: The new event data to push, can be any string.
+          isArray: false
+          name: data
+          required: true
+          secret: false
+        - default: false
+          description: Event source type.
+          isArray: false
+          name: sourcetype
+          required: true
+          secret: false
+        - default: false
+          description: Event host. Can be "Local" or "120.0.0.1".
+          isArray: false
+          name: host
+          required: true
+          secret: false
+      deprecated: false
+      description: Creates a new event in Splunk.
+      execution: false
+      name: splunk-submit-event
+    - deprecated: false
+      description: Prints all Splunk index names.
+      execution: false
+      name: splunk-get-indexes
+    - arguments:
+        - default: false
+          description: A comma-separated list of event IDs of notable events.
+          isArray: false
+          name: eventIDs
+          required: true
+          secret: false
+        - default: false
+          description: A Splunk user to assign to the notable event.
+          isArray: false
+          name: owner
+          required: false
+          secret: false
+        - default: false
+          description: Comment to add to the notable event.
+          isArray: false
+          name: comment
+          required: true
+          secret: false
+        - auto: PREDEFINED
+          default: false
+          description: Notable event urgency.
+          isArray: false
+          name: urgency
+          predefined:
+            - critical
+            - high
+            - medium
+            - low
+            - informational
+          required: false
+          secret: false
+        - default: false
+          description:
+            Notable event status. 0 - Unassigned, 1 - Assigned, 2 - In Progress,
+            3 - Pending, 4 - Resolved, 5 - Closed.
+          isArray: false
+          name: status
+          required: false
+          secret: false
+      deprecated: false
+      description: Update an existing Notable event in Splunk ES
+      execution: true
+      name: splunk-notable-event-edit
+    - arguments:
+        - default: false
+          description:
+            The Splunk search language string to execute. For example :"index=*
+            | head 3".
+          isArray: false
+          name: query
+          required: true
+          secret: false
+        - default: false
+          description:
+            A string that contains the application namespace in which to restrict
+            searches.
+          isArray: false
+          name: app
+          required: false
+          secret: false
+      deprecated: false
+      description: Creates a new search job in Splunk.
+      execution: false
+      name: splunk-job-create
+      outputs:
+        - contextPath: Splunk.Job
+          description: The SID of the created job.
+          type: Unknown
+    - arguments:
+        - default: true
+          defaultValue: ${Splunk.Result._raw}
+          description: The raw data of the Splunk event (string).
+          isArray: false
+          name: raw
+          required: false
+          secret: false
+      deprecated: false
+      description: Parses the raw part of the event.
+      execution: false
+      name: splunk-parse-raw
+      outputs:
+        - contextPath: Splunk.Raw.Parsed
+          description: The raw event data (parsed).
+          type: unknown
+    - arguments:
+        - default: false
+          description: |-
+            Event payload key-value.
+            String example: "event": "Access log test message."
+          isArray: false
+          name: event
+          required: true
+          secret: false
+        - default: false
+          description:
+            Fields for indexing that do not occur in the event payload itself.
+            Accepts a json string of key value pairs.
+          isArray: false
+          name: fields
+          required: false
+          secret: false
+        - default: false
+          description: The index name.
+          isArray: false
+          name: index
+          required: false
+          secret: false
+        - default: false
+          description: The hostname.
+          isArray: false
+          name: host
+          required: false
+          secret: false
+        - default: false
+          description: User-defined event source type.
+          isArray: false
+          name: source_type
+          required: false
+          secret: false
+        - default: false
+          description: User-defined event source.
+          isArray: false
+          name: source
+          required: false
+          secret: false
+        - default: false
+          description: Epoch-formatted time
+          isArray: false
+          name: time
+          required: false
+          secret: false
+      deprecated: false
+      description:
+        Sends events to an HTTP Event Collector using the Splunk platform
+        JSON event protocol.
+      execution: false
+      name: splunk-submit-event-hec
+    - arguments:
+        - default: false
+          description: ID of the job for which to get the status.
+          isArray: false
+          name: sid
+          required: true
+          secret: false
+      deprecated: false
+      description: Returns the status of a job.
+      execution: false
+      name: splunk-job-status
+      outputs:
+        - contextPath: Splunk.JobStatus.SID
+          description: ID of the job.
+          type: String
+        - contextPath: Splunk.JobStatus.Status
+          description: Status of the job.
+          type: String
   dockerimage45: demisto/splunksdk:1.0
   dockerimage: demisto/splunksdk:1.0.0.6822
   feed: false
@@ -383,8 +402,8 @@ script:
   longRunning: false
   longRunningPort: false
   runonce: false
-  script: '-'
+  script: "-"
   subtype: python2
   type: python
 tests:
-- SplunkPy-Test-V2
+  - SplunkPy-Test-V2

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -318,7 +318,7 @@ script:
       secret: false
     - default: false
       description: Fields for indexing that do not occur in the event payload itself.
-        Accepts multiple comma separated fields.
+        Accepts json string of key value pairs.
       isArray: false
       name: fields
       required: false

--- a/Packs/SplunkPy/ReleaseNotes/1_0_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Added optional functionality to the fields param in splunk-submit-event-hec command

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SplunkPy",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
For Splunk HEC submissions using the submit-event-hec command, fields param used to take in a comma separated string. So when you used the command, in splunk a field by the name "fields" will be created and its value will be the comma separated string. This is not the recommended usage of fields according to Splunk. Fields should actually be a JSON key value pair where you can create new fields (with the name provided in the param and not hardcoded 'fields') and values in Splunk. This PR addresses that issue.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ X] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

