### PR TITLE
Add Alexa Benign Parameter for Good Domains

### DIFF
--- a/Packs/Alexa/Integrations/Alexa/Alexa.py
+++ b/Packs/Alexa/Integrations/Alexa/Alexa.py
@@ -11,7 +11,7 @@ requests.packages.urllib3.disable_warnings()
 
 """GLOBAL VARIABLES/CONSTANTS"""
 THRESHOLD = int(demisto.params().get('threshold'))
-BENIGN = int(demisto.params().get('benign'))
+BENIGN = int(demisto.params().get('benign'), 0)
 USE_SSL = not demisto.params().get('insecure', False)
 PROXIES = handle_proxy()
 

--- a/Packs/Alexa/Integrations/Alexa/Alexa.py
+++ b/Packs/Alexa/Integrations/Alexa/Alexa.py
@@ -11,6 +11,7 @@ requests.packages.urllib3.disable_warnings()
 
 """GLOBAL VARIABLES/CONSTANTS"""
 THRESHOLD = int(demisto.params().get('threshold'))
+BENIGN = int(demisto.params().get('benign'))
 USE_SSL = not demisto.params().get('insecure', False)
 PROXIES = handle_proxy()
 
@@ -19,8 +20,8 @@ PROXIES = handle_proxy()
 
 def alexa_fallback_command(domain):
     headers = {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, '
-                      'like Gecko) Chrome/76.0.3809.132 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, '
+                      'like Gecko) Chrome/85.0.4183.121 Safari/537.36'
     }
     resp = requests.request('GET', 'https://www.alexa.com/minisiteinfo/{}'.format(domain),
                             headers=headers, verify=USE_SSL, proxies=PROXIES)
@@ -45,7 +46,10 @@ def alexa_domain_command():
         rank = root.find(".//POPULARITY").attrib['TEXT']  # type: ignore
     except:  # noqa
         rank = alexa_fallback_command(domain)
-    if int(rank) > THRESHOLD:
+    if int(rank) <= BENIGN:
+        dbot_score = 1
+        dbot_score_text = 'good'
+    elif int(rank) > THRESHOLD:
         dbot_score = 2
         dbot_score_text = 'suspicious'
     elif (int(rank) < THRESHOLD) and rank != '-1':
@@ -71,8 +75,9 @@ def alexa_domain_command():
             'Rank': rank
         }
     }
