### PR TITLE
Removed deprecated integration test (Active Directory)

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2038,10 +2038,6 @@
             "playbookID": "ExtractDomainFromEmailTest"
         },
         {
-            "playbookID": "Account Enrichment - Generic v2 - Test",
-            "integrations": "activedir"
-        },
-        {
             "playbookID": "Extract Indicators From File - Generic v2 - Test",
             "integrations": "Image OCR",
             "timeout": 300,


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26452

## Description
Removed the use of `activedir` in the Circle tests since it's deprecated.