### PR TITLE
[Enhancement] Large incidents widgets - usability changes

### DIFF
--- a/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
+++ b/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
@@ -11,6 +11,7 @@
 - Changed table header name **Size**->**Size(MB)**.
 - Changed table header **IncidentID** to a hyperlink to the incident.
 - Changed default script result format to text markdown format, rather than table format.
+- Added handling for **playground** investigation.
 - Added new argument **table_result** return a result suitable for a table widget. By default
     the script result will be in Markdown.
 

--- a/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
+++ b/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
@@ -1,27 +1,27 @@
 
 #### Scripts
 ##### GetLargestInputsAndOuputsInIncidents
-- Removed the MB suffix from the table header **Size**.
-- Changed table header name **Size**->**Size(MB)**.
-- Changed table header **IncidentID** to a hyperlink to the incident.
-- Changed table header **TaskID** to a hyperlink to the task.
-- Changed script result format to text markdown format, rather than table format.
+- Removed the MB suffix from the values of the **Size** column.
+- Changed the table header name **Size** to **Size(MB)**.
+- Changed the table header **IncidentID** to a hyperlink to the incident.
+- Changed the table header **TaskID** to a hyperlink to the task.
+- Changed the default result format to Markdown.
 ##### GetLargestInvestigations
-- Removed the MB suffix from the table header **Size**.
-- Changed table header name **Size**->**Size(MB)**.
-- Changed table header **IncidentID** to a hyperlink to the incident.
-- Changed default script result format to text markdown format, rather than table format.
-- Added handling for **playground** investigation.
-- Added new argument **table_result** return a result suitable for a table widget. By default
-    the script result will be in Markdown.
+- Removed the MB suffix from the values of the **Size** column.
+- Changed the table header name **Size** to **Size(MB)**.
+- Changed the table header **IncidentID** to a hyperlink to the incident.
+- Changed the default result format to Markdown.
+- Added handling for **Playground** investigation.
+- Added the *table_result* argument, which returns a result in either Markdown or in a format suitable for a table widget. By default,
+    the result is in Markdown.
 
 #### Widgets
 ##### Largest Incidents by Storage Size
-- Removed the MB suffix from the table header **Size**.
-- Changed table header name **Size**->**Size(MB)**.
+- Removed the MB suffix from the values of the **Size** column.
+- Changed the table header name **Size** to **Size(MB)**.
 - Changed table header **IncidentID** to a hyperlink to the incident.
 ##### Largest Inputs And Outputs In Incidents
-- Removed the MB suffix from the table header **Size**.
-- Changed table header name **Size**->**Size(MB)**.
-- Changed table header **IncidentID** to a hyperlink to the incident.
-- Changed table header **TaskID** to a hyperlink to the task.
+- Removed the MB suffix from the values of the **Size** column.
+- Changed the table header name **Size** to **Size(MB)**.
+- Changed the table header **IncidentID** to a hyperlink to the incident.
+- Changed the table header **TaskID** to a hyperlink to the task.

--- a/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
+++ b/Packs/CommonWidgets/ReleaseNotes/1_0_4.md
@@ -1,0 +1,26 @@
+
+#### Scripts
+##### GetLargestInputsAndOuputsInIncidents
+- Removed the MB suffix from the table header **Size**.
+- Changed table header name **Size**->**Size(MB)**.
+- Changed table header **IncidentID** to a hyperlink to the incident.
+- Changed table header **TaskID** to a hyperlink to the task.
+- Changed script result format to text markdown format, rather than table format.
+##### GetLargestInvestigations
+- Removed the MB suffix from the table header **Size**.
+- Changed table header name **Size**->**Size(MB)**.
+- Changed table header **IncidentID** to a hyperlink to the incident.
+- Changed default script result format to text markdown format, rather than table format.
+- Added new argument **table_result** return a result suitable for a table widget. By default
+    the script result will be in Markdown.
+
+#### Widgets
+##### Largest Incidents by Storage Size
+- Removed the MB suffix from the table header **Size**.
+- Changed table header name **Size**->**Size(MB)**.
+- Changed table header **IncidentID** to a hyperlink to the incident.
+##### Largest Inputs And Outputs In Incidents
+- Removed the MB suffix from the table header **Size**.
+- Changed table header name **Size**->**Size(MB)**.
+- Changed table header **IncidentID** to a hyperlink to the incident.
+- Changed table header **TaskID** to a hyperlink to the task.

--- a/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.py
@@ -1,15 +1,14 @@
-import traceback
-from operator import itemgetter
-
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
 
+import traceback
+
 
 def find_largest_input_or_output(all_args_list):
-    max_arg = {'Size': 0}
+    max_arg = {'Size(MB)': 0}
     for arg in all_args_list:
-        if arg.get('Size') > max_arg.get('Size'):
+        if arg.get('Size(MB)') > max_arg.get('Size(MB)'):
             max_arg = arg
 
     return max_arg
@@ -18,31 +17,37 @@ def find_largest_input_or_output(all_args_list):
 def get_largest_inputs_and_outputs(inputs_and_outputs, largest_inputs_and_outputs, incident_id):
     inputs = []
     outputs = []
+    urls = demisto.demistoUrls()
+    server_url = urls.get('server', '')
+    incident_url = os.path.join(server_url, '#', 'incident', incident_id)
     if inputs_and_outputs:
         # In case no inputs and outputs are found a getInvPlaybookMetaData will return a string.
         # in that case we ignore the results and move on.
         if isinstance(inputs_and_outputs, str):
             return
         for task in inputs_and_outputs:
+            task_id = task.get('id')
             if 'outputs' in task:
                 for output in task.get('outputs'):
+                    task_url = os.path.join(server_url, '#', 'WorkPlan', incident_id, task_id)
                     outputs.append({
-                        'IncidentID': incident_id,
-                        'TaskID': task.get('id'),
+                        'IncidentID': f"[{incident_id}]({incident_url})",
+                        'TaskID': f"[{task_id}]({task_url})",
                         'TaskName': task.get('name'),
                         'Name': output.get('name'),
-                        'Size': output.get('size'),
+                        'Size(MB)': output.get('size'),
                         "InputOrOutput": 'Output'
                     })
 
             else:
                 for arg in task.get('args'):
+                    task_url = os.path.join(server_url, '#', 'WorkPlan', incident_id, task_id)
                     inputs.append({
-                        'IncidentID': incident_id,
-                        'TaskID': task.get('id'),
+                        'IncidentID': f"[{incident_id}]({incident_url})",
+                        'TaskID': f"[{task_id}]({task_url})",
                         'TaskName': task.get('name'),
                         'Name': arg.get('name'),
-                        'Size': arg.get('size'),
+                        'Size(MB)': arg.get('size'),
                         'InputOrOutput': "Input"
                     })
     if inputs:
@@ -50,15 +55,6 @@ def get_largest_inputs_and_outputs(inputs_and_outputs, largest_inputs_and_output
 
     if outputs:
         largest_inputs_and_outputs.append(find_largest_input_or_output(outputs))
-
-
-def format_inputs_and_outputs_to_widget_table(largest_inputs_and_outputs):
-    widget_table = {
-        'data': sorted(largest_inputs_and_outputs, key=itemgetter('Size'), reverse=True),
-        'total': len(largest_inputs_and_outputs)
-    }
-
-    return widget_table
 
 
 def get_extra_data_from_investigations(investigations):
@@ -70,15 +66,17 @@ def get_extra_data_from_investigations(investigations):
                                                     })[0].get('Contents').get('tasks')
         get_largest_inputs_and_outputs(inputs_and_outputs, largest_inputs_and_outputs, inv.get('IncidentID'))
 
-    return format_inputs_and_outputs_to_widget_table(largest_inputs_and_outputs)
+    return largest_inputs_and_outputs
 
 
 def main():
     try:
-        raw_output = demisto.executeCommand('GetLargestInvestigations', args={'from': demisto.args().get('from'),
-                                                                              'to': demisto.args().get('to')})
+        raw_output = demisto.executeCommand('GetLargestInvestigations_copy', args={'from': demisto.args().get('from'),
+                                                                                   'to': demisto.args().get('to'),
+                                                                                   'table_result': 'true'})
         investigations = raw_output[0].get('Contents', {}).get('data')
-        demisto.results(get_extra_data_from_investigations(investigations))
+        demisto.results(tableToMarkdown('Largest Inputs And Outputs In Incidents',
+                                        get_extra_data_from_investigations(investigations)))
     except Exception:
         demisto.error(traceback.format_exc())  # print the traceback
         return_error(f'Failed to execute GetLargestInputsAndOuputsInIncidents. Error: {traceback.format_exc()}')

--- a/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.yml
+++ b/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.yml
@@ -24,5 +24,5 @@ tags:
 - widget
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.8.5.11789
+dockerimage: demisto/python3:3.8.6.12176
 fromversion: 6.0.0

--- a/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents_test.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents_test.py
@@ -24,20 +24,20 @@ inputs_and_outputs = [
 
 
 largest_input = {
-    'IncidentID': 1,
-    'TaskID': '10',
+    'IncidentID': '[1](https://test-address:8443/#/incident/1)',
+    'TaskID': '[10](https://test-address:8443/#/WorkPlan/1/10)',
     'TaskName': 'Extract indicators from incident again',
     'Name': 'text',
-    'Size': 11.44,
+    'Size(MB)': 11.44,
     'InputOrOutput': 'Input'
 }
 
 largest_output = {
-    'IncidentID': 1,
-    'TaskID': '200',
+    'IncidentID': '[1](https://test-address:8443/#/incident/1)',
+    'TaskID': '[200](https://test-address:8443/#/WorkPlan/1/200)',
     'TaskName': 'Malware Investigation 2',
     'Name': 'IP',
-    'Size': 200.692,
+    'Size(MB)': 200.692,
     'InputOrOutput': 'Output'
 }
 
@@ -53,7 +53,7 @@ def test_get_largest_inputs_and_outputs():
     """
     from GetLargestInputsAndOuputsInIncidents import get_largest_inputs_and_outputs
     res = []
-    get_largest_inputs_and_outputs(inputs_and_outputs, res, 1)
+    get_largest_inputs_and_outputs(inputs_and_outputs, res, '1')
     assert len(res) == 2
     assert largest_input in res
     assert largest_output in res
@@ -70,5 +70,5 @@ def test_get_largest_inputs_and_outputs__on_fail():
     """
     from GetLargestInputsAndOuputsInIncidents import get_largest_inputs_and_outputs
     res = []
-    get_largest_inputs_and_outputs('No data', res, 1)
+    get_largest_inputs_and_outputs('No data', res, '1')
     assert len(res) == 0

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
@@ -31,13 +31,21 @@ def parse_investigations_to_table(investigations, is_table_result):
         full_size = investigations[investigation].get('leafSize').split(' ')
         db_name = investigations[investigation].get('Date')
         size = float(full_size[0])
-        if db_name.isdigit() and size >= 1.0 and full_size[1] == 'MB':
-            inv_id = investigation.split('-')[1]
+        if size >= 1.0 and full_size[1] == 'MB':
+            if db_name.isdigit():
+                inv_id = investigation.split('-')[1]
+                inv_link = f"[{inv_id}]({os.path.join(server_url, '#', 'incident', inv_id)})"
+                date = db_name[:2] + "-" + db_name[2:]
+            else:
+                inv_id = "-".join(investigation.split('-')[1:])
+                inv_link = f"[playground]({os.path.join(server_url, '#', 'WarRoom', 'playground')})"
+                date = ""
+            inv_link = inv_id if is_table_result else inv_link
             data.append({
-                "IncidentID": inv_id if is_table_result else f"[{inv_id}]({os.path.join(server_url, '#', 'incident', inv_id)})",
+                "IncidentID": inv_link,
                 "Size(MB)": int(size) if size == int(size) else size,
                 "AmountOfEntries": investigations[investigation].get('keyN'),
-                "Date": db_name[:2] + "-" + db_name[2:]
+                "Date": date
             })
 
     widget_table['data'] = sorted(data, key=itemgetter('Size(MB)'), reverse=True)  # type: ignore

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
@@ -1,12 +1,12 @@
+import demistomock as demisto
+from CommonServerPython import *
+from CommonServerUserPython import *
+
 import traceback
 from typing import List, Dict
 from operator import itemgetter
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
-
-import demistomock as demisto
-from CommonServerPython import *
-from CommonServerUserPython import *
 
 
 def get_investigations(raw_output, investigations):
@@ -22,22 +22,25 @@ def get_investigations(raw_output, investigations):
                 investigations[entry].update({"Date": db.get('dbName')})
 
 
-def parse_investigations_to_table(investigations):
+def parse_investigations_to_table(investigations, is_table_result):
     data: List = []
     widget_table = {"total": len(investigations)}
+    urls = demisto.demistoUrls()
+    server_url = urls.get('server', '')
     for investigation in investigations.keys():
-        size = investigations[investigation].get('leafSize').split(' ')
-        if float(size[0]) >= 1.0 and size[1] == 'MB':
-            db_name = investigations[investigation].get('Date')
+        full_size = investigations[investigation].get('leafSize').split(' ')
+        db_name = investigations[investigation].get('Date')
+        size = float(full_size[0])
+        if db_name.isdigit() and size >= 1.0 and full_size[1] == 'MB':
+            inv_id = investigation.split('-')[1]
             data.append({
-                "IncidentID": investigation.split('-')[1],
-                "Size": investigations[investigation].get('leafSize'),
+                "IncidentID": inv_id if is_table_result else f"[{inv_id}]({os.path.join(server_url, '#', 'incident', inv_id)})",
+                "Size(MB)": int(size) if size == int(size) else size,
                 "AmountOfEntries": investigations[investigation].get('keyN'),
-                "Date": db_name[:2] + "-" + db_name[2:],
-                "SizeNumber": float(size[0])
+                "Date": db_name[:2] + "-" + db_name[2:]
             })
 
-    widget_table['data'] = sorted(data, key=itemgetter('SizeNumber'), reverse=True)  # type: ignore
+    widget_table['data'] = sorted(data, key=itemgetter('Size(MB)'), reverse=True)  # type: ignore
 
     return widget_table
 
@@ -48,13 +51,14 @@ def get_month_db_from_date(date):
     return month + year
 
 
-def get_time_object(timestring):
+def get_time_object(timestring, empty_res_as_now=True):
+    empty_res = datetime.now() if empty_res_as_now else None
     if timestring is None or timestring == '':
-        return datetime.now()
+        return empty_res
 
     date_object = parse(timestring)
     if date_object.year == 1:
-        return datetime.now()
+        return empty_res
     else:
         return date_object
 
@@ -75,10 +79,22 @@ def get_month_database_names():
 def main():
     try:
         investigations: Dict = {}
-        for db_name in get_month_database_names():
-            raw_output = demisto.executeCommand('getDBStatistics', args={"filter": db_name})
+        args: Dict = demisto.args()
+        from_date = args.get('from')
+        is_table_result = args.get('table_result') == 'true'
+        if not get_time_object(from_date, empty_res_as_now=False):
+            raw_output = demisto.executeCommand('getDBStatistics', args={})
             get_investigations(raw_output[0].get('Contents', {}), investigations)
-        demisto.results(parse_investigations_to_table(investigations))
+        else:
+            for db_name in get_month_database_names():
+                raw_output = demisto.executeCommand('getDBStatistics', args={"filter": db_name})
+                get_investigations(raw_output[0].get('Contents', {}), investigations)
+        result = parse_investigations_to_table(investigations, is_table_result)
+        if not is_table_result:
+            # change result to MD
+            result = tableToMarkdown('Largest Incidents by Storage Size', result.get("data"),
+                                     headers=["IncidentID", "Size(MB)", "AmountOfEntries", "Date"])
+        demisto.results(result)
     except Exception:
         demisto.error(traceback.format_exc())  # print the traceback
         return_error(f'Failed to execute GetLargestInvestigations. Error: {traceback.format_exc()}')

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.yml
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.yml
@@ -1,14 +1,31 @@
 args:
 - default: false
-  description: The end date for fetching incidents in ISO format. Incidents will be fetched until the last day of the specified month. For example, if you specify 2020-08-14, incidents created on the specified "from" date until  2020-08-31 will be returned.
+  description: The end date for fetching incidents in ISO format. Incidents will be
+    fetched until the last day of the specified month. For example, if you specify
+    2020-08-14, incidents created on the specified "from" date until  2020-08-31 will
+    be returned.
   isArray: false
   name: to
   required: false
   secret: false
 - default: false
-  description: The start date for fetching incidents in ISO format. Incidents will be fetched starting from the first day of the specified month. For example, if you specify 2020-08-14, incidents created on 2020-08-01 will be returned.
+  description: The start date for fetching incidents in ISO format. Incidents will
+    be fetched starting from the first day of the specified month. For example, if
+    you specify 2020-08-14, incidents created on 2020-08-01 will be returned.
   isArray: false
   name: from
+  required: false
+  secret: false
+- auto: PREDEFINED
+  default: false
+  defaultValue: 'false'
+  description: Change to true to return a result suitable for a table widget. By default
+    the return will be in Markdown.
+  isArray: false
+  name: table_result
+  predefined:
+  - 'true'
+  - 'false'
   required: false
   secret: false
 comment: Returns all investigations larger than 1 MB from all Cortex XSOAR.
@@ -24,5 +41,5 @@ tags:
 - widget
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.8.5.11789
+dockerimage: demisto/python3:3.8.6.12176
 fromversion: 6.0.0

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations_test.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations_test.py
@@ -20,9 +20,20 @@ raw_incidents_data = [
                 'newInvPlaybooks': {
                     'keyN': 9,
                     'leafSize': '29 MB'
-                }
+                },
             },
         'dbName': '082020'
+    },
+    {
+        'buckets':
+            {
+                'investigations-playground': {
+                    'keyN': 1301,
+                    'leafSize': '4.8 MB',
+                    'Date': ''
+                }
+            },
+        'dbName': 'main'
     }
 ]
 
@@ -36,6 +47,11 @@ investigations = {
         'keyN': 1301,
         'leafSize': '4.8 MB',
         'Date': '082020'
+    },
+    'investigations-playground': {
+        'keyN': 1301,
+        'leafSize': '4.8 MB',
+        'Date': 'main'
     }
 }
 
@@ -82,11 +98,13 @@ def test_parse_investigations_to_table():
     """
     from GetLargestInvestigations import parse_investigations_to_table
     table = parse_investigations_to_table(investigations, True)
-    assert table.get('total') == 2
+    assert table.get('total') == 3
     assert table.get('data')[0].get('IncidentID') == '4187'
     assert table.get('data')[0].get('Size(MB)') == 4.8
-    assert table.get('data')[1].get('IncidentID') == '4185'
-    assert table.get('data')[1].get('Date') == '08-2020'
+    assert table.get('data')[1].get('Date') == ''
+    assert table.get('data')[1].get('IncidentID') == 'playground'
+    assert table.get('data')[2].get('IncidentID') == '4185'
+    assert table.get('data')[2].get('Date') == '08-2020'
 
 
 def test_get_month_database_names(mocker):

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations_test.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations_test.py
@@ -81,10 +81,10 @@ def test_parse_investigations_to_table():
         order (sorted by size) and that the date is formatted correctly.
     """
     from GetLargestInvestigations import parse_investigations_to_table
