### PR TITLE
Only Sync Contrib Base Branch If It Isn't The Head Branch Of An Open Internal PR

### DIFF
--- a/Utils/contribution_sync/sync_contrib_base.py
+++ b/Utils/contribution_sync/sync_contrib_base.py
@@ -40,7 +40,7 @@ def get_branch_names_with_contrib(repo: Repository) -> List[str]:  # noqa: E999
             prs_with_branch_as_base = repo.get_pulls(state='OPEN', base=branch.name)
             if prs_with_branch_as_base.totalCount >= 1:
                 prs_with_branch_as_head = repo.get_pulls(state='OPEN', head=branch.name)
-                if not prs_with_branch_as_head.totalCount >= 1:
+                if prs_with_branch_as_head.totalCount == 0:
                     branch_names.append(branch.name)
     return branch_names
 

--- a/Utils/contribution_sync/sync_contrib_base.py
+++ b/Utils/contribution_sync/sync_contrib_base.py
@@ -39,7 +39,9 @@ def get_branch_names_with_contrib(repo: Repository) -> List[str]:  # noqa: E999
         if branch.name.startswith('contrib/'):
             prs_with_branch_as_base = repo.get_pulls(state='OPEN', base=branch.name)
             if prs_with_branch_as_base.totalCount >= 1:
-                branch_names.append(branch.name)
+                prs_with_branch_as_head = repo.get_pulls(state='OPEN', head=branch.name)
+                if not prs_with_branch_as_head.totalCount >= 1:
+                    branch_names.append(branch.name)
     return branch_names
 
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Can see this [internal PR](https://github.com/demisto/content/pull/8972) whose head branch was synced with `master` (therefore rendering the PR useless) because a [PR](https://github.com/demisto/content/pull/8974) to the branch `contrib/code42_master` was open at the time the scheduled sync automation executed. I've changed the sync automation to check if there is an open internal PR with the branch in question before adding it to the list of branches that should get synced with master.

## Minimum version of Demisto
- [x] 5.0.0
- [x] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
~~- Tests~~ N/A
~~- Documentation~~ N/A 

