### PR TITLE
Add docker authentication to avoid docker rate limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ references:
   container_config: &container_config
     docker:
       - image: devdemisto/content-build:3.0.0.7332  # disable-secrets-detection
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
 
   workspace_root: &workspace_root
     /home/circleci/


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/28121

## Description
On November 1st, Docker Hub will begin limiting anonymous image pulls.
Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.

This solution is documented [here](https://circleci.com/docs/2.0/private-images/?mkt_tok=eyJpIjoiTURRd01XRTFabUV5T1dSaSIsInQiOiJ4MXhVdVRHckZSTkN5RFk3M2xhMk1WTkpOSU05eXZpTDRzZmxcL08wZXk4MTl1SkRLZmc1UUtnZytzZkg5K1VtemRJeWZcL1h4VFwvakFBdnZmWUtSU2ZOa3lubk80XC9FQ2J5d1RJYlEraHp0ZzhSSGx2aUMwNDdpTU56dU9GMW1qbXYifQ%3D%3D) 

