### PR TITLE
Case Management Pack - Fixes for Incident Action Buttons on Layout, Case Report, Widgets

### DIFF
--- a/Packs/CaseManagement-Generic/Dashboards/dashboard-Incidents_Overview.json
+++ b/Packs/CaseManagement-Generic/Dashboards/dashboard-Incidents_Overview.json
@@ -2,1353 +2,1472 @@
     "fromDate": "0001-01-01T00:00:00Z",
     "fromDateLicense": "0001-01-01T00:00:00Z",
     "id": "Incidents Overview",
-    "layout": [
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "8efbf5c0-e4ff-11e7-b60b-df7995291baf",
-            "id": "8efbf5c0-e4ff-11e7-b60b-df7995291baf",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "active-incidents-by-severity",
-                "isPredefined": true,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Active Incidents by Severity",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "severity"
-                    ]
-                },
-                "prevName": "",
-                "query": "-category:job and -status:archived and -status:closed",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": -1,
-                "widgetType": "pie"
-            },
-            "x": 0,
-            "y": 1
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "8fa3a770-e4ff-11e7-b60b-df7995291baf",
-            "id": "8fa3a770-e4ff-11e7-b60b-df7995291baf",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Active Incidents by Type",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "type"
-                    ],
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "",
-                "query": "-category:job and -status:archived and -status:closed",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "pie"
-            },
-            "x": 3,
-            "y": 1
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "ab3a69b0-06a6-11e8-9f30-0903d8762b71",
-            "id": "ab3a69b0-06a6-11e8-9f30-0903d8762b71",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Unassigned Incidents",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": true,
-                        "items": {
-                            "#00CD33": {
-                                "value": -1
-                            },
-                            "#FAC100": {
-                                "value": 0
-                            }
-                        },
-                        "type": "above"
-                    },
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "",
-                "query": "-category:job and -status:archived and -status:closed and owner:\"\"",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "trend"
-            },
-            "x": 6,
-            "y": 0
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "b95f04b0-06a6-11e8-9f30-0903d8762b71",
-            "id": "b95f04b0-06a6-11e8-9f30-0903d8762b71",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": true,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Late Incidents",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": true,
-                        "items": {
-                            "#FF1B15": {
-                                "value": 0
-                            }
-                        },
-                        "type": "above"
-                    }
-                },
-                "prevName": "",
-                "query": "-category:job and -status:archived and -status:closed and dueDate:<now",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": -1,
-                "widgetType": "trend"
-            },
-            "x": 9,
-            "y": 0
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "cad75e90-06a6-11e8-9f30-0903d8762b71",
-            "id": "cad75e90-06a6-11e8-9f30-0903d8762b71",
-            "w": 12,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Active Incidents Assigned by User",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "owner"
-                    ],
-                    "hideLegend": false,
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "",
-                "query": "-category:job and -status:archived and -status:closed and -owner:\"\"",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "column"
-            },
-            "x": 0,
-            "y": 3
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "5f207d30-0746-11e8-8294-876d51689c2e",
-            "id": "5f207d30-0746-11e8-8294-876d51689c2e",
-            "w": 3,
-            "widget": {
-                "category": "others",
-                "commitMessage": "",
-                "dataType": "roi",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "saved-by-dbot",
-                "isPredefined": true,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Saved By DBot",
-                "packID": "",
-                "params": {
-                    "currencySign": "$"
-                },
-                "prevName": "",
-                "query": "",
-                "shouldCommit": false,
-                "size": 5,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": -1,
-                "widgetType": "number"
-            },
-            "x": 9,
-            "y": 1
-        },
-        {
-            "forceRange": true,
-            "h": 1,
-            "i": "0be91fe0-0747-11e8-8294-876d51689c2e",
-            "id": "0be91fe0-0747-11e8-8294-876d51689c2e",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "2018-02-01T00:00:00+02:00",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 0,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "todays-new-incidents",
-                "isPredefined": true,
-                "itemVersion": "",
-                "modified": "0001-01-01T00:00:00Z",
-                "name": "Today's New Incidents",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": true,
-                        "items": {
-                            "#00CD33": {
-                                "value": -1
-                            },
-                            "#FAC100": {
-                                "value": 10
-                            },
-                            "#FF1B15": {
-                                "value": 100
-                            }
-                        },
-                        "type": "above"
-                    }
-                },
-                "prevName": "",
-                "query": "-status:closed -category:job",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": -1,
-                "widgetType": "trend"
-            },
-            "x": 3,
-            "y": 0
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "c553bff0-a45f-11ea-9256-394fe136c3ee",
-            "id": "c553bff0-a45f-11ea-9256-394fe136c3ee",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "mean-time-to-resolution-occurred",
-                "isPredefined": true,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:27.115057596+03:00",
-                "name": "Mean Time to Resolution (Occurred)",
-                "packID": "",
-                "params": {
-                    "keys": [
-                        "avg|closed - occurred",
-                        "count|1"
-                    ]
-                },
-                "prevName": "Mean Time to Resolution (Occurred)",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "-category:job and status:closed",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 1,
-                "widgetType": "duration"
-            },
-            "x": 0,
-            "y": 5
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "7da58050-a462-11ea-9256-394fe136c3ee",
-            "id": "7da58050-a462-11ea-9256-394fe136c3ee",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": null,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "c6be9e3a-0c45-4ba1-8266-b44a4a0c6f70",
-                "isPredefined": false,
-                "itemVersion": "",
-                "modified": "2020-06-02T02:48:59.869411903+03:00",
-                "name": "Open Incidents",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": false,
-                        "items": {
-                            "#00CD33": {
-                                "value": -1
-                            },
-                            "#FAC100": {
-                                "value": 25
-                            },
-                            "#FF1B15": {
-                                "value": 50
-                            }
-                        },
-                        "type": "above"
-                    },
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "Active Incidents",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "-status:closed -category:job",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 1,
-                "widgetType": "number"
-            },
-            "x": 0,
-            "y": 0
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "27f39030-a4de-11ea-8c29-db553c036fb9",
-            "id": "27f39030-a4de-11ea-8c29-db553c036fb9",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:26.946364371+03:00",
-                "name": "Incidents Top Close Analysts",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "closingUserId"
-                    ],
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "Incidents Top Close Analysts",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "-category:job and status:closed and -closingUser:\"DBot\"",
-                "shouldCommit": false,
-                "size": 5,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "bar"
-            },
-            "x": 9,
-            "y": 5
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "93380b00-a4de-11ea-8c29-db553c036fb9",
-            "id": "93380b00-a4de-11ea-8c29-db553c036fb9",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "3201c062-1e95-4274-8374-b2f8ed10591e",
-                "isPredefined": false,
-                "itemVersion": "",
-                "modified": "2020-06-02T17:37:12.375197769+03:00",
-                "name": "Closed Incidents by Reason",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "closeReason"
-                    ],
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "Closed Incidents by Reason",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "-category:job and status:closed",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 1,
-                "widgetType": "pie"
-            },
-            "x": 6,
-            "y": 1
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "8f3e7b10-a5e2-11ea-beb5-2996637e1d9e",
-            "id": "8f3e7b10-a5e2-11ea-beb5-2996637e1d9e",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:27.035567366+03:00",
-                "name": "Open Incidents by Role",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "roles"
-                    ],
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "Incidents by Role",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "-category:job",
-                "shouldCommit": false,
-                "size": 10,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "pie"
-            },
-            "x": 3,
-            "y": 5
-        },
-        {
-            "forceRange": false,
-            "h": 2,
-            "i": "9c94c990-a5e2-11ea-beb5-2996637e1d9e",
-            "id": "9c94c990-a5e2-11ea-beb5-2996637e1d9e",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:27.260336294+03:00",
-                "name": "Closed Incidents by Role",
-                "packID": "",
-                "params": {
-                    "groupBy": [
-                        "roles"
-                    ],
-                    "tableColumns": [
-                        {
-                            "isDefault": true,
-                            "key": "id",
-                            "position": 0,
-                            "width": 110
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "name",
-                            "position": 2,
-                            "width": 300
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "type",
-                            "position": 3,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "severity",
-                            "position": 4,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "status",
-                            "position": 5,
-                            "width": 80
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "owner",
-                            "position": 6,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "roles",
-                            "position": 7,
-                            "width": 160
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "playbookId",
-                            "position": 8,
-                            "width": 150
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "occurred",
-                            "position": 9,
-                            "width": 200
-                        },
-                        {
-                            "isDefault": true,
-                            "key": "dueDate",
-                            "position": 10,
-                            "width": 200
-                        }
-                    ]
-                },
-                "prevName": "Closed Incidents by Role",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "status:closed",
-                "shouldCommit": false,
-                "size": 10,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "pie"
-            },
-            "x": 6,
-            "y": 5
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "89eecfb0-a5e3-11ea-beb5-2996637e1d9e",
-            "id": "89eecfb0-a5e3-11ea-beb5-2996637e1d9e",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "incidents",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": 7,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:27.295883968+03:00",
-                "name": "Incidents in Error Run Status",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": true,
-                        "items": {
-                            "#00CD33": {
-                                "value": 0
-                            },
-                            "#FAC100": {
-                                "value": 0
-                            },
-                            "#FF1B15": {
-                                "value": 20
-                            }
-                        },
-                        "type": "above"
-                    }
-                },
-                "prevName": "Incidents in Error Run Status",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "runStatus:error",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "number"
-            },
-            "x": 0,
-            "y": 6
-        },
-        {
-            "forceRange": false,
-            "h": 1,
-            "i": "27264f10-a5e4-11ea-beb5-2996637e1d9e",
-            "id": "27264f10-a5e4-11ea-beb5-2996637e1d9e",
-            "w": 3,
-            "widget": {
-                "category": "",
-                "commitMessage": "",
-                "dataType": "scripts",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "fromDateLicense": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byFrom": "days",
-                        "byTo": "",
-                        "field": "",
-                        "fromValue": null,
-                        "toValue": null
-                    },
-                    "toDate": "0001-01-01T00:00:00Z"
-                },
-                "description": "Showing percentage of incidents handled and closed by DBot, without an owner being assigned to, across all incidents in the provided period",
-                "fromServerVersion": "",
-                "id": "",
-                "isPredefined": false,
-                "itemVersion": "",
-                "locked": true,
-                "modified": "2020-05-27T00:37:27.181498162+03:00",
-                "name": "Closed By Dbot",
-                "packID": "",
-                "params": {
-                    "colors": {
-                        "isEnabled": true,
-                        "items": {
-                            "#00CD33": {
-                                "value": -1
-                            }
-                        },
-                        "type": "above"
-                    },
-                    "currencySign": "%",
-                    "signAlignment": "right"
-                },
-                "prevName": "Closed By Dbot",
-                "propagationLabels": [
-                    "all"
-                ],
-                "query": "DBotClosedIncidentsPercentage",
-                "shouldCommit": false,
-                "size": 0,
-                "sort": null,
-                "sortValues": null,
-                "toServerVersion": "",
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "version": 0,
-                "widgetType": "number"
-            },
-            "x": 9,
-            "y": 2
-        }
-    ],
     "name": "Incidents Overview",
