### PR TITLE
Unmock Joe Security

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3032,6 +3032,7 @@
     ],
     "unmockable_integrations": {
         "SNDBOX": "Submits a file - tests that send files shouldn't be mocked",
+        "Joe Security": "Submits a file - tests that send files shouldn't be mocked",
         "Maltiverse": "issue 24335",
         "MITRE ATT&CK": "Using taxii2client package",
         "MongoDB": "Our instance not using SSL",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: Joe Security test playbooks is mocked in our CI builds.

## Description
The `Joe Security` test playbooks are mocked (and fail) in our nightly build. Tests/Integrations that detonate files shouldn't be mocked since sending files isn't currently supported by our mocking mechanism so I added the integration to the unmockable list.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

