### PR TITLE
[code42-636] Bump py42 dependency docker container

### DIFF
--- a/Packs/Code42/Integrations/Code42/Code42.yml
+++ b/Packs/Code42/Integrations/Code42/Code42.yml
@@ -805,7 +805,7 @@ script:
     - contextPath: Code42.DepartingEmployee.DepartureDate
       description: The departure date for the Departing Employee.
       type: Unknown
-  dockerimage: demisto/py42:1.0.0.9806
+  dockerimage: demisto/py42:1.0.0.10082
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Code42/Integrations/Code42/Code42_test.py
+++ b/Packs/Code42/Integrations/Code42/Code42_test.py
@@ -802,8 +802,8 @@ MOCK_OBSERVATION_QUERIES = [
                 "filterClause": "AND",
                 "filters": [
                     {"operator": "IS_NOT", "term": "exposure", "value": "IsPublic"},
-                    {"operator": "IS_NOT", "term": "exposure", "value": "SharedViaLink"},
                     {"operator": "IS_NOT", "term": "exposure", "value": "OutsideTrustedDomains"},
+                    {"operator": "IS_NOT", "term": "exposure", "value": "SharedViaLink"},
                 ],
             },
         ],

--- a/Packs/Code42/ReleaseNotes/2_0_1.md
+++ b/Packs/Code42/ReleaseNotes/2_0_1.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Code42
+- Internal code improvements.

--- a/Packs/Code42/ReleaseNotes/2_0_1.md
+++ b/Packs/Code42/ReleaseNotes/2_0_1.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### Code42
-- Internal code improvements.
+- Fixed an issue caused by an incorrect docker image version.

--- a/Packs/Code42/pack_metadata.json
+++ b/Packs/Code42/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Code42",
     "description": "Use the Code42 integration to identify potential data exfiltration from insider threats while speeding investigation and response by providing fast access to file events and metadata across physical and cloud environments.",
     "support": "partner",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Code42",
     "url": "https://support.code42.com/Administrator/Cloud/Monitoring_and_managing",
     "email": "",


### PR DESCRIPTION
This addresses a minor bug in this dependency that causes the incorrect type of python error to be raised/thrown under some circumstances when `code42-download-file` cannot find the supplied hash.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [X] 5.0.0
- [] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Demisto Partner?
- [X] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

