### PR TITLE
[NONE] Credentials, engine, and enable/disable integration options

### DIFF
--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -506,14 +506,18 @@ def __create_integration_instance(client, integration_name, integration_instance
                     'validate "Test": {})'.format(integration_name, instance_name, validate_test)
     prints_manager.add_print_job(start_message, print, thread_index)
 
+    # allow enabling/disabling and choosing an xsoar engine by UUID
+    engine = integration_params.get('engine', '')
+    enabled = integration_params.get('enabled', 'true')
+
     # define module instance
     module_instance = {
         'brand': configuration['name'],
         'category': configuration['category'],
         'configuration': configuration,
         'data': [],
-        'enabled': "true",
-        'engine': '',
+        'enabled': str(enabled),
+        'engine': engine,
         'id': '',
         'isIntegrationScript': is_byoi,
         'name': instance_name,
@@ -532,10 +536,10 @@ def __create_integration_instance(client, integration_name, integration_instance
             if key == 'credentials':
                 credentials = integration_params[key]
                 param_value = {
-                    'credential': '',
-                    'identifier': credentials['identifier'],
-                    'password': credentials['password'],
-                    'passwordChanged': False
+                    'credential': credentials.get('credential', ''),    # allow stored credentials
+                    'identifier': credentials.get('identifier', ''),    # or username/password
+                    'password': credentials.get('password', ''),
+                    'passwordChanged': credentials.get('passwordChanged', False)
                 }
             else:
                 param_value = integration_params[key]


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

Although this works, it may be a good idea to separate `enabled` and `engine` outside of the `params` node to avoid integration param name collisions but that would require changing the signature of method `__create_integration_instance`. If everyone is in agreement and no one minds the method signature changing, I can make the change.

## Related Issues
None that I know of

## Description
The test_integration script can be used to create/update an integration instance but in a very limited way. This PR addresses this issue and allows for configuring stored credentials, enabling/disabling instances, and selection of an xsoar-engine.

## Example AD integrations configured in conf.json
The following examples illustrate the new `engine` and `enabled` fields as well as shows how to use both stored credentials and username/password credentials

Example showing use of stored credentials
```
{
  "integrations": [
    {
      "name": "Active Directory Query v2",
      "params": {
        "engine": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
        "enabled": true,
        "integrationInstanceName": "instance_name_to_create_or_update",
        "base_dn": "dc=domain,dc=com",
        "credentials": {
          "credential": "stored_credential_id",
          "passwordChanged": true
        },
        "ntlm": false,
        "page_size": "500",
        "port": "636",
        "secure_connection": "SSL",
        "server_ip": "ad.server.tld",
        "unsecure": false
      }
    }
  ]
}
```

Example conf.json using username/password
```
{
  "integrations": [
    {
      "name": "Active Directory Query v2",
      "params": {
        "engine": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
        "enabled": true,
        "integrationInstanceName": "instance_name_to_create_or_update",
        "base_dn": "dc=domain,dc=com",
        "credentials": {
	  "identifier": "username",
	  "password": "password",
          "passwordChanged": true,
        },
        "ntlm": false,
        "page_size": "500",
        "port": "636",
        "secure_connection": "SSL",
        "server_ip": "ad.server.tld",
        "unsecure": false
      }
    }
  ]
}
```
## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

This was tested with 6.0.0 but it should work with anything the test_integrations.py script works with

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

