### PR TITLE
move print statement to actual name of the instance being configured …

### DIFF
--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -259,6 +259,9 @@ class MITMProxy:
             self.empty_files.append(playbook_id)
         else:
             # Move to repo folder
+            prints_manager.add_print_job(
+                'Moving "{}" files to "{}" directory'.format(src_files, dst_folder), print, thread_index
+            )
             self.ami.call(['mkdir', '--parents', dst_folder])
             self.ami.call(['mv', src_files, dst_folder])
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -485,9 +485,6 @@ def __delete_integration_instance_if_determined_by_name(client, instance_name, p
 # return instance name if succeed, None otherwise
 def __create_integration_instance(client, integration_name, integration_instance_name,
                                   integration_params, is_byoi, prints_manager, validate_test=True, thread_index=0):
-    start_message = 'Configuring instance for {} (instance name: {}, ' \
-                    'validate "Test": {})'.format(integration_name, integration_instance_name, validate_test)
-    prints_manager.add_print_job(start_message, print, thread_index)
 
     # get configuration config (used for later rest api
     configuration = __get_integration_config(client, integration_name, prints_manager,
@@ -504,6 +501,10 @@ def __create_integration_instance(client, integration_name, integration_instance
         __delete_integration_instance_if_determined_by_name(client, instance_name, prints_manager, thread_index)
     else:
         instance_name = '{}_test_{}'.format(integration_instance_name.replace(' ', '_'), str(uuid.uuid4()))
+
+    start_message = 'Configuring instance for {} (instance name: {}, ' \
+                    'validate "Test": {})'.format(integration_name, instance_name, validate_test)
+    prints_manager.add_print_job(start_message, print, thread_index)
 
     # define module instance
     module_instance = {


### PR DESCRIPTION
## Status
- [x] Ready


## Description
When configuring an integration instance via `__create_integration_instance`, the _actual_ name given to the instance will be shown in the print message.

## Minimum version of Demisto
- [x] 4.5.0
- [x] 5.0.0
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

