### PR TITLE
ThreatX - increase test timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -340,7 +340,7 @@
         {
             "integrations": "ThreatX",
             "playbookID": "ThreatX-test",
-            "timeout": 3600
+            "timeout": 600
         },
         {
             "integrations": "Akamai WAF SIEM",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -339,7 +339,8 @@
         },
         {
             "integrations": "ThreatX",
-            "playbookID": "ThreatX-test"
+            "playbookID": "ThreatX-test",
+            "timeout": 3600
         },
         {
             "integrations": "Akamai WAF SIEM",


### PR DESCRIPTION
fixes https://github.com/demisto/etc/issues/25599

the change done in https://github.com/demisto/content/pull/7557 increases the runtime of the test

increased the timeout to allow the test to finish running