### PR TITLE
Speed up pack dependencies calculations

### DIFF
--- a/Tests/Marketplace/Tests/test_pack_dependencies.py
+++ b/Tests/Marketplace/Tests/test_pack_dependencies.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+import networkx as nx
+
+from Tests.Marketplace.packs_dependencies import calculate_single_pack_dependencies
+
+
+def find_pack_display_name_mock(pack_folder_name):
+    return pack_folder_name
+
+
+class TestCalculateSinglePackDependencies:
+    @classmethod
+    def setup_class(cls):
+        patch('demisto_sdk.commands.find_dependencies.find_dependencies.find_pack_display_name',
+              side_effect=find_pack_display_name_mock)
+        patch('Tests.scripts.utils.log_util.install_logging')
+        graph = nx.DiGraph()
+        graph.add_node('pack1', mandatory_for_packs=[])
+        graph.add_node('pack2', mandatory_for_packs=[])
+        graph.add_node('pack3', mandatory_for_packs=[])
+        graph.add_node('pack4', mandatory_for_packs=[])
+        graph.add_node('pack5', mandatory_for_packs=[])
+        graph.add_edge('pack1', 'pack2')
+        graph.add_edge('pack2', 'pack3')
+        graph.add_edge('pack1', 'pack4')
+        graph.nodes()['pack4']['mandatory_for_packs'].append('pack1')
+
+        dependencies = calculate_single_pack_dependencies('pack1', graph)
+        cls.first_level_dependencies, cls.all_level_dependencies, _ = dependencies
+
+    def test_calculate_single_pack_dependencies_first_level_dependencies(self):
+        """
+        Given
+            - A full dependency graph where:
+                - pack1 -> pack2 -> pack3
+                - pack1 -> pack4
+                - pack4 is mandatory for pack1
+                - pack5 and pack1 are not a dependency for any pack
+        When
+            - Running `calculate_single_pack_dependencies` to extract the first and all levels dependencies
+        Then
+            - Ensure first level dependencies for pack1 are only pack2 and pack4
+        """
+        all_nodes = {'pack1', 'pack2', 'pack3', 'pack4', 'pack5'}
+        expected_first_level_dependencies = {'pack2', 'pack4'}
+        for node in expected_first_level_dependencies:
+            assert node in self.first_level_dependencies
+        for node in all_nodes - expected_first_level_dependencies:
+            assert node not in self.first_level_dependencies
+
+    def test_calculate_single_pack_dependencies_all_levels_dependencies(self):
+        """
+        Given
+            - A full dependency graph where:
+                - pack1 -> pack2 -> pack3
+                - pack1 -> pack4
+                - pack4 is mandatory for pack1
+                - pack5 and pack1 are not a dependency for any pack
+        When
+            - Running `calculate_single_pack_dependencies` to extract the first and all levels dependencies
+        Then
+            - Ensure all levels dependencies for pack1 are pack2, pack3 and pack4 only
+        """
+        all_nodes = {'pack1', 'pack2', 'pack3', 'pack4', 'pack5'}
+        expected_all_level_dependencies = {'pack2', 'pack3', 'pack4'}
+        for node in expected_all_level_dependencies:
+            assert node in self.all_level_dependencies
+        for node in all_nodes - expected_all_level_dependencies:
+            assert node not in self.all_level_dependencies
+
+    def test_calculate_single_pack_dependencies_mandatory_dependencies(self):
+        """
+        Given
+            - A full dependency graph where:
+                - pack1 -> pack2 -> pack3
+                - pack1 -> pack4
+                - pack4 is mandatory for pack1
+                - pack5 and pack1 are not a dependency for any pack
+        When
+            - Running `calculate_single_pack_dependencies` to extract the first and all levels dependencies
+        Then
+            - pack4 is mandatory for pack1 and that there are no other mandatory dependencies
+        """
+        expected_mandatory_dependency = 'pack4'
+        assert self.first_level_dependencies[expected_mandatory_dependency]['mandatory']
+        for node in self.first_level_dependencies:
+            if node != expected_mandatory_dependency:
+                assert not self.first_level_dependencies[node]['mandatory']

--- a/Tests/Marketplace/packs_dependencies.py
+++ b/Tests/Marketplace/packs_dependencies.py
@@ -2,12 +2,15 @@ import os
 import json
 import argparse
 import logging
+from pprint import pformat
+from multiprocessing import cpu_count
 
