### PR TITLE
Increased RAM for server master from 4GB to 6GB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,7 +794,7 @@ jobs:
             - *store_artifacts
   Server Master:
     <<: *container_config
-    resource_class: medium
+    resource_class: medium+
     <<: *environment
     steps:
       - when:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30292

## Description
As seen in [this](https://app.circleci.com/pipelines/github/demisto/content/40934/workflows/b6b58def-07ca-43a8-8d84-87b95a3a16ba/jobs/177071) build example:
It seems like the build process is failing on content installation on nightly on what seems to be exceeding memory limits.

This PR is about increasing the memory quota from 4GB to 6GB.
See [here](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for more info
