### PR TITLE
Mocks Logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ references:
       when: always
       command: |
         echo 'export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"' >> $BASH_ENV
+        echo 'export TESTS_LOGS="${CIRCLE_ARTIFACTS}"/run_tests.log'
         echo 'export PATH="/home/circleci/.local/bin:${PWD}/node_modules/.bin:${PATH}"' >> $BASH_ENV # disable-secrets-detection
         echo 'export PYTHONPATH="/home/circleci/project:${PYTHONPATH}"' >> $BASH_ENV
         echo 'export DEMISTO_README_VALIDATION=true' >> $BASH_ENV
@@ -106,6 +107,7 @@ references:
         echo "=== sourcing $BASH_ENV ==="
         source $BASH_ENV
         sudo mkdir -p -m 777 $CIRCLE_ARTIFACTS
+        touch $TESTS_LOGS
         chmod +x ./Tests/scripts/*
         chmod +x ./Tests/lastest_server_build_scripts/*
         if [ ! -e "venv" ]; then
@@ -582,13 +584,7 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-
-                    else
-                      echo "Not AMI run, can't run on this version"
-                  fi
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
             - *destroy_instances
             - *store_artifacts
   Server 4_5:
@@ -642,13 +638,7 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-
-                    else
-                      echo "Not AMI run, can't run on this version"
-                  fi
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
             - *destroy_instances
             - *store_artifacts
   Server 5_0:
@@ -703,13 +693,7 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
-                    else
-                      echo "Not AMI run, can't run on this version"
-                  fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
 
             - *destroy_instances
             - *store_artifacts
@@ -764,16 +748,10 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-                      export RETVAL=$?
-                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                      exit $RETVAL
-
-                  else
-                      echo "Not AMI run, can't run on this version"
-                  fi
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  export RETVAL=$?
+                  cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                  exit $RETVAL
             - *destroy_instances
             - *store_artifacts
   Server 6_0:
@@ -832,7 +810,7 @@ jobs:
                     echo 'export INSTANCE_ROLE="master"' >> $BASH_ENV
                   fi
                   source $BASH_ENV
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
                   export RETVAL=$?
                   cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
                   exit $RETVAL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,7 +583,7 @@ jobs:
                       exit 0
                   fi
                   PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
-                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")_run_tests_${PUBLIC_IP}.log"
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
             - *destroy_instances
             - *store_artifacts
@@ -639,7 +639,7 @@ jobs:
                       exit 0
                   fi
                   PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
-                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")_run_tests_${PUBLIC_IP}.log"
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
             - *destroy_instances
             - *store_artifacts
@@ -696,7 +696,7 @@ jobs:
                       exit 0
                   fi
                   PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
-                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")_run_tests_${PUBLIC_IP}.log"
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
 
             - *destroy_instances
@@ -753,7 +753,7 @@ jobs:
                       exit 0
                   fi
                   PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
-                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")_run_tests_${PUBLIC_IP}.log"
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
                   export RETVAL=$?
                   cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
@@ -817,7 +817,7 @@ jobs:
                   fi
                   source $BASH_ENV
                   PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
-                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")_run_tests_${PUBLIC_IP}.log"
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
                   export RETVAL=$?
                   cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ references:
       when: always
       command: |
         echo 'export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"' >> $BASH_ENV
-        echo 'export TESTS_LOGS="${CIRCLE_ARTIFACTS}"/run_tests.log'
+        echo 'export TESTS_LOGS="${CIRCLE_ARTIFACTS}/run_tests.log"' >> $BASH_ENV
         echo 'export PATH="/home/circleci/.local/bin:${PWD}/node_modules/.bin:${PATH}"' >> $BASH_ENV # disable-secrets-detection
         echo 'export PYTHONPATH="/home/circleci/project:${PYTHONPATH}"' >> $BASH_ENV
         echo 'export DEMISTO_README_VALIDATION=true' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ references:
       when: always
       command: |
         echo 'export CIRCLE_ARTIFACTS="/home/circleci/project/artifacts"' >> $BASH_ENV
-        echo 'export TESTS_LOGS="${CIRCLE_ARTIFACTS}/run_tests.log"' >> $BASH_ENV
         echo 'export PATH="/home/circleci/.local/bin:${PWD}/node_modules/.bin:${PATH}"' >> $BASH_ENV # disable-secrets-detection
         echo 'export PYTHONPATH="/home/circleci/project:${PYTHONPATH}"' >> $BASH_ENV
         echo 'export DEMISTO_README_VALIDATION=true' >> $BASH_ENV
@@ -107,7 +106,6 @@ references:
         echo "=== sourcing $BASH_ENV ==="
         source $BASH_ENV
         sudo mkdir -p -m 777 $CIRCLE_ARTIFACTS
-        touch $TESTS_LOGS
         chmod +x ./Tests/scripts/*
         chmod +x ./Tests/lastest_server_build_scripts/*
         if [ ! -e "venv" ]; then
@@ -584,7 +582,9 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
             - *destroy_instances
             - *store_artifacts
   Server 4_5:
@@ -638,7 +638,9 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
             - *destroy_instances
             - *store_artifacts
   Server 5_0:
@@ -693,7 +695,9 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
 
             - *destroy_instances
             - *store_artifacts
@@ -748,7 +752,9 @@ jobs:
                       echo "Skipping - instance was not setup"
                       exit 0
                   fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
                   export RETVAL=$?
                   cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
                   exit $RETVAL
@@ -810,7 +816,9 @@ jobs:
                     echo 'export INSTANCE_ROLE="master"' >> $BASH_ENV
                   fi
                   source $BASH_ENV
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOGS
+                  PUBLIC_IP=$(cat ./env_results.json | jq ".[] | select(.Role == \"${INSTANCE_ROLE}\") | .InstanceDNS" | sed "s/\"//g")
+                  export TESTS_LOG_PATH="${CIRCLE_ARTIFACTS}/$(echo \"$INSTANCE_ROLE\" | tr -d '[:space:]' | sed "s/\"//g")/run_tests_${PUBLIC_IP}.log"
+                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" 2>&1 | tee -a $TESTS_LOG_PATH
                   export RETVAL=$?
                   cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
                   exit $RETVAL

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -191,6 +191,10 @@ class MITMProxy:
         self.empty_files = []
         self.rerecorded_tests = []
 
+        self.logs_file = open(os.getenv('TESTS_LOGS'), 'a') if os.getenv('TESTS_LOGS') else open(
+            '/home/circleci/project/artifacts/run_tests.log', 'a')
+        self.print_to_log = lambda *objects: print(*objects, file=self.logs_file)
+
         silence_output(self.ami.call, ['mkdir', '-p', tmp_folder], stderr='null')
 
     def configure_proxy_in_demisto(self, demisto_api_key, server, proxy=''):

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -191,8 +191,10 @@ class MITMProxy:
         self.empty_files = []
         self.rerecorded_tests = []
 
-        self.logs_file = open(os.getenv('TESTS_LOG_PATH'), 'a') if os.getenv('TESTS_LOG_PATH') else open(
-            f'/home/circleci/project/artifacts/{self.public_ip}.log', 'a')
+        if os.getenv('TESTS_LOG_PATH'):
+            self.logs_file = open(os.getenv('TESTS_LOG_PATH'), 'a')
+        else:
+            self.logs_file = open(f'/home/circleci/project/artifacts/{self.public_ip}.log', 'a')
         self.print_to_log = lambda *objects: print(*objects, file=self.logs_file, flush=True)
 
         silence_output(self.ami.call, ['mkdir', '-p', tmp_folder], stderr='null')
@@ -278,7 +280,7 @@ class MITMProxy:
             prints_manager.add_print_job(err_msg, print_error, thread_index)
             return
         problem_keys = json.loads(self.ami.check_output(['cat', problem_keys_filepath]))
-        prints_manager.add_print_job(	
+        prints_manager.add_print_job(
             f'Test "{playbook_id}" problem_keys: \n{json.dumps(problem_keys, indent=4)}',
             self.print_to_log,
             thread_index
@@ -310,7 +312,7 @@ class MITMProxy:
             prints_manager.add_print_job('Let\'s try and clean the mockfile from timestamp data!', print, thread_index)
             try:
                 clean_cmd_output = check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'))
-                prints_manager.add_print_job(	
+                prints_manager.add_print_job(
                     f'clean_cmd_output.decode()={clean_cmd_output.decode()}',
                     self.print_to_log,
                     thread_index

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -278,6 +278,11 @@ class MITMProxy:
             prints_manager.add_print_job(err_msg, print_error, thread_index)
             return
         problem_keys = json.loads(self.ami.check_output(['cat', problem_keys_filepath]))
+        prints_manager.add_print_job(	
+            f'Test "{playbook_id}" problem_keys: \n{json.dumps(problem_keys, indent=4)}',
+            self.print_to_log,
+            thread_index
+        )
 
         # is there data in problematic_keys.json that needs whitewashing?
         prints_manager.add_print_job('checking if there is data to whitewash', print, thread_index)
@@ -304,7 +309,12 @@ class MITMProxy:
             split_command = command.split()
             prints_manager.add_print_job('Let\'s try and clean the mockfile from timestamp data!', print, thread_index)
             try:
-                check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'))
+                clean_cmd_output = check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'))
+                prints_manager.add_print_job(	
+                    f'clean_cmd_output.decode()={clean_cmd_output.decode()}',
+                    self.print_to_log,
+                    thread_index
+                )
             except CalledProcessError as e:
                 cleaning_err_msg = 'There may have been a problem when filtering timestamp data from the mock file.'
                 prints_manager.add_print_job(cleaning_err_msg, print_error, thread_index)
@@ -367,7 +377,13 @@ class MITMProxy:
         repo_problem_keys_filepath = os.path.join(
             self.repo_folder, get_folder_path(playbook_id), 'problematic_keys.json'
         )
+        prints_manager.add_print_job(
+            f'repo_problem_keys_filepath={repo_problem_keys_filepath}', self.print_to_log, thread_index
+        )
         current_problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
+        prints_manager.add_print_job(
+            f'current_problem_keys_filepath={current_problem_keys_filepath}', self.print_to_log, thread_index
+        )
 
         # when recording, copy the `problematic_keys.json` for the test to current temporary directory if it exists
         # that way previously recorded or manually added keys will only be added upon and not wiped with an overwrite
@@ -377,7 +393,9 @@ class MITMProxy:
             )
 
         script_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'timestamp_replacer.py')
+        prints_manager.add_print_job(f'script_filepath={script_filepath}', self.print_to_log, thread_index)
         remote_script_path = self.ami.copy_file(script_filepath)
+        prints_manager.add_print_job(f'remote_script_path={remote_script_path}', self.print_to_log, thread_index)
 
         # if recording
         # record with detect_timestamps and then rewrite mock file
@@ -404,6 +422,7 @@ class MITMProxy:
         command = "source .bash_profile && mitmdump --ssl-insecure --verbose --listen-port {} {} {}{}".format(
             self.PROXY_PORT, actions, os.path.join(path, get_mock_file_path(playbook_id)), debug_opt
         )
+        prints_manager.add_print_job(f'mitm command: "{command}"', self.print_to_log, thread_index)
         command = command.split()
 
         # Start proxy server
@@ -435,9 +454,9 @@ class MITMProxy:
         self.ami.call(["rm", "-rf", "/tmp/_MEI*"])  # Clean up temp files
 
         # Handle logs
-        if self.debug:
-            prints_manager.add_print_job('proxy outputs:', print, thread_index)
-            prints_manager.add_print_job(f'{self.process.stdout.read()}', print, thread_index)
-            prints_manager.add_print_job(f'{self.process.stderr.read()}', print, thread_index)
+        print_func = print if self.debug else self.print_to_log
+        prints_manager.add_print_job('proxy outputs:', print_func, thread_index)
+        prints_manager.add_print_job(f'{self.process.stdout.read()}', print_func, thread_index)
+        prints_manager.add_print_job(f'{self.process.stderr.read()}', print_func, thread_index)
 
         self.process = None

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -191,9 +191,9 @@ class MITMProxy:
         self.empty_files = []
         self.rerecorded_tests = []
 
-        self.logs_file = open(os.getenv('TESTS_LOGS'), 'a') if os.getenv('TESTS_LOGS') else open(
-            '/home/circleci/project/artifacts/run_tests.log', 'a')
-        self.print_to_log = lambda *objects: print(*objects, file=self.logs_file)
+        self.logs_file = open(os.getenv('TESTS_LOG_PATH'), 'a') if os.getenv('TESTS_LOG_PATH') else open(
+            f'/home/circleci/project/artifacts/{self.public_ip}.log', 'a')
+        self.print_to_log = lambda *objects: print(*objects, file=self.logs_file, flush=True)
 
         silence_output(self.ami.call, ['mkdir', '-p', tmp_folder], stderr='null')
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -899,6 +899,7 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
                 updating_mocks_msg = "Pushing new/updated mock files to mock git repo."
                 prints_manager.add_print_job(updating_mocks_msg, print, thread_index)
                 ami.upload_mock_files(build_name, build_number)
+                prints_manager.execute_thread_prints(thread_index)
 
         if playbook_skipped_integration and build_name == 'master':
             comment = 'The following integrations are skipped and critical for the test:\n {}'. \


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Adds a `run_tests.log` file to the artifacts for each server instance `Run Tests` circleci job, to which `mock_server.py` logs extra debugging statements. The outputs of `stdout` and `stderr` of the `mitmproxy` process are logged there as well.