+from pebble import ProcessPool, ProcessFuture
 from Tests.Marketplace.upload_packs import PACKS_FULL_PATH, IGNORED_FILES, PACKS_FOLDER
 from Tests.Marketplace.marketplace_services import GCPConfig
 from demisto_sdk.commands.find_dependencies.find_dependencies import VerboseFile, PackDependencies,\
     parse_for_pack_metadata
-
+from typing import Tuple, Iterable
 from Tests.scripts.utils.log_util import install_logging
 
 
@@ -24,48 +27,148 @@ def option_handler():
     return parser.parse_args()
 
 
+def calculate_single_pack_dependencies(pack: str, dependency_graph: object) -> Tuple[dict, list, str]:
+    """
+    Calculates pack dependencies given a pack and a dependencies graph.
+    First is extract the dependencies subgraph of the given graph only using DFS algorithm with the pack as source.
+
+    Then, for all the dependencies of that pack it Replaces the 'mandatory_for_packs' key with a boolean key 'mandatory'
+    which indicates whether this dependency is mandatory for this pack or not.
+
+    Then using that subgraph we get the first-level dependencies and all-levels dependencies.
+
+    Args:
+        pack: The pack for which we need to calculate the dependencies
+        dependency_graph: The full dependencies graph
+
+    Returns:
+        first_level_dependencies: A dict of the form {'dependency_name': {'mandatory': < >, 'display_name': < >}}
+        all_level_dependencies: A list with all dependencies names
+        pack: The pack name
+    """
+    install_logging('Calculate Packs Dependencies.log', include_process_name=True)
+    first_level_dependencies = {}
+    all_level_dependencies = []
+    try:
+        logging.info(f"Calculating {pack} pack dependencies.")
+        subgraph = PackDependencies.get_dependencies_subgraph_by_dfs(dependency_graph, pack)
+        for dependency_pack, additional_data in subgraph.nodes(data=True):
+            logging.debug(f'Iterating dependency {dependency_pack} for pack {pack}')
+            additional_data['mandatory'] = pack in additional_data['mandatory_for_packs']
+            del additional_data['mandatory_for_packs']
+            first_level_dependencies, all_level_dependencies = parse_for_pack_metadata(subgraph, pack)
+    except Exception:
+        logging.exception(f"Failed calculating {pack} pack dependencies")
+    return first_level_dependencies, all_level_dependencies, pack
+
+
+def get_all_packs_dependency_graph(id_set: dict, packs: list) -> Iterable:
+    """
+    Gets a graph with dependencies for all packs
+    Args:
+        id_set: The content of id_set file
+        packs: The packs that should be part of the dependencies calculation
+
+    Returns:
+        A graph with all packs dependencies
+    """
+    logging.info("Calculating pack dependencies.")
+    try:
+        dependency_graph = PackDependencies.build_all_dependencies_graph(packs,
+                                                                         id_set=id_set,
+                                                                         verbose_file=VerboseFile(''))
+        return dependency_graph
+    except Exception:
+        logging.exception("Failed calculating dependencies graph")
+        exit(2)
+
+
+def select_packs_for_calculation() -> list:
+    """
+    Select the packs on which the dependencies will be calculated on
+    Returns:
+        A list of packs
+    """
+    IGNORED_FILES.append(GCPConfig.BASE_PACK)  # skip dependency calculation of Base pack
+    packs = []
+    for pack in os.scandir(PACKS_FULL_PATH):
+        if not pack.is_dir() or pack.name in IGNORED_FILES:
+            logging.warning(f"Skipping dependency calculation of {pack.name} pack.")
+            continue  # skipping ignored packs
+        packs.append(pack.name)
+    return packs
+
+
+def get_id_set(id_set_path: str) -> dict:
+    """
+    Parses the content of id_set_path and returns its content.
+    Args:
+        id_set_path: The path of the id_set file
+
+    Returns:
+        The parsed content of id_set
+    """
+    with open(id_set_path, 'r') as id_set_file:
+        id_set = json.load(id_set_file)
+    return id_set
+
+
+def calculate_all_packs_dependencies(pack_dependencies_result: dict, id_set: dict, packs: list) -> None:
+    """
+    Calculates the pack dependencies and adds them to 'pack_dependencies_result' in parallel.
+    First - the method generates the full dependency graph.
+
+    Them - using a process pool we extract the dependencies of each pack and adds them to the 'pack_dependencies_result'
+    Args:
+        pack_dependencies_result: The dict to which the results should be added
+        id_set: The id_set content
+        packs: The packs that should be part of the dependencies calculation
+    """
+    def add_pack_metadata_results(future: ProcessFuture) -> None:
+        """
+        This is a callback that should be called once the result of the future is ready.
+        The results include: first_level_dependencies, all_level_dependencies, pack_name
+        Using these results we write the dependencies
+        """
+        try:
+            first_level_dependencies, all_level_dependencies, pack_name = future.result()  # blocks until results ready
+            logging.debug(f'Got dependencies for pack {pack_name}\n: {pformat(all_level_dependencies)}')
+            pack_dependencies_result[pack_name] = {
+                "dependencies": first_level_dependencies,
+                "displayedImages": list(first_level_dependencies.keys()),
+                "allLevelDependencies": all_level_dependencies,
+                "path": os.path.join(PACKS_FOLDER, pack_name),
+                "fullPath": os.path.abspath(os.path.join(PACKS_FOLDER, pack_name))
+            }
+        except Exception:
+            logging.exception('Failed to collect pack dependencies results')
+
+    # Generating one graph with dependencies for all packs
+    dependency_graph = get_all_packs_dependency_graph(id_set, packs)
+
+    with ProcessPool(max_workers=cpu_count(), max_tasks=100) as pool:
+        for pack in dependency_graph:
+            future_object = pool.schedule(calculate_single_pack_dependencies, args=(pack, dependency_graph), timeout=10)
+            future_object.add_done_callback(add_pack_metadata_results)
+
+
 def main():
     """ Main function for iterating over existing packs folder in content repo and creating json of all
     packs dependencies. The logic of pack dependency is identical to sdk find-dependencies command.
 
     """
