### PR TITLE
Microsoft Graph Mail Single User - set last run to be last fetched and not now time

### DIFF
--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/CHANGELOG.md
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Fixed an issue in which some emails were not fetched as incidents.
+Fixed an issue where some emails were not fetched as incidents.
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/CHANGELOG.md
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed an issue in which some emails were not fetched as incidents.
 
 ## [20.5.0] - 2020-05-12
 -

--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.py
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.py
@@ -45,16 +45,6 @@ EMAIL_DATA_MAPPING = {
 ''' HELPER FUNCTIONS '''
 
 
-def get_now_utc():
-    """
-    Creates UTC current time of format Y-m-dTH:M:SZ (e.g. 2019-11-06T09:06:39Z)
-
-    :return: String format of current UTC time
-    :rtype: ``str``
-    """
-    return datetime.utcnow().strftime(DATE_FORMAT)
-
-
 def add_second_to_str_date(date_string, seconds=1):
     """
     Add seconds to date string.
@@ -673,7 +663,6 @@ class MsGraphClient:
         :return: Next run data and parsed fetched incidents
         :rtype: ``dict`` and ``list``
         """
-        start_time = get_now_utc()
         last_fetch = last_run.get('LAST_RUN_TIME')
         exclude_ids = last_run.get('LAST_RUN_IDS', [])
         last_run_folder_path = last_run.get('LAST_RUN_FOLDER_PATH')
@@ -694,7 +683,7 @@ class MsGraphClient:
         fetched_emails, fetched_emails_ids = self._fetch_last_emails(folder_id=folder_id, last_fetch=last_fetch,
                                                                      exclude_ids=exclude_ids)
         incidents = list(map(self._parse_email_as_incident, fetched_emails))
-        next_run_time = MsGraphClient._get_next_run_time(fetched_emails, start_time)
+        next_run_time = MsGraphClient._get_next_run_time(fetched_emails, last_fetch)
         next_run = {
             'LAST_RUN_TIME': next_run_time,
             'LAST_RUN_IDS': fetched_emails_ids,

--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
@@ -71,7 +71,6 @@ def last_run_data():
 
 @pytest.mark.parametrize('client', [oproxy_client(), self_deployed_client()])
 def test_fetch_incidents(mocker, client, emails_data, expected_incident, last_run_data):
-    mocker.patch('MicrosoftGraphListener.get_now_utc', return_value='2019-11-12T15:01:00Z')
     mocker.patch.object(client.ms_client, 'http_request', return_value=emails_data)
     mocker.patch.object(demisto, "info")
     result_next_run, result_incidents = client.fetch_incidents(last_run_data)

--- a/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_1.md
+++ b/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+- __Microsoft Graph Mail Single User__
+Fixed an issue in which some emails were not fetched as incidents.

--- a/Packs/MicrosoftGraphListener/pack_metadata.json
+++ b/Packs/MicrosoftGraphListener/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Microsoft Graph Mail Single User",
-  "description": "Microsoft Graph grants Demisto authorized access to a user's Microsoft Outlook mail data in a personal account or organization account.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Email Gateway"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Microsoft Graph Mail Single User",
+    "description": "Microsoft Graph grants Demisto authorized access to a user's Microsoft Outlook mail data in a personal account or organization account.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Email Gateway"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/24502

## Description
In case no emails were fetched, now time was set as last fetch, and led to emails missed and not fetched

set the last run to be the last fetched


## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
