### PR TITLE
Adding a Prerequisites section to EmailAskUser

### DIFF
--- a/Packs/CommonScripts/Scripts/script-EmailAskUser_README.md
+++ b/Packs/CommonScripts/Scripts/script-EmailAskUser_README.md
@@ -35,3 +35,10 @@ Asks a user a question via email and process the reply directly into the investi
 ## Outputs
 ---
 There are no outputs for this script.
+
+
+## Prerequisites
+---
+Requires an instance of one of the email integrations: Gmail, MS grpah mail, EWS, POP3, Mail sender .
+
+

--- a/Packs/CommonScripts/Scripts/script-EmailAskUser_README.md
+++ b/Packs/CommonScripts/Scripts/script-EmailAskUser_README.md
@@ -39,6 +39,6 @@ There are no outputs for this script.
 
 ## Prerequisites
 ---
-Requires an instance of one of the email integrations: Gmail, MS grpah mail, EWS, POP3, Mail sender .
+Requires an instance of one of the email integrations: Gmail, MS Graph Mail, EWS, POP3, or Mail Sender.
 
 


### PR DESCRIPTION
Adding a Prerequisites section like in https://xsoar.pan.dev/docs/reference/scripts/slack-ask.
makes it easier to the user to understand which integration instance needed in order to use the script.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

