### PR TITLE
Microsoft Teams - handle notifications from server

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -88,7 +88,7 @@ def translate_severity(severity: str) -> int:
     :return: Demisto integer severity
     """
     severity_dictionary = {
-        'Unclassified': 0,
+        'Unknown': 0,
         'Low': 1,
         'Medium': 2,
         'High': 3,

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -35,6 +35,7 @@ ENTITLEMENT_REGEX: str = \
     r'(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}'
 MENTION_REGEX = r'^@([^@;]+);| @([^@;]+);'
 ENTRY_FOOTER: str = 'From Microsoft Teams'
+INCIDENT_NOTIFICATIONS_CHANNEL = 'incidentNotificationChannel'
 
 MESSAGE_TYPES: dict = {
     'mirror_entry': 'mirrorEntry',
@@ -87,6 +88,7 @@ def translate_severity(severity: str) -> int:
     :return: Demisto integer severity
     """
     severity_dictionary = {
+        'Unclassified': 0,
         'Low': 1,
         'Medium': 2,
         'High': 3,
@@ -1064,7 +1066,8 @@ def send_message():
         return
     channel_name: str = demisto.args().get('channel', '')
 
-    if not channel_name and message_type in {MESSAGE_TYPES['status_changed'], MESSAGE_TYPES['incident_opened']}:
+    if (not channel_name and message_type in {MESSAGE_TYPES['status_changed'], MESSAGE_TYPES['incident_opened']}) \
+            or channel_name == INCIDENT_NOTIFICATIONS_CHANNEL:
         # Got a notification from server
         channel_name = demisto.params().get('incident_notifications_channel', 'General')
         severity: int = int(demisto.args().get('severity'))
@@ -1216,8 +1219,8 @@ def channel_mirror_loop():
     """
     while True:
         found_channel_to_mirror: bool = False
+        integration_context = demisto.getIntegrationContext()
         try:
-            integration_context = demisto.getIntegrationContext()
             teams: list = json.loads(integration_context.get('teams', '[]'))
             for team in teams:
                 mirrored_channels = team.get('mirrored_channels', [])
@@ -1627,10 +1630,11 @@ def long_running_loop():
                 demisto.info('Starting HTTP Server')
 
             server = WSGIServer(('0.0.0.0', port), APP, **ssl_args)
+            demisto.updateModuleHealth('')
             server.serve_forever()
         except Exception as e:
             error_message = str(e)
-            demisto.error(f'An error occurred in long running loop: {error_message}')
+            demisto.error(f'An error occurred in long running loop: {error_message} - {format_exc()}')
             demisto.updateModuleHealth(f'An error occurred: {error_message}')
         finally:
             if certificate_path:

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -33,6 +33,7 @@ configuration:
   display: Minimum incident severity to send notifications to Teams by
   name: min_incident_severity
   options:
+  - Unclassified
   - Low
   - Medium
   - High

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -286,7 +286,7 @@ script:
     description: Creates a new channel in a Microsoft Teams team.
     execution: false
     name: microsoft-teams-create-channel
-  dockerimage: demisto/teams:1.0.0.7727
+  dockerimage: demisto/teams:1.0.0.9271
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -33,7 +33,7 @@ configuration:
   display: Minimum incident severity to send notifications to Teams by
   name: min_incident_severity
   options:
-  - Unclassified
+  - Unknown
   - Low
   - Medium
   - High

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -632,6 +632,118 @@ def test_send_message(mocker, requests_mock):
     assert results[0] == 'Message was sent successfully.'
 
 
+def test_send_message_server_notifications_incident_opened(mocker, requests_mock):
+    """
+    Given:
+     - Notification from server of an incident opened.
+
+    When:
+     - Sending notification message of the incident opened.
+
+    Then:
+     - Ensure message is sent successfully.
+     - Verify the message is sent to the dedicated notifications channel.
+    """
+    from MicrosoftTeams import send_message
+    mocker.patch.object(demisto, 'results')
+    mocker.patch.object(
+        demisto,
+        'params',
+        return_value={
+            'team': 'The-A-Team',
+            'min_incident_severity': 'Low',
+            'incident_notifications_channel': 'General'
+        }
+    )
+    mocker.patch.object(
+        demisto,
+        'args',
+        return_value={
+            'channel': 'incidentNotificationChannel',
+            'message': 'user has reported an incident tadam.\nView it on https://server#/WarRoom/3247',
+            'messageType': 'incidentOpened',
+            'severity': 1,
+            'to': ''
+        }
+    )
+    requests_mock.get(
+        f'https://graph.microsoft.com/v1.0/teams/{team_aad_id}/channels',
+        json={
+            'value': [
+                {
+                    'description': 'general channel',
+                    'displayName': 'General',
+                    'id': '19:67pd3966e74g45f28d0c65f1689132bb@thread.skype'
+                }
+            ]
+        }
+    )
+    requests_mock.post(
+        f'{service_url}/v3/conversations/19:67pd3966e74g45f28d0c65f1689132bb@thread.skype/activities',
+        json={}
+    )
+    send_message()
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0] == 'Message was sent successfully.'
+
+
+def test_send_message_server_notifications_incident_changed(mocker, requests_mock):
+    """
+    Given:
+     - Notification from server of an updated incident.
+
+    When:
+     - Sending notification message of the updated incident.
+
+    Then:
+     - Ensure message is sent successfully.
+     - Verify the message is sent to the dedicated notifications channel.
+    """
+    from MicrosoftTeams import send_message
+    mocker.patch.object(demisto, 'results')
+    mocker.patch.object(
+        demisto,
+        'params',
+        return_value={
+            'team': 'The-A-Team',
+            'min_incident_severity': 'Low',
+            'incident_notifications_channel': 'General'
+        }
+    )
+    mocker.patch.object(
+        demisto,
+        'args',
+        return_value={
+            'channel': 'incidentNotificationChannel',
+            'message': 'DBot has updated an incident tadam.\nView it on https://server#/WarRoom/3247',
+            'messageType': 'incidentChanged',
+            'severity': 1,
+            'to': ''
+        }
+    )
+    requests_mock.get(
+        f'https://graph.microsoft.com/v1.0/teams/{team_aad_id}/channels',
+        json={
+            'value': [
+                {
+                    'description': 'general channel',
+                    'displayName': 'General',
+                    'id': '19:67pd3966e74g45f28d0c65f1689132bb@thread.skype'
+                }
+            ]
+        }
+    )
+    requests_mock.post(
+        f'{service_url}/v3/conversations/19:67pd3966e74g45f28d0c65f1689132bb@thread.skype/activities',
+        json={}
+    )
+    send_message()
+    results = demisto.results.call_args[0]
+    assert len(results) == 1
+    assert results[0] == 'Message was sent successfully.'
+
+
 def test_get_channel_id(requests_mock):
     from MicrosoftTeams import get_channel_id
     # get channel which is in the integration context

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_2.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Teams
+- Fixed an issue where notifications to be sent to the dedicated channel were not handled appropriately.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_2.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Microsoft Teams
-- Fixed an issue where notifications to be sent to the dedicated channel were not handled appropriately.
+Fixed an issue where notifications to be sent to the dedicated channel were not handled appropriately.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25819

## Description
 - handle notifications from server that come with notifications channel only in the arguments
 - add unclassified to incident severity notifications
 - update module health on webserver start - needed for case it crashed and spins up again
 - move integration_context init out of the try-except block, as it raised var referenced before var sometimes
 - added traceback print to logs

## Minimum version of Demisto
- [x] 5.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests