### PR TITLE
Migrating circleci build to using workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,31 @@ parameters:
   server_branch_name:
     type: string
     default: ""
+  backward_compatibility:
+    type: string
+    default: ""
+  nightly:
+    type: string
+    default: ""
+  instance_tests:
+    type: string
+    default: ""
+  demisto_sdk_nightly:
+    type: string
+    default: ""
+  mem_check:
+    type: string
+    default: ""
+  time_to_live:
+    type: string
+    default: ""
+  contrib_branch:
+    type: string
+    default: ""
+  contrib_pack_name:
+    type: string
+    default: ""
+
 
 references:
   environment: &environment
@@ -19,6 +44,16 @@ references:
       NON_AMI_RUN: << pipeline.parameters.non_ami_run >>
       ARTIFACT_BUILD_NUM: << pipeline.parameters.artifact_build_num >>
       SERVER_BRANCH_NAME: << pipeline.parameters.server_branch_name >>
+      BACKWARD_COMPATIBILITY: << pipeline.parameters.backward_compatibility >>
+      MEM_CHECK: << pipeline.parameters.mem_check >>
+      TIME_TO_LIVE: << pipeline.parameters.time_to_live >>
+      CONTRIB_BRANCH: << pipeline.parameters.contrib_branch >>
+      CONTRIB_PACK_NAME: << pipeline.parameters.contrib_pack_name >>
+      # Giving different names to the following pipeline parameters to avoid collision, handling such collision case
+      # is done in 'Prepare Environment' step.
+      NIGHTLY_PARAMETER: << pipeline.parameters.nightly >>
+      INSTANCE_TESTS_PARAMETER: << pipeline.parameters.instance_tests >>
+      DEMISTO_SDK_NIGHTLY_PARAMETER: << pipeline.parameters.demisto_sdk_nightly >>
 
   container_config: &container_config
     docker:
@@ -46,15 +81,22 @@ references:
       name: Prepare Environment
       when: always
       command: |
-        if [ -n "${INSTANCE_TESTS}" ] && [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-          then
-            echo "Skipping - instance tests tasks are running only in container number 0"
-            exit 0
-        fi
         echo 'export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"' >> $BASH_ENV
         echo 'export PATH="/home/circleci/.local/bin:${PWD}/node_modules/.bin:${PATH}"' >> $BASH_ENV # disable-secrets-detection
         echo 'export PYTHONPATH="/home/circleci/project:${PYTHONPATH}"' >> $BASH_ENV
         echo 'export DEMISTO_README_VALIDATION=true' >> $BASH_ENV
+        if [ -n "${NIGHTLY_PARAMETER}" ];
+        then
+            echo 'export NIGHTLY=true' >> $BASH_ENV
+        fi
+        if [ -n "${INSTANCE_TESTS_PARAMETER}" ];
+        then
+            echo 'export INSTANCE_TESTS=true' >> $BASH_ENV
+        fi
+        if [ -n "${DEMISTO_SDK_NIGHTLY_PARAMETER}" ];
+        then
+            echo 'export DEMISTO_SDK_NIGHTLY=true' >> $BASH_ENV
+        fi
         echo "=== sourcing $BASH_ENV ==="
         source $BASH_ENV
         sudo mkdir -p -m 777 $CIRCLE_ARTIFACTS
@@ -81,7 +123,7 @@ references:
         fi
 
         echo "========== Build Parameters =========="
-        echo "Parameters: NIGHTLY: $NIGHTLY, INSTANCE_TESTS: $INSTANCE_TESTS, NON_AMI_RUN: $NON_AMI_RUN, SERVER_BRANCH_NAME: $SERVER_BRANCH_NAME, ARTIFACT_BUILD_NUM: $ARTIFACT_BUILD_NUM, DEMISTO_SDK_NIGHTLY: $DEMISTO_SDK_NIGHTLY, TIME_TO_LIVE: $TIME_TO_LIVE, CONTRIB_BRANCH: $CONTRIB_BRANCH"
+        set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^NON_AMI_RUN=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH="
         python --version
         python3 --version
         demisto-sdk --version
@@ -104,6 +146,16 @@ references:
     run:
       name: Destroy Instances
       command: |
+        if [ -n "${TIME_TO_LIVE}" ]
+        then
+            echo "Skipping - Time to live was set to $TIME_TO_LIVE minutes"
+            exit 0
+        fi
+        if [ -n "${DEMISTO_SDK_NIGHTLY}" ]
+          then
+            echo "Skipping - not running in demisto-sdk nightly"
+            exit 0
+        fi
         echo "$INSTANCE_ROLE"
         export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
         if [[ "$TEMP" == "false" ]];
@@ -123,674 +175,114 @@ references:
       root: /home/circleci/
       paths:
         - project
-jobs:
-  build:
-    <<: *container_config
-    parallelism: 2
-    <<: *environment
-    steps:
-      - checkout
-      - setup_remote_docker
-      - restore_cache:
-          key: venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
-      - *prepare_environment
-      - save_cache:
-          paths:
-            - venv
-            - node_modules
-          key: venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
-      - add_ssh_keys:
-          fingerprints:
-            - "02:df:a5:6a:53:9a:f5:5d:bd:a6:fc:b2:db:9b:c9:47" # disable-secrets-detection
-            - "f5:25:6a:e5:ac:4b:84:fb:60:54:14:82:f1:e9:6c:f9" # disable-secrets-detection
-      - run:
-          name: Get Contributor pack
-          when: always
-          command: |
-            if [ -z $CONTRIB_BRANCH ]
-            then
-              echo "Skipping, contributor branch not given."
-              exit 0
-            else
-              USER=$(echo $CONTRIB_BRANCH | cut -d ":" -f 1)
-              BRANCH=$(echo $CONTRIB_BRANCH | cut -d ":" -f 2)
-              PACK=$(echo $CONTRIB_BRANCH | cut -d ":" -f 3)
 
-              echo "Copy the changes from the contributor branch $USER/$BRANCH in the pack $PACK"
-              git remote add $USER git@github.com:$USER/content.git
-              git fetch $USER $BRANCH
-              git checkout $USER/$BRANCH $PACK
-              exit 0
-            fi
-
-      - run:
-          name: Check if CircleCI's config file is up to date
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping, Should not run on contributor's branch."
-              exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            # Checks if there's any diff from master
-            if [[ `git diff origin/master -- .circleci/config.yml` ]]; then
-                # Checks if part of the branch's changes
-                if [[ -z `git diff origin/master..."$CIRCLE_BRANCH" --name-only | grep .circleci/config.yml` ]]; then
-                    echo ".circleci/config.yml has been changed. Merge from master"
-                    exit 1
-                else
-                    echo ".circleci/config.yml is part of the branch changes, proceeding"
-                    exit 0
-                fi
-            else
-                echo ".circleci/config.yml is up to date!"
-            fi
-      - run:
-          name: Update Tests step
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            python3 ./Tests/scripts/update_conf_json.py
-            cp "./Tests/conf.json" "$CIRCLE_ARTIFACTS/conf.json"
-      - run:
-          name: Create ID Set
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            demisto-sdk create-id-set -o ./Tests/id_set.json
-      - run:
-          name: Infrastructure testing
-          when: always
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container"
-                exit 0
-            fi
-
-            python3 -m pytest ./Tests/scripts/infrastructure_tests/ -v
-            python3 -m pytest ./Tests/Marketplace/Tests/ -v
-
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ] ; then
-                  ./Tests/scripts/sdk_pylint_check.sh
-            fi
+  Secrets: &Secrets
+    run:
+      name: Secrets
+      when: always
+      command: |
+        demisto-sdk secrets --post-commit --ignore-entropy
+  validate_files_and_yaml: &validate_files_and_yaml
+    run:
+      name: Validate Files and Yaml
+      when: always
+      command: |
+        if [ -n "${NIGHTLY}" ];
+          then
+            echo "Skipping - not running in Nightly run"
             exit 0
