### PR TITLE
Gmail add brand to send_mail

### DIFF
--- a/Packs/Gmail/TestPlaybooks/playbook-GmailTest.yml
+++ b/Packs/Gmail/TestPlaybooks/playbook-GmailTest.yml
@@ -1575,7 +1575,7 @@ tasks:
       version: -1
       name: send-mail
       description: Send an email
-      script: '|||send-mail'
+      script: 'Gmail|||send-mail'
       type: regular
       iscommand: true
       brand: "Gmail"

--- a/Packs/Gmail/TestPlaybooks/playbook-GmailTest.yml
+++ b/Packs/Gmail/TestPlaybooks/playbook-GmailTest.yml
@@ -1578,7 +1578,7 @@ tasks:
       script: '|||send-mail'
       type: regular
       iscommand: true
-      brand: ""
+      brand: "Gmail"
     nexttasks:
       '#none#':
       - "40"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Add 'Gmail' as the brand when executing the send_mail command in the test playbook.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No