### PR TITLE
Adding usage of handle_proxy + enhancing the submit-event-hec command

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -27,6 +27,7 @@ PROBLEMATIC_CHARACTERS = ['.', '(', ')', '[', ']']
 REPLACE_WITH = '_'
 REPLACE_FLAG = params.get('replaceKeys', False)
 FETCH_TIME = demisto.params().get('fetch_time')
+PROXIES = handle_proxy()
 TIME_UNIT_TO_MINUTES = {'minute': 1, 'hour': 60, 'day': 24 * 60, 'week': 7 * 24 * 60, 'month': 30 * 24 * 60,
                         'year': 365 * 24 * 60}
 
@@ -558,10 +559,17 @@ def splunk_submit_event_hec(hec_token, baseurl, event, fields, host, index, sour
     if hec_token is None:
         raise Exception('The HEC Token was not provided')
 
+    parsed_fields = None
+    if fields:
+        try:
+            parsed_fields = json.loads(fields)
+        except Exception:
+            parsed_fields = {'fields': fields}
+
     args = assign_params(
         event=event,
         host=host,
-        fields={'fields': fields} if fields else None,
+        fields=parsed_fields,
         index=index,
         sourcetype=source_type,
         source=source,

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -292,7 +292,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: Fields for indexing that do not occur in the event payload itself. Accepts multiple comma separated fields.
+      description: Fields for indexing that do not occur in the event payload itself. Accepts a JSON string of key value pairs or comma-seperated values.
       isArray: false
       name: fields
       required: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -588,7 +588,7 @@ script:
     description: Deletes the specified object in store. Search can be basic key value or a full query.
     execution: false
     name: splunk-kv-store-collection-delete-entry
-  dockerimage: demisto/splunksdk:1.0.0.11270
+  dockerimage: demisto/splunksdk:1.0.0.11989
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/ReleaseNotes/1_2_3.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_3.md
@@ -2,3 +2,4 @@
 ##### SplunkPy
 - Added optional functionality to the fields parameter in the ***splunk-submit-event-hec*** command.
 - Added usage of *handle_proxy()* for all requests.
+- Updated the Docker image to: *demisto/splunksdk:1.0.0.11989*.

--- a/Packs/SplunkPy/ReleaseNotes/1_2_3.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_3.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### SplunkPy
+- Added optional functionality to the fields parameter in the ***splunk-submit-event-hec*** command.
+- Added usage of *handle_proxy()* for all requests.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SplunkPy",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.2.2",
+  "currentVersion": "1.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status 
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
1. `handle_proxy()` was not used on SplunkPy until today, which has now changed.
2. Improved the `submit-event-hec` command to meet Splunk's recommendations.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
