### PR TITLE
Update index in case pack is missing as subfolder 

### DIFF
--- a/Tests/Marketplace/Tests/upload_packs_test.py
+++ b/Tests/Marketplace/Tests/upload_packs_test.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from Tests.Marketplace.upload_packs import get_modified_packs
+from Tests.Marketplace.upload_packs import get_packs_names
 
 
 # disable-secrets-detection-start
@@ -9,18 +9,18 @@ class TestModifiedPacks:
         ("pack1,pack2,pack1", {"pack1", "pack2"}),
         ("pack1, pack2,  pack3", {"pack1", "pack2", "pack3"})
     ])
-    def test_get_modified_packs_specific(self, packs_names_input, expected_result):
-        modified_packs = get_modified_packs(packs_names_input)
+    def test_get_packs_names_specific(self, packs_names_input, expected_result):
+        modified_packs = get_packs_names(packs_names_input)
 
         assert modified_packs == expected_result
 
     @pytest.mark.parametrize("packs_names_input", [None, ""])
-    def test_get_modified_packs_empty(self, mocker, packs_names_input):
+    def test_get_packs_names_empty(self, mocker, packs_names_input):
         modified_packs_return_value = ("Packs/Pack1/pack_metadata.json\n"
                                        "Packs/Pack1/Integrations/Integration1/CHANGELOG.md\n"
                                        "Packs/Pack2/pack_metadata.json\n")
         mocker.patch('Tests.Marketplace.upload_packs.run_command', return_value=modified_packs_return_value)
-        modified_packs = get_modified_packs(target_packs="modified")
+        modified_packs = get_packs_names(target_packs="modified")
 
         assert modified_packs == {"Pack1", "Pack2"}
 

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -140,6 +140,7 @@ class PackStatus(enum.Enum):
     FAILED_REMOVING_PACK_SKIPPED_FOLDERS = "Failed to remove pack hidden and skipped folders"
     FAILED_RELEASE_NOTES = "Failed to generate changelog.json"
     FAILED_DETECTING_MODIFIED_FILES = "Failed in detecting modified files of the pack"
+    FAILED_SEARCHING_PACK_IN_INDEX = "Failed in searching pack folder in index"
 
 
 class Pack(object):
@@ -1238,6 +1239,31 @@ class Pack(object):
                     images_list.append(image_data)
 
         return images_list
+
+    def check_if_exists_in_index(self, index_folder_path):
+        """ Checks if pack is sub-folder of downloaded index.
+
+        Args:
+            index_folder_path (str): index folder full path.
+
+        Returns:
+            bool: whether the operation succeeded.
+            bool: whether pack exists in index folder.
+
+        """
+        task_status, exists_in_index = False, False
+
+        try:
+            if not os.path.exists(index_folder_path):
+                print_error(f"{GCPConfig.INDEX_NAME} does not exists.")
+                return task_status, exists_in_index
+
+            exists_in_index = os.path.exists(os.path.join(index_folder_path, self._pack_name))
+            task_status = True
+        except Exception as e:
+            print_error(f"Failed searching {self._pack_name} pack in {GCPConfig.INDEX_NAME}. Additional info:\n{e}")
+        finally:
+            return task_status, exists_in_index
 
     def upload_integration_images(self, storage_bucket):
         """ Uploads pack integrations images to gcs.

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -14,8 +14,8 @@ from Tests.Marketplace.marketplace_services import init_storage_client, Pack, Pa
 from demisto_sdk.commands.common.tools import run_command, print_error, print_warning, print_color, LOG_COLORS, str2bool
 
 
-def get_modified_packs(target_packs):
-    """Detects and returns modified or new packs names to upload.
+def get_packs_names(target_packs):
+    """Detects and returns packs names to upload.
 
     In case that `Modified` is passed in target_packs input, checks the git difference between two commits,
     current and previous and greps only ones with prefix Packs/.
@@ -578,9 +578,9 @@ def main():
         GCPConfig.STORAGE_BASE_PATH = storage_base_path
 
     # detect packs to upload
-    modified_packs = get_modified_packs(target_packs)
+    pack_names = get_packs_names(target_packs)
     extract_packs_artifacts(packs_artifacts_path, extract_destination_path)
-    packs_list = [Pack(pack_name, os.path.join(extract_destination_path, pack_name)) for pack_name in modified_packs
+    packs_list = [Pack(pack_name, os.path.join(extract_destination_path, pack_name)) for pack_name in pack_names
                   if os.path.exists(os.path.join(extract_destination_path, pack_name))]
 
     # download and extract index from public bucket


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold 

## Related Issues
related to: https://github.com/demisto/etc/issues/26536

## Description
Update index in case it is missing pack folder for any reason. Partial solution for original issue. 
The race condition between builds will be solved by adding commit hash and in separate PR.