### PR TITLE
Fixed pytest run on Tests and Utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,13 +287,7 @@ references:
       name: Infrastructure testing
       when: always
       command: |
-        python3 -m pytest ./Tests/scripts/infrastructure_tests/ -v
-        python3 -m pytest ./Tests/Marketplace/Tests/ -v
-        python3 -m pytest ./Tests/scripts/utils/tests -v
-
-        # TODO: replace this line with running all unit tests in Utils directory
-        # see issue https://github.com/demisto/etc/issues/29435
-        python3 -m pytest ./Utils/github_workflow_scripts/ -v
+        python3 -m pytest Tests Utils -v
 
         if [ -n "${DEMISTO_SDK_NIGHTLY}" ] ; then
           ./Tests/scripts/sdk_pylint_check.sh

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -24,6 +24,11 @@ import requests
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException
 try:
+    """
+    Those dual-imports are required as Slack updated their sdk and it breaks BC.
+    `from slack import...` is for new slack and local runs.
+    `from slackclient import...` is for old slack and running in CircleCI (old slack in docker image)
+    """
     from slack import WebClient as SlackClient  # New slack
 except ModuleNotFoundError:
     from slackclient import SlackClient  # Old slack

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -23,7 +23,10 @@ import urllib3
 import requests
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException
-from slack import WebClient as SlackClient
+try:
+    from slack import WebClient as SlackClient  # New slack
+except ModuleNotFoundError:
+    from slackclient import SlackClient  # Old slack
 
 from Tests.mock_server import MITMProxy, AMIConnection
 from Tests.test_integration import Docker, test_integration, disable_all_integrations

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -23,7 +23,7 @@ import urllib3
 import requests
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException
-from slackclient import SlackClient
+from slack import WebClient as SlackClient
 
 from Tests.mock_server import MITMProxy, AMIConnection
 from Tests.test_integration import Docker, test_integration, disable_all_integrations
@@ -74,11 +74,11 @@ def options_handler():
                                                   'tests to run')
 
     options = parser.parse_args()
-    tests_settings = TestsSettings(options)
+    tests_settings = SettingsTester(options)
     return tests_settings
 
 
-class TestsSettings:
+class SettingsTester:
     def __init__(self, options):
         self.api_key = options.apiKey
         self.server = options.server
@@ -147,7 +147,7 @@ class ParallelPrintsManager:
         self.threads_print_jobs[thread_index] = []
 
 
-class TestsDataKeeper:
+class DataKeeperTester:
 
     def __init__(self):
         self.succeeded_playbooks = []
@@ -1046,7 +1046,7 @@ def manage_tests(tests_settings):
     This function manages the execution of Demisto's tests.
 
     Args:
