### PR TITLE
LogRhythm-Test - set tested alert to be ID 80

### DIFF
--- a/Packs/LogRhythm/TestPlaybooks/playbook-LogRhythm_Test_Playbook.yml
+++ b/Packs/LogRhythm/TestPlaybooks/playbook-LogRhythm_Test_Playbook.yml
@@ -48,7 +48,7 @@ tasks:
       - "10"
     scriptarguments:
       alarm-id:
-        simple: "1"
+        simple: "80"
     separatecontext: false
     view: |-
       {
@@ -114,7 +114,7 @@ tasks:
       - "11"
     scriptarguments:
       alarm-id:
-        simple: "1"
+        simple: "80"
       comments:
         simple: test
     separatecontext: false
@@ -147,7 +147,7 @@ tasks:
       - "21"
     scriptarguments:
       alarm-id:
-        simple: "1"
+        simple: "80"
       include-raw-log: {}
     separatecontext: false
     view: |-
@@ -217,7 +217,7 @@ tasks:
       - "15"
     scriptarguments:
       alarm-id:
-        simple: "1"
+        simple: "80"
       comments: {}
       status:
         simple: New
@@ -251,7 +251,7 @@ tasks:
       - "16"
     scriptarguments:
       alarm-id:
-        simple: "1"
+        simple: "80"
       comments: {}
       status:
         simple: Closed
@@ -322,7 +322,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "1"
+              simple: "80"
     view: |-
       {
         "position": {
@@ -438,7 +438,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "1"
+              simple: "80"
     view: |-
       {
         "position": {


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/27164

## Description
Test failed for alert ID 1, changed to 80