### PR TITLE
[Cofense] Add support for `inbox_reports` endpoint

### DIFF
--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
@@ -741,28 +741,30 @@ def get_report_png_by_id(triage_instance, report_id):
     ).content
 
 
+def build_triage_instance():
+    demisto_params = {
+        "start_date": parse_date_range(demisto.getParam("date_range"))[0].isoformat(),
+        "max_fetch": int(demisto.getParam("max_fetch")),
+        "category_id": demisto.getParam("category_id"),
+        "match_priority": demisto.getParam("match_priority"),
+        "tags": demisto.getParam("tags"),
+        "mailbox_location": demisto.getParam("mailbox_location"),
+    }
+
+    return TriageInstance(
+        host=demisto.getParam("host").rstrip("/") if demisto.getParam("host") else "",
+        token=demisto.getParam("token"),
+        user=demisto.getParam("user"),
+        disable_tls_verification=demisto.params().get("insecure", False),
+        demisto_params=demisto_params,
+    )
+
+
 def main():
     try:
         handle_proxy()
 
-        demisto_params = {
-            "start_date": parse_date_range(demisto.getParam('date_range'))[
-                0
-            ].isoformat(),
-            "max_fetch": int(demisto.getParam('max_fetch')),
-            "category_id": demisto.getParam("category_id"),
-            "match_priority": demisto.getParam("match_priority"),
-            "tags": demisto.getParam("tags"),
-            "mailbox_location": demisto.getParam("mailbox_location"),
-        }
-
-        triage_instance = TriageInstance(
-            host=demisto.getParam("host").rstrip("/") if demisto.getParam("host") else "",
-            token=demisto.getParam("token"),
-            user=demisto.getParam("user"),
-            disable_tls_verification=demisto.params().get("insecure", False),
-            demisto_params=demisto_params,
-        )
+        triage_instance = build_triage_instance()
 
         if demisto.command() == "test-module":
             test_function(triage_instance)

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
@@ -7,7 +7,9 @@ from PIL import Image
 from datetime import datetime
 from datetime import timezone
 import functools
+import itertools
 import json
+import math
 
 from urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
@@ -152,8 +154,26 @@ class TriageReport:
         }.get(self.attrs["category_id"], 0)
 
     @property
+    def report_subject(self):
+        return self.attrs.get("report_subject")
+
+    @property
     def report_body(self):
         return self.attrs.get("report_body")
+
+    @property
+    def email_urls(self):
+        return [email_url["url"] for email_url in self.attrs["email_urls"]]
+
+    @property
+    def email_attachment_hashes(self):
+        return [
+            [
+                att["email_attachment_payload"]["md5"],
+                att["email_attachment_payload"]["sha256"],
+            ]
+            for att in self.attrs["email_attachments"]
+        ]
 
     @property  # type: ignore
     @functools.lru_cache()
@@ -164,14 +184,15 @@ class TriageReport:
     def terse_attrs(self):
         return {key: self.attrs[key] for key in self.attrs.keys() & TERSE_FIELDS}
 
+    def to_dict(self):
+        return {
+            **self.attrs,
+            # Flatten the Reporter object to a set of `reporter_` prefixed attributes
+            **{f"reporter_{k}": v for k, v in self.reporter.attrs.items()},  # type: ignore
+        }
+
     def to_json(self):
-        """Flatten the Reporter object to a set of `reporter_` prefixed attributes"""
-        return json.dumps(
-            {
-                **self.attrs,
-                **{f"reporter_{k}": v for k, v in self.reporter.attrs.items()},  # type: ignore
-            }
-        )
+        return json.dumps(self.to_dict())
 
     @property  # type: ignore
     @functools.lru_cache()
@@ -193,6 +214,97 @@ class TriageReport:
         return cls(triage_instance, triage_instance.request(f"reports/{report_id}")[0])
 
 
