### PR TITLE
Bucket Version Assertion Fix

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -964,7 +964,7 @@ class Pack(object):
             latest_release_notes: The latest release notes version string in the current branch
         """
         changelog_latest_release_notes = max(changelog, key=lambda k: LooseVersion(k))
-        assert latest_release_notes >= changelog_latest_release_notes, \
+        assert LooseVersion(latest_release_notes) >= changelog_latest_release_notes, \
             f'{self._pack_name}: Version mismatch detected between production bucket and current branch\n' \
             f'Production bucket version: {changelog_latest_release_notes}\n' \
             f'current branch version: {latest_release_notes}\n' \

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -964,7 +964,7 @@ class Pack(object):
             latest_release_notes: The latest release notes version string in the current branch
         """
         changelog_latest_release_notes = max(changelog, key=lambda k: LooseVersion(k))
-        assert LooseVersion(latest_release_notes) >= changelog_latest_release_notes, \
+        assert LooseVersion(latest_release_notes) >= LooseVersion(changelog_latest_release_notes), \
             f'{self._pack_name}: Version mismatch detected between production bucket and current branch\n' \
             f'Production bucket version: {changelog_latest_release_notes}\n' \
             f'current branch version: {latest_release_notes}\n' \


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/29431 

## Description
Fixes an issue where versions were not wrapped with `LooseVersion` and failed to recognize greater versions correctly.

