### PR TITLE
Add 'multiple' Command Argument to Zscaler's 'url' command

### DIFF
--- a/Packs/Zscaler/.secrets-ignore
+++ b/Packs/Zscaler/.secrets-ignore
@@ -9,3 +9,4 @@ https://maybe_valid
 https://user-images.githubusercontent.com
 2.2.2.2
 3.3.3.3
+https://madeup.fake.com

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
@@ -334,8 +334,10 @@ def get_whitelist():
     return json.loads(result.content)
 
 
-def url_lookup(url):
-    response = lookup_request(url)
+def url_lookup(args):
+    url = args.get('url', '')
+    multiple = args.get('multiple', 'true').lower() == 'true'
+    response = lookup_request(url, multiple)
     hr = json.loads(response.content)
     if hr:
         data = hr[0]
@@ -444,9 +446,12 @@ def ip_lookup(ip):
     return entry
 
 
-def lookup_request(ioc):
+def lookup_request(ioc, multiple=True):
     cmd_url = '/urlLookup'
-    ioc_list = ioc.split(',')
+    if multiple:
+        ioc_list = ioc.split(',')
+    else:
+        ioc_list = [ioc]
     json_data = json.dumps(ioc_list)
     response = http_request('POST', cmd_url, json_data, DEFAULT_HEADERS)
     return response
@@ -740,7 +745,7 @@ def main():
             http_request('GET', '/authenticatedSession', None, DEFAULT_HEADERS)
             demisto.results('ok')
         elif demisto.command() == 'url':
-            demisto.results(url_lookup(demisto.args()['url']))
+            demisto.results(url_lookup(demisto.args()))
         elif demisto.command() == 'ip':
             demisto.results(ip_lookup(demisto.args()['ip']))
         elif demisto.command() == 'zscaler-blacklist-url':

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
@@ -51,6 +51,18 @@ script:
       required: false
       default: true
       description: URL to search for
+    - name: multiple
+      default: true
+      auto: PREDEFINED
+      predefined:
+      - "true"
+      - "false"
+      description: Whether submitting multiple URLs. When set to "true", the value
+        entered for the "url" command argument is interpreted as a CSV list of URLs.
+        If you wish to submit a URL that has commas in it, then you may set this value
+        to "false" and enter that singular URL for the value of the "url" command
+        argument.
+      defaultValue: "true"
     outputs:
     - contextPath: URL.Data
       description: The URL that was searched

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
@@ -57,10 +57,10 @@ script:
       predefined:
       - "true"
       - "false"
-      description: Whether submitting multiple URLs. When set to "true", the value
+      description: Whether multiple URLs are being submitted. If "true", the value
         entered for the "url" command argument is interpreted as a CSV list of URLs.
-        If you wish to submit a URL that has commas in it, then you may set this value
-        to "false" and enter that singular URL for the value of the "url" command
+        If you want to submit a URL that has commas in it, you can set this value
+        to "false" and enter the singular URL for the value of the "url" command
         argument.
       defaultValue: "true"
     outputs:

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler_test.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler_test.py
@@ -2,6 +2,7 @@ import demistomock as demisto
 import CommonServerPython
 import pytest
 import json
+import requests_mock
 
 
 class ResponseMock:
@@ -122,3 +123,50 @@ def test_get_whitelist(mocker):
                      response_path='test_data/responses/whitelist_url.json',
                      expected_result_path='test_data/results/whitelist.json',
                      mocker=mocker)
+
+
+# disable-secrets-detection-start
+test_data = [
+    ('https://madeup.fake.com/css?family=blah:1,2,3', 'true', ['https://madeup.fake.com/css?family=blah:1', '2', '3']),
+    ('https://madeup.fake.com/css?family=blah:1,2,3', 'false', ['https://madeup.fake.com/css?family=blah:1,2,3'])
+]
+# disable-secrets-detection-end
+@pytest.mark.parametrize('url,multiple,expected_data', test_data)
+def test_url_multiple_arg(mocker, url, multiple, expected_data):
+    '''Scenario: Submit a URL with commas in it
+
+    Given
+    - A URL with commas in it
+    When
+    - case A: 'multiple' argument is set to "true" (the default)
+    - case B: 'multiple' argument is set to "false"
+    Then
+    - case A: Ensure the URL is interpreted as multiple values to be sent in the subsequent API call
+    - case B: Ensure the URL is interpreted as a single value to be sent in the subsequent API call
+
+    Args:
+        mocker (Mocker): Mocker module.
+        url (str): The URL to submit.
+        multiple (str): "true" or "false" - whether to interpret the 'url' argument as multiple comma separated values.
+        expected_data (list): The data expected to be sent in the API call.
+    '''
+    params = demisto.params()
+    params['cloud'] = 'http://cloud'
+    mocker.patch.object(demisto, 'params', return_value=params)
+
+    import Zscaler
+    with requests_mock.mock() as m:
+        # 'fake_resp_content' doesn't really matter here since we are checking the data being sent in the call,
+        # not what it is that we expect to get in response
+        fake_resp_content = '[{"url": "blah", "urlClassifications": [], "urlClassificationsWithSecurityAlert": []}]'
+        m.post(Zscaler.BASE_URL + '/urlLookup', content=fake_resp_content)
+        args = {
+            'url': url,
+            'multiple': multiple
+        }
+        Zscaler.url_lookup(args)
+    assert m.called
+    assert m.call_count == 1
+    request_data = m.last_request.json()
+    assert len(request_data) == len(expected_data)
+    assert request_data == expected_data

--- a/Packs/Zscaler/ReleaseNotes/1_0_1.md
+++ b/Packs/Zscaler/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Zscaler
+  - Added a flag argument ***multiple*** to the ***url*** command enabling users to submit singular URLs with commas in them when set to ***"false"***.

--- a/Packs/Zscaler/ReleaseNotes/1_0_1.md
+++ b/Packs/Zscaler/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Zscaler
-  - Added a flag argument ***multiple*** to the ***url*** command enabling users to submit singular URLs with commas in them when set to ***"false"***.
+Added a *multiple* argument to the ***url*** command, which when set to "false" enables users to submit singular URLs that contain commas.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Zscaler",
-  "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-03-10T08:37:18Z",
-  "categories": [
-    "Network Security"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Zscaler",
+    "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-03-10T08:37:18Z",
+    "categories": [
+        "Network Security"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25684

## Description
Added an argument to the `url` command in `Zscaler` called `multiple`. By default, it's value will be `"true"` which will maintain backward compatibility. When the argument is set to `"false"`, the command won't interpret the value passed to the `url` command's `'url'` argument as a comma separated list of URLs. This will allow for the submission of singular URLs that have commas in them.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation

