### PR TITLE
farsight-security-57 Add support for DNSDB API version 2 (#9603)

### DIFF
--- a/Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2.yml
+++ b/Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2.yml
@@ -35,6 +35,81 @@ display: Farsight DNSDB v2
 name: DNSDB_v2
 script:
   commands:
+  - name: dnsdb-flex
+    arguments:
+    - name: method
+      required: true
+      auto: PREDEFINED
+      predefined:
+      - regex
+      - glob
+      description: query value type
+    - name: key
+      required: true
+      auto: PREDEFINED
+      predefined:
+      - rrnames
+      - rdata
+      description: search over rrnames or rdata
+    - name: value
+      required: true
+      description: query regex or glob
+    - name: rrtype
+      description: query rrtype
+    - name: limit
+      description: Limit the number of returned records
+      defaultValue: "50"
+    - name: time_first_before
+      description: Filter results for entries seen for first time before (ISO or UNIX timestamp,
+        relative if negative)
+    - name: time_last_before
+      description: Filter results for entries seen for last time before (ISO or UNIX timestamp,
+        relative if negative)
+    - name: time_first_after
+      description: Filter results for entries seen for first time after (ISO or UNIX timestamp,
+        relative if negative)
+    - name: time_last_after
+      description: Filter results for entries seen for last time after (ISO or UNIX timestamp,
+        relative if negative)
+    outputs:
+    - contextPath: DNSDB.Record.RRName
+      type: string
+      description: The owner name of the resource record in DNS presentation format.
+    - contextPath: DNSDB.Record.RRType
+      type: string
+      description: >
+        The resource record type of the resource record, either using the standard
+        DNS type mnemonic, or an RFC 3597
+        generic type, i.e. the string TYPE immediately followed by the decimal RRtype
+        number.
+    - contextPath: DNSDB.Record.RData
+      type: string
+      description: >
+        The record data value. The Rdata value is converted to the standard presentation
+        format based on the rrtype
+        value. If the encoder lacks a type-specific presentation format for the resource
+        record's type, then the RFC
+        3597 generic Rdata encoding will be used.
+    - contextPath: DNSDB.Record.RawRData
+      type: string
+      description: >
+        The hex-encoded raw record data value. This may be passed as a parameter to the
+        dnsdb_rdata_raw command.
+    - contextPath: DNSDB.Record.Count
+      type: number
+      description: The number of times the resource record was observed via passive
+        DNS replication.
+    - contextPath: DNSDB.Record.TimeFirst
+      type: date
+      description: The first time that the resource record was observed.
+    - contextPath: DNSDB.Record.TimeLast
+      type: date
+      description: The most recent time that the resource record was observed.
+    - contextPath: DNSDB.Record.FromZoneFile
+      type: bool
+      description: False if the resource record was observed via passive DNS replication,
+        True if by zone file import.
+    description: DNSDB flex search
   - name: dnsdb-rdata
     arguments:
     - name: type
@@ -43,6 +118,7 @@ script:
       predefined:
       - name
       - ip
+      - raw
       description: Query type
     - name: value
       required: true
@@ -114,6 +190,7 @@ script:
       predefined:
       - name
       - ip
+      - raw
       description: Query type
     - name: value
       required: true
@@ -344,6 +421,6 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.8.5.10845
+  dockerimage: demisto/python3:3.8.6.12176
   isfetch: false
 fromversion: 5.0.0

--- a/Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2_test.py
+++ b/Packs/DNSDB/Integrations/DNSDB_v2/DNSDB_v2_test.py
@@ -27,14 +27,14 @@ class TestClient(object):
         c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, apikey)
 
         requests_mock.get(
-            '{server}/lookup/rate_limit?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/rate_limit?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
             json={},
             request_headers={
-                'Accept': 'application/json',
+                'Accept': 'application/x-ndjson',
                 'X-API-Key': apikey,
             })
 
@@ -44,7 +44,7 @@ class TestClient(object):
         c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
 
         requests_mock.get(
-            '{server}/lookup/rate_limit?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/rate_limit?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
@@ -65,7 +65,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -73,7 +73,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rrset(name):
             assert rrset == json.loads(records[0])
@@ -86,7 +86,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -94,7 +94,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text=record)
+            text=_saf_wrap([record]))
 
         rrset = c.summarize_rrset(name)
         assert rrset == json.loads(record)
@@ -104,7 +104,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -133,7 +133,7 @@ class TestClient(object):
         rrtype = 'A'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}/{rrtype}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}/{rrtype}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -142,7 +142,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rrset(name, rrtype=rrtype):
             assert rrset == json.loads(records[0])
@@ -172,7 +172,7 @@ class TestClient(object):
         bailiwick = 'com'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}/{rrtype}/{bailiwick}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}/{rrtype}/{bailiwick}?swclient={swclient}&version={version}'.format(  # noqa: E501
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -182,7 +182,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rrset(name, bailiwick=bailiwick):
             assert rrset == json.loads(records[0])
@@ -213,7 +213,7 @@ class TestClient(object):
         bailiwick = 'com'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}/{rrtype}/{bailiwick}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}/{rrtype}/{bailiwick}?swclient={swclient}&version={version}'.format(  # noqa: E501
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -223,7 +223,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rrset(name, rrtype=rrtype, bailiwick=bailiwick):
             assert rrset == json.loads(records[0])
@@ -245,7 +245,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='name',
@@ -253,7 +253,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rdata_name(name):
             assert rrset == json.loads(records[0])
@@ -266,7 +266,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='name',
@@ -274,7 +274,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text=record)
+            text=_saf_wrap([record]))
 
         rrset = c.summarize_rdata_name(name)
         assert rrset == json.loads(record)
@@ -284,7 +284,7 @@ class TestClient(object):
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='name',
@@ -313,7 +313,7 @@ class TestClient(object):
         rrtype = 'PTR'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}/{rrtype}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}/{rrtype}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='name',
@@ -322,7 +322,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rdata_name(name, rrtype=rrtype):
             assert rrset == json.loads(records[0])
@@ -346,7 +346,7 @@ class TestClient(object):
         ip = '66.160.140.81'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='ip',
@@ -354,7 +354,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text='\n'.join(records))
+            text=_saf_wrap(records))
 
         for rrset in c.lookup_rdata_ip(ip):
             assert rrset == json.loads(records[0])
@@ -367,7 +367,7 @@ class TestClient(object):
         ip = '66.160.140.81'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='ip',
@@ -375,7 +375,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            text=record)
+            text=_saf_wrap([record]))
 
         rrset = c.summarize_rdata_ip(ip)
         assert rrset == json.loads(record)
@@ -385,7 +385,7 @@ class TestClient(object):
         ip = '66.160.140.81'
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{ip}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rdata',
                 type='ip',
@@ -398,30 +398,138 @@ class TestClient(object):
         with pytest.raises(DNSDB.QueryError):
             c.summarize_rdata_ip(ip)
 
-    def test_404(self, requests_mock):
+    def test_lookup_rdata_raw(self, requests_mock):
         c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
-        name = 'farsightsecurity.com'
+        records = [
+            '{"count": 7, "time_first": 1380044973, "time_last": 1380141734, "rrname": "207.4.20.149.in-addr.fsi.io.",'
+            ' "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 3, "time_first": 1372650830, "time_last": 1375220475, "rrname": "7.0.2.0.0.0.0.0.0.0.0.0.0.0.0.'
+            '0.6.6.0.0.1.0.0.0.8.f.4.0.1.0.0.2.ip6.arpa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 11, "time_first": 1380141403, "time_last": 1381263825, "rrname": "81.64-26.140.160.66.in-addr.a'
+            'rpa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 4, "time_first": 1373922472, "time_last": 1374071997, "rrname": "207.192-26.4.20.149.in-addr.ar'
+            'pa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+        ]
+        raw = '0123456789ABCDEF'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{raw}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
-                mode='rrset',
-                type='name',
-                name=name,
+                mode='rdata',
+                type='raw',
+                raw=DNSDB.quote(raw),
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            status_code=404, text='error')
+            text=_saf_wrap(records))
 
