### PR TITLE
ArcSight ESM v2 Updated REST Endpoints

### DIFF
--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -690,7 +690,7 @@ def get_entries_command():
                 "act.authToken": AUTH_TOKEN,
                 "act.resourceId": resource_id,
             }
-        }
+        }  # type: Union[str, Dict[str, Dict[str, Any]]]
         res = send_request(query_path, json=body, params=params)
     else:
         query_path = 'www/manager-service/services/ActiveListService/'
@@ -766,7 +766,7 @@ def clear_entries_command():
                 "act.authToken": AUTH_TOKEN,
                 "act.resourceId": resource_id,
             }
-        }
+        }  # type: Union[str, Dict[str, Dict[str, Any]]]
         res = send_request(query_path, json=body, params=params)
     else:
         query_path = 'www/manager-service/services/ActiveListService/'

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -678,19 +678,36 @@ def delete_case_command():
 def get_entries_command():
     resource_id = demisto.args().get('resourceId')
     entry_filter = demisto.args().get('entryFilter')
+    use_rest = demisto.params().get('use_rest', False)
 
-    query_path = 'www/manager-service/services/ActiveListService/'
-    body = REQ_SOAP_BODY(function='getEntries', auth_token=AUTH_TOKEN, resource_id=resource_id, entryList=None)
-
-    res = send_request(query_path, body=body)
+    if use_rest:
+        query_path = 'www/manager-service/rest/ActiveListService/getEntries'
+        params = {
+            'alt': 'json'
+        }
+        body = {
+            "act.getEntries": {
+                "act.authToken": AUTH_TOKEN,
+                "act.resourceId": resource_id,
+            }
+        }
+        res = send_request(query_path, json=body, params=params)
+    else:
+        query_path = 'www/manager-service/services/ActiveListService/'
+        body = REQ_SOAP_BODY(function='getEntries', auth_token=AUTH_TOKEN, resource_id=resource_id, entryList=None)
+        res = send_request(query_path, body=body)
 
     if not res.ok:
         demisto.debug(res.text)
         return_error("Failed to get entries:\nResource ID: {}\nStatus Code: {}\nRequest Body: {}\nResponse: {}".format(
             resource_id, res.status_code, body, res.text))
 
-    res_json = json.loads(xml2json((res.text).encode('utf-8')))
-    raw_entries = demisto.get(res_json, 'Envelope.Body.getEntriesResponse.return')
+    if use_rest:
+        res_json = res.json()
+        raw_entries = res_json.get('act.getEntriesResponse', {}).get('act.return', {})
+    else:
+        res_json = json.loads(xml2json((res.text).encode('utf-8')))
+        raw_entries = demisto.get(res_json, 'Envelope.Body.getEntriesResponse.return')
 
     # retrieve columns
     cols = demisto.get(raw_entries, 'columns')
@@ -737,9 +754,24 @@ def get_entries_command():
 @logger
 def clear_entries_command():
     resource_id = demisto.args().get('resourceId')
-    query_path = 'www/manager-service/services/ActiveListService/'
-    body = REQ_SOAP_BODY(function='clearEntries', auth_token=AUTH_TOKEN, resource_id=resource_id, entryList=None)
-    res = send_request(query_path, body=body)
+    use_rest = demisto.params().get('use_rest', False)
+
+    if use_rest:
+        query_path = 'www/manager-service/rest/ActiveListService/clearEntries'
+        params = {
+            'alt': 'json'
+        }
+        body = {
+            "act.clearEntries": {
+                "act.authToken": AUTH_TOKEN,
+                "act.resourceId": resource_id,
+            }
+        }
+        res = send_request(query_path, json=body, params=params)
+    else:
+        query_path = 'www/manager-service/services/ActiveListService/'
+        body = REQ_SOAP_BODY(function='clearEntries', auth_token=AUTH_TOKEN, resource_id=resource_id, entryList=None)
+        res = send_request(query_path, body=body)
 
     if not res.ok:
         demisto.debug(res.text)

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
@@ -35,6 +35,13 @@ configuration:
   name: isFetch
   required: false
   type: 8
+- display: Use REST Endpoints
+  name: use_rest
+  defaultvalue: "false"
+  type: 8
+  required: false
+  additionalinfo: Use REST endpoints for the commands related to 'entries' instead
+    of the default legacy SOAP endpoints.
 - display: Incident type
   name: incidentType
   required: false

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -1,4 +1,6 @@
 import demistomock as demisto