-      - run:
-          name: Validate Files and Yaml
-          when: always
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] || [ -n "${NIGHTLY}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container or Nightly run"
-                exit 0
-            fi
+        fi
+        # Run flake8 on all excluding Packs (Integraions and Scripts) - they will be handled in linting
+        ./Tests/scripts/pyflake.sh *.py
+        find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv \) | xargs ./Tests/scripts/pyflake.sh
 
-            # Run flake8 on all excluding Packs (Integraions and Scripts) - they will be handled in linting
-            ./Tests/scripts/pyflake.sh *.py
-            find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv \) | xargs ./Tests/scripts/pyflake.sh
+        [ -n "${BACKWARD_COMPATIBILITY}" ] && CHECK_BACKWARD="false" || CHECK_BACKWARD="true"
+        ./Tests/scripts/validate.sh
+  run_unit_testing_and_lint: &run_unit_testing_and_lint
+    run:
+      name: Run Unit Testing and Lint
+      when: always
+      no_output_timeout: 5h
+      command: |
+        echo "demisto-sdk version: $(demisto-sdk --version)"
+        echo "mypy version: $(mypy --version)"
+        echo "flake8 py2 version: $(python2 -m flake8 --version)"
+        echo "flake8 py3 version: $(python3 -m flake8 --version)"
+        echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
+        echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
+        echo "vulture py2 version: $(python2 -m vulture --version) 2>&1"
+        echo "vulture py3 version: $(python3 -m vulture --version) 2>&1"
+        SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
+        mkdir ./unit-tests
+        if [ -n "$SHOULD_LINT_ALL" ]; then
+          echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
+          demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
+        else
+          demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
+        fi
+  infrastructure_testing: &infrastructure_testing
+    run:
+      name: Infrastructure testing
+      when: always
+      command: |
+        python3 -m pytest ./Tests/scripts/infrastructure_tests/ -v
+        python3 -m pytest ./Tests/Marketplace/Tests/ -v
 
-            [ -n "${BACKWARD_COMPATIBILITY}" ] && CHECK_BACKWARD="false" || CHECK_BACKWARD="true"
-            ./Tests/scripts/validate.sh
-      - run:
-          name: Secrets
-          when: always
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container"
-                exit 0
-            fi
+        if [ -n "${DEMISTO_SDK_NIGHTLY}" ] ; then
+          ./Tests/scripts/sdk_pylint_check.sh
+        fi
+  create_id_set: &create_id_set
+    run:
+      name: Create ID Set
+      when: always
+      command: |
+        demisto-sdk create-id-set -o ./Tests/id_set.json
+  build_content_descriptor: &build_content_descriptor
+    run:
+      name: Build Content Descriptor
+      when: always
+      command: |
+        if [ -n "${GITHUB_TOKEN}" ] ;
+          then
+            # new release notes summary generator in packs format
+            python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md --github-token $GITHUB_TOKEN
+          else
+            # new release notes summary generator in packs format
+            python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md
+        fi
+  common_server_documentation: &common_server_documentation
+    run:
+      name: Common Server Documentation
+      when: always
+      command: |
+        ./Documentation/commonServerDocs.sh
+  collect_test_list_and_content_packs: &collect_test_list_and_content_packs
+    run:
+      name: Collect Test List And Content Packs
+      when: always
+      command: |
+        if [ -n "${INSTANCE_TESTS}" ];
+          then
+            echo "Skipping - not running in INSTANCE_TESTS build"
+            exit 0
+        fi
 
