### PR TITLE
MS graph mail - skipped referenceAttachment

### DIFF
--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
@@ -734,7 +734,7 @@ class MsGraphClient:
                 attachment_content = self._get_attachment_mime(message_id, attachment_id)
                 attachment_name = f'{attachment_name}.eml'
             else:
-                # skip attachments there are not of the previous types (type referenceAttachment)
+                # skip attachments that are not of the previous types (type referenceAttachment)
                 continue
             # upload the item/file attachment to War Room
             upload_file(attachment_name, attachment_content, attachment_results)

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
@@ -733,6 +733,9 @@ class MsGraphClient:
                 attachment_id = attachment.get('id', '')
                 attachment_content = self._get_attachment_mime(message_id, attachment_id)
                 attachment_name = f'{attachment_name}.eml'
+            else:
+                # skip attachments there are not of the previous types (type referenceAttachment)
+                continue
             # upload the item/file attachment to War Room
             upload_file(attachment_name, attachment_content, attachment_results)
 

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -1017,7 +1017,7 @@ script:
     description: Sends a draft email using Microsoft Graph.
     execution: false
     name: msgraph-mail-send-draft
-  dockerimage: demisto/crypto:1.0.0.12410
+  dockerimage: demisto/crypto:1.0.0.12807
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -1017,7 +1017,7 @@ script:
     description: Sends a draft email using Microsoft Graph.
     execution: false
     name: msgraph-mail-send-draft
-  dockerimage: demisto/crypto:1.0.0.12807
+  dockerimage: demisto/crypto:1.0.0.12979
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Microsoft Graph Mail
-- Fixed an issue where **fetch-incidents** failed on mail with reference attachments.
-- Upgraded the Docker image to demisto/crypto:1.0.0.12979.
+- Fixed an issue where the ***fetch-incidents*** command failed on mail with reference attachments.
+- Updated the Docker image to: *demisto/crypto:1.0.0.12979*.

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Microsoft Graph Mail
 - Fixed an issue where **fetch-incidents** failed on mail with reference attachments.
-- Upgraded the Docker image to demisto/crypto:1.0.0.12807.
+- Upgraded the Docker image to demisto/crypto:1.0.0.12979.

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_0_10.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Microsoft Graph Mail
+- Fixed an issue where **fetch-incidents** failed on mail with reference attachments.
+- Upgraded the Docker image to demisto/crypto:1.0.0.12807.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29913

## Description
According to the API there are three types of attachments and the integration only handled two of them.