-    "period": {
-        "by": "",
-        "byFrom": "days",
-        "byTo": "",
-        "field": "",
-        "fromValue": 30,
-        "toValue": null
-    },
+	"layout": [
+		{
+			"id": "8efbf5c0-e4ff-11e7-b60b-df7995291baf",
+			"forceRange": false,
+			"x": 0,
+			"y": 1,
+			"i": "8efbf5c0-e4ff-11e7-b60b-df7995291baf",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "active-incidents-by-severity",
+				"version": -1,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Active Incidents by Severity",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "-category:job and -status:archived and -status:closed",
+				"sort": null,
+				"isPredefined": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"severity"
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "8fa3a770-e4ff-11e7-b60b-df7995291baf",
+			"forceRange": false,
+			"x": 3,
+			"y": 1,
+			"i": "8fa3a770-e4ff-11e7-b60b-df7995291baf",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Active Incidents by Type",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "-category:job and -status:archived and -status:closed",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"type"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "ab3a69b0-06a6-11e8-9f30-0903d8762b71",
+			"forceRange": false,
+			"x": 6,
+			"y": 0,
+			"i": "ab3a69b0-06a6-11e8-9f30-0903d8762b71",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Unassigned Incidents",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "trend",
+				"query": "-category:job and -status:archived and -status:closed and owner:\"\"",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#00CD33": {
+								"value": -1
+							},
+							"#FAC100": {
+								"value": 0
+							}
+						},
+						"type": "above"
+					},
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "b95f04b0-06a6-11e8-9f30-0903d8762b71",
+			"forceRange": false,
+			"x": 9,
+			"y": 0,
+			"i": "b95f04b0-06a6-11e8-9f30-0903d8762b71",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "",
+				"version": -1,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Late Incidents",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "trend",
+				"query": "-category:job and -status:archived and -status:closed and dueDate:\u003cnow",
+				"sort": null,
+				"isPredefined": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#FF1B15": {
+								"value": 0
+							}
+						},
+						"type": "above"
+					}
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "cad75e90-06a6-11e8-9f30-0903d8762b71",
+			"forceRange": false,
+			"x": 0,
+			"y": 3,
+			"i": "cad75e90-06a6-11e8-9f30-0903d8762b71",
+			"w": 9,
+			"h": 2,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Active Incidents Assigned by User",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "column",
+				"query": "-category:job and -status:archived and -status:closed and -owner:\"\"",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"owner"
+					],
+					"hideLegend": false,
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "5f207d30-0746-11e8-8294-876d51689c2e",
+			"forceRange": false,
+			"x": 9,
+			"y": 3,
+			"i": "5f207d30-0746-11e8-8294-876d51689c2e",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "saved-by-dbot",
+				"version": -1,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Saved By DBot",
+				"prevName": "",
+				"dataType": "roi",
+				"widgetType": "number",
+				"query": "",
+				"sort": null,
+				"isPredefined": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"currencySign": "$"
+				},
+				"size": 5,
+				"category": "others"
+			}
+		},
+		{
+			"id": "0be91fe0-0747-11e8-8294-876d51689c2e",
+			"forceRange": true,
+			"x": 3,
+			"y": 0,
+			"i": "0be91fe0-0747-11e8-8294-876d51689c2e",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "todays-new-incidents",
+				"version": -1,
+				"modified": "0001-01-01T00:00:00Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Today's New Incidents",
+				"prevName": "",
+				"dataType": "incidents",
+				"widgetType": "trend",
+				"query": "-status:closed -category:job",
+				"sort": null,
+				"isPredefined": true,
+				"dateRange": {
+					"fromDate": "2018-01-31T22:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 0,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#00CD33": {
+								"value": -1
+							},
+							"#FAC100": {
+								"value": 10
+							},
+							"#FF1B15": {
+								"value": 100
+							}
+						},
+						"type": "above"
+					}
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "c553bff0-a45f-11ea-9256-394fe136c3ee",
+			"forceRange": false,
+			"x": 0,
+			"y": 5,
+			"i": "c553bff0-a45f-11ea-9256-394fe136c3ee",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "mean-time-to-resolution-occurred",
+				"version": 1,
+				"modified": "2020-05-26T21:37:27.115057596Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Mean Time to Resolution (Occurred)",
+				"prevName": "Mean Time to Resolution (Occurred)",
+				"dataType": "incidents",
+				"widgetType": "duration",
+				"query": "-category:job and status:closed",
+				"sort": null,
+				"isPredefined": true,
+				"locked": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"keys": [
+						"avg|closed - occurred",
+						"count|1"
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "7da58050-a462-11ea-9256-394fe136c3ee",
+			"forceRange": false,
+			"x": 0,
+			"y": 0,
+			"i": "7da58050-a462-11ea-9256-394fe136c3ee",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "c6be9e3a-0c45-4ba1-8266-b44a4a0c6f70",
+				"version": 1,
+				"modified": "2020-06-01T23:48:59.869411903Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Open Incidents",
+				"prevName": "Active Incidents",
+				"dataType": "incidents",
+				"widgetType": "number",
+				"query": "-status:closed -category:job",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": null,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": false,
+						"items": {
+							"#00CD33": {
+								"value": -1
+							},
+							"#FAC100": {
+								"value": 25
+							},
+							"#FF1B15": {
+								"value": 50
+							}
+						},
+						"type": "above"
+					},
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "27f39030-a4de-11ea-8c29-db553c036fb9",
+			"forceRange": false,
+			"x": 9,
+			"y": 5,
+			"i": "27f39030-a4de-11ea-8c29-db553c036fb9",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "2020-05-26T21:37:26.946364371Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Incidents Top Close Analysts",
+				"prevName": "Incidents Top Close Analysts",
+				"dataType": "incidents",
+				"widgetType": "bar",
+				"query": "-category:job and status:closed and -closingUser:\"DBot\"",
+				"sort": null,
+				"isPredefined": false,
+				"locked": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"closingUserId"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 5,
+				"category": ""
+			}
+		},
+		{
+			"id": "93380b00-a4de-11ea-8c29-db553c036fb9",
+			"forceRange": false,
+			"x": 9,
+			"y": 1,
+			"i": "93380b00-a4de-11ea-8c29-db553c036fb9",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "3201c062-1e95-4274-8374-b2f8ed10591e",
+				"version": 1,
+				"modified": "2020-06-02T14:37:12.375197769Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Closed Incidents by Reason",
+				"prevName": "Closed Incidents by Reason",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "-category:job and status:closed",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"closeReason"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "8f3e7b10-a5e2-11ea-beb5-2996637e1d9e",
+			"forceRange": false,
+			"x": 3,
+			"y": 5,
+			"i": "8f3e7b10-a5e2-11ea-beb5-2996637e1d9e",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "2020-05-26T21:37:27.035567366Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Open Incidents by Role",
+				"prevName": "Incidents by Role",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "-category:job",
+				"sort": null,
+				"isPredefined": false,
+				"locked": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"roles"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 10,
+				"category": ""
+			}
+		},
+		{
+			"id": "9c94c990-a5e2-11ea-beb5-2996637e1d9e",
+			"forceRange": false,
+			"x": 6,
+			"y": 5,
+			"i": "9c94c990-a5e2-11ea-beb5-2996637e1d9e",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "2020-05-26T21:37:27.260336294Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Closed Incidents by Role",
+				"prevName": "Closed Incidents by Role",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "status:closed",
+				"sort": null,
+				"isPredefined": false,
+				"locked": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"groupBy": [
+						"roles"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 10,
+				"category": ""
+			}
+		},
+		{
+			"id": "89eecfb0-a5e3-11ea-beb5-2996637e1d9e",
+			"forceRange": false,
+			"x": 0,
+			"y": 6,
+			"i": "89eecfb0-a5e3-11ea-beb5-2996637e1d9e",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "2020-05-26T21:37:27.295883968Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Incidents in Error Run Status",
+				"prevName": "Incidents in Error Run Status",
+				"dataType": "incidents",
+				"widgetType": "number",
+				"query": "runStatus:error",
+				"sort": null,
+				"isPredefined": false,
+				"locked": true,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": 7,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#00CD33": {
+								"value": 0
+							},
+							"#FAC100": {
+								"value": 0
+							},
+							"#FF1B15": {
+								"value": 20
+							}
+						},
+						"type": "above"
+					}
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "27264f10-a5e4-11ea-beb5-2996637e1d9e",
+			"forceRange": false,
+			"x": 9,
+			"y": 4,
+			"i": "27264f10-a5e4-11ea-beb5-2996637e1d9e",
+			"w": 3,
+			"h": 1,
+			"widget": {
+				"id": "",
+				"version": 0,
+				"modified": "2020-05-26T21:37:27.181498162Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"propagationLabels": [
+					"all"
+				],
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Closed By Dbot",
+				"prevName": "Closed By Dbot",
+				"dataType": "scripts",
+				"widgetType": "number",
+				"query": "DBotClosedIncidentsPercentage",
+				"sort": null,
+				"isPredefined": false,
+				"locked": true,
+				"description": "Showing percentage of incidents handled and closed by DBot, without an owner being assigned to, across all incidents in the provided period",
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": null,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#00CD33": {
+								"value": -1
+							}
+						},
+						"type": "above"
+					},
+					"currencySign": "%",
+					"signAlignment": "right"
+				},
+				"size": 0,
+				"category": ""
+			}
+		},
+		{
+			"id": "34cddfc0-e7ac-11ea-a986-6f7d22363cf7",
+			"forceRange": false,
+			"x": 6,
+			"y": 1,
+			"i": "34cddfc0-e7ac-11ea-a986-6f7d22363cf7",
+			"w": 3,
+			"h": 2,
+			"widget": {
+				"id": "c6be9e3a-0c45-4ba1-8266-b44a4a0c6f70",
+				"version": 2,
+				"modified": "2020-08-26T00:38:40.190772589Z",
+				"sortValues": null,
+				"packID": "",
+				"itemVersion": "",
+				"fromServerVersion": "",
+				"toServerVersion": "",
+				"vcShouldIgnore": false,
+				"vcShouldKeepItemLegacyProdMachine": false,
+				"commitMessage": "",
+				"shouldCommit": false,
+				"name": "Active Incidents by Source",
+				"prevName": "Active Incidents",
+				"dataType": "incidents",
+				"widgetType": "pie",
+				"query": "-status:closed -category:job",
+				"sort": null,
+				"isPredefined": false,
+				"dateRange": {
+					"fromDate": "0001-01-01T00:00:00Z",
+					"toDate": "0001-01-01T00:00:00Z",
+					"period": {
+						"by": "",
+						"byTo": "",
+						"byFrom": "days",
+						"toValue": null,
+						"fromValue": null,
+						"field": ""
+					},
+					"fromDateLicense": "0001-01-01T00:00:00Z"
+				},
+				"params": {
+					"colors": {
+						"isEnabled": true,
+						"items": {
+							"#00CD33": {
+								"value": -1
+							},
+							"#FAC100": {
+								"value": 25
+							},
+							"#FF1B15": {
+								"value": 50
+							}
+						},
+						"type": "above"
+					},
+					"groupBy": [
+						"sourceBrand"
+					],
+					"tableColumns": [
+						{
+							"isDefault": true,
+							"key": "id",
+							"position": 0,
+							"width": 110
+						},
+						{
+							"isDefault": true,
+							"key": "name",
+							"position": 2,
+							"width": 300
+						},
+						{
+							"isDefault": true,
+							"key": "type",
+							"position": 3,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "severity",
+							"position": 4,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "status",
+							"position": 5,
+							"width": 80
+						},
+						{
+							"isDefault": true,
+							"key": "owner",
+							"position": 6,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "roles",
+							"position": 7,
+							"width": 160
+						},
+						{
+							"isDefault": true,
+							"key": "playbookId",
+							"position": 8,
+							"width": 150
+						},
+						{
+							"isDefault": true,
+							"key": "occurred",
+							"position": 9,
+							"width": 200
+						},
+						{
+							"isDefault": true,
+							"key": "dueDate",
+							"position": 10,
+							"width": 200
+						}
+					]
+				},
+				"size": 0,
+				"category": ""
+			}
+		}
+	],
     "toDate": "0001-01-01T00:00:00Z",
     "version": -1,
     "fromVersion": "5.0.0",