-            demisto-sdk secrets --post-commit --ignore-entropy
-      - run:
-          name: Collect Test List And Content Packs
-          when: always
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container"
-                exit 0
-            fi
-
-            [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
-            python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
-      - run:
-          name: Spell Checks
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container"
-                exit 0
-            fi
-            python3 ./Tests/scripts/circleci_spell_checker.py $CIRCLE_BRANCH
-      - run:
-          name: Build Content Descriptor
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            if [ -n "${GITHUB_TOKEN}" ] ;
-              then
-                # new release notes summary generator in packs format
-                python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md --github-token $GITHUB_TOKEN
-              else
-                # new release notes summary generator in packs format
-                python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md
-            fi
-      - run:
-          name: Common Server Documentation
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            ./Documentation/commonServerDocs.sh
-      - run:
-          name: Content Docs Site
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ];
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            ./Documentation/docs_site_update.sh
-      - run:
-          name: Create Content Artifacts
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            demisto-sdk create-content-artifacts -a $CIRCLE_ARTIFACTS
-            # create zip with contents of content_new.zip and content_test.zip for use in updating content on instances
-            cp "$CIRCLE_ARTIFACTS/content_new.zip" "$CIRCLE_ARTIFACTS/all_content.zip"
-            unzip -q "$CIRCLE_ARTIFACTS/content_test.zip" -d "test_content_dir"
-            zip -j "$CIRCLE_ARTIFACTS/all_content.zip" test_content_dir/*
-            rm -r test_content_dir
-      - run:
-          name: Calculate Packs Dependencies
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo "Skipping - running only in container number 0"
-                exit 0
-            fi
-            python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $CIRCLE_ARTIFACTS/packs_dependencies.json
-      - run:
-          name: Run Unit Testing and Lint
-          when: always
-          no_output_timeout: 5h
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 1 ] ;
-              then
-                echo "Skipping - unit tests are running only in container number 1"
-                exit 0
-            fi
-            echo "demisto-sdk version: $(demisto-sdk --version)"
-            echo "mypy version: $(mypy --version)"
-            echo "flake8 py2 version: $(python2 -m flake8 --version)"
-            echo "flake8 py3 version: $(python3 -m flake8 --version)"
-            echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
-            echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
-            echo "vulture py2 version: $(python2 -m vulture --version) 2>&1"
-            echo "vulture py3 version: $(python3 -m vulture --version) 2>&1"
-            SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
-            mkdir ./unit-tests
-            if [ -n "$SHOULD_LINT_ALL" ]; then
-              echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
-              demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
-            else
-              demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
-            fi
-      - store_test_results:
-          path: ./unit-tests
-      - store_artifacts:
-          path: artifacts
-          destination: artifacts
-      - run:
-          name: Verify Base Branch for Contribution
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]] ;
-              then
-                python3 ./Tests/scripts/verify_base_branch_for_contribution.py $CIRCLE_BRANCH
-            fi
-      - run:
-          name: Download Configuration
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/download_demisto_conf.sh
-
-              else
-                ./Tests/lastest_server_build_scripts/download_demisto_conf.sh
-            fi
-      - run:
-          name: Download Artifacts
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                echo "Using AMI - Not downloading artifacts"
-              else
-                ./Tests/scripts/server_get_artifact.sh $SERVER_CI_TOKEN
-                cp demistoserver.sh ./Tests/scripts/awsinstancetool/ansibleinstall/demistoserver.sh
-            fi
-      - run:
-          name: Prepare Content Packs For Testing
-          when: always
-          command: |
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping, Should not run on contributor's branch."
-              exit 0
-            fi
-            ./Tests/scripts/prepare_content_packs_for_testing.sh
-      - store_artifacts:
-          path: artifacts
-          destination: artifacts
-          when: always
-      - run:
-          name: Create Instance
-          when: always
-          command: |
-            [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=180
-
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                if [ -n "${NIGHTLY}" ] ;
-                  then
-                    export IFRA_ENV_TYPE=Nightly # disable-secrets-detection
-                elif [ -n "${INSTANCE_TESTS}" ] ;
-                  then
-                    export IFRA_ENV_TYPE="Demisto PreGA" # disable-secrets-detection
-
-                elif [ -n "${CONTRIB_BRANCH}" ] ;
-                  then
-                    export IFRA_ENV_TYPE="Demisto Marketplace" # disable-secrets-detection
-
-                  else
-                    export IFRA_ENV_TYPE=Content-Env # disable-secrets-detection
-                fi
-                python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile ./env_results.json
-
-              else
-                . ./Tests/scripts/server_get_artifact.sh $SERVER_CI_TOKEN
-                python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType CustomBuild -custombuild true -circleurl $SERVER_DOWNLOAD_LINK -circleToken $SERVER_CI_TOKEN -timetolive $TTL -outfile ./env_results.json
-            fi
-      - run:
-          name: Setup Instance
-          when: always
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                python3 ./Tests/scripts/run_content_installation.py
-              else
-                ./Tests/lastest_server_build_scripts/run_installer_on_instance.sh
-            fi
-            python3 ./Tests/scripts/wait_until_server_ready.py
-      - run:
-          name: Run Tests - Server 4.1
-          shell: /bin/bash
-          when: always
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] || [ -n "${NIGHTLY}" ] || [ -n "${CONTRIB_BRANCH}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build, unit-tests container, Nightly run or contributor branch"
-                exit 0
-            fi
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto two before GA"')
-            echo "Demisto two before GA filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "Demisto two before GA"
-
-              else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - run:
-          name: Run Tests - Server 4.5
-          shell: /bin/bash
-          when: always
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] || [ -n "${NIGHTLY}" ] || [ -n "${CONTRIB_BRANCH}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build, unit-tests container, Nightly run or contributor branch"
-                exit 0
-            fi
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto one before GA"')
-            echo "Demisto one before GA filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "Demisto one before GA"
-
-              else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - run:
-          name: Run Tests - Server 5.0
-          shell: /bin/bash
-          when: always
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] || [ -n "${NIGHTLY}" ] || [ -n "${CONTRIB_BRANCH}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build, unit-tests container, Nightly run or on contributor branch"
-                exit 0
-            fi
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto GA"')
-            echo "Demisto GA filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "Demisto GA"
-
-            else
-                ./Tests/scripts/run_tests.sh "master"
-            fi
-      - run:
-          name: Run Tests - Server 5.5
-          shell: /bin/bash
-          when: always
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ] || [ -n "${NIGHTLY}" ]  || [ -n "${CONTRIB_BRANCH}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build, unit-tests container, Nightly run or contributor branch"
-                exit 0
-            fi
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto PreGA"')
-            echo "Demisto PreGA filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "Demisto PreGA"
-                export RETVAL=$?
-                cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                exit $RETVAL
-
-            else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - run:
-          name: Run Tests - Demisto Marketplace
-          shell: /bin/bash
-          when: always
-          no_output_timeout: 5h
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] || [ $CIRCLE_NODE_INDEX -ne 0 ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build or unit-tests container"
-                exit 0
-            fi
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto Marketplace"')
-            echo "Demisto Marketplace filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "Demisto Marketplace"
-                export RETVAL=$?
-                cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                exit $RETVAL
-
-            else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - store_artifacts:
-          path: artifacts
-          destination: artifacts
-          when: always
-      - run:
-          name: Slack Notifier
-          shell: /bin/bash
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${INSTANCE_TESTS}" ] ;
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build"
-                exit 0
-            fi
-            ./Tests/scripts/slack_notifier.sh $CIRCLE_NODE_INDEX ./env_results.json
-
-          when: always
-      - run:
-          name: Instance Test
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ] && [ $CIRCLE_NODE_INDEX -ne 1 ] ;
-              then
-                ./Tests/scripts/instance_test.sh
-                export RETVAL=$?
-                cp ./Tests/failed_instances.txt $CIRCLE_ARTIFACTS/failed_instances.txt
-                exit $RETVAL
-              else
-                echo "Skipping instance tests"
-                exit 0
-            fi
-          when: always
-      - run:
-          name: Destroy Instances
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping instance tests for forked PRs"
-              exit 0
-            fi
-            if [ -n "${TIME_TO_LIVE}" ]
-            then
-                echo "Skipping - Time to live was set to $TIME_TO_LIVE minutes"
-                exit 0
-            fi
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-              else
-                python3 ./Tests/scripts/destroy_instances.py $CIRCLE_ARTIFACTS ./env_results.json
-
-                export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
-                zip -P $PSWD $CIRCLE_ARTIFACTS/ServerLogs.zip $CIRCLE_ARTIFACTS/server*.log
-                rm -f $CIRCLE_ARTIFACTS/server*.log
-            fi
-          when: always
-      - run:
-          name: Upload Packs To Marketplace Storage
-          command: |
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-              echo "Skipping instance tests for sdk nightly build"
-              exit 0
-            fi
-
-            if [[ $CIRCLE_BRANCH != master ]]; then
-              echo "Skipping packs uploading on non master branch"
-              exit 0
-            fi
-
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            EXTRACT_FOLDER=$(mktemp -d)
-            PACK_ARTIFACTS=$CIRCLE_ARTIFACTS/content_packs.zip
-            PACKS_DEPENDENCIES=$CIRCLE_ARTIFACTS/packs_dependencies.json
-            ID_SET=$CIRCLE_ARTIFACTS/id_set.json
-            GCS_PATH=$(mktemp)
-            echo $GCS_MARKET_KEY > $GCS_PATH
-            python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -b 'marketplace-dist' -d $PACKS_DEPENDENCIES -i $ID_SET -s $GCS_PATH -n $CIRCLE_BUILD_NUM -k $PACK_SIGNING_KEY -pb 'marketplace-dist-private'
-            rm $GCS_PATH
-          when: on_success
-      - run:
-          name: Zip Content Packs From GCS
-          command: |
-            if [[ $CIRCLE_BRANCH != master ]]; then
-              echo "Skipping packs zipping on non master branch"
-              exit 0
-            fi
-
-            if [ $CIRCLE_NODE_INDEX -ne 0 ] ;
-              then
-                echo 'Skipping - running only in container number 0.'
-                exit 0;
-            fi
-            GCS_PATH=$(mktemp)
-            ZIP_FOLDER=$(mktemp -d)
-            echo $GCS_MARKET_KEY > $GCS_PATH
-            python3 ./Tests/Marketplace/zip_packs.py -b 'marketplace-dist' -z $ZIP_FOLDER -a $CIRCLE_ARTIFACTS -s $GCS_PATH -gp content/packs -rt False
-            rm $GCS_PATH
-          when: always
-      - store_artifacts:
-          path: artifacts
-          destination: artifacts
-          when: always
-      - run:
-          name: Store Artifacts to GCS
-          command: ./Tests/scripts/upload_artifacts.sh
-          when: always
-
+        [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
+        python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
+  calculate_packs_dependencies: &calculate_packs_dependencies
+    run:
+      name: Calculate Packs Dependencies
+      when: always
+      command: |
+        python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $CIRCLE_ARTIFACTS/packs_dependencies.json
+  update_tests_step: &update_tests_step
+    run:
+      name: Update Tests step
+      when: always
+      command: |
+        python3 ./Tests/scripts/update_conf_json.py
+        cp "./Tests/conf.json" "$CIRCLE_ARTIFACTS/conf.json"
+jobs:
   Prepare Environment:
     <<: *container_config
     resource_class: medium+
@@ -805,6 +297,21 @@ jobs:
             - venv
             - node_modules
           key: venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
+      - when:
+          condition: << pipeline.parameters.contrib_branch >>
+          steps:
+            - run:
+                name: Get Contributor pack
+                when: always
+                command: |
+                    USER=$(echo $CONTRIB_BRANCH | cut -d ":" -f 1)
+                    BRANCH=$(echo $CONTRIB_BRANCH | cut -d ":" -f 2)
+                    PACK=$(echo $CONTRIB_BRANCH | cut -d ":" -f 3)
+                    echo 'Copy the changes from the contributor branch $USER/$BRANCH in the pack $PACK'
+                    git remote add $USER git@github.com:$USER/content.git
+                    git fetch $USER $BRANCH
+                    git checkout $USER/$BRANCH $PACK
+                    exit 0
       - *add_ssh_keys
       - *persist_to_workspace
 
@@ -814,119 +321,77 @@ jobs:
     <<: *environment
     steps:
       - *attach_workspace
-      - setup_remote_docker
-      - *restore_cache
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Infrastructure testing
-          when: always
-          command: |
-            python3 -m pytest ./Tests/scripts/infrastructure_tests/ -v
-            python3 -m pytest ./Tests/Marketplace/Tests/ -v
-
-            if [ -n "${DEMISTO_SDK_NIGHTLY}" ] ; then
-                  ./Tests/scripts/sdk_pylint_check.sh
-            fi
-            exit 0
-      - run:
-          name: Run Unit Testing and Lint
-          when: always
-          no_output_timeout: 5h
-          command: |
-            echo "demisto-sdk version: $(demisto-sdk --version)"
-            echo "mypy version: $(mypy --version)"
-            echo "flake8 py2 version: $(python2 -m flake8 --version)"
-            echo "flake8 py3 version: $(python3 -m flake8 --version)"
-            echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
-            echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
-            echo "vulture py2 version: $(python2 -m vulture --version) 2>&1"
-            echo "vulture py3 version: $(python3 -m vulture --version) 2>&1"
-            SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
-            mkdir ./unit-tests
-            if [ -n "$SHOULD_LINT_ALL" ]; then
-              echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
-              demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
-            else
-              demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
-            fi
-      - store_test_results:
-          path: ./unit-tests
-      - run:
-          name: Slack Notifier
-          shell: /bin/bash
-          command: |
-            ./Tests/scripts/slack_notifier.sh 'unittests' ./env_results.json
-          when: always
-      - *store_artifacts
+      - unless:
+          condition: << pipeline.parameters.instance_tests >>
+          steps:
+            - setup_remote_docker
+            - *restore_cache
+            - *add_ssh_keys
+            - *prepare_environment
+            - *infrastructure_testing
+            - *run_unit_testing_and_lint
+            - store_test_results:
+                path: ./unit-tests
+            - run:
+                name: Slack Notifier
+                shell: /bin/bash
+                command: |
+                  ./Tests/scripts/slack_notifier.sh 'unittests' ./env_results.json
+                when: always
+            - *store_artifacts
   Run Validations:
     <<: *container_config
     resource_class: medium+
     <<: *environment
     steps:
       - *attach_workspace
-      - setup_remote_docker
-      - *restore_cache
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Secrets
-          when: always
-          command: |
-            demisto-sdk secrets --post-commit --ignore-entropy
-      - run:
-          name: Validate Files and Yaml
-          when: always
-          command: |
-            if [ -n "${NIGHTLY}" ];
-              then
-                echo "Skipping - not running in Nightly run"
-                exit 0
-            fi
-            # Run flake8 on all excluding Packs (Integraions and Scripts) - they will be handled in linting
-            ./Tests/scripts/pyflake.sh *.py
-            find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv \) | xargs ./Tests/scripts/pyflake.sh
-
-            [ -n "${BACKWARD_COMPATIBILITY}" ] && CHECK_BACKWARD="false" || CHECK_BACKWARD="true"
-            ./Tests/scripts/validate.sh
-      - run:
-          name: Content Docs Site
-          when: always
-          command: |
-            ./Documentation/docs_site_update.sh
-      - run:
-          name: Spell Checks
-          command: |
-            python3 ./Tests/scripts/circleci_spell_checker.py $CIRCLE_BRANCH
-      - run:
-          name: Check if CircleCI's config file is up to date
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
-              echo "Skipping, Should not run on contributor's branch."
-              exit 0
-            fi
-            # Checks if there's any diff from master
-            if [[ `git diff origin/master -- .circleci/config.yml` ]]; then
-                # Checks if part of the branch's changes
-                if [[ -z `git diff origin/master..."$CIRCLE_BRANCH" --name-only | grep .circleci/config.yml` ]]; then
-                    echo ".circleci/config.yml has been changed. Merge from master"
-                    exit 1
-                else
-                    echo ".circleci/config.yml is part of the branch changes, proceeding"
+      - unless:
+          condition: << pipeline.parameters.instance_tests >>
+          steps:
+            - setup_remote_docker
+            - *restore_cache
+            - *add_ssh_keys
+            - *prepare_environment
+            - *Secrets
+            - *validate_files_and_yaml
+            - run:
+                name: Content Docs Site
+                when: always
+                command: |
+                  ./Documentation/docs_site_update.sh
+            - run:
+                name: Spell Checks
+                command: |
+                  python3 ./Tests/scripts/circleci_spell_checker.py $CIRCLE_BRANCH
+            - run:
+                name: Check if CircleCI's config file is up to date
+                when: always
+                command: |
+                  if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
+                    echo "Skipping, Should not run on contributor's branch."
                     exit 0
-                fi
-            else
-                echo ".circleci/config.yml is up to date!"
-            fi
-      - run:
-          name: Verify Base Branch for Contribution
-          when: always
-          command: |
-            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]] ;
-              then
-                python3 ./Tests/scripts/verify_base_branch_for_contribution.py $CIRCLE_BRANCH
-            fi
+                  fi
+                  # Checks if there's any diff from master
+                  if [[ `git diff origin/master -- .circleci/config.yml` ]]; then
+                      # Checks if part of the branch's changes
+                      if [[ -z `git diff origin/master..."$CIRCLE_BRANCH" --name-only | grep .circleci/config.yml` ]]; then
+                          echo ".circleci/config.yml has been changed. Merge from master"
+                          exit 1
+                      else
+                          echo ".circleci/config.yml is part of the branch changes, proceeding"
+                          exit 0
+                      fi
+                  else
+                      echo ".circleci/config.yml is up to date!"
+                  fi
+            - run:
+                name: Verify Base Branch for Contribution
+                when: always
+                command: |
+                  if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]] ;
+                    then
+                      python3 ./Tests/scripts/verify_base_branch_for_contribution.py $CIRCLE_BRANCH
+                  fi
   Create Instances:
     <<: *container_config
     resource_class: medium+
@@ -939,34 +404,10 @@ jobs:
       - *restore_cache
       - *add_ssh_keys
       - *prepare_environment
-      - run:
-          name: Update Tests step
-          when: always
-          command: |
-            python3 ./Tests/scripts/update_conf_json.py
-            cp "./Tests/conf.json" "$CIRCLE_ARTIFACTS/conf.json"
-      - run:
-          name: Create ID Set
-          when: always
-          command: |
-            demisto-sdk create-id-set -o ./Tests/id_set.json
-      - run:
-          name: Build Content Descriptor
-          when: always
-          command: |
-            if [ -n "${GITHUB_TOKEN}" ] ;
-              then
-                # new release notes summary generator in packs format
-                python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md --github-token $GITHUB_TOKEN
-              else
-                # new release notes summary generator in packs format
-                python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md
-            fi
-      - run:
-          name: Common Server Documentation
-          when: always
-          command: |
-            ./Documentation/commonServerDocs.sh
+      - *update_tests_step
+      - *create_id_set
+      - *build_content_descriptor
+      - *common_server_documentation
       - *create_artifact
       - run:
           name: Download Configuration
@@ -991,75 +432,66 @@ jobs:
                 ./Tests/scripts/server_get_artifact.sh $SERVER_CI_TOKEN
                 cp demistoserver.sh ./Tests/scripts/awsinstancetool/ansibleinstall/demistoserver.sh
             fi
-      - run:
-          name: Collect Test List And Content Packs
-          when: always
-          command: |
-            if [ -n "${INSTANCE_TESTS}" ];
-              then
-                echo "Skipping - not running in INSTANCE_TESTS build"
-                exit 0
-            fi
+      - *collect_test_list_and_content_packs
+      - *calculate_packs_dependencies
+      - unless:
+          condition: << pipeline.parameters.demisto_sdk_nightly >>
+          steps:
+            - run:
+                name: Prepare Content Packs For Testing
+                when: always
+                command: |
+                  ./Tests/scripts/prepare_content_packs_for_testing.sh
+                  echo "$CIRCLE_BUILD_NUM" > create_instances_build_num.txt  # so that later jobs in this workflow could configure the right path
+            - run:
+                name: Zip Content Packs From GCS
+                command: |
+                  GCS_PATH=$(mktemp)
+                  ZIP_FOLDER=$(mktemp -d)
+                  echo $GCS_MARKET_KEY > $GCS_PATH
+                  python3 ./Tests/Marketplace/zip_packs.py -b 'marketplace-ci-build' -z $ZIP_FOLDER -a $CIRCLE_ARTIFACTS -s $GCS_PATH -n $CIRCLE_BUILD_NUM -br $CIRCLE_BRANCH
+                  rm $GCS_PATH
+                when: always
+            - run:
+                name: Store Artifacts to GCS
+                command: ./Tests/scripts/upload_artifacts.sh
+                when: always
+            - run:
+                name: Create Instance
+                when: always
+                command: |
+                  [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=180
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      if [ -n "${NIGHTLY}" ] ;
+                        then
+                          export IFRA_ENV_TYPE=Nightly # disable-secrets-detection
+                      elif [ -n "${INSTANCE_TESTS}" ] ;
+                        then
+                          export IFRA_ENV_TYPE="Demisto PreGA" # disable-secrets-detection
+                      elif [ -n "${CONTRIB_BRANCH}" ] ;
+                        then
+                          export IFRA_ENV_TYPE="Demisto Marketplace" # disable-secrets-detection
+                      else
+                        export IFRA_ENV_TYPE=Content-Env # disable-secrets-detection
+                      fi
+                      python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile ./env_results.json
 
-            [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
-            python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
-      - run:
-          name: Calculate Packs Dependencies
-          when: always
-          command: |
-            python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $CIRCLE_ARTIFACTS/packs_dependencies.json
-      - run:
-          name: Prepare Content Packs For Testing
-          when: always
-          command: |
-            ./Tests/scripts/prepare_content_packs_for_testing.sh
-            echo "$CIRCLE_BUILD_NUM" > create_instances_build_num.txt  # so that later jobs in this workflow could configure the right path
-      - run:
-          name: Zip Content Packs From GCS
-          command: |
-            GCS_PATH=$(mktemp)
-            ZIP_FOLDER=$(mktemp -d)
-            echo $GCS_MARKET_KEY > $GCS_PATH
-            python3 ./Tests/Marketplace/zip_packs.py -b 'marketplace-ci-build' -z $ZIP_FOLDER -a $CIRCLE_ARTIFACTS -s $GCS_PATH -n $CIRCLE_BUILD_NUM -br $CIRCLE_BRANCH
-            rm $GCS_PATH
-          when: always
-      - run:
-          name: Store Artifacts to GCS
-          command: ./Tests/scripts/upload_artifacts.sh
-          when: always
-      - run:
-          name: Create Instance
-          when: always
-          command: |
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                if [ -n "${NIGHTLY}" ] ;
-                  then
-                    export IFRA_ENV_TYPE=Nightly # disable-secrets-detection
-                elif [ -n "${INSTANCE_TESTS}" ] ;
-                  then
-                    export IFRA_ENV_TYPE="Demisto PreGA" # disable-secrets-detection
-
-                  else
-                    export IFRA_ENV_TYPE=Content-Env # disable-secrets-detection
-                fi
-                python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -outfile ./env_results.json
-
-              else
-                . ./Tests/scripts/server_get_artifact.sh $SERVER_CI_TOKEN
-                python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType CustomBuild -custombuild true -circleurl $SERVER_DOWNLOAD_LINK -circleToken $SERVER_CI_TOKEN -outfile ./env_results.json
-            fi
-      - run:
-          name: Setup Instance
-          when: always
-          command: |
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                python3 ./Tests/scripts/run_content_installation.py
-              else
-                ./Tests/lastest_server_build_scripts/run_installer_on_instance.sh
-            fi
-      - *store_artifacts
+                    else
+                      . ./Tests/scripts/server_get_artifact.sh $SERVER_CI_TOKEN
+                      python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType CustomBuild -custombuild true -circleurl $SERVER_DOWNLOAD_LINK -circleToken $SERVER_CI_TOKEN -timetolive $TTL -outfile ./env_results.json
+                  fi
+            - run:
+                name: Setup Instance
+                when: always
+                command: |
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      python3 ./Tests/scripts/run_content_installation.py
+                    else
+                      ./Tests/lastest_server_build_scripts/run_installer_on_instance.sh
+                  fi
+            - *store_artifacts
       - *persist_to_workspace
   Server 4_1:
     <<: *container_config
@@ -1067,226 +499,268 @@ jobs:
     <<: *environment
     steps:
       - setup_remote_docker
-      - *attach_workspace
-      - *restore_cache
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Wait until server ready
-          shell: /bin/bash
-          when: always
-          command: |
-            python3 ./Tests/scripts/wait_until_server_ready.py "Demisto two before GA"
-      - run:
-          name: Run Tests - Server 4.1
-          shell: /bin/bash
-          when: always
-          command: |
-            echo 'export INSTANCE_ROLE="Demisto two before GA"' >> $BASH_ENV
-            source $BASH_ENV
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
-            echo "$INSTANCE_ROLE filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - << pipeline.parameters.contrib_branch >>
+              - << pipeline.parameters.demisto_sdk_nightly >>
+              - << pipeline.parameters.nightly >>
+              - << pipeline.parameters.non_ami_run >>
+          steps:
+            - *attach_workspace
+            - *restore_cache
+            - *add_ssh_keys
+            - *prepare_environment
+            - run:
+                name: Wait until server ready
+                shell: /bin/bash
+                when: always
+                command: |
+                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto two before GA"
+            - run:
+                name: Run Tests - Server 4.1
+                shell: /bin/bash
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto two before GA"' >> $BASH_ENV
+                  source $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto two before GA"')
+                  echo "Demisto two before GA filter=$TEMP"
+                  if [[ "$TEMP" == "false" ]];
+                    then
+                      echo "Skipping - instance was not setup"
+                      exit 0
+                  fi
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
 
-              else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - *destroy_instances
-      - *store_artifacts
+                    else
+                      echo "Not AMI run, can't run on this version"
+                  fi
+            - *destroy_instances
+            - *store_artifacts
   Server 4_5:
     <<: *container_config
     resource_class: medium+
     <<: *environment
     steps:
       - setup_remote_docker
-      - *attach_workspace
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Wait until server ready
-          shell: /bin/bash
-          when: always
-          command: |
-            python3 ./Tests/scripts/wait_until_server_ready.py "Demisto one before GA"
-      - run:
-          name: Run Tests - Server 4.5
-          shell: /bin/bash
-          when: always
-          command: |
-            echo 'export INSTANCE_ROLE="Demisto one before GA"' >> $BASH_ENV
-            source $BASH_ENV
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
-            echo "$INSTANCE_ROLE filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - << pipeline.parameters.contrib_branch >>
+              - << pipeline.parameters.demisto_sdk_nightly >>
+              - << pipeline.parameters.nightly >>
+              - << pipeline.parameters.non_ami_run >>
+          steps:
+            - *attach_workspace
+            - *add_ssh_keys
+            - *prepare_environment
+            - run:
+                name: Wait until server ready
+                shell: /bin/bash
+                when: always
+                command: |
+                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto one before GA"
+            - run:
+                name: Run Tests - Server 4.5
+                shell: /bin/bash
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto one before GA"' >> $BASH_ENV
+                  source $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto one before GA"')
+                  echo "Demisto one before GA filter=$TEMP"
+                  if [[ "$TEMP" == "false" ]];
+                    then
+                      echo "Skipping - instance was not setup"
+                      exit 0
+                  fi
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
 
-              else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - *destroy_instances
-      - *store_artifacts
+                    else
+                      echo "Not AMI run, can't run on this version"
+                  fi
+            - *destroy_instances
+            - *store_artifacts
   Server 5_0:
     <<: *container_config
     resource_class: medium+
     <<: *environment
     steps:
-      - *attach_workspace
       - setup_remote_docker
-      - *restore_cache
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Wait until server ready
-          shell: /bin/bash
-          when: always
-          command: |
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                python3 ./Tests/scripts/wait_until_server_ready.py "Demisto GA"
-              else
-                python3 ./Tests/scripts/wait_until_server_ready.py "Demisto"
-            fi
-      - run:
-          name: Run Tests - Server 5.0
-          shell: /bin/bash
-          when: always
-          command: |
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto GA"')
-            echo "Demisto GA filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
-              else
-                'export INSTANCE_ROLE="master"' >> $BASH_ENV
-            fi
-            source $BASH_ENV
-            ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - << pipeline.parameters.contrib_branch >>
+              - << pipeline.parameters.demisto_sdk_nightly >>
+              - << pipeline.parameters.nightly >>
+          steps:
+            - *attach_workspace
+            - *restore_cache
+            - *add_ssh_keys
+            - *prepare_environment
+            - run:
+                name: Wait until server ready
+                shell: /bin/bash
+                when: always
+                command: |
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      python3 ./Tests/scripts/wait_until_server_ready.py "Demisto GA"
+                    else
+                      python3 ./Tests/scripts/wait_until_server_ready.py "Demisto"
+                  fi
+            - run:
+                name: Run Tests - Server 5.0
+                shell: /bin/bash
+                when: always
+                command: |
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto GA"')
+                  echo "Demisto GA filter=$TEMP"
+                  if [[ "$TEMP" == "false" ]];
+                    then
+                      echo "Skipping - instance was not setup"
+                      exit 0
+                  fi
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
+                    else
+                      'export INSTANCE_ROLE="master"' >> $BASH_ENV
+                  fi
+                  source $BASH_ENV
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
 
-      - *destroy_instances
-      - *store_artifacts
+            - *destroy_instances
+            - *store_artifacts
   Server 5_5:
     <<: *container_config
     resource_class: medium+
     <<: *environment
     steps:
       - setup_remote_docker
-      - *attach_workspace
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Wait until server ready
-          shell: /bin/bash
-          when: always
-          command: |
-            python3 ./Tests/scripts/wait_until_server_ready.py "Demisto PreGA"
-      - run:
-          name: Run Tests - 5.5
-          shell: /bin/bash
-          when: always
-          command: |
-            echo 'export INSTANCE_ROLE="Demisto PreGA"' >> $BASH_ENV
-            source $BASH_ENV
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
-            echo "$INSTANCE_ROLE filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-                export RETVAL=$?
-                cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                exit $RETVAL
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - << pipeline.parameters.contrib_branch >>
+              - << pipeline.parameters.demisto_sdk_nightly >>
+              - << pipeline.parameters.nightly >>
+              - << pipeline.parameters.non_ami_run >>
+          steps:
+            - *attach_workspace
+            - *add_ssh_keys
+            - *prepare_environment
+            - run:
+                name: Wait until server ready
+                shell: /bin/bash
+                when: always
+                command: |
+                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto PreGA"
+            - run:
+                name: Run Tests - 5.5
+                shell: /bin/bash
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto PreGA"' >> $BASH_ENV
+                  source $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto PreGA"')
+                  echo "Demisto PreGA filter=$TEMP"
+                  if [[ "$TEMP" == "false" ]];
+                    then
+                      echo "Skipping - instance was not setup"
+                      exit 0
+                  fi
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+                      export RETVAL=$?
+                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                      exit $RETVAL
 
-            else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - run:
-          name: Slack Notifier
-          shell: /bin/bash
-          command: |
-            ./Tests/scripts/slack_notifier.sh 'test_playbooks' ./env_results.json
-          when: always
-      - *destroy_instances
-      - *store_artifacts
+                  else
+                      echo "Not AMI run, can't run on this version"
+                  fi
+            - run:
+                name: Slack Notifier
+                shell: /bin/bash
+                command: |
+                  ./Tests/scripts/slack_notifier.sh 'test_playbooks' ./env_results.json
+                when: always
+            - *destroy_instances
+            - *store_artifacts
   Server 6_0:
     <<: *container_config
     resource_class: medium+
     <<: *environment
     steps:
       - setup_remote_docker
-      - *attach_workspace
-      - *add_ssh_keys
-      - *prepare_environment
-      - run:
-          name: Wait until server ready
-          shell: /bin/bash
-          when: always
-          command: |
-            python3 ./Tests/scripts/wait_until_server_ready.py "Demisto Marketplace"
-      - run:
-          name: Run Tests - Demisto 6.0
-          shell: /bin/bash
-          when: always
-          no_output_timeout: 5h
-          command: |
-            echo 'export INSTANCE_ROLE="Demisto Marketplace"' >> $BASH_ENV
-            source $BASH_ENV
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
-            echo "$INSTANCE_ROLE filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
-            if ./Tests/scripts/is_ami.sh ;
-              then
-                ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-                export RETVAL=$?
-                cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                exit $RETVAL
-            else
-                echo "Not AMI run, can't run on this version"
-            fi
-      - run:
-          name: Upload Packs To Marketplace Storage
-          command: |
-            if [[ $CIRCLE_BRANCH != master ]]; then
-              echo "Skipping packs uploading on non master branch"
-              exit 0
-            fi
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - << pipeline.parameters.demisto_sdk_nightly >>
+              - << pipeline.parameters.non_ami_run >>
+          steps:
+            - *attach_workspace
+            - *add_ssh_keys
+            - *prepare_environment
+            - run:
+                name: Wait until server ready
+                shell: /bin/bash
+                when: always
+                command: |
+                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto Marketplace"
+            - run:
+                name: Run Tests - Demisto 6.0
+                shell: /bin/bash
+                when: always
+                no_output_timeout: 5h
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto Marketplace"' >> $BASH_ENV
+                  source $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto Marketplace"')
+                  echo "Demisto Marketplace filter=$TEMP"
+                  if [[ "$TEMP" == "false" ]];
+                    then
+                      echo "Skipping - instance was not setup"
+                      exit 0
+                  fi
+                  if ./Tests/scripts/is_ami.sh ;
+                    then
+                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+                      export RETVAL=$?
+                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                      exit $RETVAL
+                  else
+                      echo "Not AMI run, can't run on this version"
+                  fi
+            - run:
+                name: Upload Packs To Marketplace Storage
+                command: |
+                  if [[ $CIRCLE_BRANCH != master ]]; then
+                    echo "Skipping packs uploading on non master branch"
+                    exit 0
+                  fi
 
-            EXTRACT_FOLDER=$(mktemp -d)
-            PACK_ARTIFACTS=$CIRCLE_ARTIFACTS/content_packs.zip
-            PACKS_DEPENDENCIES=$CIRCLE_ARTIFACTS/packs_dependencies.json
-            ID_SET=$CIRCLE_ARTIFACTS/id_set.json
-            GCS_PATH=$(mktemp)
-            echo $GCS_MARKET_KEY > $GCS_PATH
-            python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -b 'marketplace-dist' -d $PACKS_DEPENDENCIES -i $ID_SET -s $GCS_PATH -n $CIRCLE_BUILD_NUM -k $PACK_SIGNING_KEY -pb 'marketplace-dist-private'
-            rm $GCS_PATH
-          when: on_success
-      - *destroy_instances
-      - *store_artifacts
+                  EXTRACT_FOLDER=$(mktemp -d)
+                  PACK_ARTIFACTS=$CIRCLE_ARTIFACTS/content_packs.zip
+                  PACKS_DEPENDENCIES=$CIRCLE_ARTIFACTS/packs_dependencies.json
+                  ID_SET=$CIRCLE_ARTIFACTS/id_set.json
+                  GCS_PATH=$(mktemp)
+                  echo $GCS_MARKET_KEY > $GCS_PATH
+                  python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -b 'marketplace-dist' -d $PACKS_DEPENDENCIES -i $ID_SET -s $GCS_PATH -n $CIRCLE_BUILD_NUM -k $PACK_SIGNING_KEY -pb 'marketplace-dist-private'
+                  rm $GCS_PATH
+                when: on_success
+            - *destroy_instances
+            - *store_artifacts
   Instance Test:
     <<: *container_config
     resource_class: medium+
@@ -1301,12 +775,22 @@ jobs:
           shell: /bin/bash
           when: always
           command: |
+            if [ -z $INSTANCE_TESTS ]
+            then
+              echo "Skipping, contributor branch not given."
+              exit 0
+            fi
             python3 ./Tests/scripts/wait_until_server_ready.py "Demisto PreGA"
             echo 'export INSTANCE_ROLE="Demisto PreGA"' >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Instance Test
           command: |
+            if [ -z $INSTANCE_TESTS ]
+            then
+              echo "Skipping, contributor branch not given."
+              exit 0
+            fi
             ./Tests/scripts/instance_test.sh
             export RETVAL=$?
             cp ./Tests/failed_instances.txt $CIRCLE_ARTIFACTS/failed_instances.txt
@@ -1315,11 +799,83 @@ jobs:
       - *destroy_instances
       - *store_artifacts
 
+  Demisto SDK Nightly:
+    <<: *container_config
+    resource_class: medium+
+    <<: *environment
+    steps:
+      - checkout
+      - setup_remote_docker
+      - *restore_cache
+      - *prepare_environment
+      - *Secrets
+      - *validate_files_and_yaml
+      - *run_unit_testing_and_lint
+      - *infrastructure_testing
+      - *create_id_set
+      - *build_content_descriptor
+      - *common_server_documentation
+      - *collect_test_list_and_content_packs
+      - *calculate_packs_dependencies
+      - *update_tests_step
+      - *store_artifacts
+      - run:
+          name: Slack Notifier
+          shell: /bin/bash
+          command: |
+            ./Tests/scripts/slack_notifier.sh 'sdk_unittests' ./env_results.json
+            ./Tests/scripts/slack_notifier.sh 'sdk_faild_steps' ./env_results.json
+          when: always
+
+
 workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - Prepare Environment
+      - Create Instances:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+      - Run Unit Testing And Lint:
+          requires:
+            - Prepare Environment
+      - Run Validations:
+          requires:
+            - Prepare Environment
+      - Server 4_1:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - Create Instances
+      - Server 4_5:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - Create Instances
+      - Server 5_0:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - Create Instances
+      - Server 5_5:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - Create Instances
+      - Server 6_0:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - Create Instances
+      - Instance Test:
+          requires:
+            - Create Instances
 
   instances_testing:
     # for details of triggered builds see https://circleci.com/docs/2.0/workflows/#nightly-example
@@ -1333,8 +889,12 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
+      - Create Instances:
           context: instances_test_env
+      - Instance Test:
+          context: instances_test_env
+          requires:
+            - Create Instances
 
   nightly:
     triggers:
@@ -1345,31 +905,6 @@ workflows:
             branches:
               only:
                 - master
-    jobs:
-      - build:
-          context: nightly_env
-  sdk_nightly:
-    triggers:
-      - schedule:
-          # should trigger every day at 12 AM UTC (3 AM Israel Time)
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          context: sdk_nightly_env
-
-  nightly-workflows:
-    triggers:
-      - schedule:
-          # should trigger every day at 20:00 PM UTC (11:00 PM Israel Time)
-          cron: "0 20 * * *"
-          filters:
-            branches:
-              only:
-                - config_yaml
     jobs:
       - Prepare Environment:
           context: nightly_env
@@ -1385,3 +920,17 @@ workflows:
           requires:
             - Create Instances
           context: nightly_env
+
+  sdk_nightly:
+    triggers:
+      - schedule:
+          # should trigger every day at 12 AM UTC (3 AM Israel Time)
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - Demisto SDK Nightly:
+          context: sdk_nightly_env
+

--- a/Documentation/docs_site_update.sh
+++ b/Documentation/docs_site_update.sh
@@ -22,7 +22,7 @@ elif [ "$CIRCLE_BRANCH" == "master" ]; then
     if [ -z "$CIRCLE_COMPARE_URL" ]; then
         DIFF_COMPARE="HEAD^1...HEAD"
     else
-        DIFF_COMPARE=$(echo "$CIRCLE_COMPARE_URL" | sed 's:^.*/compare/::g')    
+        DIFF_COMPARE=$(echo "$CIRCLE_COMPARE_URL" | sed 's:^.*/compare/::g')
         if [ -z "${DIFF_COMPARE}" ]; then
             echo "Failed: extracting diff compare from CIRCLE_COMPARE_URL: ${CIRCLE_COMPARE_URL}. Fail.."
             exit 1

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -39,7 +39,7 @@ def options_handler():
     parser.add_argument('-s', '--secret', help='Path to secret conf file')
     parser.add_argument('-n', '--is-nightly', type=str2bool, help='Is nightly build')
     parser.add_argument('--branch', help='GitHub branch name', required=True)
