### PR TITLE
pan-os - Added the *source_zone*, *destination_zone* arguments to the ***panor…

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -313,8 +313,8 @@ def prepare_security_rule_params(api_action: str = None, rulename: str = None, s
                 + add_argument_list(application, 'application', True)
                 + add_argument_list(category, 'category', True)
                 + add_argument_open(source_user, 'source-user', True)
-                + add_argument_open(from_, 'from', True)  # default from will always be any
-                + add_argument_open(to, 'to', True)  # default to will always be any
+                + add_argument_list(from_, 'from', True, True)  # default from will always be any
+                + add_argument_list(to, 'to', True, True)  # default to will always be any
                 + add_argument_list(service, 'service', True, True)
                 + add_argument_yes_no(negate_source, 'negate-source')
                 + add_argument_yes_no(negate_destination, 'negate-destination')
@@ -2698,6 +2698,8 @@ def panorama_create_rule_command():
     rulename = demisto.args()['rulename'] if 'rulename' in demisto.args() else ('demisto-' + (str(uuid.uuid4()))[:8])
     source = argToList(demisto.args().get('source'))
     destination = argToList(demisto.args().get('destination'))
+    source_zone = argToList(demisto.args().get('source_zone'))
+    destination_zone = argToList(demisto.args().get('destination_zone'))
     negate_source = demisto.args().get('negate_source')
     negate_destination = demisto.args().get('negate_destination')
     action = demisto.args().get('action')
@@ -2724,7 +2726,8 @@ def panorama_create_rule_command():
                                           disable=disable, application=application, source_user=source_user,
                                           disable_server_response_inspection=disable_server_response_inspection,
                                           description=description, target=target,
-                                          log_forwarding=log_forwarding, tags=tags, category=categories)
+                                          log_forwarding=log_forwarding, tags=tags, category=categories,
+                                          from_=source_zone, to=destination_zone)
     result = http_request(
         URL,
         'POST',

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -32,7 +32,7 @@ configuration:
   name: vsys
   required: false
   type: 0
-- display: Template - Panorama instances only. routes.
+- display: Template - Panorama instances only.
   name: template
   required: false
   type: 0
@@ -1714,6 +1714,18 @@ script:
         names, or EDL object names.
       isArray: true
       name: destination
+      required: false
+      secret: false
+    - default: false
+      description: A comma-separated list of source zones.
+      isArray: true
+      name: source_zone
+      required: false
+      secret: false
+    - default: false
+      description: A comma-separated list of destination zones.
+      isArray: true
+      name: destination_zone
       required: false
       secret: false
     - auto: PREDEFINED

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -1734,6 +1734,16 @@
 <td style="width: 72px;">Optional</td>
 </tr>
 <tr>
+<td style="width: 144px;">source_zone</td>
+<td style="width: 524px;">A comma-separated list of source zones..</td>
+<td style="width: 72px;">Optional</td>
+</tr>
+<tr>
+<td style="width: 144px;">destination_zone</td>
+<td style="width: 524px;">A comma-separated list of source zones..</td>
+<td style="width: 72px;">Optional</td>
+</tr>
+<tr>
 <td style="width: 144px;">negate_source</td>
 <td style="width: 524px;">Whether to negate the source (address, address group); "Yes" or "No".</td>
 <td style="width: 72px;">Optional</td>

--- a/Packs/PAN-OS/ReleaseNotes/1_2_0.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_2_0.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Panorama
+  - Added the *source_zone*, *destination_zone* arguments to the ***panorama-create-rule*** command.

--- a/Packs/PAN-OS/TestPlaybooks/playbook-palo_alto_panorama_test_pb.yml
+++ b/Packs/PAN-OS/TestPlaybooks/playbook-palo_alto_panorama_test_pb.yml
@@ -997,6 +997,8 @@ tasks:
       service: {}
       source: {}
       source_user: {}
+      source_zone:
+        simple: test_zone_DO_NOT_DELETE
       tags:
         simple: Bark_test_tag2
       target: {}

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.2.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
…ama-create-rule*** command

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/22954

## Description
the code for the args was there in the `prepare_security_rule_params` func, but never reached. so I added the args and checked.

## Minimum version of Demisto
- [x] 3.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 