### PR TITLE
Packs changelog - added build number to display name

### DIFF
--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import os
+import random
 from unittest.mock import mock_open
 from Tests.Marketplace.marketplace_services import Pack, Metadata, input_to_list, get_valid_bool, convert_price, \
     get_higher_server_version, GCPConfig
@@ -243,7 +244,8 @@ class TestChangelogCreation:
         """
         mocker.patch("os.path.exists", return_value=False)
         dummy_path = 'Irrelevant/Test/Path'
-        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path)
+        build_number = random.randint(0, 100000)
+        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path, build_number=build_number)
         assert result is True
 
     def test_prepare_release_notes_upgrade_version(self, mocker, dummy_pack):
@@ -274,7 +276,8 @@ class TestChangelogCreation:
         }'''
         mocker.patch('builtins.open', mock_open(read_data=original_changelog))
         dummy_path = 'Irrelevant/Test/Path'
-        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path)
+        build_number = random.randint(0, 100000)
+        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path, build_number=build_number)
         assert result is True
 
     def test_prepare_release_notes_upgrade_version_mismatch(self, mocker, dummy_pack):
@@ -306,7 +309,8 @@ class TestChangelogCreation:
         }'''
         mocker.patch('builtins.open', mock_open(read_data=original_changelog))
         dummy_path = 'Irrelevant/Test/Path'
-        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path)
+        build_number = random.randint(0, 100000)
+        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path, build_number=build_number)
         assert result is False
 
     def test_prepare_release_notes_upgrade_version_dup(self, mocker, dummy_pack):
@@ -339,7 +343,8 @@ class TestChangelogCreation:
         }'''
         mocker.patch('builtins.open', mock_open(read_data=original_changelog))
         dummy_path = 'Irrelevant/Test/Path'
-        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path)
+        build_number = random.randint(0, 100000)
+        result = Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path, build_number=build_number)
         assert result is True
 
 

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -610,12 +610,13 @@ class Pack(object):
             print_error(f"Failed in uploading {self._pack_name} pack to gcs. Additional info:\n {e}")
             return task_status, True
 
-    def prepare_release_notes(self, index_folder_path):
+    def prepare_release_notes(self, index_folder_path, build_number):
         """
         Handles the creation and update of the changelog.json files.
 
         Args:
             index_folder_path (str): Path to the unzipped index json.
+            build_number (str): circleCI build number, used as an index revision.
         Returns:
             bool: whether the operation succeeded.
         """
@@ -660,7 +661,7 @@ class Pack(object):
                         with open(latest_rn_path, 'r') as changelog_md:
                             changelog_lines = changelog_md.read()
                         version_changelog = {'releaseNotes': changelog_lines,
-                                             'displayName': latest_release_notes,
+                                             'displayName': f'{latest_release_notes} ({build_number})',
                                              'released': datetime.utcnow().strftime(Metadata.DATE_FORMAT)}
                         changelog[latest_release_notes] = version_changelog
 
@@ -674,7 +675,7 @@ class Pack(object):
             elif self._current_version == Pack.PACK_INITIAL_VERSION:
                 changelog = {}
                 version_changelog = {'releaseNotes': self._description,
-                                     'displayName': Pack.PACK_INITIAL_VERSION,
+                                     'displayName': f'{Pack.PACK_INITIAL_VERSION} ({build_number})',
                                      'released': datetime.utcnow().strftime(Metadata.DATE_FORMAT)}
                 changelog[Pack.PACK_INITIAL_VERSION] = version_changelog
 

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -583,7 +583,7 @@ def main():
             pack.cleanup()
             continue
 
-        task_status = pack.prepare_release_notes(index_folder_path)
+        task_status = pack.prepare_release_notes(index_folder_path, build_number)
         if not task_status:
             pack.status = PackStatus.FAILED_RELEASE_NOTES.name
             pack.cleanup()


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold 

## Related Issues
related to: https://github.com/demisto/etc/issues/24750

## Description
Added build number to packs display name version in `changelog.json`.