### PR TITLE
Reformat STIX indicator layouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
     environment:
       CONTENT_VERSION: "20.8.2"
       SERVER_VERSION: "6.0.0"
-      GIT_SHA1: "6bee490e79e851e5f23572ad65cd456022eea753" # guardrails-disable-line disable-secrets-detection
+      GIT_SHA1: "6ccc03f58cb720062129adf0ec50a111ee96b7b5" # guardrails-disable-line disable-secrets-detection
       NON_AMI_RUN: << pipeline.parameters.non_ami_run >>
       ARTIFACT_BUILD_NUM: << pipeline.parameters.artifact_build_num >>
       SERVER_BRANCH_NAME: << pipeline.parameters.server_branch_name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
     environment:
       CONTENT_VERSION: "20.8.2"
       SERVER_VERSION: "6.0.0"
-      GIT_SHA1: "6ccc03f58cb720062129adf0ec50a111ee96b7b5" # guardrails-disable-line disable-secrets-detection
+      GIT_SHA1: "6bee490e79e851e5f23572ad65cd456022eea753" # guardrails-disable-line disable-secrets-detection
       NON_AMI_RUN: << pipeline.parameters.non_ami_run >>
       ARTIFACT_BUILD_NUM: << pipeline.parameters.artifact_build_num >>
       SERVER_BRANCH_NAME: << pipeline.parameters.server_branch_name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ parameters:
 references:
   environment: &environment
     environment:
-      CONTENT_VERSION: "20.8.1"
+      CONTENT_VERSION: "20.8.2"
       SERVER_VERSION: "6.0.0"
       GIT_SHA1: "6bee490e79e851e5f23572ad65cd456022eea753" # guardrails-disable-line disable-secrets-detection
       NON_AMI_RUN: << pipeline.parameters.non_ami_run >>

--- a/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Attack_Pattern.json
+++ b/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Attack_Pattern.json
@@ -404,9 +404,11 @@
 				],
 				"type": "custom"
 			}
-		]
+		],
+		"typeId": "Attack Pattern",
+		"version": -1
 	},
-	"typeId": "STIX Attack Pattern",
+	"typeId": "Attack Pattern",
 	"fromVersion": "5.5.0",
 	"toVersion": "5.9.9",
 	"version": -1

--- a/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Malware.json
+++ b/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Malware.json
@@ -413,10 +413,11 @@
 				],
 				"type": "custom"
 			}
-
-	]
+		],
+		"typeId": "Malware",
+		"version": -1
 	},
-	"typeId": "STIX Malware",
+	"typeId": "Malware",
 	"version": -1,
 	"fromVersion": "5.5.0",
 	"toVersion": "5.9.9"

--- a/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Report.json
+++ b/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Report.json
@@ -393,9 +393,11 @@
 				],
 				"type": "custom"
 			}
-		]
+		],
+		"typeId": "Report",
+		"version": -1
 	},
-	"typeId": "STIX Report",
+	"typeId": "Report",
 	"version": -1,
 	"fromVersion": "5.5.0",
 	"toVersion": "5.9.9"

--- a/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Threat_Actor.json
+++ b/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Threat_Actor.json
@@ -462,9 +462,11 @@
 				],
 				"type": "custom"
 			}
-		]
+		],
+		"typeId": "Threat Actor",
+		"version": -1
 	},
-	"typeId": "STIX Threat Actor",
+	"typeId": "Threat Actor",
 	"version": -1,
 	"fromVersion": "5.5.0",
 	"toVersion": "5.9.9"

--- a/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Tool.json
+++ b/Packs/CommonTypes/Layouts/layout-indicatorsDetails-STIX_Tool.json
@@ -422,9 +422,11 @@
 				],
 				"type": "custom"
 			}
-		]
+		],
+		"typeId": "Tool",
+		"version": -1
 	},
-	"typeId": "STIX Tool",
+	"typeId": "Tool",
 	"version": -1,
 	"fromVersion": "5.5.0",
 	"toVersion": "5.9.9"

--- a/Packs/CommonTypes/ReleaseNotes/1_8_6.md
+++ b/Packs/CommonTypes/ReleaseNotes/1_8_6.md
@@ -1,0 +1,7 @@
+
+#### Layouts
+- **STIX Malware**
+- **STIX Report**
+- **STIX Threat Actor**
+- **STIX Tool**
+- **STIX Attack Pattern**

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "1.8.5",
+    "currentVersion": "1.8.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
- Reformatted STIX indicator layouts and added missing `typeId` and `version` fields
- Set the right indicator type ID
- bump to content release 20.8.2
