### PR TITLE
Kenna v2 - Asset Group enhancement

### DIFF
--- a/Packs/Kenna/Integrations/KennaV2/KennaV2.py
+++ b/Packs/Kenna/Integrations/KennaV2/KennaV2.py
@@ -486,7 +486,7 @@ def get_asset_group(client: Client, args: dict) -> Tuple[str, Dict[str, Any], Li
 
     if response:
         context = {
-            'Kenna.AssetGroup':{
+            'Kenna.AssetGroup': {
                 'ID': int(response.get('id')),
                 'Name': str(response.get('name')),
                 'QueryString': str(response.get('querystring')),
@@ -537,12 +537,13 @@ def list_asset_groups(client: Client, args: dict) -> Tuple[str, Dict[str, Any], 
 
     if response:
         wanted_keys = ['ID', 'Name', 'RiskMeterScore', 'AssetCount', 'FixCount']
-        actual_keys = ['id', 'name', 'risk_meter_score', 'asset_count','fix_count']
+        actual_keys = ['id', 'name', 'risk_meter_score', 'asset_count', 'fix_count']
         context_list = parse_response(response, wanted_keys, actual_keys)
         context = {
             'Kenna.AssetGroups(val.ID === obj.ID)': context_list
         }
-        human_readable_markdown = tableToMarkdown('Asset Groups', context_list, headers=['Name','ID','RiskMeterScore', 'AssetCount', 'FixCount'])
+        asset_group_header = ['Name', 'ID', 'RiskMeterScore', 'AssetCount', 'FixCount']
+        human_readable_markdown = tableToMarkdown('Asset Groups', context_list, headers=asset_group_header)
     else:
         human_readable_markdown = "no groups in response."
     return human_readable_markdown, context, response
@@ -578,7 +579,7 @@ def get_top_fixes(client: Client, args: dict) -> Tuple[str, Dict[str, Any], List
             cur_topfix['Fixes'] = []
 
             for fix in topfix.get('fixes'):
-                cur_fix= {}
+                cur_fix = {}
                 cur_fix['ID'] = fix.get('id')
                 cur_fix['Title'] = fix.get('title')
                 cur_fix['Diagnosis'] = fix.get('diagnosis')
@@ -603,20 +604,18 @@ def get_top_fixes(client: Client, args: dict) -> Tuple[str, Dict[str, Any], List
             'Kenna.AssetGroup.TopFixes': context_topfixes
         }
 
-
         # human readable section
         human_readable = []
         human_readable_markdown += 'Group Name: ' + str(asset_group.get('name')) + '\n'
         human_readable_markdown += 'Group ID: ' + str(asset_group.get('id')) + '\n'
         human_readable_markdown += 'Current Risk Meter Score: ' + str(asset_group.get('risk_meter_score')) + '\n'
 
-
         for topfix in topfix_groups:
             fix_titles = ''
             asset_count = ''
             for fix in topfix.get('fixes'):
                 fix_titles += str('* ' + fix.get('title') + '\n')
-                asset_count += str(len(fix.get('assets')))  + '\n'
+                asset_count += str(len(fix.get('assets'))) + '\n'
 
             curr_dict = {
                 'Fix Score Reduction': topfix.get('risk_score_reduction'),
@@ -625,7 +624,8 @@ def get_top_fixes(client: Client, args: dict) -> Tuple[str, Dict[str, Any], List
             }
             human_readable.append(curr_dict)
 
-        human_readable_markdown +=  tableToMarkdown('Top Fixes', human_readable, headers=['Fix Score Reduction','Assets Involved', 'Fixes'])
+        top_fix_header = ['Fix Score Reduction', 'Assets Involved', 'Fixes']
+        human_readable_markdown += tableToMarkdown('Top Fixes', human_readable, headers=top_fix_header)
 
     else:
         human_readable_markdown = "Group not found."

--- a/Packs/Kenna/Integrations/KennaV2/KennaV2.yml
+++ b/Packs/Kenna/Integrations/KennaV2/KennaV2.yml
@@ -502,6 +502,112 @@ script:
     description: Deletes tags from the specified asset.
     execution: false
     name: kenna-delete-tag
+  - name: kenna-get-asset-group
+    arguments:
+    - name: id
+      required: true
+      description: ID of Asset Group to lookup
+    outputs:
+    - contextPath: Kenna.AssetGroup.ID
+      description: The group asset ID.
+      type: number
+    - contextPath: Kenna.AssetGroup.Name
+      description: The name of the group.
+      type: string
+    - contextPath: Kenna.AssetGroup.createdAt
+      description: Date group created
+      type: date
+    - contextPath: Kenna.AssetGroup.UpdatedAt
+      description: Date group updated
+      type: date
+    - contextPath: Kenna.AssetGroup.RiskMeterScore
+      description: Group risk meter score
+      type: number
+    - contextPath: Kenna.AssetGroup.TrueRiskMeterScore
+      description: Group true risk meter
+      type: number
+    - contextPath: Kenna.AssetGroup.AssetCount
+      description: Number of assets in group
+      type: number
+    - contextPath: Kenna.AssetGroup.VulnerabilityCount
+      description: Number of Vulnerabilities across assets in group
+      type: number
+    - contextPath: Kenna.AssetGroup.FixCount
+      description: Number of fixes
+      type: number
+    - contextPath: Kenna.AssetGroup.ActiveInternetBreachesCount
+      description: NUmber of active internet breaches
+      type: number
+    - contextPath: Kenna.AssetGroup.EasilyExploitableCount
+      description: Number of easily exploitable vulnerabilities
+      type: number
+    - contextPath: Kenna.AssetGroup.MalwareExploitableCount
+      description: Number of vulnerabilities exploiable via malware
+      type: number
+    - contextPath: Kenna.AssetGroup.PopularTargetsCount
+      description: Number of popular targets
+      type: number
+    - contextPath: Kenna.AssetGroup.UniqueOpenCVECount
+      description: Number of unique CVEs
+      type: number
+    - contextPath: Kenna.AssetGroup.PredictedExploitableCount
+      description: Predicted number of exploitable
+      type: number
+    description: Gets a asset group details
+  - name: kenna-list-asset-groups
+    arguments: []
+    outputs:
+    - contextPath: Kenna.AssetGroups.ID
+      description: Group ID
+      type: number
+    - contextPath: Kenna.AssetGroups.Name
+      description: Group name
+    - contextPath: Kenna.AssetGroups.RiskMeterScore
+      description: Risk meter score
+    - contextPath: Kenna.AssetGroups.AssetCount
+      description: Asset Count
+    - contextPath: Kenna.AssetGroups.FixCount
+      description: Number of fixes availiable
+    description: Lists the asset groups
+  - name: kenna-get-top-fixes
+    arguments:
+    - name: id
+      required: true
+      description: ID of Asset Group to lookup
+    outputs:
+    - contextPath: Kenna.AssetGroup.TopFixes.FixGroupNumber
+      description: Fix group number
+      type: number
+    - contextPath: Kenna.AssetGroup.TopFixes.RiskScoreReduction
+      description: Risk score reduction
+      type: number
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.ID
+      description: Fix ID
+      type: number
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Title
+      description: Fix title
+      type: string
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Diagnosis
+      description: Fix diagnosis
+      type: string
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Solution
+      description: Fix solution
+      type: string
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Category
+      description: Fix category
+      type: string
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Assets.ID
+      description: Fix asset ID
+      type: string
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Assets.Hostname
+      description: Fix asset hostname
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Consequence
+      description: What happens if an attack exploits this vunerability
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Assets.IP_Address
+      description: IP Address of asset
+    - contextPath: Kenna.AssetGroup.TopFixes.Fix.Assets.Operating_System
+      description: Operating system of asset
+    description: Returns top fixes for an asset group ID
   dockerimage: demisto/python3:3.8.3.9324
   isfetch: false
   longRunning: false

--- a/Packs/Kenna/Integrations/KennaV2/KennaV2.yml
+++ b/Packs/Kenna/Integrations/KennaV2/KennaV2.yml
@@ -608,7 +608,7 @@ script:
     - contextPath: Kenna.AssetGroup.TopFixes.Fix.Assets.Operating_System
       description: Operating system of asset
     description: Returns top fixes for an asset group ID
-  dockerimage: demisto/python3:3.8.3.9324
+  dockerimage: demisto/python3:3.8.6.12176
   isfetch: false
   longRunning: false
   longRunningPort: false

--- a/Packs/Kenna/ReleaseNotes/1_1_0.md
+++ b/Packs/Kenna/ReleaseNotes/1_1_0.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+##### Kenna v2
+- Added commands to retrieve Asset Group related data: 
+    * kenna-get-asset-group - Gets details of a specific asset group
+    * kenna-list-asset-groups - Lists all the possible asset groups and summary information
+    * kenna-get-top-fixes - Shows the most impactful (top) fixes for the specified asset group
+- Upgraded the Docker image to demisto/python3:3.8.6.12176.

--- a/Packs/Kenna/pack_metadata.json
+++ b/Packs/Kenna/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Kenna",
     "description": "Use the Kenna v2 integration to search and update vulnerabilities, schedule a run connector, and manage tags and attributes.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.1.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Implements additional commands to retrieve Asset Group related data from Kenna API:
* kenna-get-asset-group - Gets details of a specific asset group
* kenna-list-asset-groups - Lists all the possible asset groups and summary information
* kenna-get-top-fixes - Shows the most impactful (top) fixes for the specified asset group

## Minimum version of Demisto
- [ ] 5.0.0
- [X] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No