-    table = parse_investigations_to_table(investigations)
+    table = parse_investigations_to_table(investigations, True)
     assert table.get('total') == 2
     assert table.get('data')[0].get('IncidentID') == '4187'
-    assert table.get('data')[0].get('Size') == '4.8 MB'
+    assert table.get('data')[0].get('Size(MB)') == 4.8
     assert table.get('data')[1].get('IncidentID') == '4185'
     assert table.get('data')[1].get('Date') == '08-2020'
 

--- a/Packs/CommonWidgets/Widgets/widget-LargestInputsAndOuputsInIncidentsWidget.json
+++ b/Packs/CommonWidgets/Widgets/widget-LargestInputsAndOuputsInIncidentsWidget.json
@@ -4,7 +4,7 @@
  "modified": "2020-08-18T13:31:21.939387+03:00",
  "name": "Largest Inputs And Outputs In Incidents",
  "dataType": "scripts",
- "widgetType": "table",
+ "widgetType": "text",
  "query": "GetLargestInputsAndOuputsInIncidents",
  "dateRange": {
   "fromDate": "0001-01-01T00:00:00Z",
@@ -18,40 +18,6 @@
    "field": ""
   },
   "fromDateLicense": "0001-01-01T00:00:00Z"
- },
- "params": {
-  "tableColumns": [
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "IncidentID"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "InputOrOutput"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "Name"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "Size"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "TaskID"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "TaskName"
-   }
-  ]
  },
  "fromVersion": "6.0.0",
  "description": "",

