### PR TITLE
adding report download command to ThreatConnect v2

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
@@ -2069,6 +2069,27 @@ def download_document():
     demisto.results(fileResult(file_name, file_content))
 
 
+def download_report(group_type, group_id):
+    tc = get_client()
+    ro = RequestObject()
+    ro.set_http_method('GET')
+    ro.set_request_uri(f'/v2/groups/{group_type}/{group_id}/pdf')
+    return tc.api_request(ro)
+
+
+def tc_download_report():
+    args = demisto.args()
+    group_type = args.get('group_type', '').lower()
+    group_id = args.get('group_id')
+    allowed_types = ['adversaries', 'campaigns', 'emails', 'incidents', 'signatures', 'threats']
+    if group_type not in allowed_types:
+        raise DemistoException(f'{group_type} is not an allowed type for tc-download-report command.')
+
+    response = download_report(group_type, group_id)
+    file_entry = fileResult(filename=f'{group_type}_report_{group_id}.pdf', data=response.content)
+    demisto.results(file_entry)
+
+
 def test_integration():
     tc = get_client()
     owners = tc.owners()
@@ -2120,6 +2141,8 @@ COMMANDS = {
     'tc-get-associated-groups': get_group_associated,
     'tc-associate-group-to-group': associate_group_to_group,
     'tc-get-indicator-owners': tc_get_indicator_owners,
+
+    'tc-download-report': tc_download_report
 }
 
 

--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
@@ -2141,8 +2141,7 @@ COMMANDS = {
     'tc-get-associated-groups': get_group_associated,
     'tc-associate-group-to-group': associate_group_to_group,
     'tc-get-indicator-owners': tc_get_indicator_owners,
-
-    'tc-download-report': tc_download_report
+    'tc-download-report': tc_download_report,
 }
 
 

--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
@@ -2045,7 +2045,7 @@ script:
       description: Indicator Value
     description: Get Owner for Indicator
   - name: tc-download-report
-    description: Download group report (PDF).
+    description: The group report to download in PDF format.
     arguments:
       - name: group_type
         required: true
@@ -2057,10 +2057,10 @@ script:
         - incidents
         - signatures
         - threats
-        description: The group type.
+        description: 'The type of the group. Can be: "adversaries", "campaigns", "emails", "incidents", "signatures", or "threats".'
       - name: group_id
         required: true
-        description: The group ID.
+        description: The ID of the group.
     outputs:
     - contextPath: File.Size
       description: The size of the file.
@@ -2081,16 +2081,16 @@ script:
       description: The entry ID of the file.
       type: String
     - contextPath: File.Info
-      description: File information.
+      description: The information of the file.
       type: String
     - contextPath: File.Type
-      description: The file type.
+      description: The type of the file.
       type: String
     - contextPath: File.MD5
       description: The MD5 hash of the file.
       type: String
     - contextPath: File.Extension
-      description: The file extension.
+      description: The extension of the file.
       type: String
   dockerimage: demisto/threatconnect-py3-sdk:1.0.0.10664
   runonce: false

--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
@@ -2045,6 +2045,7 @@ script:
       description: Indicator Value
     description: Get Owner for Indicator
   - name: tc-download-report
+    description: Download group report (PDF).
     arguments:
       - name: group_type
         required: true
@@ -2056,10 +2057,11 @@ script:
         - incidents
         - signatures
         - threats
-        descriptin: The group type.
+        description: The group type.
       - name: group_id
         required: true
-    output:
+        description: The group ID.
+    outputs:
     - contextPath: File.Size
       description: The size of the file.
       type: Number
@@ -2090,7 +2092,7 @@ script:
     - contextPath: File.Extension
       description: The file extension.
       type: String
-  dockerimage: demisto/threatconnect-py3-sdk:1.0.0.8854
+  dockerimage: demisto/threatconnect-py3-sdk:1.0.0.10664
   runonce: false
   subtype: python3
 fromversion: '5.0.0'

--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
@@ -2044,6 +2044,52 @@ script:
       required: true
       description: Indicator Value
     description: Get Owner for Indicator
+  - name: tc-download-report
+    arguments:
+      - name: group_type
+        required: true
+        auto: PREDEFINED
+        predefined:
+        - adversaries
+        - campaigns
+        - emails
+        - incidents
+        - signatures
+        - threats
+        descriptin: The group type.
+      - name: group_id
+        required: true
+    output:
+    - contextPath: File.Size
+      description: The size of the file.
+      type: Number
+    - contextPath: File.SHA1
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA256 hash of the file.
+      type: String
+    - contextPath: File.Name
+      description: The name of the file.
+      type: String
+    - contextPath: File.SSDeep
+      description: The SSDeep hash of the file.
+      type: String
+    - contextPath: File.EntryID
+      description: The entry ID of the file.
+      type: String
+    - contextPath: File.Info
+      description: File information.
+      type: String
+    - contextPath: File.Type
+      description: The file type.
+      type: String
+    - contextPath: File.MD5
+      description: The MD5 hash of the file.
+      type: String
+    - contextPath: File.Extension
+      description: The file extension.
+      type: String
   dockerimage: demisto/threatconnect-py3-sdk:1.0.0.8854
   runonce: false
   subtype: python3

--- a/Packs/ThreatConnect/ReleaseNotes/2_0_4.md
+++ b/Packs/ThreatConnect/ReleaseNotes/2_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ThreatConnect v2
+- Added ***tc-download-report*** command.

--- a/Packs/ThreatConnect/ReleaseNotes/2_0_4.md
+++ b/Packs/ThreatConnect/ReleaseNotes/2_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ThreatConnect v2
-- Added ***tc-download-report*** command.
+- Added the ***tc-download-report*** command to download group reports in PDF.

--- a/Packs/ThreatConnect/TestPlaybooks/ThreatConnect_v2_-_Test.yml
+++ b/Packs/ThreatConnect/TestPlaybooks/ThreatConnect_v2_-_Test.yml
@@ -1373,7 +1373,6 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
-        description: ""
       index: {}
       key: {}
       keysToKeep: {}

--- a/Packs/ThreatConnect/TestPlaybooks/ThreatConnect_v2_-_Test.yml
+++ b/Packs/ThreatConnect/TestPlaybooks/ThreatConnect_v2_-_Test.yml
@@ -869,6 +869,7 @@ tasks:
     nexttasks:
       '#none#':
       - "25"
+      - "54"
     scriptarguments:
       group_id:
         simple: ${TC.Campaign.ID}
@@ -912,7 +913,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": -860,
+          "x": -1070,
           "y": 1955
         }
       }
@@ -1372,6 +1373,7 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
+        description: ""
       index: {}
       key: {}
       keysToKeep: {}
@@ -1871,6 +1873,40 @@ tasks:
     ignoreworker: false
     skipunavailable: false
     quietmode: 0
+  "54":
+    id: "54"
+    taskid: 9e0c933e-5f52-47fb-826b-6365e7b911f6
+    type: regular
+    task:
+      id: 9e0c933e-5f52-47fb-826b-6365e7b911f6
+      version: -1
+      name: tc-download-report
+      script: tc-download-report
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "40"
+    scriptarguments:
+      group_id:
+        simple: ${TC.Campaign.ID}
+      group_type:
+        simple: campaigns
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": -630,
+          "y": 1955
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+
 view: |-
   {
     "linkLabelsPosition": {},

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "2.0.3",
+    "currentVersion": "2.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/22513

## Description
added the command ***tc-download-report***.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests