### PR TITLE
Red Canary - bug fixes in fetch incidents

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/CHANGELOG.md
+++ b/Packs/RedCanary/Integrations/RedCanary/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-
+ - Removed timeline details for a detection fetched as incident.
+ - Fixed an issue in which acknowledged detections were fetched as incidents.
 
 ## [20.4.1] - 2020-04-29
 -

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -320,7 +320,7 @@ def get_unacknowledged_detections(t, per_page=50):
             attributes = detection.get('attributes', {})
             # If 'last_acknowledged_at' or 'last_acknowledged_by' are in attributes,
             # the detection is acknowledged and should not create a new incident.
-            if attributes.get('last_acknowledged_at') is None or attributes.get('last_acknowledged_by') is None:
+            if attributes.get('last_acknowledged_at') is None and attributes.get('last_acknowledged_by') is None:
                 yield detection
 
         page += 1

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -320,7 +320,7 @@ def get_unacknowledged_detections(t, per_page=50):
             attributes = detection.get('attributes', {})
             # If 'last_acknowledged_at' and 'last_acknowledged_by' are in attributes,
             # the detection is acknowledged and should not create a new incident.
-            if attributes.get('last_acknowledged_at') and attributes.get('last_acknowledged_by'):
+            if not (attributes.get('last_acknowledged_at') and attributes.get('last_acknowledged_by')):
                 yield detection
 
         page += 1
@@ -330,7 +330,6 @@ def get_unacknowledged_detections(t, per_page=50):
 @logger
 def detection_to_incident(raw_detection):
     detection = detection_to_context(raw_detection)
-    detection['Timeline'] = get_full_timeline(detection['ID'])
 
     return {
         'type': 'RedCanaryDetection',

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -320,7 +320,7 @@ def get_unacknowledged_detections(t, per_page=50):
             attributes = detection.get('attributes', {})
             # If 'last_acknowledged_at' or 'last_acknowledged_by' are in attributes,
             # the detection is acknowledged and should not create a new incident.
-            if attributes.get('last_acknowledged_at') is not None or attributes.get('last_acknowledged_by') is not None:
+            if attributes.get('last_acknowledged_at') is None or attributes.get('last_acknowledged_by') is None:
                 yield detection
 
         page += 1

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -318,9 +318,9 @@ def get_unacknowledged_detections(t, per_page=50):
     while res:
         for detection in res:
             attributes = detection.get('attributes', {})
-            # If 'last_acknowledged_at' and 'last_acknowledged_by' are in attributes,
+            # If 'last_acknowledged_at' or 'last_acknowledged_by' are in attributes,
             # the detection is acknowledged and should not create a new incident.
-            if not (attributes.get('last_acknowledged_at') and attributes.get('last_acknowledged_by')):
+            if attributes.get('last_acknowledged_at') is not None or attributes.get('last_acknowledged_by') is not None:
                 yield detection
 
         page += 1

--- a/Packs/RedCanary/ReleaseNotes/1_0_1.md
+++ b/Packs/RedCanary/ReleaseNotes/1_0_1.md
@@ -1,0 +1,6 @@
+
+### Integrations
+- __RedCanary__
+    - Removed timeline details for a detection fetched as incident.
+    - Fixed an issue in which acknowledged detections were fetched as incidents.
+

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Red Canary",
-  "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Endpoint"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Red Canary",
+    "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Endpoint"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25265

## Description
 - in https://github.com/demisto/content/pull/5973, a condition was fixed that led to all timeline of a detection will be fetched, instead of only the first page.
apparently a timeline can be huge, in such way that caused the issue and made the fetch times out. so I've removed the timeline retrieval from the fetch and that can be done in a playbook with a command.
 - also encountered a bug in which acknowledged detections were fetched, so fixed the condition there as well.

## Does it break backward compatibility?
   - [x] No


