### PR TITLE
[Fix] threatstream-import-indicator-with-approval not working

### DIFF
--- a/Packs/Anomali_ThreatStream/Integrations/Anomali_ThreatStream_v2/Anomali_ThreatStream_v2.py
+++ b/Packs/Anomali_ThreatStream/Integrations/Anomali_ThreatStream_v2/Anomali_ThreatStream_v2.py
@@ -614,7 +614,7 @@ def import_ioc_with_approval(import_type, import_value, confidence="50", classif
             params = build_params(datatext=import_value)
 
     # in case import_type is not file-id, http_requests will receive None as files
-    res = http_request("GET", "v1/intelligence/import/", params=params, data=data, files=files)
+    res = http_request("POST", "v1/intelligence/import/", params=params, data=data, files=files)
     # closing the opened file if exist
     if uploaded_file:
         uploaded_file.close()

--- a/Packs/Anomali_ThreatStream/Integrations/Anomali_ThreatStream_v2/Anomali_ThreatStream_v2.yml
+++ b/Packs/Anomali_ThreatStream/Integrations/Anomali_ThreatStream_v2/Anomali_ThreatStream_v2.yml
@@ -1579,7 +1579,7 @@ script:
     - contextPath: ThreatStream.URL.Severity
       description: The indicator severity ("very-high", "high", "medium", or "low").
       type: String
-  dockerimage: demisto/emoji:1.0.0.7445
+  dockerimage: demisto/emoji:1.0.0.8854
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/Anomali_ThreatStream/ReleaseNotes/1_0_1.md
+++ b/Packs/Anomali_ThreatStream/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Anomali ThreatStream v2
+Fixed an issue in **threatstream-import-indicator-with-approval** where the command would not import indicators properly. 

--- a/Packs/Anomali_ThreatStream/pack_metadata.json
+++ b/Packs/Anomali_ThreatStream/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Anomali ThreatStream",
-  "description": "Use Anomali ThreatStream to query and submit threats.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Anomali ThreatStream",
+    "description": "Use Anomali ThreatStream to query and submit threats.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fix confirmed to work in: https://github.com/demisto/etc/issues/27002

## Description
Fixed an issue in **threatstream-import-indicator-with-approval** where the command would not import indicators properly.