### PR TITLE
Skipping AD get user manager details in AccessInvestigation if pack is unavailable

### DIFF
--- a/Packs/AccessInvestigation/Playbooks/Access_Investigation_-_Generic.yml
+++ b/Packs/AccessInvestigation/Playbooks/Access_Investigation_-_Generic.yml
@@ -9,10 +9,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 9191bc70-1a40-4150-83d9-66731d89243f
+    taskid: 88c75720-f352-4a1e-8fea-91e4664c6f2e
     type: start
     task:
-      id: 9191bc70-1a40-4150-83d9-66731d89243f
+      id: 88c75720-f352-4a1e-8fea-91e4664c6f2e
       version: -1
       name: ""
       iscommand: false
@@ -32,12 +32,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "4":
     id: "4"
-    taskid: e0ffa563-92e4-428b-81ed-c0fe3eeeb2f7
+    taskid: 809b9809-6cf2-43f5-82ec-26935d8e6334
     type: title
     task:
-      id: e0ffa563-92e4-428b-81ed-c0fe3eeeb2f7
+      id: 809b9809-6cf2-43f5-82ec-26935d8e6334
       version: -1
       name: Interact with the user
       type: title
@@ -58,12 +60,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "5":
     id: "5"
-    taskid: 343205d4-9062-4954-8d57-ac3ab134d5f6
+    taskid: d8ca792a-0f62-4afa-82c1-3f0deee8cf95
     type: title
     task:
-      id: 343205d4-9062-4954-8d57-ac3ab134d5f6
+      id: d8ca792a-0f62-4afa-82c1-3f0deee8cf95
       version: -1
       name: Enrich indicators
       type: title
@@ -85,12 +89,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "9":
     id: "9"
-    taskid: 199da01e-9255-43ce-8a5a-65bd8cf2bb46
+    taskid: 86527ce8-4449-4f5f-8828-3f6b0940e43a
     type: title
     task:
-      id: 199da01e-9255-43ce-8a5a-65bd8cf2bb46
+      id: 86527ce8-4449-4f5f-8828-3f6b0940e43a
       version: -1
       name: Source & Destination IP Enrichment
       type: title
@@ -111,12 +117,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "10":
     id: "10"
-    taskid: 7abb6d21-9fa6-4da9-8556-82413f642455
+    taskid: 9d762933-5ea0-4a4a-8ce7-f03af038e32a
     type: title
     task:
-      id: 7abb6d21-9fa6-4da9-8556-82413f642455
+      id: 9d762933-5ea0-4a4a-8ce7-f03af038e32a
       version: -1
       name: Source User Enrichment
       type: title
@@ -137,12 +145,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "11":
     id: "11"
-    taskid: 7b6dfef6-28ec-4daf-8b44-e0d813674886
+    taskid: d7b6d1d4-1fc7-4c5f-89e5-87a8c5f16644
     type: condition
     task:
-      id: 7b6dfef6-28ec-4daf-8b44-e0d813674886
+      id: d7b6d1d4-1fc7-4c5f-89e5-87a8c5f16644
       version: -1
       name: Does the source user account have an email address?
       description: Verify that the source user account has an associated email address.
@@ -188,12 +198,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "12":
     id: "12"
-    taskid: 7a5f3223-0418-418a-8872-ca221ab74c5a
+    taskid: 6a801695-72c6-4eec-8b39-5954c6807564
     type: title
     task:
-      id: 7a5f3223-0418-418a-8872-ca221ab74c5a
+      id: 6a801695-72c6-4eec-8b39-5954c6807564
       version: -1
       name: Done
       type: title
@@ -211,12 +223,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "13":
     id: "13"
-    taskid: 0e9d5518-3755-4d4b-8254-631b021ad18a
+    taskid: f5306f35-038d-480e-8b59-7833c7cb230d
     type: regular
     task:
-      id: 0e9d5518-3755-4d4b-8254-631b021ad18a
+      id: f5306f35-038d-480e-8b59-7833c7cb230d
       version: -1
       name: Request user to confirm account activity
       description: Send an email to the source user email address to confirm whether
@@ -283,12 +297,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "14":
     id: "14"
-    taskid: cf2e6c57-c2cb-41cb-822d-eb13f2658fee
+    taskid: d542d6b9-8ef6-4356-8d60-a400b14f8b1a
     type: condition
     task:
