### PR TITLE
Panos threat

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4768,7 +4768,7 @@ def panorama_block_vulnerability():
     drop_mode = demisto.args().get('drop_mode', 'drop')
 
     threat = panorama_override_vulnerability(threatid, vulnerability_profile, drop_mode)
-    threat_output = {'ID': threatid, 'NewAction': drop_mode }
+    threat_output = {'ID': threatid, 'NewAction': drop_mode}
 
     demisto.results({
         'Type': entryTypes['note'],

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4750,12 +4750,13 @@ def panorama_get_predefined_threats_list(target: str):
         'GET',
         params=params
     )
-    demisto.results(fileResult('predefined-threats.json', json.dumps(result['response']['result']).encode('utf-8')))
+    return result
 
 
 def panorama_get_predefined_threats_list_command():
     target = str(demisto.args()['target']) if 'target' in demisto.args() else None
-    panorama_get_predefined_threats_list(target)
+    result = panorama_get_predefined_threats_list(target)
+    demisto.results(fileResult('predefined-threats.json', json.dumps(result['response']['result']).encode('utf-8')))
 
 
 def panorama_block_vulnerability():

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4750,7 +4750,7 @@ def panorama_get_predefined_threats_list(target: str):
         'GET',
         params=params
     )
-    demisto.results(result['response']['result'])
+    demisto.results(fileResult('predefined-threats.json', json.dumps(result['response']['result']).encode('utf-8')))
 
 
 def panorama_get_predefined_threats_list_command():
