### PR TITLE
Slack skip setting loop in long running container

### DIFF
--- a/Packs/Slack/Integrations/Slack/Slack.py
+++ b/Packs/Slack/Integrations/Slack/Slack.py
@@ -1814,7 +1814,7 @@ def long_running_main():
     asyncio.run(start_listening())
 
 
-def init_globals():
+def init_globals(command_name: str = ''):
     """
     Initializes global variables according to the integration parameters
     """
@@ -1831,10 +1831,11 @@ def init_globals():
         # Use default SSL context
         SSL_CONTEXT = None
 
-    loop = asyncio.get_event_loop()
-    if not loop._default_executor:  # type: ignore[attr-defined]
-        demisto.info(f'setting _default_executor on loop: {loop} id: {id(loop)}')
-        loop.set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=4))
+    if command_name != 'long-running-execution':
+        loop = asyncio.get_event_loop()
+        if not loop._default_executor:  # type: ignore[attr-defined]
+            demisto.info(f'setting _default_executor on loop: {loop} id: {id(loop)}')
+            loop.set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=4))
 
     BOT_TOKEN = demisto.params().get('bot_token')
     ACCESS_TOKEN = demisto.params().get('access_token')
@@ -1878,7 +1879,6 @@ def main():
     """
     if is_debug_mode():
         os.environ['PYTHONASYNCIODEBUG'] = "1"
-    init_globals()
 
     commands = {
         'test-module': test_module,
@@ -1898,8 +1898,10 @@ def main():
         'slack-get-user-details': get_user,
     }
 
+    command_name = demisto.command()
+    init_globals(command_name)
+
     try:
-        command_name = demisto.command()
         command_func = commands[command_name]
         command_func()
     except Exception as e:

--- a/Packs/Slack/Integrations/Slack/Slack.py
+++ b/Packs/Slack/Integrations/Slack/Slack.py
@@ -1837,8 +1837,8 @@ def init_globals(command_name: str = ''):
             demisto.info(f'setting _default_executor on loop: {loop} id: {id(loop)}')
             loop.set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=4))
 
-    BOT_TOKEN = demisto.params().get('bot_token')
-    ACCESS_TOKEN = demisto.params().get('access_token')
+    BOT_TOKEN = demisto.params().get('bot_token', '')
+    ACCESS_TOKEN = demisto.params().get('access_token', '')
     PROXIES = handle_proxy()
     proxy_url = demisto.params().get('proxy_url')
     PROXY_URL = proxy_url or PROXIES.get('http')  # aiohttp only supports http proxy

--- a/Packs/Slack/ReleaseNotes/1_2_1.md
+++ b/Packs/Slack/ReleaseNotes/1_2_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SlackV2
-  Added stability improvements for long running execution
+Added stability improvements for long-running execution.

--- a/Packs/Slack/ReleaseNotes/1_2_1.md
+++ b/Packs/Slack/ReleaseNotes/1_2_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SlackV2
-  -
+  Added stability improvements for long running execution

--- a/Packs/Slack/ReleaseNotes/1_2_1.md
+++ b/Packs/Slack/ReleaseNotes/1_2_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SlackV2
+  -

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

fixes: https://github.com/demisto/etc/issues/24819

Fix possible cause for long running container zombie-state for a few customers since 20.4.1 content release.

Requires force merge because of the docker image, will be fixed in the next release.