### PR TITLE
fixing build test failure recognition

### DIFF
--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -833,7 +833,7 @@ def main():
         prints_manager.add_print_job(msg, print_color, 0, LOG_COLORS.GREEN)
         prints_manager.execute_thread_prints(0)
         # If there is a failure, __test_integration_instance will print it
-        success = __test_integration_instance(testing_client, instance, prints_manager)
+        success, _ = __test_integration_instance(testing_client, instance, prints_manager)
         prints_manager.execute_thread_prints(0)
         if not success:
             preupdate_fails.add((instance_name, integration_of_instance))
@@ -883,7 +883,7 @@ def main():
         prints_manager.add_print_job(msg, print_color, 0, LOG_COLORS.GREEN)
         prints_manager.execute_thread_prints(0)
         # If there is a failure, __test_integration_instance will print it
-        success = __test_integration_instance(testing_client, instance, prints_manager)
+        success, _ = __test_integration_instance(testing_client, instance, prints_manager)
         prints_manager.execute_thread_prints(0)
         if not success:
             postupdate_fails.add((instance_name, integration_of_instance))


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25678

## Description
The __test_integration_instance method returns a tuple - previously received to a single variable. This resulted in no failure recognition for tests, hence the issue.

## Screenshots
I broke Lastline on purpose on a different build and printed the recognized successful and failing tests

here is before the fix - all tests are noted as successful though Lastline failed:
![image](https://user-images.githubusercontent.com/50295826/84697575-0fc7f680-af57-11ea-916c-57bf9b167ad0.png)
seen here: https://circleci.com/gh/demisto/content/58127

Here is after the fix - Lastline's failure has been noted:
![image](https://user-images.githubusercontent.com/50295826/84697684-3d14a480-af57-11ea-82a0-51fc12819b59.png)
can be seen here: https://circleci.com/gh/demisto/content/58133
 