@@ -4764,12 +4764,10 @@ def panorama_block_vulnerability():
     """
     threatid = demisto.args()['threat_id']
     vulnerability_profile = demisto.args()['vulnerability_profile']
-    drop_mode = "drop"
-    if demisto.args().get('drop_mode'):
-        drop_mode = demisto.args().get('drop_mode')
+    drop_mode = demisto.args().get('drop_mode', 'drop')
 
     threat = panorama_override_vulnerability(threatid, vulnerability_profile, drop_mode)
-    threat_output = {'id': threatid}
+    threat_output = {'ID': threatid, 'NewAction': drop_mode }
 
     demisto.results({
         'Type': entryTypes['note'],

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4714,8 +4714,12 @@ def panorama_add_static_route_command():
         'EntryContext': {"Panorama.StaticRoutes(val.Name == obj.Name)": static_route}
     })
 
+
 def panorama_override_vulnerability(threatid: str, vulnerability_profile: str, drop_mode: str):
-    xpath = "{}profiles/vulnerability/entry[@name='{}']/threat-exception/entry[@name='{}']/action".format(XPATH_OBJECTS, vulnerability_profile, threatid),
+    xpath = "{}profiles/vulnerability/entry[@name='{}']/threat-exception/entry[@name='{}']/action".format(
+        XPATH_OBJECTS,
+        vulnerability_profile,
+        threatid)
     params = {'action': 'set',
               'type': 'config',
               'xpath': xpath,
@@ -4730,18 +4734,42 @@ def panorama_override_vulnerability(threatid: str, vulnerability_profile: str, d
     )
 
 
+@logger
+def panorama_get_predefined_threats_list(target: str):
+    """
+    Get the entire list of predefined threats as a file in Demisto
+    """
+    params = {
+        'type': 'op',
+        'cmd': '<show><predefined><xpath>/predefined/threats</xpath></predefined></show>',
+        'target': target,
+        'key': API_KEY
+    }
+    result = http_request(
+        URL,
+        'GET',
+        params=params
+    )
+    demisto.results(result['response']['result'])
+
+
+def panorama_get_predefined_threats_list_command():
+    target = str(demisto.args()['target']) if 'target' in demisto.args() else None
+    panorama_get_predefined_threats_list(target)
+
+
 def panorama_block_vulnerability():
     """
     Ovverride a vulnerability signature such that it is in block mode
     """
     threatid = demisto.args()['threat_id']
     vulnerability_profile = demisto.args()['vulnerability_profile']
-    drop_mode = "drop" 
+    drop_mode = "drop"
     if demisto.args().get('drop_mode'):
         drop_mode = demisto.args().get('drop_mode')
 
     threat = panorama_override_vulnerability(threatid, vulnerability_profile, drop_mode)
-    threat_output  = {'id': threatid}
+    threat_output = {'id': threatid}
 
     demisto.results({
         'Type': entryTypes['note'],
@@ -4753,6 +4781,7 @@ def panorama_block_vulnerability():
             "Panorama.Vulnerability(val.Name == obj.Name)": threat_output
         }
     })
+
 
 @logger
 def panorama_delete_static_route(xpath_network: str, virtual_router: str, route_name: str) -> Dict[str, str]:
@@ -5543,10 +5572,14 @@ def main():
         # Reboot Panorama Device
         elif demisto.command() == 'panorama-device-reboot':
             panorama_device_reboot_command()
-        
-        # PAN-OS Set vulnerability to drop 
+
+        # PAN-OS Set vulnerability to drop
         elif demisto.command() == 'panorama-block-vulnerability':
             panorama_block_vulnerability()
+
+        # Get pre-defined threats list from the firewall
+        elif demisto.command() == 'panorama-get-predefined-threats-list':
+            panorama_get_predefined_threats_list_command()
 
         else:
             raise NotImplementedError(f'Command {demisto.command()} was not implemented.')

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4714,6 +4714,45 @@ def panorama_add_static_route_command():
         'EntryContext': {"Panorama.StaticRoutes(val.Name == obj.Name)": static_route}
     })
 
+def panorama_override_vulnerability(threatid: str, vulnerability_profile: str, drop_mode: str):
+    xpath = "{}profiles/vulnerability/entry[@name='{}']/threat-exception/entry[@name='{}']/action".format(XPATH_OBJECTS, vulnerability_profile, threatid),
+    params = {'action': 'set',
+              'type': 'config',
+              'xpath': xpath,
+              'key': API_KEY,
+              'element': "<{0}></{0}>".format(drop_mode)
+              }
+
+    return http_request(
+        URL,
+        'POST',
+        body=params,
+    )
+
+
+def panorama_block_vulnerability():
+    """
+    Ovverride a vulnerability signature such that it is in block mode
+    """
+    threatid = demisto.args()['threat_id']
+    vulnerability_profile = demisto.args()['vulnerability_profile']
+    drop_mode = "drop" 
+    if demisto.args().get('drop_mode'):
+        drop_mode = demisto.args().get('drop_mode')
+
+    threat = panorama_override_vulnerability(threatid, vulnerability_profile, drop_mode)
+    threat_output  = {'id': threatid}
+
+    demisto.results({
+        'Type': entryTypes['note'],
+        'ContentsFormat': formats['json'],
+        'Contents': threat,
+        'ReadableContentsFormat': formats['text'],
+        'HumanReadable': 'Threat with ID {} overridden.'.format(threatid),
+        'EntryContext': {
+            "Panorama.Vulnerability(val.Name == obj.Name)": threat_output
+        }
+    })
 
 @logger
 def panorama_delete_static_route(xpath_network: str, virtual_router: str, route_name: str) -> Dict[str, str]:
@@ -5504,6 +5543,10 @@ def main():
         # Reboot Panorama Device
         elif demisto.command() == 'panorama-device-reboot':
             panorama_device_reboot_command()
+        
+        # PAN-OS Set vulnerability to drop 
+        elif demisto.command() == 'panorama-block-vulnerability':
+            panorama_block_vulnerability()
 
         else:
             raise NotImplementedError(f'Command {demisto.command()} was not implemented.')

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -205,7 +205,35 @@ script:
      - name: target
        description: If specified, retrieves the predefined threats from a specific firewall managed by Panorama. 
     execution: false
-    description: Get pre-defined threats list from a Firewall or Panorama.
+    description: Get pre-defined threats list from a Firewall or Panorama and stores as a JSON file in the context.
+    outputs:
+    - contextPath: File.Size
+      description: File size.
+      type: number
+    - contextPath: File.Name
+      description: File name.
+      type: string
+    - contextPath: File.Type
+      description: File type.
+      type: string
+    - contextPath: File.Info
+      description: File info.
+      type: string
+    - contextPath: File.Extenstion
+      description: File extension.
+      type: string
+    - contextPath: File.EntryID
+      description: FIle entryID.
+      type: string
+    - contextPath: File.MD5
+      description: MD5 hash of the file.
+      type: string
+    - contextPath: File.SHA1
+      description: SHA1 hash of the file.
+      type: string
+    - contextPath: File.SHA256
+      description: SHA256 hash of the file.
+      type: string
 
   - deprecated: false
     description: Commits a configuration to Palo Alto Firewall or Panorama, but does
@@ -575,7 +603,6 @@ script:
       secret: false
       predefined:
         - drop
-        - reset-both
         - alert
         - block-ip
         - reset-both
@@ -597,6 +624,13 @@ script:
     description: Sets a vulnerability signature to block mode
     execution: false
     name: panorama-block-vulnerability
+    outputs:
+    - contextPath: Panorama.Vulnerability.ID
+      description: ID Of vulnerability that has been blocked/overridden  
+      type: string
+    - contextPath: Panorama.Vulnerability.NewAction
+      description: New action for vulnerability 
+      type: string
 
   - arguments:
     - default: false

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -199,6 +199,12 @@ script:
     description: Run any command supported in the API.
     execution: false
     name: panorama
+ 
+  - name: panorama-get-predefined-threats-list
+    arguments:
+     - name: target
+       description: Get pre-defined threats list from the firewall
+
   - deprecated: false
     description: Commits a configuration to Palo Alto Firewall or Panorama, but does
       not validate if the commit was successful. Committing to Panorama does not push

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -1,6 +1,6 @@
 category: Network Security
 commonfields:
-  id: Panorama
+  id: Panorama-dev
   version: -1
 configuration:
 - display: Server URL (e.g., https://192.168.0.1)
@@ -39,7 +39,7 @@ configuration:
 description: Manage Palo Alto Networks Firewall and Panorama. For more information
   see Panorama documentation.
 display: Palo Alto Networks PAN-OS
-name: Panorama
+name: Panorama-dev
 script:
   commands:
   - arguments:
@@ -556,6 +556,40 @@ script:
     - contextPath: Panorama.AddressGroups.Tag
       description: Address group tags.
       type: String
+
+  - arguments:
+    - default: false
+      auto: PREDEFINED
+      description: Type of session reject 
+      isArray: false
+      name: drop_mode 
+      required: false 
+      secret: false
+      predefined:
+        - drop 
+        - reset-both 
+        - alert 
+        - block-ip 
+        - reset-both
+        - reset-client
+        - reset-server
+    - default: false
+      description: Name of vulnerability profile 
+      isArray: false
+      name: vulnerability_profile 
+      required: true
+      secret: false
+    - default: false
+      description: Numberical Threat ID 
+      isArray: false
+      name: threat_id 
+      required: true 
+      secret: false
+    deprecated: false
+    description: Sets a vulnerability signature to block mode 
+    execution: false
+    name: panorama-block-vulnerability
+
   - arguments:
     - default: false
       description: Name of address group to delete.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -1,6 +1,6 @@
 category: Network Security
 commonfields:
-  id: Panorama-dev
+  id: Panorama
   version: -1
 configuration:
 - display: Server URL (e.g., https://192.168.0.1)
@@ -39,7 +39,7 @@ configuration:
 description: Manage Palo Alto Networks Firewall and Panorama. For more information
   see Panorama documentation.
 display: Palo Alto Networks PAN-OS
-name: Panorama-dev
+name: Panorama
 script:
   commands:
   - arguments:
@@ -199,11 +199,13 @@ script:
     description: Run any command supported in the API.
     execution: false
     name: panorama
- 
+
   - name: panorama-get-predefined-threats-list
     arguments:
      - name: target
-       description: Get pre-defined threats list from the firewall
+       description: If specified, retrieves the predefined threats from a specific firewall managed by Panorama. 
+    execution: false
+    description: Get pre-defined threats list from a Firewall or Panorama.
 
   - deprecated: false
     description: Commits a configuration to Palo Alto Firewall or Panorama, but does
@@ -566,33 +568,33 @@ script:
   - arguments:
     - default: false
       auto: PREDEFINED
-      description: Type of session reject 
+      description: Type of session reject
       isArray: false
-      name: drop_mode 
-      required: false 
+      name: drop_mode
+      required: false
       secret: false
       predefined:
-        - drop 
-        - reset-both 
-        - alert 
-        - block-ip 
+        - drop
+        - reset-both
+        - alert
+        - block-ip
         - reset-both
         - reset-client
         - reset-server
     - default: false
-      description: Name of vulnerability profile 
+      description: Name of vulnerability profile
       isArray: false
-      name: vulnerability_profile 
+      name: vulnerability_profile
       required: true
       secret: false
     - default: false
-      description: Numberical Threat ID 
+      description: Numberical Threat ID
       isArray: false
-      name: threat_id 
-      required: true 
+      name: threat_id
+      required: true
       secret: false
     deprecated: false
-    description: Sets a vulnerability signature to block mode 
+    description: Sets a vulnerability signature to block mode
     execution: false
     name: panorama-block-vulnerability
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -41,7 +41,7 @@ def patched_requests_mocker(requests_mock):
     requests_mock.get(version_path, text=mock_version_xml, status_code=200)
     mock_response_xml = """
     <response status="success" code="20">
