### PR TITLE
updated git sha1 of clear release notes of version 20.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     environment:
       CONTENT_VERSION: "20.5.1"
       SERVER_VERSION: "5.5.0"
-      GIT_SHA1: "1ac60fc841b4fbd1afeb3c44713532960f1c1ebb" # guardrails-disable-line disable-secrets-detection
+      GIT_SHA1: "3d4b0f826752ae0555051966303a825051d2596c" # guardrails-disable-line disable-secrets-detection
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
replaced `GIT_SHA1` value in order to delete the branch `20.5.0_clear_rn`.

## Screenshots
![image](https://user-images.githubusercontent.com/30797606/82507899-2cb20b00-9b0c-11ea-9d6e-7dfab831c6e2.png)
