### PR TITLE
Fix DateStringToISOFormat Unit Test

### DIFF
--- a/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
+++ b/Packs/CommonScripts/Scripts/DateStringToISOFormat/DateStringToISOFormat_test.py
@@ -1,4 +1,5 @@
 from DateStringToISOFormat import parse_datestring_to_iso
+import demistomock as demisto
 import pytest
 
 
@@ -36,7 +37,7 @@ testdata = [
 
 
 @pytest.mark.parametrize('date_value,day_first,year_first,fuzzy,expected_output', testdata)
-def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expected_output, capfd):
+def test_parse_datestring_to_iso(mocker, date_value, day_first, year_first, fuzzy, expected_output):
     '''Scenario: Parse an arbitrary date string and convert it to ISO 8601 format
 
     Given
@@ -58,5 +59,5 @@ def test_parse_datestring_to_iso(date_value, day_first, year_first, fuzzy, expec
                       January 1, 2047 at 8:21:00AM".
         expected_output (str): The iso 8601 formatted date to check the result against
     '''
-    with capfd.disabled():
-        assert parse_datestring_to_iso(date_value, day_first, year_first, fuzzy) == expected_output
+    mocker.patch.object(demisto, 'error')
+    assert parse_datestring_to_iso(date_value, day_first, year_first, fuzzy) == expected_output


### PR DESCRIPTION
## Status
- [x] Ready

## Description
I was using `capfd.disable()` to suppress `stderr` that I was outputting expectedly in certain cases since `stderr` would fail the unit test. This was bad practice since this could swallow/mask other (non-expected) errors. I replaced the use of `capfd.disable()` with simply patching `demisto.error()`.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

