### PR TITLE
ServiceNow Ticket Layout ID Revert

### DIFF
--- a/Packs/ServiceNow/IncidentTypes/incidenttype-ServiceNowTicket.json
+++ b/Packs/ServiceNow/IncidentTypes/incidenttype-ServiceNowTicket.json
@@ -20,5 +20,5 @@
  "disabled": false,
  "reputationCalc": 0,
  "preProcessingScript": "",
- "layout": "20c9bb24-7037-4597-8c32-578ffbe61c01"
+ "layout": "ServiceNow Ticket"
 }

--- a/Packs/ServiceNow/Layouts/layoutscontainer-ServiceNow_Ticket.json
+++ b/Packs/ServiceNow/Layouts/layoutscontainer-ServiceNow_Ticket.json
@@ -732,7 +732,7 @@
   ]
  },
  "group": "incident",
- "id": "20c9bb24-7037-4597-8c32-578ffbe61c01",
+ "id": "ServiceNow Ticket",
  "name": "ServiceNow Ticket",
  "system": false,
  "version": -1,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->


- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29410

## Description
Reverting ServiceNow Ticket layout to the original ID. 

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
