### PR TITLE
autofocus doc: fix formatting (missing new line)

### DIFF
--- a/Packs/AutoFocus/Integrations/FeedAutofocus/README.md
+++ b/Packs/AutoFocus/Integrations/FeedAutofocus/README.md
@@ -107,4 +107,5 @@ To bring the next batch of indicators run:
             type="video/mp4"/>
     Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content/raw/3e9401284a518efa66d9b66bb5c1b5e0e61dbdb5/Packs/FeedAutofocus/Integrations/FeedAutofocus/demo_video/AutoFocus_Feed_demo.mp4 
 </video>
+
 **Note:** The video instructs users to click the **_API** link to get the JSON query of the *Autofocus Samples Search*. An easier option to get the JSON query is available via the **Export Search** button.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Seems that a missing newline was causing formatting issue at the bottom of the page: 

![image](https://user-images.githubusercontent.com/1395797/98582085-20448900-22cb-11eb-955d-f0ce96b816a5.png)

