### PR TITLE
[Enhancement] MicrosoftCloudAppSecurity - reputation commands to return a list of results

### DIFF
--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from dateparser import parse
 from pytz import utc
@@ -93,7 +93,7 @@ class Client(BaseClient):
     Should only do requests and return data.
     """
 
-    def list_alerts(self, url_suffix, request_data):
+    def list_alerts(self, url_suffix: str, request_data: dict):
         data = self._http_request(
             method='GET',
             url_suffix=url_suffix,
@@ -101,7 +101,7 @@ class Client(BaseClient):
         )
         return data
 
-    def dismiss_bulk_alerts(self, request_data):
+    def dismiss_bulk_alerts(self, request_data: dict):
         data = self._http_request(
             method='POST',
             url_suffix='/alerts/dismiss_bulk/',
@@ -109,7 +109,7 @@ class Client(BaseClient):
         )
         return data
 
-    def resolve_bulk_alerts(self, request_data):
+    def resolve_bulk_alerts(self, request_data: dict):
         data = self._http_request(
             method='POST',
             url_suffix='/alerts/resolve/',
@@ -117,7 +117,7 @@ class Client(BaseClient):
         )
         return data
 
-    def list_activities(self, url_suffix, request_data):
+    def list_activities(self, url_suffix: str, request_data: dict):
         data = self._http_request(
             method='GET',
             url_suffix=url_suffix,
@@ -125,7 +125,7 @@ class Client(BaseClient):
         )
         return data
 
-    def list_users_accounts(self, url_suffix, request_data):
+    def list_users_accounts(self, url_suffix: str, request_data: dict):
         data = self._http_request(
             method='GET',
             url_suffix=url_suffix,
@@ -133,7 +133,7 @@ class Client(BaseClient):
         )
         return data
 
-    def list_files(self, url_suffix, request_data):
+    def list_files(self, url_suffix: str, request_data: dict):
         data = self._http_request(
             method='GET',
             url_suffix=url_suffix,
@@ -141,7 +141,7 @@ class Client(BaseClient):
         )
         return data
 
-    def list_incidents(self, filters, limit):
+    def list_incidents(self, filters: dict, limit: Union[int, str]):
         return self._http_request(
             method='POST',
             url_suffix='/alerts/',
@@ -153,7 +153,7 @@ class Client(BaseClient):
         )
 
 
-def args_to_filter(arguments):
+def args_to_filter(arguments: dict):
     request_data: Dict[str, Any] = {}
     filters: Dict[str, Any] = {}
     for key, value in arguments.items():
@@ -193,7 +193,8 @@ def args_to_filter(arguments):
     return request_data
 
 
-def build_filter_and_url_to_search_with(url_suffix, custom_filter, arguments, specific_id_to_search=''):
+def build_filter_and_url_to_search_with(url_suffix: str, custom_filter: Optional[Any], arguments: dict,
+                                        specific_id_to_search: Any = ''):
     """
         This function build the filters dict or url to filter with.
 
@@ -216,8 +217,8 @@ def build_filter_and_url_to_search_with(url_suffix, custom_filter, arguments, sp
     return request_data, url_suffix
 
 
-def args_to_filter_for_dismiss_and_resolve_alerts(alert_ids, custom_filter, comments):
-    request_data = {}
+def args_to_filter_for_dismiss_and_resolve_alerts(alert_ids: Any, custom_filter: Any, comments: Any):
+    request_data: Dict[str, Any] = {}
     filters = {}
     if alert_ids:
         ids = {'eq': alert_ids.split(',')}
@@ -228,21 +229,21 @@ def args_to_filter_for_dismiss_and_resolve_alerts(alert_ids, custom_filter, comm
     elif custom_filter:
         request_data = json.loads(custom_filter)
     else:
-        return_error("Error: You must enter at least one of these arguments: alert ID, custom filter.")
+        raise DemistoException("Error: You must enter at least one of these arguments: alert ID, custom filter.")
     return request_data
 
 
-def test_module(client):
+def test_module(client: Client, is_fetch: bool, custom_filter: Optional[str]):
     try:
         client.list_alerts(url_suffix='/alerts/', request_data={})
-        if demisto.params().get('isFetch'):
+        if is_fetch:
             client.list_incidents(filters={}, limit=1)
-            if demisto.params().get('custom_filter'):
-                custom_filter = demisto.params().get('custom_filter')
+            if custom_filter:
                 try:
                     json.loads(custom_filter)
                 except ValueError:
-                    return_error('Custom Filter Error: Your custom filter format is incorrect, please try again.')
+                    raise DemistoException('Custom Filter Error: Your custom filter format is incorrect, '
+                                           'please try again.')
     except Exception as e:
         if 'No connection' in str(e):
             return 'Connection Error: The URL you entered is probably incorrect, please try again.'
@@ -252,7 +253,7 @@ def test_module(client):
     return 'ok'
 
 
-def alerts_to_human_readable(alerts):
+def alerts_to_human_readable(alerts: List[dict]):
     alerts_readable_outputs = []
     for alert in alerts:
         readable_output = assign_params(alert_id=alert.get('_id'), title=alert.get('title'),
@@ -261,18 +262,19 @@ def alerts_to_human_readable(alerts):
                                                       if alert.get('statusValue') == value],
                                         severity_value=[key for key, value in SEVERITY_OPTIONS.items()
                                                         if alert.get('severityValue') == value],
-                                        alert_date=datetime.fromtimestamp(alert.get('timestamp') / 1000.0).isoformat())
+                                        alert_date=datetime.fromtimestamp(
+                                            alert.get('timestamp', 0) / 1000.0).isoformat())
         alerts_readable_outputs.append(readable_output)
     headers = ['alert_id', 'alert_date', 'title', 'description', 'status_value', 'severity_value', 'is_open']
     human_readable = tableToMarkdown('Microsoft CAS Alerts', alerts_readable_outputs, headers, removeNull=True)
     return human_readable
 
 
