### PR TITLE
Crowdstrike Falcon X  - emphasising the file identifiers change in the readme

### DIFF
--- a/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/README.md
+++ b/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/README.md
@@ -19,7 +19,7 @@ After you successfully execute a command, a DBot message appears in the War Room
 ### cs-fx-upload-file
 ***
 Uploads a file for sandbox analysis.
-Notice that the file identifier (sha) can be changed as seen in the example below.
+Notice that the file identifier (SHA) can be changed as shown in the example below.
 
 #### Base Command
 
@@ -69,7 +69,7 @@ Notice that the file identifier (sha) can be changed as seen in the example belo
 ### cs-fx-submit-uploaded-file
 ***
 Submits a sample SHA256 hash for sandbox analysis.
-Notice that the file identifiers, sha and id are not the same.
+Notice that the file identifiers, SHA and ID are not the same.
 
 
 #### Base Command

--- a/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/README.md
+++ b/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/README.md
@@ -19,7 +19,7 @@ After you successfully execute a command, a DBot message appears in the War Room
 ### cs-fx-upload-file
 ***
 Uploads a file for sandbox analysis.
-
+Notice that the file identifier (sha) can be changed as seen in the example below.
 
 #### Base Command
 
@@ -69,6 +69,7 @@ Uploads a file for sandbox analysis.
 ### cs-fx-submit-uploaded-file
 ***
 Submits a sample SHA256 hash for sandbox analysis.
+Notice that the file identifiers, sha and id are not the same.
 
 
 #### Base Command


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27458

## Description
When a file is uploaded using the CrowdStrike FalconX integration, its identifier is changing.
It happens again when the uploaded file is submitted.
In order to emphasising this change an extra explanation was added to the readme.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
