### PR TITLE
converting unicode response to string

### DIFF
--- a/Packs/QRadar/Integrations/QRadar/QRadar.py
+++ b/Packs/QRadar/Integrations/QRadar/QRadar.py
@@ -216,7 +216,7 @@ def send_request(method, url, headers=AUTH_HEADERS, params=None, data=None):
     except HTTPError:
         if res is not None:
             try:
-                err_json = res.json()
+                err_json = unicode_to_str_recur(res.json())
             except ValueError:
                 raise Exception('Error code {err}\nContent: {cnt}'.format(err=res.status_code, cnt=res.content))
 
@@ -237,7 +237,7 @@ def send_request(method, url, headers=AUTH_HEADERS, params=None, data=None):
     except ValueError:
         LOG('Got unexpected response from QRadar. Raw response: {}'.format(res.text))
         raise DemistoException('Got unexpected response from QRadar')
-    return json_body
+    return unicode_to_str_recur(json_body)
 
 
 def send_request_no_error_handling(headers, method, params, url, data):

--- a/Packs/QRadar/ReleaseNotes/1_0_4.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_4.md
@@ -2,3 +2,7 @@
 ### Playbooks
 - __TIM - QRadar Add IP Indicators__
 Fixed task description.
+
+#### Integrations
+##### QRadar
+- Improved handling of unicode responses.

--- a/Packs/QRadar/ReleaseNotes/1_0_4.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_4.md
@@ -2,7 +2,3 @@
 ### Playbooks
 - __TIM - QRadar Add IP Indicators__
 Fixed task description.
-
-#### Integrations
-##### QRadar
-- Improved handling of unicode responses.

--- a/Packs/QRadar/ReleaseNotes/1_0_5.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_5.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### IBM QRadar
+Improved handling of unicode responses.
+

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26007

## Description
Some responses res.json attributes can be none ascii. in this case python2 keeps it in bytes form and then when trying to use it as string it fails.

This seems to be a known issue in this integration since there is already a method that solves this recursivly- `unicode_to_str_recur`


