### PR TITLE
Updated role of several scripts - phase two

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_2_44.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_2_44.md
@@ -1,0 +1,27 @@
+
+#### Scripts
+##### IndicatorMaliciousRatioCalculation
+Updated the script to execute using the DBot role.
+
+##### GetDuplicatesMlv2
+Updated the script to execute using the LimitedUser role.
+
+##### DeleteContext
+Updated the script to execute using the DBot role.
+
+##### FindSimilarIncidents
+- Updated the script to execute using the DBot role.
+- Upgraded the Docker image to demisto/python:2.7.18.10627.
+
+##### SearchIncidentsV2
+- Updated the script to execute using the DBot role.
+- Upgraded the Docker image to demisto/python3:3.8.3.9324.
+
+##### DBotClosedIncidentsPercentage
+Updated the script to execute using the DBot role.
+
+##### MarkRelatedIncidents
+Updated the script to execute using the DBot role.
+
+##### findIncidentsWithIndicator
+Updated the script to execute using the DBot role.

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.yml
@@ -146,7 +146,9 @@ tags:
 - incidents
 timeout: 300ns
 type: python
-dockerimage: demisto/python:2.7.18.9326
+dockerimage: demisto/python:2.7.18.10627
+dockerimage45: demisto/python:2.7.18.9326
+runas: DBotRole
 runonce: false
 tests:
 - Dedup - Generic v2 - Test

--- a/Packs/CommonScripts/Scripts/GetDuplicatesMlv2/GetDuplicatesMlv2.yml
+++ b/Packs/CommonScripts/Scripts/GetDuplicatesMlv2/GetDuplicatesMlv2.yml
@@ -96,6 +96,7 @@ outputs:
   description: Similar incident name.
   type: string
 scripttarget: 0
+runas: DBotWeakRole
 runonce: false
 dockerimage: demisto/machine-learning
 tests:

--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
@@ -7,7 +7,8 @@ system: false
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.8.3.9324
+dockerimage: demisto/python3:3.8.5.10845
+dockerimage45: demisto/python3:3.8.3.9324
 tags:
 - Utility
 comment: Searches Demisto incidents
@@ -85,3 +86,4 @@ outputs:
   description: A list of incident due dates returned from the query.
 - contextPath: foundIncidents.phase
   description: A list of incident phases returned from the query.
+runas: DBotRole

--- a/Packs/CommonScripts/Scripts/script-DBotClosedIncidentsPercentage.yml
+++ b/Packs/CommonScripts/Scripts/script-DBotClosedIncidentsPercentage.yml
@@ -28,4 +28,5 @@ comment: Data output script for populating dashboard pie graph widget with the p
   of incidents closed by DBot vs. incidents closed by analysts
 enabled: true
 scripttarget: 0
+runas: DBotRole
 runonce: false

--- a/Packs/CommonScripts/Scripts/script-DBotClosedIncidentsPercentage.yml
+++ b/Packs/CommonScripts/Scripts/script-DBotClosedIncidentsPercentage.yml
@@ -30,3 +30,5 @@ enabled: true
 scripttarget: 0
 runas: DBotRole
 runonce: false
+tests:
+- No tests (auto formatted)

--- a/Packs/CommonScripts/Scripts/script-DeleteConext.yml
+++ b/Packs/CommonScripts/Scripts/script-DeleteConext.yml
@@ -136,5 +136,6 @@ args:
 - name: index
   description: index to delete in case 'key' argument was specified
 scripttarget: 0
+runas: DBotRole
 runonce: false
 sensitive: true

--- a/Packs/CommonScripts/Scripts/script-IndicatorMaliciousRatioCalculation.yml
+++ b/Packs/CommonScripts/Scripts/script-IndicatorMaliciousRatioCalculation.yml
@@ -123,3 +123,5 @@ timeout: 300ns
 runas: DBotRole
 runonce: false
 fromversion: "3.5.0"
+tests:
+- No tests (auto formatted)

--- a/Packs/CommonScripts/Scripts/script-IndicatorMaliciousRatioCalculation.yml
+++ b/Packs/CommonScripts/Scripts/script-IndicatorMaliciousRatioCalculation.yml
@@ -120,5 +120,6 @@ args:
   defaultValue: "no"
 scripttarget: 0
 timeout: 300ns
+runas: DBotRole
 runonce: false
 fromversion: "3.5.0"