--- a/Packs/CaseManagement-Generic/Layouts/layout-close-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-close-Case_layout-Case.json
@@ -1,35 +1,36 @@
 {
-    "kind": "close",
-    "layout": {
-        "id": "Case layout",
-        "name": "Case layout",
-        "version": -1,
-        "kind": "close",
-        "typeId": "Case",
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_closereason",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_closenotes",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            }
-        ]
-    },
-    "fromVersion": "5.0.0",
-    "toVersion": "5.9.9",
-    "typeId": "Case",
-    "version": -1
+ "kind": "close",
+ "layout": {
+  "id": "Case",
+  "name": "Case",
+  "version": -1,
+  "typeId": "Case",
+  "kind": "close",
+  "sections": [
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_closereason",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_closenotes",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Basic Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   }
+  ]
+ },
+ "fromVersion": "5.0.0",
+ "toVersion": "5.9.9",
+ "typeId": "Case",
+ "version": -1,
+ "description": ""
 }

--- a/Packs/CaseManagement-Generic/Layouts/layout-detailsV2-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-detailsV2-Case_layout-Case.json
@@ -707,7 +707,7 @@
    }
   ]
  },
- "fromVersion": "5.0.0",
+ "fromVersion": "5.5.0",
  "toVersion": "5.9.9",
  "typeId": "Case",
  "version": -1,

