### PR TITLE
Remove Welcome Bot Message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,0 @@
-newPRWelcomeComment: >
-  Hi and welcome to the Demisto Content project!
-  Thank you and congrats on your first pull request, we will review it soon!
-  Until then you can check out our [documentation](https://github.com/demisto/content/tree/master/docs) for more details.
-  We would be thrilled to see you get involved in our [Slack DFIR community](https://go.demisto.com/join-our-slack-community) for discussions.
-  Hope you have a great time here :)


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Removes the `Welcome` bot's message that is used to comment on new PRs. (We should also remove the `Welcome` bot from the repo)

## Minimum version of Demisto
- [x] 5.0.0
- [x] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
~~- Tests~~ N/A
~~- Documentation~~ N/A

