### PR TITLE
CircleCI Nightly Scheduled Trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,3 +605,15 @@ workflows:
     jobs:
       - build:
           context: instances_test_env
+  nightly:
+    triggers:
+      - schedule:
+          # should trigger every day at 9 PM UTC (12 AM Israel Time)
+          cron: "0 21 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: nightly_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,7 +609,7 @@ workflows:
     triggers:
       - schedule:
           # should trigger every day at 9 PM UTC (12 AM Israel Time)
-          cron: "0 21 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/23265

## Description
Schedules a nightly build to be triggered using the CircleCI `config.yml` itself. Also, disabled the pre-existing crontab job.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

