### PR TITLE
Microsoft Teams - modify API query to filter user by given entity

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -756,7 +756,7 @@ def add_user_to_channel_command():
     team_name: str = demisto.args().get('team', '')
     member = demisto.args().get('member', '')
     user: list = get_user(member)
-    if not (user or user[0].get('id')):
+    if not (user and user[0].get('id')):
         raise ValueError(f'User {member} was not found')
 
     team_aad_id = get_team_aad_id(team_name)
@@ -1544,7 +1544,7 @@ def ring_user():
     # get user to call name and id
     username_to_call = demisto.args().get('username')
     user: list = get_user(username_to_call)
-    if not (user or user[0].get('id')):
+    if not (user and user[0].get('id')):
         raise ValueError(f'User {username_to_call} was not found')
 
     call_request_data = {

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -475,16 +475,20 @@ def get_graph_access_token() -> str:
 
 
 def http_request(
-        method: str, url: str = '', json_: dict = None, api: str = 'graph'
+        method: str, url: str = '', json_: dict = None, api: str = 'graph', params: Optional[Dict] = None
 ) -> Union[dict, list]:
-    """
-    A wrapper for requests lib to send our requests and handle requests and responses better
+    """A wrapper for requests lib to send our requests and handle requests and responses better
     Headers to be sent in requests
-    :param method: any restful method
-    :param url: URL to query
-    :param json_: HTTP JSON body
-    :param api: API to query (graph/bot)
-    :return: requests.json()
+
+    Args:
+        method (str): any restful method
+        url (str): URL to query
+        json_ (dict): HTTP JSON body
+        api (str): API to query (graph/bot)
+        params (dict): Object of key-value URL query parameters
+
+    Returns:
+        Union[dict, list]: The response in list or dict format.
     """
     if api == 'graph':
         access_token = get_graph_access_token()
@@ -502,7 +506,8 @@ def http_request(
             url,
             headers=headers,
             json=json_,
-            verify=USE_SSL
+            verify=USE_SSL,
+            params=params,
         )
 
         if not response.ok:
@@ -712,13 +717,21 @@ def get_team_aad_id(team_name: str) -> str:
 #     http_request('POST', url, json_=requestjson_)
 
 
-def get_users() -> list:
-    """
-    Retrieves list of AAD users
-    :return: List of AAD users
+def get_user(user: str) -> list:
+    """Retrieves the AAD ID of requested user
+
+    Args:
+        user (str): Display name/mail/UPN of user to get ID of.
+
+    Return:
+        list: List containing the requsted user object
     """
     url: str = f'{GRAPH_BASE_URL}/v1.0/users'
-    users: dict = cast(Dict[Any, Any], http_request('GET', url))
+    params = {
+        '$filter': f"displayName eq '{user}' or mail eq '{user}' or userPrincipalName eq '{user}'",
+        '$select': 'id'
+    }
+    users: dict = http_request('GET', url, params=params)
     return users.get('value', [])
 
 
@@ -742,20 +755,13 @@ def add_user_to_channel_command():
     channel_name: str = demisto.args().get('channel', '')
     team_name: str = demisto.args().get('team', '')
     member = demisto.args().get('member', '')
-    users: list = get_users()
-    user_id: str = str()
-    found_member: bool = False
-    for user in users:
-        if member in {user.get('displayName', ''), user.get('mail'), user.get('userPrincipalName')}:
-            found_member = True
-            user_id = user.get('id', '')
-            break
-    if not found_member:
+    user: list = get_user(member)
+    if not (user or user[0].get('id')):
         raise ValueError(f'User {member} was not found')
 
     team_aad_id = get_team_aad_id(team_name)
     channel_id = get_channel_id(channel_name, team_aad_id, investigation_id=None)
-    add_user_to_channel(team_aad_id, channel_id, user_id)
+    add_user_to_channel(team_aad_id, channel_id, user[0].get('id'))
 
     demisto.results(f'The User "{member}" has been added to channel "{channel_name}" successfully.')
 
@@ -1537,13 +1543,8 @@ def ring_user():
         )
     # get user to call name and id
     username_to_call = demisto.args().get('username')
-    users: list = get_users()
-    user_id: str = str()
-    for user in users:
-        if username_to_call in {user.get('displayName', ''), user.get('mail'), user.get('userPrincipalName')}:
-            user_id = user.get('id', '')
-            break
-    if not user_id:
+    user: list = get_user(username_to_call)
+    if not (user or user[0].get('id')):
         raise ValueError(f'User {username_to_call} was not found')
 
     call_request_data = {
@@ -1568,7 +1569,7 @@ def ring_user():
                     "user": {
                         "@odata.type": "#microsoft.graph.identity",
                         "displayName": username_to_call,
-                        "id": user_id
+                        "id": user[0].get('id')
                     }
                 }
             }

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -731,7 +731,7 @@ def get_user(user: str) -> list:
         '$filter': f"displayName eq '{user}' or mail eq '{user}' or userPrincipalName eq '{user}'",
         '$select': 'id'
     }
-    users: dict = http_request('GET', url, params=params)
+    users = cast(Dict[Any, Any], http_request('GET', url, params=params))
     return users.get('value', [])
 
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -291,7 +291,7 @@ script:
     description: Creates a new channel in a Microsoft Teams team.
     execution: false
     name: microsoft-teams-create-channel
-  dockerimage: demisto/teams:1.0.0.12455
+  dockerimage: demisto/teams:1.0.0.13080
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Microsoft Teams
 - Fixed an issue in which existing users were not found.
+- Upgraded the Docker image to demisto/teams:1.0.0.13080.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Microsoft Teams
 - Fixed an issue in which existing users were not found.
-- Upgraded the Docker image to: *demisto/teams:1.0.0.13080*.
+- Updated the Docker image to: *demisto/teams:1.0.0.13080*.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Teams
+- Fixed an issue in which existing users were not found.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_0_5.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Microsoft Teams
 - Fixed an issue in which existing users were not found.
-- Upgraded the Docker image to demisto/teams:1.0.0.13080.
+- Upgraded the Docker image to: *demisto/teams:1.0.0.13080*.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/30527

## Description
Modified the API request to filter user by display name/mail/UPN instead of getting all users and iterating them

## Minimum version of Demisto
- [x] 5.0.0

## Does it break backward compatibility?
   - [x] No