--- a/Packs/CaseManagement-Generic/Layouts/layout-detailsV2-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-detailsV2-Case_layout-Case.json
@@ -1,698 +1,715 @@
 {
-    "kind": "detailsV2",
-    "layout": {
-        "id": "Case layout",
-        "name": "Case layout",
-        "version": -1,
-        "kind": "detailsV2",
-        "typeId": "Case",
-        "tabs": [
-            {
-                "id": "summary",
-                "name": "Legacy Summary",
-                "type": "summary"
-            },
-            {
-                "id": "caseinfoid",
-                "name": "Incident Info",
-                "sections": [
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                        "isVisible": true,
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "severity",
-                                "height": 22,
-                                "id": "incident-severity-field",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "type",
-                                "height": 22,
-                                "id": "incident-type-field",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "owner",
-                                "height": 22,
-                                "id": "incident-owner-field",
-                                "index": 2,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "roles",
-                                "height": 22,
-                                "id": "73a95920-a6ae-11ea-ae9d-8553407179ff",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbotcreated",
-                                "height": 22,
-                                "id": "incident-created-field",
-                                "index": 4,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "occurred",
-                                "height": 22,
-                                "id": "incident-occurred-field",
-                                "index": 6,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbotmodified",
-                                "height": 22,
-                                "id": "incident-modified-field",
-                                "index": 7,
-                                "listId": "caseinfoid-ac32f620-a0b0-11e9-b27f-13ae1773d289",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbotclosed",
-                                "height": 22,
-                                "id": "eda146a0-a1ba-11ea-8efe-d92f013a0581",
-                                "index": 8,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbottotaltime",
-                                "height": 22,
-                                "id": "c57778a0-a5e0-11ea-beb5-2996637e1d9e",
-                                "index": 9,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbotduedate",
-                                "height": 22,
-                                "id": "incident-dueDate-field",
-                                "index": 10,
-                                "listId": "caseinfoid-ac32f620-a0b0-11e9-b27f-13ae1773d289",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "moved": false,
-                        "name": "Case Details",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "h": 2,
-                        "i": "caseinfoid-61263cc0-98b1-11e9-97d7-ed26ef9e46c8",
-                        "moved": false,
-                        "name": "Notes",
-                        "static": false,
-                        "type": "notes",
-                        "w": 2,
-                        "x": 1,
-                        "y": 2
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
-                        "moved": false,
-                        "name": "Work Plan",
-                        "static": false,
-                        "type": "workplan",
-                        "w": 1,
-                        "x": 0,
-                        "y": 2
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
-                        "isVisible": true,
-                        "moved": false,
-                        "name": "Linked Incidents",
-                        "static": false,
-                        "type": "linkedIncidents",
-                        "w": 1,
-                        "x": 2,
-                        "y": 8
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-4a31afa0-98ba-11e9-a519-93a53c759fe0",
-                        "moved": false,
-                        "name": "Evidence",
-                        "static": false,
-                        "type": "evidence",
-                        "w": 1,
-                        "x": 1,
-                        "y": 8
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-7717e580-9bed-11e9-9a3f-8b4b2158e260",
-                        "moved": false,
-                        "name": "Team Members",
-                        "static": false,
-                        "type": "team",
-                        "w": 1,
-                        "x": 0,
-                        "y": 6
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-7ce69dd0-a07f-11e9-936c-5395a1acf11e",
-                        "moved": false,
-                        "name": "Indicators",
-                        "query": "",
-                        "queryType": "input",
-                        "static": false,
-                        "type": "indicators",
-                        "w": 2,
-                        "x": 1,
-                        "y": 4
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-88e6bf70-a0b1-11e9-b27f-13ae1773d289",
-                        "isVisible": true,
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "dbotclosed",
-                                "height": 22,
-                                "id": "incident-dbotClosed-field",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "closereason",
-                                "height": 22,
-                                "id": "incident-closeReason-field",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "closenotes",
-                                "height": 44,
-                                "id": "incident-closeNotes-field",
-                                "index": 2,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "closinguserid",
-                                "height": 22,
-                                "id": "85c48b10-a1be-11ea-8efe-d92f013a0581",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "moved": false,
-                        "name": "Closing Information",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 8
-                    },
-                    {
-                        "description": "",
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
-                        "isVisible": true,
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "details",
-                                "height": 44,
-                                "id": "incident-details-field",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "playbookid",
-                                "height": 22,
-                                "id": "incident-playbookId-field",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "dbotsource",
-                                "height": 22,
-                                "id": "incident-source-field",
-                                "index": 2,
-                                "listId": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "sourceinstance",
-                                "height": 22,
-                                "id": "incident-sourceInstance-field",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "sourcebrand",
-                                "height": 22,
-                                "id": "incident-sourceBrand-field",
-                                "index": 4,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "droppedcount",
-                                "height": 22,
-                                "id": "c3b7a1b0-b0cc-11ea-b214-43cd85c54102",
-                                "index": 5,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "linkedcount",
-                                "height": 22,
-                                "id": "fa230670-ce01-11ea-89bb-21cbad8301ae",
-                                "index": 6,
-                                "listId": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "moved": false,
-                        "name": "Investigation Details",
-                        "static": false,
-                        "w": 1,
-                        "x": 1,
-                        "y": 0
-                    },
-                    {
-                        "description": "",
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-2bef1500-a0f2-11ea-a9ea-3d6524d9ea90",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "incident_labels",
-                                "height": 22,
-                                "id": "2be6d7a1-a0f2-11ea-a9ea-3d6524d9ea90",
-                                "index": 0,
-                                "isVisible": true,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Labels",
-                        "static": false,
-                        "type": "labels",
-                        "w": 1,
-                        "x": 2,
-                        "y": 0
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-192828c0-a1bb-11ea-8efe-d92f013a0581",
-                        "items": [
-                            {
-                                "args": {},
-                                "buttonClass": "success",
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "",
-                                "height": 44,
-                                "id": "1d1cbb80-a1bb-11ea-8efe-d92f013a0581",
-                                "index": 0,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "name": "Assign to Me",
-                                "scriptId": "06af8e6e-d0e5-4f5c-899a-3823b99662b5",
-                                "sectionItemType": "button",
-                                "startCol": 0
-                            },
-                            {
-                                "args": {},
-                                "buttonClass": "primary",
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "",
-                                "height": 44,
-                                "id": "4d83eff0-a1bb-11ea-8efe-d92f013a0581",
-                                "index": 1,
-                                "listId": "caseinfoid-192828c0-a1bb-11ea-8efe-d92f013a0581",
-                                "name": "Close as Duplicate",
-                                "scriptId": "CloseInvestigationAsDuplicate",
-                                "sectionItemType": "button",
-                                "startCol": 0
-                            },
-                            {
-                                "args": {},
-                                "buttonClass": "warning",
-                                "endCol": 2,
-                                "fieldId": "",
-                                "height": 44,
-                                "id": "1e97e9d0-a1bb-11ea-8efe-d92f013a0581",
-                                "index": 2,
-                                "name": "Link Incidents",
-                                "scriptId": "2b9e3e5a-d49e-4ab9-8389-68b2274c760a",
-                                "sectionItemType": "button",
-                                "startCol": 0
-                            },
-                            {
-                                "args": {},
-                                "buttonClass": "error",
-                                "endCol": 2,
-                                "fieldId": "",
-                                "height": 44,
-                                "id": "67c36b80-de7d-11ea-82d9-bd6173dcd42e",
-                                "index": 3,
-                                "name": "Generate Summary Report",
-                                "scriptId": "acb34501-dbf5-4edc-80ab-d9515ec204ce",
-                                "sectionItemType": "button",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Quick Actions",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 4
-                    },
-                    {
-                        "description": "",
-                        "h": 2,
-                        "i": "caseinfoid-5f87e5c0-a4e1-11ea-8c29-db553c036fb9",
-                        "items": [],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "War Room Chat",
-                        "query": {
-                            "categories": [
-                                "chats"
-                            ],
-                            "fromTime": "0001-01-01T00:00:00Z",
-                            "pageSize": 0,
-                            "tagsAndOperator": false,
-                            "usersAndOperator": false
-                        },
-                        "queryType": "warRoomFilter",
-                        "static": false,
-                        "type": "invTimeline",
-                        "w": 2,
-                        "x": 1,
-                        "y": 6
-                    }
-                ],
-                "type": "custom"
-            },
-            {
-                "hidden": false,
-                "id": "kkq7tnozrg",
-                "name": "Investigation",
-                "sections": [
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideItemTitleOnlyOne": true,
-                        "i": "kkq7tnozrg-c504da40-a1ba-11ea-8efe-d92f013a0581",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "incident_labels",
-                                "height": 22,
-                                "id": "c4f63441-a1ba-11ea-8efe-d92f013a0581",
-                                "index": 0,
-                                "isVisible": true,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Labels",
-                        "static": false,
-                        "type": "labels",
-                        "w": 2,
-                        "x": 1,
-                        "y": 0
-                    },
-                    {
-                        "h": 3,
-                        "i": "kkq7tnozrg-a8f75840-a1bb-11ea-8efe-d92f013a0581",
-                        "items": [],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Notes",
-                        "static": false,
-                        "type": "notes",
-                        "w": 2,
-                        "x": 1,
-                        "y": 2
-                    },
-                    {
-                        "displayType": "CARD",
-                        "h": 2,
-                        "hideItemTitleOnlyOne": true,
-                        "i": "kkq7tnozrg-fe4c0ff0-a1bd-11ea-8efe-d92f013a0581",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "incident_attachment",
-                                "height": 53,
-                                "id": "fe4706e0-a1bd-11ea-8efe-d92f013a0581",
-                                "index": 0,
-                                "isVisible": true,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Attachments",
-                        "static": false,
-                        "type": "",
-                        "w": 1,
-                        "x": 2,
-                        "y": 5
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "kkq7tnozrg-454e29b0-a1be-11ea-8efe-d92f013a0581",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "details",
-                                "height": 44,
-                                "id": "64663720-a1be-11ea-8efe-d92f013a0581",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "playbookid",
-                                "height": 22,
-                                "id": "9b97df60-b0cc-11ea-b214-43cd85c54102",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "dbotsource",
-                                "height": 22,
-                                "id": "9defd920-b0cc-11ea-b214-43cd85c54102",
-                                "index": 2,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "sourceinstance",
-                                "height": 22,
-                                "id": "a47c06b0-b0cc-11ea-b214-43cd85c54102",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "sourcebrand",
-                                "height": 22,
-                                "id": "a3a8b120-b0cc-11ea-b214-43cd85c54102",
-                                "index": 4,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "droppedcount",
-                                "height": 22,
-                                "id": "c84678a0-b0cc-11ea-b214-43cd85c54102",
-                                "index": 5,
-                                "listId": "kkq7tnozrg-454e29b0-a1be-11ea-8efe-d92f013a0581",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "linkedcount",
-                                "height": 22,
-                                "id": "08a48e80-ce02-11ea-89bb-21cbad8301ae",
-                                "index": 6,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Investigation Details",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "h": 2,
-                        "i": "kkq7tnozrg-c4515bf0-a4df-11ea-8c29-db553c036fb9",
-                        "items": [],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Indicators",
-                        "query": "",
-                        "queryType": "input",
-                        "static": false,
-                        "type": "indicators",
-                        "w": 2,
-                        "x": 0,
-                        "y": 5
-                    },
-                    {
-                        "h": 3,
-                        "i": "kkq7tnozrg-68a06320-b0cc-11ea-b214-43cd85c54102",
-                        "items": [],
-                        "maxW": 3,
-                        "minH": 1,
-                        "minW": 1,
-                        "moved": false,
-                        "name": "Evidence",
-                        "static": false,
-                        "type": "evidence",
-                        "w": 1,
-                        "x": 0,
-                        "y": 2
-                    }
-                ],
-                "type": "custom"
-            },
-            {
-                "id": "warRoom",
-                "name": "War Room",
-                "type": "warRoom"
-            },
-            {
-                "id": "workPlan",
-                "name": "Work Plan",
-                "type": "workPlan"
-            },
-            {
-                "id": "evidenceBoard",
-                "name": "Evidence Board",
-                "type": "evidenceBoard"
-            },
-            {
-                "id": "relatedIncidents",
-                "name": "Related Incidents",
-                "type": "relatedIncidents"
-            },
-            {
-                "id": "canvas",
-                "name": "Canvas",
-                "type": "canvas"
-            }
-        ]
-    },
-    "fromVersion": "5.0.0",
-    "toVersion": "5.9.9",
-    "typeId": "Case",
-    "version": -1
+ "kind": "details",
+ "layout": {
+  "id": "Case",
+  "name": "Case",
+  "version": -1,
+  "kind": "details",
+  "typeId": "Case",
+  "tabs": [
+   {
+    "id": "summary",
+    "name": "Legacy Summary",
+    "type": "summary"
+   },
+   {
+    "id": "caseinfoid",
+    "name": "Incident Info",
+    "sections": [
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+      "isVisible": true,
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "severity",
+        "height": 22,
+        "id": "incident-severity-field",
+        "index": 0,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "type",
+        "height": 22,
+        "id": "incident-type-field",
+        "index": 1,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "owner",
+        "height": 22,
+        "id": "incident-owner-field",
+        "index": 2,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "roles",
+        "height": 22,
+        "id": "73a95920-a6ae-11ea-ae9d-8553407179ff",
+        "index": 3,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbotcreated",
+        "height": 22,
+        "id": "incident-created-field",
+        "index": 4,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "occurred",
+        "height": 22,
+        "id": "incident-occurred-field",
+        "index": 6,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbotmodified",
+        "height": 22,
+        "id": "incident-modified-field",
+        "index": 7,
+        "listId": "caseinfoid-ac32f620-a0b0-11e9-b27f-13ae1773d289",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbotclosed",
+        "height": 22,
+        "id": "eda146a0-a1ba-11ea-8efe-d92f013a0581",
+        "index": 8,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbottotaltime",
+        "height": 22,
+        "id": "c57778a0-a5e0-11ea-beb5-2996637e1d9e",
+        "index": 9,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbotduedate",
+        "height": 22,
+        "id": "incident-dueDate-field",
+        "index": 10,
+        "listId": "caseinfoid-ac32f620-a0b0-11e9-b27f-13ae1773d289",
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "moved": false,
+      "name": "Case Details",
+      "static": false,
+      "w": 1,
+      "x": 0,
+      "y": 0
+     },
+     {
+      "h": 2,
+      "i": "caseinfoid-61263cc0-98b1-11e9-97d7-ed26ef9e46c8",
+      "moved": false,
+      "name": "Notes",
+      "static": false,
+      "type": "notes",
+      "w": 2,
+      "x": 1,
+      "y": 2
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
+      "moved": false,
+      "name": "Work Plan",
+      "static": false,
+      "type": "workplan",
+      "w": 1,
+      "x": 0,
+      "y": 2
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
+      "isVisible": true,
+      "moved": false,
+      "name": "Linked Incidents",
+      "static": false,
+      "type": "linkedIncidents",
+      "w": 1,
+      "x": 2,
+      "y": 8
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-4a31afa0-98ba-11e9-a519-93a53c759fe0",
+      "moved": false,
+      "name": "Evidence",
+      "static": false,
+      "type": "evidence",
+      "w": 1,
+      "x": 1,
+      "y": 8
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "hideName": false,
+      "i": "caseinfoid-7717e580-9bed-11e9-9a3f-8b4b2158e260",
+      "moved": false,
+      "name": "Team Members",
+      "static": false,
+      "type": "team",
+      "w": 1,
+      "x": 0,
+      "y": 6
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-7ce69dd0-a07f-11e9-936c-5395a1acf11e",
+      "moved": false,
+      "name": "Indicators",
+      "query": "",
+      "queryType": "input",
+      "static": false,
+      "type": "indicators",
+      "w": 2,
+      "x": 1,
+      "y": 4
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-88e6bf70-a0b1-11e9-b27f-13ae1773d289",
+      "isVisible": true,
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "dbotclosed",
+        "height": 22,
+        "id": "incident-dbotClosed-field",
+        "index": 0,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "closereason",
+        "height": 22,
+        "id": "incident-closeReason-field",
+        "index": 1,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "closenotes",
+        "height": 44,
+        "id": "incident-closeNotes-field",
+        "index": 2,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "closinguserid",
+        "height": 22,
+        "id": "85c48b10-a1be-11ea-8efe-d92f013a0581",
+        "index": 3,
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "moved": false,
+      "name": "Closing Information",
+      "static": false,
+      "w": 1,
+      "x": 0,
+      "y": 8
+     },
+     {
+      "description": "",
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+      "isVisible": true,
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "details",
+        "height": 44,
+        "id": "incident-details-field",
+        "index": 0,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "playbookid",
+        "height": 22,
+        "id": "incident-playbookId-field",
+        "index": 1,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "dbotsource",
+        "height": 22,
+        "id": "incident-source-field",
+        "index": 2,
+        "listId": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "sourceinstance",
+        "height": 22,
+        "id": "incident-sourceInstance-field",
+        "index": 3,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "sourcebrand",
+        "height": 22,
+        "id": "incident-sourceBrand-field",
+        "index": 4,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "droppedcount",
+        "height": 22,
+        "id": "c3b7a1b0-b0cc-11ea-b214-43cd85c54102",
+        "index": 5,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "linkedcount",
+        "height": 22,
+        "id": "fa230670-ce01-11ea-89bb-21cbad8301ae",
+        "index": 6,
+        "listId": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "moved": false,
+      "name": "Investigation Details",
+      "static": false,
+      "w": 1,
+      "x": 1,
+      "y": 0
+     },
+     {
+      "description": "",
+      "displayType": "ROW",
+      "h": 2,
+      "i": "caseinfoid-2bef1500-a0f2-11ea-a9ea-3d6524d9ea90",
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "incident_labels",
+        "height": 22,
+        "id": "2be6d7a1-a0f2-11ea-a9ea-3d6524d9ea90",
+        "index": 0,
+        "isVisible": true,
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Labels",
+      "static": false,
+      "type": "labels",
+      "w": 1,
+      "x": 2,
+      "y": 0
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "hideName": false,
+      "i": "caseinfoid-192828c0-a1bb-11ea-8efe-d92f013a0581",
+      "items": [
+       {
+        "args": {
+
+        },
+        "buttonClass": "success",
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "",
+        "height": 44,
+        "id": "1d1cbb80-a1bb-11ea-8efe-d92f013a0581",
+        "index": 0,
+        "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+        "name": "Assign to Me",
+        "scriptId": "AssignToMeButton",
+        "sectionItemType": "button",
+        "startCol": 0
+       },
+       {
+        "args": {
+
+        },
+        "buttonClass": "primary",
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "",
+        "height": 44,
+        "id": "4d83eff0-a1bb-11ea-8efe-d92f013a0581",
+        "index": 1,
+        "listId": "caseinfoid-192828c0-a1bb-11ea-8efe-d92f013a0581",
+        "name": "Close as Duplicate",
+        "scriptId": "CloseInvestigationAsDuplicate",
+        "sectionItemType": "button",
+        "startCol": 0
+       },
+       {
+        "args": {
+
+        },
+        "buttonClass": "warning",
+        "endCol": 2,
+        "fieldId": "",
+        "height": 44,
+        "id": "1e97e9d0-a1bb-11ea-8efe-d92f013a0581",
+        "index": 2,
+        "name": "Link Incidents",
+        "scriptId": "LinkIncidentsButton",
+        "sectionItemType": "button",
+        "startCol": 0
+       },
+       {
+        "args": {
+
+        },
+        "buttonClass": "error",
+        "endCol": 2,
+        "fieldId": "",
+        "height": 44,
+        "id": "67c36b80-de7d-11ea-82d9-bd6173dcd42e",
+        "index": 3,
+        "name": "Generate Summary Report",
+        "scriptId": "GenerateSummaryReportButton",
+        "sectionItemType": "button",
+        "startCol": 0
+       }
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Quick Actions",
+      "static": false,
+      "w": 1,
+      "x": 0,
+      "y": 4
+     },
+     {
+      "description": "",
+      "h": 2,
+      "i": "caseinfoid-5f87e5c0-a4e1-11ea-8c29-db553c036fb9",
+      "items": [
+
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "War Room Chat",
+      "query": {
+       "categories": [
+        "chats"
+       ],
+       "fromTime": "0001-01-01T00:00:00Z",
+       "pageSize": 0,
+       "tagsAndOperator": false,
+       "usersAndOperator": false
+      },
+      "queryType": "warRoomFilter",
+      "static": false,
+      "type": "invTimeline",
+      "w": 2,
+      "x": 1,
+      "y": 6
+     }
+    ],
+    "type": "custom"
+   },
+   {
+    "hidden": false,
+    "id": "kkq7tnozrg",
+    "name": "Investigation",
+    "sections": [
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "hideItemTitleOnlyOne": true,
+      "i": "kkq7tnozrg-c504da40-a1ba-11ea-8efe-d92f013a0581",
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "incident_labels",
+        "height": 22,
+        "id": "c4f63441-a1ba-11ea-8efe-d92f013a0581",
+        "index": 0,
+        "isVisible": true,
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Labels",
+      "static": false,
+      "type": "labels",
+      "w": 2,
+      "x": 1,
+      "y": 0
+     },
+     {
+      "h": 3,
+      "i": "kkq7tnozrg-a8f75840-a1bb-11ea-8efe-d92f013a0581",
+      "items": [
+
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Notes",
+      "static": false,
+      "type": "notes",
+      "w": 2,
+      "x": 1,
+      "y": 2
+     },
+     {
+      "displayType": "CARD",
+      "h": 2,
+      "hideItemTitleOnlyOne": true,
+      "i": "kkq7tnozrg-fe4c0ff0-a1bd-11ea-8efe-d92f013a0581",
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "incident_attachment",
+        "height": 53,
+        "id": "fe4706e0-a1bd-11ea-8efe-d92f013a0581",
+        "index": 0,
+        "isVisible": true,
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Attachments",
+      "static": false,
+      "type": "",
+      "w": 1,
+      "x": 2,
+      "y": 5
+     },
+     {
+      "displayType": "ROW",
+      "h": 2,
+      "hideName": false,
+      "i": "kkq7tnozrg-454e29b0-a1be-11ea-8efe-d92f013a0581",
+      "items": [
+       {
+        "endCol": 2,
+        "fieldId": "details",
+        "height": 44,
+        "id": "64663720-a1be-11ea-8efe-d92f013a0581",
+        "index": 0,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "playbookid",
+        "height": 22,
+        "id": "9b97df60-b0cc-11ea-b214-43cd85c54102",
+        "index": 1,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "dbotsource",
+        "height": 22,
+        "id": "9defd920-b0cc-11ea-b214-43cd85c54102",
+        "index": 2,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "sourceinstance",
+        "height": 22,
+        "id": "a47c06b0-b0cc-11ea-b214-43cd85c54102",
+        "index": 3,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "sourcebrand",
+        "height": 22,
+        "id": "a3a8b120-b0cc-11ea-b214-43cd85c54102",
+        "index": 4,
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "dropEffect": "move",
+        "endCol": 2,
+        "fieldId": "droppedcount",
+        "height": 22,
+        "id": "c84678a0-b0cc-11ea-b214-43cd85c54102",
+        "index": 5,
+        "listId": "kkq7tnozrg-454e29b0-a1be-11ea-8efe-d92f013a0581",
+        "sectionItemType": "field",
+        "startCol": 0
+       },
+       {
+        "endCol": 2,
+        "fieldId": "linkedcount",
+        "height": 22,
+        "id": "08a48e80-ce02-11ea-89bb-21cbad8301ae",
+        "index": 6,
+        "sectionItemType": "field",
+        "startCol": 0
+       }
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Investigation Details",
+      "static": false,
+      "w": 1,
+      "x": 0,
+      "y": 0
+     },
+     {
+      "h": 2,
+      "i": "kkq7tnozrg-c4515bf0-a4df-11ea-8c29-db553c036fb9",
+      "items": [
+
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Indicators",
+      "query": "",
+      "queryType": "input",
+      "static": false,
+      "type": "indicators",
+      "w": 2,
+      "x": 0,
+      "y": 5
+     },
+     {
+      "h": 3,
+      "i": "kkq7tnozrg-68a06320-b0cc-11ea-b214-43cd85c54102",
+      "items": [
+
+      ],
+      "maxW": 3,
+      "minH": 1,
+      "minW": 1,
+      "moved": false,
+      "name": "Evidence",
+      "static": false,
+      "type": "evidence",
+      "w": 1,
+      "x": 0,
+      "y": 2
+     }
+    ],
+    "type": "custom"
+   },
+   {
+    "id": "warRoom",
+    "name": "War Room",
+    "type": "warRoom"
+   },
+   {
+    "id": "workPlan",
+    "name": "Work Plan",
+    "type": "workPlan"
+   },
+   {
+    "id": "evidenceBoard",
+    "name": "Evidence Board",
+    "type": "evidenceBoard"
+   },
+   {
+    "id": "relatedIncidents",
+    "name": "Related Incidents",
+    "type": "relatedIncidents"
+   },
+   {
+    "id": "canvas",
+    "name": "Canvas",
+    "type": "canvas"
+   }
+  ]
+ },
+ "fromVersion": "5.0.0",
+ "toVersion": "5.9.9",
+ "typeId": "Case",
+ "version": -1,
+ "description": ""
 }

--- a/Packs/CaseManagement-Generic/Layouts/layout-edit-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-edit-Case_layout-Case.json
@@ -1,71 +1,72 @@
 {
-    "kind": "edit",
-    "layout": {
-        "id": "Case layout",
-        "name": "Case layout",
-        "version": -1,
-        "kind": "edit",
-        "typeId": "Case",
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_name",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_details",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_type",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_owner",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_severity",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_occurred",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_reminder",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_labels",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_roles",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_playbookid",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_attachment",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            }
-        ]
-    },
-    "fromVersion": "5.0.0",
-    "toVersion": "5.9.9",
-    "typeId": "Case",
-    "version": -1
+ "kind": "edit",
+ "layout": {
+  "id": "Case",
+  "name": "",
+  "version": -1,
+  "kind": "edit",
+  "typeId": "Case",
+  "sections": [
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_name",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_details",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_type",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_owner",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_severity",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_occurred",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_reminder",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_labels",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_roles",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_playbookid",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_attachment",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Basic Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   }
+  ]
+ },
+ "fromVersion": "5.0.0",
+ "toVersion": "5.9.9",
+ "typeId": "Case",
+ "version": -1,
+ "description": ""
 }

--- a/Packs/CaseManagement-Generic/Layouts/layout-mobile-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-mobile-Case_layout-Case.json
@@ -1,105 +1,106 @@
 {
-    "kind": "mobile",
-    "layout": {
-        "id": "Case layout",
-        "name": "Case layout",
-        "version": -1,
-        "kind": "mobile",
-        "typeId": "Case",
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_type",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_name",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_details",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_severity",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotstatus",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_owner",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_roles",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_playbookid",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_dbotcreated",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_occurred",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotduedate",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotmodified",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbottotaltime",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Timeline Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_labels",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Labels",
-                "query": null,
-                "queryType": "",
-                "readOnly": true,
-                "type": "labels"
-            }
-        ]
-    },
-    "fromVersion": "5.0.0",
-    "toVersion": "5.9.9",
-    "typeId": "Case",
-    "version": -1
+ "kind": "mobile",
+ "layout": {
+  "id": "Case",
+  "name": "",
+  "version": -1,
+  "kind": "mobile",
+  "typeId": "Case",
+  "sections": [
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_type",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_name",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_details",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_severity",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotstatus",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_owner",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_roles",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_playbookid",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Basic Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   },
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_dbotcreated",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_occurred",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotduedate",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotmodified",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbottotaltime",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Timeline Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   },
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_labels",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Labels",
+    "query": null,
+    "queryType": "",
+    "readOnly": true,
+    "type": "labels"
+   }
+  ]
+ },
+ "fromVersion": "5.0.0",
+ "toVersion": "5.9.9",
+ "typeId": "Case",
+ "version": -1,
+ "description": ""
 }

