### PR TITLE
AlienVault memory threshold increase

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2565,7 +2565,8 @@
         {
             "integrations": "AlienVault Reputation Feed",
             "playbookID": "AlienVaultReputationFeed_Test",
-            "fromversion": "5.5.0"
+            "fromversion": "5.5.0",
+            "memory_threshold": 175
         },
         {
             "integrations": "BruteForceBlocker Feed",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26104

## Description
Checked the memory issue within alien vault feed, it is due to the feed itself, when running the get-indicators command the docker ram consumption raises up to 350 MB. This feed is using the CSV API Module, same as Bambenek feed. Checked Bambenek too, and its not changing its memory consumption much.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

