### PR TITLE
Fixed a bug in query-logs command

### DIFF
--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CHANGELOG.md
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Fixed a bug in the ***cdl-query-logs*** when no records are found for a given query.
 
 ## [20.5.0] - 2020-05-12
   - Fixed exception parsing.

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
@@ -546,7 +546,7 @@ def query_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[
 
     records, raw_results = client.query_loggings(query)
 
-    table_name = get_table_name(records)
+    table_name = get_table_name(query)
     transformed_results = [common_context_transformer(record) for record in records]
     human_readable = tableToMarkdown('Logs ' + table_name + ' table', transformed_results, removeNull=True)
     ec = {
@@ -555,16 +555,20 @@ def query_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[
     return human_readable, ec, raw_results
 
 
-def get_table_name(records: List[Dict[str, Any]]):
+def get_table_name(query: str) -> str:
     """
     Table name is stored in log_type attribute of the records
     Args:
-        records: Records to get the table name of
+        query: Query string, i.e SELECT * FROM firewall.threat LIMIT 1
 
     Returns:
-        The records table name
+        The query's table name
     """
-    return next(record.get('log_type', {}).get('value') for record in records if record.get('log_type')) or ''
+    find_table_name_from_query = r'(FROM `)(\w+.\w+)(`)'
+    search_result = re.search(find_table_name_from_query, query)
+    if search_result:
+        return search_result.group(2)
+    return "Unrecognized table name"
 
 
 def get_critical_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[dict]], List[Dict[str, Any]]]:

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
@@ -1506,7 +1506,7 @@ script:
     - contextPath: CDL.Logging.Threat.SourcePort
       description: Source port utilized by the session.
       type: Number
-  dockerimage: demisto/python_pancloud_v2:1.0.0.6519
+  dockerimage: demisto/python_pancloud_v2:1.0.0.7727
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
@@ -101,8 +101,7 @@ def test_prepare_fetch_incidents_query():
 
 def test_get_table_name():
     from CortexDataLake import get_table_name
-    # Records in each query should all have the same table (log_type)
-    # In this test records have different log_type just to verify that the function takes the first
-    records = [{'log_type': {'id': 3, 'value': 'threat'}},
-               {'log_type': {'id': 3, 'value': 'traffic'}}]
-    assert get_table_name(records) == 'threat'
+    query = 'SELECT pcap FROM `firewall.threat` WHERE is_packet_capture = true  AND severity = "Critical" LIMIT 10'
+    assert get_table_name(query) == 'firewall.threat'
+    query = 'Wrongly formmated query'
+    assert get_table_name(query) == 'Unrecognized table name'

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
@@ -776,7 +776,8 @@ Searches the Cortex panw.threat table, which is the threat logs table for PAN-OS
 | File.Type | String | The file type, as determined by libmagic (same as displayed in file entries). | 
 
 
-##### Command Example
+##### Command Examples
+```!cdl-query-threat-logs query="is_packet_capture = true AND severity = \"Critical\"" fields=pcap limit=10```
 ```!cdl-query-threat-logs action="allow" fields="vendor_name,log_source,rule_matched,dest_location,log_time" time_range="10 days" limit="1"```
 
 ##### Context Example

--- a/Packs/CortexDataLake/ReleaseNotes/1_0_1.md
+++ b/Packs/CortexDataLake/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+### Integrations
+- __Cortex Data Lake__
+  - Fixed a bug in the ***cdl-query-logs*** when no records are found for a given query.

--- a/Packs/CortexDataLake/pack_metadata.json
+++ b/Packs/CortexDataLake/pack_metadata.json
@@ -1,19 +1,19 @@
 {
-  "name": "Cortex Data Lake",
-  "description": "Palo Alto Networks Cortex Data Lake provides cloud-based, centralized log storage and aggregation for your on premise, virtual (private cloud and public cloud) firewalls, for Prisma Access, and for cloud-delivered services such as Cortex XDR",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-03-24T12:58:02Z",
-  "categories": [
-    "Analytics & SIEM"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": [
-    "CDL",
-    "Cortex Data Lake"
-  ]
+    "name": "Cortex Data Lake",
+    "description": "Palo Alto Networks Cortex Data Lake provides cloud-based, centralized log storage and aggregation for your on premise, virtual (private cloud and public cloud) firewalls, for Prisma Access, and for cloud-delivered services such as Cortex XDR",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-03-24T12:58:02Z",
+    "categories": [
+        "Analytics & SIEM"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": [
+        "CDL",
+        "Cortex Data Lake"
+    ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
When there were no records found for a given query in **!cdl-query-logs** command a `StopIteration` was raised and in the user side- there was no reason for the error at all.

So instead of getting table name from the records, table name will be taken from the query.



## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

