### PR TITLE
AlphaSOC NBA - Fix pagination bug

### DIFF
--- a/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
@@ -155,6 +155,7 @@ script:
 
         return {
             follow: response.follow,
+            more: response.more,
             content: response.alerts,
             threats: response.threats
         }
@@ -293,17 +294,36 @@ script:
                 return String(exc);
             }
         case 'fetch-incidents':
-            var follow = parseFollow();
-            var alerts = getAlerts(follow);
-
+            var more = true;
             var incidents = [];
-            if (alerts && alerts.content) {
-                for (var i = 0; i < alerts.content.length; i++) {
-                    appendIncidentsFromAlert(incidents, alerts.content[i], alerts.threats);
+            var follow = parseFollow();
+
+            try {
+                while (more) {
+                    var alerts = getAlerts(follow);
+
+                    if (alerts) {
+                        if (alerts.content) {
+                            for (var i = 0; i < alerts.content.length; i++) {
+                                appendIncidentsFromAlert(incidents, alerts.content[i], alerts.threats);
+                            }
+                        }
+
+                        more = alerts.more;
+                        follow = alerts.follow;
+                    } else {
+                        more = false;
+                    }
+
+                }
+            } catch (exc) {
+                if (incidents.length === 0) {
+                    // Throw, if it failed during the first fetch
+                    throw exc;
                 }
             }
 
-            saveFollow(alerts.follow);
+            saveFollow(follow);
             return JSON.stringify(incidents);
     }
   type: javascript

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_1.md
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlphaSOC Network Behavior Analytics
+- Fixed a bug that prevented downloading a full set of new incidents when the number of incidents was very high (over a thousand).

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AlphaSOC Network Behavior Analytics",
     "description": "Retrieve alerts from the AlphaSOC Analytics Engine",
     "support": "partner",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "AlphaSOC",
     "url": "",
     "email": "support@alphasoc.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This PR fixes a bug that prevented downloading a full set of new incidents when the number of incidents was very high (over a thousand). The integration didn't track the `more` field in the API response and was downloading only the first page of the results.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

fixes: https://github.com/demisto/etc/issues/30283
