### PR TITLE
delete the pack folder before checking out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,7 @@ references:
                 echo 'Copy the changes from the contributor branch $USER/$BRANCH in the pack $PACK'
                 git remote add $USER git@github.com:$USER/content.git
                 git fetch $USER $BRANCH
+                rm -rf $PACK
                 git checkout $USER/$BRANCH $PACK
                 exit 0
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
1. Partner deleted playbook in his branch
2. When `trigger_content_build_with_time_to_live` was triggered, it checked out the changes from partner branch , but it didn't deleted the deleted file. The reason for that is because `git checkout somefile` only copies from files. 
So I delete the pack first and then run the checkout