-        <msg>command succeeded</msg>
+    <msg>command succeeded</msg>
     </response>
     """
     requests_mock.post(base_url, text=mock_response_xml, status_code=200)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -49,13 +49,15 @@ def patched_requests_mocker(requests_mock):
 
 
 def test_panoram_get_os_version(patched_requests_mocker):
-    from Panorama import get_pan_os_major_version
-    get_pan_os_major_version()
+    from Panorama import get_pan_os_version 
+    r = get_pan_os_version()
+    assert r == '9.0.6'
 
 
-def test_panoram_block_threatid(patched_requests_mocker):
-    from Panorama import panorama_block_vulnerability
-    panorama_block_vulnerability()
+def test_panoram_override_vulnerability(patched_requests_mocker):
+    from Panorama import panorama_override_vulnerability
+    r = panorama_override_vulnerability(mock_demisto_args['threat_id'], mock_demisto_args['vulnerability_profile'], 'reset-both')
+    assert r['response']['@status'] == 'success'  
 
 
 def test_add_argument_list():

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -47,8 +47,9 @@ def patched_requests_mocker(requests_mock):
     requests_mock.post(base_url, text=mock_response_xml, status_code=200)
     return requests_mock
 
+
 def test_panoram_get_os_version(patched_requests_mocker):
-    from Panorama import get_pan_os_version 
+    from Panorama import get_pan_os_version
     r = get_pan_os_version()
     assert r == '9.0.6'
 
@@ -56,7 +57,7 @@ def test_panoram_get_os_version(patched_requests_mocker):
 def test_panoram_override_vulnerability(patched_requests_mocker):
     from Panorama import panorama_override_vulnerability
     r = panorama_override_vulnerability(mock_demisto_args['threat_id'], mock_demisto_args['vulnerability_profile'], 'reset-both')
-    assert r['response']['@status'] == 'success'  
+    assert r['response']['@status'] == 'success'
 
 
 def test_add_argument_list():

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -47,7 +47,6 @@ def patched_requests_mocker(requests_mock):
     requests_mock.post(base_url, text=mock_response_xml, status_code=200)
     return requests_mock
 
-
 def test_panoram_get_os_version(patched_requests_mocker):
     from Panorama import get_pan_os_version 
     r = get_pan_os_version()

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -1,6 +1,4 @@
 import pytest
-import requests
-import requests_mock
 import demistomock as demisto
 
 integration_params = {
@@ -8,13 +6,13 @@ integration_params = {
     'vsys': 'vsys1',
     'server': 'https://1.1.1.1',
     'key': 'thisisabogusAPIKEY!',
-#    'device_group': 'shared'
 }
 
 mock_demisto_args = {
     'threat_id': "11111",
     'vulnerability_profile': "mock_vuln_profile"
 }
+
 
 @pytest.fixture(autouse=True)
 def set_params(mocker):
@@ -25,9 +23,8 @@ def set_params(mocker):
 @pytest.fixture
 def patched_requests_mocker(requests_mock):
     """
