### PR TITLE
SetGridField - return empty table instead of error

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_2_79.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_2_79.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### SetGridField
+- Fixed an issue where the script failed when the grid did not exist in context when initiated.

--- a/Packs/CommonScripts/ReleaseNotes/1_2_79.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_2_79.md
@@ -2,3 +2,4 @@
 #### Scripts
 ##### SetGridField
 - Fixed an issue where the script failed when the grid did not exist in context when initiated.
+- Upgraded the Docker image to demisto/pandas:1.0.0.13433.

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -111,6 +111,7 @@ def get_current_table(grid_id: str) -> List[Dict[Any, Any]]:
     """
     current_table: Optional[List[dict]] = demisto.incidents()[0].get("CustomFields", {}).get(grid_id)
     if current_table is None:
+        demisto.info('SetGridField - Did not find existing table, creating a new one.')
         return pd.DataFrame()
 
     return pd.DataFrame(current_table)

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -111,10 +111,7 @@ def get_current_table(grid_id: str) -> List[Dict[Any, Any]]:
     """
     current_table: Optional[List[dict]] = demisto.incidents()[0].get("CustomFields", {}).get(grid_id)
     if current_table is None:
-        raise ValueError(f"The following grid id was not found: {grid_id}. Please make sure you "
-                         "entered the \"Machine name\" as it appears in the incident field editor in Settings->Advanced"
-                         "->Fields (Incident). Also make sure that this value appears in the incident Context Data "
-                         "under incident - if not then please consult with support.")
+        return pd.DataFrame()
 
     return pd.DataFrame(current_table)
 

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
@@ -63,5 +63,5 @@ subtype: python3
 system: false
 timeout: '0'
 type: python
-dockerimage: demisto/pandas:1.0.0.12410
+dockerimage: demisto/pandas:1.0.0.13433
 fromversion: 5.0.0

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -97,4 +97,4 @@ def test_grid_dont_exist_in_context(mocker):
     import SetGridField
     mocker.patch.object(demisto, 'incidents', return_value=[{}])
 
-    assert SetGridField.get_current_table('some_id') == []
+    assert SetGridField.get_current_table('some_id').empty

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -94,6 +94,16 @@ def test_build_grid_command(datadir, mocker, keys: List[str], columns: List[str]
 
 
 def test_grid_dont_exist_in_context(mocker):
+    """
+    Given:
+     - grid_id to update, which doesn't exist in context.
+
+    When:
+     - Updating a grid.
+
+    Then:
+     - Return an empty table instead of an error.
+    """
     import SetGridField
     mocker.patch.object(demisto, 'incidents', return_value=[{}])
 

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -95,6 +95,6 @@ def test_build_grid_command(datadir, mocker, keys: List[str], columns: List[str]
 
 def test_grid_dont_exist_in_context(mocker):
     import SetGridField
-    mocker.patch.object(demisto, 'incidents', return_value=[])
+    mocker.patch.object(demisto, 'incidents', return_value=[{}])
 
     assert SetGridField.get_current_table('some_id') == []

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -1,5 +1,6 @@
 import pytest
 from typing import List
+import demistomock as demisto
 
 
 @pytest.mark.parametrize(argnames="phrase, norm_phrase",
@@ -90,3 +91,10 @@ def test_build_grid_command(datadir, mocker, keys: List[str], columns: List[str]
                                               unpack_nested_elements=unpack_nested_elements)
     expected_results = json.load(open(datadir[expected_results_path]))
     assert json.dumps(results) == json.dumps(expected_results)
+
+
+def test_grid_dont_exist_in_context(mocker):
+    import SetGridField
+    mocker.patch.object(demisto, 'incidents', return_value=[])
+
+    assert SetGridField.get_current_table('some_id') == []

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.78",
+    "currentVersion": "1.2.79",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30495

## Description
Return an empty table instead of an error.


@michalgold @David-BMS @idovandijk @altmannyarden @michalgold 
Attaching the unified script for testing - please review it as soon as possible.
[script-SetGridField.yml.zip](https://github.com/demisto/content/files/5526979/script-SetGridField.yml.zip)
