### PR TITLE
Slack - fix typos in the README

### DIFF
--- a/Packs/Slack/Integrations/Slack/README.md
+++ b/Packs/Slack/Integrations/Slack/README.md
@@ -759,8 +759,8 @@ If a dedicated channel for incident notifications is configured, the following n
 <li>Incident SLA changed</li>
 <li>Task completed</li>
 </ul>
-<h3>Blocks and interactve components</h3>
-<span>The integration supports sending "blocks" to Slack. Blocks are a series of components that can be combined to create visually rich and compellingly interactive messages. In the integration, they can be sent as an array of JSON. More infortmation about that <a href="https://api.slack.com/reference/block-kit/blocks">here.</a> You can experiment with and build your own blocks <a href="https://api.slack.com/tools/block-kit-builder">here.</a>
+<h3>Blocks and interactive components</h3>
+<span>The integration supports sending "blocks" to Slack. Blocks are a series of components that can be combined to create visually rich and compellingly interactive messages. In the integration, they can be sent as an array of JSON. More information about that <a href="https://api.slack.com/reference/block-kit/blocks">here.</a> You can experiment with and build your own blocks <a href="https://api.slack.com/tools/block-kit-builder">here.</a>
 The integration also allows some level of interactivity. When a user interacts with an element in a Slack message, Slack sends a request with the relevant information. 
 This request is processed and stored by a dedicated endpoint outside of Cortex XSOAR in the address: <code>https://oproxy.demisto.ninja</code>
 The integration allows polling this endpoint for user interactions that contain entitlement strings, which are used to perform actions in Cortex XSOAR by external users. See the <a href="https://github.com/demisto/content/tree/master/Packs/Slack/Scripts/SlackAsk">SlackAsk</a> script for an example.


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed 2 typos in the Slack v2 integration README
