### PR TITLE
ThreatX - update test get entities timeframe

### DIFF
--- a/Packs/ThreatX/TestPlaybooks/playbook-ThreatX-test.yml
+++ b/Packs/ThreatX/TestPlaybooks/playbook-ThreatX-test.yml
@@ -1176,7 +1176,7 @@ tasks:
       entity_ip: {}
       entity_name: {}
       timeframe:
-        simple: 1-Hour
+        simple: 1-Day
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25599

## Description
Change get-entities cmd timeframe from 1 hour to 1 day to increase the change of getting entities results