-        for rrset in c.lookup_rrset(name):
-            pytest.fail('received {0}'.format(rrset))  # pragma: no cover
+        for rrset in c.lookup_rdata_raw(raw):
+            assert rrset == json.loads(records[0])
+            records = records[1:]
+        assert len(records) == 0
+
+    def test_summarize_rdata_raw(self, requests_mock):
+        c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
+        record = '{"count": 7, "num_results": 5, "time_first": 1380044973, "time_last": 1380141734}'
+        raw = '0123456789ABCDEF'
+
+        requests_mock.get(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{raw}?swclient={swclient}&version={version}'.format(
+                server=DNSDB.DEFAULT_DNSDB_SERVER,
+                mode='rdata',
+                type='raw',
+                raw=DNSDB.quote(raw),
+                swclient=DNSDB.SWCLIENT,
+                version=DNSDB.VERSION,
+            ),
+            text=_saf_wrap([record]))
+
+        rrset = c.summarize_rdata_raw(raw)
+        assert rrset == json.loads(record)
+
+    def test_summarize_rdata_raw_empty(self, requests_mock):
+        c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
+        raw = '0123456789ABCDEF'
+
+        requests_mock.get(
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{raw}?swclient={swclient}&version={version}'.format(
+                server=DNSDB.DEFAULT_DNSDB_SERVER,
+                mode='rdata',
+                type='raw',
+                raw=DNSDB.quote(raw),
+                swclient=DNSDB.SWCLIENT,
+                version=DNSDB.VERSION,
+            ),
+            text='')
+
+        with pytest.raises(DNSDB.QueryError):
+            c.summarize_rdata_raw(raw)
+
+    def test_rdata_raw_rrtype(self, requests_mock):
+        c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
+        records = [
+            '{"count": 7, "time_first": 1380044973, "time_last": 1380141734, "rrname": "207.4.20.149.in-addr.fsi.io.",'
+            ' "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 3, "time_first": 1372650830, "time_last": 1375220475, "rrname": "7.0.2.0.0.0.0.0.0.0.0.0.0.0.0.'
+            '0.6.6.0.0.1.0.0.0.8.f.4.0.1.0.0.2.ip6.arpa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 11, "time_first": 1380141403, "time_last": 1381263825, "rrname": "81.64-26.140.160.66.in-addr.a'
+            'rpa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+            '{"count": 4, "time_first": 1373922472, "time_last": 1374071997, "rrname": "207.192-26.4.20.149.in-addr.ar'
+            'pa.", "rrtype": "PTR", "rdata": "farsightsecurity.com."}',
+        ]
+        raw = '0123456789ABCDEF'
+        rrtype = 'PTR'
+
+        requests_mock.get(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{raw}/{rrtype}?swclient={swclient}&version={version}'.format(
+                server=DNSDB.DEFAULT_DNSDB_SERVER,
+                mode='rdata',
+                type='raw',
+                raw=raw,
+                rrtype=rrtype,
+                swclient=DNSDB.SWCLIENT,
+                version=DNSDB.VERSION,
+            ),
+            text=_saf_wrap(records))
+
+        for rrset in c.lookup_rdata_raw(raw, rrtype=rrtype):
+            assert rrset == json.loads(records[0])
+            records = records[1:]
+        assert len(records) == 0
+
+    def test_flex(self, requests_mock):
+        c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
+        records = [
+            '{"rdata": "10 lists.farsightsecurity.com.", "rrtype": "MX", "raw_rdata": "000A056C69737473106661727369676874736563757269747903636F6D00"}',  # noqa: E501
+            '{"rdata": "10 support.farsightsecurity.com.", "rrtype": "MX", "raw_rdata": "000A07737570706F7274106661727369676874736563757269747903636F6D00"}',  # noqa: E501
+            '{"rdata": "x.support.farsightsecurity.com.", "rrtype": "CNAME", "raw_rdata": "017807737570706F7274106661727369676874736563757269747903636F6D00"}',  # noqa: E501
+        ]
+        method = 'regex'
+        key = 'rdata'
+        value = 'farsightsecurity'
+
+        requests_mock.get(
+            '{server}/dnsdb/v2/{method}/{key}/{value}?swclient={swclient}&version={version}'.format(
+                server=DNSDB.DEFAULT_DNSDB_SERVER,
+                method=method,
+                key=key,
+                value=value,
+                swclient=DNSDB.SWCLIENT,
+                version=DNSDB.VERSION,
+            ),
+            text=_saf_wrap(records))
+
+        for rrset in c.flex(method, key, value):
+            assert rrset == json.loads(records[0])
+            records = records[1:]
+        assert len(records) == 0
 
     def test_500(self, requests_mock):
         c = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
         name = 'farsightsecurity.com'
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -441,7 +549,7 @@ class TestClient(object):
         limit = 100
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?limit={limit}&swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?limit={limit}&swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -450,7 +558,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            status_code=404)
+            text=_saf_wrap([]))
 
         for rrset in c.lookup_rrset(name, limit=limit):
             pytest.fail('received {0}'.format(rrset))  # pragma: no cover
@@ -473,7 +581,7 @@ class TestClient(object):
         aggr = 100
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?aggr={aggr}&swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?aggr={aggr}&swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -482,7 +590,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            status_code=404)
+            text=_saf_wrap([]))
 
         for rrset in c.lookup_rrset(name, aggr=aggr):
             pytest.fail('received {0}'.format(rrset))  # pragma: no cover
@@ -493,7 +601,7 @@ class TestClient(object):
         offset = 100
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?offset={offset}&swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?offset={offset}&swclient={swclient}&version={version}'.format(  # noqa: E501
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -502,7 +610,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            status_code=404)
+            text=_saf_wrap([]))
 
         for rrset in c.lookup_rrset(name, offset=offset):
             pytest.fail('received {0}'.format(rrset))  # pragma: no cover
@@ -513,7 +621,7 @@ class TestClient(object):
         max_count = 100
 
         requests_mock.get(
-            '{server}/summarize/{mode}/{type}/{name}?max_count={max_count}'
+            '{server}/dnsdb/v2/summarize/{mode}/{type}/{name}?max_count={max_count}'
             '&swclient={swclient}&version={version}'.format(server=DNSDB.DEFAULT_DNSDB_SERVER,
                                                             mode='rrset',
                                                             type='name',
@@ -521,11 +629,11 @@ class TestClient(object):
                                                             max_count=max_count,
                                                             swclient=DNSDB.SWCLIENT,
                                                             version=DNSDB.VERSION),
-            text='{}'
-        )
+            text=_saf_wrap([]))
 
-        for rrset in c.summarize_rrset(name, max_count=max_count):
-            pytest.fail('received {0}'.format(rrset))  # pragma: no cover
+        with pytest.raises(DNSDB.QueryError):
+            for rrset in c.summarize_rrset(name, max_count=max_count):
+                pytest.fail('received {0}'.format(rrset))  # pragma: no cover
 
     @staticmethod
     def _test_time_param(requests_mock, param: str):
@@ -534,7 +642,7 @@ class TestClient(object):
         when = time.time()
 
         requests_mock.get(
-            '{server}/lookup/{mode}/{type}/{name}?{param}={when}&swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/lookup/{mode}/{type}/{name}?{param}={when}&swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 mode='rrset',
                 type='name',
@@ -544,7 +652,7 @@ class TestClient(object):
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
             ),
-            status_code=404)
+            text=_saf_wrap([]))
 
         for rrset in c.lookup_rrset(name, **{param: when}):
             pytest.fail('received {0}'.format(rrset))  # pragma: no cover
@@ -594,6 +702,17 @@ class TestBuildResultContext(object):
             'FromZoneFile': False,
         })
 
+    def test_flex(self):
+        self._run_test({
+            "rdata": "10 lists.farsightsecurity.com",
+            "raw_rdata": "000A056C69737473106661727369676874736563757269747903636F6D00",
+            "rrtype": "MX",
+        }, {
+            "RData": "10 lists.farsightsecurity.com",
+            "RawRData": "000A056C69737473106661727369676874736563757269747903636F6D00",
+            "RRType": "MX",
+        })
+
     def test_summarize(self):
         self._run_test({
             "count": 1127,
@@ -615,7 +734,6 @@ class TestBuildResultContext(object):
         }, {
             'RRName': 'www.xn--frsight-exa.com',
             'Bailiwick': 'xn--frsight-exa.com',
-            'FromZoneFile': False,
         })
 
     @staticmethod
@@ -710,10 +828,10 @@ class TestRDataCommand:
             'value': 'ns5.dnsmadeeasy.com',
             'limit': '10',
         }
