### PR TITLE
SentinelOne v2 - deprecated the sentinelone-expire-site command

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -828,7 +828,7 @@ script:
       name: site_id
       required: true
       secret: false
-    deprecated: false
+    deprecated: true
     description: Expires a site.
     execution: false
     name: sentinelone-expire-site

--- a/Packs/SentinelOne/ReleaseNotes/1_0_3.md
+++ b/Packs/SentinelOne/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SentinelOne v2
+- Deprecated the ***sentinelone-expire-site*** command.

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "End point protection",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29885
related: https://github.com/demisto/etc/issues/28233
