### PR TITLE
[Enhancement] HelloWorld - reputation commands to return a list of results

### DIFF
--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
@@ -643,7 +643,8 @@ def test_module(client: Client, first_fetch_time: int) -> str:
     # Cortex XSOAR will print everything you return different than 'ok' as
     # an error
     try:
-        client.search_alerts(max_results=1, start_time=first_fetch_time, alert_status=None, alert_type=None, severity=None)
+        client.search_alerts(max_results=1, start_time=first_fetch_time, alert_status=None, alert_type=None,
+                             severity=None)
     except DemistoException as e:
         if 'Forbidden' in str(e):
             return 'Authorization Error: make sure API Key is correctly set'
@@ -839,7 +840,7 @@ def fetch_incidents(client: Client, max_results: int, last_run: Dict[str, int],
     return next_run, incidents
 
 
-def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshold: int) -> CommandResults:
+def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshold: int) -> List[CommandResults]:
     """ip command: Returns IP reputation for a list of IPs
 
     :type client: ``Client``
@@ -880,9 +881,9 @@ def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshol
     # where threshold is an actual argument of the command.
     threshold = int(args.get('threshold', default_threshold))
 
-    # Context standard for IP class
-    ip_standard_list: List[Common.IP] = []
-    ip_data_list: List[Dict[str, Any]] = []
+    # Initialize an empty list of CommandResults to return
+    # Each CommandResult will contain context standard for IP
+    command_results: List[CommandResults] = []
 
     for ip in ips:
         ip_data = client.get_ip_reputation(ip)
@@ -930,8 +931,6 @@ def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshol
             dbot_score=dbot_score
         )
 
-        ip_standard_list.append(ip_standard_context)
-
         # INTEGRATION DEVELOPER TIP
         # In the integration specific Context output (HelloWorld.IP) in this
         # example you want to provide a lot of information as it can be used
@@ -948,26 +947,27 @@ def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshol
         # Define which fields we want to exclude from the context output as
         # they are too verbose.
         ip_context_excluded_fields = ['objects', 'nir']
-        ip_data_list.append({k: ip_data[k] for k in ip_data if k not in ip_context_excluded_fields})
+        ip_data = {k: ip_data[k] for k in ip_data if k not in ip_context_excluded_fields}
 
-    # In this case we want to use an custom markdown to specify the table title,
-    # but otherwise ``CommandResults()`` will call ``tableToMarkdown()``
-    #  automatically
-    readable_output = tableToMarkdown('IP List', ip_data_list)
+        # In this case we want to use an custom markdown to specify the table title,
+        # but otherwise ``CommandResults()`` will call ``tableToMarkdown()``
+        #  automatically
+        readable_output = tableToMarkdown('IP', ip_data)
 
-    # INTEGRATION DEVELOPER TIP
-    # The output key will be ``HelloWorld.IP``, using ``ip`` as the key field.
-    # ``indicators`` is used to provide the context standard (IP)
-    return CommandResults(
-        readable_output=readable_output,
-        outputs_prefix='HelloWorld.IP',
-        outputs_key_field='ip',
-        outputs=ip_data_list,
-        indicators=ip_standard_list
-    )
+        # INTEGRATION DEVELOPER TIP
+        # The output key will be ``HelloWorld.IP``, using ``ip`` as the key field.
+        # ``indicator`` is used to provide the context standard (IP)
+        command_results.append(CommandResults(
+            readable_output=readable_output,
+            outputs_prefix='HelloWorld.IP',
+            outputs_key_field='ip',
+            outputs=ip_data,
+            indicator=ip_standard_context
+        ))
+    return command_results
 
 
-def domain_reputation_command(client: Client, args: Dict[str, Any], default_threshold: int) -> CommandResults:
+def domain_reputation_command(client: Client, args: Dict[str, Any], default_threshold: int) -> List[CommandResults]:
     """domain command: Returns domain reputation for a list of domains
 
     :type client: ``Client``