-        input = textwrap.dedent('''\
-            {"count":1078,"zone_time_first":1374250920,"zone_time_last":1468253883,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}
-            {"count":706617,"time_first":1374096380,"time_last":1468334926,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}
-            ''')
+        input = [
+            '{"count":1078,"zone_time_first":1374250920,"zone_time_last":1468253883,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}',  # noqa: E501
+            '{"count":706617,"time_first":1374096380,"time_last":1468334926,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}',  # noqa: E501
+        ]
 
         expected_readable = textwrap.dedent('''\
             ### Farsight DNSDB Lookup
@@ -721,7 +839,7 @@ class TestRDataCommand:
             |---|---|---|---|---|---|---|
             | farsightsecurity.com | NS | ns5.dnsmadeeasy.com. | 1078 | 2013-07-19T16:22:00Z | 2016-07-11T16:18:03Z | True |
             | farsightsecurity.com | NS | ns5.dnsmadeeasy.com. | 706617 | 2013-07-17T21:26:20Z | 2016-07-12T14:48:46Z | False |
-            ''')
+            ''')  # noqa: E501
 
         expected_output_prefix = 'DNSDB.Record'
         expected_outputs = [
@@ -753,10 +871,10 @@ class TestRDataCommand:
             'value': '104.244.13.104',
             'limit': '10',
         }
-        input = textwrap.dedent('''\
-            {"count":24,"time_first":1433550785,"time_last":1468312116,"rrname":"www.farsighsecurity.com.","rrtype":"A","rdata":"104.244.13.104"}
-            {"count":9429,"zone_time_first":1427897872,"zone_time_last":1468333042,"rrname":"farsightsecurity.com.","rrtype":"A","rdata":"104.244.13.104"}
-                ''')
+        input = [
+            '{"count":24,"time_first":1433550785,"time_last":1468312116,"rrname":"www.farsighsecurity.com.","rrtype":"A","rdata":"104.244.13.104"}',  # noqa: E501
+            '{"count":9429,"zone_time_first":1427897872,"zone_time_last":1468333042,"rrname":"farsightsecurity.com.","rrtype":"A","rdata":"104.244.13.104"}'  # noqa: E501
+        ]
 
         expected_readable = textwrap.dedent('''\
             ### Farsight DNSDB Lookup
@@ -788,14 +906,57 @@ class TestRDataCommand:
 
         self._run_test(requests_mock, args, input, expected_readable, expected_prefix, expected_outputs)
 
+    def test_raw(self, requests_mock):
+        args = {
+            'type': 'raw',
+            'value': '0123456789ABCDEF',
+            'limit': '10',
+        }
+        input = [
+            '{"count":1078,"zone_time_first":1374250920,"zone_time_last":1468253883,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}',  # noqa: E501
+            '{"count":706617,"time_first":1374096380,"time_last":1468334926,"rrname":"farsightsecurity.com.","rrtype":"NS","rdata":"ns5.dnsmadeeasy.com."}',  # noqa: E501
+        ]
+
+        expected_readable = textwrap.dedent('''\
+            ### Farsight DNSDB Lookup
+            |RRName|RRType|RData|Count|TimeFirst|TimeLast|FromZoneFile|
+            |---|---|---|---|---|---|---|
+            | farsightsecurity.com | NS | ns5.dnsmadeeasy.com. | 1078 | 2013-07-19T16:22:00Z | 2016-07-11T16:18:03Z | True |
+            | farsightsecurity.com | NS | ns5.dnsmadeeasy.com. | 706617 | 2013-07-17T21:26:20Z | 2016-07-12T14:48:46Z | False |
+            ''')  # noqa: E501
+
+        expected_output_prefix = 'DNSDB.Record'
+        expected_outputs = [
+            {
+                'Count': 1078,
+                'RData': 'ns5.dnsmadeeasy.com.',
+                'RRName': 'farsightsecurity.com',
+                'RRType': 'NS',
+                'TimeFirst': '2013-07-19T16:22:00Z',
+                'TimeLast': '2016-07-11T16:18:03Z',
+                'FromZoneFile': True,
+            },
+            {
+                'Count': 706617,
+                'RData': 'ns5.dnsmadeeasy.com.',
+                'RRName': 'farsightsecurity.com',
+                'RRType': 'NS',
+                'TimeFirst': '2013-07-17T21:26:20Z',
+                'TimeLast': '2016-07-12T14:48:46Z',
+                'FromZoneFile': False,
+            }
+        ]
+
+        self._run_test(requests_mock, args, input, expected_readable, expected_output_prefix, expected_outputs)
+
     @staticmethod
-    def _run_test(requests_mock, args: dict, input: dict, expected_readable: str, expected_output_prefix: str,
+    def _run_test(requests_mock, args: dict, input: list, expected_readable: str, expected_output_prefix: str,
                   expected_outputs: list):
         client = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
-        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/lookup/rdata/{args["type"]}/{args["value"]}'
+        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/dnsdb/v2/lookup/rdata/{args["type"]}/{args["value"]}'
                           f'?limit={args["limit"]}'
                           f'&swclient=demisto-integration&version=v2.0',
-                          text=input)
+                          text=_saf_wrap(input))
 
         for v in args.values():
             assert isinstance(v, str)
@@ -815,7 +976,9 @@ class TestSummarizeRDataCommand:
             'limit': '2',
             'max_count': '5000',
         }
