### PR TITLE
To ISO Format Transformer

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_1_9.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_1_9.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### __DateStringToISOFormat__
+- Added new transformer script for converting arbitrary date strings to ISO-8601 format.

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
@@ -1,0 +1,21 @@
+import demistomock as demisto
+from dateutil.parser import parse
+
+
+def parse_datestring_to_iso(date_value: str, day_first: bool, year_first: bool, fuzzy: bool) -> str:
+    return parse(date_value, dayfirst=day_first, yearfirst=year_first, fuzzy=fuzzy).isoformat()
+
+
+def main():
+    args = demisto.args()
+    date_value = args.get('value')
+    day_first = args.get('dayfirst', 'True').lower() == 'true'
+    year_first = args.get('yearfirst', 'False').lower() == 'true'
+    fuzzy = args.get('fuzzy', 'True').lower() == 'true'
+    iso_string = parse_datestring_to_iso(date_value, day_first, year_first, fuzzy)
+    demisto.results(iso_string)
+
+
+# python2 uses __builtin__ python3 uses builtins
+if __name__ in ('__builtin__', 'builtins', '__main__'):
+    main()

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
@@ -1,9 +1,14 @@
 import demistomock as demisto
-from dateutil.parser import parse
+from dateutil.parser import ParserError, parse
 
 
 def parse_datestring_to_iso(date_value: str, day_first: bool, year_first: bool, fuzzy: bool) -> str:
-    return parse(date_value, dayfirst=day_first, yearfirst=year_first, fuzzy=fuzzy).isoformat()
+    try:
+        date_string = parse(date_value, dayfirst=day_first, yearfirst=year_first, fuzzy=fuzzy).isoformat()
+    except ParserError as e:
+        demisto.error(f'ParserError occurred: {e}\n Returning the original date string.')
+        date_string = date_value
+    return date_string
 
 
 def main():

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.py
@@ -1,5 +1,5 @@
 import demistomock as demisto
-from dateutil.parser import ParserError, parse
+from dateutil.parser import ParserError, parse  # type: ignore
 
 
 def parse_datestring_to_iso(date_value: str, day_first: bool, year_first: bool, fuzzy: bool) -> str:

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
@@ -1,4 +1,3 @@
-
 commonfields:
   id: DateStringToISOFormat
   version: -1
@@ -19,31 +18,31 @@ args:
   default: true
   auto: PREDEFINED
   predefined:
-  - "True"
-  - "False"
+  - "true"
+  - "false"
   description: Whether to interpret the first value in an ambiguous 3-integer date
     (e.g. 01/05/09) as the day (``True``) or month (``False``). If ``yearfirst`` is
     set to ``True``, this distinguishes between YDM and YMD.
-  defaultValue: "True"
+  defaultValue: "true"
 - name: yearfirst
   default: true
   auto: PREDEFINED
   predefined:
-  - "True"
-  - "False"
+  - "true"
+  - "false"
   description: Whether to interpret the first value in an ambiguous 3-integer date
     (e.g. 01/05/09) as the year. If ``True``, the first number is taken to be the
     year, otherwise the last number is taken to be the year.
-  defaultValue: "False"
+  defaultValue: "false"
 - name: fuzzy
   default: true
   auto: PREDEFINED
   predefined:
-  - "True"
-  - "False"
+  - "true"
+  - "false"
   description: Whether to allow fuzzy parsing, allowing for string like "Today is
     January 1, 2047 at 8:21:00AM".
-  defaultValue: "True"
+  defaultValue: "true"
 system: false
 timeout: '0'
 subtype: python3

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
@@ -1,0 +1,50 @@
+
+commonfields:
+  id: DateStringToISOFormat
+  version: -1
+name: DateStringToISOFormat
+script: '-'
+type: python
+tags:
+- transformer
+- date
+comment: This is a thin wrapper around the `dateutil.parser.parse` function. It will
+  parse a string containing a date/time stamp and return it in ISO 8601 format.
+enabled: true
+args:
+- name: value
+  required: true
+  description: Date value to convert.
+- name: dayfirst
+  default: true
+  auto: PREDEFINED
+  predefined:
+  - "True"
+  - "False"
+  description: Whether to interpret the first value in an ambiguous 3-integer date
+    (e.g. 01/05/09) as the day (``True``) or month (``False``). If ``yearfirst`` is
+    set to ``True``, this distinguishes between YDM and YMD.
+  defaultValue: "True"
+- name: yearfirst
+  default: true
+  auto: PREDEFINED
+  predefined:
+  - "True"
+  - "False"
+  description: Whether to interpret the first value in an ambiguous 3-integer date
+    (e.g. 01/05/09) as the year. If ``True``, the first number is taken to be the
+    year, otherwise the last number is taken to be the year.
+  defaultValue: "False"
+- name: fuzzy
+  default: true
+  auto: PREDEFINED
+  predefined:
+  - "True"
+  - "False"
+  description: Whether to allow fuzzy parsing, allowing for string like "Today is
+    January 1, 2047 at 8:21:00AM".
+  defaultValue: "True"
+system: false
+timeout: '0'
+subtype: python3
+dockerimage: demisto/python3:3.8.3.8715

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat.yml
@@ -46,4 +46,4 @@ args:
 system: false
 timeout: '0'
 subtype: python3
