### PR TITLE
increase SNDBOX test playbook timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -572,7 +572,7 @@
         {
             "integrations": "SNDBOX",
             "playbookID": "Detonate File - SNDBOX - Test",
-            "timeout": 600,
+            "timeout": 1000,
             "nightly": true
         },
         {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
SNDBOX often fails on timeout. see [here](https://app.circleci.com/pipelines/github/demisto/content/19032/workflows/b3b9a93a-0e84-41c0-8458-e1880d4bc333/jobs/62671/steps), increasing the timeout back to 1000.