@@ -1004,10 +1004,9 @@ def domain_reputation_command(client: Client, args: Dict[str, Any], default_thre
 
     threshold = int(args.get('threshold', default_threshold))
 
-    # Context standard for Domain class
-    domain_standard_list: List[Common.Domain] = []
-
-    domain_data_list: List[Dict[str, Any]] = []
+    # Initialize an empty list of CommandResults to return,
+    # each CommandResult will contain context standard for IP
+    command_results: List[CommandResults] = []
 
     for domain in domains:
         domain_data = client.get_domain_reputation(domain)
@@ -1072,25 +1071,23 @@ def domain_reputation_command(client: Client, args: Dict[str, Any], default_thre
             dbot_score=dbot_score
         )
 
-        domain_standard_list.append(domain_standard_context)
-        domain_data_list.append(domain_data)
+        # In this case we want to use an custom markdown to specify the table title,
+        # but otherwise ``CommandResults()`` will call ``tableToMarkdown()``
+        #  automatically
+        readable_output = tableToMarkdown('Domain', domain_data)
 
-    # In this case we want to use an custom markdown to specify the table title,
-    # but otherwise ``CommandResults()`` will call ``tableToMarkdown()``
-    #  automatically
-    readable_output = tableToMarkdown('Domain List', domain_data_list)
-
-    # INTEGRATION DEVELOPER TIP
-    # The output key will be ``HelloWorld.Domain``, using ``domain`` as the key
-    # field.
-    # ``indicators`` is used to provide the context standard (Domain)
-    return CommandResults(
-        readable_output=readable_output,
-        outputs_prefix='HelloWorld.Domain',
-        outputs_key_field='domain',
-        outputs=domain_data_list,
-        indicators=domain_standard_list
-    )
+        # INTEGRATION DEVELOPER TIP
+        # The output key will be ``HelloWorld.Domain``, using ``domain`` as the key
+        # field.
+        # ``indicator`` is used to provide the context standard (Domain)
+        command_results.append(CommandResults(
+            readable_output=readable_output,
+            outputs_prefix='HelloWorld.Domain',
+            outputs_key_field='domain',
+            outputs=domain_data,
+            indicator=domain_standard_context
+        ))
+    return command_results
 
 
 def search_alerts_command(client: Client, args: Dict[str, Any]) -> CommandResults:
@@ -1343,7 +1340,7 @@ def scan_status_command(client: Client, args: Dict[str, Any]) -> CommandResults:
     )
 
 