-    parser.add_argument('--build-number', help='CI build number', required=True)
+    parser.add_argument('--build-number', help='CI job number where the instances were created', required=True)
 
     options = parser.parse_args()
 

--- a/Tests/scripts/destroy_instances.py
+++ b/Tests/scripts/destroy_instances.py
@@ -9,11 +9,12 @@ import Tests.scripts.awsinstancetool.aws_functions as aws_functions
 def main():
     circle_aritfact = sys.argv[1]
     env_file = sys.argv[2]
-
+    instance_role = sys.argv[3]
     with open(env_file, 'r') as json_file:
         env_results = json.load(json_file)
 
-    for env in env_results:
+    filtered_results = [env_result for env_result in env_results if env_result["Role"] == instance_role]
+    for env in filtered_results:
         print(f'Downloading server log from {env.get("Role", "Unknown role")}')
         ssh_string = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {}@{} ' \
                      '"sudo chmod -R 755 /var/log/demisto"'

--- a/Tests/scripts/run_tests.sh
+++ b/Tests/scripts/run_tests.sh
@@ -17,7 +17,9 @@ code_1=0
 code_2=0
 
 echo "starting configure_and_test_integration_instances"
-python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$CIRCLE_BUILD_NUM"
+PREVIOUS_JOB_NUMBER=`cat create_instances_build_num.txt`
+
+python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$PREVIOUS_JOB_NUMBER"
 code_1=$?
 
 echo 'export GOOGLE_APPLICATION_CREDENTIALS="creds.json"' >> $BASH_ENV

