### PR TITLE
[Enhancement] OpenPhish v2 - reputation command to return a list of results

### DIFF
--- a/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2.py
+++ b/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2.py
@@ -119,34 +119,37 @@ def remove_backslash(url: str) -> str:
     return url
 
 
-def url_command(client: Client, **kwargs) -> CommandResults:
+def url_command(client: Client, **kwargs) -> List[CommandResults]:
     data = get_integration_context()
     if _is_reload_needed(client, data):
         reload_command(client)
         data = get_integration_context()
 
-    url_object_list = []
+    command_results: List[CommandResults] = []
     if not data:
         raise DemistoException("Data was not saved correctly to the integration context.")
 
     url_list_from_user = argToList(kwargs.get('url'))
-    markdown = "### OpenPhish Database - URL Query\n"
     urls_in_db = data.get('list', [])
     for url in url_list_from_user:
         url_fixed = remove_backslash(url)
         if url_fixed in urls_in_db:
             dbotscore = Common.DBotScore.BAD
             desc = 'Match found in OpenPhish database'
-            markdown += f"#### Found matches for given URL {url}\n"
+            markdown = f"#### Found matches for given URL {url}\n"
         else:
             dbotscore = Common.DBotScore.NONE
             desc = ""
-            markdown += f"#### No matches for URL {url}\n"
+            markdown = f"#### No matches for URL {url}\n"
 
         dbot = Common.DBotScore(url, DBotScoreType.URL, 'OpenPhish', dbotscore, desc)
-        url_object_list.append(Common.URL(url, dbot))
+        url_object = Common.URL(url, dbot)
+        command_results.append(CommandResults(
+            indicator=url_object,
+            readable_output=markdown,
+        ))
 
-    return CommandResults(indicators=url_object_list, readable_output=markdown)
+    return command_results
 
 
 def reload_command(client: Client, **kwargs) -> CommandResults:

--- a/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2.yml
+++ b/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2.yml
@@ -25,7 +25,7 @@ name: OpenPhish_v2
 display: OpenPhish v2
 defaultEnabled: false
 script:
-  dockerimage: demisto/python3:3.8.5.11789
+  dockerimage: demisto/python3:3.8.6.12176
   commands:
     - name: url
       arguments:

--- a/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2_test.py
+++ b/Packs/OpenPhish/Integrations/OpenPhish_v2/OpenPhish_v2_test.py
@@ -2,47 +2,84 @@ from datetime import datetime
 import pytest
 import OpenPhish_v2
 import demistomock as demisto
-from OpenPhish_v2 import Client, _is_reload_needed, remove_backslash, reload_command, status_command, url_command
+from OpenPhish_v2 import (
+    Client,
+    _is_reload_needed,
+    remove_backslash,
+    reload_command,
+    status_command,
+    url_command,
+)
 from freezegun import freeze_time
 from test_data.api_raw import RAW_DATA
+
 MOCK_URL = "http://openphish.com"
 MOCK_DELIVERED_MESSAGE = {}
-DBOT_KEY = 'DBotScore(val.Indicator && val.Indicator == obj.Indicator && val.Vendor == obj.Vendor && val.Type == obj.Type)'
+DBOT_KEY = "DBotScore(val.Indicator && val.Indicator == obj.Indicator && val.Vendor == obj.Vendor && val.Type == obj.Type)"
 
 RELOADED_DATA = [
     (Client(MOCK_URL, True, False, 2), {}, True),  # case no data in memory
-    (Client(MOCK_URL, True, False, 2), {"list": []}, True),  # case no timestamp and list is emtpy
-    (Client(MOCK_URL, True, False, 2),
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'], "timestamp": None}, True),  # case no timestamp
-    (Client(MOCK_URL, True, False, 1),
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": 1601542800000},  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
-     True),
-    (Client(MOCK_URL, True, False, 2),
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": 1601542800000},  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
-     False),
-    (Client(MOCK_URL, True, False, 0.5),
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": 1601542800000},  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
-     True),
-
+    (
+        Client(MOCK_URL, True, False, 2),
+        {"list": []},
+        True,
+    ),  # case no timestamp and list is emtpy
+    (
+        Client(MOCK_URL, True, False, 2),
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": None,
+        },
+        True,
+    ),  # case no timestamp
+    (
+        Client(MOCK_URL, True, False, 1),
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": 1601542800000,
+        },  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
+        True,
+    ),
+    (
+        Client(MOCK_URL, True, False, 2),
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": 1601542800000,
+        },  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
+        False,
+    ),
+    (
+        Client(MOCK_URL, True, False, 0.5),
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": 1601542800000,
+        },  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)
+        True,
+    ),
 ]
 
 
