### PR TITLE
Health Check | Removed Legacy Summary from layout

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/Layouts/layoutscontainer-Integrations_and_Incidents_Health.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Layouts/layoutscontainer-Integrations_and_Incidents_Health.json
@@ -2,11 +2,6 @@
  "detailsV2": {
   "tabs": [
    {
-    "id": "summary",
-    "name": "Legacy Summary",
-    "type": "summary"
-   },
-   {
     "hidden": false,
     "id": "fnfleysvoq",
     "name": "Integrations Health Check",

--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_1_6.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_1_6.md
@@ -1,0 +1,4 @@
+
+#### Layouts
+##### Integrations and Incidents Health Check
+- Removed "Legacy Summary" tab from layout.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30150

## Description
Removed "Legacy Summary" tab from layout.

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