--- a/Tests/scripts/server_get_artifact.sh
+++ b/Tests/scripts/server_get_artifact.sh
@@ -14,12 +14,12 @@ if [ -z "${ARTIFACT_BUILD_NUM}" ]
     fi
 
     echo "Getting latest build num"
-    TEMP=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/${_server_branch_name}?limit=10&filter=successful&$TOKEN_ATTR")
+    CIRCLE_RESPONSE=$(curl -s -H "$ACCEPT_TYPE" "$SERVER_API_URI/tree/${_server_branch_name}?limit=10&filter=successful&$TOKEN_ATTR")
 
     ARTIFACT_BUILD_NUM=
     for i in `seq 0 9`; do
-        if [[ $(echo "$TEMP" | jq ".[$i].build_parameters") == "null" ]]; then
-            ARTIFACT_BUILD_NUM=$(echo "$TEMP" | jq ".[$i].build_num")
+        if [[ $(echo "$CIRCLE_RESPONSE" | jq ".[$i].build_parameters") == $(echo '[{"CIRCLE_JOB": "build"}]'|jq ".[0]") ]]; then
+            ARTIFACT_BUILD_NUM=$(echo "$CIRCLE_RESPONSE" | jq ".[$i].build_num")
             break
         fi
     done

--- a/Tests/scripts/slack_notifier.sh
+++ b/Tests/scripts/slack_notifier.sh
@@ -3,8 +3,7 @@
 echo "start slack notifier"
 
 [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
-[ -n "${DEMISTO_SDK_NIGHTLY}" ] && DEMISTO_SDK_NIGHTLY=true || DEMISTO_SDK_NIGHTLY=false
 
-python3 ./Tests/scripts/slack_notifier.py -n $IS_NIGHTLY -k $DEMISTO_SDK_NIGHTLY -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -s "$SLACK_TOKEN" -c "$CIRCLECI_TOKEN" -i $1 -f $2
+python3 ./Tests/scripts/slack_notifier.py -n $IS_NIGHTLY -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -s "$SLACK_TOKEN" -c "$CIRCLECI_TOKEN" -t $1 -f $2
 
 echo "Finished slack notifier execution"

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -36,6 +36,7 @@ def exit_if_timed_out(loop_start_time, current_time):
 
 def main():
     global SETUP_TIMEOUT
+    instance_name_to_wait_on = sys.argv[1]
     ready_ami_list = []
     failure = False
     with open('./Tests/instance_ips.txt', 'r') as instance_file:
@@ -44,7 +45,8 @@ def main():
 
     loop_start_time = time.time()
     last_update_time = loop_start_time
-    instance_ips_to_poll = [ami_instance_ip for ami_instance_name, ami_instance_ip in instance_ips]
+    instance_ips_to_poll = [ami_instance_ip for ami_instance_name, ami_instance_ip in instance_ips if
+                            ami_instance_name == instance_name_to_wait_on]
 
     print(f'[{datetime.datetime.now()}] Starting wait loop')
     while instance_ips_to_poll:

--- a/Utils/trigger_content_build_with_no_backward_check.sh
+++ b/Utils/trigger_content_build_with_no_backward_check.sh
@@ -3,18 +3,21 @@
 _branch=$1
 _circle_token=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 post_data=$(cat <<EOF
-{
-  "build_parameters": {
-    "BACKWARD_COMPATIBILITY": "false"
+ {
+    "branch": "${_branch}",
+    "parameters": {
+    "backward_compatibility": "false"
+    }
   }
-}
-EOF)
+EOF
+)
 
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_build_with_time_to_live.sh
+++ b/Utils/trigger_content_build_with_time_to_live.sh
@@ -30,7 +30,7 @@ _time_to_live=$3
 _contrib_branch=$4
 _changed_pack=$5
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 
 if [ -z $_time_to_live ] || [ $_time_to_live -lt 180 ]
@@ -53,31 +53,34 @@ fi
 
 if [ -z $_contrib_branch ]
 then
-  post_data=$(cat <<EOF
-  {
-    "build_parameters": {
-      "TIME_TO_LIVE": ${_time_to_live}
+  post_data=$(cat <<-EOF
+ {
+    "branch": "${_branch}",
+    "parameters": {
+      "time_to_live": "${_time_to_live}"
     }
   }
 EOF
 )
+
 else
   pack_name=$(echo $_changed_pack | cut -d "/" -f 2)
   post_data=$(cat <<-EOF
-  {
-    "build_parameters": {
-      "TIME_TO_LIVE": ${_time_to_live},
-      "CONTRIB_BRANCH": "${_contrib_branch}:${_changed_pack}",
-      "CONTRIB_PACK_NAME": "$pack_name"
+ {
+    "branch": "${_branch}",
+    "parameters": {
+      "time_to_live": "${_time_to_live}",
+      "contrib_branch": "${_contrib_branch}:${_changed_pack}",
+      "contrib_pack_name": "$pack_name"
     }
   }
 EOF
 )
 fi
 
-
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_nightly_build.sh
+++ b/Utils/trigger_content_nightly_build.sh
@@ -3,19 +3,23 @@
 _branch=$1
 _circle_token=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
-post_data=$(cat <<EOF
+post_data=$(cat <<-EOF
 {
-  "build_parameters": {
-    "NIGHTLY": "true",
-    "TIME_TO_LIVE": 900
+  "branch": "${_branch}",
+  "parameters": {
+    "nightly": "true",
+    "time_to_live": "900"
   }
 }
-EOF)
+EOF
+)
+
 
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_nightly_build_with_memory.sh
+++ b/Utils/trigger_content_nightly_build_with_memory.sh
@@ -3,21 +3,23 @@
 _branch=$1
 _circle_token=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 post_data=$(cat <<EOF
 {
-  "build_parameters": {
-    "NIGHTLY": "true",
-    "MEM_CHECK": "true",
-    "TIME_TO_LIVE": 900
-
+  "branch": "${_branch}",
+  "parameters": {
+    "nightly": "true",
+    "mem_check": "true",
+    "time_to_live": "900"
   }
 }
-EOF)
+EOF
+)
 
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_nightly_instance_tests.sh
+++ b/Utils/trigger_content_nightly_instance_tests.sh
@@ -3,18 +3,21 @@
 _branch=$1
 _circle_token=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 post_data=$(cat <<EOF
 {
-  "build_parameters": {
-    "INSTANCE_TESTS": "true"
+  "branch": "${_branch}",
+  "parameters": {
+    "instance_tests": "true"
   }
 }
-EOF)
+EOF
+)
 
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_non_ami_build.sh
+++ b/Utils/trigger_content_non_ami_build.sh
@@ -10,13 +10,14 @@ fi
 _branch=$1
 _circle_token=$2
 
-trigger_build_url="https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}"
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 if [ -z "$3" ]; then
   post_data=$(cat <<-EOF
-  {
-    "build_parameters": {
-      "NON_AMI_RUN": "true"
+ {
+    "branch": "${_branch}",
+    "parameters": {
+      "non_ami_run": "true"
     }
   }
 EOF
@@ -24,10 +25,11 @@ EOF
 else
   post_data=$(cat <<-EOF
   {
-    "build_parameters": {
-      "NON_AMI_RUN": "true",
-      "SERVER_BRANCH_NAME": "$3",
-      "NIGHTLY": "$4"
+    "branch": "${_branch}",
+    "parameters": {
+      "non_ami_run": "true",
+      "artifact_build_num": "$3",
+      "nightly": "true"
     }
   }
 EOF
@@ -41,4 +43,5 @@ curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_content_non_ami_build_by_number.sh
+++ b/Utils/trigger_content_non_ami_build_by_number.sh
@@ -10,13 +10,14 @@ fi
 _branch=$1
 _circle_token=$2
 
-trigger_build_url="https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}"
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
 if [ -z "$3" ]; then
   post_data=$(cat <<-EOF
-  {
-    "build_parameters": {
-      "NON_AMI_RUN": "true"
+ {
+    "branch": "${_branch}",
+    "parameters": {
+    "non_ami_run": "true"
     }
   }
 EOF
@@ -24,10 +25,10 @@ EOF
 else
   post_data=$(cat <<-EOF
   {
-    "build_parameters": {
-      "NON_AMI_RUN": "true",
-      "ARTIFACT_BUILD_NUM": "$3",
-      "NIGHTLY": "$4"
+    "branch": "${_branch}",
+    "parameters": {
+    "non_ami_run": "true",
+    "artifact_build_num": "$3"
     }
   }
 EOF
@@ -41,4 +42,5 @@ curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -3,18 +3,22 @@
 _branch=$1
 _circle_token=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/demisto/content/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
+
 
 post_data=$(cat <<EOF
 {
-  "build_parameters": {
-    "DEMISTO_SDK_NIGHTLY": "true"
+  "branch": "${_branch}",
+  "parameters": {
+    "demisto_sdk_nightly": "true"
   }
 }
-EOF)
+EOF
+)
 
 curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
 --data "${post_data}" \
---request POST ${trigger_build_url}
+--request POST ${trigger_build_url} \
+--user "$_circle_token:"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/23899

## Description
In this PR the build is migrated from single job to multiple jobs using workflows.
This PR will not be merged until @ronykoz will implement a locking mechanism.

Main changes:

- Removing the current parallelism method with container numbers 0 and 1, parallelism is implemented using workflows.
- **wait until server ready** step is done separately for each server version.
- *Slack notifier* is done once in **unit tests** job and once in **server Master** instance test job
- Destroy instances will destroy the relevant instance only, if no error occurred
- Moved the contribution branch check to circle built in branch handling, jobs that should not be executed, will not be displayed.

This implementation has the following advantages:

1. It is faster (about 50 min less for a build that uses all server versions)
2. It is more user friendly.
3. If a specific step  (some server version for example) failed and the server was not destroyed yet- there is a way to run the tests on this specific version only without the latency of creating the instances and waiting for them to be ready using the **Rerun workflow from failed** option.
4. Contribution builds will show only jobs relevant to them, all server versions testing will not be displayed.

See example build [here](https://app.circleci.com/pipelines/github/demisto/content/13886/workflows/b1ff6bee-6c75-4b74-a293-053c291866c0) 

@glicht @anara123 FYI
## Screenshots
![image](https://user-images.githubusercontent.com/41257953/83386050-05ecb200-a3f3-11ea-9905-4219e897962f.png)


