### PR TITLE
[Prisma Cloud Compute] Update compute integration endpoint (with backward compatibility)

### DIFF
--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
@@ -81,11 +81,21 @@ class Client(BaseClient):
         if from_:
             params['from'] = from_
 
-        return self._http_request(
-            method='GET',
-            url_suffix='demisto-alerts',
-            params=params
-        )
+        # If the endpoint not found, fallback to the previous demisto-alerts endpoint (backward compatibility)
+        try:
+            return self._http_request(
+                method='GET',
+                url_suffix='xsoar-alerts',
+                params=params
+            )
+        except Exception as e:
+            if '[404]' in str(e):
+                return self._http_request(
+                    method='GET',
+                    url_suffix='demisto-alerts',
+                    params=params
+                )
+            raise e
 
 
 def str_to_bool(s):

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
@@ -43,7 +43,7 @@ description: Use the Prisma Cloud Compute integration to fetch incidents from yo
 display: Palo Alto Networks - Prisma Cloud Compute
 name: PaloAltoNetworks_PrismaCloudCompute
 script:
-  dockerimage: demisto/python3:3.7.4.2245
+  dockerimage: demisto/python3:3.8.6.12176
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute_test.py
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute_test.py
@@ -1,5 +1,8 @@
+import pytest
 from PaloAltoNetworks_PrismaCloudCompute import Client, camel_case_transformer, fetch_incidents, get_headers, \
     HEADERS_BY_NAME
+
+from CommonServerPython import DemistoException
 
 
 def test_camel_case_transformer(requests_mock):
@@ -11,6 +14,34 @@ def test_camel_case_transformer(requests_mock):
         results.append(camel_case_transformer(string))
 
     assert results == expected_results
+
+
+def test_api_fallback(requests_mock):
+    test_url = 'https://test.com'
+    xsoar_endpoint = test_url + '/xsoar-alerts'
+    demisto_endpoint = test_url + '/demisto-alerts'
+    test_response = {'foo': 'bar'}
+    client = Client(base_url=test_url, verify='False', project='', auth=('test', 'test'))
+
+    # Validate new API
+    requests_mock.get(xsoar_endpoint, json=test_response)
+    assert client.list_incidents() == test_response
+
+    # Validate fallback to previous API (backward compatibility)
+    requests_mock.get(xsoar_endpoint, status_code=404)
+    requests_mock.get(demisto_endpoint, json=test_response)
+    assert client.list_incidents() == test_response
+
+    # Validate error from new API is returned without fallback
+    requests_mock.get(xsoar_endpoint, status_code=500)
+    with pytest.raises(DemistoException, match='500'):
+        client.list_incidents()
+
+    # Validate error on previous API
+    requests_mock.get(xsoar_endpoint, status_code=404)
+    requests_mock.get(demisto_endpoint, status_code=504)
+    with pytest.raises(DemistoException, match='504'):
+        client.list_incidents()
 
 
 def test_fetch_incidents(requests_mock):
@@ -333,7 +364,7 @@ def test_fetch_incidents(requests_mock):
                     'medium | ALAS-2019-1188 | fixed in 1.0.2k-16.150.amzn1 | libcrypto1.0 | openssl | 1.0.1m-r0 |  '
                     '|\\n"}'}]
 
-    requests_mock.get('https://test.com/demisto-alerts', json=json_incidents_mock_response)
+    requests_mock.get('https://test.com/xsoar-alerts', json=json_incidents_mock_response)
     client = Client(base_url='https://test.com', verify='False', project='', auth=('test', 'test'))
     assert fetch_incidents(client) == expected_incidents
 

--- a/Packs/PrismaCloudCompute/ReleaseNotes/1_0_4.md
+++ b/Packs/PrismaCloudCompute/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks - Prisma Cloud Compute
+- Updated integration endpoint

--- a/Packs/PrismaCloudCompute/pack_metadata.json
+++ b/Packs/PrismaCloudCompute/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud Compute",
     "description": "Use the Prisma Cloud Compute integration to fetch incidents from your Prisma Cloud Compute environment.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
- The endpoint was updated on Compute side to `xsoar-alerts`
- Query the new endpoint, if not found fallback to the previous endpoint)