### PR TITLE
CrowdStrike Falcon Streaming - store 5 last sample events instead of 20

### DIFF
--- a/Packs/CrowdStrikeFalconStreamingV2/Integrations/CrowdStrikeFalconStreamingV2/CrowdStrikeFalconStreamingV2.py
+++ b/Packs/CrowdStrikeFalconStreamingV2/Integrations/CrowdStrikeFalconStreamingV2/CrowdStrikeFalconStreamingV2.py
@@ -368,7 +368,7 @@ async def long_running_loop(
     """
     try:
         offset_to_store = offset
-        sample_events_to_store = deque(maxlen=20)  # type: ignore[var-annotated]
+        sample_events_to_store = deque(maxlen=5)  # type: ignore[var-annotated]
         async with init_refresh_token(base_url, client_id, client_secret, verify_ssl, proxy) as refresh_token:
             stream.set_refresh_token(refresh_token)
             async for event in stream.fetch_event(
@@ -397,7 +397,7 @@ async def long_running_loop(
                     try:
                         sample_events_to_store.append(event)
                         demisto.debug(f'Storing new {len(sample_events_to_store)} sample events')
-                        sample_events = deque(json.loads(integration_context.get('sample_events', '[]')), maxlen=20)
+                        sample_events = deque(json.loads(integration_context.get('sample_events', '[]')), maxlen=5)
                         sample_events += sample_events_to_store
                         integration_context['sample_events'] = list(sample_events)
                     except Exception as e:

--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike Falcon Streaming v2
+- Modified the integration to store the latest 5 sample events instead of 20.

--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CrowdStrike Falcon Streaming v2
-- Modified the integration to store the latest 5 sample events instead of 20.
+Modified the integration to store the 5 latest sample events (instead of 20).

--- a/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
+++ b/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon Streaming",
     "description": "Use the CrowdStrike Falcon Stream v2 integration to stream detections and audit security events.",
     "support": "xsoar",
-    "currentVersion": "1.0.10",
+    "currentVersion": "1.0.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/30215

## Description
Storing now only the latest 5 events to avoid getting the cache too big

## Does it break backward compatibility?
   - [x] No