+import pytest
+import requests_mock
 
 
 PARAMS = {
@@ -24,3 +26,81 @@ def test_decode_ip(mocker):
 
     res = ArcSightESMv2.decode_ip(3232235845)
     assert res == '192.168.1.69'
+
+
+test_data = [
+    (
+        True,
+        'get_entries_command',
+        'https://server/www/manager-service/rest/ActiveListService/getEntries?alt=json'
+    ),
+    (
+        False,
+        'get_entries_command',
+        'https://server/www/manager-service/services/ActiveListService/'
+    ),
+    (
+        True,
+        'clear_entries_command',
+        'https://server/www/manager-service/rest/ActiveListService/clearEntries?alt=json'
+    ),
+    (
+        False,
+        'clear_entries_command',
+        'https://server/www/manager-service/services/ActiveListService/'
+    )
+]
+@pytest.mark.parametrize('use_rest, cmd_name, expected_rest_endpoint', test_data)
+def test_use_rest(mocker, use_rest, cmd_name, expected_rest_endpoint):
+    '''Check that the correct endpoint is queried depending on the value of the 'use_rest' integration parameter.
+
+    This applies for the entries-related commands `as-get-entries` and `as-clear-entries`.
+
+    Args:
+        mocker (fixture): Mocking fixture
+        use_rest (bool): Whether the 'use_rest' integration parameter should be mocked as True or False
+        cmd_name (str): The entries-related command to run
+        expected_rest_endpoint (str): The endpoint that should be queried based on the parametrized configuration
+
+    Scenario: Execute the entries-related ArcSightESMv2 commands
+
+    Given
+    - The 'use_rest' integration parameter value
+    - The ArcSightESMv2 entries-related command to execute
+
+    When
+    - case A: 'use_rest' is True and the 'as-get-entries' command is executed
+    - case B: 'use_rest' is False and the 'as-get-entries' command is executed
+    - case C: 'use_rest' is True and the 'as-clear-entries' command is executed
+    - case D: 'use_rest' is False and the 'as-clear-entries' command is executed
+
+    Then
+    - case A: Ensure the REST endpoint for 'as-get-entries' is used
+    - case B: Ensure the SOAP endpoint for 'as-get-entries' is used
+    - case C: Ensure the REST endpoint for 'as-clear-entries' is used
+    - case D: Ensure the SOAP endpoint for 'as-clear-entries' is used
+    '''
+    params = {
+        'server': 'https://server',
+        'credentials': {},
+        'use_rest': use_rest,
+        'proxy': True
+    }
+    mocker.patch.object(demisto, 'params', return_value=params)
+    mocker.patch.object(demisto, 'args', return_value={'resourceId': 'blah'})
+    with requests_mock.Mocker() as m:
+        fake_response = {'log.loginResponse': {'log.return': 'fake'}}
+        m.post('https://server/www/core-service/rest/LoginService/login', json=fake_response)
+
+        import ArcSightESMv2
+
+        m.post('https://server/www/manager-service/rest/ActiveListService/clearEntries?alt=json', json={})
+        m.post('https://server/www/manager-service/rest/ActiveListService/getEntries?alt=json', json={})
+        fake_xml = '<?xml version="1.0"?><Envelope><Body><getEntriesResponse><return>' \
+                   '<entryList><entry>1.1.1.1</entry></entryList><columns>Blah</columns>' \
+                   '</return></getEntriesResponse></Body></Envelope>'
+        m.post('https://server/www/manager-service/services/ActiveListService/', text=fake_xml)
+        arcsight_cmd = getattr(ArcSightESMv2, cmd_name)
+        arcsight_cmd()
+        last_request = m.last_request
+        assert last_request.url == expected_rest_endpoint

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -4,7 +4,7 @@ import requests_mock
 
 
 PARAMS = {
-    'server': 'server',
+    'server': 'https://server',
     'credentials': {},
     'proxy': True}
 

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/README.md
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/README.md
@@ -57,6 +57,7 @@ Demisto is designed for an automatic response, so make sure to define conditions
     - **Use system proxy settings**: Select whether to communicate via the system proxy server or not.
     - **Fetch incidents**: Mark the Fetch incidents checkbox to automatically create Demisto incidents from this integration instance.
     - **Incident type**: Select the incident type to trigger.
+    - **Use REST Endpoints**: Mark this checkbox to use REST endpoints for the commands related to 'entries' instead of the default legacy SOAP endpoints.
 4. Click **Test** to validate the URLs, token, and connection.
     If you are experiencing issues with the service configuration, please contact Demisto support at support@demisto.com.
 5. After completing the test successfully, press the ‘Done’ button.

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_3.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ArcSight ESM v2
+Added a new integration parameter *Use REST Endpoints* which enables usage of REST endpoints for the ***as-get-entries*** and ***as-clear-entries*** commands.

--- a/Packs/ArcSightESM/pack_metadata.json
+++ b/Packs/ArcSightESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ArcSight ESM",
     "description": "ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/23963

## Description
Added a new parameter to the integration, `use_rest` which when `True` will change the `as-get-entries` and `as-clear-entries` commands to use the updated REST endpoints instead of the older SOAP endpoints.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation

