### PR TITLE
Run GitHub Actions Workflow to Sync Contribution Base Branches Only in `demisto/content`

### DIFF
--- a/.github/workflows/sync-contribution-base-branch.yml
+++ b/.github/workflows/sync-contribution-base-branch.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sync_contributor_base_branch:
     runs-on: ubuntu-latest
-    if: contains(github.repository, 'demisto/content')
+    if: github.repository == 'demisto/content'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/xsoar-contrib/content/actions?query=workflow%3A%22Sync+contributor+base+branch%22

## Description
Forks of the `demisto/content` repo were unintentionally having this GitHub Actions workflow scheduled job execute (and fail because bad credentials). This will restrict the job so that it doesn't run on forks but only on the `demisto/content` repository.

## Minimum version of Demisto
- [x] 5.0.0
- [x] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests - N/A
- [x] Documentation - N/A

