### PR TITLE
Skipped contributor notifier on contrib branches

### DIFF
--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
-    if: !startsWith(github.head_ref, 'contrib/') && !startsWith(github.head_ref, 'to-merge/')
+    if: !(startsWith(github.head_ref, 'contrib/')) && !(startsWith(github.head_ref, 'to-merge/'))
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'contrib/') == false
+    if: !startsWith(github.head_ref, 'contrib/') && !startsWith(github.head_ref, 'to-merge/')
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'contrib/') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
-    if: !(startsWith(github.head_ref, 'contrib/')) && !(startsWith(github.head_ref, 'to-merge/'))
+    if: startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -23,8 +23,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo "New PR number is $PR_NUMBER"
+          echo "PR number is: $PR_NUMBER"
+          echo "Target branch name is: $BRANCH_NAME"
           echo "Starting check of contributor packs"
           python Utils/request_contributor_review.py --pr_number $PR_NUMBER --github_token $GITHUB_TOKEN
           echo "Finished check of contributor packs"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

## Description
Skipped notifier in case branch name begins with `contrib/` or `to-merge/`.
