### PR TITLE
change the name status in McAfee ESM v2 test playbook for v 11.3

### DIFF
--- a/Packs/McAfee_ESM/TestPlaybooks/McAfee_ESM_v2_(v11.3)_-_Test.yml
+++ b/Packs/McAfee_ESM/TestPlaybooks/McAfee_ESM_v2_(v11.3)_-_Test.yml
@@ -48,7 +48,7 @@ tasks:
       - "2"
     scriptarguments:
       name:
-        simple: CCC
+        simple: AAA
       show_in_case_pane: {}
     separatecontext: false
     view: |-
@@ -79,9 +79,9 @@ tasks:
       - "3"
     scriptarguments:
       new_name:
-        simple: DDD
+        simple: BBB
       original_name:
-        simple: CCC
+        simple: AAA
       show_in_case_pane: {}
     separatecontext: false
     view: |-
@@ -112,7 +112,7 @@ tasks:
       - "4"
     scriptarguments:
       name:
-        simple: DDD
+        simple: BBB
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
changed the status names arguments so the init test playbook will handle them.

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

fixes: https://github.com/demisto/etc/issues/29028
fixes: https://github.com/demisto/etc/issues/29027