### PR TITLE
CrowdStrike Falcon Streaming v2 - update client headers with auth header and add log prints

### DIFF
--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CrowdStrike Falcon Streaming v2
-- Fixed an issue in which the request to refresh the stream session was not sent properly.
+Fixed an issue in which the request to refresh the stream session was not sent properly.

--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_11.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike Falcon Streaming v2
+- Fixed an issue in which the request to refresh the stream session was not sent properly.

--- a/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
+++ b/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon Streaming",
     "description": "Use the CrowdStrike Falcon Stream v2 integration to stream detections and audit security events.",
     "support": "xsoar",
-    "currentVersion": "1.0.10",
+    "currentVersion": "1.0.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/29363

## Description
- Fixed an issue in which setting the authorization headers overridden the `Content-Type` and `Accept` headers and by that led to the following error:
```
stderr: [Task exception was never retrieved
future: <Task finished name='Task-5' coro=<EventStream._discover_refresh_stream() done, defined at <string>:5263> exception=DemistoException('Error in API call [415] - Unsupported Media Type\n{"meta": {"query_time": 1.26e-07, "powered_by": "crowdstrike-api-gateway", "trace_id": "43297451-38cb-499a-8a57-d1ac9f0b4ed6"}, "errors": [{"code": 415, "message": "415: Unsupported Media Type"}]}', None)>
Traceback (most recent call last):
  File "<string>", line 5279, in _discover_refresh_stream
  File "<string>", line 5231, in refresh_stream_session
  File "<string>", line 4223, in _http_request
DemistoException: Error in API call [415] - Unsupported Media Type
```
which caused the program to get stuck and also did not refresh the stream, which led to it being to terminated every 30 minutes with the following exception:
```
2020-11-07 08:48:02.3944 debug (CrowdStrike Falcon Streaming v2_instance_1_CrowdStrike Falcon Streaming v2_long-running-execution) Failed to fetch event: Response payload is not completed - Going to sleep for 10 seconds and then retry - Traceback (most recent call last):
  File "<string>", line 5343, in fetch_event
  File "/usr/local/lib/python3.8/site-packages/aiohttp/streams.py", line 40, in __anext__
    rv = await self.read_func()
  File "/usr/local/lib/python3.8/site-packages/aiohttp/streams.py", line 339, in readline
    await self._wait("readline")
  File "/usr/local/lib/python3.8/site-packages/aiohttp/streams.py", line 307, in _wait
    await waiter
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed
```
- Added log prints 

## Does it break backward compatibility?
   - [x] No
