### PR TITLE
[Fix] Domaintools Errors on ReverseIP

### DIFF
--- a/Packs/DomainTools/Integrations/integration-DomainTools.yml
+++ b/Packs/DomainTools/Integrations/integration-DomainTools.yml
@@ -117,7 +117,7 @@ script:
                 context = {'Domain': {'Name': res.response.record_source, 'Whois': changeKeys(toCamelCase, res.response.parsed_whois)}};
             }
         } else {
-            var md += "Could not find any results. Please make sure the queried domain exists";
+            md += "Could not find any results. Please make sure the queried domain exists";
         }
 
         return {
@@ -248,7 +248,8 @@ script:
               address.domain_names.forEach(function(domain){
                   md += '* ' + domain + '\n';
                   context.Domain.push({'Name': domain, 'DNS' : {'Address' : address.ip_address}});
-              })};
+              });
+            }
         });
 
         return {

--- a/Packs/DomainTools/Integrations/integration-DomainTools.yml
+++ b/Packs/DomainTools/Integrations/integration-DomainTools.yml
@@ -97,23 +97,27 @@ script:
             parsed = false;
             log('error code 206');
         }
-        var splitRes = res.response.whois.record.split('\n');
         var md = '### DomainTools whois result for '+ query + '\n';
-        var resMap = {};
-        splitRes.forEach(function(entry){
-            splitEntry = entry.split(/:\s(.+)/);
-            if(splitEntry[1]){
-                splitEntry[0] = toCamelCase(splitEntry[0]);
-                md += '**'+splitEntry[0]+':** '+splitEntry[1]+'\n';
-                resMap[splitEntry[0]] = addKeyToJson(resMap[splitEntry[0]], splitEntry[1]);
-            }
-        });
-
         var context;
-        if(parsed === 'false'){
-            context = {'Domain': {'Name': res.response.record_source, 'Whois': resMap}};
-        }else{
-            context = {'Domain': {'Name': res.response.record_source, 'Whois': changeKeys(toCamelCase, res.response.parsed_whois)}};
+        if(res.response.whois){
+            var splitRes = res.response.whois.record.split('\n');
+            var resMap = {};
+            splitRes.forEach(function(entry){
+                splitEntry = entry.split(/:\s(.+)/);
+                if(splitEntry[1]){
+                    splitEntry[0] = toCamelCase(splitEntry[0]);
+                    md += '**'+splitEntry[0]+':** '+splitEntry[1]+'\n';
+                    resMap[splitEntry[0]] = addKeyToJson(resMap[splitEntry[0]], splitEntry[1]);
+                }
+            });
+
+            if(parsed === 'false'){
+                context = {'Domain': {'Name': res.response.record_source, 'Whois': resMap}};
+            }else{
+                context = {'Domain': {'Name': res.response.record_source, 'Whois': changeKeys(toCamelCase, res.response.parsed_whois)}};
+            }
+        } else {
+            var md += "Could not find any results. Please make sure the queried domain exists"
         }
 
         return {
@@ -239,11 +243,12 @@ script:
         }
 
         addresses.forEach(function(address){
-            md+= '\nFound ' + address.domain_count + ' domains for ' +address.ip_address + '\n';
-            address.domain_names.forEach(function(domain){
-                md += '* ' + domain + '\n';
-                context.Domain.push({'Name': domain, 'DNS' : {'Address' : address.ip_address}});
-            });
+            if(adress) {
+              md+= '\nFound ' + address.domain_count + ' domains for ' +address.ip_address + '\n';
+              address.domain_names.forEach(function(domain){
+                  md += '* ' + domain + '\n';
+                  context.Domain.push({'Name': domain, 'DNS' : {'Address' : address.ip_address}});
+              })};
         });
 
         return {

--- a/Packs/DomainTools/Integrations/integration-DomainTools.yml
+++ b/Packs/DomainTools/Integrations/integration-DomainTools.yml
@@ -117,7 +117,7 @@ script:
                 context = {'Domain': {'Name': res.response.record_source, 'Whois': changeKeys(toCamelCase, res.response.parsed_whois)}};
             }
         } else {
-            var md += "Could not find any results. Please make sure the queried domain exists"
+            var md += "Could not find any results. Please make sure the queried domain exists";
         }
 
         return {

--- a/Packs/DomainTools/ReleaseNotes/1_0_1.md
+++ b/Packs/DomainTools/ReleaseNotes/1_0_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### DomainTools
+- Fixed an issue in **reverseIP** where it would show an error when there was an empty result.
+- Fixed an issue in **whois** where it would would show an error for non-existent domains.

--- a/Packs/DomainTools/pack_metadata.json
+++ b/Packs/DomainTools/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "DomainTools",
-  "description": "Domain name, DNS and Internet OSINT-based cyber threat intelligence and cybercrime forensics products and data",
-  "support": "partner",
-  "currentVersion": "1.0.0",
-  "author": "DomainTools",
-  "url": "https://www.domaintools.com/support/",
-  "email": "memberservices@domaintools.com",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "DomainTools",
+    "description": "Domain name, DNS and Internet OSINT-based cyber threat intelligence and cybercrime forensics products and data",
+    "support": "partner",
+    "currentVersion": "1.0.1",
+    "author": "DomainTools",
+    "url": "https://www.domaintools.com/support/",
+    "email": "memberservices@domaintools.com",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [ ] Ready
- [x] In Hold - (Waiting customer validation)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26693

## Description
Added handling for empty responses in `reverseIP` and `whois`.

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests - no instance and JS integration
- [x] Documentation 