### PR TITLE
Separated the installation step from the playbook tests step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,13 +239,6 @@ references:
             echo "Skipping - not running in contribution instance"
             exit 0
         fi
-        echo "$INSTANCE_ROLE"
-        export TEMP=$(cat ./Tests/filter_envs.json | jq '."$INSTANCE_ROLE"')
-        if [[ "$TEMP" == "false" ]];
-          then
-            echo "Skipping - instance was not setup"
-            exit 0
-        fi
         python3 ./Tests/scripts/destroy_instances.py $CIRCLE_ARTIFACTS ./env_results.json "$INSTANCE_ROLE" "$TIME_TO_LIVE"
 
         export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
@@ -729,34 +722,52 @@ jobs:
             - *add_ssh_keys
             - *prepare_environment
             - run:
+                name: Collect Instance Role And Check If Instance Was Created
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto GA"')
+                  echo "Demisto GA filter=$TEMP"
+                  if [[ "$TEMP" == "true" ]];
+                    then
+                      echo 'export INSTANCE_WAS_CREATED="True"' >> $BASH_ENV
+                      exit 0
+                  fi
+                  source $BASH_ENV
+            - run:
                 name: Wait until server ready
                 shell: /bin/bash
                 when: always
                 command: |
-                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto GA"
+                  python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
+            - run:
+                name: Install Content And Configure Integrations On Server
+                shell: /bin/bash
+                when: always
+                command: |
+                  if [ -z $INSTANCE_WAS_CREATED ];
+                    then
+                      echo "Skipping - instance was not created"
+                      exit 0
+                  fi
+                  ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
             - run:
                 name: Run Tests - Server 5.0
                 shell: /bin/bash
                 when: always
                 command: |
-                  echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
-                  source $BASH_ENV
-                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto GA"')
-                  echo "Demisto GA filter=$TEMP"
-                  if [[ "$TEMP" == "false" ]];
+                  if [ -z $INSTANCE_WAS_CREATED ];
                     then
-                      echo "Skipping - Instance was not setup"
+                      echo "Skipping - instance was not created"
                       exit 0
                   fi
                   if ./Tests/scripts/is_ami.sh ;
                     then
-                      echo 'export INSTANCE_ROLE="Demisto GA"' >> $BASH_ENV
+                      ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
                     else
                       echo "Not AMI run, can't run on this version"
                       exit 0
                   fi
-                  ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-
             - *destroy_instances
             - *store_artifacts
   Server 5_5:
@@ -791,33 +802,49 @@ jobs:
             - *add_ssh_keys
             - *prepare_environment
             - run:
+                name: Collect Instance Role And Check If Instance Was Created
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto PreGA"' >> $BASH_ENV
+                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto PreGA"')
+                  echo "Demisto PreGA filter=$TEMP"
+                  if [[ "$TEMP" == "true" ]];
+                    then
+                      echo 'export INSTANCE_WAS_CREATED="True"' >> $BASH_ENV
+                      exit 0
+                  fi
+                  source $BASH_ENV
+            - run:
                 name: Wait until server ready
                 shell: /bin/bash
                 when: always
                 command: |
-                  python3 ./Tests/scripts/wait_until_server_ready.py "Demisto PreGA"
+                  python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
+            - run:
+                name: Install Content And Configure Integrations On Server
+                shell: /bin/bash
+                when: always
+                command: |
+                  if [ -z $INSTANCE_WAS_CREATED ];
+                    then
+                      echo "Skipping - instance was not created"
+                      exit 0
+                  fi
+                  ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
             - run:
                 name: Run Tests - 5.5
                 shell: /bin/bash
                 when: always
                 command: |
-                  echo 'export INSTANCE_ROLE="Demisto PreGA"' >> $BASH_ENV
-                  source $BASH_ENV
-                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto PreGA"')
-                  echo "Demisto PreGA filter=$TEMP"
-                  if [[ "$TEMP" == "false" ]];
+                  if [ -z $INSTANCE_WAS_CREATED ];
                     then
-                      echo "Skipping - instance was not setup"
+                      echo "Skipping - instance was not created"
                       exit 0
                   fi
                   if ./Tests/scripts/is_ami.sh ;
                     then
                       ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
-                      export RETVAL=$?
-                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
-                      exit $RETVAL
-
-                  else
+                    else
                       echo "Not AMI run, can't run on this version"
                       exit 0
                   fi
@@ -855,39 +882,35 @@ jobs:
             - *add_ssh_keys
             - *prepare_environment
             - run:
