### PR TITLE
Build Fixes & Tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,13 @@ references:
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+
   add_ssh_keys: &add_ssh_keys
     add_ssh_keys:
       fingerprints:
         - "02:df:a5:6a:53:9a:f5:5d:bd:a6:fc:b2:db:9b:c9:47" # disable-secrets-detection
         - "f5:25:6a:e5:ac:4b:84:fb:60:54:14:82:f1:e9:6c:f9" # disable-secrets-detection
+
   prepare_environment: &prepare_environment
     run:
       name: Prepare Environment
@@ -143,9 +145,11 @@ references:
         unzip -q "$CIRCLE_ARTIFACTS/content_test.zip" -d "test_content_dir"
         zip -j "$CIRCLE_ARTIFACTS/all_content.zip" test_content_dir/*
         rm -r test_content_dir
+
   restore_cache: &restore_cache
     restore_cache:
       key: venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
+
   destroy_instances: &destroy_instances
     run:
       name: Destroy Instances
@@ -180,12 +184,13 @@ references:
       paths:
         - project
 
-  Secrets: &Secrets
+  secrets: &secrets
     run:
       name: Secrets
       when: always
       command: |
         demisto-sdk secrets --post-commit --ignore-entropy
+
   validate_files_and_yaml: &validate_files_and_yaml
     run:
       name: Validate Files and Yaml
@@ -202,6 +207,7 @@ references:
 
         [ -n "${BACKWARD_COMPATIBILITY}" ] && CHECK_BACKWARD="false" || CHECK_BACKWARD="true"
         ./Tests/scripts/validate.sh
+
   run_unit_testing_and_lint: &run_unit_testing_and_lint
     run:
       name: Run Unit Testing and Lint
@@ -224,6 +230,7 @@ references:
         else
           demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
         fi
+
   infrastructure_testing: &infrastructure_testing
     run:
       name: Infrastructure testing
@@ -235,12 +242,14 @@ references:
         if [ -n "${DEMISTO_SDK_NIGHTLY}" ] ; then
           ./Tests/scripts/sdk_pylint_check.sh
         fi
+
   create_id_set: &create_id_set
     run:
       name: Create ID Set
       when: always
       command: |
         demisto-sdk create-id-set -o ./Tests/id_set.json
+
   build_content_descriptor: &build_content_descriptor
     run:
       name: Build Content Descriptor
@@ -254,12 +263,14 @@ references:
             # new release notes summary generator in packs format
             python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CIRCLE_BUILD_NUM --output $CIRCLE_ARTIFACTS/packs-release-notes.md
         fi
+
   common_server_documentation: &common_server_documentation
     run:
       name: Common Server Documentation
       when: always
       command: |
         ./Documentation/commonServerDocs.sh
+
   collect_test_list_and_content_packs: &collect_test_list_and_content_packs
     run:
       name: Collect Test List And Content Packs
@@ -273,12 +284,14 @@ references:
 
         [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
         python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
+
   calculate_packs_dependencies: &calculate_packs_dependencies
     run:
       name: Calculate Packs Dependencies
       when: always
       command: |
         python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $CIRCLE_ARTIFACTS/packs_dependencies.json
+
   update_tests_step: &update_tests_step
     run:
       name: Update Tests step
@@ -360,7 +373,7 @@ jobs:
             - *restore_cache
             - *add_ssh_keys
             - *prepare_environment
-            - *Secrets
+            - *secrets
             - *validate_files_and_yaml
             - run:
                 name: Content Docs Site
@@ -838,7 +851,7 @@ jobs:
       - setup_remote_docker
       - *restore_cache
       - *prepare_environment
-      - *Secrets
+      - *secrets
       - *validate_files_and_yaml
       - *run_unit_testing_and_lint
       - *infrastructure_testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ references:
       CONTRIB_BRANCH: << pipeline.parameters.contrib_branch >>
       CONTRIB_PACK_NAME: << pipeline.parameters.contrib_pack_name >>
       # Giving different names to the following pipeline parameters to avoid collision, handling such collision case
-      # is done in 'Prepare Environment' step.
+      # is done in 'Setup Environment' step.
       TIME_TO_LIVE_PARAMETER: << pipeline.parameters.time_to_live >>
       NIGHTLY_PARAMETER: << pipeline.parameters.nightly >>
       INSTANCE_TESTS_PARAMETER: << pipeline.parameters.instance_tests >>
@@ -305,7 +305,7 @@ references:
                 exit 0
     
 jobs:
-  Prepare Environment:
+  Setup Environment:
     <<: *container_config
     resource_class: medium+
     <<: *environment
@@ -862,17 +862,17 @@ workflows:
   version: 2
   commit:
     jobs:
-      - Prepare Environment
+      - Setup Environment
       - Create Instances:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
       - Run Unit Testing And Lint:
           requires:
-            - Prepare Environment
+            - Setup Environment
       - Run Validations:
           requires:
-            - Prepare Environment
+            - Setup Environment
       - Server 4_1:
           filters:
             branches:
@@ -936,17 +936,17 @@ workflows:
               only:
                 - master
     jobs:
-      - Prepare Environment:
+      - Setup Environment:
           context: nightly_env
       - Create Instances:
           context: nightly_env
       - Run Unit Testing And Lint:
           context: nightly_env
           requires:
-            - Prepare Environment
+            - Setup Environment
       - Run Validations:
           requires:
-            - Prepare Environment
+            - Setup Environment
       - Server 6_0:
           requires:
             - Create Instances

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,24 @@ references:
       command: |
         python3 ./Tests/scripts/update_conf_json.py
         cp "./Tests/conf.json" "$CIRCLE_ARTIFACTS/conf.json"
+
+  get_contribution_pack: &get_contribution_pack
+    when:
+      condition: << pipeline.parameters.contrib_branch >>
+      steps:
+        - run:
+            name: Get Contributor pack
+            when: always
+            command: |
+                USER=$(echo $CONTRIB_BRANCH | cut -d ":" -f 1)
+                BRANCH=$(echo $CONTRIB_BRANCH | cut -d ":" -f 2)
+                PACK=$(echo $CONTRIB_BRANCH | cut -d ":" -f 3)
+                echo 'Copy the changes from the contributor branch $USER/$BRANCH in the pack $PACK'
+                git remote add $USER git@github.com:$USER/content.git
+                git fetch $USER $BRANCH
+                git checkout $USER/$BRANCH $PACK
+                exit 0
+    
 jobs:
   Prepare Environment:
     <<: *container_config
@@ -301,21 +319,7 @@ jobs:
             - venv
             - node_modules
           key: venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
-      - when:
-          condition: << pipeline.parameters.contrib_branch >>
-          steps:
-            - run:
-                name: Get Contributor pack
-                when: always
-                command: |
-                    USER=$(echo $CONTRIB_BRANCH | cut -d ":" -f 1)
-                    BRANCH=$(echo $CONTRIB_BRANCH | cut -d ":" -f 2)
-                    PACK=$(echo $CONTRIB_BRANCH | cut -d ":" -f 3)
-                    echo 'Copy the changes from the contributor branch $USER/$BRANCH in the pack $PACK'
-                    git remote add $USER git@github.com:$USER/content.git
-                    git fetch $USER $BRANCH
-                    git checkout $USER/$BRANCH $PACK
-                    exit 0
+      - *get_contribution_pack
       - *add_ssh_keys
       - *persist_to_workspace
 
@@ -428,9 +432,8 @@ jobs:
       - setup_remote_docker
       - *restore_cache
       - *prepare_environment
-      - *restore_cache
+      - *get_contribution_pack
       - *add_ssh_keys
-      - *prepare_environment
       - *update_tests_step
       - *create_id_set
       - *build_content_descriptor

--- a/Tests/scripts/prepare_content_packs_for_testing.sh
+++ b/Tests/scripts/prepare_content_packs_for_testing.sh
@@ -37,10 +37,6 @@ echo "Updating modified content packs in the bucket ..."
 
 if [ ! -n "${NIGHTLY}" ]; then
     CONTENT_PACKS_TO_INSTALL_FILE="./Tests/content_packs_to_install.txt"
-
-  if [ -n "${CONTRIB_BRANCH}" ]; then
-    echo -e "\n$CONTRIB_PACK_NAME" >> $CONTENT_PACKS_TO_INSTALL_FILE
-  fi
   if [ ! -f $CONTENT_PACKS_TO_INSTALL_FILE ]; then
     echo "Could not find file $CONTENT_PACKS_TO_INSTALL_FILE."
   else


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Running the following command,
`./Utils/trigger_content_build_with_time_to_live.sh content_branch_name <CircleCiToken> 420 contrib_name:contrib_branch_name Packs/New_Pack/`
is supposed to trigger a build that will take the contribution and will run a regular content build using the contributor's code/additions. Currently, the build does not actually use the contributor's code/additions for testing on server instances. This PR implements proper handling in our build for this usecase. See this [build](https://app.circleci.com/pipelines/github/demisto/content/19257/workflows/f7a00841-2b11-4a62-a002-7a1410eb84fb) (which was triggered by `./Utils/trigger_content_build_with_time_to_live.sh code42_contrib <circle-token-redacted> 420 code42:download-file Packs/Code42/`) for an example where the contributor's code was not properly fetched for testing on server instances.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No