### PR TITLE
fix commandresults when provided only outputs_prefix

### DIFF
--- a/Packs/Base/ReleaseNotes/1_1_9.md
+++ b/Packs/Base/ReleaseNotes/1_1_9.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Fix an issue in which only **outputs_prefix** was provided to **CommandResults**
+- Fixed an issue in which improper Context DT key was generated when only **outputs_prefix** was provided to the **CommandResults** object.

--- a/Packs/Base/ReleaseNotes/1_1_9.md
+++ b/Packs/Base/ReleaseNotes/1_1_9.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fix an issue in which only **outputs_prefix** was provided to **CommandResults**

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2602,7 +2602,7 @@ class CommandResults:
         self.outputs_key_field = outputs_key_field
 
         self._outputs_key_field = None  # type: Optional[List[str]]
-        if outputs_key_field is None or outputs_key_field == '':
+        if not outputs_key_field:
             self._outputs_key_field = None
         elif isinstance(outputs_key_field, STRING_TYPES):
             self._outputs_key_field = [outputs_key_field]

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2602,12 +2602,12 @@ class CommandResults:
         self.outputs_key_field = outputs_key_field
 
         self._outputs_key_field = None  # type: Optional[List[str]]
-        if isinstance(outputs_key_field, STRING_TYPES):
+        if outputs_key_field is None or outputs_key_field == '':
+            self._outputs_key_field = None
+        elif isinstance(outputs_key_field, STRING_TYPES):
             self._outputs_key_field = [outputs_key_field]
         elif isinstance(outputs_key_field, list):
             self._outputs_key_field = outputs_key_field
-        elif outputs_key_field is None:
-            self._outputs_key_field = None
         else:
             raise TypeError('outputs_key_field must be of type str or list')
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -951,6 +951,28 @@ class TestCommandResults:
         assert list(results.to_context()['EntryContext'].keys())[0] == \
                'File(val.sha1 == obj.sha1 && val.sha256 == obj.sha256 && val.md5 == obj.md5)'
 
+    def test_output_prefix_includes_dt(self):
+        """
+        Given
+        - Returning File with only outputs_prefix which includes DT in it
+        - outputs key fields are not provided
+
+        When
+        - creating CommandResults
+
+        Then
+        - EntryContext key should contain only the outputs_prefix
+        """
+        from CommonServerPython import CommandResults
+
+        files = []
+        results = CommandResults(outputs_prefix='File(val.sha1 == obj.sha1 && val.md5 == obj.md5)',
+                                 outputs_key_field='', outputs=files)
+
+        assert list(results.to_context()['EntryContext'].keys())[0] == \
+               'File(val.sha1 == obj.sha1 && val.md5 == obj.md5)'
+
+
     def test_readable_only_context(self):
         """
         Given:

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.1.8",
+    "currentVersion": "1.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27239

## Description
Fix CommandResults when provided only outputs_prefix with DT

## Screenshots
This is how it looks in CrowdStrikeMalquery
![image](https://user-images.githubusercontent.com/7270217/89552953-8b3a7b80-d815-11ea-86f7-81423633da0a.png)


## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

