### PR TITLE
change elastic default Feed Type

### DIFF
--- a/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
+++ b/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
@@ -25,7 +25,7 @@ configuration:
     index. The Cortex XSOAR MT Shared Feed contains indicators shared by a tenant
     account in a multi-tenant environment. Generic Feed contains a feed in a format
     specified by the user
-  defaultvalue: Cortex XSOAR Feed
+  defaultvalue: Cortex XSOAR MT Shared Feed
   display: Feed Type
   hidden: false
   name: feed_type

--- a/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
+++ b/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
@@ -168,7 +168,7 @@ script:
     description: Gets indicators available in the configured Elasticsearch database.
     execution: false
     name: es-get-indicators
-  dockerimage: demisto/elasticsearch:1.0.0.10134
+  dockerimage: demisto/elasticsearch:1.0.0.11003
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedElasticsearch/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedElasticsearch/ReleaseNotes/1_0_6.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Elasticsearch Feed
+- Change the default ***Feed Type*** from ***Cortex XSOAR Feed*** to ***Cortex XSOAR MT Shared Feed***.
+- Docker image updated.

--- a/Packs/FeedElasticsearch/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedElasticsearch/ReleaseNotes/1_0_6.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Elasticsearch Feed
-- Change the default ***Feed Type*** from ***Cortex XSOAR Feed*** to ***Cortex XSOAR MT Shared Feed***.
-- Docker image updated.
+- Changed the default ***Feed Type*** from **Cortex XSOAR Feed** to **Cortex XSOAR MT Shared Feed**.
+- Updated the Docker image.

--- a/Packs/FeedElasticsearch/pack_metadata.json
+++ b/Packs/FeedElasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch Feed",
     "description": "Indicators feed from Elasticsearch database",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28320

## Description
- Change the default ***Feed Type*** from ***Cortex XSOAR Feed*** to ***Cortex XSOAR MT Shared Feed***.
- Docker image updated.

## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Documentation