+class TriageInboxReports:
+    """Represents a set of Triage reports from the `inbox` mailbox"""
+    def __init__(
+        self,
+        triage_instance,
+        *,
+        start_date=None,
+        end_date=None,
+        filter_params={},
+        max_pages=1,
+    ):
+        self.triage_instance = triage_instance
+        self.start_date = start_date
+        self.end_date = end_date
+        self.filter = TriageInboxReportFilter(filter_params)
+        self.max_pages = max_pages
+
+    def inbox_reports(self):
+        inbox_reports = [
+            TriageReport(self.triage_instance, response)
+            for response in self.fetch_reports()
+        ]
+
+        return [report for report in inbox_reports if self.filter.is_match(report)]
+
+    def fetch_reports(self):
+        return itertools.chain.from_iterable(self.fetch_report_pages())
+
+    def fetch_report_pages(self):
+        return [
+            self.triage_instance.request(
+                "inbox_reports",
+                params={
+                    "start_date": self.start_date,
+                    "end_date": self.end_date,
+                    "page": page_num,
+                },
+            )
+            for page_num in range(0, math.ceil(self.max_pages))
+        ]
+
+
+class TriageInboxReportFilter:
+    """Performs filtering for Triage Reports"""
+    def __init__(self, filter_params):
+        self.subject = filter_params.get("subject")
+        self.url = filter_params.get("url")
+        self.file_hash = filter_params.get("file_hash")
+        self.reporter_ids = filter_params.get("reporter_ids")
+
+    def is_match(self, report):
+        return (
+            (not self.subject or self.subject in report.report_subject)
+            and (
+                not self.url
+                or any(self.url in email_url for email_url in report.email_urls)
+            )
+            and (
+                not self.file_hash
+                or any(self.file_hash in h for h in report.email_attachment_hashes)
+            )
+            and (not self.reporter_ids or report.reporter.id in self.reporter_ids)
+        )
+
+
+class TriageReporters:
+    """
+    A set of Triage reporters
+    """
+
+    def __init__(self, triage_instance, *, email=None, max_pages=1):
+        self.triage_instance = triage_instance
+        self.email = email
+        self.max_pages = max_pages
+
+    def reporters(self):
+        return [
+            TriageReporter(self.triage_instance, response["id"])  # TODO causes unnecessary extra request---we can just pass in `response`, which has all the fields already # noqa: 501
+            for response in self.fetch_reporters()
+        ]
+
+    def fetch_reporters(self):
+        return itertools.chain.from_iterable(self.fetch_reporter_pages())
+
+    def fetch_reporter_pages(self):
+        for page_num in range(0, math.ceil(self.max_pages)):
+            yield self.triage_instance.request(
+                "reporters", params={"email": self.email, "page": page_num}
+            )
+
+
 class TriageReporter:
     """
     Class representing an end user who has reported a suspicious message
@@ -209,6 +321,14 @@ class TriageReporter:
             self.attrs = matching_reporters[0]
         else:
             self.attrs = {}
+
+    @property
+    def id(self):
+        return self.attrs["id"]
+
+    @property
+    def email(self):
+        return self.attrs["email"]
 
     def exists(self):
         return bool(self.attrs)
@@ -260,8 +380,13 @@ def fetch_reports(triage_instance) -> None:
     start_date = triage_instance.get_demisto_param("start_date")
     max_fetch = triage_instance.get_demisto_param("max_fetch")
 
+    if triage_instance.get_demisto_param("mailbox_location") == "Inbox_Reports":
+        endpoint = "inbox_reports"
+    else:
+        endpoint = "processed_reports"
+
     triage_response = triage_instance.request(
-        "processed_reports",
+        endpoint,
         params={
             "category_id": triage_instance.get_demisto_param("category_id"),
             "match_priority": triage_instance.get_demisto_param("match_priority"),
@@ -309,9 +434,13 @@ def search_reports_command(triage_instance) -> None:
     created_at = parse_date_range(demisto.args().get('created_at', '7 days'))[
         0
     ].replace(tzinfo=timezone.utc)
-    reporter = demisto.getArg('reporter')  # type: str
     max_matches = int(demisto.getArg('max_matches'))  # type: int
     verbose = demisto.getArg('verbose') == "true"
+
+    reporters_clause = build_reporters_clause(triage_instance)
+    if reporters_clause is None:
+        return_outputs("Reporter not found.", {}, {})
+        return
 
     results = search_reports(
         triage_instance,
@@ -320,7 +449,7 @@ def search_reports_command(triage_instance) -> None:
         file_hash,
         reported_at,
         created_at,
-        reporter,
+        reporters_clause,
         verbose,
         max_matches,
     )
@@ -345,11 +474,11 @@ def search_reports(
     file_hash=None,
     reported_at=None,
     created_at=None,
-    reporter=None,
+    reporters_clause={},
     verbose=False,
     max_matches=30,
 ) -> list:
-    params = {'start_date': reported_at}
+    params = {'start_date': reported_at, **reporters_clause}
     reports = triage_instance.request("processed_reports", params=params)
 
     matches = []
@@ -379,8 +508,6 @@ def search_reports(
             ]
         ):
             continue
-        if reporter and int(reporter) != report.get('reporter_id'):
-            continue
 
         if not verbose:
             # extract only relevant fields
@@ -391,6 +518,63 @@ def search_reports(
             break
 
     return matches
+
+
+def search_inbox_reports_command(triage_instance) -> None:
+    reported_at = parse_date_range(demisto.args().get("reported_at", "7 days"))[
+        0
+    ].replace(tzinfo=timezone.utc)
+
+    reporters_clause = build_reporters_clause(triage_instance)
+    if reporters_clause is None:
+        return_outputs("Reporter not found.", {}, {})
+        return
+
+    reports = TriageInboxReports(
+        triage_instance,
+        start_date=reported_at,
+        filter_params={
+            "subject": demisto.getArg("subject"),
+            "url": demisto.getArg("url"),
+            "file_hash": demisto.getArg("file_hash"),
+            **reporters_clause,
+        },
+        max_pages=int(demisto.getArg("max_matches") or 10)
+        / 10,  # TODO Triage's number of items per page
+    ).inbox_reports()
+
+    if not reports:
+        return_outputs("No results found.", {}, {})
+        return
+
+    reports_dict = [report.to_dict() for report in reports]
+    ec = {
+        "Cofense.Report(val.ID && val.ID == obj.ID)": snake_to_camel_keys(reports_dict)
+    }
+    hr = tableToMarkdown(
+        "Reports:", reports_dict, headerTransform=split_snake, removeNull=True
+    )
+
+    return_outputs(hr, ec, reports_dict)
+
+
+def build_reporters_clause(triage_instance):
+    reporter_address_or_id = demisto.getArg("reporter")
+
+    if not reporter_address_or_id:
+        return {}
+
+    if reporter_address_or_id.isdigit():
+        return {"reporter_ids": [int(reporter_address_or_id)]}
+
+    reporters = TriageReporters(
+        triage_instance, email=reporter_address_or_id
+    ).reporters()
+
+    if len(reporters) == 0 or not any([reporter.exists() for reporter in reporters]):
+        return None
+
+    return {"reporter_ids": [reporter.id for reporter in reporters]}
 
 
 def get_all_reporters(triage_instance, time_frame) -> list:
@@ -569,6 +753,7 @@ def main():
             "category_id": demisto.getParam("category_id"),
             "match_priority": demisto.getParam("match_priority"),
             "tags": demisto.getParam("tags"),
+            "mailbox_location": demisto.getParam("mailbox_location"),
         }
 
         triage_instance = TriageInstance(
@@ -587,6 +772,9 @@ def main():
 
         elif demisto.command() == "cofense-search-reports":
             search_reports_command(triage_instance)
+
+        elif demisto.command() == "cofense-search-inbox-reports":
+            search_inbox_reports_command(triage_instance)
 
         elif demisto.command() == "cofense-get-attachment":
             get_attachment_command(triage_instance)

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.py
@@ -542,10 +542,12 @@ def search_inbox_reports_command(triage_instance) -> None:
         return
 
     try:
-        max_pages = int(demisto.getArg("max_matches") or 10) / 10  # TODO Triage's number of items per page
+        max_matches = int(demisto.getArg("max_matches")) or 10
     except ValueError:
         return_error("max_matches must be an integer if specified")
         return
+
+    max_pages = math.ceil(max_matches / 10)  # Triage's number of items per page, rounded up
 
     reports = TriageInboxReports(
         triage_instance,
@@ -563,7 +565,7 @@ def search_inbox_reports_command(triage_instance) -> None:
         return_outputs("No results found.", {}, {})
         return
 
-    reports_dict = [report.to_dict() for report in reports]
+    reports_dict = [report.to_dict() for report in reports][:max_matches]
     ec = {
         "Cofense.Report(val.ID && val.ID == obj.ID)": snake_to_camel_keys(reports_dict)
     }

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
@@ -97,7 +97,7 @@ script:
             4 minutes, 6 month, 1 day".'
           defaultValue: 60 days
         - name: reporter
-          description: Name or ID of the reporter.
+          description: Address or ID of the reporter.
         - name: max_matches
           default: true
           description: Maximum number of matches to fetch. Default is 30.
@@ -157,6 +157,83 @@ script:
         - contextPath: Cofense.Report.Sha256
           description: SHA256 hash of the file.
       description: 'Runs a query for reports.'
+    - name: cofense-search-inbox-reports
+      arguments:
+        - name: file_hash
+          description: File hash, MD5 or SHA256.
+        - name: url
+          description: The reported URLs.
+        - name: subject
+          description: Report's subject
+        - name: reported_at
+          description: 'Retrieve reports that were reported after this time, for example: "2 hours,
+            4 minutes, 6 month, 1 day".'
+          defaultValue: 60 days
+        - name: created_at
+          description: 'Retrieve reports that were created after this time, for example: "2 hours,
+            4 minutes, 6 month, 1 day".'
+          defaultValue: 60 days
+        - name: reporter
+          description: Address or ID of the reporter.
+        - name: max_matches
+          default: true
+          description: Maximum number of matches to fetch. Default is 30.
+          defaultValue: "30"
+        - name: verbose
+          auto: PREDEFINED
+          predefined:
+            - "true"
+            - "false"
+          description: Returns all fields of a report.
+      outputs:
+        - contextPath: Cofense.Report.ID
+          description: ID number of the report.
+        - contextPath: Cofense.Report.EmailAttachments
+          description: Email attachments.
+        - contextPath: Cofense.Report.EmailAttachments.id
+          description: Email attachment ID.
+        - contextPath: Cofense.Report.Tags
+          description: Report tags.
+          type: string
+        - contextPath: Cofense.Report.ClusterId
+          description: Cluster ID number.
+          type: number
+        - contextPath: Cofense.Report.CategoryId
+          description: Report category.
+          type: number
+        - contextPath: Cofense.Report.CreatedAt
+          description: Report creation date.
+          type: date
+        - contextPath: Cofense.Report.ReportedAt
+          description: Reporting time.
+          type: string
+        - contextPath: Cofense.Report.MatchPriority
+          description: The highest match priority based on rule hits for the report.
+          type: number
+        - contextPath: Cofense.Report.ReporterId
+          description: Reporter ID.
+          type: number
+        - contextPath: Cofense.Report.Location
+          description: Location of the report.
+          type: string
+        - contextPath: Cofense.Report.Reporter
+          description: Reporter email address.
+          type: string
+        - contextPath: Cofense.Report.SuspectFromAddress
+          description: Suspect from address.
+          type: string
+        - contextPath: Cofense.Report.ReportSubject
+          description: Report subject.
+          type: string
+        - contextPath: Cofense.Report.ReportBody
+          description: Report body.
+          type: string
+        - contextPath: Cofense.Report.Md5
+          description: MD5 hash of the file.
+          type: number
+        - contextPath: Cofense.Report.Sha256
+          description: SHA256 hash of the file.
+      description: 'Runs a query for reports from the `inbox` mailbox.'
     - name: cofense-get-attachment
       arguments:
         - name: attachment_id
@@ -332,7 +409,7 @@ script:
           type: string
       description: Threat Indicators that are designated by analysts as malicious, suspicious
         or benign
-  dockerimage: demisto/chromium:1.0.0.11033
+  dockerimage: demisto/chromium:1.0.0.11930
   isfetch: true
   runonce: false
 tests:

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
@@ -409,7 +409,7 @@ script:
           type: string
       description: Threat Indicators that are designated by analysts as malicious, suspicious
         or benign
-  dockerimage: demisto/chromium:1.0.0.11930
+  dockerimage: demisto/chromium:1.0.0.12337
   isfetch: true
   runonce: false
 tests:

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2.yml
@@ -30,6 +30,14 @@ configuration:
     name: incidentType
     type: 13
     required: false
+  - display: "Mailbox Location"
+    name: mailbox_location
+    defaultvalue: Processed_Reports
+    type: 15
+    required: true
+    options:
+      - Inbox_Reports
+      - Processed_Reports
   - display: First fetch time (<number> <time unit>, e.g., 12 hours, 7 days, 3 months,
       1 year)
     name: date_range

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_description.md
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_description.md
@@ -1,4 +1,4 @@
 Cofense Triage provides an API that superusers can use to 
 programmatically extract data from Cofense Triage in JSON format.
 
-This integration was tested with Cofense Triage version 1.19.0.
+This integration was tested with Cofense Triage version 1.20.0.

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_test.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_test.py
@@ -7,6 +7,7 @@ from CofenseTriagev2 import TriageInboxReports
 from CofenseTriagev2 import TriageReport
 from CofenseTriagev2 import TriageReporter
 from CofenseTriagev2 import TriageRequestFailedError
+from CofenseTriagev2 import TriageNoReportersFoundError
 from freezegun import freeze_time
 
 
@@ -210,7 +211,8 @@ class TestCofenseTriage:
             text="[]",
         )
 
-        assert CofenseTriagev2.build_reporters_clause(triage_instance) is None
+        with pytest.raises(TriageNoReportersFoundError):
+            CofenseTriagev2.build_reporters_clause(triage_instance)
 
     def test_build_reporters_clause_nothing_specified(self, requests_mock, triage_instance):
         set_demisto_arg("reporter", "")

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_test.py
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/CofenseTriagev2_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from CofenseTriagev2 import TriageInboxReports
 from CofenseTriagev2 import TriageReport
 from CofenseTriagev2 import TriageReporter
 from CofenseTriagev2 import TriageRequestFailedError
@@ -91,6 +92,7 @@ class TestCofenseTriage:
         set_demisto_arg("category_id", 5)
         set_demisto_arg("match_priority", 2)
         set_demisto_arg("tags", "")
+        set_demisto_arg("mailbox_location", "Processed_Reports")
         requests_mock.get(
             "https://some-triage-host/api/public/v1/processed_reports?category_id=5&"
             "match_priority=2&tags=&start_date=2000-10-30+00%3A00%3A00",
@@ -130,6 +132,7 @@ class TestCofenseTriage:
                 "category_id": 5,
                 "match_priority": 2,
                 "tags": "",
+                "mailbox_location": "Processed_Reports",
             }
         )
         requests_mock.get(
@@ -179,6 +182,45 @@ class TestCofenseTriage:
             "| 5 | 2020-03-19T16:43:09.715Z | {'id': 18054, 'report_id': 13363, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 7286, 'email_attachment_payload': {'id': 7082, 'md5': '123', 'sha256': '1234', 'mime_type': 'image/png; charset=binary'}} | 13363 | Processed | 1 | 111 | From: Sender <sender@example.com><br>Reply-To: \"sender@example.com\" <sender@example.com><br>Date: Wednesday, March 18, 2020 at 3:34 PM<br>To: recipient@example.com<br>Subject: suspicious subject<br>click on this link! trust me! <a href=\"http://example.com/malicious\">here</a> | suspicious subject | 2020-03-19T16:42:22.000Z | 5331 | 222 |\n"  # noqa: 501
         )
 
+    def test_build_reporters_clause_found(self, requests_mock, triage_instance):
+        set_demisto_arg("reporter", "reporter2@example.com")
+
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters?email=reporter2%40example.com&page=0", # noqa: 501
+            text=fixture_from_file("reporters_by_email_reporter2.json"),
+        )
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters/222",
+            text=fixture_from_file("reporters.json"),
+        )
+
+        assert CofenseTriagev2.build_reporters_clause(triage_instance) == {"reporter_ids": [111]}
+
+    def test_build_reporters_clause_id(self, requests_mock, triage_instance):
+        set_demisto_arg("reporter", "222")
+
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters/222",
+            text=fixture_from_file("reporters.json"),
+        )
+
+        assert CofenseTriagev2.build_reporters_clause(triage_instance) == {"reporter_ids": [222]}
+
+    def test_build_reporters_clause_not_found(self, requests_mock, triage_instance):
+        set_demisto_arg("reporter", "does_not_exist@example.com")
+
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters?email=does_not_exist%40example.com&page=0", # noqa: 501
+            text="[]",
+        )
+
+        assert CofenseTriagev2.build_reporters_clause(triage_instance) is None
+
+    def test_build_reporters_clause_nothing_specified(self, requests_mock, triage_instance):
+        set_demisto_arg("reporter", "")
+
+        assert CofenseTriagev2.build_reporters_clause(triage_instance) == {}
+
     @freeze_time("2000-10-31")
     def test_search_reports_command_not_found(self, requests_mock, triage_instance):
         set_demisto_arg("subject", "my great subject")
@@ -213,8 +255,6 @@ class TestCofenseTriage:
             ({"file_hash": "123"}, [13363]),
             ({"file_hash": "1234"}, [13363]),
             ({"file_hash": "5"}, []),
-            ({"reporter": "5331"}, [13363, 13392]),
-            ({"reporter": "2000"}, []),
         ],
     )
     def test_search_reports_filtering(
@@ -229,6 +269,93 @@ class TestCofenseTriage:
             triage_instance, **filter_attrs, reported_at=datetime.datetime.now()
         )
         assert [report["id"] for report in found_reports] == expected_found_report_ids
+
+    @freeze_time("2000-10-31")
+    def test_search_inbox_reports_command(self, requests_mock, triage_instance):
+        set_demisto_arg("subject", "aaa")
+        set_demisto_arg("url", "")
+        set_demisto_arg("file_hash", "")
+        set_demisto_arg("reporter", "")
+        set_demisto_arg("max_matches", 10)
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/inbox_reports?start_date=2000-10-24+00%3A00%3A00%2B00%3A00&page=0",  # noqa: 501
+            text=fixture_from_file("inbox_reports.json"),
+        )
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters/222",
+            text=fixture_from_file("reporters.json"),
+        )
+
+        CofenseTriagev2.search_inbox_reports_command(triage_instance)
+
+        demisto_results = CofenseTriagev2.demisto.results.call_args_list[0][0]
+        assert len(demisto_results) == 1
+        assert demisto_results[0]["HumanReadable"] == (
+            "### Reports:\n"
+            "|Cluster Id|Created At|Email Attachments|Email Urls|Id|Location|Match Priority|Md5|Report Body|Report Headers|Report Subject|Reported At|Reporter Created At|Reporter Credibility Score|Reporter Email|Reporter Id|Reporter Last Reported At|Reporter Phishme Reports Count|Reporter Reports Count|Reporter Updated At|Reporter Vip|Rules|Sha256|Suspect Received At|Updated At|\n"
+            "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n"
+            "| 3887 | 2020-08-26T15:13:30.920Z | {'id': 18054, 'report_id': 13363, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 7286, 'email_attachment_payload': {'id': 7082, 'md5': '123', 'sha256': '1234', 'mime_type': 'image/png; charset=binary'}} | {'url': 'https://example.com/url1.png'},<br>{'url': 'https://example.com/url2.png'},<br>{'url': 'https://example.com/url3.png'} | 13461 | Inbox | 1 | 555 | Report body 1 | Date: Wed, 26 Aug 2020 15:13:30 +0000<br>Subject: Report subject 1<br>Mime-Version: 1.0<br>Content-Type: multipart/mixed;<br>charset=UTF-8<br>Content-Transfer-Encoding: 7bit | Report subject 1 aaa | 2020-08-26T14:36:43.000Z | 2019-04-12T02:58:17.401Z | 0 | reporter1@example.com | 111 | 2016-02-18T00:24:45.000Z | 0 | 3 | 2019-04-12T02:59:22.287Z | false | {'id': 6417, 'name': 'Triage_rule_1', 'reports_count': 67, 'active': True, 'created_at': '2019-04-11T17:15:53.940Z', 'updated_at': '2019-04-11T17:15:53.940Z', 'priority': 1, 'author_name': 'Cofense'} | 555555 | 2020-08-26T14:36:51.000Z | 2020-08-26T15:13:35.200Z |\n"
+            "| 3884 | 2020-08-24T16:43:04.412Z |  | {'url': 'https://example.com/url1.png'},<br>{'url': 'https://example.com/url2.png'},<br>{'url': 'https://example.com/url3.png'} | 13458 | Inbox | 1 | 555 | Report body 3 | Date: Wed, 26 Aug 2020 15:13:30 +0000<br>Subject: Report subject 3<br>Mime-Version: 1.0<br>Content-Type: multipart/mixed;<br>charset=UTF-8<br>Content-Transfer-Encoding: 7bit | Report subject 3 aaa | 2020-08-24T16:15:52.000Z | 2019-04-12T02:58:17.401Z | 0 | reporter1@example.com | 111 | 2016-02-18T00:24:45.000Z | 0 | 3 | 2019-04-12T02:59:22.287Z | false | {'id': 667, 'name': 'Triage_rule_1', 'reports_count': 41, 'active': True, 'created_at': '2019-04-11T16:46:11.078Z', 'updated_at': '2019-04-11T16:46:11.078Z', 'priority': 1, 'author_name': 'Cofense'} | 555555 | 2020-08-24T16:21:07.000Z | 2020-08-24T16:43:05.946Z |\n"
+        )
+
+    @freeze_time("2000-10-31")
+    def test_search_inbox_reports_command_with_reporter(self, requests_mock, triage_instance):
+        set_demisto_arg("subject", "aaa")
+        set_demisto_arg("url", "")
+        set_demisto_arg("file_hash", "")
+        set_demisto_arg("reporter", "reporter2")
+        set_demisto_arg("max_matches", 10)
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/inbox_reports?start_date=2000-10-24+00%3A00%3A00%2B00%3A00&page=0",  # noqa: 501
+            text=fixture_from_file("inbox_reports.json"),
+        )
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters?email=reporter2&page=0",
+            text=fixture_from_file("reporters_by_email_reporter2.json"),
+        )
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters/222",
+            text=fixture_from_file("reporters.json"),
+        )
+
+        CofenseTriagev2.search_inbox_reports_command(triage_instance)
+
+        demisto_results = CofenseTriagev2.demisto.results.call_args_list[0][0]
+        assert len(demisto_results) == 1
+        assert demisto_results[0]["HumanReadable"] == (
+            "### Reports:\n"
+            "|Cluster Id|Created At|Email Attachments|Email Urls|Id|Location|Match Priority|Md5|Report Body|Report Headers|Report Subject|Reported At|Reporter Created At|Reporter Credibility Score|Reporter Email|Reporter Id|Reporter Last Reported At|Reporter Phishme Reports Count|Reporter Reports Count|Reporter Updated At|Reporter Vip|Rules|Sha256|Suspect Received At|Updated At|\n"
+            "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n"
+            "| 3887 | 2020-08-26T15:13:30.920Z | {'id': 18054, 'report_id': 13363, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 7286, 'email_attachment_payload': {'id': 7082, 'md5': '123', 'sha256': '1234', 'mime_type': 'image/png; charset=binary'}} | {'url': 'https://example.com/url1.png'},<br>{'url': 'https://example.com/url2.png'},<br>{'url': 'https://example.com/url3.png'} | 13461 | Inbox | 1 | 555 | Report body 1 | Date: Wed, 26 Aug 2020 15:13:30 +0000<br>Subject: Report subject 1<br>Mime-Version: 1.0<br>Content-Type: multipart/mixed;<br>charset=UTF-8<br>Content-Transfer-Encoding: 7bit | Report subject 1 aaa | 2020-08-26T14:36:43.000Z | 2019-04-12T02:58:17.401Z | 0 | reporter1@example.com | 111 | 2016-02-18T00:24:45.000Z | 0 | 3 | 2019-04-12T02:59:22.287Z | false | {'id': 6417, 'name': 'Triage_rule_1', 'reports_count': 67, 'active': True, 'created_at': '2019-04-11T17:15:53.940Z', 'updated_at': '2019-04-11T17:15:53.940Z', 'priority': 1, 'author_name': 'Cofense'} | 555555 | 2020-08-26T14:36:51.000Z | 2020-08-26T15:13:35.200Z |\n"
+            "| 3884 | 2020-08-24T16:43:04.412Z |  | {'url': 'https://example.com/url1.png'},<br>{'url': 'https://example.com/url2.png'},<br>{'url': 'https://example.com/url3.png'} | 13458 | Inbox | 1 | 555 | Report body 3 | Date: Wed, 26 Aug 2020 15:13:30 +0000<br>Subject: Report subject 3<br>Mime-Version: 1.0<br>Content-Type: multipart/mixed;<br>charset=UTF-8<br>Content-Transfer-Encoding: 7bit | Report subject 3 aaa | 2020-08-24T16:15:52.000Z | 2019-04-12T02:58:17.401Z | 0 | reporter1@example.com | 111 | 2016-02-18T00:24:45.000Z | 0 | 3 | 2019-04-12T02:59:22.287Z | false | {'id': 667, 'name': 'Triage_rule_1', 'reports_count': 41, 'active': True, 'created_at': '2019-04-11T16:46:11.078Z', 'updated_at': '2019-04-11T16:46:11.078Z', 'priority': 1, 'author_name': 'Cofense'} | 555555 | 2020-08-24T16:21:07.000Z | 2020-08-24T16:43:05.946Z |\n"
+        )
+
+    @freeze_time("2000-10-31")
+    def test_search_inbox_reports_command_with_file_hash(self, requests_mock, triage_instance):
+        set_demisto_arg("subject", "aaa")
+        set_demisto_arg("url", "")
+        set_demisto_arg("file_hash", "1234")
+        set_demisto_arg("reporter", "")
+        set_demisto_arg("max_matches", 10)
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/inbox_reports?start_date=2000-10-24+00%3A00%3A00%2B00%3A00&page=0",  # noqa: 501
+            text=fixture_from_file("inbox_reports.json"),
+        )
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/reporters/222",
+            text=fixture_from_file("reporters.json"),
+        )
+
+        CofenseTriagev2.search_inbox_reports_command(triage_instance)
+
+        demisto_results = CofenseTriagev2.demisto.results.call_args_list[0][0]
+        assert len(demisto_results) == 1
+        assert demisto_results[0]["HumanReadable"] == (
+            "### Reports:\n"
+            "|Cluster Id|Created At|Email Attachments|Email Urls|Id|Location|Match Priority|Md5|Report Body|Report Headers|Report Subject|Reported At|Reporter Created At|Reporter Credibility Score|Reporter Email|Reporter Id|Reporter Last Reported At|Reporter Phishme Reports Count|Reporter Reports Count|Reporter Updated At|Reporter Vip|Rules|Sha256|Suspect Received At|Updated At|\n"
+            "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n"
+            "| 3887 | 2020-08-26T15:13:30.920Z | {'id': 18054, 'report_id': 13363, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 7286, 'email_attachment_payload': {'id': 7082, 'md5': '123', 'sha256': '1234', 'mime_type': 'image/png; charset=binary'}} | {'url': 'https://example.com/url1.png'},<br>{'url': 'https://example.com/url2.png'},<br>{'url': 'https://example.com/url3.png'} | 13461 | Inbox | 1 | 555 | Report body 1 | Date: Wed, 26 Aug 2020 15:13:30 +0000<br>Subject: Report subject 1<br>Mime-Version: 1.0<br>Content-Type: multipart/mixed;<br>charset=UTF-8<br>Content-Transfer-Encoding: 7bit | Report subject 1 aaa | 2020-08-26T14:36:43.000Z | 2019-04-12T02:58:17.401Z | 0 | reporter1@example.com | 111 | 2016-02-18T00:24:45.000Z | 0 | 3 | 2019-04-12T02:59:22.287Z | false | {'id': 6417, 'name': 'Triage_rule_1', 'reports_count': 67, 'active': True, 'created_at': '2019-04-11T17:15:53.940Z', 'updated_at': '2019-04-11T17:15:53.940Z', 'priority': 1, 'author_name': 'Cofense'} | 555555 | 2020-08-26T14:36:51.000Z | 2020-08-26T15:13:35.200Z |\n"
+        )
 
     def test_get_attachment_command(self, mocker, requests_mock, triage_instance):
         set_demisto_arg("attachment_id", "5")
@@ -440,6 +567,37 @@ class TestTriageInstance:
         assert triage_instance.api_url("endpoint") == "https://some-triage-host/api/public/v1/endpoint"
         assert triage_instance.api_url("/endpoint") == "https://some-triage-host/api/public/v1/endpoint"
         assert triage_instance.api_url("///endpoint/edit?query_string&") == "https://some-triage-host/api/public/v1/endpoint/edit?query_string&"  # noqa 501
+
+
+class TestTriageInboxReports:
+    def test_inbox_reports(self, requests_mock, triage_instance, fixture_from_file):
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/inbox_reports?page=0",
+            text=fixture_from_file("inbox_reports.json"),
+        )
+
+        reports = TriageInboxReports(triage_instance).inbox_reports()
+
+        assert len(reports) == 3
+        assert reports[0].id == 13461
+        assert reports[2].date == "2020-08-24T16:43:04.412Z"
+
+    def test_inbox_reports_with_filter(
+        self, requests_mock, triage_instance, fixture_from_file
+    ):
+        requests_mock.get(
+            "https://some-triage-host/api/public/v1/inbox_reports?page=0",
+            text=fixture_from_file("inbox_reports.json"),
+        )
+
+        reports = TriageInboxReports(
+            triage_instance, filter_params={"subject": "aaa"}
+        ).inbox_reports()
+
+        assert [report.report_subject for report in reports] == [
+            "Report subject 1 aaa",
+            "Report subject 3 aaa",
+        ]
 
 
 class TestTriageReport:

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/README.md
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/README.md
@@ -1,5 +1,5 @@
 Use the Cofense Triage integration to ingest reported phishing indicators.
-This integration was integrated and tested with version 1.19.1 of Cofense Triage v2
+This integration was integrated and tested with version 1.20 of Cofense Triage v2
 ## Configure Cofense Triage v2 on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
@@ -42,7 +42,7 @@ Runs a query for reports.
 | subject | Report's subject | Optional | 
 | reported_at | Retrieve reports that were reported after this time, for example: "2 hours, 4 minutes, 6 month, 1 day". | Optional | 
 | created_at | Retrieve reports that were created after this time, for example: "2 hours, 4 minutes, 6 month, 1 day". | Optional | 
-| reporter | Name or ID of the reporter. | Optional | 
+| reporter | Address or ID of the reporter. | Optional | 
 | max_matches | Maximum number of matches to fetch. Default is 30. | Optional | 
 | verbose | Returns all fields of a report. | Optional | 
 
@@ -178,7 +178,7 @@ Runs a query for reports.
             "Location": "Processed",
             "MatchPriority": 1,
             "Md5": "d312e79695d5de744436006aab6b4ec1",
-            "ReportBody": "Testing PDF attachment\r\n\r\n\r\nMike Saurbaugh  |  Director, Technical Alliances\r\nCOFENSE\r\nm. 607-368-2012\r\ne. test@test.com<mailto:test@test.com>\r\n\r\nConnect with Cofense:\r\n\r\n[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense>\r\n\r\nUniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/>\r\n\r\n",
+            "ReportBody": "Testing PDF attachment\r\n\r\n\r\nTest User  |  Director\r\nTEST\r\nm. 123-456-7890\r\ne. test@test.com<mailto:test@test.com>\r\n\r\nConnect with Cofense:\r\n\r\n[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense>\r\n\r\nUniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/>\r\n\r\n",
             "ReportSubject": "2020-06-04 XSOAR attachment test",
             "ReportedAt": "2020-06-04T13:40:29.000Z",
             "ReporterId": 5331,
@@ -194,7 +194,179 @@ Runs a query for reports.
 >### Reports:
 >|Category Id|Created At|Email Attachments|Id|Location|Match Priority|Md5|Report Body|Report Subject|Reported At|Reporter Id|Sha256|
 >|---|---|---|---|---|---|---|---|---|---|---|---|
->| 4 | 2020-06-04T13:42:26.173Z | {'id': 18087, 'report_id': 13429, 'decoded_filename': 'image001.png', 'content_type': 'image/png; name=image001.png', 'size_in_bytes': 1397, 'email_attachment_payload': {'id': 7095, 'md5': '5008fb6e6652f56cac5bdc5bf1cbe9c2', 'sha256': '554aeaaace31c7038a09dd408945583e1035ec124a46b04e5c6c5b148dc96f68', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18089, 'report_id': 13429, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 1701, 'email_attachment_payload': {'id': 7097, 'md5': '731ffb7846c22e41e9de8de307c93ece', 'sha256': 'c911d07d1f7be624e00e44821148629d98cf6d0f2bfac112362c7c564522ea51', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18092, 'report_id': 13429, 'decoded_filename': 'image006.png', 'content_type': 'image/png; name=image006.png', 'size_in_bytes': 1994, 'email_attachment_payload': {'id': 7100, 'md5': '124bd437f87181fdfe3154b31fd2cf6b', 'sha256': '3d804c705545bf2a1e5ac6b0ea9b93a41ceb16d7453adebc58fba5df75335b20', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18088, 'report_id': 13429, 'decoded_filename': 'image002.png', 'content_type': 'image/png; name=image002.png', 'size_in_bytes': 1430, 'email_attachment_payload': {'id': 7096, 'md5': 'cc07463ceeaaed79783a7f2a607797f9', 'sha256': 'c6c2c95238f52648faaef4520fa9bba49c10ca0f1df9bfd1912be544f319b80b', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18090, 'report_id': 13429, 'decoded_filename': 'image004.png', 'content_type': 'image/png; name=image004.png', 'size_in_bytes': 1557, 'email_attachment_payload': {'id': 7098, 'md5': '95878e37974ed3cad67154d36dd58a9a', 'sha256': 'e0d478f6ce56721867a0584ddea0016d713b9b2ab758fd0c9be3f1409d6e2634', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18091, 'report_id': 13429, 'decoded_filename': 'image005.png', 'content_type': 'image/png; name=image005.png', 'size_in_bytes': 1609, 'email_attachment_payload': {'id': 7099, 'md5': '0e911498bf4dc5eddb544ab5ece4b06a', 'sha256': '5f2046b3c55a874aadde052f9da4af3c17e2b5bf5baf704f58b1dd1eadf08544', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18093, 'report_id': 13429, 'decoded_filename': 'XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf', 'content_type': 'application/pdf; name="XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf"', 'size_in_bytes': 49597, 'email_attachment_payload': {'id': 7110, 'md5': 'fb7f083f4fb93a88ab8110d857312978', 'sha256': '15ab1b20ada04dfc6285caff5e4da4eab09a9157c2cbe32cd96113da6304a5ee', 'mime_type': 'application/pdf; charset=binary'}} | 13429 | Processed | 1 | d312e79695d5de744436006aab6b4ec1 | Testing PDF attachment<br/><br/><br/>Mike Saurbaugh  \|  Director, Technical Alliances<br/>COFENSE<br/>m. 607-368-2012<br/>e. test@test.com<mailto:test@test.com><br/><br/>Connect with Cofense:<br/><br/>[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense><br/><br/>Uniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/><br/><br/> | 2020-06-04 XSOAR attachment test | 2020-06-04T13:40:29.000Z | 5331 | ba77b5d984f7da97b6f96daa442535c79f47e4b6ea0055e3472b855ee8c244e4 |
+>| 4 | 2020-06-04T13:42:26.173Z | {'id': 18087, 'report_id': 13429, 'decoded_filename': 'image001.png', 'content_type': 'image/png; name=image001.png', 'size_in_bytes': 1397, 'email_attachment_payload': {'id': 7095, 'md5': '5008fb6e6652f56cac5bdc5bf1cbe9c2', 'sha256': '554aeaaace31c7038a09dd408945583e1035ec124a46b04e5c6c5b148dc96f68', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18089, 'report_id': 13429, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 1701, 'email_attachment_payload': {'id': 7097, 'md5': '731ffb7846c22e41e9de8de307c93ece', 'sha256': 'c911d07d1f7be624e00e44821148629d98cf6d0f2bfac112362c7c564522ea51', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18092, 'report_id': 13429, 'decoded_filename': 'image006.png', 'content_type': 'image/png; name=image006.png', 'size_in_bytes': 1994, 'email_attachment_payload': {'id': 7100, 'md5': '124bd437f87181fdfe3154b31fd2cf6b', 'sha256': '3d804c705545bf2a1e5ac6b0ea9b93a41ceb16d7453adebc58fba5df75335b20', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18088, 'report_id': 13429, 'decoded_filename': 'image002.png', 'content_type': 'image/png; name=image002.png', 'size_in_bytes': 1430, 'email_attachment_payload': {'id': 7096, 'md5': 'cc07463ceeaaed79783a7f2a607797f9', 'sha256': 'c6c2c95238f52648faaef4520fa9bba49c10ca0f1df9bfd1912be544f319b80b', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18090, 'report_id': 13429, 'decoded_filename': 'image004.png', 'content_type': 'image/png; name=image004.png', 'size_in_bytes': 1557, 'email_attachment_payload': {'id': 7098, 'md5': '95878e37974ed3cad67154d36dd58a9a', 'sha256': 'e0d478f6ce56721867a0584ddea0016d713b9b2ab758fd0c9be3f1409d6e2634', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18091, 'report_id': 13429, 'decoded_filename': 'image005.png', 'content_type': 'image/png; name=image005.png', 'size_in_bytes': 1609, 'email_attachment_payload': {'id': 7099, 'md5': '0e911498bf4dc5eddb544ab5ece4b06a', 'sha256': '5f2046b3c55a874aadde052f9da4af3c17e2b5bf5baf704f58b1dd1eadf08544', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18093, 'report_id': 13429, 'decoded_filename': 'XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf', 'content_type': 'application/pdf; name="XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf"', 'size_in_bytes': 49597, 'email_attachment_payload': {'id': 7110, 'md5': 'fb7f083f4fb93a88ab8110d857312978', 'sha256': '15ab1b20ada04dfc6285caff5e4da4eab09a9157c2cbe32cd96113da6304a5ee', 'mime_type': 'application/pdf; charset=binary'}} | 13429 | Processed | 1 | d312e79695d5de744436006aab6b4ec1 | Testing PDF attachment<br/><br/><br/>Test User  \|  Director<br/>COFENSE<br/>m. 123-456-7890<br/>e. test@test.com<mailto:test@test.com><br/><br/>Connect with Cofense:<br/><br/>[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense><br/><br/>Uniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/><br/><br/> | 2020-06-04 XSOAR attachment test | 2020-06-04T13:40:29.000Z | 5331 | ba77b5d984f7da97b6f96daa442535c79f47e4b6ea0055e3472b855ee8c244e4 |
+
+
+### cofense-search-inbox-reports
+***
+Runs a query for reports from the `inbox` mailbox.
+
+
+#### Base Command
+
+`cofense-search-reports`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| file_hash | File hash, MD5 or SHA256. | Optional | 
+| url | The reported URLs. | Optional | 
+| subject | Report's subject | Optional | 
+| reported_at | Retrieve reports that were reported after this time, for example: "2 hours, 4 minutes, 6 month, 1 day". | Optional | 
+| created_at | Retrieve reports that were created after this time, for example: "2 hours, 4 minutes, 6 month, 1 day". | Optional | 
+| reporter | Address or ID of the reporter. | Optional | 
+| max_matches | Maximum number of matches to fetch. Default is 30. | Optional | 
+| verbose | Returns all fields of a report. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Cofense.Report.ID | unknown | ID number of the report. | 
+| Cofense.Report.EmailAttachments | unknown | Email attachments. | 
+| Cofense.Report.EmailAttachments.id | unknown | Email attachment ID. | 
+| Cofense.Report.Tags | string | Report tags. | 
+| Cofense.Report.ClusterId | number | Cluster ID number. | 
+| Cofense.Report.CategoryId | number | Report category. | 
+| Cofense.Report.CreatedAt | date | Report creation date. | 
+| Cofense.Report.ReportedAt | string | Reporting time. | 
+| Cofense.Report.MatchPriority | number | The highest match priority based on rule hits for the report. | 
+| Cofense.Report.ReporterId | number | Reporter ID. | 
+| Cofense.Report.Location | string | Location of the report. | 
+| Cofense.Report.Reporter | string | Reporter email address. | 
+| Cofense.Report.SuspectFromAddress | string | Suspect from address. | 
+| Cofense.Report.ReportSubject | string | Report subject. | 
+| Cofense.Report.ReportBody | string | Report body. | 
+| Cofense.Report.Md5 | number | MD5 hash of the file. | 
+| Cofense.Report.Sha256 | unknown | SHA256 hash of the file. | 
+
+
+#### Command Example
+```!cofense-search-inbox-reports reported_at="7 days" created_at="7 days" max_matches="1"```
+
+#### Context Example
+```json
+{
+    "Cofense": {
+        "Report": {
+            "CategoryId": 4,
+            "ClusterId": null,
+            "CreatedAt": "2020-06-04T13:42:26.173Z",
+            "EmailAttachments": [
+                {
+                    "content_type": "image/png; name=image001.png",
+                    "decoded_filename": "image001.png",
+                    "email_attachment_payload": {
+                        "id": 7095,
+                        "md5": "5008fb6e6652f56cac5bdc5bf1cbe9c2",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "554aeaaace31c7038a09dd408945583e1035ec124a46b04e5c6c5b148dc96f68"
+                    },
+                    "id": 18087,
+                    "report_id": 13429,
+                    "size_in_bytes": 1397
+                },
+                {
+                    "content_type": "image/png; name=image003.png",
+                    "decoded_filename": "image003.png",
+                    "email_attachment_payload": {
+                        "id": 7097,
+                        "md5": "731ffb7846c22e41e9de8de307c93ece",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "c911d07d1f7be624e00e44821148629d98cf6d0f2bfac112362c7c564522ea51"
+                    },
+                    "id": 18089,
+                    "report_id": 13429,
+                    "size_in_bytes": 1701
+                },
+                {
+                    "content_type": "image/png; name=image006.png",
+                    "decoded_filename": "image006.png",
+                    "email_attachment_payload": {
+                        "id": 7100,
+                        "md5": "124bd437f87181fdfe3154b31fd2cf6b",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "3d804c705545bf2a1e5ac6b0ea9b93a41ceb16d7453adebc58fba5df75335b20"
+                    },
+                    "id": 18092,
+                    "report_id": 13429,
+                    "size_in_bytes": 1994
+                },
+                {
+                    "content_type": "image/png; name=image002.png",
+                    "decoded_filename": "image002.png",
+                    "email_attachment_payload": {
+                        "id": 7096,
+                        "md5": "cc07463ceeaaed79783a7f2a607797f9",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "c6c2c95238f52648faaef4520fa9bba49c10ca0f1df9bfd1912be544f319b80b"
+                    },
+                    "id": 18088,
+                    "report_id": 13429,
+                    "size_in_bytes": 1430
+                },
+                {
+                    "content_type": "image/png; name=image004.png",
+                    "decoded_filename": "image004.png",
+                    "email_attachment_payload": {
+                        "id": 7098,
+                        "md5": "95878e37974ed3cad67154d36dd58a9a",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "e0d478f6ce56721867a0584ddea0016d713b9b2ab758fd0c9be3f1409d6e2634"
+                    },
+                    "id": 18090,
+                    "report_id": 13429,
+                    "size_in_bytes": 1557
+                },
+                {
+                    "content_type": "image/png; name=image005.png",
+                    "decoded_filename": "image005.png",
+                    "email_attachment_payload": {
+                        "id": 7099,
+                        "md5": "0e911498bf4dc5eddb544ab5ece4b06a",
+                        "mime_type": "image/png; charset=binary",
+                        "sha256": "5f2046b3c55a874aadde052f9da4af3c17e2b5bf5baf704f58b1dd1eadf08544"
+                    },
+                    "id": 18091,
+                    "report_id": 13429,
+                    "size_in_bytes": 1609
+                },
+                {
+                    "content_type": "application/pdf; name=\"XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf\"",
+                    "decoded_filename": "XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf",
+                    "email_attachment_payload": {
+                        "id": 7110,
+                        "md5": "fb7f083f4fb93a88ab8110d857312978",
+                        "mime_type": "application/pdf; charset=binary",
+                        "sha256": "15ab1b20ada04dfc6285caff5e4da4eab09a9157c2cbe32cd96113da6304a5ee"
+                    },
+                    "id": 18093,
+                    "report_id": 13429,
+                    "size_in_bytes": 49597
+                }
+            ],
+            "ID": 13429,
+            "Location": "Inbox",
+            "MatchPriority": 1,
+            "Md5": "d312e79695d5de744436006aab6b4ec1",
+            "ReportBody": "Testing PDF attachment\r\n\r\n\r\nTest User  |  Director\r\nTEST\r\nm. 123-456-7890\r\ne. test@test.com<mailto:test@test.com>\r\n\r\nConnect with Cofense:\r\n\r\n[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense>\r\n\r\nUniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/>\r\n\r\n",
+            "ReportSubject": "2020-06-04 XSOAR attachment test",
+            "ReportedAt": "2020-06-04T13:40:29.000Z",
+            "ReporterId": 5331,
+            "Sha256": "ba77b5d984f7da97b6f96daa442535c79f47e4b6ea0055e3472b855ee8c244e4",
+            "Tags": []
+        }
+    }
+}
+```
+
+#### Human Readable Output
+
+>### Reports:
+>|Category Id|Created At|Email Attachments|Id|Location|Match Priority|Md5|Report Body|Report Subject|Reported At|Reporter Id|Sha256|
+>|---|---|---|---|---|---|---|---|---|---|---|---|
+>| 4 | 2020-06-04T13:42:26.173Z | {'id': 18087, 'report_id': 13429, 'decoded_filename': 'image001.png', 'content_type': 'image/png; name=image001.png', 'size_in_bytes': 1397, 'email_attachment_payload': {'id': 7095, 'md5': '5008fb6e6652f56cac5bdc5bf1cbe9c2', 'sha256': '554aeaaace31c7038a09dd408945583e1035ec124a46b04e5c6c5b148dc96f68', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18089, 'report_id': 13429, 'decoded_filename': 'image003.png', 'content_type': 'image/png; name=image003.png', 'size_in_bytes': 1701, 'email_attachment_payload': {'id': 7097, 'md5': '731ffb7846c22e41e9de8de307c93ece', 'sha256': 'c911d07d1f7be624e00e44821148629d98cf6d0f2bfac112362c7c564522ea51', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18092, 'report_id': 13429, 'decoded_filename': 'image006.png', 'content_type': 'image/png; name=image006.png', 'size_in_bytes': 1994, 'email_attachment_payload': {'id': 7100, 'md5': '124bd437f87181fdfe3154b31fd2cf6b', 'sha256': '3d804c705545bf2a1e5ac6b0ea9b93a41ceb16d7453adebc58fba5df75335b20', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18088, 'report_id': 13429, 'decoded_filename': 'image002.png', 'content_type': 'image/png; name=image002.png', 'size_in_bytes': 1430, 'email_attachment_payload': {'id': 7096, 'md5': 'cc07463ceeaaed79783a7f2a607797f9', 'sha256': 'c6c2c95238f52648faaef4520fa9bba49c10ca0f1df9bfd1912be544f319b80b', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18090, 'report_id': 13429, 'decoded_filename': 'image004.png', 'content_type': 'image/png; name=image004.png', 'size_in_bytes': 1557, 'email_attachment_payload': {'id': 7098, 'md5': '95878e37974ed3cad67154d36dd58a9a', 'sha256': 'e0d478f6ce56721867a0584ddea0016d713b9b2ab758fd0c9be3f1409d6e2634', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18091, 'report_id': 13429, 'decoded_filename': 'image005.png', 'content_type': 'image/png; name=image005.png', 'size_in_bytes': 1609, 'email_attachment_payload': {'id': 7099, 'md5': '0e911498bf4dc5eddb544ab5ece4b06a', 'sha256': '5f2046b3c55a874aadde052f9da4af3c17e2b5bf5baf704f58b1dd1eadf08544', 'mime_type': 'image/png; charset=binary'}},<br/>{'id': 18093, 'report_id': 13429, 'decoded_filename': 'XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf', 'content_type': 'application/pdf; name="XSOAR Attachment Test -Inquiry - Agent Tesla Keylogger.pdf"', 'size_in_bytes': 49597, 'email_attachment_payload': {'id': 7110, 'md5': 'fb7f083f4fb93a88ab8110d857312978', 'sha256': '15ab1b20ada04dfc6285caff5e4da4eab09a9157c2cbe32cd96113da6304a5ee', 'mime_type': 'application/pdf; charset=binary'}} | 13429 | Processed | 1 | d312e79695d5de744436006aab6b4ec1 | Testing PDF attachment<br/><br/><br/>Test User  \|  Director<br/>TEST<br/>m. 123-456-7890<br/>e. test@test.com<mailto:test@test.com><br/><br/>Connect with Cofense:<br/><br/>[signature_527626984]<https://cofense.com/>[signature_379086648]<https://facebook.com/cofense>[signature_426568440]<https://twitter.com/cofense>[signature_1467413640]<https://linkedin.com/company/cofense>[signature_749445379]<https://www.instagram.com/cofense/>[signature_1384270593]<https://www.themuse.com/profiles/cofense><br/><br/>Uniting Humanity Against Phishing. Watch Our Video<https://cofense.com/project/uhap-video/><br/><br/> | 2020-06-04 XSOAR attachment test | 2020-06-04T13:40:29.000Z | 5331 | ba77b5d984f7da97b6f96daa442535c79f47e4b6ea0055e3472b855ee8c244e4 |
 
 
 ### cofense-get-attachment
@@ -362,7 +534,7 @@ Retrieves a report by the report ID number.
             "Location": "Processed",
             "MatchPriority": 0,
             "Md5": "f13bbc172fe7d394828ccabb25c3c99e",
-            "ReportSubject": "test@demisto.net Reset password instruction",
+            "ReportSubject": "test@test.net Reset password instruction",
             "ReportedAt": "2019-04-17T16:54:57.000Z",
             "ReporterId": 3280,
             "Sha256": "4f6bc0d9c1217a2a6f327423e16b7a6e9294c68cfb33864541bd805fe4ab2d72",
@@ -377,7 +549,7 @@ Retrieves a report by the report ID number.
 >{"HumanReadable":"### Cofense HTML Report:\nHTML report download request has been completed","name":"5760-report.html","path":"aaf1160b-9176-45d9-aab9-90efd278e05d"}### Report Summary:
 >|Category Id|Created At|Id|Location|Match Priority|Md5|Report Subject|Reported At|Reporter Id|Sha256|
 >|---|---|---|---|---|---|---|---|---|---|
->| 4 | 2019-04-17T20:53:02.090Z | 5760 | Processed | 0 | f13bbc172fe7d394828ccabb25c3c99e | test@demisto.net Reset password instruction | 2019-04-17T16:54:57.000Z | 3280 | 4f6bc0d9c1217a2a6f327423e16b7a6e9294c68cfb33864541bd805fe4ab2d72 |
+>| 4 | 2019-04-17T20:53:02.090Z | 5760 | Processed | 0 | f13bbc172fe7d394828ccabb25c3c99e | test@test.nul Reset password instruction | 2019-04-17T16:54:57.000Z | 3280 | 4f6bc0d9c1217a2a6f327423e16b7a6e9294c68cfb33864541bd805fe4ab2d72 |
 
 
 ### cofense-get-report-png-by-id
@@ -466,7 +638,7 @@ Threat Indicators that are designated by analysts as malicious, suspicious or be
             "ReportId": 5760,
             "ThreatKey": "URL",
             "ThreatLevel": "Malicious",
-            "ThreatValue": "http://bold-air.000webhostapp.com/notification.php?email=test@demisto.net.net"
+            "ThreatValue": "http://bold-air0example.com/notification.php?email=test@test.net"
         }
     }
 }
@@ -477,5 +649,5 @@ Threat Indicators that are designated by analysts as malicious, suspicious or be
 >### Threat Indicators:
 >|Created At|Id|Operator Id|Report Id|Threat Key|Threat Level|Threat Value|
 >|---|---|---|---|---|---|---|
->| 2020-05-28T22:14:52.690Z | 75 | 2 | 5760 | URL | Malicious | `http://bold-air.000webhostapp.com/notification.php?email=test@demisto.net.net` |
+>| 2020-05-28T22:14:52.690Z | 75 | 2 | 5760 | URL | Malicious | `http://bold-air0example.com/notification.php?email=test@test.net` |
 

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/command_examples.txt
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/command_examples.txt
@@ -1,6 +1,7 @@
 !cofense-get-report-by-id report_id="5760"
 !cofense-get-attachment attachment_id="13311"
 !cofense-search-reports reported_at="7 days" created_at="7 days" max_matches="1"
+!cofense-search-inbox-reports reported_at="7 days" created_at="7 days" max_matches="1"
 !cofense-get-reporter reporter_id="1"
 !cofense-get-report-png-by-id report_id="5760" set_white_bg="True"
 !cofense-get-threat-indicators type="URL" level="Malicious" start_date="2020-05-28"

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/test/fixtures/inbox_reports.json
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/test/fixtures/inbox_reports.json
@@ -1,0 +1,160 @@
+[
+  {
+    "id": 13461,
+    "cluster_id": 3887,
+    "reporter_id": 222,
+    "location": "Inbox",
+    "primary_recipe_id": null,
+    "recipe_name": null,
+    "processing_operator_id": null,
+    "created_at": "2020-08-26T15:13:30.920Z",
+    "updated_at": "2020-08-26T15:13:35.200Z",
+    "reported_at": "2020-08-26T14:36:43.000Z",
+    "processed_at": null,
+    "report_subject": "Report subject 1 aaa",
+    "report_headers": "Date: Wed, 26 Aug 2020 15:13:30 +0000\r\nSubject: Report subject 1\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\ncharset=UTF-8\r\nContent-Transfer-Encoding: 7bit",
+    "report_body": "Report body 1",
+    "md5": "555",
+    "sha256": "555555",
+    "category_id": null,
+    "match_priority": 1,
+    "tags": [],
+    "reporter_phishme_reports_count": 0,
+    "suspect_received_at": "2020-08-26T14:36:51.000Z",
+    "suspect_from_address": null,
+    "email_attachments": [
+      {
+        "id": 18054,
+        "report_id": 13363,
+        "decoded_filename": "image003.png",
+        "content_type": "image/png; name=image003.png",
+        "size_in_bytes": 7286,
+        "email_attachment_payload": {
+          "id": 7082,
+          "md5": "123",
+          "sha256": "1234",
+          "mime_type": "image/png; charset=binary"
+        }
+      }
+    ],
+    "email_urls": [
+      {
+        "url": "https://example.com/url1.png"
+      },
+      {
+        "url": "https://example.com/url2.png"
+      },
+      {
+        "url": "https://example.com/url3.png"
+      }
+    ],
+    "rules": [
+      {
+        "id": 6417,
+        "name": "Triage_rule_1",
+        "reports_count": 67,
+        "active": true,
+        "created_at": "2019-04-11T17:15:53.940Z",
+        "updated_at": "2019-04-11T17:15:53.940Z",
+        "priority": 1,
+        "author_name": "Cofense"
+      }
+    ]
+  },
+  {
+    "id": 13459,
+    "cluster_id": 3885,
+    "reporter_id": 222,
+    "location": "Inbox",
+    "primary_recipe_id": null,
+    "recipe_name": null,
+    "processing_operator_id": null,
+    "created_at": "2020-08-24T19:48:34.938Z",
+    "updated_at": "2020-08-24T19:48:37.433Z",
+    "reported_at": "2020-08-24T19:36:04.000Z",
+    "processed_at": null,
+    "report_subject": "Report subject 2",
+    "report_headers": "Date: Wed, 26 Aug 2020 15:13:30 +0000\r\nSubject: Report subject 2\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\ncharset=UTF-8\r\nContent-Transfer-Encoding: 7bit",
+    "report_body": "Report body 2",
+    "md5": "555",
+    "sha256": "555555",
+    "category_id": null,
+    "match_priority": 1,
+    "tags": [],
+    "reporter_phishme_reports_count": 0,
+    "suspect_received_at": "2020-08-24T19:36:12.000Z",
+    "suspect_from_address": null,
+    "email_attachments": [],
+    "email_urls": [
+      {
+        "url": "https://example.com/url1.png"
+      },
+      {
+        "url": "https://example.com/url2.png"
+      },
+      {
+        "url": "https://example.com/url3.png"
+      }
+    ],
+    "rules": [
+      {
+        "id": 6417,
+        "name": "Triage_rule_1",
+        "reports_count": 67,
+        "active": true,
+        "created_at": "2019-04-11T17:15:53.940Z",
+        "updated_at": "2019-04-11T17:15:53.940Z",
+        "priority": 1,
+        "author_name": "Cofense"
+      }
+    ]
+  },
+  {
+    "id": 13458,
+    "cluster_id": 3884,
+    "reporter_id": 222,
+    "location": "Inbox",
+    "primary_recipe_id": null,
+    "recipe_name": null,
+    "processing_operator_id": null,
+    "created_at": "2020-08-24T16:43:04.412Z",
+    "updated_at": "2020-08-24T16:43:05.946Z",
+    "reported_at": "2020-08-24T16:15:52.000Z",
+    "processed_at": null,
+    "report_subject": "Report subject 3 aaa",
+    "report_headers": "Date: Wed, 26 Aug 2020 15:13:30 +0000\r\nSubject: Report subject 3\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\ncharset=UTF-8\r\nContent-Transfer-Encoding: 7bit",
+    "report_body": "Report body 3",
+    "md5": "555",
+    "sha256": "555555",
+    "category_id": null,
+    "match_priority": 1,
+    "tags": [],
+    "reporter_phishme_reports_count": 0,
+    "suspect_received_at": "2020-08-24T16:21:07.000Z",
+    "suspect_from_address": null,
+    "email_attachments": [],
+    "email_urls": [
+      {
+        "url": "https://example.com/url1.png"
+      },
+      {
+        "url": "https://example.com/url2.png"
+      },
+      {
+        "url": "https://example.com/url3.png"
+      }
+    ],
+    "rules": [
+      {
+        "id": 667,
+        "name": "Triage_rule_1",
+        "reports_count": 41,
+        "active": true,
+        "created_at": "2019-04-11T16:46:11.078Z",
+        "updated_at": "2019-04-11T16:46:11.078Z",
+        "priority": 1,
+        "author_name": "Cofense"
+      }
+    ]
+  }
+]

--- a/Packs/CofenseTriage/Integrations/CofenseTriagev2/test/fixtures/reporters_by_email_reporter2.json
+++ b/Packs/CofenseTriage/Integrations/CofenseTriagev2/test/fixtures/reporters_by_email_reporter2.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 222,
+    "email": "reporter2@example.com",
+    "created_at": "2019-04-12T02:58:17.401Z",
+    "updated_at": "2019-04-12T02:59:22.287Z",
+    "credibility_score": 0,
+    "reports_count": 3,
+    "last_reported_at": "2016-02-18T00:24:45.000Z",
+    "vip": false
+  }
+]

--- a/Packs/CofenseTriage/ReleaseNotes/1_1_6.md
+++ b/Packs/CofenseTriage/ReleaseNotes/1_1_6.md
@@ -1,0 +1,6 @@
+#### Integrations
+##### Cofense Triage v2
+- Added new `cofense-search-inbox-reports` command
+- Added new `mailbox_location` parameter to control the source of the periodic incident poll
+- Expanded existing `cofense-search-reports` command to support specifying reporter by email address. The new `cofense-search-inbox-reports` command already supports this.
+- Upgraded the Docker image to 1.0.0.11930

--- a/Packs/CofenseTriage/ReleaseNotes/1_1_6.md
+++ b/Packs/CofenseTriage/ReleaseNotes/1_1_6.md
@@ -3,4 +3,4 @@
 - Added new `cofense-search-inbox-reports` command
 - Added new `mailbox_location` parameter to control the source of the periodic incident poll
 - Expanded existing `cofense-search-reports` command to support specifying reporter by email address. The new `cofense-search-inbox-reports` command already supports this.
-- Upgraded the Docker image to 1.0.0.11930
+- Upgraded the Docker image to 1.0.0.12337

--- a/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
+++ b/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
@@ -1,4 +1,4 @@
-id: dc8a6cce-9ec5-46db-8250-129ad2ef6d6f
+id: Cofense Triage Test
 version: -1
 vcShouldKeepItemLegacyProdMachine: false
 name: Cofense Triage Test_copy

--- a/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
+++ b/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
@@ -1,7 +1,7 @@
 id: Cofense Triage Test
 version: -1
 vcShouldKeepItemLegacyProdMachine: false
-name: Cofense Triage Test_copy
+name: Cofense Triage Test
 starttaskid: "0"
 tasks:
   "0":

--- a/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
+++ b/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
@@ -345,4 +345,5 @@ view: |-
   }
 inputs: []
 outputs: []
+fromversion: 5.0.0,
 sourceplaybookid: Cofense Triage Test

--- a/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
+++ b/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
@@ -1,5 +1,5 @@
 id: dc8a6cce-9ec5-46db-8250-129ad2ef6d6f
-version: 4
+version: -1
 vcShouldKeepItemLegacyProdMachine: false
 name: Cofense Triage Test_copy
 starttaskid: "0"

--- a/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
+++ b/Packs/CofenseTriage/TestPlaybooks/playbook-Cofense_Triage_v2-Test.yml
@@ -1,20 +1,19 @@
-id: Cofense Triage v2 Test
-version: -1
-name: Cofense Triage v2 Test
-description: A test playbook for Cofense Triage v2.
+id: dc8a6cce-9ec5-46db-8250-129ad2ef6d6f
+version: 4
+vcShouldKeepItemLegacyProdMachine: false
+name: Cofense Triage Test_copy
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 7448b5f3-9d33-40bd-866a-ff8eec1fb87e
+    taskid: 3c435c1f-2d7f-4fe3-8b3b-d7f4c2f67265
     type: start
     task:
-      id: 7448b5f3-9d33-40bd-866a-ff8eec1fb87e
+      id: 3c435c1f-2d7f-4fe3-8b3b-d7f4c2f67265
       version: -1
       name: ""
       iscommand: false
       brand: ""
-      description: ''
     nexttasks:
       '#none#':
       - "1"
@@ -29,18 +28,20 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "1":
     id: "1"
-    taskid: 665c5482-7721-48dd-881f-0eacb3822f00
+    taskid: 83a5e3b3-042b-4f1d-8901-7f0db5aee4e2
     type: regular
     task:
-      id: 665c5482-7721-48dd-881f-0eacb3822f00
+      id: 83a5e3b3-042b-4f1d-8901-7f0db5aee4e2
       version: -1
       name: DeleteContext
-      description: ''
-      script: DeleteContext
+      description: Delete field from context
+      scriptName: DeleteContext
       type: regular
-      iscommand: true
+      iscommand: false
       brand: ""
     nexttasks:
       '#none#':
@@ -48,6 +49,10 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
+      index: {}
+      key: {}
+      keysToKeep: {}
+      subplaybook: {}
     separatecontext: false
     view: |-
       {
@@ -59,16 +64,18 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "2":
     id: "2"
-    taskid: 33ca1c17-0fa7-4b5b-89b2-dacb340f3ea4
+    taskid: 9279da5f-9965-4504-8e34-f2c5e55cf67a
     type: regular
     task:
-      id: 33ca1c17-0fa7-4b5b-89b2-dacb340f3ea4
+      id: 9279da5f-9965-4504-8e34-f2c5e55cf67a
       version: -1
-      name: cofense-search-reports
-      description: ''
-      script: '|||cofense-search-reports'
+      name: Get repot by ID
+      description: 'Retrieve a report by it''s ID number '
+      script: '|||cofense-get-report-by-id'
       type: regular
       iscommand: true
       brand: ""
@@ -76,18 +83,8 @@ tasks:
       '#none#':
       - "3"
     scriptarguments:
-      created_at:
-        simple: 60 days
-      file_hash: {}
-      max_matches:
-        simple: "1"
-      reported_at:
-        simple: 60 days
-      reporter: {}
-      subject: {}
-      url: {}
-      verbose:
-        simple: "true"
+      report_id:
+        simple: "5790"
     separatecontext: false
     view: |-
       {
@@ -99,65 +96,28 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "3":
     id: "3"
-    taskid: ad07b94e-f26f-4a6c-832f-014f5ec33240
-    type: condition
+    taskid: 0294486d-bf5a-4fc0-8138-f9f8bd803118
+    type: regular
     task:
-      id: ad07b94e-f26f-4a6c-832f-014f5ec33240
+      id: 0294486d-bf5a-4fc0-8138-f9f8bd803118
       version: -1
-      name: Verify Outputs
-      description: ''
-      type: condition
-      iscommand: false
+      name: Get attachment
+      description: 'Retrieve attachment by it''s ID number '
+      script: '|||cofense-get-attachment'
+      type: regular
+      iscommand: true
       brand: ""
     nexttasks:
-      "yes":
+      '#none#':
       - "4"
+    scriptarguments:
+      attachment_id:
+        simple: "10336"
     separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ID
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.CategoryId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.CreatedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReportedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReporterId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReportSubject
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReportBody
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.Sha256
-            iscontext: true
     view: |-
       {
         "position": {
@@ -168,16 +128,18 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "4":
     id: "4"
-    taskid: 2dbadefc-cb53-41a3-8125-e702b51f1004
+    taskid: 48b30a59-0f00-4dc4-8c3e-438ce56588bf
     type: regular
     task:
-      id: 2dbadefc-cb53-41a3-8125-e702b51f1004
+      id: 48b30a59-0f00-4dc4-8c3e-438ce56588bf
       version: -1
-      name: cofense-get-attachment
-      description: ''
-      script: '|||cofense-get-attachment'
+      name: Search reports
+      description: query for different reports
+      script: '|||cofense-search-reports'
       type: regular
       iscommand: true
       brand: ""
@@ -185,87 +147,36 @@ tasks:
       '#none#':
       - "5"
     scriptarguments:
-      attachment_id:
-        simple: "10336"
+      created_at: {}
+      file_hash: {}
+      max_matches: {}
+      reported_at: {}
+      reporter: {}
+      subject: {}
+      url: {}
+      verbose: {}
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 720
+          "y": 680
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "5":
     id: "5"
-    taskid: e70508ea-f6dc-44c0-815d-7ea3d173ccf6
-    type: condition
-    task:
-      id: e70508ea-f6dc-44c0-815d-7ea3d173ccf6
-      version: -1
-      name: Verify Outputs
-      description: ''
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "yes":
-      - "6"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.Size
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.EntryID
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.Name
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.SHA1
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.SHA256
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.MD5
-            iscontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 895
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "6":
-    id: "6"
-    taskid: 00b96ff0-87e7-4bc3-85fe-abe6bfbce6ed
+    taskid: d6d68063-3db4-4459-8596-74a96f91196d
     type: regular
     task:
-      id: 00b96ff0-87e7-4bc3-85fe-abe6bfbce6ed
+      id: d6d68063-3db4-4459-8596-74a96f91196d
       version: -1
-      name: cofense-get-reporter
-      description: ''
+      name: Get reporter
+      description: Retrieves Email address of the reporter by ID
       script: '|||cofense-get-reporter'
       type: regular
       iscommand: true
@@ -275,230 +186,100 @@ tasks:
       - "7"
     scriptarguments:
       reporter_id:
-        simple: ${Cofense.Report.ReporterId}
+        simple: "1"
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1070
+          "y": 985
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "6":
+    id: "6"
+    taskid: 35c6b67b-1ca4-40af-870d-2025de3344e4
+    type: title
+    task:
+      id: 35c6b67b-1ca4-40af-870d-2025de3344e4
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1450
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "7":
     id: "7"
-    taskid: fec016da-c894-4d8c-8479-447ebee70035
-    type: condition
-    task:
-      id: fec016da-c894-4d8c-8479-447ebee70035
-      version: -1
-      name: Verify Outputs
-      description: ''
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "yes":
-      - "14"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.ID
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.Email
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.CreatedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.UpdatedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.CredibilityScore
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.ReportsCount
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.LastReportedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Reporter.Vip
-            iscontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1245
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "8":
-    id: "8"
-    taskid: a74bb909-12a2-4cc2-8f71-48f45d4f28e4
+    taskid: bcde1016-8d2d-4ff7-8081-237314795db7
     type: regular
     task:
-      id: a74bb909-12a2-4cc2-8f71-48f45d4f28e4
+      id: bcde1016-8d2d-4ff7-8081-237314795db7
       version: -1
-      name: cofense-get-report-by-id
-      description: ''
-      script: '|||cofense-get-report-by-id'
-      type: regular
-      iscommand: true
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "9"
-    scriptarguments:
-      report_id:
-        simple: ${CofenseReportID}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1770
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "9":
-    id: "9"
-    taskid: 6776ce54-0a6e-42c0-8e33-1caa4d9cf107
-    type: condition
-    task:
-      id: 6776ce54-0a6e-42c0-8e33-1caa4d9cf107
-      version: -1
-      name: Verify Outputs
-      description: ''
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "yes":
-      - "10"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ID
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.CategoryId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.CreatedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReportedAt
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReporterId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.Report.ReportSubject
-            iscontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1945
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "10":
-    id: "10"
-    taskid: 82ecaea5-c420-4a6f-8f7c-a4c38dc767b4
-    type: regular
-    task:
-      id: 82ecaea5-c420-4a6f-8f7c-a4c38dc767b4
-      version: -1
-      name: cofense-get-report-png-by-id
-      description: ''
+      name: Get Report By PNG
+      description: 'Retrieves a report by the report ID number and displays as PNG '
       script: '|||cofense-get-report-png-by-id'
       type: regular
       iscommand: true
       brand: ""
     nexttasks:
       '#none#':
-      - "11"
+      - "8"
     scriptarguments:
       report_id:
-        simple: ${CofenseReportID}
-      set_white_bg:
-        simple: "True"
+        simple: "5790"
+      set_white_bg: {}
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 2120
+          "y": 1130
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "11":
-    id: "11"
-    taskid: 9ef8e959-5368-479a-8936-04f24ffafbd4
+    skipunavailable: false
+    quietmode: 0
+  "8":
+    id: "8"
+    taskid: 4496f8e2-ae76-4590-87fb-6a3655efb2e4
     type: regular
     task:
-      id: 9ef8e959-5368-479a-8936-04f24ffafbd4
+      id: 4496f8e2-ae76-4590-87fb-6a3655efb2e4
       version: -1
-      name: cofense-get-threat-indicators
-      description: ''
+      name: Cofense Threat Indicators
+      description: Threat Indicators that are designated by analysts as malicious,
+        suspicious or benign
       script: '|||cofense-get-threat-indicators'
       type: regular
       iscommand: true
       brand: ""
     nexttasks:
       '#none#':
-      - "12"
+      - "6"
     scriptarguments:
       end_date: {}
       level:
         simple: Malicious
       start_date:
-        simple: 2020-05-28
+        simple: "2020-03-01"
       type:
         simple: URL
     separatecontext: false
@@ -506,173 +287,56 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 2295
+          "y": 1305
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "12":
-    id: "12"
-    taskid: 97070a10-7f01-45b5-8e16-bb657394e49d
-    type: condition
-    task:
-      id: 97070a10-7f01-45b5-8e16-bb657394e49d
-      version: -1
-      name: Verify Outputs
-      description: ''
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "yes":
-      - "13"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.ID
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.OperatorId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.ReportId
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.ThreatKey
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.ThreatLevel
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: Cofense.ThreatIndicators.ThreatValue
-            iscontext: true
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 2470
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "13":
-    id: "13"
-    taskid: 1aacb719-5c32-4df9-89d0-0e91f253ac11
-    type: title
-    task:
-      id: 1aacb719-5c32-4df9-89d0-0e91f253ac11
-      version: -1
-      name: Test Done
-      type: title
-      iscommand: false
-      brand: ""
-      description: ''
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 2645
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-  "14":
-    id: "14"
-    taskid: 6782df63-754b-40ee-8a48-77f03872041b
+    skipunavailable: false
+    quietmode: 0
+  "9":
+    id: "9"
+    taskid: 218fa40b-1deb-4b4a-8bc8-741218c0c6c6
     type: regular
     task:
-      id: 6782df63-754b-40ee-8a48-77f03872041b
+      id: 218fa40b-1deb-4b4a-8bc8-741218c0c6c6
       version: -1
-      name: Save Report ID Key
-      description: Sets a value into the context with the given context key
-      scriptName: Set
+      name: cofense-search-inbox-reports
+      description: Searches Cofense Triage inbox for reported email
+      script: '|||cofense-search-inbox-reports'
       type: regular
-      iscommand: false
+      iscommand: true
       brand: ""
-    nexttasks:
-      '#none#':
-      - "15"
     scriptarguments:
-      append: {}
-      key:
-        simple: CofenseReportID
-      stringify: {}
-      value:
-        simple: ${Cofense.Report.ID}
+      created_at: {}
+      file_hash: {}
+      max_matches: {}
+      number_of_pages: {}
+      reported_at: {}
+      reporter: {}
+      subject: {}
+      url: {}
+      verbose: {}
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1420
+          "y": 845
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
-  "15":
-    id: "15"
-    taskid: 6ff68fe1-7a69-480b-86f8-d00039ced1b6
-    type: regular
-    task:
-      id: 6ff68fe1-7a69-480b-86f8-d00039ced1b6
-      version: -1
-      name: Delete Cofense Report Key
-      description: Delete field from context
-      scriptName: DeleteContext
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "8"
-    scriptarguments:
-      all: {}
-      index: {}
-      key:
-        simple: Cofense.Report
-      keysToKeep: {}
-      subplaybook: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 50,
-          "y": 1595
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 2660,
+        "height": 1465,
         "width": 380,
         "x": 50,
         "y": 50
@@ -681,4 +345,4 @@ view: |-
   }
 inputs: []
 outputs: []
-fromversion: 5.0.0
+sourceplaybookid: Cofense Triage Test

--- a/Packs/CofenseTriage/pack_metadata.json
+++ b/Packs/CofenseTriage/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cofense Triage",
     "description": "Use the Cofense Triage integration to manage reports and attachments.",
     "support": "partner",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cofense",
     "url": "https://cofense.com/contact-support/",
     "email": "support@cofense.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## XSOAR [Partner](https://xsoar.pan.dev/docs/partners/become-a-tech-partner)?
In case you are a technological partner:
- [x] The title must be in the following format: **[YOUR_PARTNER_ID] short description**.

If you are not a technological partner (i.e. PANW employee, customer or individual developer), please delete this section.

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
The `cofense-search-inbox-reports` command allows searching for reports in the inbox.

The `mailbox_location` parameter controls the source of reports for the periodic fetch functionality.

The new command and the legacy `cofense-search-reports` command both support querying by reporter address in addition to reporter ID.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation