### PR TITLE
Add ability to set Duo user status and query Duo admin name

### DIFF
--- a/Packs/DuoAdminApi/Integrations/DuoAdminApi/DuoAdminApi.py
+++ b/Packs/DuoAdminApi/Integrations/DuoAdminApi/DuoAdminApi.py
@@ -330,6 +330,27 @@ def delete_u2f_token(token_id):
     demisto.results('Token with ID ' + token_id + ' deleted successfully')
 
 
+def set_user_status(username, status):
+    result = admin_api.get_users_by_name(username)
+    user_id = result[0]["user_id"]
+    res = admin_api.update_user(user_id, status=status)
+    demisto.results('User ' + username + 'was set to status ' + status)
+
+
+def get_duo_admin_by_name(name):
+    duo_administrators = admin_api.get_admins()
+    duo_administrator = next((admin for admin in duo_administrators if admin['name'] == name), None)
+
+    entry = get_entry_for_object(
+        'Information about admin ' + name, duo_administrator, duo_administrator,
+        {
+            'DuoAdmin.AdminDetail(val.name && val.name==obj.name)':
+                {'details': duo_administrator}
+        }
+    )
+    demisto.results(entry)
+
+
 # Execution
 try:
     admin_api = create_api_call()
@@ -361,6 +382,12 @@ try:
 
     if demisto.command() == 'duoadmin-delete-u2f-token':
         delete_u2f_token(demisto.getArg('token_id'))
+
+    if demisto.command() == 'duoadmin-set-user-status':
+        set_user_status(demisto.getArg('username'), demisto.getArg('status'))
+
+    if demisto.command() == 'duoadmin-get-admin-by-name':
+        get_duo_admin_by_name(demisto.getArg('name'))
 
 except Exception as e:
     demisto.error("Duo Admin failed on: {} on this command {}".format(e, demisto.command))

--- a/Packs/DuoAdminApi/Integrations/DuoAdminApi/DuoAdminApi.yml
+++ b/Packs/DuoAdminApi/Integrations/DuoAdminApi/DuoAdminApi.yml
@@ -231,6 +231,27 @@ script:
     description: Associates a device to a user
     execution: false
     name: duoadmin-associate-device-to-user
+  - name: duoadmin-set-user-status
+    arguments:
+    - name: username
+      required: true
+    - name: status
+      required: true
+      default: true
+      auto: PREDEFINED
+      predefined:
+      - active
+      - disabled
+      - bypass
+      defaultValue: active
+    execution: true
+  - name: duoadmin-get-admin-by-name
+    arguments:
+    - name: name
+      required: true
+      description: The name field of the administrator
+    outputs:
+    - contextPath: DuoAdmin.AdminDetail.details
   dockerimage: demisto/duoadmin:1.0.0.11989
   isfetch: false
   longRunning: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
There are several features in the Duo Admin API that are not supported by this integration.
This pull requests adds support for modifying a Duo user's status (e.g. active, disabled, or bypass) and 
also allows querying for a Duo admins information from their name (which is the field returned in several logs types)

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [X] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