-@pytest.mark.parametrize('client,data,output', RELOADED_DATA)
+@pytest.mark.parametrize("client,data,output", RELOADED_DATA)
 def test_is_reload_needed(mocker, client, data, output):
     """
     Given:
@@ -59,12 +96,10 @@ def test_is_reload_needed(mocker, client, data, output):
         assert _is_reload_needed(client, data) == output
 
 
-LINKS = [
-    ("goo.co/", "goo.co"),
-    ("goo.co", "goo.co")]
+LINKS = [("goo.co/", "goo.co"), ("goo.co", "goo.co")]
 
 
-@pytest.mark.parametrize('url, expected_result', LINKS)
+@pytest.mark.parametrize("url, expected_result", LINKS)
 def test_remove_backslash(url: str, expected_result: str):
     """
        Given:
@@ -90,36 +125,46 @@ def test_reload_command(mocker):
 
            """
     mock_data_from_api = RAW_DATA
-    mocker.patch.object(Client, 'http_request', return_value=mock_data_from_api)
+    mocker.patch.object(Client, "http_request", return_value=mock_data_from_api)
     mocker.patch.object(demisto, "setIntegrationContext")
     client = Client(
-        url=MOCK_URL,
-        use_ssl=False,
-        use_proxy=False,
-        fetch_interval_hours=1)
+        url=MOCK_URL, use_ssl=False, use_proxy=False, fetch_interval_hours=1
+    )
     status = reload_command(client)
-    assert status.readable_output == "Database was updated successfully to the integration context."
+    assert (
+        status.readable_output
+        == "Database was updated successfully to the integration context."
+    )
 
 
-STANDARD_NOT_LOADED_MSG = 'OpenPhish Database Status\nDatabase not loaded.\n'
-STANDARD_4_LOADED_MSG = "OpenPhish Database Status\n" \
-                        "Total **4** URLs loaded.\n" \
-                        "Last load time **Thu Oct 01 2020 06:00:00 (UTC)**\n"
+STANDARD_NOT_LOADED_MSG = "OpenPhish Database Status\nDatabase not loaded.\n"
+STANDARD_4_LOADED_MSG = (
+    "OpenPhish Database Status\n"
+    "Total **4** URLs loaded.\n"
+    "Last load time **Thu Oct 01 2020 06:00:00 (UTC)**\n"
+)
 CONTEXT_MOCK_WITH_STATUS = [
     ({}, STANDARD_NOT_LOADED_MSG),  # case no data in memory
-    ({"list": [], "timestamp": "1601532000000"},
-     STANDARD_NOT_LOADED_MSG),  # case no timestamp and list is emtpy
     (
-        {"list": ['hxxp://www.niccakorea.com/board/index.html',
-                  'hxxp://lloyds.settlemypayee.uk',
-                  'hxxp://whatsapp-chat02.zzux.com',
-                  'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-         "timestamp": "1601532000000"},  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)}
-        STANDARD_4_LOADED_MSG)
+        {"list": [], "timestamp": "1601532000000"},
+        STANDARD_NOT_LOADED_MSG,
+    ),  # case no timestamp and list is emtpy
+    (
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": "1601532000000",
+        },  # datetime(2020, 10, 1, 10, 00, 00, 0) - timedelta(hours=1)}
+        STANDARD_4_LOADED_MSG,
+    ),
 ]
 
 
-@pytest.mark.parametrize('data,expected_result', CONTEXT_MOCK_WITH_STATUS)
+@pytest.mark.parametrize("data,expected_result", CONTEXT_MOCK_WITH_STATUS)
 @freeze_time("1993-06-17 11:00:00 GMT")
 def test_status_command(mocker, data, expected_result):
     """
