### PR TITLE
Skip sndbox integration

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3203,6 +3203,7 @@
         "Bambenek Consulting Feed": "Issue 26184",
         "AWS - Athena - Beta": "Issue 19834",
         "Blueliv ThreatCompass": "Community contribution",
+        "SNDBOX": "Issue 28826",
 
         "_comment2": "~~~ UNSTABLE ~~~",
         "ServiceNow": "Instance goes to hibernate every few hours",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3051,7 +3051,6 @@
         "SentinelOne V2 - test": "Issue 24933",
         "TestDedupIncidentsPlaybook": "Issue 24344",
         "CreateIndicatorFromSTIXTest": "Issue 24345",
-        "SNDBOX_Test": "Issue 24349",
         "Endpoint data collection test": "Uses a deprecated playbook called Endpoint data collection",
         "Prisma_Access_Egress_IP_Feed-Test": "unskip after we will get Prisma Access instance - Issue 27112",
         "Prisma_Access-Test": "unskip after we will get Prisma Access instance - Issue 27112",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/28826
https://github.com/demisto/etc/issues/24349

## Description
SNDBOX instance is returning status code: 503 and reason: Service Unavailable: Back-end server is at capacity.
so it will be skipped until the issue will be solved.

note the that this pr also remove the skip from "SNDBOX Test" because it should have been removed from skip in: https://github.com/demisto/etc/issues/24349.
