### PR TITLE
timestamp_to_datestring uses `utcfromtimestamp`

### DIFF
--- a/Packs/Base/ReleaseNotes/1_0_7.md
+++ b/Packs/Base/ReleaseNotes/1_0_7.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+Fixed incorrect time zone parsing for **timestamp_to_datestring**

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -3069,7 +3069,7 @@ def timestamp_to_datestring(timestamp, date_format="%Y-%m-%dT%H:%M:%S.000Z"):
       :return: The parsed timestamp in the date_format
       :rtype: ``str``
     """
-    return datetime.fromtimestamp(int(timestamp) / 1000.0).strftime(date_format)
+    return datetime.utcfromtimestamp(int(timestamp) / 1000.0).strftime(date_format)
 
 
 def date_to_timestamp(date_str_or_dt, date_format='%Y-%m-%dT%H:%M:%S'):

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
`timestamp_to_datestring`'s default date format includes Z for the time
zone. However, it uses `datetime.fromtimestamp` which is in localtime.
This yields incorrect results when the default time zone is anything
other than UTC.

The `epochToTimestamp` function in the same file does correctly use
`utcfromtimestamp`. This commit corrects and normalizes the timestamp
processing.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

