### PR TITLE
[Fix] return_results incorrect output for list of commands

### DIFF
--- a/Packs/Base/ReleaseNotes/1_3_23.md
+++ b/Packs/Base/ReleaseNotes/1_3_23.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Maintenance and stability enhancements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2770,7 +2770,7 @@ def return_results(results):
 
     if results and isinstance(results, list) and len(results) > 0 and isinstance(results[0], CommandResults):
         for result in results:
-            demisto.results(result)
+            demisto.results(result.to_context())
         return
 
     if isinstance(results, CommandResults):

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -2693,3 +2693,4 @@ def test_return_results_multiple_dict_results(mocker):
     mock_command_results = [{'MockContext': 0}, {'MockContext': 1}]
     return_results(mock_command_results)
     assert demisto_results_mock.call_count == 1
+    assert demisto_results_mock.call_args.args[0] == [{'MockContext': 0}, {'MockContext': 1}]

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -2692,5 +2692,6 @@ def test_return_results_multiple_dict_results(mocker):
     demisto_results_mock = mocker.patch.object(demisto, 'results')
     mock_command_results = [{'MockContext': 0}, {'MockContext': 1}]
     return_results(mock_command_results)
+    args, kwargs = demisto_results_mock.call_args_list[0]
     assert demisto_results_mock.call_count == 1
-    assert demisto_results_mock.call_args.args[0] == [{'MockContext': 0}, {'MockContext': 1}]
+    assert [{'MockContext': 0}, {'MockContext': 1}] in args

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.3.22",
+    "currentVersion": "1.3.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed an issue where return_results incorrect output for list of commands

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
