### PR TITLE
Encourage migrating to GenericSQL

### DIFF
--- a/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.py
+++ b/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.py
@@ -256,6 +256,7 @@ def main():
         commands: Dict[str, Callable[[Client, Dict[str, str], str], Tuple[str, Dict[Any, Any], List[Any]]]] = {
             'test-module': test_module,
             'query': sql_query_execute,
+            'pgsql-query': sql_query_execute,
             'sql-command': sql_query_execute
         }
         if command in commands:

--- a/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
+++ b/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
@@ -94,7 +94,7 @@ script:
       required: false
       secret: false
     deprecated: true
-    description: Runs a SQL query.
+    description: Runs a SQL query. Deprecated. Use the generic sql-command instead.
     execution: false
     name: pgsql-query
   - arguments:
@@ -131,7 +131,7 @@ script:
       required: false
       secret: false
     deprecated: true
-    description: Runs a SQL query.
+    description: Runs a SQL query. Deprecated. Use the generic sql-command instead.
     execution: false
     name: query
   - arguments:

--- a/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
+++ b/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
@@ -62,17 +62,17 @@ script:
   commands:
   - arguments:
     - default: false
+      description: The SQL query to run.
+      isArray: false
+      name: query
+      required: true
+      secret: false
+    - default: false
       defaultValue: '50'
       description: The maximum number of results to return.
       isArray: false
       name: limit
       required: false
-      secret: false
-    - default: false
-      description: The SQL query to run.
-      isArray: false
-      name: query
-      required: true
       secret: false
     - default: false
       defaultValue: '0'
@@ -93,7 +93,44 @@ script:
       name: bind_variables_values
       required: false
       secret: false
-    deprecated: false
+    deprecated: true
+    description: Runs a SQL query.
+    execution: false
+    name: pgsql-query
+  - arguments:
+    - default: false
+      description: The SQL query to run.
+      isArray: false
+      name: query
+      required: true
+      secret: false
+    - default: false
+      defaultValue: '50'
+      description: The maximum number of results to return.
+      isArray: false
+      name: limit
+      required: false
+      secret: false
+    - default: false
+      defaultValue: '0'
+      description: The offset at which to start the results. The default is 0.
+      isArray: false
+      name: skip
+      required: false
+      secret: false
+    - default: false
+      description: 'A comma-separated list of names, for example: "foo","bar","alpha".'
+      isArray: true
+      name: bind_variables_names
+      required: false
+      secret: false
+    - default: false
+      description: 'A comma-separated list of value, for example: 7,"foo",3.'
+      isArray: true
+      name: bind_variables_values
+      required: false
+      secret: false
+    deprecated: true
     description: Runs a SQL query.
     execution: false
     name: query

--- a/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
+++ b/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
@@ -106,7 +106,7 @@ script:
       secret: false
     - default: false
       defaultValue: '50'
-      description: The maximum number of results to return.
+      description: The maximum number of results to return. The default is 50.
       isArray: false
       name: limit
       required: false

--- a/Packs/GenericSQL/ReleaseNotes/1_0_5.md
+++ b/Packs/GenericSQL/ReleaseNotes/1_0_5.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Generic SQL
+  - Added *pgsql-query* command to make migrating from PostgreSQL easier
+  - Marked *query* command as depracated to encourage using *sql-command*

--- a/Packs/GenericSQL/ReleaseNotes/1_0_5.md
+++ b/Packs/GenericSQL/ReleaseNotes/1_0_5.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Generic SQL
-  - Added *pgsql-query* command to make migrating from PostgreSQL easier
-  - Marked *query* command as depracated to encourage using *sql-command*
+  - Added the ***pgsql-query*** command, which simplifies migrating from PostgreSQL.
+  - Marked the ***query*** command as depracated. Use the ***sql-command*** command instead.

--- a/Packs/GenericSQL/pack_metadata.json
+++ b/Packs/GenericSQL/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Connecting ang executing sql queries in 4 Databases: MYSQL, PostgreSQL, Microsoft SQL Server and Oracle",
     "support": "xsoar",
     "serverMinVersion": "5.0.0",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
This change marks *query* command as depracated and adds *pgsql-query*
so it's seamless to switch over to GenericSQL integration,
and encourages switching to *sql-command*.

Signed-off-by: Omer Cohen <git@omer.io>

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27036

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

