### PR TITLE
release notes generator - add white spaces between entities of 2 words

### DIFF
--- a/Tests/scripts/infrastructure_tests/release_notes_generator_test.py
+++ b/Tests/scripts/infrastructure_tests/release_notes_generator_test.py
@@ -438,5 +438,5 @@ class TestMergeVersionBlocks:
         """
         entities_data = {'IndicatorTypes': {'accountRep': ''}}
         rn = construct_entities_block(entities_data)
-        assert '### IndicatorTypes' in rn
+        assert '### Indicator Types' in rn
         assert '- **accountRep**' in rn

--- a/Utils/release_notes_generator.py
+++ b/Utils/release_notes_generator.py
@@ -113,7 +113,8 @@ def construct_entities_block(entities_data: dict):
     """
     release_notes = ''
     for entity_type, entities_description in sorted(entities_data.items()):
-        release_notes += f'#### {entity_type}\n'
+        pretty_entity_type = re.sub(r'(\w)([A-Z])', r'\1 \2', entity_type)
+        release_notes += f'#### {pretty_entity_type}\n'
         for name, description in entities_description.items():
             if entity_type in ('Connections', 'IncidentTypes', 'IndicatorTypes', 'Layouts', 'IncidentFields'):
                 release_notes += f'- **{name}**\n'


### PR DESCRIPTION

## Status
- [x] Ready

## Description
Added a space between content entities that are separated by capital letters, such as IncidentFields
