### PR TITLE
Fixed print when GCS_MARKET_KEY is not set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,10 @@ jobs:
                 echo 'Skipping - running only in container number 0.'
                 exit 0;
             fi
+            if [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
+              echo "Skipping, Should not run on contributor's branch."
+              exit 0
+            fi
             ./Tests/scripts/prepare_content_packs_for_testing.sh
       - run:
           name: Zip Content Packs From GCS

--- a/Tests/scripts/prepare_content_packs_for_testing.sh
+++ b/Tests/scripts/prepare_content_packs_for_testing.sh
@@ -11,7 +11,7 @@ ID_SET=$CIRCLE_ARTIFACTS/id_set.json
 EXTRACT_FOLDER=$(mktemp -d)
 
 if [[ -z "$GCS_MARKET_KEY" ]]; then
-    echo "$GCS_MARKET_KEY not set aborting!"
+    echo "GCS_MARKET_KEY not set aborting!"
     exit 1
 fi
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Description
When $GCS_MARKET_KEY is not set- print `GCS_MARKET_KEY not set aborting!` instead of `not set aborting!`


##Screenshots
![image](https://user-images.githubusercontent.com/41257953/84242979-3c6cb000-ab0a-11ea-96ad-07afbe3ff13a.png)
