### PR TITLE
Gmail bugfix send mail

### DIFF
--- a/Packs/Gmail/Integrations/Gmail/Gmail.py
+++ b/Packs/Gmail/Integrations/Gmail/Gmail.py
@@ -1670,7 +1670,7 @@ def send_mail(emailto, emailfrom, subject, body, entry_ids, cc, bcc, htmlBody, r
         # if there is only body and no attachments to the mail , we would like to send it without attaching every part
         message = MIMEText(body, 'plain', 'utf-8')  # type: ignore
     else:
-        message = MIMEMultipart()  # type: ignore
+        message = MIMEMultipart('alternative') if body and htmlBody else MIMEMultipart()  # type: ignore
 
     message['to'] = header(','.join(emailto))
     message['cc'] = header(','.join(cc))

--- a/Packs/Gmail/Integrations/Gmail/Gmail.yml
+++ b/Packs/Gmail/Integrations/Gmail/Gmail.yml
@@ -1836,7 +1836,7 @@ script:
     - contextPath: Gmail.Role.Privilege.Name
       description: The name of the privilege.
       type: String
-  dockerimage: demisto/google-api:1.0.0.10497
+  dockerimage: demisto/google-api:1.0.0.10663
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/Gmail/ReleaseNotes/1_0_4.md
+++ b/Packs/Gmail/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Gmail
+- Fixed handling of sending emails with both textual body and HTML body.

--- a/Packs/Gmail/ReleaseNotes/1_0_4.md
+++ b/Packs/Gmail/ReleaseNotes/1_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Gmail
-- Fixed handling of sending emails with both textual body and HTML body.
+- Fixed an issue where the ***send-email*** command sends emails with both the textual body and HTML body.

--- a/Packs/Gmail/pack_metadata.json
+++ b/Packs/Gmail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Gmail",
     "description": "Gmail API and user management (This integration replaces the Gmail functionality in the GoogleApps API and G Suite integration).",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/content/pull/8167

## Description
Fixes a bug where in Gmail integration where send-mail command would send both body and htmlBody

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/46294017/90331730-7c935780-dfbf-11ea-9622-8f3216b31f8f.png)
After:
![image](https://user-images.githubusercontent.com/46294017/90331786-f4618200-dfbf-11ea-99fc-54cacbc79793.png)


## Minimum version of Demisto
- [x] 5.0.0
- [x] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [x] Yes
       - It's possible that there are some customers that may expect the incorrect behavior when sending emails with both `body` and `htmlBody` arguments...

## Must have
- [ ] Tests
- [ ] Documentation 
