### PR TITLE
query-ai-3526: Updated QueryAI timeout

### DIFF
--- a/Packs/QueryAI/Integrations/QueryAI/QueryAI.py
+++ b/Packs/QueryAI/Integrations/QueryAI/QueryAI.py
@@ -9,16 +9,19 @@ import urllib.parse
 # Disable insecure warnings
 urllib3.disable_warnings()
 
+DEFAULT_TIMEOUT = 60    # in seconds
+
 
 class Client(BaseClient):   # type: ignore
 
     def __init__(self, base_url, verify=True, proxy=False, ok_codes=tuple(), headers=None, auth=None,
-                 email=None, license_key=None, connection_params='{}', alias=None):
+                 email=None, license_key=None, connection_params='{}', alias=None, timeout=DEFAULT_TIMEOUT):
         super().__init__(base_url, verify, proxy, ok_codes, headers, auth)
         self._email = email
         self._license_key = license_key
         self.alias = alias
         self.connection_params = safe_load_json(connection_params) if connection_params else {}
+        self.timeout = timeout
 
     def queryai_http_request(self, method, url_suffix, json_data=None, params=None, data=None, **kwargs):
         if not json_data:
@@ -32,7 +35,7 @@ class Client(BaseClient):   # type: ignore
             params=params,
             json_data=json_data,
             data=data,
-            timeout=60,
+            timeout=self.timeout,
             **kwargs
         )
 
@@ -183,6 +186,7 @@ def main() -> None:
     base_url = urljoin(demisto.params()['url'], '/api/v1')
     alias = demisto.params().get('alias')
     connection_params = demisto.params().get('connection_params', '{}')
+    timeout = int(demisto.params().get('timeout', DEFAULT_TIMEOUT))
 
     verify_certificate = not demisto.params().get('insecure', False)
     proxy = demisto.params().get('proxy', False)
@@ -199,6 +203,7 @@ def main() -> None:
             license_key=license_key,
             alias=alias,
             connection_params=connection_params,
+            timeout=timeout
         )
 
         if demisto.command() == 'test-module':

--- a/Packs/QueryAI/Integrations/QueryAI/QueryAI.py
+++ b/Packs/QueryAI/Integrations/QueryAI/QueryAI.py
@@ -32,6 +32,7 @@ class Client(BaseClient):   # type: ignore
             params=params,
             json_data=json_data,
             data=data,
+            timeout=60,
             **kwargs
         )
 

--- a/Packs/QueryAI/Integrations/QueryAI/QueryAI.yml
+++ b/Packs/QueryAI/Integrations/QueryAI/QueryAI.yml
@@ -24,6 +24,11 @@ configuration:
   name: connection_params
   required: true
   type: 12
+- display: Request Timeout (in seconds).
+  additionalinfo: Default value is 60 seconds.
+  name: timeout
+  required: false
+  type: 0
 - display: Trust any certificate (not secure)
   name: insecure
   required: false

--- a/Packs/QueryAI/ReleaseNotes/1_0_1.md
+++ b/Packs/QueryAI/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Query.AI
+- Updated request timeout

--- a/Packs/QueryAI/pack_metadata.json
+++ b/Packs/QueryAI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "QueryAI",
     "description": "Query.AI is a decentralized data access and analysis technology that simplifies security investigations across disparate platforms without data duplication.",
     "support": "partner",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Query.AI",
     "url": "https://www.query.ai",
     "email": "support@query.ai",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## XSOAR [Partner](https://xsoar.pan.dev/docs/partners/become-a-tech-partner)?
- [x] query-ai-3526: Updated QueryAI timeout

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Updated request timeout for Query.AI integration

## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
