### PR TITLE
VxStream Test - remove check for totals VMs

### DIFF
--- a/Packs/CrowdStrikeFalconSandbox/TestPlaybooks/playbook-VxStream_Test.yml
+++ b/Packs/CrowdStrikeFalconSandbox/TestPlaybooks/playbook-VxStream_Test.yml
@@ -238,11 +238,6 @@ tasks:
           - - operator: isExists
               left:
                 value:
-                  simple: CrowdStrike.Environment.VMs_total
-                iscontext: true
-          - - operator: isExists
-              left:
-                value:
                   simple: CrowdStrike.Environment.VMs_busy
                 iscontext: true
           - - operator: isExists


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/29280

## Description
seems like the total VMs property is no longer returned from the API, removed validation of it