### PR TITLE
remove Duo Admin test from skipped tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2926,7 +2926,6 @@
     "skipped_tests": {
         "PAN-OS DAG Configuration Test": "Issue 60693",
         "Phishing Classifier V2 ML Test": "Issue 26066",
-        "DuoAdmin API test playbook": "Issue 24937",
         "Workday - Test": "Issue 25896",
         "CuckooTest": "Issue 25601",
         "RedLockTest": "Issue 24600",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
related: https://github.com/demisto/etc/issues/24937

## Description
Remove Duo Admin from skipped tests