### PR TITLE
Changing WordTokenizerNLP docker image to dl:1.4

### DIFF
--- a/Packs/Base/Scripts/WordTokenizerV2/WordTokenizerV2.yml
+++ b/Packs/Base/Scripts/WordTokenizerV2/WordTokenizerV2.yml
@@ -186,7 +186,7 @@ tags:
 - ml
 timeout: 60µs
 type: python
-dockerimage: demisto/dl:1.2
+dockerimage: demisto/dl:1.4
 runas: DBotWeakRole
 runonce: true
 tests:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
Changing WordTokenizerNLP docker image to dl:1.4

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

## Demisto Partner?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**

