### PR TITLE
ArcSight ESM v2 - Fixed an issue where long *eventId* were not proces…

### DIFF
--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -125,6 +125,8 @@ def decode_arcsight_output(d, depth=0, remove_nones=True):
                 elif key in TIMESTAMP_FIELDS:
                     key = key.replace('Time', 'Date').replace('stamp', '')
                     d[key] = parse_timestamp_to_datestring(value)
+                elif key in ['eventId', 'baseEventIds']:
+                    d[key] = str(value)
     return d
 
 

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
@@ -276,7 +276,7 @@ script:
       type: string
     - contextPath: ArcSightESM.SecurityEvents.eventId
       description: Event ID
-      type: number
+      type: string
     - contextPath: ArcSightESM.SecurityEvents.type
       description: Event type (e.g., CORRELATION)
       type: string

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
@@ -282,7 +282,7 @@ script:
       type: string
     - contextPath: ArcSightESM.SecurityEvents.baseEventIds
       description: Base event IDs
-      type: Unknown
+      type: string
     - contextPath: ArcSightESM.SecurityEvents.source.address
       description: Event source address
       type: Unknown

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -108,7 +108,7 @@ def test_use_rest(mocker, use_rest, cmd_name, expected_rest_endpoint):
 
 
 def test_decode_arcsight_output_event_ids():
-    """Unit test
+    """Unit test - When output to the incident context integers, demisto can round them if they are bigger than 2^32
     Given
     - a long eventId, baseEventIds
     When

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -2,7 +2,6 @@ import demistomock as demisto
 import pytest
 import requests_mock
 
-
 PARAMS = {
     'server': 'https://server',
     'credentials': {},
@@ -106,3 +105,22 @@ def test_use_rest(mocker, use_rest, cmd_name, expected_rest_endpoint):
         arcsight_cmd()
         last_request = m.last_request
         assert last_request.url == expected_rest_endpoint
+
+
+def test_decode_arcsight_output_event_ids():
+    """Unit test
+    Given
+    - a long eventId, baseEventIds
+    When
+    - running decode_arcsight_output
+    Then
+    - run the command on the input
+    Validate that the eventId, baseEventIds values were casted to string
+    """
+    import ArcSightESMv2
+    raw = {'eventId': 2305843016676439806, 'baseEventIds': 2305843016676439600}
+    expected = {'eventId': '2305843016676439806', 'baseEventIds': '2305843016676439600'}
+    d = ArcSightESMv2.decode_arcsight_output(raw)
+    assert isinstance(d.get('eventId'), str)
+    assert isinstance(d.get('baseEventIds'), str)
+    assert d == expected

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ArcSight ESM v2
+- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command.

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ArcSight ESM v2
-- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command.
+- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ArcSight ESM v2
-- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command
+- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command.

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ArcSight ESM v2
-- Fixed an issue where long *eventId* were not processed correctly in the ***as-get-security-events*** command.
+- Fixed an issue where a long *eventId* is not processed correctly in the ***as-get-security-events*** command.

--- a/Packs/ArcSightESM/pack_metadata.json
+++ b/Packs/ArcSightESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ArcSight ESM",
     "description": "ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
…sed correctly in the ***as-get-security-events*** command

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26425


## Screenshots
in the referenced issue

## Does it break backward compatibility?
   - [x] maybe - changing outputs in the yml from int to str and from unknown to str. @yaakovi WDYT?

## Must have
- [x] Tests