--- a/Packs/CaseManagement-Generic/Layouts/layout-quickView-Case_layout-Case.json
+++ b/Packs/CaseManagement-Generic/Layouts/layout-quickView-Case_layout-Case.json
@@ -1,105 +1,106 @@
 {
-    "kind": "quickView",
-    "layout": {
-        "id": "Case layout",
-        "name": "Case layout",
-        "version": -1,
-        "kind": "quickView",
-        "typeId": "Case",
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_type",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_name",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_details",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_severity",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotstatus",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_owner",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_roles",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_playbookid",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_dbotcreated",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_occurred",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotduedate",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbotmodified",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dbottotaltime",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Timeline Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_labels",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Labels",
-                "query": null,
-                "queryType": "",
-                "readOnly": true,
-                "type": "labels"
-            }
-        ]
-    },
-    "fromVersion": "5.0.0",
-    "toVersion": "5.9.9",
-    "typeId": "Case",
-    "version": -1
+ "kind": "quickView",
+ "layout": {
+  "id": "Case",
+  "name": "",
+  "version": -1,
+  "kind": "quickView",
+  "typeId": "Case",
+  "sections": [
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_type",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_name",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_details",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_severity",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotstatus",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_owner",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_roles",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_playbookid",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Basic Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   },
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_dbotcreated",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_occurred",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotduedate",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbotmodified",
+      "isVisible": true
+     },
+     {
+      "fieldId": "incident_dbottotaltime",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Timeline Information",
+    "query": null,
+    "queryType": "",
+    "readOnly": false,
+    "type": ""
+   },
+   {
+    "description": "",
+    "fields": [
+     {
+      "fieldId": "incident_labels",
+      "isVisible": true
+     }
+    ],
+    "isVisible": true,
+    "name": "Labels",
+    "query": null,
+    "queryType": "",
+    "readOnly": true,
+    "type": "labels"
+   }
+  ]
+ },
+ "fromVersion": "5.0.0",
+ "toVersion": "5.9.9",
+ "typeId": "Case",
+ "version": -1,
+ "description": ""
 }

--- a/Packs/CaseManagement-Generic/Layouts/layoutscontainer-Case_layout.json
+++ b/Packs/CaseManagement-Generic/Layouts/layoutscontainer-Case_layout.json
@@ -405,7 +405,7 @@
         "index": 0,
         "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
         "name": "Assign to Me",
-        "scriptId": "06af8e6e-d0e5-4f5c-899a-3823b99662b5",
+        "scriptId": "AssignToMeButton",
         "sectionItemType": "button",
         "startCol": 0
        },
@@ -437,7 +437,7 @@
         "id": "1e97e9d0-a1bb-11ea-8efe-d92f013a0581",
         "index": 2,
         "name": "Link Incidents",
-        "scriptId": "2b9e3e5a-d49e-4ab9-8389-68b2274c760a",
+        "scriptId": "LinkIncidentsButton",
         "sectionItemType": "button",
         "startCol": 0
        },
