### PR TITLE
Reverting restrictive api change

### DIFF
--- a/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
+++ b/Packs/CheckpointFirewall/Integrations/integration-CheckpointFirewall.yml
@@ -928,10 +928,7 @@ script:
       type: string
     description: Block one or more IP addresses using Checkpoint Firewall
   - name: checkpoint
-    arguments:
-    - name: command
-      required: true
-      description: The command to execute.
+    arguments: []
     description: Use Check Point's Management API (requires management server R80
       or later). Specifying 'command'=<API command> is mandatory
   - name: checkpoint-delete-rule

--- a/Packs/CheckpointFirewall/ReleaseNotes/1_0_3.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Check Point
+Allowing all arguments as input to the ***checkpoint*** command

--- a/Packs/CheckpointFirewall/ReleaseNotes/1_0_3.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/1_0_3.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Check Point
-Allowing all arguments as input to the ***checkpoint*** command
+ - Fixed an issue where the ***checkpoint*** command did not work as expected.

--- a/Packs/CheckpointFirewall/pack_metadata.json
+++ b/Packs/CheckpointFirewall/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Check Point Firewall",
     "description": "Manage Check Point firewall via API",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/25915

## Description
For some reason if there are no arguments configured for a command- all arguments are accepted and used in `demisto.args()`
But if there are arguments configured for a command- all non-configured arguments will be ignored

Therefore, the change that added this `command`argument have broke backwards compatibility, so reverting it back is the solution.



