### PR TITLE
[Documentation] Expanded demistomock docstring to emphasise incidents keys

### DIFF
--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -863,7 +863,7 @@ def createIncidents(incidents, lastRun=None, userID=None):
         List of incident objects to create, with the following required keys, and some common optional keys
             - name (required) - str
             - type (required) - if not provided will create unclassified incident) - str
-            - labels (required) - list of {"type": _, "value": _} objects
+            - labels (optonal) - list of {"type": _, "value": _} objects
             - rawJSON (required) - str
             - occurred (optional) - str
             - details (optional) - str

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -859,7 +859,12 @@ def createIncidents(incidents, lastRun=None, userID=None):
     Creates incident in long running execution
 
     Args:
-      incidents (list): List of incident objects to create
+      incidents (list): List of incident objects to create, with the following keys:
+        - name (required) - str
+        - type (required - if not provided will create unclassified incident) - str
+        - labels (required) - list
+        - rawJSON (required) - str
+        - occurred (optional) - str
       lastRun (dict): the LastRun object to set (Default value = None)
       userID lastIndicator: The user associated with the request (Default value = None)
 

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -859,12 +859,15 @@ def createIncidents(incidents, lastRun=None, userID=None):
     Creates incident in long running execution
 
     Args:
-      incidents (list): List of incident objects to create, with the following keys:
-        - name (required) - str
-        - type (required - if not provided will create unclassified incident) - str
-        - labels (required) - list
-        - rawJSON (required) - str
-        - occurred (optional) - str
+      incidents (list):
+        List of incident objects to create, with the following required keys, and some common optional keys
+            - name (required) - str
+            - type (required) - if not provided will create unclassified incident) - str
+            - labels (required) - list of {"type": _, "value": _} objects
+            - rawJSON (required) - str
+            - occurred (optional) - str
+            - details (optional) - str
+            - severity (optional) - str
       lastRun (dict): the LastRun object to set (Default value = None)
       userID lastIndicator: The user associated with the request (Default value = None)
 

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -862,7 +862,7 @@ def createIncidents(incidents, lastRun=None, userID=None):
       incidents (list):
         List of incident objects to create, with the following required keys, and some common optional keys
             - name (required) - str
-            - type (required) - if not provided will create unclassified incident) - str
+            - type (required - if not provided will create unclassified incident) - str
             - labels (optonal) - list of {"type": _, "value": _} objects
             - rawJSON (required) - str
             - occurred (optional) - str


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Added docstring detailing the fields that are expected to be in incidents when calling `demisto.createIncidents`, with emphasis on `type` - as it's not required by the server, but should be provided.