@@ -452,7 +452,7 @@
         "id": "67c36b80-de7d-11ea-82d9-bd6173dcd42e",
         "index": 3,
         "name": "Generate Summary Report",
-        "scriptId": "acb34501-dbf5-4edc-80ab-d9515ec204ce",
+        "scriptId": "GenerateSummaryReportButton",
         "sectionItemType": "button",
         "startCol": 0
        }
@@ -972,7 +972,7 @@
    }
   ]
  },
- "system": false,
+ "system": true,
  "version": -1,
  "fromVersion": "6.0.0",
  "description": ""

--- a/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
+++ b/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
@@ -28,3 +28,16 @@
 - Displays a count of the Active Incidents where the current user is not the owner, but is an investigation Team Member
 ##### New: My Incidents by Type
 - Displays the Incidents assigned to the current user, by Type.
+
+#### Script
+##### TimersOnOwnerChange
+- Updated automation to use the latest python3 docker image (11789)
+
+##### LinkIncidentsButton
+- Updated automation to use the latest python3 docker image (11789)
+
+##### GenerateSummaryReportButton
+- Updated automation to use the latest python3 docker image (11789)
+
+##### AssignToMeButton
+- Updated automation to use the latest python3 docker image (11789)

--- a/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
+++ b/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
@@ -1,7 +1,7 @@
 
 #### Dashboards
 ##### Incidents Overview
-- %%UPDATE_RN%%
+- Added Active Incidents by Source widget
 
 #### Layouts
 - **layout-detailsV2-Case_layout-Case.json**

--- a/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
+++ b/Packs/CaseManagement-Generic/ReleaseNotes/1_1_0.md
@@ -1,0 +1,30 @@
+
+#### Dashboards
+##### Incidents Overview
+- %%UPDATE_RN%%
+
+#### Layouts
+- **layout-detailsV2-Case_layout-Case.json**
+- **Case layout**
+- **layout-mobile-Case_layout-Case.json**
+- **layout-close-Case_layout-Case.json**
+- **layout-quickView-Case_layout-Case.json**
+- **layout-edit-Case_layout-Case.json**
+
+#### Reports
+##### New: Case Report
+- Investigation Summary Report from Case Management Pack
+
+#### Widgets
+##### New: My Mean Time to Remediation (Remediation SLA)
+- The mean time (average time) to remediation across all incidents where the remediation sla timer completed where the Owner is the currnt user. The widget takes into account incidents from the last 30 days by default.
+##### New: Mean Time to Remediation (Remediation SLA)
+- The mean time (average time) to remediation across all incidents where the remediation sla timer completed. The widget takes into account incidents from the last 30 days by default.
+##### New: Mean Time to Assignment (Time to Assignment)
+- The mean time (average time) to remediation across all incidents where the time to assignment sla timer completed. The widget takes into account incidents from the last 30 days by default.
+##### New: Participating Incidents
+- Displays a table of the Active Incidents where the current user is not the owner, but is an investigation Team Member
+##### New: Participating Incidents Count
+- Displays a count of the Active Incidents where the current user is not the owner, but is an investigation Team Member
+##### New: My Incidents by Type
+- Displays the Incidents assigned to the current user, by Type.

--- a/Packs/CaseManagement-Generic/Reports/report-CaseReport.json
+++ b/Packs/CaseManagement-Generic/Reports/report-CaseReport.json
@@ -1,0 +1,1027 @@
+{
+	"cronView": false,
+	"decoder": {
+		"evidences.fetched": {
+			"type": "date",
+			"value": "02/01/06 3:04:05 PM"
+		},
+		"evidences.markedDate": {
+			"type": "date",
+			"value": "02/01/06 3:04:05 PM"
+		},
+		"evidences.occurred": {
+			"type": "date",
+			"value": "02/01/06 3:04:05 PM"
+		},
+		"incident.activated": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.closed": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.created": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.dbotStatus.0": {
+			"type": "string",
+			"value": "Pending"
+		},
+		"incident.dbotStatus.1": {
+			"type": "string",
+			"value": "Active"
+		},
+		"incident.dbotStatus.2": {
+			"type": "string",
+			"value": "Closed"
+		},
+		"incident.dbotStatus.3": {
+			"type": "string",
+			"value": "Closed"
+		},
+		"incident.dbotStatus.4": {
+			"type": "string",
+			"value": "On Hold"
+		},
+		"incident.dueDate": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.modified": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.occurred": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.openDuration": {
+			"type": "duration",
+			"value": ""
+		},
+		"incident.phase.": {
+			"type": "string",
+			"value": "Unassigned"
+		},
+		"incident.reminder": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"incident.roles.": {
+			"type": "string",
+			"value": "Unassigned"
+		},
+		"incident.severity.0": {
+			"type": "string",
+			"value": "Unknown"
+		},
+		"incident.severity.0.5": {
+			"type": "string",
+			"value": "Informational"
+		},
+		"incident.severity.1": {
+			"type": "string",
+			"value": "Low"
+		},
+		"incident.severity.2": {
+			"type": "string",
+			"value": "Medium"
+		},
+		"incident.severity.3": {
+			"type": "string",
+			"value": "High"
+		},
+		"incident.severity.4": {
+			"type": "string",
+			"value": "Critical"
+		},
+		"incident.status.0": {
+			"type": "string",
+			"value": "Pending"
+		},
+		"incident.status.1": {
+			"type": "string",
+			"value": "Active"
+		},
+		"incident.status.2": {
+			"type": "string",
+			"value": "Closed"
+		},
+		"incident.status.3": {
+			"type": "string",
+			"value": "Closed"
+		},
+		"incident.status.4": {
+			"type": "string",
+			"value": "On Hold"
+		},
+		"incident.totalTime": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"indicators.firstSeen": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"indicators.lastSeen": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"indicators.score.0": {
+			"type": "string",
+			"value": "None"
+		},
+		"indicators.score.1": {
+			"type": "string",
+			"value": "Good"
+		},
+		"indicators.score.2": {
+			"type": "string",
+			"value": "suspicious"
+		},
+		"indicators.score.3": {
+			"type": "string",
+			"value": "Bad"
+		},
+		"investigation.closed": {
+			"type": "date",
+			"value": "02 Jan 2006"
+		},
+		"investigation.created": {
+			"type": "date",
+			"value": "Mon, 02 Jan 2006 15:04:05 MST"
+		},
+		"investigation.openDuration": {
+			"type": "duration",
+			"value": ""
+		},
+		"investigation.status.0": {
+			"type": "string",
+			"value": "Active"
+		},
+		"investigation.status.1": {
+			"type": "string",
+			"value": "Done"
+		},
+		"investigation.type.0": {
+			"type": "string",
+			"value": "Standard"
+		},
+		"investigation.type.1": {
+			"type": "string",
+			"value": "Restricted"
+		},
+		"investigation.type.9": {
+			"type": "string",
+			"value": "Playground"
+		}
+	},
+	"sections": [
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNCIgaGVpZ2h0PSIzNCIgdmlld0JveD0iMCAwIDM0IDM0Ij4gIDxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+ICAgIDxwb2x5Z29uIGZpbGw9IiMzODM4M0QiIHBvaW50cz0iMjQuMzU5IDI0LjMwNSAzNC4wMTUgMzQuMDE2IDMzLjk5NCAxNC43NzIiLz4gICAgPHBvbHlnb24gZmlsbD0iIzk1QzgzRCIgcG9pbnRzPSIzMy45OTUgMCAwIC4wMTQgMjIuNzc3IDIyLjg1OCAzMy45MzYgMTEuNTI1Ii8+ICA8L2c+PC9zdmc+",
+			"layout": {
+				"class": "fixed",
+				"columnPos": 0,
+				"h": 1,
+				"i": "2cba731e-c580-44a6-9c25-e474295158f5",
+				"rowPos": 0,
+				"style": {
+					"position": "fixed",
+					"right": -1,
+					"top": 0
+				},
+				"w": 12
+			},
+			"query": {},
+			"titleStyle": null,
+			"type": "image"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"layout": {
+				"columnPos": 6,
+				"h": 1,
+				"i": "51de8bfd-fb30-481f-afe0-a524e38a4867",
+				"rowPos": 1,
+				"style": {
+					"float": "right",
+					"height": 40,
+					"marginTop": 10,
+					"width": "auto"
+				},
+				"w": 6
+			},
+			"query": {
+				"type": "customer"
+			},
+			"titleStyle": null,
+			"type": "logo"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"layout": {
+				"columnPos": 0,
+				"h": 1,
+				"i": "c85c425b-9f0e-4e34-82ef-208ae2d4a4a1",
+				"rowPos": 1,
+				"style": {
+					"height": 35,
+					"marginTop": 10,
+					"padding": 5,
+					"width": "auto"
+				},
+				"w": 6
+			},
+			"query": {},
+			"titleStyle": null,
+			"type": "logo"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": "{0} #{1}",
+			"layout": {
+				"columnPos": 0,
+				"h": 1,
+				"i": "94bc90ae-d1ef-4ec1-99ee-779bfc19061d",
+				"rowPos": 2,
+				"style": {
+					"color": "#4e6767",
+					"fontSize": 22,
+					"textAlign": "left"
+				},
+				"w": 12
+			},
+			"query": {
+				"filter": "investigation",
+				"keys": [
+					"name",
+					"id"
+				],
+				"type": "sessionData"
+			},
+			"titleStyle": null,
+			"type": "placeholder"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"layout": {
+				"columnPos": 0,
+				"format": "MMMM Do YYYY, h:mm:ss a z",
+				"h": 1,
+				"i": "581de1ac-d26e-4e28-992b-8bc6dbee4fea",
+				"rowPos": 3,
+				"style": {
+					"fontSize": 14,
+					"marginBottom": 12,
+					"textAlign": "left"
+				},
+				"w": 12
+			},
+			"query": {},
+			"titleStyle": null,
+			"type": "date"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": "Generated by: {0}",
+			"layout": {
+				"columnPos": 0,
+				"h": 1,
+				"i": "05d69815-e93f-4d34-8c9b-eff980eedb26",
+				"rowPos": 4,
+				"rowStyle": {
+					"marginTop": -20
+				},
+				"style": {
+					"fontSize": 14,
+					"textAlign": "left"
+				},
+				"w": 12
+			},
+			"query": {
+				"filter": "sessionUser",
+				"keys": [
+					"name"
+				],
+				"type": "sessionData"
+			},
+			"titleStyle": null,
+			"type": "placeholder"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": [
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "severity",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 0,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "type",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 1,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "owner",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 2,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "roles",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 3,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotcreated",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 4,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "occurred",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 5,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotmodified",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 6,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotduedate",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 7,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbottotaltime",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 8,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotclosed",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 9,
+					"startCol": 0
+				}
+			],
+			"displayType": "row",
+			"layout": {
+				"columnPos": 0,
+				"h": 3,
+				"i": "v5dejmwwyv-caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+				"rowPos": 6,
+				"w": 12
+			},
+			"query": {
+				"type": "incident"
+			},
+			"title": "Case Details",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "itemsSection"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"emptyNotification": "No entries were found for the following filter: \"\"",
+			"layout": {
+				"columnPos": 4,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-61263cc0-98b1-11e9-97d7-ed26ef9e46c8",
+				"rowPos": 22,
+				"w": 8
+			},
+			"query": {
+				"filter": {
+					"categories": [
+						"notes"
+					],
+					"pageSize": 10000
+				},
+				"type": "entries"
+			},
+			"title": "Notes",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "placeholder"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"displayType": "row",
+			"emptyNotification": "This incident is not linked to any other incidents.",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
+				"readableHeaders": {
+					"closeNotes": "Close Notes",
+					"id": "ID",
+					"name": "Name",
+					"status": "Status",
+					"type": "Type"
+				},
+				"rowPos": 20,
+				"tableColumns": [
+					{
+						"isDefault": true,
+						"key": "id",
+						"position": 0,
+						"width": 110
+					},
+					{
+						"hidden": false,
+						"isDefault": true,
+						"key": "name",
+						"position": 2,
+						"width": 262
+					},
+					{
+						"hidden": false,
+						"isDefault": true,
+						"key": "type",
+						"position": 3,
+						"width": 200
+					},
+					{
+						"isDefault": true,
+						"key": "status",
+						"position": 5,
+						"width": 80
+					},
+					{
+						"hidden": false,
+						"isDefault": true,
+						"key": "closeNotes",
+						"position": 18,
+						"width": 300
+					}
+				],
+				"w": 12
+			},
+			"query": {
+				"filter": {},
+				"type": "linkedIncidents"
+			},
+			"title": "Linked Incidents",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "table"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"displayType": "row",
+			"emptyNotification": "This incident does not contain evidence.",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-4a31afa0-98ba-11e9-a519-93a53c759fe0",
+				"readableHeaders": {
+					"description": "Description",
+					"markedBy": "Submitter",
+					"occurred": "Occurred",
+					"tags": "Tags"
+				},
+				"rowPos": 18,
+				"tableColumns": [
+					{
+						"isDefault": true,
+						"key": "occurred",
+						"position": 1,
+						"width": 200
+					},
+					{
+						"isDefault": true,
+						"key": "description",
+						"position": 2,
+						"width": 300
+					},
+					{
+						"isDefault": true,
+						"key": "markedBy",
+						"position": 3,
+						"width": 150
+					},
+					{
+						"isDefault": true,
+						"key": "tags",
+						"position": 4,
+						"width": 400
+					}
+				],
+				"w": 12
+			},
+			"query": {
+				"filter": {},
+				"type": "evidences"
+			},
+			"title": "Evidence",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "table"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"displayType": "row",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-7717e580-9bed-11e9-9a3f-8b4b2158e260",
+				"rowPos": 22,
+				"tableColumns": [
+					"Avatar",
+					"Name",
+					"Email"
+				],
+				"w": 4
+			},
+			"query": {
+				"filter": "investigationUsers",
+				"type": "sessionData"
+			},
+			"title": "Team Members",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "list"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": null,
+			"displayType": "row",
+			"emptyNotification": "This incident does not contain any indicators that apply to the following filter: \"\".",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-7ce69dd0-a07f-11e9-936c-5395a1acf11e",
+				"readableHeaders": {
+					"indicator_type": "Type",
+					"score": "Reputation",
+					"sourceBrands": "Source Brands",
+					"value": "Value"
+				},
+				"rowPos": 16,
+				"tableColumns": [
+					{
+						"displayed": true,
+						"isDefault": true,
+						"key": "indicator_type",
+						"width": 120
+					},
+					{
+						"displayed": true,
+						"isDefault": true,
+						"key": "value",
+						"width": 300
+					},
+					{
+						"displayed": true,
+						"isDefault": true,
+						"key": "score",
+						"width": 120
+					},
+					{
+						"displayed": true,
+						"isDefault": true,
+						"key": "sourceBrands",
+						"width": 175
+					}
+				],
+				"w": 12
+			},
+			"query": {
+				"filter": {
+					"query": "investigationIDs:{{.investigationID}}"
+				},
+				"type": "indicators"
+			},
+			"title": "Indicators",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "table"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": [
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotclosed",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 0,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "closereason",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 1,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "closenotes",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 2,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "closinguserid",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 3,
+					"startCol": 0
+				}
+			],
+			"displayType": "row",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-88e6bf70-a0b1-11e9-b27f-13ae1773d289",
+				"rowPos": 14,
+				"w": 12
+			},
+			"query": {
+				"type": "incident"
+			},
+			"title": "Closing Information",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "itemsSection"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": [
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "details",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 0,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "playbookid",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 1,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "dbotsource",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 2,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "sourceinstance",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 3,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "sourcebrand",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 4,
+					"startCol": 0
+				},
+				{
+					"displayType": "row",
+					"endCol": 6,
+					"fieldId": "droppedcount",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 5,
+					"startCol": 0
+				}
+			],
+			"displayType": "row",
+			"layout": {
+				"columnPos": 0,
+				"h": 3,
+				"i": "v5dejmwwyv-caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+				"rowPos": 9,
+				"w": 12
+			},
+			"query": {
+				"type": "incident"
+			},
+			"title": "Investigation Details",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "itemsSection"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": [
+				{
+					"displayType": "row",
+					"endCol": 2,
+					"fieldId": "labels",
+					"headerStyle": {
+						"color": "rgba(64, 65, 66, 0.7)",
+						"fontSize": "12px",
+						"fontWeight": 700
+					},
+					"index": 0,
+					"startCol": 0
+				}
+			],
+			"displayType": "row",
+			"layout": {
+				"columnPos": 0,
+				"h": 2,
+				"i": "v5dejmwwyv-caseinfoid-2bef1500-a0f2-11ea-a9ea-3d6524d9ea90",
+				"rowPos": 12,
+				"w": 12
+			},
+			"query": {
+				"type": "labels"
+			},
+			"title": "Labels",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "itemsSection"
+		},
+		{
+			"automation": {
+				"args": null,
+				"id": "",
+				"name": "",
+				"noEvent": false
+			},
+			"data": [],
+			"emptyNotification": "No entries were found for the following filter: \"[object Object]\"",
+			"layout": {
+				"columnPos": 0,
+				"h": 1,
+				"i": "v5dejmwwyv-caseinfoid-5f87e5c0-a4e1-11ea-8c29-db553c036fb9",
+				"rowPos": 24,
+				"w": 12
+			},
+			"query": {
+				"filter": {
+					"categories": [
+						"chats"
+					],
+					"fromTime": "0001-01-01T00:00:00Z",
+					"pageSize": 0,
+					"tagsAndOperator": false,
+					"usersAndOperator": false
+				},
+				"type": "entries"
+			},
+			"title": "War Room Chat",
+			"titleStyle": {
+				"borderBottom": "1px solid rgba(64, 65, 66, 0.16)",
+				"color": "#768BA1"
+			},
+			"type": "placeholder"
+		}
+	],
+	"disableHeader": true,
+	"endingDate": "0001-01-01T00:00:00Z",
+	"id": "CaseReport",
+	"description": "Investigation Summary Report from Case Management Pack",
+	"latestReportTime": "0001-01-01T00:00:00Z",
+	"latestScheduledReportTime": "0001-01-01T00:00:00Z",
+	"locked": false,
+	"name": "Case Report",
+	"nextScheduledTime": "0001-01-01T00:00:00Z",
+	"orientation": "portrait",
+	"paperSize": "A4",
+	"recurrent": false,
+	"reportType": "investigation",
+	"runOnce": false,
+	"runningUser": "",
+	"scheduled": false,
+	"sensitive": false,
+	"startDate": "0001-01-01T00:00:00Z",
+	"system": false,
+	"times": 0,
+	"timezoneOffset": 0,
+	"type": "pdf",
+	"tags": [],
+	"createdBy": "DBot",
+	"fromVersion": "5.5.0",
+	"recipients": [
+
+	]
+}