-def extract_ip_indicators(activities):
-    indicators = []
+def create_ip_command_results(activities: List[dict]):
+    command_results: List[CommandResults] = []
     for activity in activities:
         ip_address = dict_safe_get(activity, ['device', 'clientIP'])
-        indicators.append(Common.IP(
+        indicator = Common.IP(
             ip=ip_address,
             dbot_score=Common.DBotScore(
                 ip_address,
@@ -282,19 +284,28 @@ def extract_ip_indicators(activities):
             ),
             geo_latitude=dict_safe_get(activity, ['location', 'latitude']),
             geo_longitude=dict_safe_get(activity, ['location', 'longitude']),
+        )
+        human_readable = activity_to_human_readable(activity)
+        command_results.append(CommandResults(
+            readable_output=human_readable,
+            outputs_prefix='MicrosoftCloudAppSecurity.Activities',
+            outputs_key_field='_id',
+            outputs=activities,
+            indicator=indicator
         ))
-    return indicators
+    return command_results
 
 
-def arrange_alerts_descriptions(alerts):
+def arrange_alerts_descriptions(alerts: List[dict]):
     for alert in alerts:
-        if alert.get('description') and '__siteIcon__' in alert.get('description'):
-            description = alert.get('description').replace('__siteIcon__', 'siteIcon')
+        description = alert.get('description', '')
+        if isinstance(description, str) and '__siteIcon__' in description:
+            description = description.replace('__siteIcon__', 'siteIcon')
             alert['description'] = description
     return alerts
 
 
-def set_alerts_is_open(alerts):
+def set_alerts_is_open(alerts: List[dict]):
     for alert in alerts:
         if alert.get('resolveTime'):
             alert['is_open'] = False
@@ -303,7 +314,7 @@ def set_alerts_is_open(alerts):
     return alerts
 
 
-def list_alerts_command(client, args):
+def list_alerts_command(client: Client, args: dict):
     url_suffix = '/alerts/'
     alert_id = args.get('alert_id')
     custom_filter = args.get('custom_filter')
@@ -323,7 +334,7 @@ def list_alerts_command(client, args):
     )
 
 
-def bulk_dismiss_alert_command(client, args):
+def bulk_dismiss_alert_command(client: Client, args: dict):
     alert_ids = args.get('alert_ids')
     custom_filter = args.get('custom_filter')
     comment = args.get('comment')
@@ -333,7 +344,7 @@ def bulk_dismiss_alert_command(client, args):
         dismissed_alerts_data = client.dismiss_bulk_alerts(request_data)
     except Exception as e:
         if 'alertsNotFound' in str(e):
-            return_error('Error: This alert id is already dismissed or does not exist.')
+            raise DemistoException('Error: This alert id is already dismissed or does not exist.')
     number_of_dismissed_alerts = dismissed_alerts_data['dismissed']
     return CommandResults(
         readable_output=f'{number_of_dismissed_alerts} alerts dismissed',
@@ -342,7 +353,7 @@ def bulk_dismiss_alert_command(client, args):
     )
 
 
-def bulk_resolve_alert_command(client, args):
+def bulk_resolve_alert_command(client: Client, args: dict):
     alert_ids = args.get('alert_ids')
     custom_filter = args.get('custom_filter')
     comment = args.get('comment')
@@ -357,20 +368,17 @@ def bulk_resolve_alert_command(client, args):
     )
 
 
