### PR TITLE
Not failing instance creation when a test-conf branch exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
                   fi
   Create Instances:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - checkout
@@ -518,7 +518,7 @@ jobs:
       - *persist_to_workspace
   Server 4_1:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -566,7 +566,7 @@ jobs:
             - *store_artifacts
   Server 4_5:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -613,7 +613,7 @@ jobs:
             - *store_artifacts
   Server 5_0:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -665,7 +665,7 @@ jobs:
             - *store_artifacts
   Server 5_5:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -715,7 +715,7 @@ jobs:
             - *store_artifacts
   Server 6_0:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -786,7 +786,7 @@ jobs:
             - *store_artifacts
   Instance Test:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - setup_remote_docker
@@ -824,7 +824,7 @@ jobs:
 
   Demisto SDK Nightly:
     <<: *container_config
-    resource_class: medium+
+    resource_class: medium
     <<: *environment
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,29 @@ jobs:
                     then
                       python3 ./Tests/scripts/verify_base_branch_for_contribution.py $CIRCLE_BRANCH
                   fi
+      - unless:
+          condition:
+            or:
+              - << pipeline.parameters.instance_tests >>
+              - equal:
+                  - master
+                  - << pipeline.git.branch >>
+          steps:
+            - run:
+                name: validate content-test-conf branch merged
+                shell: /bin/bash
+                when: always
+                command: |
+                  # replace slashes ('/') in the branch name, if exist, with underscores ('_')
+                  UNDERSCORE_CIRCLE_BRANCH=${CIRCLE_BRANCH//\//_}
+                  wget --header "Accept: application/vnd.github.v3.raw" --header "Authorization: token $GITHUB_TOKEN" "https://github.com/demisto/content-test-conf/archive/$UNDERSCORE_CIRCLE_BRANCH.zip" --no-check-certificate -q
+                  if [ "$?" != "0" ]; then
+                    echo "No such branch in content-test-conf: $UNDERSCORE_CIRCLE_BRANCH"
+                    exit 0
+                  else
+                    echo "ERROR: Found a branch with the same name in contest-test-conf conf.json - $UNDERSCORE_CIRCLE_BRANCH.\n Merge it in order to merge the current branch into content repo."
+                    exit 1
+                  fi
   Create Instances:
     <<: *container_config
     resource_class: medium+

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -36,11 +36,6 @@ if [ "$?" != "0" ]; then
     cp -r ./content-test-conf-$UNDERSCORE_CIRCLE_BRANCH/signDirectory $DEMISTO_PACK_SIGNATURE_UTIL_PATH
     rm -rf ./content-test-conf-$UNDERSCORE_CIRCLE_BRANCH
     rm -rf ./test_configuration.zip
-    if [ "$UNDERSCORE_CIRCLE_BRANCH" != "master" ]; then
-        echo "ERROR: Found a branch with the same name in contest-test-conf conf.json - $UNDERSCORE_CIRCLE_BRANCH.\n Merge it in order to merge the current branch into content repo."
-        exit 1
-    fi
-
 fi
 
 set -e


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
When  a branch exists in `content-test-conf` repo with same name is the current `content` branch name, The step **Download configurations** fails in order to remind the developer to push the `content-test-conf` branch to master.

Since this step is part of `Create Instances` job- it prevent the Instances jobs from being created.

This PR is about moving the failure to `Run Validations` job and letting `Create Instances` job succeed.