--- a/Packs/CaseManagement-Generic/Scripts/AssignToMeButton/AssignToMeButton.yml
+++ b/Packs/CaseManagement-Generic/Scripts/AssignToMeButton/AssignToMeButton.yml
@@ -2,7 +2,7 @@ comment: 'Assigns the current Incident to the Demisto user who clicked the butto
 commonfields:
   id: AssignToMeButton
   version: -1
-dockerimage: demisto/python3:3.8.5.10845
+dockerimage: demisto/python3:3.8.5.11789
 enabled: true
 name: AssignToMeButton
 runas: DBotWeakRole

--- a/Packs/CaseManagement-Generic/Scripts/GenerateSummaryReportButton/GenerateSummaryReportButton.yml
+++ b/Packs/CaseManagement-Generic/Scripts/GenerateSummaryReportButton/GenerateSummaryReportButton.yml
@@ -2,7 +2,7 @@ comment: This button will generate summary 'Case Report' template for a given In
 commonfields:
   id: GenerateSummaryReportButton
   version: -1
-dockerimage: demisto/python3:3.8.5.10845
+dockerimage: demisto/python3:3.8.5.11789
 enabled: true
 name: GenerateSummaryReportButton
 runas: DBotWeakRole

--- a/Packs/CaseManagement-Generic/Scripts/LinkIncidentsButton/LinkIncidentsButton.yml
+++ b/Packs/CaseManagement-Generic/Scripts/LinkIncidentsButton/LinkIncidentsButton.yml
@@ -15,7 +15,7 @@ comment: |
 commonfields:
   id: LinkIncidentsButton
   version: -1
-dockerimage: demisto/python3:3.8.5.10845
+dockerimage: demisto/python3:3.8.5.11789
 enabled: true
 name: LinkIncidentsButton
 runas: DBotWeakRole

--- a/Packs/CaseManagement-Generic/Scripts/TimersOnOwnerChange/TimersOnOwnerChange.yml
+++ b/Packs/CaseManagement-Generic/Scripts/TimersOnOwnerChange/TimersOnOwnerChange.yml
@@ -9,7 +9,7 @@ comment: |-
 commonfields:
   id: TimersOnOwnerChange
   version: -1
-dockerimage: demisto/python3:3.8.5.10845
+dockerimage: demisto/python3:3.8.5.11789
 enabled: true
 name: TimersOnOwnerChange
 runas: DBotWeakRole

--- a/Packs/CaseManagement-Generic/Widgets/widget-Mean_Time_To_Remediation_SLA.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Mean_Time_To_Remediation_SLA.json
@@ -1,0 +1,27 @@
+{
+  "id": "mean-time-to-remediation-sla",
+  "version": -1,
+  "fromVersion": "5.5",
+  "name": "Mean Time to Remediation (Remediation SLA)",
+  "dataType": "incidents",
+  "widgetType": "duration",
+  "query": "-category:job and remediationsla.runStatus:ended",
+  "isPredefined": true,
+  "dateRange": {
+    "fromDate": "0001-01-01T00:00:00Z",
+    "toDate": "0001-01-01T00:00:00Z",
+    "period": {
+      "byTo": "",
+      "byFrom": "days",
+      "toValue": null,
+      "fromValue": 30,
+      "field": ""
+    }
+  },
+  "params": {
+    "keys": [
+      "avg|remediationsla.totalDuration"
+    ]
+  },
+  "description": "The mean time (average time) to remediation across all incidents where the remediation sla timer completed. The widget takes into account incidents from the last 30 days by default."
+}

