### PR TITLE
Recorded Future Feed - handle sparse response in fetch indicators command

### DIFF
--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/CHANGELOG.md
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Improved parsing of IOC objects.
 
 ## [20.3.4] - 2020-03-30
 Renamed the **Sub-Feeds** parameter to **Services** in the instance configuration.

--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture_test.py
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture_test.py
@@ -1,6 +1,6 @@
 import pytest
 from collections import OrderedDict
-from FeedRecordedFuture import get_indicator_type, get_indicators_command, Client
+from FeedRecordedFuture import get_indicator_type, get_indicators_command, Client, fetch_indicators_command
 
 GET_INDICATOR_TYPE_INPUTS = [
     ('ip', OrderedDict([('Name', '192.168.1.1'), ('Risk', '89'), ('RiskString', '5/12'),
@@ -113,3 +113,24 @@ def test_calculate_dbot_score(risk_from_feed, threshold, expected_score):
     client = Client(indicator_type='ip', api_token='123', services=['fusion'], threshold=threshold)
     score = client.calculate_indicator_score(risk_from_feed)
     assert score == expected_score
+
+
+def test_fetch_indicators_command(mocker):
+    """
+    Given:
+     - Recorded Future Feed client initialized with ip indicator type
+     - Iterator which returns entry of IP object with name only
+
+    When:
+     - Fetching indicators
+
+    Then:
+     - Verify the fetch runs successfully.
+    """
+    indicator_type = 'ip'
+    client = Client(indicator_type=indicator_type, api_token='dummytoken', services='fusion')
+    mocker.patch(
+        'FeedRecordedFuture.Client.build_iterator',
+        return_value=[{'Name': '192.168.1.1'}]
+    )
+    fetch_indicators_command(client, indicator_type)

--- a/Packs/FeedRecordedFuture/ReleaseNotes/1_0_1.md
+++ b/Packs/FeedRecordedFuture/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+### Integrations
+- __Recorded Future Feed__
+Improved parsing of IOC objects.

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Recorded Future Feed",
-  "description": "Ingests indicators from Recorded Future feeds into Demisto.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-03-09T16:35:16Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Recorded Future Feed",
+    "description": "Ingests indicators from Recorded Future feeds into Demisto.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-03-09T16:35:16Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25336

## Description
`fetch_indicators_command` did not handle well response with missing fields

## Minimum version of Demisto
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

See failing test at https://app.circleci.com/pipelines/github/demisto/content/14735/workflows/a5304f86-fcfa-4961-a003-01e4e2dceb2b/jobs/56470/parallel-runs/1?filterBy=FAILED