### PR TITLE
changed classifier's id and mapper's id

### DIFF
--- a/Packs/FeedAWS/Classifiers/classifier-FeedAWS.json
+++ b/Packs/FeedAWS/Classifiers/classifier-FeedAWS.json
@@ -1,5 +1,5 @@
 {
-    "id": "AWS Feed",
+    "id": "AWS Feed Classifier",
     "name": "AWS Feed - Classifier",
     "type": "classification",
     "description": "Classifies AWS IOCs.",

--- a/Packs/FeedAWS/Classifiers/classifier-mapper-incoming-FeedAWS.json
+++ b/Packs/FeedAWS/Classifiers/classifier-mapper-incoming-FeedAWS.json
@@ -1,5 +1,5 @@
 {
-    "id": "AWS Feed",
+    "id": "AWS Feed Mapper",
     "name": "AWS Feed - Incoming Mapper",
     "type": "mapping-incoming",
     "description": "Maps incoming AWS indicator fields.",

--- a/Packs/FeedAWS/Integrations/FeedAWS/FeedAWS.yml
+++ b/Packs/FeedAWS/Integrations/FeedAWS/FeedAWS.yml
@@ -143,7 +143,7 @@ script:
     description: Fetches indicators from the feed.
     execution: false
     name: aws-get-indicators
-  dockerimage: demisto/jmespath:1.0.0.10854
+  dockerimage: demisto/jmespath:1.0.0.12410
   feed: true
   isfetch: false
   longRunning: false
@@ -153,5 +153,5 @@ script:
   subtype: python3
   type: python
 fromversion: 5.5.0
-defaultclassifier: AWS Feed
-defaultmapperin: AWS Feed-mapper
+defaultclassifier: AWS Feed Classifier
+defaultmapperin: AWS Feed Mapper

--- a/Packs/FeedAWS/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedAWS/ReleaseNotes/1_0_6.md
@@ -4,3 +4,7 @@
 - Fixed an issue where the classifier's id was incorrect.
 ##### AWS Feed - Incoming Mapper
 - Fixed an issue where the mapper's id was incorrect.
+
+#### Integration
+##### AWS Feed
+- Upgraded the Docker image to demisto/jmespath:1.0.0.12410.

--- a/Packs/FeedAWS/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedAWS/ReleaseNotes/1_0_6.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+##### AWS Feed - Classifier
+- Fixed an issue by changing classifier's id
+##### AWS Feed - Incoming Mapper
+- Fixed an issue by changing mapper's id

--- a/Packs/FeedAWS/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedAWS/ReleaseNotes/1_0_6.md
@@ -1,6 +1,6 @@
 
 #### Classifiers
 ##### AWS Feed - Classifier
-- Fixed an issue by changing classifier's id
+- Fixed an issue where the classifier's id was incorrect.
 ##### AWS Feed - Incoming Mapper
-- Fixed an issue by changing mapper's id
+- Fixed an issue where the mapper's id was incorrect.

--- a/Packs/FeedAWS/pack_metadata.json
+++ b/Packs/FeedAWS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS Feed",
     "description": "Indicators feed from AWS",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29814

## Description
Fixed an issue where the classifier and the mapper have the same id. Updated these ids.

## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