--- a/Packs/CommonScripts/Scripts/script-MarkRelatedIncidents.yml
+++ b/Packs/CommonScripts/Scripts/script-MarkRelatedIncidents.yml
@@ -37,3 +37,5 @@ args:
   isArray: true
 scripttarget: 0
 runas: DBotRole
+tests:
+- No tests (auto formatted)

--- a/Packs/CommonScripts/Scripts/script-MarkRelatedIncidents.yml
+++ b/Packs/CommonScripts/Scripts/script-MarkRelatedIncidents.yml
@@ -36,3 +36,4 @@ args:
   description: The list of related incident IDs we want to mark
   isArray: true
 scripttarget: 0
+runas: DBotRole

--- a/Packs/CommonScripts/Scripts/script-findIncidentsWithIndicator.yml
+++ b/Packs/CommonScripts/Scripts/script-findIncidentsWithIndicator.yml
@@ -1,6 +1,6 @@
 commonfields:
   id: findIncidentsWithIndicator
-  version: -1 
+  version: -1
 name: findIncidentsWithIndicator
 script: |-
   var res = executeCommand("getIncidents", {"query": 'indicator.value:"'+args.indicator+'"'});
@@ -55,6 +55,7 @@ outputs:
   description: Indicator that was found in other incidents
 - contextPath: IncidentsWithIndicator.incidentIDs
   description: Incident IDs that the indicator was found in
+runas: DBotRole
 scripttarget: 0
 tests:
   - No test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.43",
+    "currentVersion": "1.2.44",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2,7 +2,7 @@
     "testTimeout": 160,
     "testInterval": 20,
     "tests": [
-         {
+        {
             "integrations": "SecurityIntelligenceServicesFeed",
             "playbookID": "SecurityIntelligenceServicesFeed - Test",
             "fromversion": "5.5.0"
@@ -3009,6 +3009,7 @@
         "PCAP File Carving Test": "Merged with PCAP Analysis Test",
         "PCAP Parsing And Indicator Enrichment Test": "Merged with PCAP Analysis Test",
         "PCAP Search test": "Merged with PCAP Analysis Test",
+        "Blueliv_ThreatContext_test": "community pack",
         "Protectwise-Test": "Issue 28168",
         "Phishing Classifier V2 ML Test": "Issue 26066",
         "CuckooTest": "Issue 25601",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28562
fixes: https://github.com/demisto/etc/issues/27980
phase one PR: https://github.com/demisto/content/pull/9009

## Description
scripts executing `setIncident`:
- [x] Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.py - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/NumberOfPhishingAttemptPerUser/NumberOfPhishingAttemptPerUser.py - already has `runas` settings.
- [x] Packs/CommonScripts/Scripts/script-findIncidentsWithIndicator.yml - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/script-MarkRelatedIncidents.yml - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/CompareIncidentsLabels/CompareIncidentsLabels.py - already has `runas` settings.
- [x] Packs/CommonScripts/Scripts/script-IndicatorMaliciousRatioCalculation.yml - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/script-DeleteConext.yml - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.py - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/script-DBotClosedIncidentsPercentage.yml - added `DBotRole`.
- [x] Packs/CommonScripts/Scripts/GetDuplicatesMlv2/GetDuplicatesMlv2.py - added `DBotWeakRole`.
- [x] Packs/CommonScripts/Scripts/CopyContextToField/CopyContextToField.py - already has `runas` settings.


scripts executing `setIncident`:
- [x] ~~Packs/CommonScripts/Scripts/SetGridField/SetGridField.py~~ - no need to modify, setting current incident.
- [x] Packs/CommonScripts/Scripts/PopulateCriticalAssets/PopulateCriticalAssets.py - already has `runas` settings.
- [x] Packs/CommonScripts/Scripts/script-ChangeRemediationSLAOnSevChange.yml - already has `runas` settings.
- [x] ~~Packs/CommonScripts/Scripts/script-SetDateField.yml~~ - no need to modify, setting current incident.
- [x] Packs/CommonScripts/Scripts/IncreaseIncidentSeverity/IncreaseIncidentSeverity.js - already has `runas` settings.
- [x] ~~Packs/CommonScripts/Scripts/script-SetTime.yml~~ - no need to modify, setting current incident.
- [x] Packs/CommonScripts/Scripts/CopyContextToField/CopyContextToField.py - already has `runas` settings.

