### PR TITLE
[expanse-272] Domain command fix

### DIFF
--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -314,8 +314,8 @@ def get_domain_context(data):
     """
     return {
         "Name": data['domain'],
-        "DNS": ((data['details'] or {}).get('recentIps')
-                if is_not_empty_value((data['details'] or {}).get('recentIps'))
+        "DNS": ((data.get('details') or {}).get('recentIps')
+                if is_not_empty_value((data.get('details') or {}).get('recentIps'))
                 else None),
         "CreationDate": data['whois'][0]['creationDate'],
         "DomainStatus": data['dnsResolutionStatus'],
@@ -371,8 +371,8 @@ def get_expanse_domain_context(data):
     """
     c = {
         "Name": data['domain'],
-        "DNS": ((data['details'] or {}).get('recentIps')
-                if is_not_empty_value(((data['details'] or {}).get('recentIps')))
+        "DNS": ((data.get('details') or {}).get('recentIps')
+                if is_not_empty_value(((data.get('details') or {}).get('recentIps')))
                 else None),
         "CreationDate": data['whois'][0].get('creationDate'),
         "DomainStatus": data.get('dnsResolutionStatus'),
@@ -467,8 +467,8 @@ def get_expanse_domain_context(data):
         "Tenant": data['tenant'].get('name') if is_not_empty_value(data['tenant'].get('name')) else None,
         "BusinessUnits": [],
         "DNSSEC": data['whois'][0].get('dnssec') if is_not_empty_value(data['whois'][0].get('dnssec')) else None,
-        "RecentIPs": ((data['details'] or {}).get('recentIps')
-                      if is_not_empty_value(((data['details'] or {}).get('recentIps')))
+        "RecentIPs": ((data.get('details') or {}).get('recentIps')
+                      if is_not_empty_value(((data.get('details') or {}).get('recentIps')))
                       else None),
         "CloudResources": ((data['details'] or {}).get('cloudResources')
                            if is_not_empty_value(((data['details'] or {}).get('cloudResources')))

--- a/Packs/Expanse/Integrations/Expanse/Expanse.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.py
@@ -73,7 +73,7 @@ def make_headers(endpoint, token):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'User-Agent': 'Expanse_Demisto/1.1.1'
+        'User-Agent': 'Expanse_Demisto/1.1.3'
     }
     if endpoint == "IdToken":
         headers['Authorization'] = 'Bearer ' + token
@@ -314,7 +314,9 @@ def get_domain_context(data):
     """
     return {
         "Name": data['domain'],
-        "DNS": data['details'].get('recentIps') if is_not_empty_value(data['details'].get('recentIps')) else None,
+        "DNS": ((data['details'] or {}).get('recentIps')
+                if is_not_empty_value((data['details'] or {}).get('recentIps'))
+                else None),
         "CreationDate": data['whois'][0]['creationDate'],
         "DomainStatus": data['dnsResolutionStatus'],
         "ExpirationDate": data['whois'][0]['registryExpiryDate'],
@@ -369,7 +371,9 @@ def get_expanse_domain_context(data):
     """
     c = {
         "Name": data['domain'],
-        "DNS": data['details'].get('recentIps') if is_not_empty_value(data['details'].get('recentIps')) else None,
+        "DNS": ((data['details'] or {}).get('recentIps')
+                if is_not_empty_value(((data['details'] or {}).get('recentIps')))
+                else None),
         "CreationDate": data['whois'][0].get('creationDate'),
         "DomainStatus": data.get('dnsResolutionStatus'),
         "ExpirationDate": (data['whois'][0].get('registryExpiryDate')
@@ -463,9 +467,11 @@ def get_expanse_domain_context(data):
         "Tenant": data['tenant'].get('name') if is_not_empty_value(data['tenant'].get('name')) else None,
         "BusinessUnits": [],
         "DNSSEC": data['whois'][0].get('dnssec') if is_not_empty_value(data['whois'][0].get('dnssec')) else None,
-        "RecentIPs": data['details'].get('recentIps') if is_not_empty_value(data['details'].get('recentIps')) else None,
-        "CloudResources": (data['details'].get('cloudResources')
-                           if is_not_empty_value(data['details'].get('cloudResources'))
+        "RecentIPs": ((data['details'] or {}).get('recentIps')
+                      if is_not_empty_value(((data['details'] or {}).get('recentIps')))
+                      else None),
+        "CloudResources": ((data['details'] or {}).get('cloudResources')
+                           if is_not_empty_value(((data['details'] or {}).get('cloudResources')))
                            else None),
         "LastSubdomainMetadata": (data.get('lastSubdomainMetadata')
                                   if is_not_empty_value(data.get('lastSubdomainMetadata'))

--- a/Packs/Expanse/Integrations/Expanse/Expanse.yml
+++ b/Packs/Expanse/Integrations/Expanse/Expanse.yml
@@ -673,7 +673,7 @@ script:
     - contextPath: Expanse.IPDomains.DomainList
       description: An array of domain objects. This is truncated at 50.
       type: Unknown
-  dockerimage: demisto/python3:3.8.5.10845
+  dockerimage: demisto/python3:3.8.6.12176
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Expanse/Integrations/Expanse/Expanse_test.py
+++ b/Packs/Expanse/Integrations/Expanse/Expanse_test.py
@@ -749,10 +749,7 @@ MOCK_DOMAIN_RESPONSE = {
             ],
             'isCollapsed': False,
             'lastSampledIp': '192.64.147.150',
-            'details': {
-                'recentIps': [],
-                'cloudResources': []
-            },
+            'details': None,
             'lastSubdomainMetadata': None,
             'dnsResolutionStatus': ['HAS_DNS_RESOLUTION'],
             'serviceStatus': ['NO_ACTIVE_SERVICE', 'NO_ACTIVE_CLOUD_SERVICE', 'NO_ACTIVE_ON_PREM_SERVICE']

--- a/Packs/Expanse/ReleaseNotes/1_1_3.md
+++ b/Packs/Expanse/ReleaseNotes/1_1_3.md
@@ -1,3 +1,4 @@
 #### Integrations
 ##### Expanse
 - Addressed issue where domains command failed in some circumstances.
+- Updated docker image from `3.8.5.10845` to `3.8.6.12176`.

--- a/Packs/Expanse/ReleaseNotes/1_1_3.md
+++ b/Packs/Expanse/ReleaseNotes/1_1_3.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Expanse
+- Addressed issue where domains command failed in some circumstances.

--- a/Packs/Expanse/pack_metadata.json
+++ b/Packs/Expanse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Expanse",
     "description": "The Expanse App for Demisto leverages the Expander API to retrieve network exposures and create incidents in Demisto.",
     "support": "partner",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Expanse",
     "url": "https://www.expanse.co/",
     "email": "help@expanseinc.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Blocking https://github.com/demisto/content/pull/9305 due to test playbook failure.

## Description
A change in Expanses API is causing this command to fail in some circumstances. This change should make the integration more resilient to conditions where `recentIps` is null.

## Screenshots


## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
