### PR TITLE
ParseEmailFiles - add support for message/rfc822 eml type

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_1_14.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_1_14.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### ParseEmailFiles
+- Fixed an issue in which EML of content type message/rfc822 were not recognized as expected.

--- a/Packs/CommonScripts/ReleaseNotes/1_1_14.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_1_14.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### ParseEmailFiles
-- Fixed an issue in which EML of content type message/rfc822 were not recognized as expected.
+- Fixed an issue where .eml files with the content type "message/rfc822" were not recognized as expected.

--- a/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3653,7 +3653,8 @@ def main():
         if is_error(result):
             return_error(get_error(result))
 
-        file_type = result[0]['FileMetadata'].get('info', '')
+        file_metadata = result[0]['FileMetadata']
+        file_type = file_metadata.get('info', '') or file_metadata.get('type', '')
 
     except Exception as ex:
         return_error(
@@ -3667,8 +3668,8 @@ def main():
             email_data, attached_emails = handle_msg(file_path, file_name, parse_only_headers, max_depth)
             output = create_email_output(email_data, attached_emails)
 
-        elif 'rfc 822 mail' in file_type_lower or 'smtp mail' in file_type_lower or 'multipart/signed' \
-                in file_type_lower:
+        elif any(eml_candidate in file_type_lower for eml_candidate in
+                 ['rfc 822 mail', 'smtp mail', 'multipart/signed', 'message/rfc822']):
             if 'unicode (with bom) text' in file_type_lower:
                 email_data, attached_emails = handle_eml(
                     file_path, False, file_name, parse_only_headers, max_depth, bom=True

--- a/Packs/CommonScripts/Scripts/ParseEmailFiles/parse_email_files_test.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFiles/parse_email_files_test.py
@@ -5,7 +5,12 @@ import demistomock as demisto
 import pytest
 
 
-def exec_command_for_file(file_path, info="RFC 822 mail text, with CRLF line terminators", file_name=None):
+def exec_command_for_file(
+        file_path,
+        info="RFC 822 mail text, with CRLF line terminators",
+        file_name=None,
+        file_type="",
+):
     """
     Return a executeCommand function which will return the passed path as an entry to the call 'getFilePath'
 
@@ -38,7 +43,8 @@ def exec_command_for_file(file_path, info="RFC 822 mail text, with CRLF line ter
                 {
                     'Type': entryTypes['file'],
                     'FileMetadata': {
-                        'info': info
+                        'info': info,
+                        'type': file_type
                     }
                 }
             ]
@@ -647,3 +653,32 @@ def test_eml_base64_header_comment_although_string(mocker):
     assert 'Attacker+email+.msg' in results[0]['EntryContext']['Email'][0]['Attachments']
     assert results[0]['EntryContext']['Email'][1]["Subject"] == 'Attacker email'
     assert results[0]['EntryContext']['Email'][1]['Depth'] == 1
+
+
+def test_message_rfc822_without_info(mocker):
+    """
+    Given:
+     - EML file with content type message/rfc822
+     - Demisto entry metadata returned without info, but with type
+
+    When:
+     - Running the script on the email file
+
+    Then:
+     - Verify the script runs successfully
+     - Ensure 2 entries are returned as expected
+    """
+    mocker.patch.object(demisto, 'args', return_value={'entryid': 'test', 'max_depth': '1'})
+    mocker.patch.object(
+        demisto,
+        'executeCommand',
+        side_effect=exec_command_for_file('eml_contains_base64_eml2.eml', info='', file_type='message/rfc822')
+    )
+    mocker.patch.object(demisto, 'results')
+    main()
+    assert demisto.results.call_count == 2
+    results = demisto.results.call_args_list
+    assert len(results) == 2
+    assert results[0][0][0]['Type'] == entryTypes['file']
+    assert results[1][0][0]['Type'] == entryTypes['note']
+    assert results[1][0][0]['EntryContext']['Email']['From'] == 'koko@demisto.com'

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.13",
+    "currentVersion": "1.1.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26004

## Description
- seems like sometimes the `info` field in the file entry metadata is returned empty and its values is returned in the `type` field
- added `message/rfc822` file type to be handled as eml 

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

See failing test at https://app.circleci.com/pipelines/github/demisto/content/17863/workflows/7cfbe4af-195a-4879-a5c4-006c97a7e109/jobs/60457/parallel-runs/1?filterBy=FAILED