-dockerimage: demisto/python3:3.8.3.8715
+dockerimage: demisto/python3:3.8.3.9324

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
@@ -42,7 +42,7 @@ def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expec
     Given
     - An arbitrary date string
     When
-    - The date string can be an ambiguous 3-integer date, fuzzy date string or an 
+    - The date string can be an ambiguous 3-integer date, fuzzy date string or an
       already iso-8601 formatted date string
     Then
     - Ensure the output date string is in iso-8601 format in all cases

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
@@ -1,0 +1,46 @@
+from DateStringToISOFormat import parse_datestring_to_iso
+import pytest
+
+
+# date_value, day_first, year_first, fuzzy, expected_output
+testdata = [
+    ('05-11-2929', True, True, True, '2929-11-05T00:00:00'),
+    ('05-11-2929', True, False, True, '2929-11-05T00:00:00'),
+    ('05-11-2929', True, True, False, '2929-11-05T00:00:00'),
+    ('05-11-2929', True, False, False, '2929-11-05T00:00:00'),
+    ('05-11-2929', False, True, True, '2929-05-11T00:00:00'),
+    ('05-11-2929', False, False, True, '2929-05-11T00:00:00'),
+    ('05-11-2929', False, False, False, '2929-05-11T00:00:00'),
+    ('2020-06-11T17:34:35.754203+03:00', True, True, True, '2020-11-06T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', True, False, True, '2020-11-06T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', True, True, False, '2020-11-06T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', True, False, False, '2020-11-06T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', False, True, True, '2020-06-11T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', False, False, True, '2020-06-11T17:34:35.754203+03:00'),
+    ('2020-06-11T17:34:35.754203+03:00', False, False, False, '2020-06-11T17:34:35.754203+03:00')
+]
+
+
+@pytest.mark.parametrize('date_value,day_first,year_first,fuzzy,expected_output', testdata)
+def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expected_output):
+    '''Scenario: Parse an arbitrary date string and convert it to ISO 8601 format
+
+    Given
+    - An arbitrary date string
+    When
+    - The date string can be an ambiguous 3-integer date or already an iso-8601 formatted date string
+    Then
+    - Ensure the output date string is in iso-8601 format in all cases
+
+    Args:
+        date_value (str): A string containing a date stamp.
+        day_first (bool): Whether to interpret the first value in an ambiguous 3-integer date
+                          (e.g. 01/05/09) as the day or month.
+        year_first (bool): Whether to interpret the first value in an ambiguous 3-integer date
+                           (e.g. 01/05/09) as the year. If ``True``, the first number is taken to
+                           be the year, otherwise the last number is taken to be the year.
+        fuzzy (bool): Whether to allow fuzzy parsing, allowing for string like "Today is
+                      January 1, 2047 at 8:21:00AM".
+        expected_output (str): The iso 8601 formatted date to check the result against
+    '''
+    assert parse_datestring_to_iso(date_value, day_first, year_first, fuzzy) == expected_output

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
@@ -17,7 +17,21 @@ testdata = [
     ('2020-06-11T17:34:35.754203+03:00', True, False, False, '2020-11-06T17:34:35.754203+03:00'),
     ('2020-06-11T17:34:35.754203+03:00', False, True, True, '2020-06-11T17:34:35.754203+03:00'),
     ('2020-06-11T17:34:35.754203+03:00', False, False, True, '2020-06-11T17:34:35.754203+03:00'),
-    ('2020-06-11T17:34:35.754203+03:00', False, False, False, '2020-06-11T17:34:35.754203+03:00')
+    ('2020-06-11T17:34:35.754203+03:00', False, False, False, '2020-06-11T17:34:35.754203+03:00'),
+    ("June 21st 2020 Eastern Standard Time", True, True, True, "2020-06-21T00:00:00"),
+    ("June 21st 2020 Eastern Standard Time", True, False, True, "2020-06-21T00:00:00"),
+    ("June 21st 2020 Eastern Standard Time", True, True, False, "June 21st 2020 Eastern Standard Time"),
+    ("June 21st 2020 Eastern Standard Time", True, False, False, "June 21st 2020 Eastern Standard Time"),
+    ("June 21st 2020 Eastern Standard Time", False, True, True, "2020-06-21T00:00:00"),
+    ("June 21st 2020 Eastern Standard Time", False, False, True, "2020-06-21T00:00:00"),
+    ("June 21st 2020 Eastern Standard Time", False, False, False, "June 21st 2020 Eastern Standard Time"),
+    ("The 1st of June 2020", True, True, True, "2020-06-01T00:00:00"),
+    ("The 1st of June 2020", True, False, True, "2020-06-01T00:00:00"),
+    ("The 1st of June 2020", True, True, False, "The 1st of June 2020"),
+    ("The 1st of June 2020", True, False, False, "The 1st of June 2020"),
+    ("The 1st of June 2020", False, True, True, "2020-06-01T00:00:00"),
+    ("The 1st of June 2020", False, False, True, "2020-06-01T00:00:00"),
+    ("The 1st of June 2020", False, False, False, "The 1st of June 2020")
 ]
 
 