+                name: Collect Instance Role
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto 6.0"' >> $BASH_ENV
+                  source $BASH_ENV
+            - run:
                 name: Wait until server ready
                 shell: /bin/bash
                 when: always
                 command: |
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      python3 ./Tests/scripts/wait_until_server_ready.py "Demisto 6.0"
-                  else
-                      python3 ./Tests/scripts/wait_until_server_ready.py "Demisto"
-                  fi
+                  python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
+            - run:
+                name: Install Content And Configure Integrations On Server
+                shell: /bin/bash
+                when: always
+                command: |
+                  ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
             - run:
                 name: Run Tests - Demisto 6.0
                 shell: /bin/bash
                 when: always
                 no_output_timeout: 5h
                 command: |
-                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto 6.0"')
-                  echo "Demisto 6.0 filter=$TEMP"
-                  if [[ "$TEMP" == "false" ]];
-                    then
-                      echo "Skipping - instance was not setup"
-                      exit 0
-                  fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      echo 'export INSTANCE_ROLE="Demisto 6.0"' >> $BASH_ENV
-                  else
-                    echo 'export INSTANCE_ROLE="master"' >> $BASH_ENV
-                  fi
-                  source $BASH_ENV
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
                   export RETVAL=$?
-                  cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                  if [ -f ./Tests/failed_tests.txt ];
+                    then
+                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                  fi
                   exit $RETVAL
             - run:
                 name: Upload Packs To Marketplace Storage
@@ -941,39 +964,35 @@ jobs:
             - *add_ssh_keys
             - *prepare_environment
             - run:
+                name: Collect Instance Role
+                when: always
+                command: |
+                  echo 'export INSTANCE_ROLE="Demisto Marketplace"' >> $BASH_ENV
+                  source $BASH_ENV
+            - run:
                 name: Wait until server ready
                 shell: /bin/bash
                 when: always
                 command: |
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      python3 ./Tests/scripts/wait_until_server_ready.py "Demisto Marketplace"
-                  else
-                      python3 ./Tests/scripts/wait_until_server_ready.py "master"
-                  fi
+                  python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
+            - run:
+                name: Install Content And Configure Integrations On Server
+                shell: /bin/bash
+                when: always
+                command: |
+                  ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
             - run:
                 name: Run Tests - Demisto Master
                 shell: /bin/bash
                 when: always
                 no_output_timeout: 5h
                 command: |
-                  export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto Marketplace"')
-                  echo "Demisto Marketplace filter=$TEMP"
-                  if [[ "$TEMP" == "false" ]];
-                    then
-                      echo "Skipping - instance was not setup"
-                      exit 0
-                  fi
-                  if ./Tests/scripts/is_ami.sh ;
-                    then
-                      echo 'export INSTANCE_ROLE="Demisto Marketplace"' >> $BASH_ENV
-                  else
-                    echo 'export INSTANCE_ROLE="master"' >> $BASH_ENV
-                  fi
-                  source $BASH_ENV
                   ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
                   export RETVAL=$?
-                  cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                  if [ -f ./Tests/failed_tests.txt ];
+                    then
+                      cp ./Tests/failed_tests.txt $CIRCLE_ARTIFACTS/failed_tests.txt
+                  fi
                   exit $RETVAL
             - run:
                 name: Slack Notifier
@@ -1040,7 +1059,7 @@ jobs:
                   SOURCE_TESTING_PATH="dev/content/packs"
 
                   python3 ./Tests/Marketplace/copy_and_upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -pb "$GCS_MARKET_TESTING_BUCKET" -bb "$GCS_BUILD_BUCKET" -s $GCS_PATH -n $CREATE_INSTANCES_JOB_NUMBER -c $CIRCLE_BRANCH -o false -pbp "$SOURCE_TESTING_PATH"
-                  rm $GCS_PATH 
+                  rm $GCS_PATH
       - run:
           name: Slack Notifier
           shell: /bin/bash
@@ -1190,13 +1209,6 @@ jobs:
           when: always
           no_output_timeout: 5h
           command: |
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto 6.0"')
-            echo "Demisto 6.0 filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
             echo 'export INSTANCE_ROLE="Demisto 6.0"' >> $BASH_ENV
             source $BASH_ENV
             ./Tests/Marketplace/install_packs.sh "$INSTANCE_ROLE"
@@ -1226,13 +1238,6 @@ jobs:
           when: always
           no_output_timeout: 5h
           command: |
-            export TEMP=$(cat ./Tests/filter_envs.json | jq '."Demisto Marketplace"')
-            echo "Demisto Marketplace filter=$TEMP"
-            if [[ "$TEMP" == "false" ]];
-              then
-                echo "Skipping - instance was not setup"
-                exit 0
-            fi
             echo 'export INSTANCE_ROLE="Demisto Marketplace"' >> $BASH_ENV
             source $BASH_ENV
             ./Tests/Marketplace/install_packs.sh "$INSTANCE_ROLE"

