### PR TITLE
POST requests params should be passed through body and not uri

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/CHANGELOG.md
+++ b/Packs/PAN-OS/Integrations/Panorama/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+- POST request parameterss are now passed through body and not through the URI.
 
 ## [20.5.2] - 2020-05-26
 - Added the option to list predefined applications in PAN-OS 9.X in the ***panorama-get-applications*** command using the argument *predefined*.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -480,7 +480,7 @@ def panorama_command():
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     demisto.results({
@@ -502,7 +502,7 @@ def panorama_commit():
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     return result
@@ -603,7 +603,7 @@ def panorama_push_to_device_group():
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     return result
@@ -868,7 +868,7 @@ def panorama_create_address(address_name: str, fqdn: str = None, ip_netmask: str
     http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
 
@@ -930,7 +930,7 @@ def panorama_delete_address(address_name: str):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1109,7 +1109,7 @@ def panorama_create_static_address_group(address_group_name: str, addresses: lis
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1130,7 +1130,7 @@ def panorama_create_dynamic_address_group(address_group_name: str, match: str,
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1200,7 +1200,7 @@ def panorama_delete_address_group(address_group_name: str):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1284,7 +1284,7 @@ def panorama_edit_address_group_command():
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
         address_group_output['Match'] = match
 
@@ -1294,7 +1294,7 @@ def panorama_edit_address_group_command():
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
         address_group_output['Addresses'] = addresses
 
@@ -1306,7 +1306,7 @@ def panorama_edit_address_group_command():
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
         address_group_output['Description'] = description
 
@@ -1318,7 +1318,7 @@ def panorama_edit_address_group_command():
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
         address_group_output['Tags'] = tags
 
@@ -1503,7 +1503,7 @@ def panorama_create_service(service_name: str, protocol: str, destination_port: 
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1560,7 +1560,7 @@ def panorama_delete_service(service_name: str):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1719,7 +1719,7 @@ def panorama_create_service_group(service_group_name, services, tags):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1768,7 +1768,7 @@ def panorama_delete_service_group(service_group_name):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -1815,7 +1815,7 @@ def panorama_edit_service_group(service_group_name, services, tag):
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
 
     if tag:
@@ -1826,7 +1826,7 @@ def panorama_edit_service_group(service_group_name, services, tag):
         result = http_request(
             URL,
             'POST',
-            params=params
+            body=params
         )
 
     return result
@@ -1981,7 +1981,7 @@ def panorama_create_custom_url_category(custom_url_category_name: str, type_: An
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     custom_url_category_output = {'Name': custom_url_category_name}
@@ -2036,7 +2036,7 @@ def panorama_delete_custom_url_category(custom_url_category_name):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -2089,7 +2089,7 @@ def panorama_edit_custom_url_category(custom_url_category_name, type_, items, de
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     custom_url_category_output = {'Name': custom_url_category_name,
@@ -2192,7 +2192,7 @@ def panorama_get_url_category(url_cmd, url):
     raw_result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
     result = raw_result['response']['result']
     if url_cmd == 'url-info-host':
@@ -2381,7 +2381,7 @@ def panorama_create_url_filter(
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
     return result
 
@@ -2447,7 +2447,7 @@ def panorama_edit_url_filter(url_filter_name, element_to_change, element_value, 
         params['xpath'] = XPATH_OBJECTS + "profiles/url-filtering/entry[@name='" + url_filter_name + "']/"
         + element_to_change
         params['element'] = add_argument_open(element_value, 'description', False)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         url_filter_output['Description'] = element_value
 
     elif element_to_change == 'override_allow_list':
@@ -2459,7 +2459,7 @@ def panorama_edit_url_filter(url_filter_name, element_to_change, element_value, 
 
         params['xpath'] = XPATH_OBJECTS + "profiles/url-filtering/entry[@name='" + url_filter_name + "']/allow-list"
         params['element'] = add_argument_list(new_override_allow_list, 'allow-list', True)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         url_filter_output[element_to_change] = new_override_allow_list
 
     # element_to_change == 'override_block_list'
@@ -2472,7 +2472,7 @@ def panorama_edit_url_filter(url_filter_name, element_to_change, element_value, 
 
         params['xpath'] = XPATH_OBJECTS + "profiles/url-filtering/entry[@name='" + url_filter_name + "']/block-list"
         params['element'] = add_argument_list(new_override_block_list, 'block-list', True)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         url_filter_output[element_to_change] = new_override_block_list
 
     return result, url_filter_output
@@ -2515,7 +2515,7 @@ def panorama_delete_url_filter(url_filter_name):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -2667,7 +2667,7 @@ def panorama_move_rule_command():
     if 'dst' in demisto.args():
         params['dst'] = demisto.args()['dst']
 
-    result = http_request(URL, 'POST', params=params)
+    result = http_request(URL, 'POST', body=params)
     rule_output = {'Name': rulename}
     if DEVICE_GROUP:
         rule_output['DeviceGroup'] = DEVICE_GROUP
@@ -2725,7 +2725,7 @@ def panorama_create_rule_command():
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     rule_output = {SECURITY_RULE_ARGS[key]: value for key, value in demisto.args().items() if key in SECURITY_RULE_ARGS}
@@ -2806,7 +2806,7 @@ def panorama_edit_rule_items(rulename: str, element_to_change: str, element_valu
             raise Exception(f'The object: {element_to_change} must have at least one item.')
 
     params['element'] = add_argument_list(values, element_to_change, True)
-    result = http_request(URL, 'POST', params=params)
+    result = http_request(URL, 'POST', body=params)
     rule_output = {
         'Name': rulename,
         SECURITY_RULE_ARGS[element_to_change]: values
@@ -2870,7 +2870,7 @@ def panorama_edit_rule_command():
             params['xpath'] = XPATH_SECURITY_RULES + '[@name=\'' + rulename + '\']'
         params['xpath'] += '/' + element_to_change
 
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
 
         rule_output = {
             'Name': rulename,
@@ -2915,7 +2915,7 @@ def panorama_delete_rule_command():
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     demisto.results({
@@ -2967,12 +2967,12 @@ def panorama_custom_block_rule_command():
             params = prepare_security_rule_params(api_action='set', action='drop', source=object_value,
                                                   destination=['any'], rulename=rulename + '-from', target=target,
                                                   log_forwarding=log_forwarding, tags=tags)
-            result = http_request(URL, 'POST', params=params)
+            result = http_request(URL, 'POST', body=params)
         if block_destination:
             params = prepare_security_rule_params(api_action='set', action='drop', destination=object_value,
                                                   source=['any'], rulename=rulename + '-to', target=target,
                                                   log_forwarding=log_forwarding, tags=tags)
-            result = http_request(URL, 'POST', params=params)
+            result = http_request(URL, 'POST', body=params)
         custom_block_output['IP'] = object_value
 
     elif object_type in ['address-group', 'edl']:
@@ -2980,26 +2980,26 @@ def panorama_custom_block_rule_command():
             params = prepare_security_rule_params(api_action='set', action='drop', source=object_value,
                                                   destination=['any'], rulename=rulename + '-from', target=target,
                                                   log_forwarding=log_forwarding, tags=tags)
-            result = http_request(URL, 'POST', params=params)
+            result = http_request(URL, 'POST', body=params)
         if block_destination:
             params = prepare_security_rule_params(api_action='set', action='drop', destination=object_value,
                                                   source=['any'], rulename=rulename + '-to', target=target,
                                                   log_forwarding=log_forwarding, tags=tags)
-            result = http_request(URL, 'POST', params=params)
+            result = http_request(URL, 'POST', body=params)
         custom_block_output['AddressGroup'] = object_value
 
     elif object_type == 'url-category':
         params = prepare_security_rule_params(api_action='set', action='drop', source=['any'], destination=['any'],
                                               category=object_value, rulename=rulename, target=target,
                                               log_forwarding=log_forwarding, tags=tags)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         custom_block_output['CustomURLCategory'] = object_value
 
     elif object_type == 'application':
         params = prepare_security_rule_params(api_action='set', action='drop', source=['any'], destination=['any'],
                                               application=object_value, rulename=rulename, target=target,
                                               log_forwarding=log_forwarding, tags=tags)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         custom_block_output['Application'] = object_value
 
     demisto.results({
@@ -3176,7 +3176,7 @@ def panorama_list_applications(predefined: bool):
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
     applications = result['response']['result']
     if predefined:
@@ -3357,7 +3357,7 @@ def panorama_create_edl(edl_name, url, type_, recurring, certificate_profile=Non
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3417,17 +3417,17 @@ def panorama_edit_edl(edl_name, element_to_change, element_value):
 
     if element_to_change == 'url':
         params['element'] = add_argument_open(element_value, 'url', False)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         edl_output['URL'] = element_value
 
     elif element_to_change == 'certificate_profile':
         params['element'] = add_argument_open(element_value, 'certificate-profile', False)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         edl_output['CertificateProfile'] = element_value
 
     elif element_to_change == 'description':
         params['element'] = add_argument_open(element_value, 'description', False)
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         edl_output['Description'] = element_value
 
     # element_to_change == 'recurring'
@@ -3435,7 +3435,7 @@ def panorama_edit_edl(edl_name, element_to_change, element_value):
         if element_value not in ['five-minute', 'hourly']:
             raise Exception('Recurring segment must be five-minute or hourly')
         params['element'] = '<recurring><' + element_value + '/></recurring>'
-        result = http_request(URL, 'POST', params=params)
+        result = http_request(URL, 'POST', body=params)
         edl_output['Recurring'] = element_value
 
     return result, edl_output
@@ -3476,7 +3476,7 @@ def panorama_delete_edl(edl_name):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3518,7 +3518,7 @@ def panorama_refresh_edl(edl_name):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3563,7 +3563,7 @@ def panorama_register_ip_tag(tag: str, ips: List, persistent: str):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3624,7 +3624,7 @@ def panorama_unregister_ip_tag(tag: str, ips: list):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3667,7 +3667,7 @@ def panorama_register_user_tag(tag: str, users: List):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -3725,7 +3725,7 @@ def panorama_unregister_user_tag(tag: str, users: list):
     result = http_request(
         URL,
         'POST',
-        params=params,
+        body=params,
     )
 
     return result
@@ -4791,7 +4791,7 @@ def panorama_download_latest_content_update_content(target: str):
     result = http_request(
         URL,
         'POST',
-        params=params
+        body=params
     )
 
     return result
@@ -5498,5 +5498,5 @@ def main():
         LOG.print_log()
 
 
-if __name__ in ["__builtin__", "builtins"]:
+if __name__ in ["__builtin__", "builtins", '__main__']:
     main()

--- a/Packs/PAN-OS/ReleaseNotes/1_0_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
-- __Panorama__ Replaced the spaces in the URL context output of the **!panorama-create-edl** command to `%20`.   
-
+- __Panorama__ 
+- Replaced the spaces in the URL context output of the **!panorama-create-edl** command to `%20`.   

--- a/Packs/PAN-OS/ReleaseNotes/1_0_2.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+- __Panorama__
+- POST request parameterss are now passed through body and not through the URI.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "PAN-OS",
-  "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
-  "support": "xsoar",
-  "currentVersion": "1.0.1",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Network Security"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "PAN-OS",
+    "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
+    "support": "xsoar",
+    "currentVersion": "1.0.2",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Network Security"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: demisto/etc#24535:

## Description
For some reason the server failed to return a proper response with status line, instead it sent a body without it.
That's why when the client tried to parse the first line of the body (the status line) it came across the first line of the following body:
```
<html>
<head><title>414 Request-URI Too Large</title></head>
<body bgcolor="white">
<center><h1>414 Request-URI Too Large</h1></center>
<hr><center></center>
</body>
</html>
```
And that's why the erroring status line was `BadStatusLine('<html>\r\n')`

Thing is when using a post request- the standard is to send the parameters through the body and not through the uri since the uri has a limit of =~ 2 kB which the body does not have.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [x] Documentation 