-    hr_string = ('The Alexa rank of {} is {} and has been marked as {}'
-                 ' while the threshold is {}'.format(domain, rank, dbot_score_text, THRESHOLD))
+    hr_string = ('The Alexa rank of {} is {} and has been marked as {}. '
+                 'The benign threshold is {} while the suspicious '
+                 'threshold is {}.'.format(domain, rank, dbot_score_text, BENIGN, THRESHOLD))
     demisto.results({
         'Type': entryTypes['note'],
         'ContentsFormat': formats['markdown'],

--- a/Packs/Alexa/Integrations/Alexa/Alexa.yml
+++ b/Packs/Alexa/Integrations/Alexa/Alexa.yml
@@ -1,43 +1,43 @@
-commonfields:
-  id: Alexa Rank Indicator_copy
-  version: -1
-vcShouldKeepItemLegacyProdMachine: false
-name: Alexa Rank Indicator_copy
-display: Alexa Rank Indicator_copy
 category: Data Enrichment & Threat Intelligence
-description: Alexa provides website ranking information that can be useful in determining
-  if the domain in question has a strong web presence.
+commonfields:
+  id: Alexa Rank Indicator
+  version: -1
 configuration:
-- display: Sensitivity threshold for configuring which domains are suspicious versus
-    trusted.
+- defaultvalue: '2000000'
+  display: Sensitivity threshold for configuring which domains are suspicious versus trusted.
   name: threshold
-  defaultvalue: "2000000"
-  type: 0
   required: true
-- display: 'Alexa rank - top X domains to be considered trusted. '
+  type: 0
+- display: Alexa rank - top domains to be considered trusted.
   name: benign
   defaultvalue: "1000"
   type: 0
   required: true
-  additionalinfo: 'These domains will be given a DbotScore of "good". '
+  additionalinfo: These domains will be given a DbotScore of good.
 - display: Use system proxy settings
   name: proxy
-  type: 8
   required: false
+  type: 8
 - display: Trust any certificate (not secure)
   name: insecure
-  type: 8
   required: false
+  type: 8
+description: Alexa provides website ranking information that can be useful in determining if the domain in question has a strong web presence.
+display: Alexa Rank Indicator
+name: Alexa Rank Indicator
 script:
-  script: ''
-  type: python
   commands:
-  - name: domain
-    arguments:
-    - name: domain
-      required: true
-      default: true
+  - arguments:
+    - default: true
       description: Domain to search.
+      isArray: false
+      name: domain
+      required: true
+      secret: false
+    deprecated: false
+    description: Provides an Alexa ranking of the Domain in question.
+    execution: false
+    name: domain
     outputs:
     - contextPath: Domain.Name
       description: The Domain being checked
@@ -66,7 +66,11 @@ script:
     - contextPath: Alexa.Domain.Rank
       description: Alexa rank as determined by Amazon
       type: string
-    description: Provides an Alexa ranking of the Domain in question.
+  isfetch: false
   runonce: false
+  script: ''
+  type: python
   subtype: python2
-sourcemoduleid: Alexa Rank Indicator
+tests:
+- Alexa Test Playbook
+fromversion: 5.0.0

--- a/Packs/Alexa/Integrations/Alexa/Alexa.yml
+++ b/Packs/Alexa/Integrations/Alexa/Alexa.yml
@@ -1,37 +1,43 @@
-category: Data Enrichment & Threat Intelligence
 commonfields:
-  id: Alexa Rank Indicator
+  id: Alexa Rank Indicator_copy
   version: -1
+vcShouldKeepItemLegacyProdMachine: false
+name: Alexa Rank Indicator_copy
+display: Alexa Rank Indicator_copy
+category: Data Enrichment & Threat Intelligence
+description: Alexa provides website ranking information that can be useful in determining
+  if the domain in question has a strong web presence.
 configuration:
-- defaultvalue: '2000000'
-  display: Sensitivity threshold for configuring which domains are suspicious versus trusted.
+- display: Sensitivity threshold for configuring which domains are suspicious versus
+    trusted.
   name: threshold
-  required: true
+  defaultvalue: "2000000"
   type: 0
+  required: true
+- display: 'Alexa rank - top X domains to be considered trusted. '
+  name: benign
+  defaultvalue: "1000"
+  type: 0
+  required: true
+  additionalinfo: 'These domains will be given a DbotScore of "good". '
 - display: Use system proxy settings
   name: proxy
-  required: false
   type: 8
+  required: false
 - display: Trust any certificate (not secure)
   name: insecure
-  required: false
   type: 8
-description: Alexa provides website ranking information that can be useful in determining if the domain in question has a strong web presence.
-display: Alexa Rank Indicator
-name: Alexa Rank Indicator
+  required: false
 script:
+  script: ''
+  type: python
   commands:
-  - arguments:
-    - default: true
-      description: Domain to search.
-      isArray: false
-      name: domain
+  - name: domain
+    arguments:
+    - name: domain
       required: true
-      secret: false
-    deprecated: false
-    description: Provides an Alexa ranking of the Domain in question.
-    execution: false
-    name: domain
+      default: true
+      description: Domain to search.
     outputs:
     - contextPath: Domain.Name
       description: The Domain being checked
@@ -60,11 +66,7 @@ script:
     - contextPath: Alexa.Domain.Rank
       description: Alexa rank as determined by Amazon
       type: string
-  isfetch: false
+    description: Provides an Alexa ranking of the Domain in question.
   runonce: false
-  script: ''
-  type: python
   subtype: python2
-tests:
-- Alexa Test Playbook
-fromversion: 5.0.0
+sourcemoduleid: Alexa Rank Indicator

--- a/Packs/Alexa/ReleaseNotes/1_1_0.md
+++ b/Packs/Alexa/ReleaseNotes/1_1_0.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Alexa Rank Indicator_copy
+- Add Alexa Benign Parameter for Good Domains

--- a/Packs/Alexa/ReleaseNotes/1_1_0.md
+++ b/Packs/Alexa/ReleaseNotes/1_1_0.md
@@ -1,4 +1,4 @@
 
 #### Integrations
-##### Alexa Rank Indicator_copy
+##### Alexa Rank Indicator
 - Add Alexa Benign Parameter for Good Domains

--- a/Packs/Alexa/pack_metadata.json
+++ b/Packs/Alexa/pack_metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "Alexa Rank Indicator",
-  "description": "Alexa provides website ranking information that can be useful in determining if the domain in question has a strong web presence.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-04-14T00:00:00Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": []
+    "name": "Alexa Rank Indicator",
+    "description": "Alexa provides website ranking information that can be useful in determining if the domain in question has a strong web presence.",
+    "support": "xsoar",
+    "currentVersion": "1.1.0",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-04-14T00:00:00Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": []
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)
 - [x] Done

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Update to the `Alexa` Pack Integration to add the `benign` parameter. The current `threshold` parameter only accounts for `unknown` or `suspicious` domains, however the top X domains (i.e. top 1000) could easily be considered `good` which is helpful context for an analyst. 

> **NOTE:** It was clear this integration is a bit older and does not use the new coding conventions. There's several things that could be cleaned up to align with best practices. While I think it'd be easy to go ahead and update that now, I thought it best to keep the solution simple and avoid breaking any backward compatibility. 

## Screenshots
<img width="362" alt="Benign" src="https://user-images.githubusercontent.com/12013964/95688599-67aafd00-0bd9-11eb-877a-6941d7f17b82.png">

<img width="1223" alt="Benign War Room" src="https://user-images.githubusercontent.com/12013964/95688622-7e515400-0bd9-11eb-99ca-d83ab894a902.png">


## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
