### PR TITLE
ArcSight ESM v2 - Fixed an issue where the *entry_filter* argument in…

### DIFF
--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -130,6 +130,33 @@ def decode_arcsight_output(d, depth=0, remove_nones=True):
     return d
 
 
+@logger
+def filter_entries(entries, entry_filter):
+    """ Filters the entries according to the entry_filter given """
+    if not entry_filter:
+        return entries
+
+    filtered_entries = []
+    filters = entry_filter.split(',')
+    for entry in entries:
+        append_flag = True
+
+        for f in filters:
+            k, v = f.split(':')
+            if k:
+                if not entry.get(k) == v:
+                    # if there is a key and its value is not equal to the entry_filter value
+                    append_flag = False
+            elif v not in entry.values():
+                # if there is no key check that the value exists in one of the entry's keys
+                append_flag = False
+
+        if append_flag:
+            filtered_entries.append(entry)
+
+    return filtered_entries
+
+
 def login():
     query_path = 'www/core-service/rest/LoginService/login'
     headers = {
@@ -730,13 +757,9 @@ def get_entries_command():
         # if the user wants only entries that contain certain 'field:value' sets (filters)
         # e.g., "name:myName,eventId:0,:ValueInUnknownField"
         # if the key is empty, search in every key
-        filtered = entries
-        if entry_filter:
-            for f in entry_filter.split(','):
-                k, v = f.split(':')
-                filtered = [entry for entry in filtered if ((entry.get(k) == v) if k else (v in entry.values()))]
+        filtered_entries = filter_entries(entries, entry_filter)
 
-        contents = decode_arcsight_output(filtered)
+        contents = decode_arcsight_output(filtered_entries)
         ActiveListContext = {
             'ResourceID': resource_id,
             'Entries': contents,
@@ -745,7 +768,7 @@ def get_entries_command():
             'ArcSightESM.ActiveList.{id}'.format(id=resource_id): contents,
             'ArcSightESM.ActiveList(val.ResourceID===obj.ResourceID)': ActiveListContext
         }
-        human_readable = tableToMarkdown(name='Active List entries: {}'.format(resource_id), t=filtered,
+        human_readable = tableToMarkdown(name='Active List entries: {}'.format(resource_id), t=filtered_entries,
                                          removeNull=True)
         return_outputs(readable_output=human_readable, outputs=outputs, raw_response=contents)
 

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -770,7 +770,7 @@ def get_entries_command():
         }
         human_readable = tableToMarkdown(name='Active List entries: {}'.format(resource_id), t=filtered_entries,
                                          removeNull=True)
-        return_outputs(readable_output=human_readable, outputs=outputs, raw_response=contents)
+        return_outputs(readable_output=human_readable, outputs=outputs, raw_response=entries)
 
     else:
         demisto.results('Active List has no entries')

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -124,3 +124,24 @@ def test_decode_arcsight_output_event_ids():
     assert isinstance(d.get('eventId'), str)
     assert isinstance(d.get('baseEventIds'), str)
     assert d == expected
+
+
+def test_filtered():
+    import ArcSightESMv2
+    entries = [
+        {'userAccount': 'abba', 'internalAddress': '127.0.0.2', 'externalLocation': 'Russia',
+         'externalAddress': '1.2.3.4'},
+        {'userAccount': 'abba', 'internalAddress': '127.0.0.1', 'externalLocation': 'USA',
+         'externalAddress': '1.2.3.4'},
+        {'userAccount': 'abba', 'internalAddress': '127.0.0.1', 'externalLocation': 'ISS',
+         'externalAddress': '1.2.3.4'}
+    ]
+    entry_filter = 'userAccount:abba,internalAddress:127.0.0.1'
+    expected_output = [
+        {'userAccount': 'abba', 'internalAddress': '127.0.0.1', 'externalLocation': 'USA',
+         'externalAddress': '1.2.3.4'},
+        {'userAccount': 'abba', 'internalAddress': '127.0.0.1', 'externalLocation': 'ISS',
+         'externalAddress': '1.2.3.4'}
+    ]
+    filtered_entries = ArcSightESMv2.filter_entries(entries, entry_filter)
+    assert filtered_entries == expected_output

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/README.md
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/README.md
@@ -460,6 +460,9 @@ There is no context output for this command.
 Returns all entries in the Active List
 
 
+### Limitations
+Returns up to 2000 entries.
+
 #### Base Command
 
 `as-get-entries`

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_5.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ArcSight ESM v2
+- Fixed an issue where the *entry_filter* argument in the ***as-get-entries*** command was not working with multiple filters.

--- a/Packs/ArcSightESM/pack_metadata.json
+++ b/Packs/ArcSightESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ArcSight ESM",
     "description": "ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
… the ***as-get-entries*** command was not working with multiple filters

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/27056

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 