### PR TITLE
Private VirusTotal return clickable links

### DIFF
--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.py
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.py
@@ -132,7 +132,7 @@ def create_file_output(file_hash, threshold, vt_response, short_format):
     md += 'Scan ID: **' + str(vt_response.get('scan_id')) + '**\n'
     md += 'Scan date: **' + str(vt_response.get('scan_date')) + '**\n'
     md += 'Detections / Total: **' + str(positives) + '/' + str(vt_response.get('total')) + '**\n'
-    md += 'Resource: [' + str(vt_response.get('resource')) + '](' + str(vt_response.get('resource')) + ')\n'
+    md += 'Resource: ' + str(vt_response.get('resource')) + '\n'
     md += 'VT Link: [' + str(vt_response.get('permalink')) + '](' + str(vt_response.get('permalink')) + ')\n'
     dbotScore = 0
 
@@ -674,7 +674,7 @@ def create_url_report_output(url, response, threshold, max_len, short_format):
     md += 'Scan ID: **' + str(response.get('scan_id', '')) + '**\n'
     md += 'Scan date: **' + str(response.get('scan_date', '')) + '**\n'
     md += 'Detections / Total: **' + str(positives) + '/' + str(response.get('total', '')) + '**\n'
-    md += 'Resource: [' + str(response.get('resource')) + '](' + str(response.get('resource')) + ')\n'
+    md += 'Resource: ' + str(response.get('resource')) + '\n'
     md += 'VT Link: [' + str(response.get('permalink')) + '](' + str(response.get('permalink')) + ')\n'
     dbotScore = 0
     ec_url = {}

--- a/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_2.md
+++ b/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### VirusTotal - Private API
-- Fixed an issue where the possible malicious was returned in a clickable format 
+- Fixed an issue where the *possible malicious* URL was returned in a clickable format.

--- a/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_2.md
+++ b/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VirusTotal - Private API
+- Fixed an issue where the possible malicious was returned in a clickable format 

--- a/Packs/VirusTotal-Private_API/pack_metadata.json
+++ b/Packs/VirusTotal-Private_API/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "VirusTotal - Private API",
-  "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
-  "support": "xsoar",
-  "currentVersion": "1.0.1",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "VirusTotal - Private API",
+    "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
+    "support": "xsoar",
+    "currentVersion": "1.0.2",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27383

## Description
Made the resource url that was returned from viruses total a simple text instead of clickable link because it can be malicious

## Screenshots
before:
![89923063-fb5a5000-dbcd-11ea-9240-330ce82a1595](https://user-images.githubusercontent.com/19407287/90016438-a8a69400-dcb2-11ea-876b-b8963127f78d.png)

after: 
![#15062 ras-pdf - War Room 2020-08-12 15-38-02](https://user-images.githubusercontent.com/19407287/90016456-ae9c7500-dcb2-11ea-8545-ff4952056490.png)

## Minimum version of Demisto
- [ ] 4.5.0
- [ ] 5.0.0
- [ ] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No


## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

