### PR TITLE
IPv6 support added in search

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -1,9 +1,9 @@
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
-from typing import Dict
 
 '''IMPORTS'''
+from typing import Dict
 import time
 import requests
 import collections

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -3,7 +3,6 @@ from CommonServerPython import *
 from CommonServerUserPython import *
 
 '''IMPORTS'''
-from typing import Dict
 import time
 import requests
 import collections
@@ -35,7 +34,7 @@ BLACKLISTED_URL_ERROR_MESSAGE = 'The submitted domain is on our blacklist. ' \
 
 def http_request(method, url_suffix, json=None, wait=0, retries=0):
     if method == 'GET':
-        headers = {}  # type: Dict[str, str]
+        headers = {}  # type: ignore
     elif method == 'POST':
         headers = {
             'API-Key': APIKEY,

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -1,6 +1,7 @@
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
+from typing import Dict
 
 '''IMPORTS'''
 import time
@@ -120,8 +121,9 @@ def is_truthy(val):
     return bool(val)
 
 
-def poll(target, step, args=(), kwargs=None, timeout=None, max_tries=None, check_success=is_truthy,
-         step_function=step_constant, ignore_exceptions=(), poll_forever=False, collect_values=None, *a, **k):
+def poll(target, step, args=(), kwargs=None, timeout=None,
+         check_success=is_truthy, step_function=step_constant,
+         ignore_exceptions=(), collect_values=None, **k):
 
     kwargs = kwargs or dict()
     values = collect_values or Queue()

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -84,19 +84,6 @@ def makehash():
     return collections.defaultdict(makehash)
 
 
-def is_valid_ip(s):
-    a = s.split('.')
-    if len(a) != 4:
-        return False
-    for x in a:
-        if not x.isdigit():
-            return False
-        i = int(x)
-        if i < 0 or i > 255:
-            return False
-    return True
-
-
 def get_result_page():
     uuid = demisto.args().get('uuid')
     uri = BASE_URL + 'result/{}'.format(uuid)
@@ -407,16 +394,16 @@ def urlscan_search_command():
     LIMIT = int(demisto.args().get('limit'))
     HUMAN_READBALE_HEADERS = ['URL', 'Domain', 'IP', 'ASN', 'Scan ID', 'Scan Date']
     raw_query = demisto.args().get('searchParameter', '')
-    if is_valid_ip(raw_query):
+    if is_ip_valid(raw_query, accept_v6_ips=True):
         search_type = 'ip'
-
-    # Parsing query to see if it's a url
-    parsed = urlparse(raw_query)
-    # Checks to see if Netloc is present. If it's not a url, Netloc will not exist
-    if parsed[1] == '' and len(raw_query) == 64:
-        search_type = 'hash'
     else:
-        search_type = 'page.url'
+        # Parsing query to see if it's a url
+        parsed = urlparse(raw_query)
+        # Checks to see if Netloc is present. If it's not a url, Netloc will not exist
+        if parsed[1] == '' and len(raw_query) == 64:
+            search_type = 'hash'
+        else:
+            search_type = 'page.url'
 
     # Making the query string safe for Elastic Search
     query = quote(raw_query, safe='')

--- a/Packs/UrlScan/ReleaseNotes/1_0_5.md
+++ b/Packs/UrlScan/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- functionality enhanced

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,11 +2,11 @@
     "name": "urlscan.io",
     "description": "Urlscan.io reputation",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
-    "created": "2020-04-14T00:00:00Z",
+    "created": "2020-10-15T16:00:00Z",
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: N/A

## Description
Wanted to have IPv6 support on Urlscan search. Also chaned query type logic (no further checks are made if valid IP address is found).
Didn't test with Demisto versions other than 6.0.0

Please label PR with _hacktoberfest-accepted_ if you accept this PR.

## Screenshots
<img width="1308" alt="Screenshot 2020-10-15 at 15 16 01" src="https://user-images.githubusercontent.com/364866/96131377-5fb0cd00-0ef9-11eb-8272-f6a5c62d4bd5.png">

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x ] No

## Must have
- [ ] Tests
- [ ] Documentation 
