### PR TITLE
McAfee-ATD removed from skipped tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3254,7 +3254,6 @@
         "IntSights": "Issue 26742",
         "Traps": "Issue 24122",
         "Fidelis Elevate Network": "Issue 26453",
-        "McAfee Advanced Threat Defense": "Issue 16909",
         "CrowdStrike Falcon X": "Issue 26209",
         "Deep Instinct": "The partner didn't provide an instance",
         "Cofense Triage v2": "No instance - partner integration",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/16909

## Description
removed McAfee ATD from skipped tests

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