--- a/Packs/CommonWidgets/Widgets/widget-LargestInvestigationsWidget.json
+++ b/Packs/CommonWidgets/Widgets/widget-LargestInvestigationsWidget.json
@@ -2,9 +2,9 @@
  "id": "LargestInvestigationsWidget",
  "version": -1,
  "modified": "2020-08-18T13:28:59.339259+03:00",
- "name": "Largest Investigations",
+ "name": "Largest Incidents by Storage Size",
  "dataType": "scripts",
- "widgetType": "table",
+ "widgetType": "text",
  "query": "GetLargestInvestigations",
  "dateRange": {
   "fromDate": "0001-01-01T00:00:00Z",
@@ -18,30 +18,6 @@
    "field": ""
   },
   "fromDateLicense": "0001-01-01T00:00:00Z"
- },
- "params": {
-  "tableColumns": [
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "IncidentID"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "Size"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "Date"
-   },
-   {
-    "displayed": true,
-    "isDefault": true,
-    "key": "AmountOfEntries"
-   }
-  ]
  },
  "fromVersion": "6.0.0",
  "description": "",

--- a/Packs/CommonWidgets/pack_metadata.json
+++ b/Packs/CommonWidgets/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Widgets",
     "description": "Frequently used widgets pack.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/29128
fixes: https://github.com/demisto/etc/issues/29235

## Description
* Fixed an issue where the widgets/scripts did not work for "All times".
* Changed header Size->Size(MB)
* Changed header Size value to float
* Changed investigation IDs to Hyperlink
* Changed task IDs to Heyperlink
* GetLargestInvestigations now returns by default Text, but can also return table
* GetLargestInputsAndOuputsInIncidents now returns Text result
* Added handling for **playground** investigation
## Does it break backward compatibility?
   - [x] Yes
       - Further details: changes from table to text result (to support links) may adversely affect widgets/scripts that used it before

## ScreenShots
![image](https://user-images.githubusercontent.com/20818773/95470452-7a2ef780-0989-11eb-8d5f-b7d027796738.png)

![image](https://user-images.githubusercontent.com/20818773/95470421-71d6bc80-0989-11eb-902c-f5ab003c5e4d.png)


## Must have
- [x] Tests

@kirbles19 please review:
* Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.yml
* Packs/CommonWidgets/ReleaseNotes/1_0_4.md