### PR TITLE
Added reputation command under the MITRE indicator type

### DIFF
--- a/Packs/FeedMitreAttack/IndicatorTypes/reputation-mitreAttck.json
+++ b/Packs/FeedMitreAttack/IndicatorTypes/reputation-mitreAttck.json
@@ -9,7 +9,7 @@
     "details": "MITRE ATT&CK",
     "prevDetails": "MITRE ATT&CK",
     "reputationScriptName": "",
-    "reputationCommand": "",
+    "reputationCommand": "mitre-reputation",
     "enhancementScriptNames": [],
     "system": false,
     "locked": false,

--- a/Packs/FeedMitreAttack/pack_metadata.json
+++ b/Packs/FeedMitreAttack/pack_metadata.json
@@ -1,20 +1,20 @@
 {
-  "name": "MITRE ATT&CK",
-  "description": "Fetches indicators from MITRE ATT&CK.",
-  "support": "xsoar",
-  "currentVersion": "1.0.1",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "created": "2020-04-23T17:32:00Z",
-  "useCases": [],
-  "keywords": [
-    "MITRE",
-    "Feed",
-    "ATT&CK"
-  ]
+    "name": "MITRE ATT&CK",
+    "description": "Fetches indicators from MITRE ATT&CK.",
+    "support": "xsoar",
+    "currentVersion": "1.0.2",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "created": "2020-04-23T17:32:00Z",
+    "useCases": [],
+    "keywords": [
+        "MITRE",
+        "Feed",
+        "ATT&CK"
+    ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24939

## Description
Adds a default reputation command to the MITRE indicator type

## Screenshots
Edited indicator:
![image](https://user-images.githubusercontent.com/53576129/82885871-a0ee1380-9f3d-11ea-8eb0-85eed0826f2e.png)

Results in reputation command providing hyper-link in "quick-view" pane:
![image](https://user-images.githubusercontent.com/53576129/82886008-d266df00-9f3d-11ea-8613-5a19a47a3a6b.png)



## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
NA