@@ -138,45 +183,120 @@ def test_status_command(mocker, data, expected_result):
 
 
 CONTEXT_MOCK_WITH_URL = [
-    ({'url': 'hxxp://lloyds.settlemypayee.uk'},
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": "1601532000000"},
-     [{'URL': [{'Data': 'hxxp://lloyds.settlemypayee.uk',
-               'Malicious': {'Vendor': 'OpenPhish', 'Description': 'Match found in OpenPhish database'}}],
-      'DBOTSCORE': [{'Indicator': 'hxxp://lloyds.settlemypayee.uk', 'Type': 'url', 'Vendor': 'OpenPhish', 'Score': 3}]}]
-     ),
-    ({'url': 'hxxp://goo.co'},
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": "1601532000000"},
-     [{'URL': [{'Data': 'hxxp://goo.co'}],
-      'DBOTSCORE': [{'Indicator': 'hxxp://goo.co', 'Type': 'url', 'Vendor': 'OpenPhish', 'Score': 0}]}]
-     ),
-    ({'url': 'hxxp://whatsapp-chat02.zzux.com,hxxp://lloyds.settlemypayee.uk'},
-     {"list": ['hxxp://www.niccakorea.com/board/index.html',
-               'hxxp://lloyds.settlemypayee.uk',
-               'hxxp://whatsapp-chat02.zzux.com',
-               'hxxp://dd0ddddddcuser.ey.r.appspot.com'],
-      "timestamp": "1601532000000"},
-     [{'URL': [{'Data': 'hxxp://whatsapp-chat02.zzux.com', 'Malicious':
-      {'Vendor': 'OpenPhish', 'Description': 'Match found in OpenPhish database'}}],
-       'DBOTSCORE': [{'Indicator': 'hxxp://whatsapp-chat02.zzux.com', 'Score': 3, 'Type': 'url', 'Vendor': 'OpenPhish'}]
-      },
-      {'URL': [{'Data': 'hxxp://lloyds.settlemypayee.uk', 'Malicious':
-       {'Vendor': 'OpenPhish', 'Description': 'Match found in OpenPhish database'}}],
-       'DBOTSCORE': [{'Indicator': 'hxxp://lloyds.settlemypayee.uk', 'Score': 3, 'Type': 'url', 'Vendor': 'OpenPhish'}]
-       },
-      ]
-     )
+    (
+        {"url": "hxxp://lloyds.settlemypayee.uk"},
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": "1601532000000",
+        },
+        [
+            {
+                "URL": [
+                    {
+                        "Data": "hxxp://lloyds.settlemypayee.uk",
+                        "Malicious": {
+                            "Vendor": "OpenPhish",
+                            "Description": "Match found in OpenPhish database",
+                        },
+                    }
+                ],
+                "DBOTSCORE": [
+                    {
+                        "Indicator": "hxxp://lloyds.settlemypayee.uk",
+                        "Type": "url",
+                        "Vendor": "OpenPhish",
+                        "Score": 3,
+                    }
+                ],
+            }
+        ],
+    ),
+    (
+        {"url": "hxxp://goo.co"},
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": "1601532000000",
+        },
+        [
+            {
+                "URL": [{"Data": "hxxp://goo.co"}],
+                "DBOTSCORE": [
+                    {
+                        "Indicator": "hxxp://goo.co",
+                        "Type": "url",
+                        "Vendor": "OpenPhish",
+                        "Score": 0,
+                    }
+                ],
+            }
+        ],
+    ),
+    (
+        {"url": "hxxp://whatsapp-chat02.zzux.com,hxxp://lloyds.settlemypayee.uk"},
+        {
+            "list": [
+                "hxxp://www.niccakorea.com/board/index.html",
+                "hxxp://lloyds.settlemypayee.uk",
+                "hxxp://whatsapp-chat02.zzux.com",
+                "hxxp://dd0ddddddcuser.ey.r.appspot.com",
+            ],
+            "timestamp": "1601532000000",
+        },
+        [
+            {
+                "URL": [
+                    {
+                        "Data": "hxxp://whatsapp-chat02.zzux.com",
+                        "Malicious": {
+                            "Vendor": "OpenPhish",
+                            "Description": "Match found in OpenPhish database",
+                        },
+                    }
+                ],
+                "DBOTSCORE": [
+                    {
+                        "Indicator": "hxxp://whatsapp-chat02.zzux.com",
+                        "Score": 3,
+                        "Type": "url",
+                        "Vendor": "OpenPhish",
+                    }
+                ],
+            },
+            {
+                "URL": [
+                    {
+                        "Data": "hxxp://lloyds.settlemypayee.uk",
+                        "Malicious": {
+                            "Vendor": "OpenPhish",
+                            "Description": "Match found in OpenPhish database",
+                        },
+                    }
+                ],
+                "DBOTSCORE": [
+                    {
+                        "Indicator": "hxxp://lloyds.settlemypayee.uk",
+                        "Score": 3,
+                        "Type": "url",
+                        "Vendor": "OpenPhish",
+                    }
+                ],
+            },
+        ],
+    ),
 ]
 
 
