### PR TITLE
Checkout contrib remote branch exists fix

### DIFF
--- a/Utils/checkout_contribution.sh
+++ b/Utils/checkout_contribution.sh
@@ -15,10 +15,17 @@ if [[ $2 == "true" ]]; then
     git pull
 fi
 
-git remote add $USER git@github.com:$USER/content.git
-git fetch $USER
-git checkout -t $USER/$BRANCH
-git pull
+git remote set-url $USER git@github.com:$USER/content.git
+LOCAL_BRANCH_EXISTS=$(git show-branch --list "${USER}/${BRANCH}")
+if [[ -z ${LOCAL_BRANCH_EXISTS} ]]; then
+      git fetch "${USER}"
+      git checkout -t "${USER}/${BRANCH}"
+      git pull
+else
+      git checkout "${USER}/${BRANCH}"
+      git switch "${BRANCH}"
+      git pull
+fi
 
 if [[ $2 == "true" ]]; then
     echo merging branch with origin/master

--- a/Utils/checkout_contribution.sh
+++ b/Utils/checkout_contribution.sh
@@ -15,13 +15,17 @@ if [[ $2 == "true" ]]; then
     git pull
 fi
 
+# if remote does not exists already add it, if exists re-add it.
 git remote set-url $USER git@github.com:$USER/content.git
+# Check if branch exists locally
 LOCAL_BRANCH_EXISTS=$(git show-branch --list "${USER}/${BRANCH}")
 if [[ -z ${LOCAL_BRANCH_EXISTS} ]]; then
+    # If branch does not exists - fetch and checkout to it with a trace to the origin.
       git fetch "${USER}"
       git checkout -t "${USER}/${BRANCH}"
       git pull
 else
+    # If branch already exists - checkout to it(will checkout to head) and switch to wanted branch.
       git checkout "${USER}/${BRANCH}"
       git switch "${BRANCH}"
       git pull


### PR DESCRIPTION
check if branch exists already and switches to it.


## XSOAR [Partner](https://xsoar.pan.dev/docs/partners/become-a-tech-partner)?
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27227

## Description
added checks if remote branch exists 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

