### PR TITLE
Fixing call to proxy.stop without thread_index and prints_manager

### DIFF
--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -423,7 +423,7 @@ class MITMProxy:
             time.sleep(PROXY_PROCESS_INIT_INTERVAL)
             seconds_since_init += PROXY_PROCESS_INIT_INTERVAL
         if not log_file_exists:
-            self.stop()
+            self.stop(thread_index, prints_manager)
             raise Exception("Proxy process took to long to go up.")
         proxy_up_message = 'Proxy process up and running. Took {} seconds'.format(seconds_since_init)
         prints_manager.add_print_job(proxy_up_message, print, thread_index)


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Currently we're calling proxy.stop without sending the prints manager.
This is a bug which is now fixed.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 