-        tests_settings (TestsSettings): An object containing all the relevant data regarding how the tests should be ran
+        tests_settings (SettingsTester): An object containing all the relevant data regarding how the tests should be ran
 
     """
     tests_settings.serverNumericVersion = get_server_numeric_version(tests_settings.serverVersion,
@@ -1055,7 +1055,7 @@ def manage_tests(tests_settings):
     is_nightly = tests_settings.nightly
     number_of_instances = len(instances_ips)
     prints_manager = ParallelPrintsManager(number_of_instances)
-    tests_data_keeper = TestsDataKeeper()
+    tests_data_keeper = DataKeeperTester()
 
     if tests_settings.server:
         # If the user supplied a server - all tests will be done on that server.

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:
     from slackclient import SlackClient  # Old slack
 
 from Tests.mock_server import MITMProxy, AMIConnection
-from Tests.test_integration import Docker, test_integration, disable_all_integrations
+from Tests.test_integration import Docker, check_integration, disable_all_integrations
 from Tests.test_dependencies import get_used_integrations, get_tests_allocation_for_threads
 from demisto_sdk.commands.common.constants import RUN_ALL_TESTS_FORMAT, FILTER_CONF, PB_Status
 from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
@@ -329,8 +329,8 @@ def run_test_logic(conf_json_test_details, tests_queue, tests_settings, c, faile
                            thread_index,
                            tests_settings.conf_path) as lock:
         if lock:
-            status, inc_id = test_integration(c, server_url, integrations, playbook_id, prints_manager, test_options,
-                                              is_mock_run, thread_index=thread_index)
+            status, inc_id = check_integration(c, server_url, integrations, playbook_id, prints_manager, test_options,
+                                               is_mock_run, thread_index=thread_index)
             # c.api_client.pool.close()
             if status == PB_Status.COMPLETED:
                 prints_manager.add_print_job('PASS: {} succeed'.format(test_message), print_color, thread_index,
@@ -391,8 +391,8 @@ def mock_run(conf_json_test_details, tests_queue, tests_settings, c, proxy, fail
         prints_manager.add_print_job(start_mock_message, print, thread_index, include_timestamp=True)
         proxy.start(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
         # run test
-        status, _ = test_integration(c, server_url, integrations, playbook_id, prints_manager, test_options,
-                                     is_mock_run=True, thread_index=thread_index)
+        status, _ = check_integration(c, server_url, integrations, playbook_id, prints_manager, test_options,
+                                      is_mock_run=True, thread_index=thread_index)
         # use results
         proxy.stop(thread_index=thread_index, prints_manager=prints_manager)
         if status == PB_Status.COMPLETED:

--- a/Tests/test_dependencies.py
+++ b/Tests/test_dependencies.py
@@ -2,7 +2,7 @@ import json
 import math
 
 
-class TestVertex:
+class VertexTester:
     def __init__(self, test_name):
         self.neighbors = {}
         self.test_name = test_name
@@ -23,7 +23,7 @@ class TestVertex:
         return tests_in_component
 
 
-class TestsGraph:
+class GraphTester:
     """A graph representing the tests in Demisto and whether they use mutual integrations.
 
     Attributes:
@@ -39,7 +39,7 @@ class TestsGraph:
         for test_playbook_record in tests_data:
             playbook_name_in_record = test_playbook_record.get("playbookID")
             if playbook_name_in_record and playbook_name_in_record not in self.test_vertices:
-                new_test_vertex = TestVertex(playbook_name_in_record)
+                new_test_vertex = VertexTester(playbook_name_in_record)
                 self.test_vertices[playbook_name_in_record] = new_test_vertex
 
     def add_test_graph_neighbors(self, tests_data):
@@ -148,7 +148,7 @@ def get_test_dependencies(tests_file_path):
 
 
 def get_dependent_integrations_clusters_data(tests_file_path, dependent_tests):
-    tests_graph = TestsGraph()
+    tests_graph = GraphTester()
     tests_graph.build_tests_graph_from_conf_json(tests_file_path, dependent_tests)
     return tests_graph.clusters
 

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -7,6 +7,8 @@ from pprint import pformat
 import uuid
 import ast
 import urllib.parse
+
+import pytest
 import urllib3
 import requests.exceptions
 from demisto_client.demisto_api.rest import ApiException
@@ -818,6 +820,7 @@ def configure_proxy_unsecure(integration_params):
 # 3. wait for playbook to finish run
 # 4. if test pass - delete incident & instance
 # return playbook status
+@pytest.mark.skip(reason="Not a test")
 def test_integration(client, server_url, integrations, playbook_id, prints_manager, options=None, is_mock_run=False,
                      thread_index=0):
     options = options if options is not None else {}

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -1,23 +1,24 @@
 from __future__ import print_function
-import copy
-import time
-import re
-from subprocess import Popen, PIPE
-from pprint import pformat
-import uuid
+
 import ast
-import urllib.parse
-
-import pytest
-import urllib3
-import requests.exceptions
-from demisto_client.demisto_api.rest import ApiException
-import demisto_client
+import copy
 import json
