### PR TITLE
MicrosoftCloudAppSecurity adding defaultValue to max_fetch

### DIFF
--- a/Packs/MicrosoftCloudAppSecurity/.pack-ignore
+++ b/Packs/MicrosoftCloudAppSecurity/.pack-ignore
@@ -1,2 +1,0 @@
-[file:MicrosoftCloudAppSecurity.yml]
-ignore=IN125

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
@@ -39,7 +39,7 @@ configuration:
   type: 16
 - display: Maximum alerts to fetch
   hidden: false
-  defaultValue: '50'
+  defaultvalue: '50'
   name: max_fetch
   required: false
   type: 0

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
@@ -39,6 +39,7 @@ configuration:
   type: 16
 - display: Maximum alerts to fetch
   hidden: false
+  defaultValue: '50'
   name: max_fetch
   required: false
   type: 0

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_2.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Cloud App Security
+- Maintenance and stability enhancements.

--- a/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
+++ b/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MicrosoftCloudAppSecurity",
     "description": "Microsoft Cloud App Security Integration, a Cloud Access Security Broker that supports various deployment modes",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Updated `demisto-sdk` to check if there is a `defaultValue` in the `max_fetch` param.
The defaultValue was set to 50 as it was defined in the integration in `DEFAULT_INCIDENT_TO_FETCH`.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

