### PR TITLE
move vt private to unmockable

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3246,6 +3246,7 @@
         "VulnDB"
     ],
     "unmockable_integrations": {
+        "VirusTotal - Private API": "proxy failures with recording. related issue: ",
         "SecurityIntelligenceServicesFeed": "Need proxy configuration in server",
         "BPA": "Playbook using GenericPolling which is inconsistent",
         "Mail Listener v2": "Integration has no proxy checkbox",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3246,7 +3246,7 @@
         "VulnDB"
     ],
     "unmockable_integrations": {
-        "VirusTotal - Private API": "proxy failures with recording. related issue: ",
+        "VirusTotal - Private API": "proxy failures with recording. related issues: 26463, 28888",
         "SecurityIntelligenceServicesFeed": "Need proxy configuration in server",
         "BPA": "Playbook using GenericPolling which is inconsistent",
         "Mail Listener v2": "Integration has no proxy checkbox",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## XSOAR [Partner](https://xsoar.pan.dev/docs/partners/become-a-tech-partner)?
In case you are a technological partner:
- [ ] The title must be in the following format: **[YOUR_PARTNER_ID] short description**.

If you are not a technological partner (i.e. PANW employee, customer or individual developer), please delete this section.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26463

## Description
VT private encounter issues with the mocker on nightly on `URL Enrichment - Generic v2 - Test`.
So it will be moved to unmockable integrations for now.
a relevant dev-bug was opened about the mocker issue: https://github.com/demisto/etc/issues/28888
