### PR TITLE
Increased test timeout for service now polling playbook

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -598,7 +598,8 @@
         {
             "playbookID": "Create ServiceNow Ticket and State Polling Test",
             "integrations": "ServiceNow v2",
-            "fromversion": "6.0.0"
+            "fromversion": "6.0.0",
+            "timeout": 500
         },
         {
             "integrations": "ExtraHop v2",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description:
It seems like the default timeout of 160 seconds is not enough for `Create ServiceNow Ticket and State Polling Test`.

See here for example:
https://app.circleci.com/pipelines/github/demisto/content/32112/workflows/8c4d05b5-277a-4b13-82e6-e830450971a2/jobs/140267
Increased it to 500 seconds
