### PR TITLE
Hod/rtir history and link fixes

### DIFF
--- a/Packs/RTIR/Integrations/RTIR/CHANGELOG.md
+++ b/Packs/RTIR/Integrations/RTIR/CHANGELOG.md
@@ -1,14 +1,9 @@
 ## [Unreleased]
-
-
-## [20.5.2] - 2020-05-26
-- Fixed an issue where the ***fetch-incidents*** and ***search-tickets*** commands did not behave as expected.
-- Fixed an issue where the test module did not work as expected.
-- Added the *Fetch limit* parameter to the instance configuration, which specified the maximum number of results to fetch.
-- Added the *results_limit* argument to the ***search-tickets*** command, which specified the maximum number of results to return.
-- Improved ticket history parsing
-- Improved ticket links parsing
-
+  - Fixed an issue where the ***fetch-incidents*** and ***search-tickets*** commands did not behave as expected.
+  - Fixed an issue where the test module did not work as expected.
+  - Added the *Fetch limit* parameter to the instance configuration, which specifies the maximum number of results to fetch.
+  - Added the *results_limit* argument to the ***search-tickets*** command, which specifies the maximum number of results to return.
+  - Improved parsing of ticket history and ticket links.
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/RTIR/Integrations/RTIR/CHANGELOG.md
+++ b/Packs/RTIR/Integrations/RTIR/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Fixed an issue where the test module did not work as expected.
 - Added the *Fetch limit* parameter to the instance configuration, which specified the maximum number of results to fetch.
 - Added the *results_limit* argument to the ***search-tickets*** command, which specified the maximum number of results to return.
-
+- Improved ticket history parsing
+- Improved ticket links parsing
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/RTIR/Integrations/RTIR/RTIR_test.py
+++ b/Packs/RTIR/Integrations/RTIR/RTIR_test.py
@@ -32,3 +32,61 @@ def test_query_formatting(mocker):
     from RTIR import build_search_query
     query = build_search_query()
     assert not (query.endswith('+OR+') or query.endswith('+AND+'))
+
+
+RAW_HISTORY = """
+RT/4.4.2 200 Ok
+
+# 24/24 (id/80/total)
+
+id: 80
+Ticket: 5
+TimeTaken: 0
+Type: Create
+Field:
+OldValue:
+NewValue: some new value
+Data:
+Description: Ticket created by root
+Content: Some
+Multi line
+Content
+Creator: root
+Created: 2018-07-09 11:25:59
+Attachments:
+
+"""
+
+
+def test_parse_history_response():
+    from RTIR import parse_history_response
+    parsed_history = parse_history_response(RAW_HISTORY)
+    assert parsed_history == {'ID': '80',
+                              'Ticket': '5',
+                              'TimeTaken': '0',
+                              'Type': 'Create',
+                              'Field': '',
+                              'OldValue': '',
+                              'NewValue': 'some new value',
+                              'Data': '',
+                              'Description': 'Ticket created by root',
+                              'Content': 'Some\nMulti line\nContent',
+                              'Creator': 'root',
+                              'Created': '2018-07-09 11:25:59',
+                              'Attachments': ''}
+
+
+RAW_LINKS = """RT/4.4.4 200 Ok
+
+id: ticket/68315/links
+
+Members: some-url.com/ticket/65461,
+         some-url.com/ticket/65462,
+         some-url.com/ticket/65463"""
+
+
+def test_parse_ticket_links():
+    from RTIR import parse_ticket_links
+    response = parse_ticket_links(RAW_LINKS)
+    expected = [{'ID': '65461'}, {'ID': '65462'}, {'ID': '65463'}]
+    assert response == expected

--- a/Packs/RTIR/ReleaseNotes/1_0_1.md
+++ b/Packs/RTIR/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+- __RTIR__
+Improved parsing of ticket history and ticket links.

--- a/Packs/RTIR/pack_metadata.json
+++ b/Packs/RTIR/pack_metadata.json
@@ -2,7 +2,7 @@
   "name": "RTIR",
   "description": "Request Tracker for Incident Response is a ticketing system which provides pre-configured queues and workflows designed for incident response teams.",
   "support": "xsoar",
-  "currentVersion": "1.0.0",
+  "currentVersion": "1.0.1",
   "author": "Cortex XSOAR",
   "url": "https://www.paloaltonetworks.com/cortex",
   "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24633
fixes: https://github.com/demisto/etc/issues/24640

## Description
Since the history response is text- the history object is parsed line by line.
The current parsing did not take into account the possibility that a history object will have more than one line in the **Content** data.

The response always comes back in this structore: 
```
RT/4.4.2 200 Ok

# 24/24 (id/80/total)

id: 80
Ticket: 5
TimeTaken: 0
Type: Create
Field:
OldValue:
NewValue:
Data:
Description: Ticket created by root
Content: This transaction appears to have no content
Creator: root
Created: 2018-07-09 11:25:59
Attachments:
```
So the fix is to split the response based on regex pattern of keys (`\n[a-z|A-Z]+:`)
and then, relying on the constant order of the response attributes extracting the relevant fields. 


## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 


