### PR TITLE
phishtank readme - did not close the br

### DIFF
--- a/Packs/PhishTank/Integrations/README.md
+++ b/Packs/PhishTank/Integrations/README.md
@@ -107,7 +107,7 @@ There is no context output for this command.
 ```!phishtank-status```
 
 #### Human Readable Output
-<br>PhishTank Database Status<br>
-<br>Total 15939 URLs loaded.<br>
-<br>Last load time Sun Jul 26 2020 18:56:10 GMT+0300 (IDT)<br>
+<br>PhishTank Database Status</br>
+<br>Total 15939 URLs loaded.</br>
+<br>Last load time Sun Jul 26 2020 18:56:10 GMT+0300 (IDT)</br>
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

```
Validating Packs/PhishTank unique pack files

Validating Packs/PhishTank/Integrations/README.md as readme
Validating scheme for Packs/PhishTank/Integrations/README.md
Packs/PhishTank/Integrations/README.md: [RM100] - Failed verifying README.md Error Message is: SyntaxError: unknown: Unterminated JSX contents (184:16)

  182 | <br>Total 15939 URLs loaded.<br>
  183 | <br>Last load time Sun Jul 26 2020 18:56:10 GMT+0300 (IDT)<br>
> 184 |     </MDXLayout>
      |                 ^
  185 |   )
  186 | };
  187 | MDXContent.isMDXComponent = true
    at Object._raise (/home/circleci/project/node_modules/@babel/core/node_modules/@babel/parser/lib/index.js:757:17)
```

## Related Issues
fixes: master