### PR TITLE
Removing duplicated test configuration

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2207,9 +2207,6 @@
             "playbookID": "CheckDockerImageAvailableTest"
         },
         {
-            "playbookID": "ExtractDomainFromEmailTest"
-        },
-        {
             "playbookID": "Extract Indicators From File - Generic v2 - Test",
             "integrations": "Image OCR",
             "timeout": 300,


### PR DESCRIPTION
Removing duplicated configuration of test playbook ExtractDomainFromEmailTest as it's in the configuration twice