### PR TITLE
[Fix] tenable-io-launch-scan ignores scanTargets argument

### DIFF
--- a/Packs/Tenable_io/Integrations/Tenable_io/Tenable_io.py
+++ b/Packs/Tenable_io/Integrations/Tenable_io/Tenable_io.py
@@ -286,7 +286,7 @@ def get_scans_command():
 
 
 def launch_scan_command():
-    scan_id, targets = demisto.getArg('scanId'), demisto.getArg('scanTartgets')
+    scan_id, targets = demisto.getArg('scanId'), demisto.getArg('scanTargets')
     scan_info = send_scan_request(scan_id)['info']
     if not targets:
         targets = scan_info.get('targets', '')

--- a/Packs/Tenable_io/ReleaseNotes/1_0_1.md
+++ b/Packs/Tenable_io/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Tenable.io
+Fixed an issue in `tenable-io-launch-scan` command where `scanTargets` argument was ignored.

--- a/Packs/Tenable_io/ReleaseNotes/1_0_1.md
+++ b/Packs/Tenable_io/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Tenable.io
-Fixed an issue in `tenable-io-launch-scan` command where `scanTargets` argument was ignored.
+Fixed an issue in the `tenable-io-launch-scan` command where the `scanTargets` argument was ignored.

--- a/Packs/Tenable_io/pack_metadata.json
+++ b/Packs/Tenable_io/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Tenable.io",
-  "description": "A comprehensive asset centric solution to accurately track\u00a0resources while accommodating\u00a0dynamic assets such as cloud, mobile devices, containers and web applications.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Tenable.io",
+    "description": "A comprehensive asset centric solution to accurately track\u00a0resources while accommodating\u00a0dynamic assets such as cloud, mobile devices, containers and web applications.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26481

## Description
Fixed an issue in `tenable-io-launch-scan` command where `scanTargets` argument was ignored.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
