### PR TITLE
Generic detonate file/url - adding CrowsStrike Falcon X

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -674,6 +674,7 @@ tasks:
       type: playbook
       iscommand: false
       brand: ""
+      description: ''
     nexttasks:
       '#none#':
       - "3"

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -6,10 +6,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 9f1790b9-f686-4ef0-88a1-67a99c6fd22a
+    taskid: f4bc1e99-ce54-40cf-8f46-cf8dd60ee50a
     type: start
     task:
-      id: 9f1790b9-f686-4ef0-88a1-67a99c6fd22a
+      id: f4bc1e99-ce54-40cf-8f46-cf8dd60ee50a
       version: -1
       name: ""
       description: Playbook start point
@@ -29,6 +29,7 @@ tasks:
       - "18"
       - "19"
       - "20"
+      - "21"
     separatecontext: false
     view: |-
       {
@@ -44,10 +45,10 @@ tasks:
     quietmode: 0
   "3":
     id: "3"
-    taskid: d792cc3a-8145-4a6d-8b64-70659abb4a3b
+    taskid: f701f075-2d2e-437a-8b6e-a29dc612f403
     type: title
     task:
-      id: d792cc3a-8145-4a6d-8b64-70659abb4a3b
+      id: f701f075-2d2e-437a-8b6e-a29dc612f403
       version: -1
       name: Done
       description: Done
@@ -69,10 +70,10 @@ tasks:
     quietmode: 0
   "8":
     id: "8"
-    taskid: 741e8a36-af99-4a71-8bea-7a9a29a19cf6
+    taskid: ca3ff448-c771-4677-8a01-f97f9f2e4e0f
     type: playbook
     task:
-      id: 741e8a36-af99-4a71-8bea-7a9a29a19cf6
+      id: ca3ff448-c771-4677-8a01-f97f9f2e4e0f
       version: -1
       name: Detonate File - JoeSecurity
       description: |-
@@ -119,10 +120,10 @@ tasks:
     quietmode: 0
   "9":
     id: "9"
-    taskid: 3699b4d4-4b78-40fb-854b-4685fc11884d
+    taskid: 38257fa2-5614-4a0a-8e3b-397319a19060
     type: playbook
     task:
-      id: 3699b4d4-4b78-40fb-854b-4685fc11884d
+      id: 38257fa2-5614-4a0a-8e3b-397319a19060
       version: -1
       name: ATD - Detonate File
       description: |-
@@ -179,10 +180,10 @@ tasks:
     quietmode: 0
   "10":
     id: "10"
-    taskid: 1e1e8ced-8254-4e0f-87df-6a66361990ac
+    taskid: 06f91adc-e9aa-4a6a-8468-2ad515c2c439
     type: playbook
     task:
-      id: 1e1e8ced-8254-4e0f-87df-6a66361990ac
+      id: 06f91adc-e9aa-4a6a-8468-2ad515c2c439
       version: -1
       name: Detonate File - ThreatGrid
       description: Detonate one or more files using the ThreatGrid integration. This
@@ -234,10 +235,10 @@ tasks:
     quietmode: 0
   "11":
     id: "11"
-    taskid: 9936b2c1-6b2d-4dd0-8ad1-5a4a20d8d2a4
+    taskid: dd700400-cea2-4392-802d-97f970ebd9da
     type: playbook
     task:
-      id: 9936b2c1-6b2d-4dd0-8ad1-5a4a20d8d2a4
+      id: dd700400-cea2-4392-802d-97f970ebd9da
       version: -1
       name: CrowdStrike Falcon Sandbox - Detonate file
       description: Detonate one or more files using the CrowdStrike Falcon Sandbox
@@ -283,10 +284,10 @@ tasks:
     quietmode: 0
   "13":
     id: "13"
-    taskid: f642e2fa-ccad-4649-8dec-9efc24383a97
+    taskid: 4a01e683-6dae-4efb-82fc-da878dd94ed5
     type: playbook
     task:
-      id: f642e2fa-ccad-4649-8dec-9efc24383a97
+      id: 4a01e683-6dae-4efb-82fc-da878dd94ed5
       version: -1
       name: WildFire - Detonate file
       description: |-
@@ -330,10 +331,10 @@ tasks:
     quietmode: 0
   "14":
     id: "14"
-    taskid: 3c9fb593-0fd1-4add-8ec0-9b9c90df990a
+    taskid: 91d41089-65d3-47e9-8285-8ad94518975b
     type: playbook
     task:
-      id: 3c9fb593-0fd1-4add-8ec0-9b9c90df990a
+      id: 91d41089-65d3-47e9-8285-8ad94518975b
       version: -1
       name: Detonate File - Lastline v2
       description: |-
@@ -375,10 +376,10 @@ tasks:
     quietmode: 0
   "15":
     id: "15"
-    taskid: d5773904-ddd5-4fa7-83f0-9df15bd55a53
+    taskid: 7a9a5930-fcbe-45c1-8874-86511286ca0a
     type: playbook
     task:
-      id: d5773904-ddd5-4fa7-83f0-9df15bd55a53
+      id: 7a9a5930-fcbe-45c1-8874-86511286ca0a
       version: -1
       name: Detonate File - Cuckoo
       description: Detonating file with Cuckoo
@@ -416,10 +417,10 @@ tasks:
     quietmode: 0
   "16":
     id: "16"
-    taskid: f6f3e837-e456-4391-82b6-fd155d458556
+    taskid: 368f6aac-2dce-4cbd-8987-f47a8cf08f61
     type: playbook
     task:
-      id: f6f3e837-e456-4391-82b6-fd155d458556
+      id: 368f6aac-2dce-4cbd-8987-f47a8cf08f61
       version: -1
       name: Detonate File - SNDBOX
       description: |-
@@ -468,10 +469,10 @@ tasks:
     quietmode: 0
   "17":
     id: "17"
-    taskid: 4022a15a-2575-4d34-886f-0ca4e6b1832d
+    taskid: 399c7179-86a9-47d7-80a6-04b0187b6d56
     type: playbook
     task:
-      id: 4022a15a-2575-4d34-886f-0ca4e6b1832d
+      id: 399c7179-86a9-47d7-80a6-04b0187b6d56
       version: -1
       name: Detonate File - HybridAnalysis
       description: |-
@@ -520,10 +521,10 @@ tasks:
     quietmode: 0
   "18":
     id: "18"
-    taskid: fb7c44ba-da96-430f-88b0-6a4b70c2300f
+    taskid: cd9d9b6e-5462-48a4-86e0-fe3cba3a496e
     type: playbook
     task:
-      id: fb7c44ba-da96-430f-88b0-6a4b70c2300f
+      id: cd9d9b6e-5462-48a4-86e0-fe3cba3a496e
       version: -1
       name: Detonate File - ANYRUN
       description: |-
@@ -565,10 +566,10 @@ tasks:
     quietmode: 0
   "19":
     id: "19"
-    taskid: b268ceda-3965-44c9-8313-e836f32e0bb0
+    taskid: 71f95c31-2616-4c75-8499-bc61ae9ca352
     type: playbook
     task:
-      id: b268ceda-3965-44c9-8313-e836f32e0bb0
+      id: 71f95c31-2616-4c75-8499-bc61ae9ca352
       version: -1
       name: Detonate File - FireEye AX
       description: Detonate one or more files using the FireEye AX integration. This
@@ -612,10 +613,10 @@ tasks:
     quietmode: 0
   "20":
     id: "20"
-    taskid: 2804e4f1-1eb7-46ea-8b1d-af6affff25e2
+    taskid: c7037dca-1db2-4c5a-81b5-a19021c1d2f3
     type: playbook
     task:
-      id: 2804e4f1-1eb7-46ea-8b1d-af6affff25e2
+      id: c7037dca-1db2-4c5a-81b5-a19021c1d2f3
       version: -1
       name: Detonate File - VMRay
       description: Detonating file with VMRay
@@ -661,13 +662,54 @@ tasks:
     ignoreworker: false
     skipunavailable: true
     quietmode: 0
+  "21":
+    id: "21"
+    taskid: f9e89698-7370-4312-8793-e7281a7dcaef
+    type: playbook
+    task:
+      id: f9e89698-7370-4312-8793-e7281a7dcaef
+      version: -1
+      name: Detonate File - CrowsStrike Falcon X
+      playbookId: Detonate File - CrowsStrike Falcon X
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      File:
+        complex:
+          root: File
+      Interval:
+        simple: "1"
+      Timeout:
+        simple: "15"
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+      max: 100
+    view: |-
+      {
+        "position": {
+          "x": 4770,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
         "height": 385,
-        "width": 4680,
+        "width": 5100,
         "x": 50,
         "y": 50
       }
@@ -1087,6 +1129,18 @@ outputs:
   type: String
 - contextPath: ANYRUN.Task.Process.Version.Version
   description: Version of the program executed.
+  type: String
+- contextPath: DBotScore.Indicator
+  description: The indicator that was tested.
+  type: String
+- contextPath: DBotScore.Score
+  description: The actual score.
+  type: Number
+- contextPath: DBotScore.Type
+  description: Type of indicator.
+  type: String
+- contextPath: DBotScore.Vendor
+  description: Vendor used to calculate the score.
   type: String
 - contextPath: File.Extension
   description: Extension of the file submitted for analysis.

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_CHANGELOG.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Adding CrowdStrike Falcon X.
 
 ## [20.5.2] - 2020-05-26
 -

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic.yml
@@ -1,16 +1,15 @@
 id: detonate_url_-_generic
 version: -1
 name: Detonate URL - Generic
-fromversion: 4.0.0
 description: Detonate URL through active integrations that support URL detonation
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 32fe7da3-a280-49c6-83d4-6cb1fb474458
+    taskid: cdf4a31e-5729-43d9-8efb-300c5a69f530
     type: start
     task:
-      id: 32fe7da3-a280-49c6-83d4-6cb1fb474458
+      id: cdf4a31e-5729-43d9-8efb-300c5a69f530
       version: -1
       name: ""
       description: Playbook start point
@@ -25,6 +24,7 @@ tasks:
       - "15"
       - "16"
       - "17"
+      - "18"
     separatecontext: false
     view: |-
       {
@@ -36,12 +36,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "3":
     id: "3"
-    taskid: 40c6a1c6-dce9-4a0b-87b8-fec50f7933ae
+    taskid: 65db710d-d079-4f53-8efa-55a3c074a73e
     type: title
     task:
-      id: 40c6a1c6-dce9-4a0b-87b8-fec50f7933ae
+      id: 65db710d-d079-4f53-8efa-55a3c074a73e
       version: -1
       name: Done
       description: Done
@@ -59,12 +61,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "11":
     id: "11"
-    taskid: 7902e341-c29c-4037-8e6a-6c2289d3806e
+    taskid: 369f2ab0-f5a1-4dba-8367-effc8077495d
     type: playbook
     task:
-      id: 7902e341-c29c-4037-8e6a-6c2289d3806e
+      id: 369f2ab0-f5a1-4dba-8367-effc8077495d
       version: -1
       name: Detonate URL - ThreatGrid
       description: Detonate one or more URLs using the Threat Grid integration. This
@@ -82,8 +86,8 @@ tasks:
         simple: file-detonated-via-demisto
       Interval:
         simple: "1"
-      OS: {}
-      OSVersion: {}
+      Playbook:
+        simple: default
       Private: {}
       Source: {}
       Tags: {}
@@ -99,6 +103,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -109,12 +114,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "12":
     id: "12"
-    taskid: 7119396c-ac89-473c-82fa-c634c25788d6
+    taskid: 1495395c-bf56-4024-86da-501985cd322f
     type: playbook
     task:
-      id: 7119396c-ac89-473c-82fa-c634c25788d6
+      id: 1495395c-bf56-4024-86da-501985cd322f
       version: -1
       name: Detonate URL - McAfee ATD
       description: Detonates a URL using the McAfee Advanced Threat Defense sandbox
@@ -127,19 +134,20 @@ tasks:
       '#none#':
       - "3"
     scriptarguments:
+      Interval:
+        simple: "1"
+      Timeout:
+        simple: "15"
       URL:
         complex:
           root: inputs.URL
           accessor: Data
-      interval:
-        simple: "1"
-      timeout:
-        simple: "15"
     separatecontext: true
     loop:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -150,12 +158,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "13":
     id: "13"
-    taskid: 7a53b305-64ef-47c4-85f7-8ff702cb4209
+    taskid: 38275eac-6704-430d-8ac2-cc49a9526246
     type: playbook
     task:
-      id: 7a53b305-64ef-47c4-85f7-8ff702cb4209
+      id: 38275eac-6704-430d-8ac2-cc49a9526246
       version: -1
       name: Detonate URL - JoeSecurity
       description: |-
@@ -169,25 +179,26 @@ tasks:
       '#none#':
       - "3"
     scriptarguments:
+      Comments: {}
+      InternetAccess:
+        simple: "True"
+      Interval:
+        simple: "1"
+      ReportFileType:
+        simple: html
+      Systems: {}
+      Timeout:
+        simple: "15"
       URL:
         complex:
           root: inputs.URL
           accessor: Data
-      comments: {}
-      internet-access:
-        simple: "True"
-      interval:
-        simple: "1"
-      report-file-type:
-        simple: html
-      systems: {}
-      timeout:
-        simple: "15"
     separatecontext: true
     loop:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -198,17 +209,19 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "14":
     id: "14"
-    taskid: 2555400f-2fd3-4bdc-82e4-3e5be8948952
+    taskid: 54d2b592-31c6-4e6c-8498-27bffe1519e2
     type: playbook
     task:
-      id: 2555400f-2fd3-4bdc-82e4-3e5be8948952
+      id: 54d2b592-31c6-4e6c-8498-27bffe1519e2
       version: -1
       name: Detonate URL - CrowdStrike
-      description: Detonate one or more files using the Wildfire integration. This
-        playbook returns relevant reports to the War Room and file reputations to
-        the context data.
+      description: Detonate one or more files using the CrowdStrike Falcon Sandbox
+        integration. This playbook returns relevant reports to the War Room and file
+        reputations to the context data.
       playbookName: Detonate URL - CrowdStrike
       type: playbook
       iscommand: false
@@ -232,6 +245,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -242,16 +256,18 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "15":
     id: "15"
-    taskid: 4e47aa4e-bef0-4566-8aae-b249bdf06ce0
+    taskid: 2de7a1ac-8ac2-4766-89d1-7ffae250d17e
     type: playbook
     task:
-      id: 4e47aa4e-bef0-4566-8aae-b249bdf06ce0
+      id: 2de7a1ac-8ac2-4766-89d1-7ffae250d17e
       version: -1
-      name: Detonate URL - Lastline v2
+      name: Detonate URL - Lastline
       description: Detonates a URL using the Lastline sandbox integration.
-      playbookName: Detonate URL - Lastline v2
+      playbookName: Detonate URL - Lastline
       type: playbook
       iscommand: false
       brand: ""
@@ -272,6 +288,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -282,15 +299,17 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "16":
     id: "16"
-    taskid: 317e29bb-856f-4081-8fdd-f4a189d01c90
+    taskid: aadfd123-bdb5-4159-8463-530ba3617d72
     type: playbook
     task:
-      id: 317e29bb-856f-4081-8fdd-f4a189d01c90
+      id: aadfd123-bdb5-4159-8463-530ba3617d72
       version: -1
       name: Detonate URL - Cuckoo
-      description: Detonates a file using Cuckoo sandbox
+      description: Detonating URL with Cuckoo
       playbookName: Detonate URL - Cuckoo
       type: playbook
       iscommand: false
@@ -303,11 +322,16 @@ tasks:
         complex:
           root: inputs.URL
           accessor: Data
+      interval:
+        simple: "1"
+      timeout:
+        simple: "10"
     separatecontext: true
     loop:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -318,15 +342,19 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "17":
     id: "17"
-    taskid: a2cbc7cf-2d9e-4eda-87e9-909b88265839
+    taskid: e889ae78-22f7-45ba-8302-e2c0b8b0265b
     type: playbook
     task:
-      id: a2cbc7cf-2d9e-4eda-87e9-909b88265839
+      id: e889ae78-22f7-45ba-8302-e2c0b8b0265b
       version: -1
       name: Detonate URL - ANYRUN
-      description: Detonates a URL using ANYRUN sandbox
+      description: |-
+        Detonates one or more URLs using the ANYRUN sandbox integration.
+        Returns relevant reports to the War Room and url reputations to the context data.
       playbookName: Detonate URL - ANYRUN
       type: playbook
       iscommand: false
@@ -334,7 +362,20 @@ tasks:
     nexttasks:
       '#none#':
       - "3"
+    scriptarguments:
+      Interval:
+        simple: "1"
+      Timeout:
+        simple: "15"
+      URL:
+        complex:
+          root: URL
     separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+      max: 100
     view: |-
       {
         "position": {
@@ -345,13 +386,59 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
+  "18":
+    id: "18"
+    taskid: bf90633c-01ae-4e10-82dd-9b663da9e3b9
+    type: playbook
+    task:
+      id: bf90633c-01ae-4e10-82dd-9b663da9e3b9
+      version: -1
+      name: Detonate URL - CrowsStrike Falcon X
+      playbookId: Detonate URL - CrowsStrike Falcon X
+      type: playbook
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      EnvironmentID:
+        simple: "100"
+      Interval:
+        simple: "5"
+      Timeout:
+        simple: "30"
+      URL:
+        complex:
+          root: URL
+          accessor: Data
+    separatecontext: true
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+      max: 100
+    view: |-
+      {
+        "position": {
+          "x": 3050,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
         "height": 385,
-        "width": 2960,
+        "width": 3380,
         "x": 50,
         "y": 50
       }
@@ -364,6 +451,7 @@ inputs:
       root: URL
   required: false
   description: URL object of url to be detonated.
+  playbookInputQuery: null
 outputs:
 - contextPath: File
   description: The File's object

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic.yml
@@ -400,6 +400,7 @@ tasks:
       type: playbook
       iscommand: false
       brand: ""
+      description: ''
     nexttasks:
       '#none#':
       - "3"
@@ -451,7 +452,7 @@ inputs:
       root: URL
   required: false
   description: URL object of url to be detonated.
-  playbookInputQuery: null
+  playbookInputQuery:
 outputs:
 - contextPath: File
   description: The File's object
@@ -784,3 +785,4 @@ outputs:
   type: String
 tests:
 - Detonate URL - Generic Test
+fromversion: 4.0.0

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic_CHANGELOG.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_URL_-_Generic_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-
+Adding CrowdStrike Falcon X.
 
 ## [20.5.2] - 2020-05-26
 -

--- a/Packs/CommonPlaybooks/ReleaseNotes/1_0_1.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
-### Playbooks
-- __Detonate File - Generic__
--
+#### Playbooks
+##### Detonate File - Generic
+Added CrowdStrike Falcon X to the generic detonate url and generic detonate file playbooks.

--- a/Packs/CommonPlaybooks/ReleaseNotes/1_1_0.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/1_1_0.md
@@ -1,4 +1,0 @@
-
-#### Playbooks
-##### Detonate File - Generic
-

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.2.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Adding the CrowdStrike Falcon X detonate url and detonate file to the generic detonate pbs.
Added the advanced option "Skip this branch if this automation/playbook is unavailable" that is available in 6.0, checked for 5.0 - dosen't break bc.

## Minimum version of Demisto
- [ ] 4.5.0
- [x] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

