### PR TITLE
[Documentation] Zscaler - remove html elements from docs

### DIFF
--- a/Packs/Zscaler/Integrations/Zscaler/README.md
+++ b/Packs/Zscaler/Integrations/Zscaler/README.md
@@ -1,8 +1,8 @@
-<p>Use the Zscaler integration to block and manage domains using whitelists and blacklists.</p>
-<p>For the integration to work properly, the Zscaler user must have admin permissions.</p>
-<p>Category ID is the same as the category name, except all letters are capitalized and each word is separated with an underscore instead of spaces. For example, if the category name is Other Education, then the Category ID is OTHER_EDUCATION.</p>
-<p>A custom category ID has the format <code>CUSTOM_01</code>, which is not indicative of the category. Use the <code style="font-size: 13px;">zscaler-get-categories</code> command to get a custom category and its configured name.</p>
-<h2>Use the Zscaler integration to block manage domains using whitelists and blacklists.
+Use the Zscaler integration to block and manage domains using whitelists and blacklists.
+For the integration to work properly, the Zscaler user must have admin permissions.
+Category ID is the same as the category name, except all letters are capitalized and each word is separated with an underscore instead of spaces. For example, if the category name is Other Education, then the Category ID is OTHER_EDUCATION.
+A custom category ID has the format `CUSTOM_01`, which is not indicative of the category. Use the `zscaler-get-categories` command to get a custom category and its configured name.
+Use the Zscaler integration to block manage domains using whitelists and blacklists.
 
 ## Configure Zscaler on Cortex XSOAR
 

--- a/Packs/Zscaler/Integrations/Zscaler/README.md
+++ b/Packs/Zscaler/Integrations/Zscaler/README.md
@@ -1,6 +1,9 @@
-Use the Zscaler integration to block and manage domains using whitelists and blacklists.
+Use the Zscaler integration to block manage domains using whitelists and blacklists..
+
 For the integration to work properly, the Zscaler user must have admin permissions.
+
 Category ID is the same as the category name, except all letters are capitalized and each word is separated with an underscore instead of spaces. For example, if the category name is Other Education, then the Category ID is OTHER_EDUCATION.
+
 A custom category ID has the format `CUSTOM_01`, which is not indicative of the category. Use the `zscaler-get-categories` command to get a custom category and its configured name.
 
 ## Configure Zscaler on Cortex XSOAR

--- a/Packs/Zscaler/Integrations/Zscaler/README.md
+++ b/Packs/Zscaler/Integrations/Zscaler/README.md
@@ -2,7 +2,6 @@ Use the Zscaler integration to block and manage domains using whitelists and bla
 For the integration to work properly, the Zscaler user must have admin permissions.
 Category ID is the same as the category name, except all letters are capitalized and each word is separated with an underscore instead of spaces. For example, if the category name is Other Education, then the Category ID is OTHER_EDUCATION.
 A custom category ID has the format `CUSTOM_01`, which is not indicative of the category. Use the `zscaler-get-categories` command to get a custom category and its configured name.
-Use the Zscaler integration to block manage domains using whitelists and blacklists.
 
 ## Configure Zscaler on Cortex XSOAR
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Removed HTML elements from the readme, because they made the Readme render incorrectly.