@@ -28,7 +42,8 @@ def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expec
     Given
     - An arbitrary date string
     When
-    - The date string can be an ambiguous 3-integer date or already an iso-8601 formatted date string
+    - The date string can be an ambiguous 3-integer date, fuzzy date string or an 
+      already iso-8601 formatted date string
     Then
     - Ensure the output date string is in iso-8601 format in all cases
 

--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
@@ -36,7 +36,7 @@ testdata = [
 
 
 @pytest.mark.parametrize('date_value,day_first,year_first,fuzzy,expected_output', testdata)
-def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expected_output):
+def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expected_output, capfd):
     '''Scenario: Parse an arbitrary date string and convert it to ISO 8601 format
 
     Given
@@ -58,4 +58,5 @@ def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expec
                       January 1, 2047 at 8:21:00AM".
         expected_output (str): The iso 8601 formatted date to check the result against
     '''
-    assert parse_datestring_to_iso(date_value, day_first, year_first, fuzzy) == expected_output
+    with capfd.disabled():
+        assert parse_datestring_to_iso(date_value, day_first, year_first, fuzzy) == expected_output

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.8",
+    "currentVersion": "1.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CommonTypes/IndicatorTypes/reputation-domain.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-domain.json
@@ -121,6 +121,23 @@
 						{
 							"operator": "uniq",
 							"args": {}
+						},
+						{
+							"operator": "DateStringToISOFormat",
+							"args": {
+								"dayfirst": {
+									"value": null,
+									"isContext": false
+								},
+								"fuzzy": {
+									"value": null,
+									"isContext": false
+								},
+								"yearfirst": {
+									"value": null,
+									"isContext": false
+								}
+							}
 						}
 					]
 				}
@@ -415,6 +432,23 @@
 						{
 							"operator": "uniq",
 							"args": {}
+						},
+						{
+							"operator": "DateStringToISOFormat",
+							"args": {
+								"dayfirst": {
+									"value": null,
+									"isContext": false
+								},
+								"fuzzy": {
+									"value": null,
+									"isContext": false
+								},
+								"yearfirst": {
+									"value": null,
+									"isContext": false
+								}
+							}
 						}
 					]
 				}

--- a/Packs/CommonTypes/ReleaseNotes/1_2_1.md
+++ b/Packs/CommonTypes/ReleaseNotes/1_2_1.md
@@ -1,0 +1,4 @@
+
+#### IndicatorTypes
+##### domainRepUnified
+- Updated ***Domain*** indicator type's default mapping to use the new transformer *DateStringToISOFormat* where relevant.

--- a/Packs/CommonTypes/ReleaseNotes/1_2_1.md
+++ b/Packs/CommonTypes/ReleaseNotes/1_2_1.md
@@ -1,4 +1,4 @@
 
 #### IndicatorTypes
 ##### domainRepUnified
-- Updated ***Domain*** indicator type's default mapping to use the new transformer *DateStringToISOFormat* where relevant.
+Updated the ***Domain*** indicator type's default mapping to use the new transformer *DateStringToISOFormat* (where relevant).

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "Common types pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25351

## Description
This PR adds a transformer that takes a date string and converts it to ISO-8601 format. That transformer has then been added as an additional transformer to the `CreationDate` and `UpdatedDate` indicator fields for the `Domain` indicator type.

## Minimum version of Demisto
- [x] 5.5.0 (for the updated indicator type)

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation

