### PR TITLE
no xsoar linter in v4.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,9 +204,9 @@ references:
         mkdir ./unit-tests
         if [ -n "$SHOULD_LINT_ALL" ]; then
           echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
-          demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
+          demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --no-xsoar-linter
         else
-          demisto-sdk lint -p 8 -g --prev-ver $FEATURE_BRANCH -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts
+          demisto-sdk lint -p 8 -g --prev-ver $FEATURE_BRANCH -v --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --no-xsoar-linter
         fi
 
 


### PR DESCRIPTION
turning off xsoar linter for 4.5 feature branch
preventing existing linter issues: https://app.circleci.com/pipelines/github/demisto/content/28656/workflows/9eaa4cfc-055f-4b49-afba-b0ec1042a298/jobs/126600