-from Tests.tools import update_server_configuration
+import re
+import time
+import urllib.parse
+import uuid
+from pprint import pformat
+from subprocess import PIPE, Popen
 
-from demisto_sdk.commands.common.tools import print_error, print_warning, print_color, LOG_COLORS
+import demisto_client
+import requests.exceptions
+import urllib3
+from demisto_client.demisto_api.rest import ApiException
 from demisto_sdk.commands.common.constants import PB_Status
+from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
+                                               print_error, print_warning)
+
+from Tests.tools import update_server_configuration
 
 # Disable insecure warnings
 urllib3.disable_warnings()
@@ -820,9 +821,8 @@ def configure_proxy_unsecure(integration_params):
 # 3. wait for playbook to finish run
 # 4. if test pass - delete incident & instance
 # return playbook status
-@pytest.mark.skip(reason="Not a test")
-def test_integration(client, server_url, integrations, playbook_id, prints_manager, options=None, is_mock_run=False,
-                     thread_index=0):
+def check_integration(client, server_url, integrations, playbook_id, prints_manager, options=None, is_mock_run=False,
+                      thread_index=0):
     options = options if options is not None else {}
     # create integrations instances
     module_instances = []

--- a/Utils/tests/update_playbook_test.py
+++ b/Utils/tests/update_playbook_test.py
@@ -1,20 +1,17 @@
-import pytest
-
+from ruamel import yaml
+import os
 from Utils.update_playbook import update_playbook
 
 
-@pytest.mark.skip(reason="Not a test")
 def test_hello():
-    update_playbook("../../TestData/Phishing_Investigation_-_Generic.yml", None)
+    actual_yml_path = "playbook-Phishing_Investigation_-_Generic.yml"
+    try:
+        update_playbook("./TestData/Phishing_Investigation_-_Generic.yml", None)
 
-    with open("../../TestData/playbook-Phishing_Investigation_-_Generic.yml", "r") as f:
-        expected_yml = f.read().encode('utf-8').splitlines()
+        expected_yml = yaml.safe_load(open("./TestData/playbook-Phishing_Investigation_-_Generic.yml"))
+        actual_yml = yaml.safe_load(open(actual_yml_path))
 
-        with open("playbook-Phishing_Investigation_-_Generic.yml", "r") as f2:
-            actual_yml = f2.read().encode('utf-8').splitlines()
-
-            assert expected_yml == actual_yml, "the yml files aren't equal"
-            tested = True
-
-    if not tested:
-        assert False, "for some reason the test was not reached assert"
+        assert sorted(expected_yml) == sorted(actual_yml), "the yml files aren't equal"
+    finally:
+        if os.path.isfile(actual_yml_path):
+            os.remove(actual_yml_path)

--- a/Utils/tests/update_playbook_test.py
+++ b/Utils/tests/update_playbook_test.py
@@ -1,10 +1,12 @@
+import pytest
+
 from Utils.update_playbook import update_playbook
 
 
+@pytest.mark.skip(reason="Not a test")
 def test_hello():
     update_playbook("../../TestData/Phishing_Investigation_-_Generic.yml", None)
 
-    tested = False
     with open("../../TestData/playbook-Phishing_Investigation_-_Generic.yml", "r") as f:
         expected_yml = f.read().encode('utf-8').splitlines()
 

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -20,6 +20,3 @@ circleci==1.2.2
 pylint==2.6.0
 coloredlogs==14.0
 pandas==1.1.0
-pyarrow==1.0.0
-prettytable==1.0.1
-slackclient==2.9.3

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -21,3 +21,5 @@ pylint==2.6.0
 coloredlogs==14.0
 pandas==1.1.0
 pyarrow==1.0.0
+prettytable==1.0.1
+slackclient==2.9.3


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29435

## Description
Refactored names to not be collected by Pytest, added import to globally work (slack import).
Running pytest on both Utils and Tests folder.


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
