### PR TITLE
Added a break condition in case the installation failed on pack that …

### DIFF
--- a/Tests/Marketplace/Tests/search_and_install_packs_test.py
+++ b/Tests/Marketplace/Tests/search_and_install_packs_test.py
@@ -247,8 +247,20 @@ def test_not_find_malformed_pack_id():
                                         'Reason: This is an error message without pack ID'):
         script.find_malformed_pack_id('This is an error message without pack ID')
 
+
 @timeout_decorator.timeout(3)
 def test_install_nightly_packs_endless_loop(mocker):
+    """
+    Given
+    - Packs to install with two packs that cannot be installed
+        (usually because their version does not exist in the bucket)
+    When
+    - Run install_nightly_packs method with those packs
+    Then
+    - Ensure the function does not enter an endless loop and that it gracefully removes the two damaged packs from the
+     installation list
+    """
+
     def generic_request_mock(self, path: str, method, body=None, accept=None, _request_timeout=None):
         requested_pack_ids = {pack['id'] for pack in body['packs']}
         for bad_integration in {'bad_integration1', 'bad_integration2'}:

--- a/Tests/Marketplace/Tests/search_and_install_packs_test.py
+++ b/Tests/Marketplace/Tests/search_and_install_packs_test.py
@@ -1,5 +1,6 @@
 import demisto_client
 import pytest
+import timeout_decorator
 
 import Tests.Marketplace.search_and_install_packs as script
 
@@ -245,3 +246,25 @@ def test_not_find_malformed_pack_id():
     with pytest.raises(Exception, match='The request to install packs has failed. '
                                         'Reason: This is an error message without pack ID'):
         script.find_malformed_pack_id('This is an error message without pack ID')
+
+@timeout_decorator.timeout(3)
+def test_install_nightly_packs_endless_loop(mocker):
+    def generic_request_mock(self, path: str, method, body=None, accept=None, _request_timeout=None):
+        requested_pack_ids = {pack['id'] for pack in body['packs']}
+        for bad_integration in {'bad_integration1', 'bad_integration2'}:
+            if bad_integration in requested_pack_ids:
+                raise Exception(f'invalid version 1.2.0 for pack with ID {bad_integration}')
+        return MOCK_PACKS_INSTALLATION_RESULT, 200, None
+
+    client = MockClient()
+    mocker.patch.object(demisto_client, 'generic_request_func', generic_request_mock)
+    mocker.patch("Tests.Marketplace.search_and_install_packs.logging")
+    packs_to_install = [
+        {'id': 'HelloWorld'},
+        {'id': 'TestPack'},
+        {'id': 'AzureSentinel'},
+        {'id': 'Base'},
+        {'id': 'bad_integration1'},
+        {'id': 'bad_integration2'},
+    ]
+    script.install_nightly_packs(client, 'my_host', packs_to_install)

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -196,7 +196,6 @@ def install_nightly_packs(client: demisto_client,
     Returns:
         None: No data returned.
     """
-    packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
     logging.info(f'Installing packs on server {host}')
     # make the pack installation request
     all_packs_install_successfully = False
@@ -206,6 +205,7 @@ def install_nightly_packs(client: demisto_client,
     }
     while not all_packs_install_successfully:
         try:
+            packs_to_install_str = ', '.join([pack['id'] for pack in packs_to_install])
             logging.debug(f'Installing the following packs in server {host}:\n{packs_to_install_str}')
             response_data, status_code, _ = demisto_client.generic_request_func(client,
                                                                                 path='/contentpacks/marketplace/install',
@@ -230,12 +230,17 @@ def install_nightly_packs(client: demisto_client,
             malformed_pack_id = find_malformed_pack_id(str(e))
             if not malformed_pack_id:
                 logging.exception('The request to install packs has failed')
-                break
+                raise
+            pack_ids_to_install = {pack['id'] for pack in packs_to_install}
+            if malformed_pack_id not in pack_ids_to_install:
+                logging.exception(
+                    f'The pack {malformed_pack_id} has failed to install even though it was not in the installation list')
+                raise
             logging.warning(f'The request to install packs has failed, retrying without {malformed_pack_id}')
             # Remove the malformed pack from the pack to install list.
-            packs = [pack for pack in packs_to_install if pack['id'] not in malformed_pack_id]
+            packs_to_install = [pack for pack in packs_to_install if pack['id'] not in malformed_pack_id]
             request_data = {
-                'packs': packs,
+                'packs': packs_to_install,
                 'ignoreWarnings': True
             }
 

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -232,6 +232,7 @@ def install_nightly_packs(client: demisto_client,
                 logging.exception('The request to install packs has failed')
                 raise
             pack_ids_to_install = {pack['id'] for pack in packs_to_install}
+            malformed_pack_id = malformed_pack_id[0]
             if malformed_pack_id not in pack_ids_to_install:
                 logging.exception(
                     f'The pack {malformed_pack_id} has failed to install even though it was not in the installation list')

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -19,3 +19,4 @@ git+https://github.com/coyo8/parinx.git@6493798ceba8089345d970f71be4a896eb6b081d
 pylint==2.6.0
 coloredlogs==14.0
 pandas==1.1.0
+timeout-decorator==0.5.0


### PR DESCRIPTION
…wasn't on the installation list


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
As seen in [this nightly build](https://app.circleci.com/pipelines/github/demisto/content/43378/workflows/2b1bf87f-bb05-474c-9c81-452aa28d8dac/jobs/187377) - There are two options to why it entered the endless loop.
1. The QRadar and CommonTypes packs are a mandatory dependencies for other packs in the list and that's why the installation failed with them even after they were removed.
2. The removal mechanism can only differ in one pack from the original packs to install that the method has received since the parameter `packs` is a set of packs made of `packs_to_install` - the malformed packs.

### The installation step should fail if the installation fails.