-      id: cf2e6c57-c2cb-41cb-822d-eb13f2658fee
+      id: d542d6b9-8ef6-4356-8d60-a400b14f8b1a
       version: -1
       name: Get user response
       description: Use the user response (yes or no) to direct the playbook.
@@ -313,12 +329,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "22":
     id: "22"
-    taskid: e0dc594d-6a63-47e7-85d1-cadb733f3544
+    taskid: a9846347-7756-4b70-894d-8480140f90f5
     type: title
     task:
-      id: e0dc594d-6a63-47e7-85d1-cadb733f3544
+      id: a9846347-7756-4b70-894d-8480140f90f5
       version: -1
       name: User confirmed account activity
       type: title
@@ -339,12 +357,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "23":
     id: "23"
-    taskid: d78f9aeb-aaab-47c1-8359-4518d529c00a
+    taskid: 3ec0bffb-db20-4112-8808-ecf72d0555ee
     type: title
     task:
-      id: d78f9aeb-aaab-47c1-8359-4518d529c00a
+      id: 3ec0bffb-db20-4112-8808-ecf72d0555ee
       version: -1
       name: User denied account activity
       type: title
@@ -365,12 +385,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "24":
     id: "24"
-    taskid: 7201e19f-4202-41ec-8b24-246679d7621f
+    taskid: 16ba7ef2-9920-4c65-886a-c689239186a8
     type: regular
     task:
-      id: 7201e19f-4202-41ec-8b24-246679d7621f
+      id: 16ba7ef2-9920-4c65-886a-c689239186a8
       version: -1
       name: Set severity to low
       description: Set the incident severity to low.
@@ -480,12 +502,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "25":
     id: "25"
-    taskid: eb5afea3-4cbc-4ec6-82f5-d9b80ac4ed1b
+    taskid: 01042d15-0cae-40f8-8ee4-c920f865092a
     type: regular
     task:
-      id: eb5afea3-4cbc-4ec6-82f5-d9b80ac4ed1b
+      id: 01042d15-0cae-40f8-8ee4-c920f865092a
       version: -1
       name: Close Investigation
       description: Close the investigation.
@@ -516,12 +540,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "26":
     id: "26"
-    taskid: 38e9a862-18da-401c-88e7-9ed6e2b0e9a4
+    taskid: 64df8fe6-98e4-4364-812e-1f0b3aa146a0
     type: regular
     task:
-      id: 38e9a862-18da-401c-88e7-9ed6e2b0e9a4
+      id: 64df8fe6-98e4-4364-812e-1f0b3aa146a0
       version: -1
       name: Set severity to high
       description: Set the incident severity to high.
@@ -631,12 +657,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "27":
     id: "27"
-    taskid: b914ceed-2615-4c1b-8d64-74b2a8da5cd0
+    taskid: fc1a3a27-1849-4965-8815-94cd27e18982
     type: regular
     task:
-      id: b914ceed-2615-4c1b-8d64-74b2a8da5cd0
+      id: fc1a3a27-1849-4965-8815-94cd27e18982
       version: -1
       name: Assign to analyst
       description: |
@@ -669,12 +697,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "28":
     id: "28"
-    taskid: 8ae1ca42-1f1d-4ae7-883e-814705b8aae2
+    taskid: a762c9b2-95c6-459a-8fe0-398d9721ce0b
     type: regular
     task:
-      id: 8ae1ca42-1f1d-4ae7-883e-814705b8aae2
+      id: a762c9b2-95c6-459a-8fe0-398d9721ce0b
       version: -1
       name: Manually remediate  the incident
       description: "Review the incident to determine if the account activity is malicious.\n\
@@ -699,12 +729,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "29":
     id: "29"
-    taskid: 8573d178-ba34-421a-8c32-8391a51a8960
+    taskid: 05185a2c-da2e-4ebd-8ee1-065bdaf64237
     type: playbook
     task:
-      id: 8573d178-ba34-421a-8c32-8391a51a8960
+      id: 05185a2c-da2e-4ebd-8ee1-065bdaf64237
       version: -1
       name: Account Enrichment - Generic v2.1
       playbookName: Account Enrichment - Generic v2.1
@@ -726,6 +758,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -736,19 +769,22 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "30":
     id: "30"
-    taskid: b13b1567-ab00-4846-86e4-7f8efe20c7f7
+    taskid: 7b32be50-0650-4319-81d4-86b65225d07c
     type: playbook
     task:
-      id: b13b1567-ab00-4846-86e4-7f8efe20c7f7
+      id: 7b32be50-0650-4319-81d4-86b65225d07c
       version: -1
       name: Active Directory - Get User Manager Details
