### PR TITLE
Small Tweaks to Mocking Process

### DIFF
--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -364,11 +364,13 @@ class MITMProxy:
             self.repo_folder, get_folder_path(playbook_id), 'problematic_keys.json'
         )
         current_problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
-        # copy the `problematic_keys.json` for the test to current temporary directory if it exists that way
-        # previously recorded or manually added keys will only be added upon and not wiped with an overwrite
-        silence_output(
-            self.ami.check_call, ['mv', repo_problem_keys_filepath, current_problem_keys_filepath], stdout='null'
-        )
+
+        # when recording, copy the `problematic_keys.json` for the test to current temporary directory if it exists
+        # that way previously recorded or manually added keys will only be added upon and not wiped with an overwrite
+        if record:
+            silence_output(
+                self.ami.check, ['mv', repo_problem_keys_filepath, current_problem_keys_filepath], stdout='null'
+            )
 
         script_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'timestamp_replacer.py')
         remote_script_path = self.ami.copy_file(script_filepath)

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -364,6 +364,9 @@ class MITMProxy:
             self.repo_folder, get_folder_path(playbook_id), 'problematic_keys.json'
         )
         current_problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
+        silence_output(
+            self.ami.check_call, ['mv', repo_problem_keys_filepath, current_problem_keys_filepath], stdout='null'
+        )
 
         script_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'timestamp_replacer.py')
         remote_script_path = self.ami.copy_file(script_filepath)

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -364,6 +364,8 @@ class MITMProxy:
             self.repo_folder, get_folder_path(playbook_id), 'problematic_keys.json'
         )
         current_problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
+        # copy the `problematic_keys.json` for the test to current temporary directory if it exists that way
+        # previously recorded or manually added keys will only be added upon and not wiped with an overwrite
         silence_output(
             self.ami.check_call, ['mv', repo_problem_keys_filepath, current_problem_keys_filepath], stdout='null'
         )

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -365,8 +365,8 @@ def run_and_record(conf_json_test_details, tests_queue, tests_settings, c, proxy
                              playbook_id, succeed_playbooks, test_message, test_options, slack, circle_ci, build_number,
                              server_url, build_name, prints_manager, thread_index=thread_index, is_mock_run=True)
     proxy.stop(thread_index=thread_index, prints_manager=prints_manager)
-    proxy.clean_mock_file(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
     if succeed:
+        proxy.clean_mock_file(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
         proxy.move_mock_file_to_repo(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
 
     proxy.set_repo_folder()


### PR DESCRIPTION
## Status
- [x] Ready


## Description
1. Changed the `run_and_record` method in `test_content.py` to only try and clean a mock file if the recording was successful - otherwise, there is no point.
2. Updated the `start` method of `MITMProxy` class to copy over a pre-existing `problematic_keys.json` (if there is one for that test) to the temporary directory in which the mock recording and log files for a given test are written to. The idea here is that `problematic_keys.json` files should only ever get added to, never freshly overwritten. That way, if someone has manually added problematic keys for a test (presumably keys that `timestamp_replacer.py` does not successfully detect itself), those keys will not get overwritten in a case where for example, the test playbook has been updated with additional commands and therefore is rerecorded the first time it runs after the update.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