--- a/Packs/CaseManagement-Generic/Widgets/widget-My_Incidents_by_Type.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-My_Incidents_by_Type.json
@@ -88,5 +88,6 @@
 	"size": 0,
 	"version": -1,
 	"widgetType": "pie",
-	"description": "Displays the Incidents assigned to the current user, by Type."
+	"description": "Displays the Incidents assigned to the current user, by Type.",
+	"fromVersion": "5.0.0"
 }

--- a/Packs/CaseManagement-Generic/Widgets/widget-My_Incidents_by_Type.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-My_Incidents_by_Type.json
@@ -1,0 +1,92 @@
+{
+	"category": "",
+	"dataType": "incidents",
+	"dateRange": {
+		"fromDate": "0001-01-01T00:00:00Z",
+		"fromDateLicense": "0001-01-01T00:00:00Z",
+		"period": {
+			"by": "",
+			"byFrom": "days",
+			"byTo": "",
+			"field": "",
+			"fromValue": 7,
+			"toValue": null
+		},
+		"toDate": "0001-01-01T00:00:00Z"
+	},
+	"id": "my-incidents-by-type",
+	"isPredefined": true,
+	"name": "My Incidents by Type",
+	"params": {
+		"groupBy": [
+			"type"
+		],
+		"tableColumns": [
+			{
+				"isDefault": true,
+				"key": "id",
+				"position": 0,
+				"width": 110
+			},
+			{
+				"isDefault": true,
+				"key": "name",
+				"position": 2,
+				"width": 300
+			},
+			{
+				"isDefault": true,
+				"key": "type",
+				"position": 3,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "severity",
+				"position": 4,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "status",
+				"position": 5,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "owner",
+				"position": 6,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "roles",
+				"position": 7,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "playbookId",
+				"position": 8,
+				"width": 150
+			},
+			{
+				"isDefault": true,
+				"key": "occurred",
+				"position": 9,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "dueDate",
+				"position": 10,
+				"width": 200
+			}
+		]
+	},
+	"query": "-category:job and -status:archived and -status:closed and owner:\"{me}\"",
+	"size": 0,
+	"version": -1,
+	"widgetType": "pie",
+	"description": "Displays the Incidents assigned to the current user, by Type."
+}

--- a/Packs/CaseManagement-Generic/Widgets/widget-My_Mean_Time_To_Remediation_SLA.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-My_Mean_Time_To_Remediation_SLA.json
@@ -1,0 +1,27 @@
+{
+  "id": "my-mean-time-to-remediation-sla",
+  "version": -1,
+  "fromVersion": "5.5",
+  "name": "My Mean Time to Remediation (Remediation SLA)",
+  "dataType": "incidents",
+  "widgetType": "duration",
+  "query": "-category:job and remediationsla.runStatus:ended and owner:{me}",
+  "isPredefined": true,
+  "dateRange": {
+    "fromDate": "0001-01-01T00:00:00Z",
+    "toDate": "0001-01-01T00:00:00Z",
+    "period": {
+      "byTo": "",
+      "byFrom": "days",
+      "toValue": null,
+      "fromValue": 30,
+      "field": ""
+    }
+  },
+  "params": {
+    "keys": [
+      "avg|remediationsla.totalDuration"
+    ]
+  },
+  "description": "The mean time (average time) to remediation across all incidents where the remediation sla timer completed where the Owner is the currnt user. The widget takes into account incidents from the last 30 days by default."
+}

--- a/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents.json
@@ -1,0 +1,89 @@
+{
+	"category": "",
+	"dataType": "incidents",
+	"dateRange": {
+		"fromDate": "0001-01-01T00:00:00Z",
+		"fromDateLicense": "0001-01-01T00:00:00Z",
+		"period": {
+			"by": "",
+			"byFrom": "days",
+			"byTo": "",
+			"field": "",
+			"fromValue": 7,
+			"toValue": null
+		},
+		"toDate": "0001-01-01T00:00:00Z"
+	},
+	"id": "participating-incidents",
+	"isPredefined": true,
+	"name": "Participating Incidents",
+	"params": {
+		"tableColumns": [
+			{
+				"isDefault": true,
+				"key": "id",
+				"position": 0,
+				"width": 110
+			},
+			{
+				"isDefault": true,
+				"key": "name",
+				"position": 2,
+				"width": 300
+			},
+			{
+				"isDefault": true,
+				"key": "type",
+				"position": 3,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "severity",
+				"position": 4,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "status",
+				"position": 5,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "owner",
+				"position": 6,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "roles",
+				"position": 7,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "playbookId",
+				"position": 8,
+				"width": 150
+			},
+			{
+				"isDefault": true,
+				"key": "occurred",
+				"position": 9,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "dueDate",
+				"position": 10,
+				"width": 200
+			}
+		]
+	},
+	"query": "-status:closed -category:job investigation.users:{me} and -owner:{me}",
+	"size": 0,
+	"version": -1,
+	"widgetType": "table",
+	"description": "Displays a table of the Active Incidents where the current user is not the owner, but is an investigation Team Member"
+}

--- a/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents.json
@@ -85,5 +85,6 @@
 	"size": 0,
 	"version": -1,
 	"widgetType": "table",
-	"description": "Displays a table of the Active Incidents where the current user is not the owner, but is an investigation Team Member"
+	"description": "Displays a table of the Active Incidents where the current user is not the owner, but is an investigation Team Member",
+	"fromVersion": "5.0.0"
 }

--- a/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents_Count.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents_Count.json
@@ -85,5 +85,6 @@
 	"size": 0,
 	"version": -1,
 	"widgetType": "number",
-	"description": "Displays a count of the Active Incidents where the current user is not the owner, but is an investigation Team Member"
+	"description": "Displays a count of the Active Incidents where the current user is not the owner, but is an investigation Team Member",
+	"fromVersion": "5.0.0"
 }

--- a/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents_Count.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Participating_Incidents_Count.json
@@ -1,0 +1,89 @@
+{
+	"category": "",
+	"dataType": "incidents",
+	"dateRange": {
+		"fromDate": "0001-01-01T00:00:00Z",
+		"fromDateLicense": "0001-01-01T00:00:00Z",
+		"period": {
+			"by": "",
+			"byFrom": "days",
+			"byTo": "",
+			"field": "",
+			"fromValue": 7,
+			"toValue": null
+		},
+		"toDate": "0001-01-01T00:00:00Z"
+	},
+	"id": "participating-incidents-count",
+	"isPredefined": true,
+	"name": "Participating Incidents Count",
+	"params": {
+		"tableColumns": [
+			{
+				"isDefault": true,
+				"key": "id",
+				"position": 0,
+				"width": 110
+			},
+			{
+				"isDefault": true,
+				"key": "name",
+				"position": 2,
+				"width": 300
+			},
+			{
+				"isDefault": true,
+				"key": "type",
+				"position": 3,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "severity",
+				"position": 4,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "status",
+				"position": 5,
+				"width": 80
+			},
+			{
+				"isDefault": true,
+				"key": "owner",
+				"position": 6,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "roles",
+				"position": 7,
+				"width": 160
+			},
+			{
+				"isDefault": true,
+				"key": "playbookId",
+				"position": 8,
+				"width": 150
+			},
+			{
+				"isDefault": true,
+				"key": "occurred",
+				"position": 9,
+				"width": 200
+			},
+			{
+				"isDefault": true,
+				"key": "dueDate",
+				"position": 10,
+				"width": 200
+			}
+		]
+	},
+	"query": "-status:closed -category:job investigation.users:{me} and -owner:{me}",
+	"size": 0,
+	"version": -1,
+	"widgetType": "number",
+	"description": "Displays a count of the Active Incidents where the current user is not the owner, but is an investigation Team Member"
+}

--- a/Packs/CaseManagement-Generic/Widgets/widget-Time_To_Assignment.json
+++ b/Packs/CaseManagement-Generic/Widgets/widget-Time_To_Assignment.json
@@ -1,0 +1,27 @@
+{
+  "id": "mean-time-to-assignment",
+  "version": -1,
+  "fromVersion": "5.5",
+  "name": "Mean Time to Assignment (Time to Assignment)",
+  "dataType": "incidents",
+  "widgetType": "duration",
+  "query": "-category:job and timetoassignment.runStatus:ended",
+  "isPredefined": true,
+  "dateRange": {
+    "fromDate": "0001-01-01T00:00:00Z",
+    "toDate": "0001-01-01T00:00:00Z",
+    "period": {
+      "byTo": "",
+      "byFrom": "days",
+      "toValue": null,
+      "fromValue": 30,
+      "field": ""
+    }
+  },
+  "params": {
+    "keys": [
+      "avg|timetoassignment.totalDuration"
+    ]
+  },
+  "description": "The mean time (average time) to remediation across all incidents where the time to assignment sla timer completed. The widget takes into account incidents from the last 30 days by default."
+}

--- a/Packs/CaseManagement-Generic/pack_metadata.json
+++ b/Packs/CaseManagement-Generic/pack_metadata.json
@@ -2,14 +2,22 @@
     "name": "CaseManagement-Generic",
     "description": "Case Management - Beta\n\nBuilt by the Cortex Customer Success Team to provide quick and valuable deployment of XSOAR for the main use of Case Management",
     "support": "community",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.1.0",
     "author": "Cortex XSOAR Customer Success",
     "url": "",
     "email": "",
     "created": "2020-08-20T14:37:35Z",
     "categories": [],
-    "tags": ["siem"],
-    "useCases": ["Case Management"],
-    "keywords": ["Case Management", "siem", "SIEM"],
+    "tags": [
+        "siem"
+    ],
+    "useCases": [
+        "Case Management"
+    ],
+    "keywords": [
+        "Case Management",
+        "siem",
+        "SIEM"
+    ],
     "beta": true
 }


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
This fixes the incident action buttons on the layout for the case type, which had the script guid instead of the name.  Buttons didn't appear as a result on they layout when you created a new Incident.

In addition we have added the Case Report to the Pack, as there was an issue uploading it the first time. 

Added 'Active Incidents by Source' panel to the Incidents Overview Dashboard, showing where Incidents were coming from.

Lastly adding in the widgets for the Time to Assignment, Remediation SLA Timers, and Participating Incidents (My Incidents Dashboard) which can be optionally added to dashboards from this pack. 

Tested with 6.0 (81077), 6.0.1 (84583), and 5.5 (78518) instances.

## Screenshots

Case Mgmt - Button issue
<img width="1086" alt="case mgmt buttons issue" src="https://user-images.githubusercontent.com/2559685/94206214-20570980-fe82-11ea-984b-8e870d751fab.png">

Case Mgmt - Fixed button on layout (what it should look like)
![case mgmt buttons fix](https://user-images.githubusercontent.com/2559685/94206302-5ac0a680-fe82-11ea-8c51-51460ce58462.png)

Incidents Overview Dashboard Update:
![case mgmt - incident overview dashboard add by source](https://user-images.githubusercontent.com/2559685/94206505-cefb4a00-fe82-11ea-9cc9-5a73cc1471e2.png)

Widgets added:
![case mgmt widgets](https://user-images.githubusercontent.com/2559685/94206438-aa06d700-fe82-11ea-8bb6-6a278e51e621.png)

## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