-def scan_results_command(client: Client, args: Dict[str, Any]) -> Union[Dict[str, Any], CommandResults]:
+def scan_results_command(client: Client, args: Dict[str, Any]) -> Union[Dict[str, Any], CommandResults, List[CommandResults]]:
     """helloworld-scan-results command: Returns results for a HelloWorld scan
 
     :type client: ``Client``
@@ -1394,19 +1391,31 @@ def scan_results_command(client: Client, args: Dict[str, Any]) -> Union[Dict[str
         # context standard, so we must extract CVE IDs and return them also.
         # See: https://xsoar.pan.dev/docs/integrations/context-standards#cve
         cves: List[Common.CVE] = []
+        command_results: List[CommandResults] = []
         entities = results.get('entities', [])
         for e in entities:
             if 'vulns' in e.keys() and isinstance(e['vulns'], list):
                 cves.extend([Common.CVE(id=c, cvss=None, published=None, modified=None, description=None) for c in e['vulns']])
 
+        # INTEGRATION DEVELOPER TIP
+        # We want to provide a unique result for every CVE indicator.
+        # Since every entity may contain several CVE indicators,
+        # we will split the entities result and CVE indicator results.
         readable_output = tableToMarkdown(f'Scan {scan_id} results', entities)
-        return CommandResults(
+        command_results.append(CommandResults(
             readable_output=readable_output,
             outputs_prefix='HelloWorld.Scan',
             outputs_key_field='scan_id',
-            outputs=results,
-            indicators=list(set(cves))  # make the indicator list unique
-        )
+            outputs=results
+        ))
+
+        cves = list(set(cves))  # make the indicator list unique
+        for cve in cves:
+            command_results.append(CommandResults(
+                readable_output=f"CVE {cve}",
+                indicator=cve
+            ))
+        return command_results
     else:
         raise ValueError('Incorrect format, must be "json" or "file"')
 
@@ -1533,7 +1542,6 @@ def main() -> None:
 
 
 ''' ENTRY POINT '''
-
 
 if __name__ in ('__main__', '__builtin__', 'builtins'):
     main()

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
@@ -882,7 +882,7 @@ def ip_reputation_command(client: Client, args: Dict[str, Any], default_threshol
     threshold = int(args.get('threshold', default_threshold))
 
     # Initialize an empty list of CommandResults to return
-    # Each CommandResult will contain context standard for IP
+    # each CommandResult will contain context standard for IP
     command_results: List[CommandResults] = []
 
     for ip in ips:
@@ -1005,7 +1005,7 @@ def domain_reputation_command(client: Client, args: Dict[str, Any], default_thre
     threshold = int(args.get('threshold', default_threshold))
 
     # Initialize an empty list of CommandResults to return,
-    # each CommandResult will contain context standard for IP
+    # each CommandResult will contain context standard for Domain
     command_results: List[CommandResults] = []
 
     for domain in domains:

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld_test.py
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld_test.py
@@ -206,14 +206,15 @@ def test_scan_results(mocker, requests_mock):
 
     response = scan_results_command(client, args)
 
-    assert response.outputs == mock_response
-    assert response.outputs_prefix == 'HelloWorld.Scan'
-    assert response.outputs_key_field == 'scan_id'
+    assert response[0].outputs == mock_response
+    assert response[0].outputs_prefix == 'HelloWorld.Scan'
+    assert response[0].outputs_key_field == 'scan_id'
 
     # This command also returns Common.CVE data
-    assert isinstance(response.indicators, list)
-    assert len(response.indicators) > 0
-    assert isinstance(response.indicators[0], Common.CVE)
+    assert isinstance(response, list)
+    assert len(response) > 1
+    for i in range(1, len(response)):
+        assert isinstance(response[i].indicator, Common.CVE)
 
 
 def test_search_alerts(requests_mock):
@@ -361,15 +362,14 @@ def test_ip(requests_mock):
 
     response = ip_reputation_command(client, args, 65)
 
-    assert response.outputs[0] == mock_response
-    assert response.outputs_prefix == 'HelloWorld.IP'
-    assert response.outputs_key_field == 'ip'
+    assert response[0].outputs == mock_response
+    assert response[0].outputs_prefix == 'HelloWorld.IP'
+    assert response[0].outputs_key_field == 'ip'
 
     # This command also returns Common.IP data
-    assert isinstance(response.indicators, list)
-    assert len(response.indicators) == 1
-    assert isinstance(response.indicators[0], Common.IP)
-    assert response.indicators[0].ip == ip_to_check
+    assert isinstance(response, list)
+    assert isinstance(response[0].indicator, Common.IP)
+    assert response[0].indicator.ip == ip_to_check
 
 
 def test_domain(requests_mock):
@@ -408,15 +408,14 @@ def test_domain(requests_mock):
     mock_response['creation_date'] = '1997-09-15T04:00:00.000Z'
     mock_response['updated_date'] = '2019-09-09T15:39:04.000Z'
 
-    assert response.outputs[0] == mock_response
-    assert response.outputs_prefix == 'HelloWorld.Domain'
-    assert response.outputs_key_field == 'domain'
+    assert response[0].outputs == mock_response
+    assert response[0].outputs_prefix == 'HelloWorld.Domain'
+    assert response[0].outputs_key_field == 'domain'
 
     # This command also returns Common.Domain data
-    assert isinstance(response.indicators, list)
-    assert len(response.indicators) == 1
-    assert isinstance(response.indicators[0], Common.Domain)
-    assert response.indicators[0].domain == domain_to_check
+    assert isinstance(response, list)
+    assert isinstance(response[0].indicator, Common.Domain)
+    assert response[0].indicator.domain == domain_to_check
 
 
 def test_fetch_incidents(requests_mock):

--- a/Packs/HelloWorld/Integrations/HelloWorld/README.md
+++ b/Packs/HelloWorld/Integrations/HelloWorld/README.md
@@ -1,4 +1,4 @@
-This is the Hello World integration for getting started and learn how to build an integration with Cortex XSOAR.
+~~~~This is the Hello World integration for getting started and learn how to build an integration with Cortex XSOAR.
 You can check the Design Document of this integration [here](https://docs.google.com/document/d/1wETtBEKg37PHNU8tYeB56M1LE314ux086z3HFeF_cX0).
 
 Please make sure you look at the integration source code and comments.

--- a/Packs/HelloWorld/ReleaseNotes/1_1_12.md
+++ b/Packs/HelloWorld/ReleaseNotes/1_1_12.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### HelloWorld
-The  commands **ip** **domain** and **helloworld-scan-results** were changed to return multiple entries (entry per indicator) instead of a single entry.
+The **ip**, **domain**, and **helloworld-scan-results** commands were changed to return multiple entries (entry per indicator) instead of a single entry.

--- a/Packs/HelloWorld/ReleaseNotes/1_1_12.md
+++ b/Packs/HelloWorld/ReleaseNotes/1_1_12.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### HelloWorld
+The  commands **ip** **domain** and **helloworld-scan-results** were changed to return multiple entries (entry per indicator) instead of a single entry.

--- a/Packs/HelloWorld/pack_metadata.json
+++ b/Packs/HelloWorld/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HelloWorld",
     "description": "This is the Hello World integration for getting started.",
     "support": "community",
-    "currentVersion": "1.1.11",
+    "currentVersion": "1.1.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
epic: https://github.com/demisto/etc/issues/29016

## Description
* Use the new `CommandResults.indicator` parameter.
* Update the reputation command **file** to return a different result for each indicator.

## Does it break backward compatibility?
   - [x] Yes
       - Further details: custom scripts that run these commands using `executeCommand` might miss the switch, and handle only the first result.

## Must have
- [x] Tests