### PR TITLE
[Fix] Error fetching incidents from Alienvault USM Anywhere

### DIFF
--- a/Packs/AlienVault_USM_Anywhere/ReleaseNotes/1_0_1.md
+++ b/Packs/AlienVault_USM_Anywhere/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlienVault USM Anywhere
+- Fixed an issue where `fetch-incidents` would fail when there was no `timestamp_received_iso8601` field in the fetched incident.

--- a/Packs/AlienVault_USM_Anywhere/pack_metadata.json
+++ b/Packs/AlienVault_USM_Anywhere/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "AlienVault USM Anywhere",
-  "description": "Searches for and monitors alarms and events from AlienVault USM Anywhere.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "AlienVault USM Anywhere",
+    "description": "Searches for and monitors alarms and events from AlienVault USM Anywhere.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] In Hold - (Pending Customer Verificaton)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26117

## Description
Fixed an issue where `fetch-incidents` would fail when there was no `timestamp_received_iso8601` field in the fetched incident.

## Does it break backward compatibility?
   - [x] Yes

## Must have
- [ ] Tests