### PR TITLE
Fix FindSimilarIncidentsV2

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_1_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_1_11.md
@@ -1,0 +1,5 @@
+
+### Scripts
+##### FindSimilarIncidents
+  - Allow searching for for similar incidents using numeric and boolean fields
+  - Sort similar incidents with identical timestamp by ID

--- a/Packs/CommonScripts/ReleaseNotes/1_1_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_1_11.md
@@ -1,5 +1,5 @@
 
 ### Scripts
 ##### FindSimilarIncidents
-  - Allow searching for for similar incidents using numeric and boolean fields
-  - Sort similar incidents with identical timestamp by ID
+  - You can now search for for similar incidents using numeric and boolean fields.
+  - Added support for sorting by ID of similar incidents with identical timestamp.

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+  - Allow searching for for similar incidents using numeric and boolean fields
+  - Sort similar incidents with identical timestamp by ID
 
 
 ## [20.5.2] - 2020-05-26

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-  - Allow searching for for similar incidents using numeric and boolean fields
-  - Sort similar incidents with identical timestamp by ID
+- You can now search for for similar incidents using numeric and boolean fields.
+- Added support for sorting by ID of similar incidents with identical timestamp.
 
 
 ## [20.5.2] - 2020-05-26

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.py
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.py
@@ -117,6 +117,7 @@ def get_incidents_by_keys(similar_incident_keys, time_field, incident_time, inci
                                    .replace('"', r'\"')
                                    .replace("\n", "\\n")
                                    .replace("\r", "\\r")
+                                   if type(t[1]) not in (int, float, bool) else t[1]
                                    ),
             similar_incident_keys.items()))
     incident_time = parse_datetime(incident_time)
@@ -362,7 +363,7 @@ def main():
     if len(duplicate_incidents or []) > 0:
         duplicate_incidents_rows = map(lambda x: incident_to_record(x, TIME_FIELD), duplicate_incidents)
 
-        duplicate_incidents_rows = list(sorted(duplicate_incidents_rows, key=lambda x: x['time']))
+        duplicate_incidents_rows = list(sorted(duplicate_incidents_rows, key=lambda x: (x['time'], x['id'])))
 
         context = {
             'similarIncidentList': duplicate_incidents_rows[:MAX_CANDIDATES_IN_LIST],

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
@@ -146,7 +146,7 @@ tags:
 - incidents
 timeout: 300ns
 type: python
-dockerimage: demisto/python:2.7.17.6981
+dockerimage: demisto/python:2.7.18.9326
 runonce: false
 tests:
 - Dedup - Generic v2 - Test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.10",
+    "currentVersion": "1.1.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://support.demisto.com/hc/en-us/requests/13701

## Description
The method `get_incidents_by_keys` called `.replace` on all values. This failed on boolean and numeric values, therefore I excluded them.
I also added id as second sort key to the output to ensure the oldest incident is first when multiple incidents with the same time exist.


## Minimum version of Demisto
- [x] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

