### PR TITLE
CyberArk PAS - adding cyberark-pas-account-get-details command

### DIFF
--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.py
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.py
@@ -82,7 +82,7 @@ def filter_by_score(events_data: list, score: int) -> list:
 
 class Client(BaseClient):
     """
-    Client to use in the CrowdStrikeFalconX integration. Uses BaseClient
+    Client to use in the CyberArk PAS integration. Uses BaseClient
     """
 
     def __init__(self, server_url: str, username: str, password: str, use_ssl: bool, proxy: bool, max_fetch: int):
@@ -465,6 +465,12 @@ class Client(BaseClient):
                                   account_id: str,
                                   ):
         url_suffix = f"/PasswordVault/api/Accounts/{account_id}/Activities"
+        return self._http_request("GET", url_suffix)
+
+    def get_account_details(self,
+                            account_id: str,
+                            ):
+        url_suffix = f"/PasswordVault/api/Accounts/{account_id}"
         return self._http_request("GET", url_suffix)
 
     def change_credentials_random_password(self,
@@ -1118,6 +1124,25 @@ def get_list_account_activity_command(
     return results
 
 
+def get_account_details_command(
+        client: Client,
+        account_id: str = "",
+) -> CommandResults:
+    """Returns information of a specific account that is identified by its account id.
+    :param client: The client object with an access token
+    :param account_id: The id of the account whose details will be retrieved.
+    :return: CommandResults
+    """
+    response = client.get_account_details(account_id)
+    results = CommandResults(
+        raw_response=response,
+        outputs_prefix='CyberArkPAS.Accounts',
+        outputs_key_field='id',
+        outputs=response
+    )
+    return results
+
+
 def change_credentials_random_password_command(
         client: Client,
         account_id: str,
@@ -1327,6 +1352,7 @@ def main():
         'cyberark-pas-account-delete': delete_account_command,
         'cyberark-pas-accounts-list': get_list_accounts_command,
         'cyberark-pas-account-get-list-activity': get_list_account_activity_command,
+        'cyberark-pas-account-get-details': get_account_details_command,
 
         'cyberark-pas-credentials-change-random-password': change_credentials_random_password_command,
         'cyberark-pas-credentials-change-set-new-password': change_credentials_set_new_password_command,

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.yml
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.yml
@@ -1177,14 +1177,14 @@ script:
       type: String
   - arguments:
       - default: false
-        description: The ID of the account whose information will be retrieved.
+        description: The ID of the account for which to retrieve information.
         isArray: false
         name: account_id
         required: true
         secret: false
     deprecated: false
-    description: Returns information of a specific account that is identified by
-      its account ID.
+    description: Returns information for the specified account, identified by
+      the account ID.
     execution: false
     name: cyberark-pas-account-get-details
     outputs:
@@ -1192,7 +1192,7 @@ script:
         description: The unique ID of the account.
         type: String
       - contextPath: CyberArkPAS.Accounts.categoryModificationTime
-        description: The last modified date of the account.
+        description: The date the account was last modified.
         type: Number
       - contextPath: CyberArkPAS.Accounts.createdTime
         description: The date the account was created.

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.yml
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS.yml
@@ -1176,6 +1176,49 @@ script:
       description: The names or addresses of the machine where the accounts are used.
       type: String
   - arguments:
+      - default: false
+        description: The ID of the account whose information will be retrieved.
+        isArray: false
+        name: account_id
+        required: true
+        secret: false
+    deprecated: false
+    description: Returns information of a specific account that is identified by
+      its account ID.
+    execution: false
+    name: cyberark-pas-account-get-details
+    outputs:
+      - contextPath: CyberArkPAS.Accounts.id
+        description: The unique ID of the account.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.categoryModificationTime
+        description: The last modified date of the account.
+        type: Number
+      - contextPath: CyberArkPAS.Accounts.createdTime
+        description: The date the account was created.
+        type: Number
+      - contextPath: CyberArkPAS.Accounts.name
+        description: The name of the account.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.platformId
+        description: The platform assigned to this account.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.safeName
+        description: The safe where the account is created.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.secretManagement
+        description: Whether the account secret is automatically managed by the CPM.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.secretType
+        description: The type of password.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.userName
+        description: The name of the account user.
+        type: String
+      - contextPath: CyberArkPAS.Accounts.address
+        description: The name or address of the machine where the account will be used.
+        type: String
+  - arguments:
     - default: false
       description: The ID of the account whose activities will be retrieved.
       isArray: false
@@ -1326,7 +1369,7 @@ script:
     - contextPath: CyberArkPAS.SecurityEvents.type
       description: The type of the security events.
       type: String
-  dockerimage: demisto/python3:3.8.5.10455
+  dockerimage: demisto/python3:3.8.5.10845
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS_test.py
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/CyberArkPAS_test.py
@@ -3,19 +3,21 @@ import pytest
 from CyberArkPAS import Client, add_user_command, get_users_command, \
     update_user_command, add_safe_command, update_safe_command, get_list_safes_command, get_safe_by_name_command, \
     add_safe_member_command, update_safe_member_command, list_safe_members_command, add_account_command, \
-    update_account_command, get_list_accounts_command, get_list_account_activity_command, fetch_incidents
+    update_account_command, get_list_accounts_command, get_list_account_activity_command, fetch_incidents, \
+    get_account_details_command
 from test_data.context import ADD_USER_CONTEXT, GET_USERS_CONTEXT, \
     UPDATE_USER_CONTEXT, UPDATE_SAFE_CONTEXT, GET_LIST_SAFES_CONTEXT, GET_SAFE_BY_NAME_CONTEXT, ADD_SAFE_CONTEXT, \
     ADD_SAFE_MEMBER_CONTEXT, UPDATE_SAFE_MEMBER_CONTEXT, LIST_SAFE_MEMBER_CONTEXT, ADD_ACCOUNT_CONTEXT, \
     UPDATE_ACCOUNT_CONTEXT, GET_LIST_ACCOUNT_CONTEXT, GET_LIST_ACCOUNT_ACTIVITIES_CONTEXT, INCIDENTS, INCIDENTS_AFTER_FETCH, \
-    INCIDENTS_LIMITED_BY_MAX_SIZE, INCIDENTS_FILTERED_BY_SCORE
+    INCIDENTS_LIMITED_BY_MAX_SIZE, INCIDENTS_FILTERED_BY_SCORE, GET_ACCOUNT_CONTEXT
 from test_data.http_resonses import ADD_USER_RAW_RESPONSE, \
     UPDATE_USER_RAW_RESPONSE, GET_USERS_RAW_RESPONSE, ADD_SAFE_RAW_RESPONSE, UPDATE_SAFE_RAW_RESPONSE, \
     GET_LIST_SAFES_RAW_RESPONSE, GET_SAFE_BY_NAME_RAW_RESPONSE, ADD_SAFE_MEMBER_RAW_RESPONSE, \
     UPDATE_SAFE_MEMBER_RAW_RESPONSE, LIST_SAFE_MEMBER_RAW_RESPONSE, ADD_ACCOUNT_RAW_RESPONSE, \
     UPDATE_ACCOUNT_RAW_RESPONSE, GET_LIST_ACCOUNT_RAW_RESPONSE, GET_LIST_ACCOUNT_ACTIVITIES_RAW_RESPONSE, \
     GET_SECURITY_EVENTS_RAW_RESPONSE, GET_SECURITY_EVENTS_WITH_UNNECESSARY_INCIDENT_RAW_RESPONSE, \
-    GET_SECURITY_EVENTS_WITH_15_INCIDENT_RAW_RESPONSE
+    GET_SECURITY_EVENTS_WITH_15_INCIDENT_RAW_RESPONSE, GET_ACCOUNT_RAW_RESPONSE
+
 
 ADD_USER_ARGS = {
     "change_password_on_the_next_logon": "true",
@@ -98,6 +100,10 @@ UPDATE_ACCOUNT_ARGS = {
     "account_name": "NewName"
 }
 
+GET_ACCOUNT_ARGS = {
+    "account_id": "11_1",
+}
+
 GET_LIST_ACCOUNT_ARGS = {
     "limit": "2",
     "offset": "0"
@@ -121,6 +127,7 @@ GET_LIST_ACCOUNT_ACTIVITIES_ARGS = {
     (list_safe_members_command, LIST_SAFE_MEMBER_ARGS, LIST_SAFE_MEMBER_RAW_RESPONSE, LIST_SAFE_MEMBER_CONTEXT),
     (add_account_command, ADD_ACCOUNT_ARGS, ADD_ACCOUNT_RAW_RESPONSE, ADD_ACCOUNT_CONTEXT),
     (update_account_command, UPDATE_ACCOUNT_ARGS, UPDATE_ACCOUNT_RAW_RESPONSE, UPDATE_ACCOUNT_CONTEXT),
+    (get_account_details_command, GET_ACCOUNT_ARGS, GET_ACCOUNT_RAW_RESPONSE, GET_ACCOUNT_CONTEXT),
     (get_list_accounts_command, GET_LIST_ACCOUNT_ARGS, GET_LIST_ACCOUNT_RAW_RESPONSE, GET_LIST_ACCOUNT_CONTEXT),
     (get_list_account_activity_command, GET_LIST_ACCOUNT_ACTIVITIES_ARGS, GET_LIST_ACCOUNT_ACTIVITIES_RAW_RESPONSE,
      GET_LIST_ACCOUNT_ACTIVITIES_CONTEXT),
@@ -144,6 +151,7 @@ def test_cyberark_pas_commands(command, args, http_response, context, mocker):
 
     outputs = command(client, **args)
     results = outputs.to_context()
+
     assert results.get("EntryContext") == context
 
 

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/README.md
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/README.md
@@ -1531,6 +1531,77 @@ Returns the activities of a specific account that is identified by its account I
 >| Add File Category | 105 | false | 1 | 1597863168 | CreationMethod | Value=[ABC] | Administrator |
 
 
+### cyberark-pas-account-get-details
+***
+Returns information of a specific account that is identified by its account ID.
+
+
+#### Base Command
+
+`cyberark-pas-account-get-details`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| account_id | The ID of the account whose information will be retrieved. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| CyberArkPAS.Accounts.id | String | The unique ID of the account. | 
+| CyberArkPAS.Accounts.categoryModificationTime | Number | The last modified date of the account. | 
+| CyberArkPAS.Accounts.createdTime | Number | The date the account was created. | 
+| CyberArkPAS.Accounts.name | String | The name of the account. | 
+| CyberArkPAS.Accounts.platformId | String | The platform assigned to this account. | 
+| CyberArkPAS.Accounts.safeName | String | The safe where the account is created. | 
+| CyberArkPAS.Accounts.secretManagement | String | Whether the account secret is automatically managed by the CPM. | 
+| CyberArkPAS.Accounts.secretType | String | The type of password. | 
+| CyberArkPAS.Accounts.userName | String | The name of the account user. | 
+| CyberArkPAS.Accounts.address | String | The name or address of the machine where the account will be used. | 
+
+
+#### Command Example
+```!cyberark-pas-account-get-details account_id=46_7```
+
+#### Context Example
+```
+{
+    "CyberArkPAS": {
+        "Accounts": {
+            "address": "address.com",
+            "categoryModificationTime": 1597581174,
+            "createdTime": 1595431869,
+            "id": "46_7",
+            "name": "Operating System-UnixSSH",
+            "platformAccountProperties": {
+                "Tags": "SSH",
+                "UseSudoOnReconcile": "No"
+            },
+            "platformId": "UnixSSH",
+            "safeName": "Linux Accounts",
+            "secretManagement": {
+                "automaticManagementEnabled": true,
+                "lastModifiedTime": 1595417469,
+                "lastReconciledTime": 1576120341,
+                "status": "success"
+            },
+            "secretType": "password",
+            "userName": "user1"
+        }
+    }
+}
+```
+
+#### Human Readable Output
+
+>### Results
+>|address|categoryModificationTime|createdTime|id|name|platformAccountProperties|platformId|safeName|secretManagement|secretType|userName|
+>|---|---|---|---|---|---|---|---|---|---|---|
+>| address | 1597581174 | 1595431869 | 46_7 | Operating System-UnixSSH | UseSudoOnReconcile: No<br/>Tags: SSH | UnixSSH | Linux Accounts | automaticManagementEnabled: true<br/>status: success<br/>lastModifiedTime: 1595417469<br/>lastReconciledTime: 1576120341 | password | user1 |
+
+
 
 ### cyberark-pas-credentials-change-in-vault-only
 ***

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/README.md
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/README.md
@@ -1533,7 +1533,7 @@ Returns the activities of a specific account that is identified by its account I
 
 ### cyberark-pas-account-get-details
 ***
-Returns information of a specific account that is identified by its account ID.
+Returns information for the specified account, identified by the account ID.
 
 
 #### Base Command
@@ -1543,7 +1543,7 @@ Returns information of a specific account that is identified by its account ID.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| account_id | The ID of the account whose information will be retrieved. | Required | 
+| account_id | The ID of the account for which to retrieve information. | Required | 
 
 
 #### Context Output
@@ -1551,7 +1551,7 @@ Returns information of a specific account that is identified by its account ID.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | CyberArkPAS.Accounts.id | String | The unique ID of the account. | 
-| CyberArkPAS.Accounts.categoryModificationTime | Number | The last modified date of the account. | 
+| CyberArkPAS.Accounts.categoryModificationTime | Number | The date the account was last modified. | 
 | CyberArkPAS.Accounts.createdTime | Number | The date the account was created. | 
 | CyberArkPAS.Accounts.name | String | The name of the account. | 
 | CyberArkPAS.Accounts.platformId | String | The platform assigned to this account. | 

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/test_data/context.py
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/test_data/context.py
@@ -506,6 +506,19 @@ UPDATE_ACCOUNT_CONTEXT = {
   }
 }
 
+GET_ACCOUNT_CONTEXT = {
+  'CyberArkPAS.Accounts(val.id == obj.id)': {'categoryModificationTime': 1597581174, 'id': '11_1',
+                                             'name': 'Operating System-UnixSSH', 'address': 'address',
+                                             'userName': 'firecall2', 'platformId': 'UnixSSH',
+                                             'safeName': 'Linux Accounts', 'secretType': 'password',
+                                             'platformAccountProperties': {'UseSudoOnReconcile': 'No',
+                                                                           'Tags': 'SSH'},
+                                             'secretManagement': {'automaticManagementEnabled': True,
+                                                                  'status': 'success',
+                                                                  'lastModifiedTime': 1595417469,
+                                                                  'lastReconciledTime': 1576120341},
+                                             'createdTime': 1595431869}}
+
 GET_LIST_ACCOUNT_CONTEXT = {
   "CyberArkPAS.Accounts(val.id == obj.id)": [
     {

--- a/Packs/CyberArkPAS/Integrations/CyberArkPAS/test_data/http_resonses.py
+++ b/Packs/CyberArkPAS/Integrations/CyberArkPAS/test_data/http_resonses.py
@@ -149,6 +149,16 @@ ADD_ACCOUNT_RAW_RESPONSE = {"address": "/", "categoryModificationTime": 15948350
                                                  "lastModifiedTime": 1594824056}, "secretType": "password",
                             "userName": "TestUser"}
 
+GET_ACCOUNT_RAW_RESPONSE = {'categoryModificationTime': 1597581174, 'id': '11_1',
+                            'name': 'Operating System-UnixSSH',
+                            'address': 'address', 'userName': 'firecall2', 'platformId': 'UnixSSH',
+                            'safeName': 'Linux Accounts',
+                            'secretType': 'password',
+                            'platformAccountProperties': {'UseSudoOnReconcile': 'No', 'Tags': 'SSH'},
+                            'secretManagement': {'automaticManagementEnabled': True, 'status': 'success',
+                                                 'lastModifiedTime': 1595417469,
+                                                 'lastReconciledTime': 1576120341}, 'createdTime': 1595431869}
+
 UPDATE_ACCOUNT_RAW_RESPONSE = {"address": "/", "categoryModificationTime": 1594835018, "createdTime": 1594838456,
                                "id": "77_4", "name": "NewName", "platformId": "WinServerLocal",
                                "safeName": "TestSafe", "secretManagement": {"automaticManagementEnabled": True,

--- a/Packs/CyberArkPAS/ReleaseNotes/1_0_2.md
+++ b/Packs/CyberArkPAS/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CyberArk PAS
+- Added the **cyberark-pas-account-get-details** command.

--- a/Packs/CyberArkPAS/ReleaseNotes/1_0_2.md
+++ b/Packs/CyberArkPAS/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CyberArk PAS
-- Added the **cyberark-pas-account-get-details** command.
+Added the ***cyberark-pas-account-get-details*** command.

--- a/Packs/CyberArkPAS/pack_metadata.json
+++ b/Packs/CyberArkPAS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CyberArk",
     "description": "Provides a Safe Haven, where all your administrative passwords can be securely archived, transferred and shared by authorized users.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27830

## Description
Part of the deprecation of the CyberArk AIM integration, moving the account-get-details command that uses the PAS API from the AIM integration to the PAS.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

