### PR TITLE
Mongodb: nested dicts fix

### DIFF
--- a/Packs/MongoDB/Integrations/MongoDB/MongoDB.py
+++ b/Packs/MongoDB/Integrations/MongoDB/MongoDB.py
@@ -170,13 +170,13 @@ def convert_id_to_object_id(
 
 
 def convert_str_to_datetime(entries: Any) -> Any:
-    """ Converts list or dict with date values of type str to Datetime.
+    """ Recursively searches for a string that fit a date format and converts it to string.
 
     Args:
-        entries: The object contains list or dict with possible dates value.
+        entries: An object that may contain a timestamp string with possible dates value.
 
     Returns:
-        All Dates converted to Datetime.
+        Same object with converted string date formats to datetime object.
     """
     # regex for finding timestamp in string
     regex_for_timestamp = re.compile(r'\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?Z?')

--- a/Packs/MongoDB/Integrations/MongoDB/MongoDB_test.py
+++ b/Packs/MongoDB/Integrations/MongoDB/MongoDB_test.py
@@ -48,7 +48,7 @@ class TestConvertStrToDatetime:
         {"testing": 123, "time": "ISODate('2020-06-12T08:23:07.000Z')"},
         pytest.param(
             {"testing": 123, "time": "ISODate('2018-06-12T08:23:07.000')"},
-            marks=pytest.mark.xfail),
+            marks=pytest.mark.xfail)
     ]
 
     @pytest.mark.parametrize("func_input", dict_inputs)
@@ -60,6 +60,11 @@ class TestConvertStrToDatetime:
         inputs = {1: 2}
         res = convert_str_to_datetime(inputs)
         assert isinstance(res[1], int)
+
+    def test_dict_inside_dict(self):
+        func_input = {"k": {"$gte": "ISODate('2020-06-12T08:23:07.000Z')"}}
+        res = convert_str_to_datetime(func_input)
+        assert isinstance(res["k"]["$gte"], datetime)
 
 
 class TestDatetimeToStr:

--- a/Packs/MongoDB/Integrations/MongoDB/MongoDB_test.py
+++ b/Packs/MongoDB/Integrations/MongoDB/MongoDB_test.py
@@ -61,7 +61,18 @@ class TestConvertStrToDatetime:
         res = convert_str_to_datetime(inputs)
         assert isinstance(res[1], int)
 
-    def test_dict_inside_dict(self):
+    def test_nested_dict(self):
+        """
+        Given:
+        A nested dict with a timestamp
+
+        When:
+        Running a query or insert
+
+        Then:
+        Validating all keys in the dict are there and the timestamp is valid
+
+        """
         func_input = {"k": {"$gte": "ISODate('2020-06-12T08:23:07.000Z')"}}
         res = convert_str_to_datetime(func_input)
         assert isinstance(res["k"]["$gte"], datetime)

--- a/Packs/MongoDB/ReleaseNotes/1_0_4.md
+++ b/Packs/MongoDB/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MongoDB
+Fixed an issue where nested dictionaries containing a datetime object were not parsed properly.

--- a/Packs/MongoDB/pack_metadata.json
+++ b/Packs/MongoDB/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MongoDB",
     "description": "Use the MongoDB integration to search and query entries in your MongoDB.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25735

## Description
Nested dicts were not parsed properly when they had a datetime object.
Test introducing the bug:
![image](https://user-images.githubusercontent.com/11165655/84862850-93c7ce80-b07c-11ea-8d53-cc47164c51c9.png)


## Does it break backward compatibility?
   - [ ] No

## Must have
- [x] Tests
