### PR TITLE
[4.5.0] Changed Microsoft Graph User test name to reflect changes in 5.0.0+

### DIFF
--- a/Packs/MicrosoftGraphUser/TestPlaybooks/Microsoft_Graph_User_test.yml
+++ b/Packs/MicrosoftGraphUser/TestPlaybooks/Microsoft_Graph_User_test.yml
@@ -1,6 +1,6 @@
-id: Microsoft Graph - Test
+id: Microsoft Graph User - Test
 version: -1
-name: Microsoft Graph - Test
+name: Microsoft Graph User - Test
 starttaskid: "0"
 tasks:
   "0":

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1511,12 +1511,12 @@
         },
         {
             "integrations": "Microsoft Graph User",
-            "playbookID": "Microsoft Graph - Test",
+            "playbookID": "Microsoft Graph User - Test",
             "instance_names": "ms_graph_user_dev"
         },
         {
             "integrations": "Microsoft Graph User",
-            "playbookID": "Microsoft Graph - Test",
+            "playbookID": "Microsoft Graph User - Test",
             "instance_names": "ms_graph_user_prod"
         },
         {


### PR DESCRIPTION
## Status
- [x] Ready

## Description
The previous name of this test is different in later versions.
This change aligns the test name to version 5.0.0 test and beyond.