+      description: Takes an email address or a username of a user account in Active
+        Directory, and returns the email address of the user's manager.
       playbookName: Active Directory - Get User Manager Details
       type: playbook
       iscommand: false
       brand: ""
-      description: ''
     nexttasks:
       '#none#':
       - "4"
@@ -762,6 +798,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -772,12 +809,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
   "31":
     id: "31"
-    taskid: 410e0fc3-585b-4a7d-8797-9cfe741b5827
+    taskid: eee39e39-e016-4a06-8b99-2e9457281933
     type: playbook
     task:
-      id: 410e0fc3-585b-4a7d-8797-9cfe741b5827
+      id: eee39e39-e016-4a06-8b99-2e9457281933
       version: -1
       name: IP Enrichment - Generic v2
       playbookName: IP Enrichment - Generic v2
@@ -808,6 +847,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -818,6 +858,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {},
@@ -838,6 +880,7 @@ inputs:
       accessor: src
   required: false
   description: The source IP address from which the incident originated.
+  playbookInputQuery:
 - key: DstIP
   value:
     complex:
@@ -845,6 +888,7 @@ inputs:
       accessor: dest
   required: false
   description: The target IP address that was accessed.
+  playbookInputQuery:
 - key: Username
   value:
     complex:
@@ -852,17 +896,20 @@ inputs:
       accessor: srcuser
   required: false
   description: The username of the account that was used to access the DstIP.
+  playbookInputQuery:
 - key: Role
   value:
     simple: Administrator
   required: true
   description: The default role to assign the incident to.
+  playbookInputQuery:
 - key: OnCall
   value:
     simple: "false"
   required: false
   description: Set to true to assign only the users that are currently on shift. Requires
     Cortex XSOAR v5.5 or later.
+  playbookInputQuery:
 outputs:
 - contextPath: Account.Email.Address
   description: The email address object associated with the Account

--- a/Packs/AccessInvestigation/ReleaseNotes/1_2_0.md
+++ b/Packs/AccessInvestigation/ReleaseNotes/1_2_0.md
@@ -1,0 +1,5 @@
+<!--
+#### Playbooks
+##### Access Investigation - Generic
+- The subplaybook that retrieves the user manager details will be skipped of the Active Directory pack is not installed.
+-->

--- a/Packs/AccessInvestigation/pack_metadata.json
+++ b/Packs/AccessInvestigation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Access Investigation",
     "description": "Investigates an access incident by gathering user and IP information and interacting with the user to confirm whether or not they initiated the access action.",
     "support": "xsoar",
-    "currentVersion": "1.1.4",
+    "currentVersion": "1.2.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
@@ -11,6 +11,8 @@
         "Network Security"
     ],
     "tags": [],
-    "useCases": ["Access"],
+    "useCases": [
+        "Access"
+    ],
     "keywords": []
 }

--- a/Packs/AccessInvestigation/pack_metadata.json
+++ b/Packs/AccessInvestigation/pack_metadata.json
@@ -32,11 +32,5 @@
             "mandatory": true,
             "display_name": "Common Scripts"
         }
-    },
-    "displayedImages": [
-        "Active_Directory_Query",
-        "CommonTypes",
-        "CommonPlaybooks",
-        "CommonScripts"
-    ]
+    }
 }

--- a/Packs/AccessInvestigation/pack_metadata.json
+++ b/Packs/AccessInvestigation/pack_metadata.json
@@ -14,5 +14,29 @@
     "useCases": [
         "Access"
     ],
-    "keywords": []
+    "keywords": [],
+    "dependencies": {
+        "Active_Directory_Query": {
+            "mandatory": false,
+            "display_name": "Active Directory Query"
+        },
+        "CommonTypes": {
+            "mandatory": true,
+            "display_name": "Common Types"
+        },
+        "CommonPlaybooks": {
+            "mandatory": true,
+            "display_name": "Common Playbooks"
+        },
+        "CommonScripts": {
+            "mandatory": true,
+            "display_name": "Common Scripts"
+        }
+    },
+    "displayedImages": [
+        "Active_Directory_Query",
+        "CommonTypes",
+        "CommonPlaybooks",
+        "CommonScripts"
+    ]
 }


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related to: https://github.com/demisto/etc/issues/26510

## Description
`Access Investigation - Generic` will skip `Active Directory - Get User Manager Details` if the AD pack is not installed

## Does it break backward compatibility?
No


