### PR TITLE
Threat Types layouts fix

### DIFF
--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-domain.json
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-domain.json
@@ -509,7 +509,26 @@
 						"displayType": "CARD",
 						"h": 2,
 						"i": "default-main-93588850-6f49-11ea-a717-9facf5f245ed",
-						"items": [],
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "threatcategory",
+								"height": 24,
+								"id": "1cf1e851-4e74-11ea-8bf6-67db400d7da6",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "threatcategoryconfidence",
+								"height": 24,
+								"id": "1cf1e870-4e74-11ea-8bf6-67db400d7da6",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
 						"maxW": 3,
 						"minH": 1,
 						"minW": 1,

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-domain_CHANGELOG.md
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-domain_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- Fixed an issue where Extended Details would not display the `Threat Category` and `Threat Category Confidence` fields.
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-ip.json
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-ip.json
@@ -363,7 +363,26 @@
 						"displayType": "CARD",
 						"h": 2,
 						"i": "main-6aabb980-6f4f-11ea-a717-9facf5f245ed",
-						"items": [],
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "threatcategory",
+								"height": 24,
+								"id": "1cf1e851-4e74-11ea-8bf6-67db400d7da5",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "threatcategoryconfidence",
+								"height": 24,
+								"id": "1cf1e870-4e74-11ea-8bf6-67db400d7da5",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
 						"maxW": 3,
 						"minH": 1,
 						"minW": 1,

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-ip_CHANGELOG.md
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-ip_CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+- Fixed an issue where Extended Details would not display the `Threat Category` and `Threat Category Confidence` fields.
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-ip_CHANGELOG.md
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-ip_CHANGELOG.md
@@ -1,3 +1,4 @@
+## [Unreleased]
 - Fixed an issue where Extended Details would not display the `Threat Category` and `Threat Category Confidence` fields.
 
 

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-unifiedFile.json
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-unifiedFile.json
@@ -514,7 +514,26 @@
 						"displayType": "CARD",
 						"h": 2,
 						"i": "main-f2c99c60-6f4f-11ea-a717-9facf5f245ed",
-						"items": [],
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "threatcategory",
+								"height": 24,
+								"id": "1cf1e851-4e74-11ea-8bf6-67db400d7da8",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "threatcategoryconfidence",
+								"height": 24,
+								"id": "1cf1e870-4e74-11ea-8bf6-67db400d7da8",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
 						"maxW": 3,
 						"minH": 1,
 						"minW": 1,

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-unifiedFile_CHANGELOG.md
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-unifiedFile_CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Fixed an issue where Extended Details would not display the `Threat Category` and `Threat Category Confidence` fields.
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-url.json
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-url.json
@@ -319,7 +319,26 @@
 						"displayType": "CARD",
 						"h": 2,
 						"i": "default-main-61fe3d20-6f50-11ea-a717-9facf5f245ed",
-						"items": [],
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "threatcategory",
+								"height": 24,
+								"id": "1cf1e851-4e74-11ea-8bf6-67db400d7da7",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "threatcategoryconfidence",
+								"height": 24,
+								"id": "1cf1e870-4e74-11ea-8bf6-67db400d7da7",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
 						"maxW": 3,
 						"minH": 1,
 						"minW": 1,

--- a/Packs/Legacy/Layouts/layout-indicatorsDetails-url_CHANGELOG.md
+++ b/Packs/Legacy/Layouts/layout-indicatorsDetails-url_CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [Unreleased]
-
+- Fixed an issue where Extended Details would not display the `Threat Category` and `Threat Category Confidence` fields.
 
 ## [20.5.0] - 2020-05-12
 -
-
 
 ## [20.3.4] - 2020-03-30
 - Added Custom details and Extended details sections.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fixes an issue where Extended Details would not display the Threat Category and Threat Category Confidence fields.

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
