### PR TITLE
[trustar-150] Phishing Triage API changes  + Updating some contexts 

### DIFF
--- a/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
+++ b/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Non Breaking changes:
 - Fixed `from_time` description on `trustar-get-phishing-indicators` and `trustar-get-phishing-submissions` to '24 hours ago'
 - Added -1 to list of default values in `priority_event_score` on `trustar-get-phishing-submissions`
+- Added -1 to list of default values in `priority_event_score` and `normalized_indicator_score` on `trustar-get-phishing-indicators`
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
+++ b/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-- Updated docker image
-- Removed duplicated values on context
+Breaking changes:
+- `normalized_triage_score` argument replaced by `priority_event_score` in `trustar-get-phishing-submissions` command
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
+++ b/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
@@ -9,6 +9,7 @@ Non Breaking changes:
 - Added -1 to list of default values in `priority_event_score` on `trustar-get-phishing-submissions`
 - Added -1 to list of default values in `priority_event_score` and `normalized_indicator_score` on `trustar-get-phishing-indicators`
 
+
 ## [20.5.0] - 2020-05-12
 -
 

--- a/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
+++ b/Packs/TruSTAR/Integrations/TruSTAR/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [Unreleased]
 Breaking changes:
-- `normalized_triage_score` argument replaced by `priority_event_score` in `trustar-get-phishing-submissions` command
+- `normalized_triage_score` argument replaced by `priority_event_score` in `trustar-get-phishing-submissions` and `trustar-get-phishing-indicators` command.
+- `normalized_source_score` argument replaced by `normalized_indicator_score` in `trustar-get-phishing-indicators` command.
+- Updated context outputs on `trustar-get-phishing-submissions` and `trustar-get-phishing-indicators`.
+
+Non Breaking changes:
+- Fixed `from_time` description on `trustar-get-phishing-indicators` and `trustar-get-phishing-submissions` to '24 hours ago'
+- Added -1 to list of default values in `priority_event_score` on `trustar-get-phishing-submissions`
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
@@ -90,6 +90,12 @@ def translate_triage_submission(submissions):
     return submission_dicts, ec
 
 
+def translate_phishing_indicators(indicators):
+    indicator_dicts = [i.to_dict(remove_nones=True) for i in indicators]
+    ec = {'TruSTAR.PhishingIndicator(val.value == obj.value)': indicator_dicts}
+    return indicator_dicts, ec
+
+
 def translate_specific_indicators(ts_indicators, specific_types):
     res = []
     for indicator in ts_indicators:
@@ -665,7 +671,7 @@ def get_all_phishing_indicators(priority_event_score,
             'from_time': date_to_unix(from_time) if from_time else None,
             'to_time': date_to_unix(to_time) if to_time else None}
     response = ts.get_phishing_indicators_page(**args)
