### PR TITLE
Kafka v2 - set auto_offset_reset to intial offset to fetch from

### DIFF
--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
@@ -171,7 +171,7 @@ def print_topics(client):
     """
     Prints available topics in Broker
     """
-
+    include_offsets = demisto.args().get('include_offsets', 'true') == 'true'
     kafka_topics = client.topics.values()
     if kafka_topics:
         topics = []
@@ -179,13 +179,14 @@ def print_topics(client):
             partitions = []
             for partition in topic.partitions.values():
                 partition_output = {'ID': partition.id}
-                try:
-                    partition_output['EarliestOffset'] = partition.earliest_available_offset()
-                    partition_output['OldestOffset'] = partition.latest_available_offset()
-                except Exception as e:
-                    demisto.error('Failed fetching available offset for topic {} partition {} - {}'.format(
-                        topic.name, partition.id, str(e))
-                    )
+                if include_offsets:
+                    try:
+                        partition_output['EarliestOffset'] = partition.earliest_available_offset()
+                        partition_output['OldestOffset'] = partition.latest_available_offset()
+                    except Exception as e:
+                        demisto.error('Failed fetching available offset for topic {} partition {} - {}'.format(
+                            topic.name, partition.id, str(e))
+                        )
                 partitions.append(partition_output)
 
             topics.append({

--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
@@ -178,11 +178,15 @@ def print_topics(client):
         for topic in kafka_topics:
             partitions = []
             for partition in topic.partitions.values():
-                partitions.append({
-                    'ID': partition.id,
-                    'EarliestOffset': partition.earliest_available_offset(),
-                    'OldestOffset': partition.latest_available_offset()
-                })
+                partition_output = {'ID': partition.id}
+                try:
+                    partition_output['EarliestOffset'] = partition.earliest_available_offset()
+                    partition_output['OldestOffset'] = partition.latest_available_offset()
+                except Exception as e:
+                    demisto.error('Failed fetching available offset for topic {} partition {} - {}'.format(
+                        topic.name, partition.id, str(e))
+                    )
+                partitions.append(partition_output)
 
             topics.append({
                 'Name': topic.name,

--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.py
@@ -347,7 +347,8 @@ def fetch_incidents(client):
 
         consumer_args = {
             'consumer_timeout_ms': 2000,  # wait max 2 seconds for new messages
-            'reset_offset_on_start': True
+            'reset_offset_on_start': True,
+            'auto_offset_reset': offset_to_fetch_from
         }
 
         if partition_to_fetch_from:

--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
@@ -158,7 +158,7 @@ script:
       description: Prints all partitions for a topic.
       type: number
   dockerimage45: demisto/pykafka:1.0.0.128
-  dockerimage: demisto/pykafka:1.0.0.7970
+  dockerimage: demisto/pykafka:1.0.0.9548
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
@@ -41,11 +41,13 @@ configuration:
   name: partition
   required: false
   type: 0
-- display: Offset to fetch messages from (Exclusive)
+- additionalinfo: The initial offset to start fetching from, not including the value
+    set (e.g. if 3 is set, the first event that will be fetched will be with offset
+    4).
+  display: Offset to fetch messages from (Exclusive)
   name: offset
   required: false
   type: 0
-  additionalinfo: The initial offset to start fetching from, not including the value set (e.g. if 3 is set, the first event that will be fetched will be with offset 4).
 - defaultvalue: '50'
   display: Max number of messages to fetch
   name: max_messages
@@ -64,7 +66,19 @@ display: Kafka v2
 name: Kafka V2
 script:
   commands:
-  - deprecated: false
+  - arguments:
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'true'
+      description: Whether to fetch topics available offsets or not.
+      isArray: false
+      name: include_offsets
+      predefined:
+      - 'true'
+      - 'false'
+      required: false
+      secret: false
+    deprecated: false
     description: Prints all partitions of a topic.
     execution: false
     name: kafka-print-topics
@@ -157,14 +171,14 @@ script:
     - contextPath: Kafka.Topic.Partition
       description: Prints all partitions for a topic.
       type: number
-  dockerimage45: demisto/pykafka:1.0.0.128
   dockerimage: demisto/pykafka:1.0.0.9548
+  feed: false
   isfetch: true
   longRunning: false
   longRunningPort: false
   runonce: false
   script: '-'
-  type: python
   subtype: python2
+  type: python
 tests:
 - No Test - Can not connect to instance from remote

--- a/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
+++ b/Packs/Kafka/Integrations/Kafka_V2/Kafka_V2.yml
@@ -12,8 +12,8 @@ configuration:
   required: false
   type: 8
 - display: |-
-    ┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉
-    ‎                                        Certificate Settings
+    ┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉
+    ‎                                   Certificate Settings
     CA certificate of Kafka server (.cer)
   name: ca_cert
   required: false
@@ -31,8 +31,8 @@ configuration:
   required: false
   type: 4
 - display: |-
-    ┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉
-    ‎                                        Fetch Incidents Settings
+    ┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉
+    ‎                               Fetch Incidents Settings
     Topic to fetch incidents from (Required for fetch incidents)
   name: topic
   required: false
@@ -41,10 +41,11 @@ configuration:
   name: partition
   required: false
   type: 0
-- display: Offset to fetch messages from
+- display: Offset to fetch messages from (Exclusive)
   name: offset
   required: false
   type: 0
+  additionalinfo: The initial offset to start fetching from, not including the value set (e.g. if 3 is set, the first event that will be fetched will be with offset 4).
 - defaultvalue: '50'
   display: Max number of messages to fetch
   name: max_messages

--- a/Packs/Kafka/Integrations/Kafka_V2/test_data/README.md
+++ b/Packs/Kafka/Integrations/Kafka_V2/test_data/README.md
@@ -10,13 +10,16 @@ git clone https://github.com/wurstmeister/kafka-docker .
 ```
 <!-- disable-secrets-detection-start -->
 * Edit file `docker-compose-single-broker.yml`
-* Change KAFKA_ADVERTISED_HOST_NAME to your machine's IP. use `ifconfig | grep 'inet '` to see available ips. Recommneded to use an IP which doesn't change. Otherwise you will need to bring up again the cluster everytime the ip changes. You can use the IP of global protect interface: gpd0. On my machine it has a value of: `10.196.100.168`.
+* Change KAFKA_ADVERTISED_HOST_NAME to your machine's IP. Use `ifconfig | grep 'inet '` to see available ips. It is recommended to use an IP which doesn't change. Otherwise you will need to bring up again the cluster every time the ip changes. You can use the IP of global protect interface: gpd0. On my machine it has a value of: `10.196.100.168`.
 * Start a Kafka cluster:
 ```
 docker-compose -f docker-compose-single-broker.yml up
 ```
 
 This will startup a kafka with a default topic named `test`.
+
+## Configure an integration instance
+* For the broker, set your machine IP address, the one set as KAFKA_ADVERTISED_HOST_NAME in the previous step, with addition of the port `9092`, e.g.  `10.196.100.168:9092`.
 
 ## Creating Additional Topics for Testing 
 In the `kafka-docker` dir run the following to start a shell:
@@ -28,7 +31,7 @@ In the shell run:
 * Create topic with lz4 compression: `$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $ZK --create --topic test-lz4  --replication-factor 1 --config compression.type=lz4 --partitions 1`
 * List topics: `$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $ZK --list`
 
-### Producin 10 messages:
+### Producing 10 messages:
 ```
 for i in `seq 1 10`; do echo '{"id":'$i',"user":"test","date":"'`date -R`'","message":"this is a test from kafka shell"}' | $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list=`broker-list.sh` --topic mytest-topic; done
 ```
@@ -50,6 +53,6 @@ Another good cmdline client: https://github.com/fgeller/kt
 
 ## Stop the cluster
 Press control+c in the terminal running `docker-compose`. 
-You can later on brin up the cluster with your configured topic by running: `docker-compose -f docker-compose-single-broker.yml up`
+You can later on bring up the cluster with your configured topic by running: `docker-compose -f docker-compose-single-broker.yml up`
 
 To full delete the cluster from the disk run: `docker-compose -f docker-compose-single-broker.yml down`. 

--- a/Packs/Kafka/ReleaseNotes/1_0_1.md
+++ b/Packs/Kafka/ReleaseNotes/1_0_1.md
@@ -1,5 +1,5 @@
 #### Integrations
 
 ##### Kafka V2
-- Fixed an issue in which the offset for the fetch did not function as expected.
-- Improved error handling in the command ***kafka-print-topics***.
+  - Fixed an issue in which the offset for the fetch did not function as expected.
+  - Improved error handling in the ***kafka-print-topics*** command.

--- a/Packs/Kafka/ReleaseNotes/1_0_1.md
+++ b/Packs/Kafka/ReleaseNotes/1_0_1.md
@@ -2,3 +2,4 @@
 
 ##### Kafka V2
 - Fixed an issue in which the offset for the fetch did not function as expected.
+- Improved error handling in the command ***kafka-print-topics***.

--- a/Packs/Kafka/ReleaseNotes/1_0_1.md
+++ b/Packs/Kafka/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+#### Integrations
+
+##### Kafka V2
+- Fixed an issue in which the offset for the fetch did not function as expected.

--- a/Packs/Kafka/pack_metadata.json
+++ b/Packs/Kafka/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Kafka",
-  "description": "The Open source distributed streaming platform",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Messaging"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Kafka",
+    "description": "The Open source distributed streaming platform",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Messaging"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/25999 https://github.com/demisto/etc/issues/25976

## Description
- Apparently `reset_offsets` does not set the first offset to fetch from as expected, so added the keyword arg `auto_offset_reset` according to https://pykafka.readthedocs.io/en/latest/usage.html?highlight=reset_offsets#setting-the-initial-offset
- Wrapped the available offset fetch, which seems to timeout in some cases, in try-except 

## Does it break backward compatibility?
   - [x] No

