### PR TITLE
Skip/Unmock Joe Security

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3033,6 +3033,7 @@
     ],
     "unmockable_integrations": {
         "SNDBOX": "Submits a file - tests that send files shouldn't be mocked",
+        "Joe Security": "Submits a file - tests that send files shouldn't be mocked",
         "Maltiverse": "issue 24335",
         "MITRE ATT&CK": "Using taxii2client package",
         "MongoDB": "Our instance not using SSL",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2950,6 +2950,7 @@
         "Check Point": "Issue 18643",
         "Preempt": "Issue 20268",
         "iDefense": "Issue 20095",
+        "Joe Security": "Issue 17996",
         "ZeroFox": "Issue 19161",
         "Jask": "Issue 18879",
         "vmray": "Issue 18752",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: Joe Security test playbooks fail in nightly.

## Description
The `Joe Security` test playbooks fail in our nightly build.
1. Tests/Integrations that detonate files shouldn't be mocked since sending files isn't currently supported by our mocking mechanism so I added the integration to the unmockable list.
2. The quota associated to our `Joe Security` license is too limited to run the test playbooks every night.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

