### PR TITLE
removed event argument from gmail-list-users command

### DIFF
--- a/Packs/Gmail/Integrations/Gmail/Gmail.py
+++ b/Packs/Gmail/Integrations/Gmail/Gmail.py
@@ -617,7 +617,6 @@ def list_users_command():
     args = demisto.args()
     domain = args.get('domain', ADMIN_EMAIL.split('@')[1])  # type: ignore
     customer = args.get('customer')
-    event = args.get('event')
     view_type = args.get('view-type-public-domain', 'admin_view')
     query = args.get('query')
     sort_order = args.get('sort-order')
@@ -628,17 +627,16 @@ def list_users_command():
         'custom_field_mask') if projection == 'custom' else None
     page_token = args.get('page-token')
 
-    users, next_page_token = list_users(domain, customer, event, query, sort_order, view_type,
+    users, next_page_token = list_users(domain, customer, query, sort_order, view_type,
                                         show_deleted, max_results, projection, custom_field_mask, page_token)
     return users_to_entry('Users:', users, next_page_token)
 
 
-def list_users(domain, customer=None, event=None, query=None, sort_order=None, view_type='admin_view',
+def list_users(domain, customer=None, query=None, sort_order=None, view_type='admin_view',
                show_deleted=False, max_results=100, projection='basic', custom_field_mask=None, page_token=None):
     command_args = {
         'domain': domain,
         'customer': customer,
-        'event': event,
         'viewType': view_type,
         'query': query,
         'sortOrder': sort_order,
@@ -1877,5 +1875,5 @@ def main():
 
 
 # python2 uses __builtin__ python3 uses builtins
-if __name__ == "__builtin__" or __name__ == "builtins":
+if __name__ in ("__builtin__", "builtins"):
     main()

--- a/Packs/Gmail/Integrations/Gmail/Gmail.yml
+++ b/Packs/Gmail/Integrations/Gmail/Gmail.yml
@@ -717,20 +717,6 @@ script:
       name: customer
       required: false
       secret: false
-    - auto: PREDEFINED
-      default: false
-      description: The event on which subscription intended (if subscribing). Can
-        be add/delete/makeAdmin/undelete/update
-      isArray: false
-      name: event
-      predefined:
-      - add
-      - delete
-      - makeAdmin
-      - undelete
-      - update
-      required: false
-      secret: false
     - default: false
       description: Maximum number of results to return. Default is 100. Maximum is
         500. Can be 1 to 500, inclusive.
@@ -1836,7 +1822,7 @@ script:
     - contextPath: Gmail.Role.Privilege.Name
       description: The name of the privilege.
       type: String
-  dockerimage: demisto/google-api:1.0.0.10663
+  dockerimage: demisto/google-api:1.0.0.10873
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/Gmail/ReleaseNotes/1_0_5.md
+++ b/Packs/Gmail/ReleaseNotes/1_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Gmail
-Removed deperecated argument *event* from the ***gmail-list-users*** command.
+Breaking Changes: Removed deprecated argument *event* from the ***gmail-list-users*** command.

--- a/Packs/Gmail/ReleaseNotes/1_0_5.md
+++ b/Packs/Gmail/ReleaseNotes/1_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Gmail
-Breaking Changes: Removed deprecated argument *event* from the ***gmail-list-users*** command.
+Breaking Change: Removed the deprecated *event* argument from the ***gmail-list-users*** command.

--- a/Packs/Gmail/ReleaseNotes/1_0_5.md
+++ b/Packs/Gmail/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Gmail
+Removed deperecated argument *event* from the ***gmail-list-users*** command.

--- a/Packs/Gmail/pack_metadata.json
+++ b/Packs/Gmail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Gmail",
     "description": "Gmail API and user management (This integration replaces the Gmail functionality in the GoogleApps API and G Suite integration).",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MailListener/TestPlaybooks/playbook-MailListener_Test.yml
+++ b/Packs/MailListener/TestPlaybooks/playbook-MailListener_Test.yml
@@ -79,10 +79,10 @@ tasks:
       version: -1
       name: Send mail with that subject
       description: Send an email
-      script: '|||send-mail'
+      script: 'Mail Sender (New)|||send-mail'
       type: regular
       iscommand: true
-      brand: ""
+      brand: "Mail Sender (New)"
     nexttasks:
       '#none#':
       - "3"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27361
fixes: https://github.com/demisto/etc/issues/27057
fixes: https://github.com/demisto/etc/issues/27362
fixes: https://github.com/demisto/etc/issues/27811
fixes: https://github.com/demisto/etc/issues/27845

## Description
removed event argument from `gmail-list-users` command, the argument was removed on in the Gmail API.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

