### PR TITLE
CofenseTriage Force attachment type to be string; Add .swp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TestData/EmailWithNonUnicodeAttachmentName.eml
 TestData/EmailWithNonUnicodeSubject.eml
 Integrations/SymantecMSS/test_data/SymantecXML.txt
 *.pyc
+*.swp
 .pytest_cache
 .python-version
 CommonServerPython.py

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
@@ -425,7 +425,7 @@ def get_reporter_command(triage_instance) -> None:
 
 
 def get_attachment_command(triage_instance) -> None:
-    attachment_id = demisto.getArg('attachment_id')  # type: str
+    attachment_id = str(demisto.getArg('attachment_id'))  # type: str
     file_name = demisto.getArg('file_name') or attachment_id  # type: str
 
     res = triage_instance.request(f'attachment/{attachment_id}', raw_response=True)

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
@@ -324,7 +324,7 @@ script:
           type: string
       description: Threat Indicators that are designated by analysts as malicious, suspicious
         or benign
-  dockerimage: demisto/chromium:1.0.0.7857
+  dockerimage: demisto/chromium:1.0.0.10664
   isfetch: true
   runonce: false
 tests:

--- a/Packs/CofenseTriage/ReleaseNotes/1_1_3.md
+++ b/Packs/CofenseTriage/ReleaseNotes/1_1_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cofense Triage v2
+- Fixed an issue in *cofense-get-attachment* command.

--- a/Packs/CofenseTriage/pack_metadata.json
+++ b/Packs/CofenseTriage/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cofense Triage",
     "description": "Use the Cofense Triage integration to manage reports and attachments.",
     "support": "partner",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Cofense",
     "url": "https://cofense.com/contact-support/",
     "email": "support@cofense.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Cofense was throwing an error when getting the attachment if the attachment was ID was reference in context.  This is because this value needs to be passed as a string to the API call. 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

