### PR TITLE
increase sshd MaxStartups and restart sshd

### DIFF
--- a/Tests/scripts/ami_mock_dependencies_setup.sh
+++ b/Tests/scripts/ami_mock_dependencies_setup.sh
@@ -15,3 +15,8 @@ pipx inject mitmproxy python-dateutil
 echo "'mitmproxy' installed and 'python-dateutil' dependency injected"
 echo "mitmproxy dependencies setup completed"
 echo "--------------------------------------"
+
+echo "increasing MaxStartups in sshd_config to prevent the 'ssh_exchange_identification: Connection closed by remote host' error"
+sudo sed -i "s/#MaxStartups 10:30:100/MaxStartups 20:30:100/g" /etc/ssh/sshd_config
+echo "restarting sshd"
+sudo kill -SIGHUP $(pgrep -f "sshd -D")

--- a/Tests/scripts/ami_mock_dependencies_setup.sh
+++ b/Tests/scripts/ami_mock_dependencies_setup.sh
@@ -15,8 +15,3 @@ pipx inject mitmproxy python-dateutil
 echo "'mitmproxy' installed and 'python-dateutil' dependency injected"
 echo "mitmproxy dependencies setup completed"
 echo "--------------------------------------"
-
-echo "increasing MaxStartups in sshd_config to prevent the 'ssh_exchange_identification: Connection closed by remote host' error"
-sudo sed -i "s/#MaxStartups 10:30:100/MaxStartups 20:30:100/g" /etc/ssh/sshd_config
-echo "restarting sshd"
-sudo kill -SIGHUP $(pgrep -f "sshd -D")

--- a/Tests/scripts/copy_content_data.sh
+++ b/Tests/scripts/copy_content_data.sh
@@ -12,6 +12,14 @@ ssh-keyscan -H ${PUBLIC_IP} >> ~/.ssh/known_hosts
 MOCKS_SETUP_DEPS_COMMAND=`cat ./Tests/scripts/ami_mock_dependencies_setup.sh`
 ssh ${USER}@${PUBLIC_IP} "eval ${MOCKS_SETUP_DEPS_COMMAND}" &>/dev/null
 
+echo "increasing MaxStartups in sshd_config to prevent the 'ssh_exchange_identification: Connection closed by remote host' error"
+MODIFY_SSHD_CONFIG_CMD='sudo sed -i "s/#MaxStartups 10:30:100/MaxStartups 20:30:100/g" /etc/ssh/sshd_config'
+ssh -t ${USER}@${PUBLIC_IP} ${MODIFY_SSHD_CONFIG_CMD}
+
+echo "restarting sshd"
+RESTART_SSHD_CMD="sudo service sshd restart"
+ssh -t ${USER}@${PUBLIC_IP} ${RESTART_SSHD_CMD}
+
 echo "[`date`] ${PUBLIC_IP}: start server"
 
 START_SERVER_COMMAND="sudo systemctl start demisto"

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -58,9 +58,13 @@ def main():
                 try:
                     res = requests.request(method=method, url=(host + path), verify=False)
                 except (requests.exceptions.RequestException, requests.exceptions.HTTPError) as exp:
-                    print_error(f'{ami_instance_name} encountered an error: {str(exp)}\n'
-                                f'Spot instance was dropped by amazon, if raised often - report to team leader.')
-                    instance_ips_to_poll.remove(ami_instance_ip)
+                    # print_error(f'{ami_instance_name} encountered an error: {str(exp)}\n'
+                    #             f'Spot instance was dropped by amazon, if raised often - report to team leader.')
+                    print_error(f'{ami_instance_name} encountered an error: {str(exp)}')
+                    if SETUP_TIMEOUT != 60 * 10:  # noqa: F823
+                        print_warning('Setting SETUP_TIMEOUT to 10 minutes.')
+                        SETUP_TIMEOUT = 60 * 10
+                    # instance_ips_to_poll.remove(ami_instance_ip)
                     failure = True
                     continue
                 except Exception as exp:
@@ -68,6 +72,9 @@ def main():
                                   f'Will retry this step later.')
                     continue
                 if res.status_code == 200:
+                    if SETUP_TIMEOUT != 60 * 60:
+                        print(f'Resetting SETUP_TIMEOUT to an hour.')
+                        SETUP_TIMEOUT = 60 * 60
                     print(f'[{datetime.datetime.now()}] {ami_instance_name} is ready to use')
                     # ready_ami_list.append(ami_instance_name)
                     instance_ips_to_poll.remove(ami_instance_ip)

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -62,6 +62,7 @@ def main():
                                 f'Spot instance was dropped by amazon, if raised often - report to team leader.')
                     instance_ips_to_poll.remove(ami_instance_ip)
                     failure = True
+                    continue
                 except Exception as exp:
                     print_warning(f'{ami_instance_name} encountered an error: {str(exp)}\n'
                                   f'Will retry this step later.')

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -35,6 +35,7 @@ def exit_if_timed_out(loop_start_time, current_time):
 
 
 def main():
+    global SETUP_TIMEOUT
     ready_ami_list = []
     failure = False
     with open('./Tests/instance_ips.txt', 'r') as instance_file:
@@ -61,7 +62,7 @@ def main():
                     # print_error(f'{ami_instance_name} encountered an error: {str(exp)}\n'
                     #             f'Spot instance was dropped by amazon, if raised often - report to team leader.')
                     print_error(f'{ami_instance_name} encountered an error: {str(exp)}')
-                    if SETUP_TIMEOUT != 60 * 10:  # noqa: F823
+                    if SETUP_TIMEOUT != 60 * 10:
                         print_warning('Setting SETUP_TIMEOUT to 10 minutes.')
                         SETUP_TIMEOUT = 60 * 10
                     # instance_ips_to_poll.remove(ami_instance_ip)

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -59,13 +59,10 @@ def main():
                 try:
                     res = requests.request(method=method, url=(host + path), verify=False)
                 except (requests.exceptions.RequestException, requests.exceptions.HTTPError) as exp:
-                    # print_error(f'{ami_instance_name} encountered an error: {str(exp)}\n'
-                    #             f'Spot instance was dropped by amazon, if raised often - report to team leader.')
                     print_error(f'{ami_instance_name} encountered an error: {str(exp)}')
                     if SETUP_TIMEOUT != 60 * 10:
                         print_warning('Setting SETUP_TIMEOUT to 10 minutes.')
                         SETUP_TIMEOUT = 60 * 10
-                    # instance_ips_to_poll.remove(ami_instance_ip)
                     failure = True
                     continue
                 except Exception as exp:
@@ -77,7 +74,6 @@ def main():
                         print(f'Resetting SETUP_TIMEOUT to an hour.')
                         SETUP_TIMEOUT = 60 * 60
                     print(f'[{datetime.datetime.now()}] {ami_instance_name} is ready to use')
-                    # ready_ami_list.append(ami_instance_name)
                     instance_ips_to_poll.remove(ami_instance_ip)
                 # printing the message every 30 seconds
                 elif current_time - last_update_time > PRINT_INTERVAL_IN_SECONDS:


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25349

## Description
For each server instance, we increase the MaxStartups to `20:30:100` and then restart the `sshd` service. Because the build runs in threads and the mocking mechanism executes commands on a given server instance via ssh, we may be hitting the `sshd` connection limit of the server instance. Can read more about it [here](https://appuals.com/fix-ssh_exchange_identification-connection-closed-by-remote-host/).

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

