### PR TITLE
[Test Fail] Removed ews o365 from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2842,7 +2842,6 @@
         "MSGraph_DeviceManagement_Test": "Issue 25603",
         "CuckooTest": "Issue 25601",
         "Active Directory - Get User Manager Details - Test": "Issue 25604",
-        "EWS_O365_test": "Issue 25605",
         "Cortex XDR - IOC - Test": "Issue 25598",
         "RedLockTest": "Issue 24600",
         "Test - Cofense Intelligence": "Issue 25498",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25605

## Description
Removed EWS O365 from skipped.