### PR TITLE
FeedCofense: 'test' button always returned a positive answer

### DIFF
--- a/Packs/FeedCofense/Integrations/FeedCofense/CHANGELOG.md
+++ b/Packs/FeedCofense/Integrations/FeedCofense/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-
+Fixed a bug where the 'test' button always returned a positive 
+answer.
 
 ## [20.3.4] - 2020-03-30
 -

--- a/Packs/FeedCofense/Integrations/FeedCofense/CHANGELOG.md
+++ b/Packs/FeedCofense/Integrations/FeedCofense/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-Fixed a bug where the 'test' button always returned a positive 
-answer.
+Fixed a bug where the 'Test' button always returned a positive 
+result.
 
 ## [20.3.4] - 2020-03-30
 -

--- a/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
+++ b/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
@@ -304,10 +304,11 @@ def main():
     # handle params
     url = "https://www.threathq.com"
     credentials = params.get("credentials", {})
-    auth = (credentials.get("identifier"), credentials.get("password"))
-    if not auth[0] or not auth[1]:
+    if not credentials:
         raise DemistoException("Credentials are empty. "
                                "Fill up the username/password fields in the integration configuration.")
+
+    auth = (credentials.get("identifier"), credentials.get("password"))
     verify = not params.get("insecure")
     proxy = params.get("proxy")
     threat_type = params.get("threat_type")

--- a/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
+++ b/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
@@ -305,6 +305,9 @@ def main():
     url = "https://www.threathq.com"
     credentials = params.get("credentials", {})
     auth = (credentials.get("identifier"), credentials.get("password"))
+    if not auth[0] or not auth[1]:
+        raise DemistoException("Credentials are empty. "
+                               "Fill up the username/password fields in the integration configuration.")
     verify = not params.get("insecure")
     proxy = params.get("proxy")
     threat_type = params.get("threat_type")

--- a/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
+++ b/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.py
@@ -194,7 +194,8 @@ def test_module(client: Client) -> Tuple[str, dict, dict]:
     Returns:
         str -- "ok" if succeeded, else raises a error.
     """
-    client.build_iterator()
+    for _ in client.build_iterator():
+        return "ok", {}, {}
     return "ok", {}, {}
 
 

--- a/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.yml
+++ b/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.yml
@@ -117,7 +117,7 @@ script:
     description: Gets indicators from the feed.
     execution: false
     name: cofense-get-indicators
-  dockerimage: demisto/python3:3.8.2.8347
+  dockerimage: demisto/python3:3.8.3.8347
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.yml
+++ b/Packs/FeedCofense/Integrations/FeedCofense/FeedCofense.yml
@@ -117,7 +117,7 @@ script:
     description: Gets indicators from the feed.
     execution: false
     name: cofense-get-indicators
-  dockerimage: demisto/python3:3.8.2.6981
+  dockerimage: demisto/python3:3.8.2.8347
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedCofense/ReleaseNotes/1_0_1.md
+++ b/Packs/FeedCofense/ReleaseNotes/1_0_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+- __Cofense Feed__
+Fixed a bug where the 'test' button always returned a positive 
+answer.

--- a/Packs/FeedCofense/pack_metadata.json
+++ b/Packs/FeedCofense/pack_metadata.json
@@ -1,19 +1,19 @@
 {
-  "name": "Cofense Feed",
-  "description": "Indicators feed from Cofense",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-03-09T16:04:45Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": [
-    "Cofense",
-    "Feed"
-  ]
+    "name": "Cofense Feed",
+    "description": "Indicators feed from Cofense",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-03-09T16:04:45Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": [
+        "Cofense",
+        "Feed"
+    ]
 }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24794

## Description
Fixed a bug where the 'test' button always returned a positive 
answer.


## Screenshots
before:
![image](https://user-images.githubusercontent.com/11165655/82748103-f8f31180-9da7-11ea-9269-6bf0e9d105c1.png)
after:
![image](https://user-images.githubusercontent.com/11165655/82748084-dd880680-9da7-11ea-8499-128dbd2a0785.png)

## Minimum version of Demisto
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] No


