### PR TITLE
Fixing the logic for find none added packs

### DIFF
--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1234,8 +1234,9 @@ def get_non_added_packs_ids(build: Build):
     :param build: the build object
     :return: all non added packs i.e. unchanged packs (dependencies) and modified packs
     """
+    compare_against = 'origin/master{}'.format('' if not build.branch_name == 'master' else '~1')
     added_files = run_command(f'git diff --name-only --diff-filter=A '
-                              f'origin/master..refs/heads/{build.branch_name} -- Packs/*/pack_metadata.json')
+                              f'{compare_against}..refs/heads/{build.branch_name} -- Packs/*/pack_metadata.json')
     added_files = filter(lambda x: x, added_files.split('\n'))
     added_pack_ids = map(lambda x: x.split('/')[1], added_files)
     return set(get_pack_ids_to_install()) - set(added_pack_ids)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28468

## Description
changes the comparison against commit.
in standard branches against `origin/master`.
and `origin/master~1` in the master branch.