### PR TITLE
fixing error in parsing oproxy response

### DIFF
--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
@@ -87,7 +87,9 @@ class Client(BaseClient):
         api_url = oproxy_response.get('url')
         refresh_token = oproxy_response.get(REFRESH_TOKEN_CONST)
         instance_id = oproxy_response.get(INSTANCE_ID_CONST)
-        expires_in = int(oproxy_response.get(EXPIRES_IN, MINUTES_60))
+        # In case the response has EXPIRES_IN key with empty string as value, we need to make sure we don't try to cast
+        # an empty string to an int.
+        expires_in = int(oproxy_response.get(EXPIRES_IN, MINUTES_60) or 0)
         if not access_token or not api_url or not instance_id:
             raise DemistoException(f'Missing attribute in response: access_token, instance_id or api are missing.\n'
                                    f'Oproxy response: {oproxy_response}')

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
@@ -1211,7 +1211,7 @@ script:
       defaultValue: all
       description: The fields that are selected in the query. Selection can be "all"
         (same as *) or or a comma separated list of specific fields. List of fields can
-        be found after viewing all the outputted fields with "all". 
+        be found after viewing all the outputted fields with "all".
       isArray: true
       name: fields
       predefined:
@@ -1966,7 +1966,7 @@ script:
     - contextPath: CDL.Logging.URL.DestDeviceHost
       description: Hostname of the device session destination.
       type: String
-  dockerimage: demisto/python_pancloud_v2:1.0.0.10370
+  dockerimage: demisto/python_pancloud_v2:1.0.0.10828
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CortexDataLake/ReleaseNotes/1_2_2.md
+++ b/Packs/CortexDataLake/ReleaseNotes/1_2_2.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Cortex Data Lake
+Fixed an error with oproxy response parsing
+Updated docker image from 1.0.0.10370 to 1.0.0.10828

--- a/Packs/CortexDataLake/ReleaseNotes/1_2_2.md
+++ b/Packs/CortexDataLake/ReleaseNotes/1_2_2.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Cortex Data Lake
-Fixed an error with oproxy response parsing
-Updated docker image from 1.0.0.10370 to 1.0.0.10828
+- Fixed an error with parsing of authentication responses.
+- Updated the Docker image from 1.0.0.10370 to 1.0.0.10828.

--- a/Packs/CortexDataLake/pack_metadata.json
+++ b/Packs/CortexDataLake/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Data Lake",
     "description": "Palo Alto Networks Cortex Data Lake provides cloud-based, centralized log storage and aggregation for your on premise, virtual (private cloud and public cloud) firewalls, for Prisma Access, and for cloud-delivered services such as Cortex XDR",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24346
## Description
Failed with the following error 
```
Error: [Traceback (most recent call last):
   
   File "<string>", line 897, in <module>
   File "<string>", line 856, in main
   File "<string>", line 47, in __init__
   File "<string>", line 64, in _get_access_token
   File "<string>", line 90, in _oproxy_authorize
 ValueError: invalid literal for int() with base 10: ''
```

When executing this line `expires_in = int(oproxy_response.get(EXPIRES_IN, MINUTES_60))`
It seems like a case where the `EXPIRES_IN` key was in the dict but with empty string as value.
The solution is to add a fallback to 0 in case the value was empty string


