### PR TITLE
Enhanced DT in Get Original Email to output HeadersMap

### DIFF
--- a/Packs/Phishing/Playbooks/Get_Original_Email_-_EWS.yml
+++ b/Packs/Phishing/Playbooks/Get_Original_Email_-_EWS.yml
@@ -106,8 +106,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": -54,
-          "y": 1744
+          "x": -60,
+          "y": 1840
         }
       }
     note: false
@@ -369,10 +369,10 @@ tasks:
     ignoreworker: false
   "9":
     id: "9"
-    taskid: fab3c34b-010a-4203-830a-7dbf0dde26e5
+    taskid: 91028b3f-61f2-4383-8bfd-eff9dd01af96
     type: regular
     task:
-      id: fab3c34b-010a-4203-830a-7dbf0dde26e5
+      id: 91028b3f-61f2-4383-8bfd-eff9dd01af96
       version: -1
       name: Set output
       description: Set the playbook outputs to context.
@@ -384,13 +384,16 @@ tasks:
       '#none#':
       - "2"
     scriptarguments:
-      append: {}
+      append:
+        simple: "false"
       key:
         simple: Email
+      stringify: {}
       value:
-        simple: '${EWS.Items={Subject: val[''subject''], To: val[''toRecipients''],
-          From: val[''sender''], Text: val[''textBody''],HTML: val[''body''], Headers:
-          val[''headers'']}}'
+        simple: '${.={Subject: val[''EWS''][''Items''][''subject''], To: val[''EWS''][''Items''][''toRecipients''],
+          From: val[''EWS''][''Items''][''sender''], Text: val[''EWS''][''Items''][''textBody''],HTML:
+          val[''EWS''][''Items''][''body''], Headers: val[''EWS''][''Items''][''headers''],
+          ''HeadersMap'': val[''Email''][''0''][''HeadersMap''] }}'
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -485,9 +488,9 @@ view: |-
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1759,
-        "width": 1261.5,
-        "x": -54,
+        "height": 1855,
+        "width": 1267.5,
+        "x": -60,
         "y": 50
       }
     }

--- a/Packs/Phishing/Playbooks/Get_Original_Email_-_EWS_CHANGELOG.md
+++ b/Packs/Phishing/Playbooks/Get_Original_Email_-_EWS_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-Added an output of email headers.
+Added the email headersmap output. This change allows phishing incidents to display email headers if the original email was retrieved.
 
 ## [20.5.2] - 2020-05-26
 -

--- a/Packs/Phishing/ReleaseNotes/1_6_0.md
+++ b/Packs/Phishing/ReleaseNotes/1_6_0.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Get Original Email - EWS
+  - Added the email headersmap output. This change allows phishing incidents to display email headers if the original email was retrieved.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "A pack used for the complete investigation of potential phishing incidents. It can retrieve emails from user inboxes, extract and analyze attachments, authenticate the email using SPF, DKIM and DMARC checks, provide reputation for links and email adresses involved, and contain and remediate the incident by blocking malicious indicators found in the process with analyst approval.",
     "support": "xsoar",
-    "currentVersion": "1.5.0",
+    "currentVersion": "1.6.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25746

## Description
Fixed the DT that sets details of the original email to the email context. Now Email.HeadersMap will also be outputted and set in the layout properly. By fixing the DT, the headersmap get outputted from `Get Original Email - EWS` to `Get Original Email - Generic` and then to `Process Email - Generic`, where the headers are set in the grid using `SetGridField`:
![image](https://user-images.githubusercontent.com/43602124/85226752-d9202f00-b3e1-11ea-80c5-2b4ebb1760e3.png)


## Does it break backward compatibility?
No

## Must have
- [x] Tests
- [ ] Documentation 