--- a/Tests/scripts/install_content_and_test_integrations.sh
+++ b/Tests/scripts/install_content_and_test_integrations.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# exit on errors
+set -e
+
+SECRET_CONF_PATH=$(cat secret_conf_path)
+CONF_PATH="./Tests/conf.json"
+
+[ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
+
+PREVIOUS_JOB_NUMBER=`cat create_instances_build_num.txt`
+
+python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$PREVIOUS_JOB_NUMBER"
+if [ -f ./Tests/test_pack.zip ]; then
+  cp ./Tests/test_pack.zip $CIRCLE_ARTIFACTS
+fi

--- a/Tests/scripts/run_tests.sh
+++ b/Tests/scripts/run_tests.sh
@@ -1,27 +1,13 @@
 #!/usr/bin/env bash
 
-echo "start content tests"
-
 SECRET_CONF_PATH=$(cat secret_conf_path)
 CONF_PATH="./Tests/conf.json"
-DEMISTO_API_KEY=$(cat $SECRET_CONF_PATH | jq '.temp_apikey')
-
-temp="${DEMISTO_API_KEY%\"}"
-temp="${temp#\"}"
-DEMISTO_API_KEY=$temp
 
 [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
 [ -n "${MEM_CHECK}" ] && MEM_CHECK=true || MEM_CHECK=false
+[ -z "${NON_AMI_RUN}" ] && IS_AMI_RUN=true || IS_AMI_RUN=false
 
-code_1=0
-code_2=0
-
-echo "starting configure_and_test_integration_instances"
 PREVIOUS_JOB_NUMBER=`cat create_instances_build_num.txt`
-
-python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$PREVIOUS_JOB_NUMBER"
-code_1=$?
-cp ./Tests/test_pack.zip $CIRCLE_ARTIFACTS
 
 echo 'export GOOGLE_APPLICATION_CREDENTIALS="creds.json"' >> $BASH_ENV
 source $BASH_ENV
@@ -29,25 +15,15 @@ cat <<EOF > "$GOOGLE_APPLICATION_CREDENTIALS"
 $GCS_ARTIFACTS_KEY
 EOF
 
-if [ $code_1 -ne 1 ] ; then
-  if [ -n "${NON_AMI_RUN}" ]; then
-    # non AMI
-    python3 ./Tests/test_content.py -k "$DEMISTO_API_KEY" -c "$CONF_PATH" -e "$SECRET_CONF_PATH" -n $IS_NIGHTLY -t "$SLACK_TOKEN" -a "$CIRCLECI_TOKEN" -b "$CIRCLE_BUILD_NUM" -g "$CIRCLE_BRANCH" -m "$MEM_CHECK" -d "$1"
-  else
-    # AMI
-    python3 ./Tests/test_content.py -k "$DEMISTO_API_KEY" -c "$CONF_PATH" -e "$SECRET_CONF_PATH" -n $IS_NIGHTLY -t "$SLACK_TOKEN" -a "$CIRCLECI_TOKEN" -b "$CIRCLE_BUILD_NUM" -g "$CIRCLE_BRANCH" -m "$MEM_CHECK" --isAMI true -d "$1"
-  fi
-fi
+python3 ./Tests/test_content.py -k "$DEMISTO_API_KEY" -c "$CONF_PATH" -e "$SECRET_CONF_PATH" -n $IS_NIGHTLY -t "$SLACK_TOKEN" -a "$CIRCLECI_TOKEN" -b "$CIRCLE_BUILD_NUM" -g "$CIRCLE_BRANCH" -m "$MEM_CHECK" --isAMI $IS_AMI_RUN -d "$1"
 
-code_2=$?
+RETVAL=$?
+rm $GOOGLE_APPLICATION_CREDENTIALS
 
-if [ $code_1 -eq 0 ] && [ $code_2 -eq 0 ] ; then
-  role="$(echo -e "${INSTANCE_ROLE}" | tr -d '[:space:]')"
+if [ $RETVAL -eq 0 ]; then
+  role="$(echo -e "$1" | tr -d '[:space:]')"
   filepath="./Tests/is_build_passed_${role}.txt"
   touch "$filepath"
 fi
 
-let "exit_code = $code_1 + $code_2"
-rm $GOOGLE_APPLICATION_CREDENTIALS
-
-exit $exit_code
+exit $RETVAL


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29259

## Description
* For each server job added a step that collects the instance role and checks if the instance was created. This step passes that information on to next steps with environment variables.
* Separated the installation step from the playbook tests step

## A nightly build with those changes: 
https://app.circleci.com/pipelines/github/demisto/content/42321/workflows/201b6c89-e501-433e-90e8-35bf3cf873cb