-    install_logging('Calculate Packs Dependencies.log')
+    install_logging('Calculate Packs Dependencies.log', include_process_name=True)
     option = option_handler()
     output_path = option.output_path
     id_set_path = option.id_set_path
-    IGNORED_FILES.append(GCPConfig.BASE_PACK)  # skip dependency calculation of Base pack
-    # loading id set json
-    with open(id_set_path, 'r') as id_set_file:
-        id_set = json.load(id_set_file)
+    id_set = get_id_set(id_set_path)
 
     pack_dependencies_result = {}
 
-    logging.info("Starting dependencies calculation")
-    # starting iteration over pack folders
-    for pack in os.scandir(PACKS_FULL_PATH):
-        if not pack.is_dir() or pack.name in IGNORED_FILES:
-            logging.warning(f"Skipping dependency calculation of {pack.name} pack.")
-            continue  # skipping ignored packs
-        logging.info(f"Calculating {pack.name} pack dependencies.")
+    logging.info("Selecting packs for dependencies calculation")
+    packs = select_packs_for_calculation()
 
-        try:
-            dependency_graph = PackDependencies.build_dependency_graph(pack_id=pack.name,
-                                                                       id_set=id_set,
-                                                                       verbose_file=VerboseFile(''),
-                                                                       )
-            first_level_dependencies, all_level_dependencies = parse_for_pack_metadata(dependency_graph, pack.name)
-
-        except Exception:
-            logging.exception(f"Failed calculating {pack.name} pack dependencies")
-            continue
-
-        pack_dependencies_result[pack.name] = {
-            "dependencies": first_level_dependencies,
-            "displayedImages": list(first_level_dependencies.keys()),
-            "allLevelDependencies": all_level_dependencies,
-            "path": os.path.join(PACKS_FOLDER, pack.name),
-            "fullPath": pack.path
-        }
+    calculate_all_packs_dependencies(pack_dependencies_result, id_set, packs)
 
     logging.info(f"Number of created pack dependencies entries: {len(pack_dependencies_result.keys())}")
     # finished iteration over pack folders


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29255

## Description
Improved the timing from ~10-13 minutes to ~15 seconds.

1. Instead of generating a new dependencies graph for each pack from scratch and calculate its dependencies - A full dependencies graph of all packs will be generated once, saved into memory, and from it the dependency sub-graph of each pack will be extracted and used for the calculations
2. Once the full graph is ready, the dependency calculation of each pack will be executed concurrently using multiprocessing.

See the related sdk PR [here](https://github.com/demisto/demisto-sdk/pull/855)
## Screenshots
### Before: 
![image](https://user-images.githubusercontent.com/41257953/97967403-d6890980-1dc5-11eb-88c0-34bb1279695a.png)
### After:
![image](https://user-images.githubusercontent.com/41257953/97967623-24057680-1dc6-11eb-8ec4-b8064021170d.png)


## Must have
- [ ] Tests
- [x] Documentation 
