### PR TITLE
Active Directory - get-computer attributes bug

### DIFF
--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
@@ -1,8 +1,8 @@
 commonfields:
-  id: Active Directory Query v2 test
+  id: Active Directory Query v2
   version: -1
-name: Active Directory Query v2 test
-display: Active Directory Query v2 test
+name: Active Directory Query v2
+display: Active Directory Query v2
 category: Data Enrichment & Threat Intelligence
 description: Active Directory Query integration enables you to  access and manage Active Directory objects (users, contacts, and computers).
 configuration:

--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
@@ -1,8 +1,8 @@
 commonfields:
-  id: Active Directory Query v2
+  id: Active Directory Query v2 test
   version: -1
-name: Active Directory Query v2
-display: Active Directory Query v2
+name: Active Directory Query v2 test
+display: Active Directory Query v2 test
 category: Data Enrichment & Threat Intelligence
 description: Active Directory Query integration enables you to  access and manage Active Directory objects (users, contacts, and computers).
 configuration:

--- a/Packs/Active_Directory_Query/ReleaseNotes/1_0_7.md
+++ b/Packs/Active_Directory_Query/ReleaseNotes/1_0_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Active Directory Query v2
+- Fixed an issue where the **attributes** argument equal to * did not work, in the ***search-computer*** command.

--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Active Directory Query",
     "description": "Active Directory Query integration enables you to access and manage Active Directory objects (users, contacts, and computers).",
     "support": "xsoar",
-  "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29356

## Description
Fixed an issue where the **attributes** argument equal to * did not work, in the ***search-computer*** command.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
