### PR TITLE
[Fix] QRadar v2 enrichment fails to enrich IP values

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v2/QRadar_v2.py
+++ b/Packs/QRadar/Integrations/QRadar_v2/QRadar_v2.py
@@ -602,7 +602,7 @@ def epoch_to_iso(ms_passed_since_epoch):
     """
     Converts epoch (miliseconds) to ISO string
     """
-    if ms_passed_since_epoch >= 0:
+    if isinstance(ms_passed_since_epoch, int) and ms_passed_since_epoch >= 0:
         return datetime.utcfromtimestamp(ms_passed_since_epoch / 1000.0).strftime(
             "%Y-%m-%dT%H:%M:%S.%fZ"
         )
@@ -613,13 +613,13 @@ def print_debug_msg(msg, lock: Lock = None):
     """
     Prints a debug message with QRadarMsg prefix, while handling lock.acquire (if available)
     """
-    err_msg = f"QRadarMsg - {msg}"
+    debug_msg = f"QRadarMsg - {msg}"
     if lock:
         if lock.acquire(timeout=LOCK_WAIT_TIME):
-            demisto.debug(err_msg)
+            demisto.debug(debug_msg)
             lock.release()
     else:
-        demisto.debug(err_msg)
+        demisto.debug(debug_msg)
 
 
 def filter_dict_null(d):
@@ -960,8 +960,8 @@ def fetch_incidents_long_running_events(
                 events_limit=events_limit,
             )
         )
-        for future in concurrent.futures.as_completed(futures):
-            enriched_offenses.append(future.result())
+    for future in concurrent.futures.as_completed(futures):
+        enriched_offenses.append(future.result())
 
     if is_reset_triggered(client.lock, handle_reset=True):
         return
@@ -1264,18 +1264,16 @@ def enrich_single_offense_res_with_source_and_destination_address(
     asset_ips = set()
     if isinstance(offense.get("source_address_ids"), list):
         for i in range(len(offense["source_address_ids"])):
+            source_address = src_adrs[offense["source_address_ids"][i]]
             if not skip_enrichment:
-                offense["source_address_ids"][i] = src_adrs[
-                    offense["source_address_ids"][i]
-                ]
-            asset_ips.add(src_adrs[offense["source_address_ids"][i]])
+                offense["source_address_ids"][i] = source_address
+            asset_ips.add(source_address)
     if isinstance(offense.get("local_destination_address_ids"), list):
         for i in range(len(offense["local_destination_address_ids"])):
+            destination_address = dst_adrs[offense["local_destination_address_ids"][i]]
             if not skip_enrichment:
-                offense["local_destination_address_ids"][i] = dst_adrs[
-                    offense["local_destination_address_ids"][i]
-                ]
-            asset_ips.add(dst_adrs[offense["local_destination_address_ids"][i]])
+                offense["local_destination_address_ids"][i] = destination_address
+            asset_ips.add(destination_address)
 
     return asset_ips
 

--- a/Packs/QRadar/Integrations/QRadar_v2/QRadar_v2_test.py
+++ b/Packs/QRadar/Integrations/QRadar_v2/QRadar_v2_test.py
@@ -21,7 +21,8 @@ from QRadar_v2 import (
     enrich_offense_with_events,
     try_create_search_with_retry,
     try_poll_offense_events_with_retry,
-    enrich_offense_result
+    enrich_offense_result,
+    enrich_single_offense_res_with_source_and_destination_address
 )
 
 with open("TestData/commands_outputs.json", "r") as f:
@@ -344,3 +345,49 @@ def test_enrich_offense_result(mocker):
     assert 'domain_name' in response[0]
     assert 'domain_name' in response[0]['assets'][0]
     assert 'name' in response[0]['rules'][0]
+
+
+def test_enrich_single_offense_res_with_source_and_destination_address__no_enrich():
+    """
+    Run offense ips enrichment with skip_enrichment=True
+
+    Given:
+        - Offense response was fetched from QRadar with source_ip and destination_ip
+    When:
+        - Enriching fetched offense with skip_enrichment=True
+    Then:
+        - IPs are not enriched
+        - Asset map is returned as a result
+    """
+    offense = deepcopy(RAW_RESPONSES["qradar-update-offense"])
+    src_adrs = {254: '8.8.8.8'}
+    dst_adrs = {4: '1.2.3.4'}
+    expected = {'8.8.8.8', '1.2.3.4'}
+    actual = enrich_single_offense_res_with_source_and_destination_address(
+        offense, src_adrs, dst_adrs, skip_enrichment=True)
+    assert offense == RAW_RESPONSES["qradar-update-offense"]
+    assert expected == actual
+
+
+def test_enrich_single_offense_res_with_source_and_destination_address__with_enrich():
+    """
+    Run offense ips enrichment with skip_enrichment=False
+
+    Given:
+        - Offense response was fetched from QRadar with source_ip and destination_ip
+    When:
+        - Enriching fetched offense with skip_enrichment=False
+    Then:
+        - IPs are enriched
+        - Asset map is returned as a result
+    """
+    offense = deepcopy(RAW_RESPONSES["qradar-update-offense"])
+    src_adrs = {254: '8.8.8.8', 5: '1.2.3.5'}
+    dst_adrs = {4: '1.2.3.4'}
+    expected_assets = {'8.8.8.8', '1.2.3.4'}
+    actual = enrich_single_offense_res_with_source_and_destination_address(
+        offense, src_adrs, dst_adrs, skip_enrichment=False)
+    assert offense != RAW_RESPONSES["qradar-update-offense"]
+    assert offense['source_address_ids'] == [src_adrs[254]]
+    assert offense['local_destination_address_ids'] == [dst_adrs[4]]
+    assert expected_assets == actual

--- a/Packs/QRadar/ReleaseNotes/1_0_11.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_11.md
@@ -1,4 +1,4 @@
 
 #### Integrations
-##### IBM QRadar V2
-Fixed an issue where IP values from fetched incidents were not enriched correctly.
+##### IBM QRadar v2
+- Fixed an issue where IP values from fetched incidents were not enriched correctly.

--- a/Packs/QRadar/ReleaseNotes/1_0_11.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_11.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### IBM QRadar V2
+Fixed an issue where fetched incidents IP values weren't enriched correctly.

--- a/Packs/QRadar/ReleaseNotes/1_0_11.md
+++ b/Packs/QRadar/ReleaseNotes/1_0_11.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### IBM QRadar V2
-Fixed an issue where fetched incidents IP values weren't enriched correctly.
+Fixed an issue where IP values from fetched incidents were not enriched correctly.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "1.0.10",
+    "currentVersion": "1.0.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -638,7 +638,7 @@
         {
             "integrations": "QRadar",
             "playbookID": "test playbook - QRadarCorrelations",
-            "timeout": 600,
+            "timeout": 1000,
             "fromversion": "5.0.0"
         },
         {


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed an issue where fetched incidents IP values weren't enriched correctly.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

