### PR TITLE
Fix the perm problem in sane-pdf non root

### DIFF
--- a/Packs/Base/ReleaseNotes/1_3_20.md
+++ b/Packs/Base/ReleaseNotes/1_3_20.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### SanePdfReports
+- Fixed the sane-pdf-reports issue when using a non root user.

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.py
@@ -11,7 +11,7 @@ import string
 import subprocess
 from pathlib import Path
 
-WORKING_DIR = Path("/app")
+WORKING_DIR = Path("/tmp")
 INPUT_FILE_PATH = 'sample.json'
 OUTPUT_FILE_PATH = 'out{id}.pdf'
 DISABLE_LOGOS = True  # Bugfix before sane-reports can work with image files.

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.3.19",
+    "currentVersion": "1.3.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29671

## Description
Fixes path that caused non root users failure to run pdf reports via docker.

## Screenshots
..

## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
