### PR TITLE
Fix cfw extra arg

### DIFF
--- a/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
+++ b/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
@@ -835,8 +835,12 @@ script:
       description: Whether to block traffic "to" or "from" the IPs, or "both". Default     is
         "both".
     - name: rulename
-      required: true
+      required: false
       description: Base name for added rules inside checkpoint db
+      deprecated: true
+    - name: ipname
+      required: true
+      description: Base name for added ip/hosts inside checkpoint db
     outputs:
     - contextPath: CheckpointFWRule.Name
       description: Object name. Should be unique in domain

--- a/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
+++ b/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
@@ -837,9 +837,6 @@ script:
     - name: rulename
       required: true
       description: Base name for added rules inside checkpoint db
-    - name: ipname
-      required: true
-      description: Base name for added ip/hosts inside checkpoint db
     outputs:
     - contextPath: CheckpointFWRule.Name
       description: Object name. Should be unique in domain

--- a/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall_README.md
+++ b/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall_README.md
@@ -787,11 +787,6 @@
 <td style="width: 531px;">The base name for added rules inside Check Point DB.</td>
 <td style="width: 73px;">Required</td>
 </tr>
-<tr>
-<td style="width: 136px;">ipname</td>
-<td style="width: 531px;">The base name for added IP addresses/hosts inside Check Point DB.</td>
-<td style="width: 73px;">Required</td>
-</tr>
 </tbody>
 </table>
 </div>

--- a/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Check Point
-Deprecated an unused argument `ipname` from **checkpoint-block-ip** command.
+Deprecated the *ipname* argument from the ***checkpoint-block-ip*** command.

--- a/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Check Point
+Removed an unused argument `ipname` from **checkpoint-block-ip** command.

--- a/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Check Point
-Removed an unused argument `ipname` from **checkpoint-block-ip** command.
+Deprecated an unused argument `ipname` from **checkpoint-block-ip** command.

--- a/Packs/CheckpointFirewall/pack_metadata.json
+++ b/Packs/CheckpointFirewall/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Check Point Firewall",
     "description": "Manage Check Point firewall via API",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25725

## Description
ipname argument has been never used and not needed for the command to work. So now it's deprecated to not break BC.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No