-def activities_to_human_readable(activities):
-    activities_readable_outputs = []
-    for activity in activities:
-        readable_output = assign_params(activity_id=activity.get('_id'), severity=activity.get('severity'),
-                                        activity_date=datetime.fromtimestamp(activity.get('timestamp') / 1000.0)
-                                        .isoformat(),
-                                        app_name=activity.get('appName'), description=activity.get('description'))
-        activities_readable_outputs.append(readable_output)
+def activity_to_human_readable(activity: dict):
+    readable_output = assign_params(activity_id=activity.get('_id'), severity=activity.get('severity'),
+                                    activity_date=datetime.fromtimestamp(activity.get('timestamp', 0) / 1000.0)
+                                    .isoformat(),
+                                    app_name=activity.get('appName'), description=activity.get('description'))
     headers = ['activity_id', 'activity_date', 'app_name', 'description', 'severity']
-    human_readable = tableToMarkdown('Microsoft CAS Activities', activities_readable_outputs, headers, removeNull=True)
+    human_readable = tableToMarkdown('Microsoft CAS Activity', readable_output, headers, removeNull=True)
     return human_readable
 
 
-def arrange_entities_data(activities):
+def arrange_entities_data(activities: List[dict]):
     for activity in activities:
         entities_data = []
         if 'entityData' in activity.keys():
@@ -384,7 +392,7 @@ def arrange_entities_data(activities):
     return activities
 
 
-def list_activities_command(client, args):
+def list_activities_command(client: Client, args: dict):
     url_suffix = '/activities/'
     activity_id = args.get('activity_id')
     custom_filter = args.get('custom_filter')
@@ -394,18 +402,10 @@ def list_activities_command(client, args):
     list_activities = activities_response_data.get('data') if activities_response_data.get('data') \
         else [activities_response_data]
     activities = arrange_entities_data(list_activities)