-@pytest.mark.parametrize('url,context,expected_results', CONTEXT_MOCK_WITH_URL)
+@pytest.mark.parametrize("url,context,expected_results", CONTEXT_MOCK_WITH_URL)
 def test_url_command(mocker, url, context, expected_results):
     """
     Given:
@@ -189,12 +309,16 @@ def test_url_command(mocker, url, context, expected_results):
         - validating whether the url is malicious (in integration context)
 
     """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value=context, )
+    mocker.patch.object(
+        demisto, "getIntegrationContext", return_value=context,
+    )
     mocker.patch.object(OpenPhish_v2, "_is_reload_needed", return_value=False)
     client = Client(MOCK_URL, True, False, 1)
     results = url_command(client, **url)
     assert len(results) >= 1
     for i in range(len(results)):
-        output = results[i].to_context().get('EntryContext', {})
-        assert output.get('URL(val.Data && val.Data == obj.Data)', []) == expected_results[i].get('URL')
-        assert output.get(DBOT_KEY, []) == expected_results[i].get('DBOTSCORE')
+        output = results[i].to_context().get("EntryContext", {})
+        assert output.get(
+            "URL(val.Data && val.Data == obj.Data)", []
+        ) == expected_results[i].get("URL")
+        assert output.get(DBOT_KEY, []) == expected_results[i].get("DBOTSCORE")

--- a/Packs/OpenPhish/ReleaseNotes/2_0_1.md
+++ b/Packs/OpenPhish/ReleaseNotes/2_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### New: OpenPhish v2
-- Updated the command **url** to return a different result for each indicator. 
+**Breaking Change** url command changed to return multiple entries (entry per indicator) instead of a single entry.

--- a/Packs/OpenPhish/ReleaseNotes/2_0_1.md
+++ b/Packs/OpenPhish/ReleaseNotes/2_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### New: OpenPhish v2
+- Updated the command **url** to return a different result for each indicator. 

--- a/Packs/OpenPhish/pack_metadata.json
+++ b/Packs/OpenPhish/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "OpenPhish",
     "description": "OpenPhish uses proprietary Artificial Intelligence algorithms to automatically identify zero-day phishing sites and provide comprehensive, actionable, real-time threat intelligence.",
     "support": "xsoar",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
epic: https://github.com/demisto/etc/issues/29016

## Description
* Use the new `CommandResults.indicator` parameter.
* Update the reputation command **url** to return a different result for each indicator.

## Does it break backward compatibility?
   - [x] Yes
       - Further details: custom scripts that run these commands using `executeCommand` might miss the switch, and handle only the first result.

## Must have
- [x] Tests