-        input = {"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}
+        input = [
+            '{"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}',
+        ]
 
         expected_readable = textwrap.dedent('''\
                 ### Farsight DNSDB Summarize
@@ -841,7 +1004,9 @@ class TestSummarizeRDataCommand:
             'limit': '2',
             'max_count': '5000',
         }
-        input = {"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}
+        input = [
+            '{"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}',
+        ]
 
         expected_readable = textwrap.dedent('''\
                 ### Farsight DNSDB Summarize
@@ -861,6 +1026,34 @@ class TestSummarizeRDataCommand:
 
         self._run_test(requests_mock, args, input, expected_readable, expected_output_prefix, expected_outputs)
 
+    def test_raw(self, requests_mock):
+        args = {
+            'type': 'raw',
+            'value': '0123456789ABCDEF',
+            'limit': '2',
+            'max_count': '5000',
+        }
+        input = [
+            '{"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}',
+        ]
+
+        expected_readable = textwrap.dedent('''\
+                ### Farsight DNSDB Summarize
+                |Count|NumResults|TimeFirst|TimeLast|
+                |---|---|---|---|
+                | 1127 | 2 | 2019-05-14T18:41:53Z | 2019-06-14T18:35:33Z |
+                ''')
+        expected_output_prefix = 'DNSDB.Summary'
+        expected_outputs = {
+            'Count': 1127,
+            'NumResults': 2,
+            'TimeFirst': '2019-05-14T18:41:53Z',
+            'TimeLast': '2019-06-14T18:35:33Z',
+            'FromZoneFile': False,
+        }
+
+        self._run_test(requests_mock, args, input, expected_readable, expected_output_prefix, expected_outputs)
+
     def test_zone(self, requests_mock):
         args = {
             'type': 'name',
@@ -868,7 +1061,9 @@ class TestSummarizeRDataCommand:
             'limit': '10',
             'max_count': '50',
         }
-        input = {"count": 1127, "num_results": 2, "zone_time_first": 1557859313, "zone_time_last": 1560537333}
+        input = [
+            '{"count": 1127, "num_results": 2, "zone_time_first": 1557859313, "zone_time_last": 1560537333}',
+        ]
 
         expected_readable = textwrap.dedent('''\
                         ### Farsight DNSDB Summarize
@@ -892,11 +1087,11 @@ class TestSummarizeRDataCommand:
     def _run_test(requests_mock, args: dict, input: dict, expected_readable: str, expected_output_prefix: str,
                   expected_outputs: dict):
         client = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
-        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/summarize/rdata/{args["type"]}/{args["value"]}'
+        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/dnsdb/v2/summarize/rdata/{args["type"]}/{args["value"]}'
                           f'?limit={args["limit"]}'
                           f'&max_count={args["max_count"]}'
                           f'&swclient=demisto-integration&version=v2.0',
-                          json=input)
+                          text=_saf_wrap(input))
 
         for v in args.values():
             assert isinstance(v, str)
@@ -914,7 +1109,7 @@ class TestRRSetCommand:
             'owner_name': '*.farsightsecurity.com',
             'limit': '10',
         }
-        input = ''
+        input = []
         expected_readable = textwrap.dedent('''\
                     ### Farsight DNSDB Lookup
                     **No entries.**
@@ -929,10 +1124,10 @@ class TestRRSetCommand:
             'owner_name': '*.farsightsecurity.com',
             'limit': '10',
         }
-        input = textwrap.dedent('''\
-        {"count":5059,"time_first":1380139330,"time_last":1427881899,"rrname":"www.farsightsecurity.com.","rrtype":"A","bailiwick":"farsightsecurity.com.","rdata":["66.160.140.81"]}
-        {"count":17381,"zone_time_first":1427893644,"zone_time_last":1468329272,"rrname":"farsightsecurity.com.","rrtype":"A","bailiwick":"com.","rdata":["104.244.13.104"]}
-        ''')
+        input = [
+            '{"count":5059,"time_first":1380139330,"time_last":1427881899,"rrname":"www.farsightsecurity.com.","rrtype":"A","bailiwick":"farsightsecurity.com.","rdata":["66.160.140.81"]}',  # noqa: E501
+            '{"count":17381,"zone_time_first":1427893644,"zone_time_last":1468329272,"rrname":"farsightsecurity.com.","rrtype":"A","bailiwick":"com.","rdata":["104.244.13.104"]}',  # noqa: E501
+        ]
 
         expected_readable = textwrap.dedent('''\
         ### Farsight DNSDB Lookup
@@ -969,13 +1164,13 @@ class TestRRSetCommand:
         self._run_test(requests_mock, args, input, expected_readable, expected_output_prefix, expected_outputs)
 
     @staticmethod
-    def _run_test(requests_mock, args: dict, input: dict, expected_readable: str, expected_output_prefix: str,
+    def _run_test(requests_mock, args: dict, input: list, expected_readable: str, expected_output_prefix: str,
                   expected_outputs: list):
         client = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
-        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/lookup/rrset/name/{DNSDB.quote(args["owner_name"])}'
+        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/dnsdb/v2/lookup/rrset/name/{DNSDB.quote(args["owner_name"])}'
                           f'?limit={args["limit"]}'
                           f'&swclient=demisto-integration&version=v2.0',
-                          text=input)
+                          text=_saf_wrap(input))
 
         for v in args.values():
             assert isinstance(v, str)
@@ -994,7 +1189,9 @@ class TestSummarizeRRSetCommand:
             'limit': '2',
             'max_count': '5000',
         }
-        input = {"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}
+        input = [
+            '{"count": 1127, "num_results": 2, "time_first": 1557859313, "time_last": 1560537333}',
+        ]
 
         expected_readable = textwrap.dedent('''\
                 ### Farsight DNSDB Summarize
@@ -1020,7 +1217,9 @@ class TestSummarizeRRSetCommand:
             'limit': '10',
             'max_count': '50',
         }
-        input = {"count": 1127, "num_results": 2, "zone_time_first": 1557859313, "zone_time_last": 1560537333}
+        input = [
+            '{"count": 1127, "num_results": 2, "zone_time_first": 1557859313, "zone_time_last": 1560537333}',
+        ]
 
         expected_readable = textwrap.dedent('''\
                         ### Farsight DNSDB Summarize
@@ -1041,14 +1240,14 @@ class TestSummarizeRRSetCommand:
         self._run_test(requests_mock, args, input, expected_readable, expected_output_prefix, expected_outputs)
 
     @staticmethod
-    def _run_test(requests_mock, args: dict, input: dict, expected_readable: str, expected_output_prefix: str,
+    def _run_test(requests_mock, args: dict, input: list, expected_readable: str, expected_output_prefix: str,
                   expected_outputs: dict):
         client = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
-        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/summarize/rrset/name/{args["owner_name"]}'
+        requests_mock.get(f'{DNSDB.DEFAULT_DNSDB_SERVER}/dnsdb/v2/summarize/rrset/name/{args["owner_name"]}'
                           f'?limit={args["limit"]}'
                           f'&max_count={args["max_count"]}'
                           f'&swclient=demisto-integration&version=v2.0',
-                          json=input)
+                          text=_saf_wrap(input))
 
         for v in args.values():
             assert isinstance(v, str)
@@ -1112,7 +1311,7 @@ class TestRateLimitCommand:
     def _run_test(requests_mock, input: dict, expected_readable: str):
         client = DNSDB.Client(DNSDB.DEFAULT_DNSDB_SERVER, '')
         requests_mock.get(
-            '{server}/lookup/rate_limit?swclient={swclient}&version={version}'.format(
+            '{server}/dnsdb/v2/rate_limit?swclient={swclient}&version={version}'.format(
                 server=DNSDB.DEFAULT_DNSDB_SERVER,
                 swclient=DNSDB.SWCLIENT,
                 version=DNSDB.VERSION,
@@ -1144,3 +1343,9 @@ class TestParseRData:
 
     def test_idna_email(self):
         assert DNSDB.parse_rdata("test@xn--frsight-exa.com.") == "test@fårsight.com."
+
+
+def _saf_wrap(records):
+    return '\n'.join(
+        ['{"cond":"begin"}'] + [f'{{"obj":{r}}}' for r in records] + ['{"cond":"succeeded"}']
+    )

--- a/Packs/DNSDB/Integrations/DNSDB_v2/README.md
+++ b/Packs/DNSDB/Integrations/DNSDB_v2/README.md
@@ -14,24 +14,125 @@ since 2010.
 This integration uses Farsight Security’s DNSDB solution to interactively
 lookup rich, historical DNS information – either as playbook tasks or through
 API calls in the War Room – to access rdata and rrset records.  It was
-integrated and tested with version 1 of the DNSDB API.
+integrated and tested with version 2 of the DNSDB API.
 
-## Configure DNSDB on Cortex XSOAR
+## Configure DNSDB v2 on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
-2. Search for DNSDB.
+2. Search for DNSDB v2.
 3. Click **Add instance** to create and configure a new integration instance.
 
 | **Parameter** | **Description** | **Required** |
 | --- | --- | --- |
 | apikey | API Key | True |
 | url | DNSDB Service URL | False |
+| insecure | Trust any certificate \(not secure\) | False |
 | useproxy | Use system proxy settings | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
 ## Commands
 You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
+### dnsdb-flex
+***
+DNSDB flex search
+
+
+#### Base Command
+
+`dnsdb-flex`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| method | query value type | Required | 
+| key | search over rrnames or rdata | Required | 
+| value | query regex or glob | Required | 
+| rrtype | query rrtype | Optional | 
+| limit | Limit the number of returned records | Optional | 
+| time_first_before | Filter results for entries seen for first time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_before | Filter results for entries seen for last time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_first_after | Filter results for entries seen for first time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_after | Filter results for entries seen for last time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| DNSDB.Record.RRName | string | The owner name of the resource record in DNS presentation format. | 
+| DNSDB.Record.RRType | string | The resource record type of the resource record, either using the standard DNS type mnemonic, or an RFC 3597 generic type, i.e. the string TYPE immediately followed by the decimal RRtype number.
+ | 
+| DNSDB.Record.RData | string | The record data value. The Rdata value is converted to the standard presentation format based on the rrtype value. If the encoder lacks a type-specific presentation format for the resource record's type, then the RFC 3597 generic Rdata encoding will be used.
+ | 
+| DNSDB.Record.Count | number | The number of times the resource record was observed via passive DNS replication. | 
+| DNSDB.Record.TimeFirst | date | The first time that the resource record was observed. | 
+| DNSDB.Record.TimeLast | date | The most recent time that the resource record was observed. | 
+| DNSDB.Record.FromZoneFile | bool | False if the resource record was observed via passive DNS replication, True if by zone file import. | 
+
+
+#### Command Example
+```!dnsdb-flex method=regex key=rrnames value=farsightsecurity limit=5```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Record": [
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity.yahoo.com.au",
+                "RRType": "CNAME"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity-2432183.starbucks.com.cn",
+                "RRType": "A"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity.com.cn",
+                "RRType": "NS"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity.com.cn",
+                "RRType": "SOA"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity.com.cn",
+                "RRType": "CNAME"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "www.farsightsecurity.com.cn",
+                "RRType": "CNAME"
+            },
+            {
+                "FromZoneFile": false,
+                "RRName": "farsightsecurity.damai.cn",
+                "RRType": "CNAME"
+            }
+        ]
+    }
+}
+```
+
+#### Human Readable Output
+
+>### Farsight DNSDB Flex Search
+>|RRName|RRType|Count|TimeFirst|TimeLast|
+>|---|---|---|---|---|
+>| farsightsecurity.yahoo.com.au | CNAME |  |  |  |
+>| farsightsecurity-2432183.starbucks.com.cn | A |  |  |  |
+>| farsightsecurity.com.cn | NS |  |  |  |
+>| farsightsecurity.com.cn | SOA |  |  |  |
+>| farsightsecurity.com.cn | CNAME |  |  |  |
+>| www.farsightsecurity.com.cn | CNAME |  |  |  |
+>| farsightsecurity.damai.cn | CNAME |  |  |  |
+
+
 ### dnsdb-rdata
 ***
 Lookup RData records
@@ -48,12 +149,12 @@ Lookup RData records
 | value | Query value | Required | 
 | rrtype | query rrtype | Optional | 
 | limit | Limit the number of returned records | Optional | 
-| time_first_before | Filter results for entries seen for first time before (UNIX timestamp, relative if negative) | Optional | 
-| time_last_before | Filter results for entries seen for last time before (UNIX timestamp, relative if negative) | Optional | 
-| time_first_after | Filter results for entries seen for first time after (UNIX timestamp, relative if negative) | Optional | 
-| time_last_after | Filter results for entries seen for last time after (UNIX timestamp, relative if negative) | Optional | 
+| time_first_before | Filter results for entries seen for first time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_before | Filter results for entries seen for last time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_first_after | Filter results for entries seen for first time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_after | Filter results for entries seen for last time after (ISO or UNIX timestamp, relative if negative) | Optional | 
 | aggr | Aggregate identical RRsets | Optional | 
-| offset | How many rows to offset (e.g. skip) in the results. | Optional | 
+| offset | How many rows to offset in the results. | Optional | 
 
 
 #### Context Output
@@ -63,7 +164,7 @@ Lookup RData records
 | DNSDB.Record.RRName | string | The owner name of the resource record in DNS presentation format. | 
 | DNSDB.Record.RRType | string | The resource record type of the resource record, either using the standard DNS type mnemonic, or an RFC 3597 generic type, i.e. the string TYPE immediately followed by the decimal RRtype number.
  | 
-| DNSDB.Record.RData | string | The record data value. The Rdata value is converted to the standard presentation format based on the rrtype value. If the encoder lacks a type\-specific presentation format for the resource record's type, then the RFC 3597 generic Rdata encoding will be used.
+| DNSDB.Record.RData | string | The record data value. The Rdata value is converted to the standard presentation format based on the rrtype value. If the encoder lacks a type-specific presentation format for the resource record's type, then the RFC 3597 generic Rdata encoding will be used.
  | 
 | DNSDB.Record.Count | number | The number of times the resource record was observed via passive DNS replication. | 
 | DNSDB.Record.TimeFirst | date | The first time that the resource record was observed. | 
@@ -72,10 +173,59 @@ Lookup RData records
 
 
 #### Command Example
-``` ```
+```!dnsdb-rdata type=name value=www.farsightsecurity.com limit=5```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Record": [
+            {
+                "Count": 606,
+                "FromZoneFile": false,
+                "RData": [
+                    "www.farsightsecurity.com."
+                ],
+                "RRName": "scout.dnsdb.info",
+                "RRType": "CNAME",
+                "TimeFirst": "2020-03-27T18:37:24Z",
+                "TimeLast": "2020-10-21T18:11:47Z"
+            },
+            {
+                "Count": 121,
+                "FromZoneFile": false,
+                "RData": [
+                    "www.farsightsecurity.com."
+                ],
+                "RRName": "scout-beta.dnsdb.info",
+                "RRType": "CNAME",
+                "TimeFirst": "2020-08-20T22:52:29Z",
+                "TimeLast": "2020-10-20T17:54:58Z"
+            },
+            {
+                "Count": 546,
+                "FromZoneFile": false,
+                "RData": [
+                    "www.farsightsecurity.com."
+                ],
+                "RRName": "81.64-26.140.160.66.in-addr.arpa",
+                "RRType": "PTR",
+                "TimeFirst": "2013-12-10T01:20:08Z",
+                "TimeLast": "2020-10-10T15:47:19Z"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Farsight DNSDB Lookup
+>|RRName|RRType|RData|Count|TimeFirst|TimeLast|FromZoneFile|
+>|---|---|---|---|---|---|---|
+>| scout.dnsdb.info | CNAME | www.farsightsecurity.com. | 606 | 2020-03-27T18:37:24Z | 2020-10-21T18:11:47Z | False |
+>| scout-beta.dnsdb.info | CNAME | www.farsightsecurity.com. | 121 | 2020-08-20T22:52:29Z | 2020-10-20T17:54:58Z | False |
+>| 81.64-26.140.160.66.in-addr.arpa | PTR | www.farsightsecurity.com. | 546 | 2013-12-10T01:20:08Z | 2020-10-10T15:47:19Z | False |
 
 
 ### dnsdb-summarize-rdata
@@ -94,10 +244,10 @@ Summarize RData records
 | value | Query value | Required | 
 | rrtype | query rrtype | Optional | 
 | limit | Limit the number of returned records | Optional | 
-| time_first_before | Filter results for entries seen for first time before (UNIX timestamp, relative if negative) | Optional | 
-| time_last_before | Filter results for entries seen for last time before (UNIX timestamp, relative if negative) | Optional | 
-| time_first_after | Filter results for entries seen for first time after (UNIX timestamp, relative if negative) | Optional | 
-| time_last_after | Filter results for entries seen for last time after (UNIX timestamp, relative if negative) | Optional | 
+| time_first_before | Filter results for entries seen for first time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_before | Filter results for entries seen for last time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_first_after | Filter results for entries seen for first time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_after | Filter results for entries seen for last time after (ISO or UNIX timestamp, relative if negative) | Optional | 
 | aggr | Aggregate identical RRsets | Optional | 
 | max_count | Stop when the summary count is reached | Optional | 
 
@@ -108,16 +258,36 @@ Summarize RData records
 | --- | --- | --- |
 | DNSDB.Summary.Count | number | The number of times the resource record was observed via passive DNS replication. | 
 | DNSDB.Summary.NumResults | number | The number of results \(resource records\) that would be returned from a Lookup. | 
-| DNSDB.Summary.TimeFirst | date | The first time that the resource record was observed. | 
-| DNSDB.Summary.TimeLast | date | The most recent time that the resource record was observed. | 
-| DNSDB.Summary.FromZoneFile | bool | False if the resource record was observed via passive DNS replication, True if by zone file import. | 
+| DNSDB.Summary.TimeFirst | date | The first time that the resource record was observed via passive DNS replication. | 
+| DNSDB.Summary.TimeLast | date | The most recent time that the resource record was observed via passive DNS replication. | 
+| DNSDB.Summary.ZoneTimeFirst | date | The first time that the resource record was observed in a zone file. | 
+| DNSDB.Summary.ZoneTimeLast | date | The most recent time that the resource record was observed in a zone file. | 
 
 
 #### Command Example
-``` ```
+```!dnsdb-summarize-rdata type=name value=www.farsightsecurity.com limit=5```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Summary": {
+            "Count": 1273,
+            "FromZoneFile": false,
+            "NumResults": 3,
+            "TimeFirst": "2013-12-10T01:20:08Z",
+            "TimeLast": "2020-10-21T18:11:47Z"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Farsight DNSDB Summarize
+>|Count|NumResults|TimeFirst|TimeLast|
+>|---|---|---|---|
+>| 1273 | 3 | 2013-12-10T01:20:08Z | 2020-10-21T18:11:47Z |
 
 
 ### dnsdb-rrset
@@ -136,12 +306,12 @@ Lookup RRset records
 | rrtype | rrtype value to query | Optional | 
 | bailiwick | Bailiwick value to query | Optional | 
 | limit | Limit the number of returned records | Optional | 
-| time_first_before | Filter results for entries seen for first time before (seconds) | Optional | 
-| time_first_after | Filter results for entries seen for first time after (seconds) | Optional | 
-| time_last_before | Filter results for entries seen for last time before (seconds) | Optional | 
-| time_last_after | Filter results for entries seen for last time after (seconds) | Optional | 
+| time_first_before | Filter results for entries seen for first time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_first_after | Filter results for entries seen for first time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_before | Filter results for entries seen for last time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_after | Filter results for entries seen for last time after (ISO or UNIX timestamp, relative if negative) | Optional | 
 | aggr | Aggregate identical RRsets | Optional | 
-| offset | How many rows to offset (e.g. skip) in the results. | Optional | 
+| offset | How many rows to offset in the results. | Optional | 
 
 
 #### Context Output
@@ -153,7 +323,7 @@ Lookup RRset records
  | 
 | DNSDB.Record.Bailiwick | string | The closest enclosing zone delegated to a nameserver which served the RRset, or the name of the zone containing the RRset if FromZoneFile is True.
  | 
-| DNSDB.Record.RData | string | An array of one or more Rdata values. The Rdata values are converted to the standard presentation format based on the rrtype value. If the encoder lacks a type\-specific presentation format for the RRset's rrtype, then the RFC 3597 generic Rdata encoding will be used.
+| DNSDB.Record.RData | string | An array of one or more Rdata values. The Rdata values are converted to the standard presentation format based on the rrtype value. If the encoder lacks a type-specific presentation format for the RRset's rrtype, then the RFC 3597 generic Rdata encoding will be used.
  | 
 | DNSDB.Record.Count | number | The number of times the RRset was observed via passive DNS replication. | 
 | DNSDB.Record.TimeFirst | date | The first time that the RRset was observed. | 
@@ -162,10 +332,94 @@ Lookup RRset records
 
 
 #### Command Example
-``` ```
+```!dnsdb-rrset owner_name=*.farsightsecurity.com type=NS limit=5```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Record": [
+            {
+                "Bailiwick": "com",
+                "Count": 19,
+                "FromZoneFile": true,
+                "RData": [
+                    "ns.lah1.vix.com.",
+                    "ns1.isc-sns.net.",
+                    "ns2.isc-sns.com.",
+                    "ns3.isc-sns.info."
+                ],
+                "RRName": "farsightsecurity.com",
+                "RRType": "NS",
+                "TimeFirst": "2013-06-30T16:21:41Z",
+                "TimeLast": "2013-07-18T16:22:47Z"
+            },
+            {
+                "Bailiwick": "com",
+                "Count": 157,
+                "FromZoneFile": true,
+                "RData": [
+                    "ns.sjc1.vix.com.",
+                    "ns.sql1.vix.com."
+                ],
+                "RRName": "farsightsecurity.com",
+                "RRType": "NS",
+                "TimeFirst": "2013-01-24T17:18:05Z",
+                "TimeLast": "2013-06-29T16:19:01Z"
+            },
+            {
+                "Bailiwick": "com",
+                "Count": 1890,
+                "FromZoneFile": true,
+                "RData": [
+                    "ns5.dnsmadeeasy.com.",
+                    "ns6.dnsmadeeasy.com.",
+                    "ns7.dnsmadeeasy.com."
+                ],
+                "RRName": "farsightsecurity.com",
+                "RRType": "NS",
+                "TimeFirst": "2013-07-19T16:22:00Z",
+                "TimeLast": "2020-07-24T16:02:05Z"
+            },
+            {
+                "Bailiwick": "farsightsecurity.com",
+                "Count": 6350,
+                "FromZoneFile": false,
+                "RData": [
+                    "66.160.140.81"
+                ],
+                "RRName": "farsightsecurity.com",
+                "RRType": "A",
+                "TimeFirst": "2013-09-25T15:37:03Z",
+                "TimeLast": "2015-04-01T06:17:25Z"
+            },
+            {
+                "Bailiwick": "farsightsecurity.com",
+                "Count": 36770,
+                "FromZoneFile": false,
+                "RData": [
+                    "104.244.13.104"
+                ],
+                "RRName": "farsightsecurity.com",
+                "RRType": "A",
+                "TimeFirst": "2015-04-01T14:17:52Z",
+                "TimeLast": "2018-09-27T00:29:43Z"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Farsight DNSDB Lookup
+>|RRName|RRType|Bailiwick|RData|Count|TimeFirst|TimeLast|FromZoneFile|
+>|---|---|---|---|---|---|---|---|
+>| farsightsecurity.com | NS | com | ns.lah1.vix.com.<br/>ns1.isc-sns.net.<br/>ns2.isc-sns.com.<br/>ns3.isc-sns.info. | 19 | 2013-06-30T16:21:41Z | 2013-07-18T16:22:47Z | True |
+>| farsightsecurity.com | NS | com | ns.sjc1.vix.com.<br/>ns.sql1.vix.com. | 157 | 2013-01-24T17:18:05Z | 2013-06-29T16:19:01Z | True |
+>| farsightsecurity.com | NS | com | ns5.dnsmadeeasy.com.<br/>ns6.dnsmadeeasy.com.<br/>ns7.dnsmadeeasy.com. | 1890 | 2013-07-19T16:22:00Z | 2020-07-24T16:02:05Z | True |
+>| farsightsecurity.com | A | farsightsecurity.com | 66.160.140.81 | 6350 | 2013-09-25T15:37:03Z | 2015-04-01T06:17:25Z | False |
+>| farsightsecurity.com | A | farsightsecurity.com | 104.244.13.104 | 36770 | 2015-04-01T14:17:52Z | 2018-09-27T00:29:43Z | False |
 
 
 ### dnsdb-summarize-rrset
@@ -180,14 +434,14 @@ Lookup RRset records
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| owner | Owner name to query | Required | 
+| owner_name | Owner name to query | Required | 
 | rrtype | rrtype value to query | Optional | 
 | bailiwick | Bailiwick value to query | Optional | 
 | limit | Limit the number of returned records | Optional | 
-| time_first_before | Filter results for entries seen for first time before (seconds) | Optional | 
-| time_first_after | Filter results for entries seen for first time after (seconds) | Optional | 
-| time_last_before | Filter results for entries seen for last time before (seconds) | Optional | 
-| time_last_after | Filter results for entries seen for last time after (seconds) | Optional | 
+| time_first_before | Filter results for entries seen for first time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_first_after | Filter results for entries seen for first time after (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_before | Filter results for entries seen for last time before (ISO or UNIX timestamp, relative if negative) | Optional | 
+| time_last_after | Filter results for entries seen for last time after (ISO or UNIX timestamp, relative if negative) | Optional | 
 | aggr | Aggregate identical RRsets | Optional | 
 | max_count | Stop when the summary count is reached | Optional | 
 
@@ -198,16 +452,36 @@ Lookup RRset records
 | --- | --- | --- |
 | DNSDB.Summary.Count | number | The number of times the resource record was observed via passive DNS replication. | 
 | DNSDB.Summary.NumResults | number | The number of results \(resource records\) that would be returned from a Lookup. | 
-| DNSDB.Summary.TimeFirst | date | The first time that the resource record was observed. | 
-| DNSDB.Summary.TimeLast | date | The most recent time that the resource record was observed. | 
-| DNSDB.Summary.FromZoneFile | bool | False if the resource record was observed via passive DNS replication, True if by zone file import. | 
+| DNSDB.Summary.TimeFirst | date | The first time that the resource record was observed via passive DNS replication. | 
+| DNSDB.Summary.TimeLast | date | The most recent time that the resource record was observed via passive DNS replication. | 
+| DNSDB.Summary.ZoneTimeFirst | date | The first time that the resource record was observed in a zone file. | 
+| DNSDB.Summary.ZoneTimeLast | date | The most recent time that the resource record was observed in a zone file. | 
 
 
 #### Command Example
-``` ```
+```!dnsdb-summarize-rrset owner_name=*.farsightsecurity.com type=NS limit=5```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Summary": {
+            "Count": 45186,
+            "FromZoneFile": true,
+            "NumResults": 5,
+            "TimeFirst": "2013-01-24T17:18:05Z",
+            "TimeLast": "2020-07-24T16:02:05Z"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Farsight DNSDB Summarize
+>|Count|NumResults|TimeFirst|TimeLast|ZoneTimeFirst|ZoneTimeLast|
+>|---|---|---|---|---|---|
+>| 45186 | 5 | 2013-09-25T15:37:03Z | 2018-09-27T00:29:43Z | 2013-01-24T17:18:05Z | 2020-07-24T16:02:05Z |
 
 
 ### dnsdb-rate-limit
@@ -228,25 +502,40 @@ There are no input arguments for this command.
 | --- | --- | --- |
 | DNSDB.Rate.Limit | number | The maximum number of API lookups that may be performed. This is the initial quota. | 
 | DNSDB.Rate.Unlimited | bool | True if there is no maximum number of API lookups that may be performed. | 
-| DNSDB.Rate.Remaining | number | For time\-based quotas: the remaining number of API lookups that may be performed until the reset time.
-For block\-based quotas: the remaining number of API lookups in the block quota.
+| DNSDB.Rate.Remaining | number | For time-based quotas: the remaining number of API lookups that may be performed until the reset time.
+For block-based quotas: the remaining number of API lookups in the block quota.
  | 
-| DNSDB.Rate.Reset | date | For time\-based quotas: When the quota limit will be reset. Usually this is at 00:00 \(midnight\) UTC.
+| DNSDB.Rate.Reset | date | For time-based quotas: When the quota limit will be reset. Usually this is at 00:00 \(midnight\) UTC.
  | 
-| DNSDB.Rate.NeverResets | bool | True for block\-based quotas that do not reset. | 
-| DNSDB.Rate.Expires | date | Only present for block\-based quota. When the quota will expire. | 
-| DNSDB.Rate.ResultsMax | number | The maximum number of results that can be returned by these lookup methods. This overrides a "limit" query parameter if provided. For example, if "?limit=20000" is appended to the URL path but results\_max=1000 then only up to 1000 results will be returned.
+| DNSDB.Rate.NeverResets | bool | True for block-based quotas that do not reset. | 
+| DNSDB.Rate.Expires | date | Only present for block-based quota. When the quota will expire. | 
+| DNSDB.Rate.ResultsMax | number | The maximum number of results that can be returned by these lookup methods. This overrides a "limit" query parameter if provided. For example, if "?limit=20000" is appended to the URL path but results_max=1000 then only up to 1000 results will be returned.
  | 
 | DNSDB.Rate.OffsetMax | number | The maximum value that the offset query parameter can be. If it is higher then an HTTP 416 "Requested Range Not Satisfiable" response code will be returned with message "Error: offset value greater than maximum allowed."
  | 
 | DNSDB.Rate.OffsetNotAllowed | number | True if the offset parameter is not allowed for this API key, and similar 416 error will be generated. | 
-| DNSDB.Rate.BurstSize | number | The maximum number of API lookups that may be performed within this burst\_window number of seconds. | 
+| DNSDB.Rate.BurstSize | number | The maximum number of API lookups that may be performed within this burst_window number of seconds. | 
 | DNSDB.Rate.BurstWindow | number | The number of seconds over which a burst of queries is measured. | 
 
 
 #### Command Example
-``` ```
+```!dnsdb-rate-limit```
+
+#### Context Example
+```json
+{
+    "DNSDB": {
+        "Rate": {
+            "Unlimited": true
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Farsight DNSDB Service Limits
+>|Unlimited|
+>|---|
+>| true |
 

--- a/Packs/DNSDB/Integrations/DNSDB_v2/command_examples
+++ b/Packs/DNSDB/Integrations/DNSDB_v2/command_examples
@@ -1,5 +1,6 @@
-!dnsdb-rdata type=name value=www.farsightsecurity.com
-!dnsdb-summarize-rdata type=name value=www.farsightsecurity.com
+!dnsdb-flex method=regex key=rrnames value=farsightsecurity limit=5
+!dnsdb-rdata type=name value=www.farsightsecurity.com limit=5
+!dnsdb-summarize-rdata type=name value=www.farsightsecurity.com limit=5
 !dnsdb-rrset owner_name=*.farsightsecurity.com type=NS limit=5
 !dnsdb-summarize-rrset owner_name=*.farsightsecurity.com type=NS limit=5
 !dnsdb-rate-limit

--- a/Packs/DNSDB/README.md
+++ b/Packs/DNSDB/README.md
@@ -19,7 +19,7 @@ To measurably improve the speed and accuracy of incident response, security anal
 
 **Benefit**: Automated IP to Hostname queries reduces the time needed to respond to incursions and provide a comprehensive view of the attacker’s infrastructure. Automatic expansion and enrichment of search base saves time because all of data is assembled.
 
-![Playbook summary](doc_files/playbook.png)
+![Playbook summary](https://raw.githubusercontent.com/demisto/content/master/Packs/DNSDB/doc_files/playbook.png)
 
 ##### Use Case #2: Automated enhancement of interactive forensic investigations
 
@@ -29,7 +29,7 @@ To measurably improve the speed and accuracy of incident response, security anal
 
 **Benefit**: Increases the efficacy of other playbooks by automatically enriching the findings with real-time and historical DNS data.
 
-![DBot example](doc_files/dbot.png)
+![DBot example](https://raw.githubusercontent.com/demisto/content/master/Packs/DNSDB/doc_files/dbot.png)
 
 ##### About Farsight Security 
 

--- a/Packs/DNSDB/ReleaseNotes/2_1_0.md
+++ b/Packs/DNSDB/ReleaseNotes/2_1_0.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### Farsight DNSDB v2
+- Update to DNSDB API version 2 with Flexible Search
+- Upgraded the Docker image to demisto/python3:3.8.6.12176.
+- Add raw to dnsdb\_rdata and dnsdb\_summarize\_rdata commands.

--- a/Packs/DNSDB/TestPlaybooks/playbook-DNSDB-Test.yml
+++ b/Packs/DNSDB/TestPlaybooks/playbook-DNSDB-Test.yml
@@ -1,20 +1,20 @@
 id: DNSDB-Test
 version: -1
+vcShouldKeepItemLegacyProdMachine: false
 name: DNSDB-Test
 description: Test suite for the DNSDB integration.
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: dc8a6195-4d6a-4233-8a57-fd3a1cdeaf71
+    taskid: 51f509e3-c9cd-425a-8106-2066a14fac5c
     type: start
     task:
-      id: dc8a6195-4d6a-4233-8a57-fd3a1cdeaf71
+      id: 51f509e3-c9cd-425a-8106-2066a14fac5c
       version: -1
       name: ""
       iscommand: false
       brand: ""
-      description: ''
     nexttasks:
       '#none#':
       - "1"
@@ -33,10 +33,10 @@ tasks:
     quietmode: 0
   "1":
     id: "1"
-    taskid: c82fb831-d9e7-4404-8eae-d80e9e449b78
+    taskid: 33196be3-67c4-4b61-8215-3218a53dadb5
     type: regular
     task:
-      id: c82fb831-d9e7-4404-8eae-d80e9e449b78
+      id: 33196be3-67c4-4b61-8215-3218a53dadb5
       version: -1
       name: DeleteContext
       script: DeleteContext
@@ -64,33 +64,34 @@ tasks:
     quietmode: 0
   "2":
     id: "2"
-    taskid: e3f71089-12fa-43a5-8ba7-4d38b2795533
+    taskid: 5b696fe7-089b-4a5b-8bc1-92fe6f79da58
     type: regular
     task:
-      id: e3f71089-12fa-43a5-8ba7-4d38b2795533
+      id: 5b696fe7-089b-4a5b-8bc1-92fe6f79da58
       version: -1
-      name: dnsdb-rdata
-      script: '|||dnsdb-rdata'
+      name: dnsdb-flex
+      description: DNSDB flex search
+      script: dnsdb-flex
       type: regular
       iscommand: true
-      brand: ""
+      brand: DNSDB_v2
     nexttasks:
       '#none#':
       - "3"
     scriptarguments:
-      aggr: {}
+      key:
+        simple: rrnames
       limit:
         simple: "1"
-      offset: {}
+      method:
+        simple: regex
       rrtype: {}
       time_first_after: {}
       time_first_before: {}
       time_last_after: {}
       time_last_before: {}
-      type:
-        simple: ip
       value:
-        simple: 8.8.8.8
+        simple: demisto
     separatecontext: false
     view: |-
       {
@@ -106,10 +107,10 @@ tasks:
     quietmode: 0
   "3":
     id: "3"
-    taskid: 85042d2d-efa1-4784-8d0c-3465de058f5d
+    taskid: 000bfd4f-28a6-4551-8363-8370b2be12a3
     type: condition
     task:
-      id: 85042d2d-efa1-4784-8d0c-3465de058f5d
+      id: 000bfd4f-28a6-4551-8363-8370b2be12a3
       version: -1
       name: Verify Outputs
       type: condition
@@ -117,7 +118,7 @@ tasks:
       brand: ""
     nexttasks:
       "yes":
-      - "4"
+      - "16"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -131,31 +132,6 @@ tasks:
           left:
             value:
               simple: DNSDB.Record.RRType
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: DNSDB.Record.RData
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: DNSDB.Record.Count
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: DNSDB.Record.TimeFirst
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: DNSDB.Record.TimeLast
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: DNSDB.Record.FromZoneFile
             iscontext: true
     view: |-
       {
@@ -171,10 +147,10 @@ tasks:
     quietmode: 0
   "4":
     id: "4"
-    taskid: d594fb36-dd0d-4898-8784-e155fd2abef4
+    taskid: 4f5e495d-026b-4acd-8ce3-af67bd5746de
     type: regular
     task:
-      id: d594fb36-dd0d-4898-8784-e155fd2abef4
+      id: 4f5e495d-026b-4acd-8ce3-af67bd5746de
       version: -1
       name: dnsdb-summarize-rdata
       script: '|||dnsdb-summarize-rdata'
@@ -202,7 +178,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 720
+          "y": 1420
         }
       }
     note: false
@@ -212,10 +188,10 @@ tasks:
     quietmode: 0
   "5":
     id: "5"
-    taskid: 63819fb7-e959-4899-89a4-543a92b3af08
+    taskid: c1cf7325-2dd8-4e88-8e4d-50069495e50f
     type: condition
     task:
-      id: 63819fb7-e959-4899-89a4-543a92b3af08
+      id: c1cf7325-2dd8-4e88-8e4d-50069495e50f
       version: -1
       name: Verify Outputs
       type: condition
@@ -223,7 +199,7 @@ tasks:
       brand: ""
     nexttasks:
       "yes":
-      - "6"
+      - "18"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -257,7 +233,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 895
+          "y": 1595
         }
       }
     note: false
@@ -267,10 +243,10 @@ tasks:
     quietmode: 0
   "6":
     id: "6"
-    taskid: dc4f9b16-d2e7-43cf-8988-177bf5bf0c00
+    taskid: 1b83f35f-5547-4c02-8ef8-aa274960b077
     type: regular
     task:
-      id: dc4f9b16-d2e7-43cf-8988-177bf5bf0c00
+      id: 1b83f35f-5547-4c02-8ef8-aa274960b077
       version: -1
       name: dnsdb-rrset
       script: '|||dnsdb-rrset'
@@ -297,7 +273,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1070
+          "y": 1945
         }
       }
     note: false
@@ -307,10 +283,10 @@ tasks:
     quietmode: 0
   "7":
     id: "7"
-    taskid: 8da2934a-f585-4794-8117-c90b887f9506
+    taskid: 33c868ed-72ac-45bd-8f89-ca717e0445f1
     type: condition
     task:
-      id: 8da2934a-f585-4794-8117-c90b887f9506
+      id: 33c868ed-72ac-45bd-8f89-ca717e0445f1
       version: -1
       name: Verify Outputs
       type: condition
@@ -318,7 +294,7 @@ tasks:
       brand: ""
     nexttasks:
       "yes":
-      - "8"
+      - "19"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -367,7 +343,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1245
+          "y": 2120
         }
       }
     note: false
@@ -377,10 +353,10 @@ tasks:
     quietmode: 0
   "8":
     id: "8"
-    taskid: f93c357d-3e70-4146-82bd-935bbe273675
+    taskid: 83f54b7d-8346-4e30-88f3-a8151947a386
     type: regular
     task:
-      id: f93c357d-3e70-4146-82bd-935bbe273675
+      id: 83f54b7d-8346-4e30-88f3-a8151947a386
       version: -1
       name: dnsdb-summarize-rrset
       script: '|||dnsdb-summarize-rrset'
@@ -407,7 +383,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1420
+          "y": 2470
         }
       }
     note: false
@@ -417,10 +393,10 @@ tasks:
     quietmode: 0
   "9":
     id: "9"
-    taskid: e7283e85-e5c1-49a9-80a3-094ec7bee8a5
+    taskid: 574fbc85-b65e-4dae-81c6-52dc19f3e020
     type: condition
     task:
-      id: e7283e85-e5c1-49a9-80a3-094ec7bee8a5
+      id: 574fbc85-b65e-4dae-81c6-52dc19f3e020
       version: -1
       name: Verify Outputs
       type: condition
@@ -428,7 +404,7 @@ tasks:
       brand: ""
     nexttasks:
       "yes":
-      - "10"
+      - "20"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -462,7 +438,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1595
+          "y": 2645
         }
       }
     note: false
@@ -472,10 +448,10 @@ tasks:
     quietmode: 0
   "10":
     id: "10"
-    taskid: a4cf219a-0bb8-4680-836d-94637af9dae4
+    taskid: 058c1071-6582-4c8c-833e-0f18963cac16
     type: regular
     task:
-      id: a4cf219a-0bb8-4680-836d-94637af9dae4
+      id: 058c1071-6582-4c8c-833e-0f18963cac16
       version: -1
       name: dnsdb-rate-limit
       script: '|||dnsdb-rate-limit'
@@ -490,7 +466,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1770
+          "y": 2995
         }
       }
     note: false
@@ -500,10 +476,10 @@ tasks:
     quietmode: 0
   "11":
     id: "11"
-    taskid: 9104bcd9-d65b-4263-8628-3a4a8afba448
+    taskid: 3ff0f34c-a9af-47b3-828e-649962b4c460
     type: condition
     task:
-      id: 9104bcd9-d65b-4263-8628-3a4a8afba448
+      id: 3ff0f34c-a9af-47b3-828e-649962b4c460
       version: -1
       name: Verify Outputs
       type: condition
@@ -525,7 +501,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 1945
+          "y": 3170
         }
       }
     note: false
@@ -535,22 +511,21 @@ tasks:
     quietmode: 0
   "12":
     id: "12"
-    taskid: d6677106-6d22-461d-8094-945cfb802452
+    taskid: d3ccb451-d72f-4389-811b-4cc82e1fa22a
     type: title
     task:
-      id: d6677106-6d22-461d-8094-945cfb802452
+      id: d3ccb451-d72f-4389-811b-4cc82e1fa22a
       version: -1
       name: Test Done
       type: title
       iscommand: false
       brand: ""
-      description: ''
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 2295
+          "y": 3520
         }
       }
     note: false
@@ -560,10 +535,10 @@ tasks:
     quietmode: 0
   "13":
     id: "13"
-    taskid: 4e1c67eb-18ec-4d80-8ca6-3cf294fad63a
+    taskid: a9fbb422-d02f-4683-8d92-23ae3f8e6da0
     type: regular
     task:
-      id: 4e1c67eb-18ec-4d80-8ca6-3cf294fad63a
+      id: a9fbb422-d02f-4683-8d92-23ae3f8e6da0
       version: -1
       name: closeInvestigation
       description: Close the current incident
@@ -587,7 +562,269 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 2120
+          "y": 3345
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "14":
+    id: "14"
+    taskid: 5f5825a5-763a-492f-8696-5d147f4f66f8
+    type: regular
+    task:
+      id: 5f5825a5-763a-492f-8696-5d147f4f66f8
+      version: -1
+      name: dnsdb-rdata
+      script: '|||dnsdb-rdata'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "15"
+    scriptarguments:
+      aggr: {}
+      limit:
+        simple: "1"
+      offset: {}
+      rrtype: {}
+      time_first_after: {}
+      time_first_before: {}
+      time_last_after: {}
+      time_last_before: {}
+      type:
+        simple: ip
+      value:
+        simple: 8.8.8.8
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "15":
+    id: "15"
+    taskid: 488ff170-5864-443e-8822-40c1a4a6cd01
+    type: condition
+    task:
+      id: 488ff170-5864-443e-8822-40c1a4a6cd01
+      version: -1
+      name: Verify Outputs
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      "yes":
+      - "17"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.RRName
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.RRType
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.RData
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.Count
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.TimeFirst
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.TimeLast
+            iscontext: true
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: DNSDB.Record.FromZoneFile
+            iscontext: true
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "16":
+    id: "16"
+    taskid: d44b78b0-6be4-4322-83f3-b47ccfdacd19
+    type: regular
+    task:
+      id: d44b78b0-6be4-4322-83f3-b47ccfdacd19
+      version: -1
+      name: DeleteContext
+      script: DeleteContext
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "14"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "17":
+    id: "17"
+    taskid: afcff252-b475-449f-87bc-213d0d707fa3
+    type: regular
+    task:
+      id: afcff252-b475-449f-87bc-213d0d707fa3
+      version: -1
+      name: DeleteContext
+      script: DeleteContext
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1245
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "18":
+    id: "18"
+    taskid: b58fc6f4-a6cc-42ba-858d-761cfe70ac66
+    type: regular
+    task:
+      id: b58fc6f4-a6cc-42ba-858d-761cfe70ac66
+      version: -1
+      name: DeleteContext
+      script: DeleteContext
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1770
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "19":
+    id: "19"
+    taskid: 1d5dc264-d38c-4284-8827-50092df1bb21
+    type: regular
+    task:
+      id: 1d5dc264-d38c-4284-8827-50092df1bb21
+      version: -1
+      name: DeleteContext
+      script: DeleteContext
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "8"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2295
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "20":
+    id: "20"
+    taskid: 1c192fb3-bd68-4acf-86ba-dd37ab252fe5
+    type: regular
+    task:
+      id: 1c192fb3-bd68-4acf-86ba-dd37ab252fe5
+      version: -1
+      name: DeleteContext
+      script: DeleteContext
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "10"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 2820
         }
       }
     note: false
@@ -602,7 +839,7 @@ view: |-
     },
     "paper": {
       "dimensions": {
-        "height": 2310,
+        "height": 3535,
         "width": 380,
         "x": 50,
         "y": 50

--- a/Packs/DNSDB/pack_metadata.json
+++ b/Packs/DNSDB/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Farsight DNSDB",
     "description": "Query Farsight DNSDB service",
     "support": "partner",
-    "currentVersion": "2.0.1",
+    "currentVersion": "2.1.0",
     "author": "Farsight Security, Inc.",
     "url": "https://www.farsightsecurity.com",
     "email": "support@farsightsecurity.com",


### PR DESCRIPTION
* farsight-security-57 Add support for DNSDB API version 2

* README tweaks per @ShahafBenYakir

* Add rdata raw

* Change version to 2.1.0, add raw to release notes

* unbind the dnsdb-flex command in test playbook

* Update readme to mention version 2 of the api

* remove unneccessary check for http status 404

* Add RawRData to flex context

* Add test cases for flex

* quiet some pep8 errors

* Fix indentation

* Update urls to png files in README

* Increase timeout

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