-    ip_indicators = extract_ip_indicators(activities)
-    human_readable = activities_to_human_readable(activities)
-    return CommandResults(
-        readable_output=human_readable,
-        outputs_prefix='MicrosoftCloudAppSecurity.Activities',
-        outputs_key_field='_id',
-        outputs=activities,
-        indicators=ip_indicators,
-    )
+    return create_ip_command_results(activities)
 
 
-def files_to_human_readable(files):
+def files_to_human_readable(files: List[dict]):
     files_readable_outputs = []
     for file in files:
         readable_output = assign_params(owner_name=file.get('ownerName'), file_id=file.get('_id'),
@@ -420,7 +420,7 @@ def files_to_human_readable(files):
     return human_readable
 
 
-def arrange_files_type_access_level_and_status(files):
+def arrange_files_type_access_level_and_status(files: List[dict]):
     """
         This function refines the file to look better.
 
@@ -440,7 +440,7 @@ def arrange_files_type_access_level_and_status(files):
     return files
 
 
-def list_files_command(client, args):
+def list_files_command(client: Client, args: dict):
     url_suffix = '/files/'
     file_id = args.get('file_id')
     custom_filter = args.get('custom_filter')
@@ -458,7 +458,7 @@ def list_files_command(client, args):
     )
 
 
-def users_accounts_to_human_readable(users_accounts):
+def users_accounts_to_human_readable(users_accounts: List[dict]):
     users_accounts_readable_outputs = []
     for entity in users_accounts:
         readable_output = assign_params(display_name=entity.get('displayName'), last_seen=entity.get('lastSeen'),
@@ -472,7 +472,7 @@ def users_accounts_to_human_readable(users_accounts):
     return human_readable
 
 
-def list_users_accounts_command(client, args):
+def list_users_accounts_command(client: Client, args: dict):
     url_suffix = '/entities/'
     custom_filter = args.get('custom_filter')
     arguments = assign_params(**args)
@@ -489,7 +489,7 @@ def list_users_accounts_command(client, args):
     )
 
 
-def calculate_fetch_start_time(last_fetch, first_fetch):
+def calculate_fetch_start_time(last_fetch: Optional[str], first_fetch: Optional[str]):
     if last_fetch is None:
         if not first_fetch:
             first_fetch = '3 days'
@@ -501,7 +501,7 @@ def calculate_fetch_start_time(last_fetch, first_fetch):
         return int(last_fetch)
 
 
-def arrange_alerts_by_incident_type(alerts):
+def arrange_alerts_by_incident_type(alerts: List[dict]):
     for alert in alerts:
         incident_types: Dict[str, Any] = {}
         for entity in alert['entities']:
@@ -513,13 +513,13 @@ def arrange_alerts_by_incident_type(alerts):
     return alerts
 
 
-def is_the_first_alert_is_already_fetched_in_previous_fetch(alerts, last_run):
+def is_the_first_alert_is_already_fetched_in_previous_fetch(alerts: List[dict], last_run: dict):
     last_incident_in_previous_fetch = last_run.get('last_fetch_id')
     alert = alerts[0]
     return alert.get('_id') == last_incident_in_previous_fetch
 
 
-def alerts_to_incidents_and_fetch_start_from(alerts, fetch_start_time, last_run):
+def alerts_to_incidents_and_fetch_start_from(alerts: List[dict], fetch_start_time: str, last_run: dict):
     incidents = []
     current_last_incident_fetched = ''
     if is_the_first_alert_is_already_fetched_in_previous_fetch(alerts, last_run):
@@ -536,15 +536,16 @@ def alerts_to_incidents_and_fetch_start_from(alerts, fetch_start_time, last_run)
         incidents.append(incident)
         if incident_created_time > fetch_start_time:
             fetch_start_time = incident_created_time
-            current_last_incident_fetched = alert.get('_id')
+            current_last_incident_fetched = str(alert.get('_id', ''))
 
     if not current_last_incident_fetched:
-        current_last_incident_fetched = last_run.get('last_fetch_id')
+        current_last_incident_fetched = str(last_run.get('last_fetch_id', ''))
 
     return incidents, fetch_start_time, current_last_incident_fetched
 
 
-def fetch_incidents(client, max_results, last_run, first_fetch, filters):
+def fetch_incidents(client: Client, max_results: Optional[str], last_run: dict, first_fetch: Optional[str],
+                    filters: dict):
     max_results = int(max_results) if max_results else DEFAULT_INCIDENT_TO_FETCH
     last_fetch = last_run.get('last_fetch')
     fetch_start_time = calculate_fetch_start_time(last_fetch, first_fetch)
@@ -558,7 +559,7 @@ def fetch_incidents(client, max_results, last_run, first_fetch, filters):
     return next_run, incidents
 
 
-def params_to_filter(severity, resolution_status):
+def params_to_filter(severity: List[str], resolution_status: str):
     filters: Dict[str, Any] = {}
     if len(severity) == 1:
         filters['severity'] = {'eq': SEVERITY_OPTIONS[severity[0]]}
@@ -603,7 +604,7 @@ def main():
             proxy=proxy)
 
         if demisto.command() == 'test-module':
-            result = test_module(client)
+            result = test_module(client, params.get('isFetch'), params.get('custom_filter'))
             return_results(result)
 
         elif demisto.command() == 'fetch-incidents':

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity_test.py
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity_test.py
@@ -83,11 +83,11 @@ def test_list_activities_command(requests_mock):
                       '97134000_15600_97ee2049-893e-4c9d-a312-08d82b46faf7',
                       json=activities["ACTIVITIES_BY_ID_DATA"])
     res = list_activities_command(client_mocker, {'activity_id': '97134000_15600_97ee2049-893e-4c9d-a312-08d82b46faf7'})
-    assert res.outputs[0] == activities["ACTIVITIES_BY_ID_DATA_CONTEXT"]
-    assert isinstance(res.indicators[0], Common.IP)
-    assert res.indicators[0].ip == '8.8.8.8'
-    assert res.indicators[0].geo_latitude == 32.0679
-    assert res.indicators[0].geo_longitude == 34.7604
+    assert res[0].outputs[0] == activities["ACTIVITIES_BY_ID_DATA_CONTEXT"]
+    assert isinstance(res[0].indicator, Common.IP)
+    assert res[0].indicator.ip == '8.8.8.8'
+    assert res[0].indicator.geo_latitude == 32.0679
+    assert res[0].indicator.geo_longitude == 34.7604
 
 
 def test_list_files_command(requests_mock):

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_9.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Cloud App Security
+- **Breaking Change** microsoft-cas-activities-list command changed to return multiple entries (entry per indicator) instead of a single entry.

--- a/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
+++ b/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Cloud App Security",
     "description": "Microsoft Cloud App Security Integration, a Cloud Access Security Broker that supports various deployment modes",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
epic: https://github.com/demisto/etc/issues/29016

## Description
* Use the new `CommandResults.indicator` parameter.
* Update the command **microsoft-cas-activities-list** to return a different result for each indicator.
* Various linter corrections

## Does it break backward compatibility?
   - [x] Yes
       - Further details: custom scripts that run these commands using `executeCommand` might miss the switch, and handle only the first result.

## Must have
- [x] Tests