### PR TITLE
Added logs for content installation

### DIFF
--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import logging
 import os
 import ast
 import json
@@ -7,13 +8,11 @@ import glob
 import re
 import sys
 import demisto_client
-from demisto_client.demisto_api.rest import ApiException
 from threading import Thread, Lock
-from demisto_sdk.commands.common.tools import print_color, LOG_COLORS, run_threads_list, print_error
+from demisto_sdk.commands.common.tools import run_threads_list
 from typing import List
 
 from Tests.Marketplace.marketplace_services import PACKS_FULL_PATH, IGNORED_FILES
-from Tests.test_content import ParallelPrintsManager
 
 PACK_METADATA_FILE = 'pack_metadata.json'
 SUCCESS_FLAG = True
@@ -64,21 +63,18 @@ def create_dependencies_data_structure(response_data: dict, dependants_ids: list
         create_dependencies_data_structure(response_data, next_call_dependants_ids, dependencies_data, checked_packs)
 
 
-def get_pack_dependencies(client: demisto_client, prints_manager: ParallelPrintsManager, pack_data: dict,
-                          thread_index: int, lock: Lock):
+def get_pack_dependencies(client: demisto_client, pack_data: dict, lock: Lock):
     """ Get the pack's required dependencies.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): A prints manager object.
         pack_data (dict): Contains the pack ID and version.
-        thread_index (int): the thread index.
         lock (Lock): A lock object.
     Returns:
         (list) The pack's dependencies.
     """
     pack_id = pack_data['id']
-
+    logging.debug(f'Getting dependencies for pack {pack_id}')
     try:
         response_data, status_code, _ = demisto_client.generic_request_func(
             client,
@@ -96,24 +92,17 @@ def get_pack_dependencies(client: demisto_client, prints_manager: ParallelPrints
             create_dependencies_data_structure(reseponse_data, dependants_ids, dependencies_data, dependants_ids)
             dependencies_str = ', '.join([dep['id'] for dep in dependencies_data])
             if dependencies_data:
-                message = 'Found the following dependencies for pack {}:\n{}\n'.format(pack_id, dependencies_str)
-                prints_manager.add_print_job(message, print_color, thread_index, LOG_COLORS.GREEN)
-                prints_manager.execute_thread_prints(thread_index)
+                logging.debug(f'Found the following dependencies for pack {pack_id}: {dependencies_str}')
             return dependencies_data
         if status_code == 400:
-            err_msg = f"Unable to find dependencies for {pack_id}."
-            prints_manager.add_print_job(err_msg, print_color, thread_index, LOG_COLORS.RED)
-            prints_manager.execute_thread_prints(thread_index)
+            logging.error(f'Unable to find dependencies for {pack_id}.')
             return []
         else:
             result_object = ast.literal_eval(response_data)
             msg = result_object.get('message', '')
-            err_msg = 'Failed to get pack {} dependencies - with status code {}\n{}\n'.format(pack_id, status_code, msg)
-            raise Exception(err_msg)
-    except Exception as e:
-        err_msg = 'The request to get pack {} dependencies has failed. Reason:\n{}\n'.format(pack_id, str(e))
-        prints_manager.add_print_job(err_msg, print_color, thread_index, LOG_COLORS.RED)
-        prints_manager.execute_thread_prints(thread_index)
+            raise Exception(f'Failed to get pack {pack_id} dependencies - with status code {status_code}\n{msg}\n')
+    except Exception:
+        logging.exception(f'The request to get pack {pack_id} dependencies has failed.')
 
         lock.acquire()
         global SUCCESS_FLAG
@@ -121,16 +110,16 @@ def get_pack_dependencies(client: demisto_client, prints_manager: ParallelPrints
         lock.release()
 
 
-def search_pack(client: demisto_client, prints_manager: ParallelPrintsManager, pack_display_name: str, pack_id: str,
-                thread_index: int, lock: Lock) -> dict:
+def search_pack(client: demisto_client,
+                pack_display_name: str,
+                pack_id: str,
+                lock: Lock) -> dict:
     """ Make a pack search request.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object.
         pack_display_name (string): The pack display name.
         pack_id (string): The pack ID.
-        thread_index (int): the thread index.
         lock (Lock): A lock object.
     Returns:
         (dict): Returns the pack data if found, or empty dict otherwise.
@@ -148,9 +137,7 @@ def search_pack(client: demisto_client, prints_manager: ParallelPrintsManager, p
             result_object = ast.literal_eval(response_data)
 
             if result_object and result_object.get('currentVersion'):
-                print_msg = f'Found pack "{pack_display_name}" by its ID "{pack_id}" in bucket!\n'
-                prints_manager.add_print_job(print_msg, print_color, thread_index, LOG_COLORS.GREEN)
-                prints_manager.execute_thread_prints(thread_index)
+                logging.debug(f'Found pack "{pack_display_name}" by its ID "{pack_id}" in bucket!')
 
                 pack_data = {
                     'id': result_object.get('id'),
@@ -159,19 +146,15 @@ def search_pack(client: demisto_client, prints_manager: ParallelPrintsManager, p
                 return pack_data
 
             else:
-                print_msg = f'Did not find pack "{pack_display_name}" by its ID "{pack_id}" in bucket.\n'
-                prints_manager.add_print_job(print_msg, print_color, thread_index, LOG_COLORS.RED)
-                prints_manager.execute_thread_prints(thread_index)
-                raise Exception(print_msg)
+                raise Exception(f'Did not find pack "{pack_display_name}" by its ID "{pack_id}" in bucket.')
         else:
             result_object = ast.literal_eval(response_data)
             msg = result_object.get('message', '')
             err_msg = f'Search request for pack "{pack_display_name}" with ID "{pack_id}", failed with status code ' \
                       f'{status_code}\n{msg}'
             raise Exception(err_msg)
-    except Exception as e:
-        err_msg = f'Search request for pack "{pack_display_name}" with ID "{pack_id}", failed. Reason:\n{str(e)}'
-        prints_manager.add_print_job(err_msg, print_color, thread_index, LOG_COLORS.RED)
+    except Exception:
+        logging.exception(f'Search request for pack "{pack_display_name}" with ID "{pack_id}", failed.')
 
         lock.acquire()
         global SUCCESS_FLAG
@@ -196,8 +179,10 @@ def find_malformed_pack_id(error_message: str) -> List:
         raise Exception(f'The request to install packs has failed. Reason: {str(error_message)}')
 
 
-def install_nightly_packs(client: demisto_client, host: str, prints_manager: ParallelPrintsManager, thread_index: int,
-                          packs_to_install: List, request_timeout: int = 999999):
+def install_nightly_packs(client: demisto_client,
+                          host: str,
+                          packs_to_install: List,
+                          request_timeout: int = 999999):
     """
     Install content packs on nightly build.
     We will catch the exception if pack fails to install and send the request to install packs again without the
@@ -205,8 +190,6 @@ def install_nightly_packs(client: demisto_client, host: str, prints_manager: Par
     Args:
         client(demisto_client): The configured client to use.
         host (str): The server URL.
-        prints_manager (ParallelPrintsManager): Print manager object.
-        thread_index (int): the thread index.
         packs_to_install (list): A list of the packs to install.
         request_timeout (int): Timeout settings for the installation request.
 
@@ -214,9 +197,8 @@ def install_nightly_packs(client: demisto_client, host: str, prints_manager: Par
         None: No data returned.
     """
     packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
-    message = 'Installing the following packs in server {}:\n{}'.format(host, packs_to_install_str)
-    prints_manager.add_print_job(message, print_color, thread_index, LOG_COLORS.GREEN, include_timestamp=True)
-    prints_manager.execute_thread_prints(thread_index)
+    logging.info(f'Installing packs on server {host}')
+    logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
     # make the pack installation request
     all_packs_install_successfully = False
     request_data = {
@@ -235,24 +217,20 @@ def install_nightly_packs(client: demisto_client, host: str, prints_manager: Par
             if 200 <= status_code < 300:
                 packs_data = [{'ID': pack.get('id'), 'CurrentVersion': pack.get('currentVersion')} for pack in
                               ast.literal_eval(response_data)]
-                packs_message = f'The following packs were successfully installed:\n{packs_data}'
-                prints_manager.add_print_job(packs_message, print_color, thread_index, LOG_COLORS.GREEN,
-                                             include_timestamp=True)
+                logging.debug(f'The following packs were successfully installed on server {host}:\n{packs_data}')
             else:
                 result_object = ast.literal_eval(response_data)
                 message = result_object.get('message', '')
-                err_msg = f'Failed to install packs - with status code {status_code}\n{message}\n'
-                prints_manager.add_print_job(err_msg, print_error, thread_index, include_timestamp=True)
-                raise Exception(err_msg)
+                raise Exception(f'Failed to install packs - with status code {status_code}\n{message}\n')
             break
 
         except Exception as e:
-            err_msg = f'The request to install packs has failed. Reason:\n{str(e)}\n'
-            prints_manager.add_print_job(err_msg, print_error, thread_index, include_timestamp=True)
             all_packs_install_successfully = False
             malformed_pack_id = find_malformed_pack_id(str(e))
             if not malformed_pack_id:
+                logging.exception('The request to install packs has failed')
                 break
+            logging.warning(f'The request to install packs has failed, retrying without {malformed_pack_id}')
             # Remove the malformed pack from the pack to install list.
             packs = [pack for pack in packs_to_install if pack['id'] not in malformed_pack_id]
             request_data = {
@@ -260,82 +238,70 @@ def install_nightly_packs(client: demisto_client, host: str, prints_manager: Par
                 'ignoreWarnings': True
             }
 
-        finally:
-            prints_manager.execute_thread_prints(thread_index)
 
-
-def install_packs_from_artifacts(client: demisto_client, host: str, prints_manager: ParallelPrintsManager,
-                                 thread_index: int, test_pack_path: str, pack_ids_to_install: List):
+def install_packs_from_artifacts(client: demisto_client, host: str, test_pack_path: str, pack_ids_to_install: List):
     """
     Installs all the packs located in the artifacts folder of the BitHub actions build. Please note:
     The server always returns a 200 status even if the pack was not installed.
 
     :param client: Demisto-py client to connect to the server.
     :param host: FQDN of the server.
-    :param prints_manager: ParallelPrintsManager - Will be deprecated.
-    :param thread_index: Integer indicating which thread the test is running on.
     :param test_pack_path: Path the the test pack directory.
     :param pack_ids_to_install: List of pack IDs to install.
     :return: None. Call to server waits until a successful response.
     """
-    print(f"Test pack path is: {test_pack_path}")
-    print(f"Pack IDs to install are: {pack_ids_to_install}")
+    logging.info(f"Test pack path is: {test_pack_path}")
+    logging.info(f"Pack IDs to install are: {pack_ids_to_install}")
     local_packs = glob.glob(f"{test_pack_path}/*.zip")
     for local_pack in local_packs:
         if any(pack_id in local_pack for pack_id in pack_ids_to_install):
-            packs_install_msg = f'Installing the following pack: {local_pack}'
-            prints_manager.add_print_job(packs_install_msg, print_color, thread_index,
-                                         LOG_COLORS.GREEN,
-                                         include_timestamp=True)
-            upload_zipped_packs(client=client, host=host, prints_manager=prints_manager,
-                                thread_index=thread_index, pack_path=local_pack)
+            logging.info(f'Installing the following pack: {local_pack}')
+            upload_zipped_packs(client=client, host=host, pack_path=local_pack)
 
 
-def install_packs_private(client: demisto_client, host: str,
-                          prints_manager: ParallelPrintsManager, thread_index: int,
-                          pack_ids_to_install: List, test_pack_path: str):
+def install_packs_private(client: demisto_client,
+                          host: str,
+                          pack_ids_to_install: List,
+                          test_pack_path: str):
     """ Make a packs installation request.
 
     Args:
         client (demisto_client): The configured client to use.
         host (str): The server URL.
-        prints_manager (ParallelPrintsManager): Print manager object.
-        thread_index (int): the thread index.
         pack_ids_to_install (list): List of Pack IDs to install.
         test_pack_path (str): Path where test packs are located.
     """
-    install_packs_from_artifacts(client, host, prints_manager, thread_index,
+    install_packs_from_artifacts(client,
+                                 host,
                                  pack_ids_to_install=pack_ids_to_install,
                                  test_pack_path=test_pack_path)
 
 
-def install_packs(client: demisto_client, host: str, prints_manager: ParallelPrintsManager,
-                  thread_index: int, packs_to_install: list, request_timeout: int = 999999,
+def install_packs(client: demisto_client,
+                  host: str,
+                  packs_to_install: list,
+                  request_timeout: int = 999999,
                   is_nightly: bool = False):
     """ Make a packs installation request.
 
     Args:
         client (demisto_client): The configured client to use.
         host (str): The server URL.
-        prints_manager (ParallelPrintsManager): Print manager object.
-        thread_index (int): the thread index.
         packs_to_install (list): A list of the packs to install.
         request_timeout (int): Timeout settings for the installation request.
         is_nightly (bool): Is the build nightly or not.
     """
     if is_nightly:
-        install_nightly_packs(client, host, prints_manager, thread_index, packs_to_install)
+        install_nightly_packs(client, host, packs_to_install)
         return
     request_data = {
         'packs': packs_to_install,
         'ignoreWarnings': True
     }
 
+    logging.info(f'Installing packs to server {host}')
     packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
-    message = 'Installing the following packs in server {}:\n{}'.format(host, packs_to_install_str)
-    prints_manager.add_print_job(message, print_color, thread_index, LOG_COLORS.GREEN,
-                                 include_timestamp=True)
-    prints_manager.execute_thread_prints(thread_index)
+    logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
 
     # make the pack installation request
     try:
@@ -350,45 +316,37 @@ def install_packs(client: demisto_client, host: str, prints_manager: ParallelPri
             packs_data = [{'ID': pack.get('id'), 'CurrentVersion': pack.get('currentVersion')} for
                           pack in
                           ast.literal_eval(response_data)]
-            packs_message = f'The following packs were successfully installed:\n{packs_data}'
-            prints_manager.add_print_job(packs_message, print_color, thread_index, LOG_COLORS.GREEN,
-                                         include_timestamp=True)
+            logging.debug(f'The following packs were successfully installed on server {host}:\n{packs_data}')
         else:
             result_object = ast.literal_eval(response_data)
             message = result_object.get('message', '')
-            err_msg = f'Failed to install packs - with status code {status_code}\n{message}\n'
-            prints_manager.add_print_job(err_msg, print_error, thread_index, include_timestamp=True)
-            raise Exception(err_msg)
-    except Exception as e:
-        err_msg = f'The request to install packs has failed. Reason:\n{str(e)}\n'
-        prints_manager.add_print_job(err_msg, print_error, thread_index, include_timestamp=True)
-
+            raise Exception(f'Failed to install packs - with status code {status_code}\n{message}')
+    except Exception:
+        logging.exception('The request to install packs has failed.')
         global SUCCESS_FLAG
         SUCCESS_FLAG = False
-    finally:
-        prints_manager.execute_thread_prints(thread_index)
 
 
-def search_pack_and_its_dependencies(client: demisto_client, prints_manager: ParallelPrintsManager,
-                                     pack_id: str, packs_to_install: list, installation_request_body: list,
-                                     thread_index: int, lock: Lock):
+def search_pack_and_its_dependencies(client: demisto_client,
+                                     pack_id: str,
+                                     packs_to_install: list,
+                                     installation_request_body: list,
+                                     lock: Lock):
     """ Searches for the pack of the specified file path, as well as its dependencies,
         and updates the list of packs to be installed accordingly.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): A prints manager object.
         pack_id (str): The id of the pack to be installed.
         packs_to_install (list) A list of the packs to be installed in this iteration.
         installation_request_body (list): A list of packs to be installed, in the request format.
-        thread_index (int): the thread index.
         lock (Lock): A lock object.
     """
     pack_data = []
     if pack_id not in packs_to_install:
         pack_display_name = get_pack_display_name(pack_id)
         if pack_display_name:
-            pack_data = search_pack(client, prints_manager, pack_display_name, pack_id, thread_index, lock)
+            pack_data = search_pack(client, pack_display_name, pack_id, lock)
         if pack_data is None:
             pack_data = {
                 'id': pack_id,
@@ -396,7 +354,7 @@ def search_pack_and_its_dependencies(client: demisto_client, prints_manager: Par
             }
 
     if pack_data:
-        dependencies = get_pack_dependencies(client, prints_manager, pack_data, thread_index, lock)
+        dependencies = get_pack_dependencies(client, pack_data, lock)
 
         current_packs_to_install = [pack_data]
         if dependencies:
@@ -429,15 +387,12 @@ def add_pack_to_installation_request(pack_id: str, installation_request_body: Li
         })
 
 
-def install_all_content_packs(client: demisto_client, host: str, prints_manager: ParallelPrintsManager,
-                              thread_index: int = 0):
+def install_all_content_packs(client: demisto_client, host: str):
     """
     Iterates over the packs currently located in the Packs directory. Wrapper for install_packs.
 
     :param client: Demisto-py client to connect to the server.
     :param host: FQDN of the server.
-    :param prints_manager: ParallelPrintsManager - Will be deprecated.
-    :param thread_index: Integer indicating which thread the test is running on.
     :return: None. Prints the response from the server in the build.
     """
     all_packs = []
@@ -445,18 +400,17 @@ def install_all_content_packs(client: demisto_client, host: str, prints_manager:
     for pack_id in os.listdir(PACKS_FULL_PATH):
         if pack_id not in IGNORED_FILES:
             add_pack_to_installation_request(pack_id, all_packs)
-    install_packs(client, host, prints_manager, thread_index, all_packs, is_nightly=True)
+    install_packs(client, host, all_packs, is_nightly=True)
 
 
-def upload_zipped_packs(client: demisto_client, host: str, prints_manager: ParallelPrintsManager,
-                        thread_index: int, pack_path: str):
+def upload_zipped_packs(client: demisto_client,
+                        host: str,
+                        pack_path: str):
     """ Install packs from zip file.
 
         Args:
             client (demisto_client): The configured client to use.
             host (str): The server URL.
-            prints_manager (ParallelPrintsManager): Print manager object.
-            thread_index (int): the index (for prints_manager).
             pack_path (str): path to pack zip.
         """
     header_params = {
@@ -465,9 +419,7 @@ def upload_zipped_packs(client: demisto_client, host: str, prints_manager: Paral
     file_path = os.path.abspath(pack_path)
     files = {'file': file_path}
 
-    message = 'Making "POST" request to server {} - to install all packs from file {}'.format(host, pack_path)
-    prints_manager.add_print_job(message, print_color, thread_index, LOG_COLORS.GREEN)
-    prints_manager.execute_thread_prints(thread_index)
+    logging.info(f'Making "POST" request to server {host} - to install all packs from file {pack_path}')
 
     # make the pack installation request
     try:
@@ -476,35 +428,24 @@ def upload_zipped_packs(client: demisto_client, host: str, prints_manager: Paral
                                                                    header_params=header_params, files=files)
 
         if 200 <= status_code < 300:
-            message = 'All packs from {} were successfully installed!\n'.format(pack_path)
-            prints_manager.add_print_job(message, print_color, thread_index, LOG_COLORS.GREEN)
-            prints_manager.execute_thread_prints(thread_index)
+            logging.info(f'All packs from file {pack_path} were successfully installed!')
         else:
             result_object = ast.literal_eval(response_data)
             message = result_object.get('message', '')
-            err_msg = 'Failed to install packs - with status code {}\n{}\n'.format(status_code, message)
-            raise Exception(err_msg)
-    except Exception as e:
-        if e.__class__ == ApiException:
-            err_msg = 'The request to install packs has failed. Reason:\n{}\n'.format(str(e.body))
-        else:
-            err_msg = 'The request to install packs has failed. Reason:\n{}\n'.format(str(e))
-        prints_manager.add_print_job(err_msg, print_color, thread_index, LOG_COLORS.GREEN)
-        prints_manager.execute_thread_prints(thread_index)
+            raise Exception(f'Failed to install packs - with status code {status_code}\n{message}')
+    except Exception:
+        logging.exception('The request to install packs has failed.')
         sys.exit(1)
 
 
-def search_and_install_packs_and_their_dependencies_private(test_pack_path: str, pack_ids: list,
-                                                            client: demisto_client,
-                                                            prints_manager: ParallelPrintsManager,
-                                                            thread_index: int = 0):
+def search_and_install_packs_and_their_dependencies_private(test_pack_path: str,
+                                                            pack_ids: list,
+                                                            client: demisto_client):
     """ Searches for the packs from the specified list, searches their dependencies, and then installs them.
     Args:
         test_pack_path (str): Path of where the test packs are located.
         pack_ids (list): A list of the pack ids to search and install.
         client (demisto_client): The client to connect to.
-        prints_manager (ParallelPrintsManager): A prints manager object.
-        thread_index (int): the thread index.
 
     Returns (list, bool):
         A list of the installed packs' ids, or an empty list if is_nightly == True.
@@ -512,25 +453,20 @@ def search_and_install_packs_and_their_dependencies_private(test_pack_path: str,
     """
     host = client.api_client.configuration.host
 
-    msg = f'Starting to search and install packs in server: {host}'
-    prints_manager.add_print_job(msg, print_color, thread_index, LOG_COLORS.GREEN)
-    prints_manager.execute_thread_prints(thread_index)
+    logging.info(f'Starting to search and install packs in server: {host}')
 
-    install_packs_private(client, host, prints_manager, thread_index, pack_ids, test_pack_path)
+    install_packs_private(client, host, pack_ids, test_pack_path)
 
     return SUCCESS_FLAG
 
 
-def search_and_install_packs_and_their_dependencies(pack_ids: list, client: demisto_client,
-                                                    prints_manager: ParallelPrintsManager,
-                                                    thread_index: int = 0):
+def search_and_install_packs_and_their_dependencies(pack_ids: list,
+                                                    client: demisto_client):
     """ Searches for the packs from the specified list, searches their dependencies, and then
     installs them.
     Args:
         pack_ids (list): A list of the pack ids to search and install.
         client (demisto_client): The client to connect to.
-        prints_manager (ParallelPrintsManager): A prints manager object.
-        thread_index (int): the thread index.
 
     Returns (list, bool):
         A list of the installed packs' ids, or an empty list if is_nightly == True.
@@ -538,9 +474,7 @@ def search_and_install_packs_and_their_dependencies(pack_ids: list, client: demi
     """
     host = client.api_client.configuration.host
 
-    msg = f'Starting to search and install packs in server: {host}'
-    prints_manager.add_print_job(msg, print_color, thread_index, LOG_COLORS.GREEN)
-    prints_manager.execute_thread_prints(thread_index)
+    logging.info(f'Starting to search and install packs in server: {host}')
 
     packs_to_install = []  # we save all the packs we want to install, to avoid duplications
     installation_request_body = []  # the packs to install, in the request format
@@ -551,15 +485,13 @@ def search_and_install_packs_and_their_dependencies(pack_ids: list, client: demi
     for pack_id in pack_ids:
         thread = Thread(target=search_pack_and_its_dependencies,
                         kwargs={'client': client,
-                                'prints_manager': prints_manager,
                                 'pack_id': pack_id,
                                 'packs_to_install': packs_to_install,
                                 'installation_request_body': installation_request_body,
-                                'thread_index': thread_index,
                                 'lock': lock})
         threads_list.append(thread)
     run_threads_list(threads_list)
 
-    install_packs(client, host, prints_manager, thread_index, installation_request_body)
+    install_packs(client, host, installation_request_body)
 
     return packs_to_install, SUCCESS_FLAG

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -198,7 +198,6 @@ def install_nightly_packs(client: demisto_client,
     """
     packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
     logging.info(f'Installing packs on server {host}')
-    logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
     # make the pack installation request
     all_packs_install_successfully = False
     request_data = {
@@ -207,6 +206,7 @@ def install_nightly_packs(client: demisto_client,
     }
     while not all_packs_install_successfully:
         try:
+            logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
             response_data, status_code, _ = demisto_client.generic_request_func(client,
                                                                                 path='/contentpacks/marketplace/install',
                                                                                 method='POST',
@@ -217,6 +217,7 @@ def install_nightly_packs(client: demisto_client,
             if 200 <= status_code < 300:
                 packs_data = [{'ID': pack.get('id'), 'CurrentVersion': pack.get('currentVersion')} for pack in
                               ast.literal_eval(response_data)]
+                logging.success(f'Packs were successfully installed on server {host}')
                 logging.debug(f'The following packs were successfully installed on server {host}:\n{packs_data}')
             else:
                 result_object = ast.literal_eval(response_data)
@@ -298,10 +299,9 @@ def install_packs(client: demisto_client,
         'packs': packs_to_install,
         'ignoreWarnings': True
     }
-
-    logging.info(f'Installing packs to server {host}')
+    logging.info(f'Installing packs on server {host}')
     packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
-    logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
+    logging.debug(f'Installing the following packs on server {host}:\n{packs_to_install_str}')
 
     # make the pack installation request
     try:
@@ -316,6 +316,7 @@ def install_packs(client: demisto_client,
             packs_data = [{'ID': pack.get('id'), 'CurrentVersion': pack.get('currentVersion')} for
                           pack in
                           ast.literal_eval(response_data)]
+            logging.success(f'Packs were successfully installed on server {host}')
             logging.debug(f'The following packs were successfully installed on server {host}:\n{packs_data}')
         else:
             result_object = ast.literal_eval(response_data)

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-import logging
 import os
 import uuid
 import json
@@ -11,27 +10,33 @@ import sys
 import zipfile
 from datetime import datetime
 from enum import IntEnum
+from pprint import pformat
 from time import sleep
 from threading import Thread
 from distutils.version import LooseVersion
+import logging
 
-from demisto_sdk.commands.validate.validate_manager import ValidateManager
+from Tests.scripts.utils.log_util import install_logging
+
 from paramiko.client import SSHClient, AutoAddPolicy
 import demisto_client
 from ruamel import yaml
-
 from demisto_sdk.commands.common.tools import print_error, print_warning, print_color, LOG_COLORS, run_threads_list, \
     run_command, get_yaml, str2bool, format_version, find_type
 from demisto_sdk.commands.common.constants import RUN_ALL_TESTS_FORMAT, FileType
 from Tests.test_integration import __get_integration_config, __test_integration_instance, \
     __disable_integrations_instances
-from Tests.test_content import extract_filtered_tests, ParallelPrintsManager, \
-    get_server_numeric_version
+from Tests.test_content import extract_filtered_tests, get_server_numeric_version
 from Tests.update_content_data import update_content
 from Tests.Marketplace.search_and_install_packs import search_and_install_packs_and_their_dependencies, \
     install_all_content_packs, upload_zipped_packs
-
 from Tests.tools import update_server_configuration
+if __name__ == '__main__':
+    # The ValidateManager class imports a package that's configuring logging's basicConfig.
+    # This configuration overwrites any later configuration, so installing logging the way we want it should
+    # happen before importing this class
+    install_logging('Install Content And Configure Integrations On Server.log')
+from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 MARKET_PLACE_MACHINES = ('master',)
 SKIPPED_PACKS = ['NonSupported', 'ApiModules']
@@ -228,7 +233,7 @@ def options_handler():
     return options
 
 
-def check_test_version_compatible_with_server(test, server_version, prints_manager):
+def check_test_version_compatible_with_server(test, server_version):
     """
     Checks if a given test is compatible wis the given server version.
     Arguments:
@@ -237,8 +242,6 @@ def check_test_version_compatible_with_server(test, server_version, prints_manag
             "integrations", "instance_names", "timeout", "nightly", "fromversion", "toversion.
         server_version: (int)
             The server numerical version.
-        prints_manager: (ParallelPrintsManager)
-            Print manager object.
     Returns:
         (bool) True if test is compatible with server version or False otherwise.
     """
@@ -247,17 +250,15 @@ def check_test_version_compatible_with_server(test, server_version, prints_manag
     server_version = format_version(server_version)
 
     if not (LooseVersion(test_from_version) <= LooseVersion(server_version) <= LooseVersion(test_to_version)):
-        warning_message = 'Test Playbook: {} was ignored in the content installation test due to version mismatch ' \
-                          '(test versions: {}-{}, server version: {})'.format(test.get('playbookID'),
-                                                                              test_from_version,
-                                                                              test_to_version,
-                                                                              server_version)
-        prints_manager.add_print_job(warning_message, print_warning, 0)
+        playbook_id = test.get('playbookID')
+        logging.debug(
+            f'Test Playbook: {playbook_id} was ignored in the content installation test due to version mismatch '
+            f'(test versions: {test_from_version}-{test_to_version}, server version: {server_version})')
         return False
     return True
 
 
-def filter_tests_with_incompatible_version(tests, server_version, prints_manager):
+def filter_tests_with_incompatible_version(tests, server_version):
     """
     Filter all tests with incompatible version to the given server.
     Arguments:
@@ -265,20 +266,16 @@ def filter_tests_with_incompatible_version(tests, server_version, prints_manager
             List of test objects.
         server_version: (int)
             The server numerical version.
-        prints_manager: (ParallelPrintsManager)
-            Print manager object.
-
     Returns:
         (lst): List of filtered tests (compatible version)
     """
 
     filtered_tests = [test for test in tests if
-                      check_test_version_compatible_with_server(test, server_version, prints_manager)]
-    prints_manager.execute_thread_prints(0)
+                      check_test_version_compatible_with_server(test, server_version)]
     return filtered_tests
 
 
-def configure_integration_instance(integration, client, prints_manager, placeholders_map):
+def configure_integration_instance(integration, client, placeholders_map):
     """
     Configure an instance for an integration
 
@@ -287,8 +284,6 @@ def configure_integration_instance(integration, client, prints_manager, placehol
             Integration object whose params key-values are set
         client: (demisto_client)
             The client to connect to
-        prints_manager: (ParallelPrintsManager)
-            Print manager object
         placeholders_map: (dict)
              Dict that holds the real values to be replaced for each placeholder.
 
@@ -296,28 +291,22 @@ def configure_integration_instance(integration, client, prints_manager, placehol
         (dict): Configured integration instance
     """
     integration_name = integration.get('name')
-    prints_manager.add_print_job('Configuring instance for integration "{}"\n'.format(integration_name),
-                                 print_color, 0, LOG_COLORS.GREEN)
-    prints_manager.execute_thread_prints(0)
+    logging.info(f'Configuring instance for integration "{integration_name}"')
     integration_instance_name = integration.get('instance_name', '')
     integration_params = change_placeholders_to_values(placeholders_map, integration.get('params'))
     is_byoi = integration.get('byoi', True)
     validate_test = integration.get('validate_test', True)
 
-    integration_configuration = __get_integration_config(client, integration_name, prints_manager)
-    prints_manager.execute_thread_prints(0)
+    integration_configuration = __get_integration_config(client, integration_name)
     if not integration_configuration:
         return None
 
     # In the integration configuration in content-test-conf conf.json, the test_validate flag was set to false
     if not validate_test:
-        skipping_configuration_message = \
-            "Skipping configuration for integration: {} (it has test_validate set to false)".format(integration_name)
-        prints_manager.add_print_job(skipping_configuration_message, print_warning, 0)
-        prints_manager.execute_thread_prints(0)
+        logging.debug(f'Skipping configuration for integration: {integration_name} (it has test_validate set to false)')
         return None
     module_instance = set_integration_instance_parameters(integration_configuration, integration_params,
-                                                          integration_instance_name, is_byoi, client, prints_manager)
+                                                          integration_instance_name, is_byoi, client)
     return module_instance
 
 
@@ -340,18 +329,18 @@ def get_integration_names_from_files(integration_files_list):
     return [name for name in integration_names_list if name]  # remove empty values
 
 
-def get_new_and_modified_integration_files(build):
-    """Return 2 lists - list of new integrations and list of modified integrations since the commit of the git_sha1.
+def get_new_and_modified_integration_files(branch_name):
+    """Return 2 lists - list of new integrations and list of modified integrations since the first commit of the branch.
 
     Args:
-        git_sha1 (str): The git sha of the commit against which we will run the 'git diff' command.
+        branch_name: The branch name against which we will run the 'git diff' command.
 
     Returns:
         (tuple): Returns a tuple of two lists, the file paths of the new integrations and modified integrations.
     """
     # get changed yaml files (filter only added and modified files)
     file_validator = ValidateManager()
-    file_validator.branch_name = build.branch_name
+    file_validator.branch_name = branch_name
     modified_files, added_files, _, _, _ = file_validator.get_modified_and_added_files('...', 'origin/master')
 
     new_integration_files = [
@@ -363,25 +352,20 @@ def get_new_and_modified_integration_files(build):
         file_path for file_path in modified_files if
         isinstance(file_path, str) and find_type(file_path) in [FileType.INTEGRATION, FileType.BETA_INTEGRATION]
     ]
-
     return new_integration_files, modified_integration_files
 
 
-def is_content_update_in_progress(client, prints_manager, thread_index):
+def is_content_update_in_progress(client):
     """Make request to check if content is updating.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object
-        thread_index (int): The thread index
 
     Returns:
         (str): Returns the request response data which is 'true' if updating and 'false' if not.
     """
     host = client.api_client.configuration.host
-    prints_manager.add_print_job(
-        '\nMaking "Get" request to server - "{}" to check if content is installing.'.format(host), print,
-        thread_index)
+    logging.debug(f'Making "Get" request to server - "{host}" to check if content is installing.')
 
     # make request to check if content is updating
     response_data, status_code, _ = demisto_client.generic_request_func(self=client, path='/content/updating',
@@ -390,28 +374,24 @@ def is_content_update_in_progress(client, prints_manager, thread_index):
     if status_code >= 300 or status_code < 200:
         result_object = ast.literal_eval(response_data)
         message = result_object.get('message', '')
-        msg = "Failed to check if content is installing - with status code " + str(status_code) + '\n' + message
-        prints_manager.add_print_job(msg, print_error, thread_index)
+        logging.error(f"Failed to check if content is installing - with status code {status_code}\n{message}")
         return 'request unsuccessful'
 
     return response_data
 
 
-def get_content_version_details(client, ami_name, prints_manager, thread_index):
+def get_content_version_details(client, ami_name):
     """Make request for details about the content installed on the demisto instance.
 
     Args:
         client (demisto_client): The configured client to use.
         ami_name (string): the role name of the machine
-        prints_manager (ParallelPrintsManager): Print manager object
-        thread_index (int): The thread index
 
     Returns:
         (tuple): The release version and asset ID of the content installed on the demisto instance.
     """
     host = client.api_client.configuration.host
-    installed_content_message = '\nMaking "POST" request to server - "{}" to check installed content.'.format(host)
-    prints_manager.add_print_job(installed_content_message, print_color, thread_index, LOG_COLORS.GREEN)
+    logging.info(f'Making "POST" request to server - "{host}" to check installed content.')
 
     # make request to installed content details
     uri = '/content/installedlegacy' if ami_name in MARKET_PLACE_MACHINES else '/content/installed'
@@ -420,14 +400,14 @@ def get_content_version_details(client, ami_name, prints_manager, thread_index):
 
     try:
         result_object = ast.literal_eval(response_data)
-    except ValueError as err:
-        print_error('failed to parse response from demisto. response is {}.\nError:\n{}'.format(response_data, err))
+        logging.debug(f'Response was {response_data}')
+    except ValueError:
+        logging.exception('failed to parse response from demisto.')
         return '', 0
 
     if status_code >= 300 or status_code < 200:
         message = result_object.get('message', '')
-        msg = "Failed to check if installed content details - with status code " + str(status_code) + '\n' + message
-        print_error(msg)
+        logging.error(f'Failed to check if installed content details - with status code {status_code}\n{message}')
     return result_object.get('release', ''), result_object.get('assetId', 0)
 
 
@@ -549,12 +529,11 @@ def set_module_params(param_conf, integration_params):
     return param_conf
 
 
-def __set_server_keys(client, prints_manager, integration_params, integration_name):
+def __set_server_keys(client, integration_params, integration_name):
     """Adds server configuration keys using the demisto_client.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object.
         integration_params (dict): The values to use for an integration's parameters to configure an instance.
         integration_name (str): The name of the integration which the server configurations keys are related to.
 
@@ -562,8 +541,7 @@ def __set_server_keys(client, prints_manager, integration_params, integration_na
     if 'server_keys' not in integration_params:
         return
 
-    prints_manager.add_print_job(f'Setting server keys for integration: {integration_name}',
-                                 print_color, 0, LOG_COLORS.GREEN)
+    logging.info(f'Setting server keys for integration: {integration_name}')
 
     data = {
         'data': {},
@@ -578,19 +556,20 @@ def __set_server_keys(client, prints_manager, integration_params, integration_na
 
     try:
         result_object = ast.literal_eval(response_data)
-    except ValueError as err:
-        print_error(
-            'failed to parse response from demisto. response is {}.\nError:\n{}'.format(response_data, err))
+    except ValueError:
+        logging.exception(f'failed to parse response from demisto. response is {response_data}')
         return
 
     if status_code >= 300 or status_code < 200:
         message = result_object.get('message', '')
-        msg = "Failed to set server keys " + str(status_code) + '\n' + message
-        print_error(msg)
+        logging.error(f'Failed to set server keys, status_code: {status_code}, message: {message}')
 
 
-def set_integration_instance_parameters(integration_configuration, integration_params, integration_instance_name,
-                                        is_byoi, client, prints_manager):
+def set_integration_instance_parameters(integration_configuration,
+                                        integration_params,
+                                        integration_instance_name,
+                                        is_byoi,
+                                        client):
     """Set integration module values for integration instance creation
 
     The integration_configuration and integration_params should match, in that
@@ -611,8 +590,6 @@ def set_integration_instance_parameters(integration_configuration, integration_p
             If the integration is byoi or not
         client: (demisto_client)
             The client to connect to
-        prints_manager: (ParallelPrintsManager)
-            Print manager object
 
     Returns:
         (dict): The configured module instance to send to the Demisto server for
@@ -643,7 +620,7 @@ def set_integration_instance_parameters(integration_configuration, integration_p
     }
 
     # set server keys
-    __set_server_keys(client, prints_manager, integration_params, integration_configuration['name'])
+    __set_server_keys(client, integration_params, integration_configuration['name'])
 
     # set module params
     for param_conf in module_configuration:
@@ -711,55 +688,49 @@ def get_integrations_for_test(test, skipped_integrations_conf):
     return integrations
 
 
-def update_content_on_demisto_instance(client, server, ami_name, prints_manager, thread_index):
+def update_content_on_demisto_instance(client, server, ami_name):
     """Try to update the content
 
     Args:
         client (demisto_client): The configured client to use.
         server (str): The server url to pass to Tests/update_content_data.py
-        prints_manager (ParallelPrintsManager): Print manager object
-        thread_index (int): The thread index
     """
     content_zip_path = 'artifacts/all_content.zip'
     update_content(content_zip_path, server=server, client=client)
 
     # Check if content update has finished installing
     sleep_interval = 20
-    updating_content = is_content_update_in_progress(client, prints_manager, thread_index)
+    updating_content = is_content_update_in_progress(client)
     while updating_content.lower() == 'true':
         sleep(sleep_interval)
-        updating_content = is_content_update_in_progress(client, prints_manager, thread_index)
+        updating_content = is_content_update_in_progress(client)
 
     if updating_content.lower() == 'request unsuccessful':
         # since the request to check if content update installation finished didn't work, can't use that mechanism
         # to check and just try sleeping for 30 seconds instead to allow for content update installation to complete
+        logging.debug('Request to install content was unsuccessful, sleeping for 30 seconds and retrying')
         sleep(30)
     else:
         # check that the content installation updated
         # verify the asset id matches the circleci build number / asset_id in the content-descriptor.json
-        release, asset_id = get_content_version_details(client, ami_name, prints_manager, thread_index)
+        release, asset_id = get_content_version_details(client, ami_name)
         with open('content-descriptor.json', 'r') as cd_file:
             cd_json = json.loads(cd_file.read())
             cd_release = cd_json.get('release')
             cd_asset_id = cd_json.get('assetId')
         if release == cd_release and asset_id == cd_asset_id:
-            prints_manager.add_print_job('Content Update Successfully Installed!', print_color, thread_index,
-                                         LOG_COLORS.GREEN)
+            logging.success(f'Content Update Successfully Installed on server {server}.')
         else:
-            err_details = 'Attempted to install content with release "{}" and assetId '.format(cd_release)
-            err_details += '"{}" but release "{}" and assetId "{}" were '.format(cd_asset_id, release, asset_id)
-            err_details += 'retrieved from the instance post installation.'
-            prints_manager.add_print_job(
-                'Content Update to version: {} was Unsuccessful:\n{}'.format(release, err_details),
-                print_error, thread_index)
-            prints_manager.execute_thread_prints(thread_index)
-
+            logging.error(
+                f'Content Update to version: {release} was Unsuccessful:\nAttempted to install content with release '
+                f'"{cd_release}" and assetId "{cd_asset_id}" but release "{release}" and assetId "{asset_id}" '
+                f'were retrieved from the instance post installation.')
             if ami_name not in MARKET_PLACE_MACHINES:
                 os._exit(1)
 
 
 def report_tests_status(preupdate_fails, postupdate_fails, preupdate_success, postupdate_success,
-                        new_integrations_names, prints_manager):
+                        new_integrations_names):
     """Prints errors and/or warnings if there are any and returns whether whether testing was successful or not.
 
     Args:
@@ -778,8 +749,6 @@ def report_tests_status(preupdate_fails, postupdate_fails, preupdate_success, po
         new_integrations_names (list): List of the names of integrations that are new since the last official
             content release and that will only be present on the demisto instance after the content update is
             performed.
-        prints_manager: (ParallelPrintsManager)
-            Print manager object
 
     Returns:
         (bool): False if there were integration instances that succeeded prior to the content update and then
@@ -791,13 +760,12 @@ def report_tests_status(preupdate_fails, postupdate_fails, preupdate_success, po
     # fail on one of them(mismatched_statuses variable), or on both(failed_pre_and_post variable)
     succeeded_pre_and_post = preupdate_success.intersection(postupdate_success)
     if succeeded_pre_and_post:
-        succeeded_message = '\nIntegration instances that had ("Test" Button) succeeded' \
-                            ' both before and after the content update'
-        prints_manager.add_print_job(succeeded_message, print_color, 0, LOG_COLORS.GREEN)
-        for instance_name, integration_of_instance in succeeded_pre_and_post:
-            prints_manager.add_print_job(
-                'Integration: "{}", Instance: "{}"'.format(integration_of_instance, instance_name),
-                print_color, 0, LOG_COLORS.GREEN)
+        succeeded_pre_and_post_string = "\n".join(
+            [f'Integration: "{integration_of_instance}", Instance: "{instance_name}"' for
+             instance_name, integration_of_instance in succeeded_pre_and_post])
+        logging.success(
+            'Integration instances that had ("Test" Button) succeeded both before and after the content update:\n'
+            f'{succeeded_pre_and_post_string}')
 
     failed_pre_and_post = preupdate_fails.intersection(postupdate_fails)
     mismatched_statuses = postupdate_fails - preupdate_fails
@@ -811,30 +779,26 @@ def report_tests_status(preupdate_fails, postupdate_fails, preupdate_success, po
 
     # warnings but won't fail the build step
     if failed_but_is_new:
-        prints_manager.add_print_job('New Integrations ("Test" Button) Failures', print_warning, 0)
-        for instance_name, integration_of_instance in failed_but_is_new:
-            prints_manager.add_print_job(
-                'Integration: "{}", Instance: "{}"'.format(integration_of_instance, instance_name), print_warning, 0)
+        failed_but_is_new_string = "\n".join(
+            [f'Integration: "{integration_of_instance}", Instance: "{instance_name}"'
+             for instance_name, integration_of_instance in failed_but_is_new])
+        logging.warning(f'New Integrations ("Test" Button) Failures:\n{failed_but_is_new_string}')
     if failed_pre_and_post:
-        failure_category = '\nIntegration instances that had ("Test" Button) failures' \
-                           ' both before and after the content update'
-        prints_manager.add_print_job(failure_category, print_warning, 0)
-        for instance_name, integration_of_instance in failed_pre_and_post:
-            prints_manager.add_print_job(
-                'Integration: "{}", Instance: "{}"'.format(integration_of_instance, instance_name), print_warning, 0)
+        failed_pre_and_post_string = "\n".join(
+            [f'Integration: "{integration_of_instance}", Instance: "{instance_name}"'
+             for instance_name, integration_of_instance in failed_pre_and_post])
+        logging.warning(f'Integration instances that had ("Test" Button) failures '
+                        f'both before and after the content update:\n{pformat(failed_pre_and_post_string)}')
 
     # fail the step if there are instances that only failed after content was updated
     if failed_only_after_update:
+        failed_only_after_update_string = "\n".join(
+            [f'Integration: "{integration_of_instance}", Instance: "{instance_name}"' for
+             instance_name, integration_of_instance in failed_only_after_update])
         testing_status = False
-        failure_category = '\nIntegration instances that had ("Test" Button) failures' \
-                           ' only after content was updated. This indicates that your' \
-                           ' updates introduced breaking changes to the integration.'
-        prints_manager.add_print_job(failure_category, print_error, 0)
-        for instance_name, integration_of_instance in failed_only_after_update:
-            prints_manager.add_print_job(
-                'Integration: "{}", Instance: "{}"'.format(integration_of_instance, instance_name), print_error, 0)
-
-    prints_manager.execute_thread_prints(0)
+        logging.critical('Integration instances that had ("Test" Button) failures only after content was updated:\n'
+                         f'{pformat(failed_only_after_update_string)}.\n'
+                         f'This indicates that your updates introduced breaking changes to the integration.')
 
     return testing_status
 
@@ -847,6 +811,8 @@ def set_marketplace_gcp_bucket_for_build(client, prints_manager, branch_name, ci
         prints_manager (ParallelPrintsManager): Print manager object
         branch_name (str): GitHub branch name
         ci_build_number (str): CI build number
+        is_nightly: Whether this is a nightly build
+        is_private: Whether this is a private build
 
     Returns:
         response_data: The response data
@@ -866,15 +832,13 @@ def set_marketplace_gcp_bucket_for_build(client, prints_manager, branch_name, ci
     }
     if is_private:
         server_configuration['marketplace.bootstrap.bypass.url'] = 'https://storage.googleapis.com/marketplace-ci-build'
-        server_configuration['marketplace.gcp.path'] = 'content/builds/{}/{}/content/packs'.format(branch_name,
-                                                                                                   ci_build_number)
+        server_configuration['marketplace.gcp.path'] = f'content/builds/{branch_name}/{ci_build_number}/content/packs'
         server_configuration['jobs.marketplacepacks.schedule'] = '1m'
         server_configuration[
             'marketplace.premium.gateway.service.url'] = 'https://xsoar-premium-content-team-gateway.demisto.works'
     elif not is_nightly:
         server_configuration['marketplace.bootstrap.bypass.url'] = \
-            'https://storage.googleapis.com/marketplace-ci-build/content/builds/{}/{}'.format(
-                branch_name, ci_build_number)
+            f'https://storage.googleapis.com/marketplace-ci-build/content/builds/{branch_name}/{ci_build_number}'
     error_msg = "Failed to set GCP bucket server config - with status code "
     # disable-secrets-detection-end
     return update_server_configuration(client, server_configuration, error_msg)
@@ -952,7 +916,7 @@ def get_json_file(path):
         return json.loads(json_file.read())
 
 
-def configure_servers_and_restart(build, prints_manager):
+def configure_servers_and_restart(build, prints_manager=None):
     if LooseVersion(build.server_numeric_version) >= LooseVersion('5.5.0'):
         configurations = DOCKER_HARDENING_CONFIGURATION
         configure_types = ['docker hardening']
@@ -968,22 +932,24 @@ def configure_servers_and_restart(build, prints_manager):
         if manual_restart:
             input('restart your server and then press enter.')
         else:
-            prints_manager.add_print_job('Done restarting servers.\nSleeping for 1 minute...', print_warning, 0)
-            prints_manager.execute_thread_prints(0)
+            if prints_manager:
+                prints_manager.add_print_job('Done restarting servers.\nSleeping for 1 minute...', print_warning, 0)
+                prints_manager.execute_thread_prints(0)
+            else:
+                logging.info('Done restarting servers. Sleeping for 1 minute')
             sleep(60)
 
 
 def restart_server(server):
     try:
-        print('Restarting servers to apply server config ...')
+        logging.info('Restarting servers to apply server config ...')
 
         # copy from .demisto_bashrc stop_server && start_server
         command = 'sudo systemctl restart demisto'
         SimpleSSH(host=server.replace('https://', '').replace('http://', ''), key_file_path=Build.key_file_path,
                   user='ec2-user').exec_command(command)
-    except Exception as error:
-        print_error(f'New SSH restart demisto failed with error: {str(error)}')
-        print(error.__traceback__)
+    except Exception:
+        logging.exception('New SSH restart demisto failed')
         restart_server_legacy(server)
 
 
@@ -993,28 +959,31 @@ def restart_server_legacy(server):
                      '"sudo systemctl restart demisto"'
         subprocess.check_output(
             ssh_string.format('ec2-user', server.replace('https://', '')), shell=True)
-    except subprocess.CalledProcessError as exc:
-        print(exc.output)
+    except subprocess.CalledProcessError:
+        logging.exception('Legacy SSH restart demisto failed')
 
 
-def get_tests(server_numeric_version, prints_manager, tests):
+def get_tests(server_numeric_version: str, tests: list) -> list:
+    """
+    Selects the tests from that should be run in this execution and filters those that cannot run in this server version
+    Args:
+        server_numeric_version: The server numeric versions
+        tests: All conf.json tests
+
+    Returns:
+        Test configurations from conf.json that should be run in this execution
+    """
     if Build.run_environment == Running.CIRCLECI_RUN:
         filtered_tests, filter_configured, run_all_tests = extract_filtered_tests()
         if run_all_tests:
-            # skip test button testing
-            skipped_instance_test_message = 'Not running instance tests when {} is turned on'.format(
-                RUN_ALL_TESTS_FORMAT)
-            prints_manager.add_print_job(skipped_instance_test_message, print_warning, 0)
+            logging.warning(f'Not running instance tests when {RUN_ALL_TESTS_FORMAT} is turned on')
             tests_for_iteration = []
         elif filter_configured and filtered_tests:
             tests_for_iteration = [test for test in tests if test.get('playbookID', '') in filtered_tests]
         else:
             tests_for_iteration = tests
 
-        tests_for_iteration = filter_tests_with_incompatible_version(tests_for_iteration, server_numeric_version,
-                                                                     prints_manager)
-        prints_manager.execute_thread_prints(0)
-
+        tests_for_iteration = filter_tests_with_incompatible_version(tests_for_iteration, server_numeric_version)
         return tests_for_iteration
     else:
         # START CHANGE ON LOCAL RUN #
@@ -1033,23 +1002,26 @@ def get_tests(server_numeric_version, prints_manager, tests):
         #  END CHANGE ON LOCAL RUN  #
 
 
-def get_changed_integrations(build, prints_manager):
+def get_changed_integrations(build: Build) -> tuple:
+    """
+    Return 2 lists - list of new integrations and list of modified integrations since the commit of the git_sha1.
+
+    Args:
+        build: the build object
+    Returns:
+        list of new integrations and list of modified integrations
+    """
     new_integrations_files, modified_integrations_files = get_new_and_modified_integration_files(
-        build) if not build.is_private else ([], [])
+        build.branch_name) if not build.is_private else ([], [])
     new_integrations_names, modified_integrations_names = [], []
 
     if new_integrations_files:
         new_integrations_names = get_integration_names_from_files(new_integrations_files)
-        new_integrations_names_message = \
-            'New Integrations Since Last Release:\n{}\n'.format('\n'.join(new_integrations_names))
-        prints_manager.add_print_job(new_integrations_names_message, print_warning, 0)
+        logging.debug(f'New Integrations Since Last Release:\n{new_integrations_names}')
 
     if modified_integrations_files:
         modified_integrations_names = get_integration_names_from_files(modified_integrations_files)
-        modified_integrations_names_message = \
-            'Updated Integrations Since Last Release:\n{}\n'.format('\n'.join(modified_integrations_names))
-        prints_manager.add_print_job(modified_integrations_names_message, print_warning, 0)
-    prints_manager.execute_thread_prints(0)
+        logging.debug(f'Updated Integrations Since Last Release:\n{modified_integrations_names}')
     return new_integrations_names, modified_integrations_names
 
 
@@ -1066,75 +1038,64 @@ def get_pack_ids_to_install():
         #  END CHANGE ON LOCAL RUN  #
 
 
-def nightly_install_packs(build, threads_print_manager, install_method=install_all_content_packs, pack_path=None):
+def nightly_install_packs(build, install_method=install_all_content_packs, pack_path=None):
     threads_list = []
 
     # For each server url we install pack/ packs
     for thread_index, server in enumerate(build.servers):
-        kwargs = {'client': server.client, 'host': server.host,
-                  'prints_manager': threads_print_manager,
-                  'thread_index': thread_index}
+        kwargs = {'client': server.client, 'host': server.host}
         if pack_path:
             kwargs['pack_path'] = pack_path
         threads_list.append(Thread(target=install_method, kwargs=kwargs))
     run_threads_list(threads_list)
 
 
-def install_nightly_pack(build, prints_manager):
-    threads_print_manager = ParallelPrintsManager(len(build.servers))
-    nightly_install_packs(build, threads_print_manager, install_method=install_all_content_packs)
+def install_nightly_pack(build):
+    nightly_install_packs(build, install_method=install_all_content_packs)
     create_nightly_test_pack()
-    nightly_install_packs(build, threads_print_manager, install_method=upload_zipped_packs,
+    nightly_install_packs(build, install_method=upload_zipped_packs,
                           pack_path=f'{Build.test_pack_target}/test_pack.zip')
 
-    prints_manager.add_print_job('Sleeping for 45 seconds...', print_warning, 0, include_timestamp=True)
-    prints_manager.execute_thread_prints(0)
+    logging.info('Sleeping for 45 seconds while installing nightly packs')
     sleep(45)
 
 
-def install_packs(build, prints_manager, pack_ids=None):
+def install_packs(build, pack_ids=None):
     pack_ids = get_pack_ids_to_install() if pack_ids is None else pack_ids
     installed_content_packs_successfully = True
     for server in build.servers:
         try:
-            _, flag = search_and_install_packs_and_their_dependencies(pack_ids, server.client,
-                                                                      prints_manager)
+            _, flag = search_and_install_packs_and_their_dependencies(pack_ids, server.client)
             if not flag:
                 raise Exception('Failed to search and install packs.')
-        except Exception as exc:
-            prints_manager.add_print_job(str(exc), print_error, 0)
-            prints_manager.execute_thread_prints(0)
+        except Exception:
+            logging.exception('Failed to search and install packs')
             installed_content_packs_successfully = False
 
     return installed_content_packs_successfully
 
 
-def configure_server_instances(build: Build, tests_for_iteration, all_new_integrations, modified_integrations,
-                               prints_manager):
+def configure_server_instances(build: Build, tests_for_iteration, all_new_integrations, modified_integrations):
     all_module_instances = []
     brand_new_integrations = []
     testing_client = build.servers[0].client
     for test in tests_for_iteration:
         integrations = get_integrations_for_test(test, build.skipped_integrations_conf)
 
-        integrations_names = [i.get('name') for i in integrations]
-        prints_manager.add_print_job('All Integrations for test "{}":'.format(test.get('playbookID')), print_warning, 0)
-        prints_manager.add_print_job(integrations_names, print_warning, 0)
+        playbook_id = test.get('playbookID')
 
         new_integrations, modified_integrations, unchanged_integrations, integration_to_status = group_integrations(
             integrations, build.skipped_integrations_conf, all_new_integrations, modified_integrations
         )
-
+        integration_to_status_string = '\n\t\t\t\t\t\t'.join(
+            [f'"{key}" - {val}' for key, val in integration_to_status.items()])
+        if integration_to_status_string:
+            logging.info(f'All Integrations for test "{playbook_id}":\n\t\t\t\t\t\t{integration_to_status_string}')
+        else:
+            logging.info(f'No Integrations for test "{playbook_id}"')
         instance_names_conf = test.get('instance_names', [])
         if not isinstance(instance_names_conf, list):
             instance_names_conf = [instance_names_conf]
-
-        integrations_names = [i.get('name') for i in integrations]
-        prints_manager.add_print_job('All Integrations for test "{}":'.format(test.get('playbookID')), print_warning, 0)
-        prints_manager.add_print_job(integrations_names, print_warning, 0)
-
-        integrations_msg = '\n'.join(['"{}" - {}'.format(key, val) for key, val in integration_to_status.items()])
-        prints_manager.add_print_job('{}\n'.format(integrations_msg), print_warning, 0)
 
         integrations_to_configure = modified_integrations[:]
         integrations_to_configure.extend(unchanged_integrations)
@@ -1146,60 +1107,45 @@ def configure_server_instances(build: Build, tests_for_iteration, all_new_integr
                                                               build.secret_conf['integrations'],
                                                               instance_names_conf, placeholders_map)
         if not new_ints_params_set:
-            prints_manager.add_print_job(
-                'failed setting parameters for integrations "{}"'.format('\n'.join(new_integrations)), print_error, 0)
+            logging.error(f'failed setting parameters for integrations: {new_integrations}')
         if not ints_to_configure_params_set:
-            prints_manager.add_print_job(
-                'failed setting parameters for integrations\n "{}"'.format(integrations_to_configure), print_error, 0)
+            logging.error(f'failed setting parameters for integrations: {integrations_to_configure}')
         if not (new_ints_params_set and ints_to_configure_params_set):
             continue
-        prints_manager.execute_thread_prints(0)
-
         module_instances = []
         for integration in integrations_to_configure:
             placeholders_map = {'%%SERVER_HOST%%': build.servers[0]}
-            module_instance = configure_integration_instance(integration, testing_client, prints_manager,
-                                                             placeholders_map)
+            module_instance = configure_integration_instance(integration, testing_client, placeholders_map)
             if module_instance:
                 module_instances.append(module_instance)
 
         all_module_instances.extend(module_instances)
         for integration in new_integrations:
             placeholders_map = {'%%SERVER_HOST%%': build.servers[0]}
-            module_instance = configure_integration_instance(integration, testing_client, prints_manager,
-                                                             placeholders_map)
+            module_instance = configure_integration_instance(integration, testing_client, placeholders_map)
             if module_instance:
                 module_instances.append(module_instance)
-
         brand_new_integrations.extend(module_instances)
     return all_module_instances, brand_new_integrations
 
 
-def instance_testing(build: Build, all_module_instances, prints_manager, pre_update):
+def instance_testing(build: Build, all_module_instances, pre_update):
     update_status = 'Pre' if pre_update else 'Post'
     failed_tests = set()
     successful_tests = set()
     # Test all module instances (of modified + unchanged integrations) pre-updating content
     if all_module_instances:
         # only print start message if there are instances to configure
-        prints_manager.add_print_job(f'Start of Instance Testing ("Test" button) ({update_status}-update)',
-                                     print_warning, 0)
+        logging.info(f'Start of Instance Testing ("Test" button) ({update_status}-update)')
     else:
-        prints_manager.add_print_job(f'No integrations to configure for the chosen tests. ({update_status}-update)',
-                                     print_warning, 0)
-    prints_manager.execute_thread_prints(0)
+        logging.info(f'No integrations to configure for the chosen tests. ({update_status}-update)')
 
     testing_client = build.servers[0].client
     for instance in all_module_instances:
         integration_of_instance = instance.get('brand', '')
         instance_name = instance.get('name', '')
-        msg = 'Testing ("Test" button) for instance "{}" of integration "{}".'.format(instance_name,
-                                                                                      integration_of_instance)
-        prints_manager.add_print_job(msg, print_color, 0, LOG_COLORS.GREEN)
-        prints_manager.execute_thread_prints(0)
         # If there is a failure, __test_integration_instance will print it
-        success, _ = __test_integration_instance(testing_client, instance, prints_manager)
-        prints_manager.execute_thread_prints(0)
+        success, _ = __test_integration_instance(testing_client, instance)
         if not success:
             failed_tests.add((instance_name, integration_of_instance))
         else:
@@ -1210,21 +1156,19 @@ def instance_testing(build: Build, all_module_instances, prints_manager, pre_upd
 
 def update_content_till_v6(build: Build):
     threads_list = []
-    threads_prints_manager = ParallelPrintsManager(len(build.servers))
     # For each server url we install content
     for thread_index, server in enumerate(build.servers):
         t = Thread(target=update_content_on_demisto_instance,
-                   kwargs={'client': server.client, 'server': server.host, 'ami_name': build.ami_env,
-                           'prints_manager': threads_prints_manager,
-                           'thread_index': thread_index})
+                   kwargs={'client': server.client, 'server': server.host, 'ami_name': build.ami_env})
         threads_list.append(t)
 
     run_threads_list(threads_list)
 
 
-def disable_instances(build: Build, all_module_instances, prints_manager):
+def disable_instances(build: Build, all_module_instances, prints_manager=None):
     __disable_integrations_instances(build.servers[0].client, all_module_instances, prints_manager)
-    prints_manager.execute_thread_prints(0)
+    if prints_manager:
+        prints_manager.execute_thread_prints(0)
 
 
 def create_nightly_test_pack():
@@ -1322,48 +1266,47 @@ def set_marketplace_url(servers, branch_name, ci_build_number):
     config = {config_path: f'https://storage.googleapis.com/marketplace-ci-build/content/builds/{url_suffix}'}
     for server in servers:
         server.add_server_configuration(config, 'failed to configure marketplace custom url ', True)
+    logging.success('Updated marketplace url and restarted servers')
+    logging.info('sleeping for 60 seconds')
     sleep(60)
 
 
 def main():
     build = Build(options_handler())
 
-    prints_manager = ParallelPrintsManager(1)
-
-    configure_servers_and_restart(build, prints_manager)
+    configure_servers_and_restart(build)
     installed_content_packs_successfully = False
 
     if LooseVersion(build.server_numeric_version) >= LooseVersion('6.0.0'):
         if build.is_nightly:
-            install_nightly_pack(build, prints_manager)
+            install_nightly_pack(build)
             installed_content_packs_successfully = True
         else:
             if not build.is_private:
                 pack_ids = get_non_added_packs_ids(build)
-                installed_content_packs_successfully = install_packs(build, prints_manager, pack_ids=pack_ids)
+                installed_content_packs_successfully = install_packs(build, pack_ids=pack_ids)
     else:
         installed_content_packs_successfully = True
 
-    tests_for_iteration = get_tests(build.server_numeric_version, prints_manager, build.tests)
-    new_integrations, modified_integrations = get_changed_integrations(build, prints_manager)
-    all_module_instances, brand_new_integrations = \
-        configure_server_instances(build, tests_for_iteration, new_integrations, modified_integrations, prints_manager)
-    successful_tests_pre, failed_tests_pre = instance_testing(build, all_module_instances, prints_manager,
-                                                              pre_update=True)
+    tests_for_iteration = get_tests(build.server_numeric_version, build.tests)
+    new_integrations, modified_integrations = get_changed_integrations(build)
+    all_module_instances, brand_new_integrations = configure_server_instances(build,
+                                                                              tests_for_iteration,
+                                                                              new_integrations,
+                                                                              modified_integrations)
+    successful_tests_pre, failed_tests_pre = instance_testing(build, all_module_instances, pre_update=True)
     if LooseVersion(build.server_numeric_version) < LooseVersion('6.0.0'):
         update_content_till_v6(build)
     elif not build.is_nightly:
         set_marketplace_url(build.servers, build.branch_name, build.ci_build_number)
-        installed_content_packs_successfully = install_packs(build,
-                                                             prints_manager) and installed_content_packs_successfully
+        installed_content_packs_successfully = install_packs(build) and installed_content_packs_successfully
 
     all_module_instances.extend(brand_new_integrations)
-    successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, prints_manager,
-                                                                pre_update=False)
-    disable_instances(build, all_module_instances, prints_manager)
+    successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
+    disable_instances(build, all_module_instances)
 
     success = report_tests_status(failed_tests_pre, failed_tests_post, successful_tests_pre, successful_tests_post,
-                                  new_integrations, prints_manager)
+                                  new_integrations)
     if not success or not installed_content_packs_successfully:
         sys.exit(2)
 

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -31,11 +31,6 @@ from Tests.update_content_data import update_content
 from Tests.Marketplace.search_and_install_packs import search_and_install_packs_and_their_dependencies, \
     install_all_content_packs, upload_zipped_packs
 from Tests.tools import update_server_configuration
-if __name__ == '__main__':
-    # The ValidateManager class imports a package that's configuring logging's basicConfig.
-    # This configuration overwrites any later configuration, so installing logging the way we want it should
-    # happen before importing this class
-    install_logging('Install Content And Configure Integrations On Server.log')
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 MARKET_PLACE_MACHINES = ('master',)
@@ -1272,6 +1267,7 @@ def set_marketplace_url(servers, branch_name, ci_build_number):
 
 
 def main():
+    install_logging('Install Content And Configure Integrations On Server.log')
     build = Build(options_handler())
 
     configure_servers_and_restart(build)

--- a/Tests/instance_notifier.py
+++ b/Tests/instance_notifier.py
@@ -3,6 +3,8 @@ import argparse
 
 import demisto_client
 from slackclient import SlackClient
+
+from Tests.scripts.utils.log_util import install_simple_logging
 from Tests.test_integration import __create_integration_instance, __delete_integrations_instances
 from Tests.test_content import ParallelPrintsManager
 from demisto_sdk.commands.common.tools import str2bool, print_color, print_error, LOG_COLORS, print_warning
@@ -26,9 +28,7 @@ def options_handler():
 
 
 def install_new_content(client, server):
-    prints_manager = ParallelPrintsManager(1)
-    update_content_on_demisto_instance(client, server, 'Demisto Marketplace', prints_manager, 0)
-    prints_manager.execute_thread_prints(0)
+    update_content_on_demisto_instance(client, server, 'Demisto Marketplace')
 
 
 def get_integrations(secret_conf_path):
@@ -148,6 +148,7 @@ def slack_notifier(slack_token, secret_conf_path, server, user, password, build_
 
 
 if __name__ == "__main__":
+    install_simple_logging()
     options = options_handler()
     if options.instance_tests:
         with open('./env_results.json', 'r') as json_file:

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -7,7 +7,8 @@ from time import sleep
 from ruamel import yaml
 from typing import List
 
-from demisto_sdk.commands.common.tools import print_error, print_warning, find_type
+from Tests.scripts.utils.log_util import install_simple_logging
+from demisto_sdk.commands.common.tools import print_error, find_type
 from Tests.test_content import ParallelPrintsManager
 from Tests.configure_and_test_integration_instances import Build, configure_servers_and_restart, \
     get_tests, \
@@ -18,24 +19,17 @@ from Tests.Marketplace.search_and_install_packs import \
     search_and_install_packs_and_their_dependencies_private, upload_zipped_packs
 
 
-def install_private_testing_pack(build: Build, prints_manager: ParallelPrintsManager, test_pack_zip_path: str):
+def install_private_testing_pack(build: Build, test_pack_zip_path: str):
     """
     Creates and installs the test pack used in the private build. This pack contains the test
     playbooks and test scripts that will be used for the tests.
 
     :param build: Build object containing the build settings.
-    :param prints_manager: PrintsManager object used for reporting status. Will be deprecated.
     :param test_pack_zip_path: Path to test_pack zip.
     :return: No object is returned. nightly_install_packs will wait for the process to finish.
     """
-    threads_print_manager = ParallelPrintsManager(len(build.servers))
-    nightly_install_packs(build, threads_print_manager, install_method=upload_zipped_packs,
+    nightly_install_packs(build, install_method=upload_zipped_packs,
                           pack_path=test_pack_zip_path)
-
-    prints_manager.add_print_job('Sleeping for 45 seconds...', print_warning, 0,
-                                 include_timestamp=True)
-    prints_manager.execute_thread_prints(0)
-    # sleep(45)
 
 
 def install_packs_private(build: Build, prints_manager: ParallelPrintsManager, pack_ids: list = None) -> bool:
@@ -52,8 +46,7 @@ def install_packs_private(build: Build, prints_manager: ParallelPrintsManager, p
     for server in build.servers:
         try:
             flag = search_and_install_packs_and_their_dependencies_private(build.test_pack_path,
-                                                                           pack_ids, server.client,
-                                                                           prints_manager)
+                                                                           pack_ids, server.client)
             if not flag:
                 raise Exception('Failed to search and install packs.')
         except Exception as exc:
@@ -120,32 +113,28 @@ def write_test_pack_zip(tests_file_paths: set, path_to_content: str,
 
 
 def main():
+    install_simple_logging()
     build = Build(options_handler())
     prints_manager = ParallelPrintsManager(1)
 
     configure_servers_and_restart(build, prints_manager)
     #  Get a list of the test we need to run.
-    tests_for_iteration = get_tests(build.server_numeric_version, prints_manager, build.tests)
+    tests_for_iteration = get_tests(build.server_numeric_version, build.tests)
     #  Installing the packs.
     installed_content_packs_successfully = install_packs_private(build, prints_manager)
     #  Get a list of the integrations that have changed.
-    new_integrations, modified_integrations = get_changed_integrations(build, prints_manager)
+    new_integrations, modified_integrations = get_changed_integrations(build)
     #  Configuring the instances which are used in testing.
     all_module_instances, brand_new_integrations = \
-        configure_server_instances(build, tests_for_iteration, new_integrations,
-                                   modified_integrations, prints_manager)
+        configure_server_instances(build, tests_for_iteration, new_integrations, modified_integrations)
 
     #  Running the instance tests (pushing the test button)
-    successful_tests_pre, failed_tests_pre = instance_testing(build, all_module_instances,
-                                                              prints_manager,
-                                                              pre_update=True)
+    successful_tests_pre, failed_tests_pre = instance_testing(build, all_module_instances, pre_update=True)
     #  Adding the new integrations to the instance test list and testing them.
     all_module_instances.extend(brand_new_integrations)
-    successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances,
-                                                                prints_manager,
-                                                                pre_update=False)
+    successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
     #  Done running tests so we are disabling the instances.
-    disable_instances(build, all_module_instances, prints_manager)
+    disable_instances(build, all_module_instances)
     #  Gather tests to add to test pack
     test_playbooks_from_id_set = build.id_set.get('TestPlaybooks', [])
     tests_to_add_to_test_pack = find_needed_test_playbook_paths(test_playbooks=test_playbooks_from_id_set,
@@ -156,10 +145,10 @@ def main():
                                                    tests_file_paths=tests_to_add_to_test_pack,
                                                    path_to_content=build.content_root)
     # Create and install private test pack
-    install_private_testing_pack(build, prints_manager, private_content_test_zip)
+    install_private_testing_pack(build, private_content_test_zip)
 
     success = report_tests_status(failed_tests_pre, failed_tests_post, successful_tests_pre, successful_tests_post,
-                                  new_integrations, prints_manager)
+                                  new_integrations)
     sleep(30)
     if not success or not installed_content_packs_successfully:
         sys.exit(2)

--- a/Tests/private_build/run_content_tests_private.py
+++ b/Tests/private_build/run_content_tests_private.py
@@ -12,6 +12,7 @@ import urllib3
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException
 
+from Tests.scripts.utils.log_util import install_simple_logging
 from Tests.test_integration import Docker, check_integration, disable_all_integrations
 from demisto_sdk.commands.common.constants import PB_Status
 from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
@@ -433,6 +434,7 @@ def manage_tests(tests_settings: SettingsTester):
 
 
 def main():
+    install_simple_logging()
     print("Time is: {}\n\n\n".format(datetime.datetime.now()))
     tests_settings = options_handler()
     manage_tests(tests_settings)

--- a/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
@@ -110,8 +110,6 @@ def test_create_install_private_testing_pack(mocker):
 
     """
 
-    prints_manager = ParallelPrintsManager(len(BuildMock().servers))
-
     def mocked_generic_request_func(self, path: str, method, body=None, accept=None,
                                     _request_timeout=None):
         if path == '/contentpacks/marketplace/install':
@@ -121,7 +119,7 @@ def test_create_install_private_testing_pack(mocker):
     mocker.patch.object(demisto_client, 'generic_request_func',
                         side_effect=mocked_generic_request_func)
     mock_build = BuildMock()
-    install_private_testing_pack(mock_build, prints_manager, 'testing/path/to/test_pack.zip')
+    install_private_testing_pack(mock_build, 'testing/path/to/test_pack.zip')
     assert script.SUCCESS_FLAG
 
 

--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -96,3 +96,21 @@ def install_logging(log_file_name: str, include_process_name=False) -> str:
     logging.basicConfig(level=logging.DEBUG,
                         handlers=[ch, fh])
     return log_file_path
+
+
+def install_simple_logging():
+    """
+    This method implements logging module to print the message only with colors
+    This function is implemented to support backwards compatibility for functions that cannot yes support the full
+    `install_logging` method capabilities
+    """
+    if not hasattr(logging, 'success'):
+        _add_logging_level('SUCCESS', 25)
+    coloredlogs.install(fmt='%(message)s',
+                        level_styles={
+                            'critical': {'bold': True, 'color': 'red'},
+                            'debug': {'color': 'cyan'},
+                            'error': {'color': 'red'},
+                            'info': {},
+                            'warning': {'color': 'yellow'},
+                            'success': {'color': 'green'}})

--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -94,14 +94,15 @@ def install_logging(log_file_name: str, include_process_name=False) -> str:
     ch.setLevel(logging.INFO)
     fh.setLevel(logging.DEBUG)
     logging.basicConfig(level=logging.DEBUG,
-                        handlers=[ch, fh])
+                        handlers=[ch, fh],
+                        force=True)
     return log_file_path
 
 
 def install_simple_logging():
     """
     This method implements logging module to print the message only with colors
-    This function is implemented to support backwards compatibility for functions that cannot yes support the full
+    This function is implemented to support backward compatibility for functions that cannot yet support the full
     `install_logging` method capabilities
     """
     if not hasattr(logging, 'success'):

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+
+import logging
 import os
 import re
 import sys
@@ -23,6 +25,9 @@ import urllib3
 import requests
 import demisto_client.demisto_api
 from demisto_client.demisto_api.rest import ApiException
+
+from Tests.scripts.utils.log_util import install_simple_logging
+
 try:
     """
     Those dual-imports are required as Slack updated their sdk and it breaks BC.
@@ -774,18 +779,18 @@ def get_server_numeric_version(ami_env, is_local_run=False):
     """
     default_version = '99.99.98'
     if is_local_run:
-        print_color(f'Local run, assuming server version is {default_version}', LOG_COLORS.GREEN)
+        logging.info(f'Local run, assuming server version is {default_version}')
         return default_version
 
     env_json = load_env_results_json()
     if not env_json:
-        print_warning(f'Did not find {ENV_RESULTS_PATH} file, assuming server version is {default_version}.')
+        logging.warning(f'Did not find {ENV_RESULTS_PATH} file, assuming server version is {default_version}.')
         return default_version
 
     instances_ami_names = {env.get('AmiName') for env in env_json if ami_env in env.get('Role', '')}
     if len(instances_ami_names) != 1:
-        print_warning(f'Did not get one AMI Name, got {instances_ami_names}.'
-                      f' Assuming server version is {default_version}')
+        logging.warning(f'Did not get one AMI Name, got {instances_ami_names}.'
+                        f' Assuming server version is {default_version}')
         return default_version
 
     instances_ami_name = list(instances_ami_names)[0]
@@ -803,7 +808,7 @@ def extract_server_numeric_version(instances_ami_name, default_version):
         server_numeric_version = extracted_version[0]
     else:
         if 'Master' in instances_ami_name:
-            print_color('Server version: Master', LOG_COLORS.GREEN)
+            logging.info('Server version: Master')
             return default_version
         else:
             server_numeric_version = default_version
@@ -812,7 +817,7 @@ def extract_server_numeric_version(instances_ami_name, default_version):
     if server_numeric_version.count('.') == 1:
         server_numeric_version += ".0"
 
-    print_color(f'Server version: {server_numeric_version}', LOG_COLORS.GREEN)
+    logging.info(f'Server version: {server_numeric_version}')
     return server_numeric_version
 
 
@@ -1511,6 +1516,7 @@ def lock_expired(lock_file: storage.Blob, lock_timeout: str) -> bool:
 
 
 def main():
+    install_simple_logging()
     print("Time is: {}\n\n\n".format(datetime.datetime.now()))
     tests_settings = options_handler()
 

--- a/Tests/tools.py
+++ b/Tests/tools.py
@@ -1,6 +1,8 @@
 import ast
+import logging
+from pprint import pformat
+
 import demisto_client
-from demisto_sdk.commands.common.tools import print_error
 
 
 def update_server_configuration(client, server_configuration, error_msg):
@@ -15,12 +17,14 @@ def update_server_configuration(client, server_configuration, error_msg):
         response_data: The response data
         status_code: The response status code
     """
+    logging.debug(f'Updating server configurations with {pformat(server_configuration)}')
     system_conf_response = demisto_client.generic_request_func(
         self=client,
         path='/system/config',
         method='GET'
     )
     system_conf = ast.literal_eval(system_conf_response[0]).get('sysConf', {})
+    logging.debug(f'Current server configurations are {pformat(system_conf)}')
     system_conf.update(server_configuration)
     data = {
         'data': system_conf,
@@ -31,12 +35,12 @@ def update_server_configuration(client, server_configuration, error_msg):
 
     try:
         result_object = ast.literal_eval(response_data)
+        logging.debug(f'Updated server configurations with response: {pformat(result_object)}')
     except ValueError as err:
-        print_error('failed to parse response from demisto. response is {}.\nError:\n{}'.format(response_data, err))
+        logging.exception('failed to parse response from demisto. response is {}.\nError:\n{}'.format(response_data, err))
         return
 
     if status_code >= 300 or status_code < 200:
         message = result_object.get('message', '')
-        msg = f'{error_msg} {status_code}\n{message}'
-        print_error(msg)
+        logging.error(f'{error_msg} {status_code}\n{message}')
     return response_data, status_code


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Related: https://github.com/demisto/etc/issues/30511

## Description
* Implemented logging in `Install Content And Configure Integrations On Server`
* Removed `printsManager` from where possible (All functions that are not being used in `Run Tests` step too)
* Added a `install_simple_logging` function that only configures the success logging level, the colors and the log format (message only) so that when replacing it with print_error, print_warning etc. will behave the same for the common functions with  `Run Tests`.
* It appears the sdk validator imports a package that calls logging basicConfig method before the log_util function.
Therefore, the `install_logging` method is executed before the sdk Validator is imported to enforce the correct logging configurations.
* Added debug logs and modified info logs where ever seems right

## Guidance:

### When reviewing - be sure to look at the log files also and not only the console logs

## Special build examples:
* Nightly: https://app.circleci.com/pipelines/github/demisto/content/42965/workflows/6c4b8bb6-8006-4d98-a1c8-9bd50bc216d5
* Instance Testing:  https://app.circleci.com/pipelines/github/demisto/content/42739/workflows/953cbfbf-a6e4-4e67-b214-a5977e9fafd4
* Private build: https://github.com/demisto/content-private/runs/1390923024
