### PR TITLE
Added from version to DNSDB test conf to match the integrations fromv…

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2878,7 +2878,8 @@
         },
         {
             "integrations": "DNSDB_v2",
-            "playbookID": "DNSDB-Test"
+            "playbookID": "DNSDB-Test",
+            "fromversion": "5.0.0"
         },
         {
             "playbookID": "DBotCreatePhishingClassifierV2FromFile-Test",
@@ -3166,7 +3167,7 @@
         "Indeni_test": "Non-certified partner pack, this should be skipped for now"
     },
     "skipped_integrations": {
-        
+
         "_comment1": "~~~ NO INSTANCE ~~~",
         "ZeroFox": "Issue 29284",
         "Recorded Future v2": "Issue 29090",
@@ -3263,11 +3264,11 @@
         "Hatching Triage": "Community contribution",
         "SNDBOX": "Issue 28826",
         "illuminate": "Will be replaced by analyst1 - Issue 9401",
-        
+
         "_comment2": "~~~ UNSTABLE ~~~",
         "Tenable.sc": "unstable instance",
         "ThreatConnect v2": "unstable instance",
-        
+
         "_comment3": "~~~ QUOTA ISSUES ~~~",
         "Joe Security": "Issue 25650",
         "XFE_v2": "Required proper instance, otherwise we get quota errors",
@@ -3275,13 +3276,13 @@
         "Google Resource Manager": "Cannot create projects because have reached allowed quota.",
         "Looker": "Warehouse 'DEMO_WH' cannot be resumed because resource monitor 'LIMITER' has exceeded its quota.",
         "Ipstack": "Issue 26266",
-        
+
         "_comment4": "~~~ NO INSTANCE - SUPPORTED BY THE COMMUNITY ~~~",
         "Zabbix": "Supported by external developer",
         "Humio": "supported by the partner",
         "Digital Guardian": "partner integration",
         "Smokescreen IllusionBLACK": "partner integration",
-        
+
         "_comment5": "~~~ OTHER ~~~",
         "XFE": "We have the new integration XFE_v2, so no need to test the old one because they use the same quote",
         "Endace": "Issue 24304",
@@ -3449,7 +3450,7 @@
         "Mail Listener v2"
     ],
     "docker_thresholds": {
-        
+
         "_comment": "Add here docker images which are specific to an integration and require a non-default threshold (such as rasterize or ews). That way there is no need to define this multiple times. You can specify full image name with version or without.",
         "images": {
             "demisto/chromium": {


### PR DESCRIPTION
…ersion


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description:
The DNSDB v2 integration has fromversion 5.0.0 and still it was run and failed in 4.5 [here](https://app.circleci.com/pipelines/github/demisto/content/33342/workflows/be26bf24-1a4c-4835-a140-547317006daf/jobs/145866), therefore adding the fromversion limitation to the test conf.