-    This function mocks various PANOS API responses so we can accurately test the instance 
+    This function mocks various PANOS API responses so we can accurately test the instance
     """
-
     base_url = "{}:{}/api/".format(integration_params['server'], integration_params['port'])
     # Version information
     mock_version_xml = """
@@ -40,26 +37,26 @@ def patched_requests_mocker(requests_mock):
         </result>
     </response>
     """
-    version_path = "{}{}{}".format(base_url, "?type=version&key=", integration_params['key']) 
+    version_path = "{}{}{}".format(base_url, "?type=version&key=", integration_params['key'])
     requests_mock.get(version_path, text=mock_version_xml, status_code=200)
-    
     mock_response_xml = """
     <response status="success" code="20">
         <msg>command succeeded</msg>
     </response>
     """
-    set_path = base_url
-    requests_mock.post(base_url, text=mock_response_xml, status_code=200) 
-
+    requests_mock.post(base_url, text=mock_response_xml, status_code=200)
     return requests_mock
+
 
 def test_panoram_get_os_version(patched_requests_mocker):
     from Panorama import get_pan_os_major_version
     get_pan_os_major_version()
 
+
 def test_panoram_block_threatid(patched_requests_mocker):
-    from Panorama import panorama_block_vulnerability 
+    from Panorama import panorama_block_vulnerability
     panorama_block_vulnerability()
+
 
 def test_add_argument_list():
     from Panorama import add_argument_list

--- a/Packs/PAN-OS/ReleaseNotes/1_1_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_1_1.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+##### Panorama
+- __PAN-OS - Panorama block vulnerability__ 
+  - Override single vulnerability signature and change the default action
+- __PAN-OS - Get predefined threat lists__
+  - Retrieve the entire signature database from a PANOS device 

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress

## Description
Adds support for two new commands to the PAN-OS integration
* panorama-block-vulnerability
  * Allows threat IDs to be overridden by user-configurable actions  (drop/alert/reset-both etc.)
* panorama-get-predefined-threats-list
  * Retrieves the entire signature database from a PANOS device for reference purposes such as looking up CSVs

Credit enir@paloaltonetworks.com for panorama-get-predefined-threats list!

## Minimum version of Demisto
- [X] 3.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

