### PR TITLE
fortisiem bug fix

### DIFF
--- a/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
+++ b/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-Fixed an issue where the authentication did not work properly.
-Fixed an issue where the ***fortisiem-get-events-by-incident*** command wasn't returning results.
+  - Fixed an issue where the authentication did not work properly.
+  - Fixed an issue where the ***fortisiem-get-events-by-incident*** command did not returning results.
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
+++ b/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
   - Fixed an issue where the authentication did not work properly.
-  - Fixed an issue where the ***fortisiem-get-events-by-incident*** command did not returning results.
+  - Fixed an issue where the ***fortisiem-get-events-by-incident*** command did not return results.
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
+++ b/Packs/FortiSIEM/Integrations/FortiSIEM/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 Fixed an issue where the authentication did not work properly.
+Fixed an issue where the ***fortisiem-get-events-by-incident*** command wasn't returning results.
 
 
 ## [20.5.0] - 2020-05-12

--- a/Packs/FortiSIEM/Integrations/FortiSIEM/FortiSIEM.py
+++ b/Packs/FortiSIEM/Integrations/FortiSIEM/FortiSIEM.py
@@ -132,15 +132,30 @@ def clear_incident(incident_id, reason):
 @logger
 def getEventsByIncident(incident_id, max_results, extended_data, max_wait_time):
     session = login()
-    response = session.get(HOST + '/phoenix/rest/h5/report/triggerEvent?rawMsg=' + incident_id)
-    validateSuccessfulResponse(response, "triggering events report")
+    # response = session.get(HOST + '/phoenix/rest/h5/report/triggerEvent?rawMsg=' + incident_id)
+    # validateSuccessfulResponse(response, "triggering events report")
+    #
+    # try:
+    #     jsonRes = response.json()
+    #     queryData = jsonRes[0]['right']
+    # except (ValueError, KeyError):
+    #     return_error("Got wrong response format when triggering events report. "
+    #                  "Expected a json array but got:\n" + response.text)
 
-    try:
-        jsonRes = response.json()
-        queryData = jsonRes[0]['right']
-    except (ValueError, KeyError):
-        return_error("Got wrong response format when triggering events report. "
-                     "Expected a json array but got:\n" + response.text)
+    queryData = {
+        "isReportService": True,
+        "selectClause": "eventSeverityCat,incidentLastSeen,eventName,incidentRptDevName,incidentSrc,incidentTarget,"
+                        "incidentDetail,incidentStatus,incidentReso,incidentId,eventType,incidentTicketStatus,"
+                        "bizService,count,incidentClearedTime,incidentTicketUser,incidentNotiRecipients,"
+                        "incidentClearedReason,incidentComments,eventSeverity,incidentFirstSeen,incidentRptIp,"
+                        "incidentTicketId,customer,incidentNotiStatus,incidentClearedUser,incidentExtUser,"
+                        "incidentExtClearedTime,incidentExtResoTime,incidentExtTicketId,incidentExtTicketState,"
+                        "incidentExtTicketType,incidentViewStatus,rawEventMsg,phIncidentCategory,phSubIncidentCategory,"
+                        "incidentRptDevStatus",
+        "eventFilters": [{"name": "Filter_OVERALL_STATUS",
+                          "singleConstraint": "(phEventCategory = 1) AND incidentId = {}".format(incident_id)}],
+        "hints": "IgnoreTime",
+    }
 
     return getEventsByQuery(session, queryData, max_results, extended_data, max_wait_time,
                             "FortiSIEM events for Incident " + incident_id, incident_id=incident_id)

--- a/Packs/FortiSIEM/ReleaseNotes/1_0_0.md
+++ b/Packs/FortiSIEM/ReleaseNotes/1_0_0.md
@@ -1,5 +1,4 @@
 
-### Integrations
+#### Integrations
 - __FortiSIEM__
 Fixed an issue where the authentication did not work properly.
-

--- a/Packs/FortiSIEM/ReleaseNotes/1_0_1.md
+++ b/Packs/FortiSIEM/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+- __FortiSIEM__
+Fixed an issue where the ***fortisiem-get-events-by-incident*** command wasn't returning results.

--- a/Packs/FortiSIEM/ReleaseNotes/1_0_1.md
+++ b/Packs/FortiSIEM/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 - __FortiSIEM__
-Fixed an issue where the ***fortisiem-get-events-by-incident*** command wasn't returning results.
+Fixed an issue where the ***fortisiem-get-events-by-incident*** command did not return results.

--- a/Packs/FortiSIEM/pack_metadata.json
+++ b/Packs/FortiSIEM/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "FortiSIEM",
-  "description": "Search and update events of FortiSIEM and manage resource lists.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Analytics & SIEM"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "FortiSIEM",
+    "description": "Search and update events of FortiSIEM and manage resource lists.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Analytics & SIEM"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25331

## Description
Disabled the request to trigger an event in order to get the query data, instead, now query data is a hardcoded dict.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

