### PR TITLE
lastline v2 skip nightly

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3020,7 +3020,8 @@
         "HelloWorldSimple": "This is just an example integration - no need for test",
         "TestHelloWorldPlaybook": "This is just an example integration - no need for test",
         "Lockpath KeyLight": "Deprecated. No tests.",
-        "Cymulate": "Partner didn't provided test playbook"
+        "Cymulate": "Partner didn't provided test playbook",
+        "Lastline v2": "Temporary skipping, due to quota issues, in order to merge a PR"
     },
     "nightly_integrations": [
         "Lastline v2",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/25654

## Description
Skipping lastline v2 integration, to disable the nightly run. This is because we have quota issues with the integration and we want to save all quota for the upcoming PR https://github.com/demisto/content/pull/7580.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