-    indicators, ec = translate_indicators(response.items, 'TruSTAR.PhishingIndicator')
+    indicators, ec = translate_phishing_indicators(response.items)
     if indicators:
         title = 'TruSTAR phishing indicators'
         entry = {

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.py
@@ -652,14 +652,14 @@ def get_enclaves():
     return entry
 
 
-def get_all_phishing_indicators(normalized_triage_score,
-                                normalized_source_score,
+def get_all_phishing_indicators(priority_event_score,
+                                normalized_indicator_score,
                                 from_time,
                                 to_time,
                                 status):
     cursor = encode_cursor(1000, 0)
-    args = {'normalized_triage_score': normalized_triage_score,
-            'normalized_source_score': normalized_source_score,
+    args = {'priority_event_score': priority_event_score,
+            'normalized_indicator_score': normalized_indicator_score,
             'status': status,
             'cursor': cursor,
             'from_time': date_to_unix(from_time) if from_time else None,
@@ -680,12 +680,12 @@ def get_all_phishing_indicators(normalized_triage_score,
     return 'No phishing indicators were found.'
 
 
-def get_phishing_submissions(normalized_triage_score,
+def get_phishing_submissions(priority_event_score,
                              from_time,
                              to_time,
                              status):
     cursor = encode_cursor(1000, 0)
-    args = {'normalized_triage_score': normalized_triage_score,
+    args = {'priority_event_score': priority_event_score,
             'status': status,
             'cursor': cursor,
             'from_time': date_to_unix(from_time) if from_time else None,
@@ -811,15 +811,15 @@ try:
                                                  ('Domain', 'URL',), create_domain_ec))
 
     elif demisto.command() == 'trustar-get-phishing-indicators':
-        nts = argToList(demisto.args().get('normalized_triage_score'))
-        nss = argToList(demisto.args().get('normalized_source_score'))
+        nts = argToList(demisto.args().get('priority_event_score'))
+        nss = argToList(demisto.args().get('normalized_indicator_score'))
         ft = demisto.args().get('from_time')
         tt = demisto.args().get('to_time')
         st = argToList(demisto.args().get('status'))
         demisto.results(get_all_phishing_indicators(nts, nss, ft, tt, st))
 
     elif demisto.command() == 'trustar-get-phishing-submissions':
-        nts = argToList(demisto.args().get('normalized_triage_score'))
+        nts = argToList(demisto.args().get('priority_event_score'))
         ft = demisto.args().get('from_time')
         tt = demisto.args().get('to_time')
         st = argToList(demisto.args().get('status'))

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
@@ -629,9 +629,9 @@ script:
     - name: priority_event_score
       description: Score of email submission
       isArray: true
-      defaultValue: 0,1,2,3
+      defaultValue: -1,0,1,2,3
     - name: from_time
-      description: Start of time window (defaults to 7 days ago) (YYYY-MM-DD HH:MM:SS)
+      description: Start of time window (defaults to 1 day ago) (YYYY-MM-DD HH:MM:SS)
     - name: to_time
       description: End of time window (defaults to current time) (YYYY-MM-DD HH:MM:SS)
     - name: status
@@ -664,6 +664,10 @@ script:
     - contextPath: TruSTAR.PhishingSubmission.context.normalizedIndicatorScore
       description: Indicator score
       type: number
+    - contextPath: TruSTAR.PhishingSubmission.context.originalIndicatorScore.name
+      description: Original Indicator score name
+    - contextPath: TruSTAR.PhishingSubmission.context.originalIndicatorScore.value
+      description: Original Indicator score value
     description: Fetches all phishing submissions that fit the given criteria
   - name: trustar-set-triage-status
     arguments:
@@ -690,7 +694,7 @@ script:
       isArray: true
       defaultValue: 0,1,2,3
     - name: from_time
-      description: Start of time window (defaults to 7 days ago) (YYYY-MM-DD HH:MM:SS)
+      description: Start of time window (defaults to 1 day ago) (YYYY-MM-DD HH:MM:SS)
     - name: to_time
       description: End of time window (defaults to current time) (YYYY-MM-DD HH:MM:SS)
     - name: status
@@ -705,32 +709,20 @@ script:
       isArray: true
       defaultValue: UNRESOLVED,CONFIRMED,IGNORED
     outputs:
-    - contextPath: TruSTAR.PhishingIndicator.File.Name
-      description: File name
+    - contextPath: TruSTAR.PhishingIndicator.indicatorType
+      description: Indicator Type
       type: string
-    - contextPath: TruSTAR.PhishingIndicator.File.MD5
-      description: File MD5
+    - contextPath: TruSTAR.PhishingIndicator.normalizedIndicatorScore
+      description: Indicator normalized score
+    - contextPath: TruSTAR.PhishingIndicator.originalIndicatorScore.name
+      description: Indicator original score name
+    - contextPath: TruSTAR.PhishingIndicator.originalIndicatorScore.value
+      description: Indicator original score value
+    - contextPath: TruSTAR.PhishingIndicator.sourceKey
+      description: Indicator source key
       type: string
-    - contextPath: TruSTAR.PhishingIndicator.File.SHA1
-      description: File SHA1
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.File.SHA256
-      description: File SHA256
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.URL.Address
-      description: URL address
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.IP.Address
-      description: IP address
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.Account.Email.Address
-      description: Email address
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.RegistryKey.Path
-      description: Registry key path
-      type: string
-    - contextPath: TruSTAR.PhishingIndicator.CVE.ID
-      description: CVE ID
+    - contextPath: TruSTAR.PhishingIndicator.value
+      description: Indicator value
       type: string
     description: Get phishing indicators that match the given criteria.
   dockerimage45: demisto/trustar:latest

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
@@ -688,11 +688,11 @@ script:
     - name: normalized_indicator_score
       description: Intel score of the indicator
       isArray: true
-      defaultValue: 0,1,2,3
+      defaultValue: -1,0,1,2,3
     - name: priority_event_score
       description: Score of email submission
       isArray: true
-      defaultValue: 0,1,2,3
+      defaultValue: -1,0,1,2,3
     - name: from_time
       description: Start of time window (defaults to 24 hours ago) (YYYY-MM-DD HH:MM:SS)
     - name: to_time

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
@@ -631,7 +631,7 @@ script:
       isArray: true
       defaultValue: -1,0,1,2,3
     - name: from_time
-      description: Start of time window (defaults to 1 day ago) (YYYY-MM-DD HH:MM:SS)
+      description: Start of time window (defaults to 24 hours ago) (YYYY-MM-DD HH:MM:SS)
     - name: to_time
       description: End of time window (defaults to current time) (YYYY-MM-DD HH:MM:SS)
     - name: status
@@ -694,7 +694,7 @@ script:
       isArray: true
       defaultValue: 0,1,2,3
     - name: from_time
-      description: Start of time window (defaults to 1 day ago) (YYYY-MM-DD HH:MM:SS)
+      description: Start of time window (defaults to 24 hours ago) (YYYY-MM-DD HH:MM:SS)
     - name: to_time
       description: End of time window (defaults to current time) (YYYY-MM-DD HH:MM:SS)
     - name: status

--- a/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
+++ b/Packs/TruSTAR/Integrations/TruSTAR/TruSTAR.yml
@@ -626,7 +626,7 @@ script:
     description: Check Domain reputation on TruStar
   - name: trustar-get-phishing-submissions
     arguments:
-    - name: normalized_triage_score
+    - name: priority_event_score
       description: Score of email submission
       isArray: true
       defaultValue: 0,1,2,3
@@ -652,7 +652,7 @@ script:
     - contextPath: TruSTAR.PhishingSubmission.title
       description: Submission title
       type: string
-    - contextPath: TruSTAR.PhishingSubmission.normalizedTriageScore
+    - contextPath: TruSTAR.PhishingSubmission.priorityEventScore
       description: Submission triage score
       type: number
     - contextPath: TruSTAR.PhishingSubmission.context.indicatorType
@@ -661,7 +661,7 @@ script:
     - contextPath: TruSTAR.PhishingSubmission.context.sourceKey
       description: Indicator source
       type: string
-    - contextPath: TruSTAR.PhishingSubmission.context.normalizedSourceScore
+    - contextPath: TruSTAR.PhishingSubmission.context.normalizedIndicatorScore
       description: Indicator score
       type: number
     description: Fetches all phishing submissions that fit the given criteria
@@ -681,11 +681,11 @@ script:
       tags
   - name: trustar-get-phishing-indicators
     arguments:
-    - name: normalized_source_score
+    - name: normalized_indicator_score
       description: Intel score of the indicator
       isArray: true
       defaultValue: 0,1,2,3
-    - name: normalized_triage_score
+    - name: priority_event_score
       description: Score of email submission
       isArray: true
       defaultValue: 0,1,2,3
@@ -734,6 +734,6 @@ script:
       type: string
     description: Get phishing indicators that match the given criteria.
   dockerimage45: demisto/trustar:latest
-  dockerimage: demisto/trustar:20.0.0.7752
+  dockerimage: demisto/trustar:20.1.0.8039
   runonce: false
   subtype: python2

--- a/Packs/TruSTAR/pack_metadata.json
+++ b/Packs/TruSTAR/pack_metadata.json
@@ -1,16 +1,18 @@
 {
   "name": "TruSTAR",
   "description": "TruSTAR's threat intelligence platform enriches every stage of the security operations workflow from the trusted and relevant data sources.",
-  "support": "xsoar",
+  "support": "partner",
   "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
+  "author": "TruSTAR",
+  "url": "https://www.trustar.co",
+  "email": "support@trustar.co",
   "created": "2020-04-14T00:00:00Z",
   "categories": [
     "Data Enrichment & Threat Intelligence"
   ],
   "tags": [],
   "useCases": [],
-  "keywords": []
+  "keywords": [
+    "TruSTAR"
+  ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Changes in TruSTAR Phishing Triage API

## Description
Some names and contracts changed in our API the last couple of weeks prior to GA of Phishing Triage.
Updating context outputs on `trustar-get-phishing-indicators` and `trustar-get-phishing-submissions` due to the phishing triage API changes. 
Fixing some default values and docs on the phishing commands

## Screenshots
![82069826-44236b00-96aa-11ea-9a4d-ec4e2e8eae64](https://user-images.githubusercontent.com/18565325/82598554-39247b00-9b81-11ea-9a8b-da4482646bdb.png)

![82069825-42f23e00-96aa-11ea-8641-7170cd832fe8](https://user-images.githubusercontent.com/18565325/82598645-61ac7500-9b81-11ea-8fb7-3ad6b5e427cd.png)

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details: We changed parts of the contract of our Phishing Triage API. This has an impact in some commands that we recently added. Given that we are making Phishing Triage GA after May 18 we needed to replicate it in the integration. **Although from an implementation perspective this are breaking changes, we are safe because there are no users using these features yet.**
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [x] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

