### PR TITLE
Microsoft Defender ATP - set scope to default

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -32,7 +32,8 @@ class MsClient:
                  alert_severities_to_fetch, alert_status_to_fetch, alert_time_to_fetch):
         self.ms_client = MicrosoftClient(
             tenant_id=tenant_id, auth_id=auth_id, enc_key=enc_key, app_name=app_name,
-            base_url=base_url, verify=verify, proxy=proxy, self_deployed=self_deployed)
+            base_url=base_url, verify=verify, proxy=proxy, self_deployed=self_deployed,
+            scope='https://securitycenter.onmicrosoft.com/windowsatpservice/.default')
         self.alert_severities_to_fetch = alert_severities_to_fetch,
         self.alert_status_to_fetch = alert_status_to_fetch
         self.alert_time_to_fetch = alert_time_to_fetch

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_1_2.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_1_2.md
@@ -1,0 +1,4 @@
+
+### Integrations
+- __Microsoft Defender Advanced Threat Protection__
+Updated the permission scope for self-deployed applications to be Microsoft Defender Advanced Threat Protection default. 

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender Advanced Threat Protection",
     "description": "Microsoft Defender Advanced ThreatProtection",
     "support": "xsoar",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
##  Status
- [x] Ready

## Description
The default scope that was set was for graph, changed it to ATP one

## Does it break backward compatibility?
   - [x] No

