### PR TITLE
Process Email Generic+Core - continueonerror for SetGridField

### DIFF
--- a/Packs/Phishing/Playbooks/Process_Email_-_Core.yml
+++ b/Packs/Phishing/Playbooks/Process_Email_-_Core.yml
@@ -648,6 +648,7 @@ tasks:
         simple: headername
       unpack_nested_elements:
         simple: "true"
+    continueonerror: true
     separatecontext: false
     view: |-
       {

--- a/Packs/Phishing/Playbooks/Process_Email_-_Generic.yml
+++ b/Packs/Phishing/Playbooks/Process_Email_-_Generic.yml
@@ -1135,6 +1135,7 @@ tasks:
       unpack_nested_elements:
         simple: "true"
     reputationcalc: 3
+    continueonerror: true
     separatecontext: false
     view: |-
       {

--- a/Packs/Phishing/ReleaseNotes/1_8_0.md
+++ b/Packs/Phishing/ReleaseNotes/1_8_0.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+##### Process Email - Generic
+- The task that updates the incident layout with email headers will not stop on errors
+##### Process Email - Core
+- The task that updates the incident layout with email headers will not stop on errors

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "1.7.2",
+    "currentVersion": "1.8.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/27113

## Description
Will now continue on error in the tasks that use `SetGridField` due to customer complaints. Need to understand the cause of the bug too https://panw-global.slack.com/archives/C011E5T5K17/p1596227521158100

## Does it break backward compatibility?
No


