### PR TITLE
Upload flow fixes

### DIFF
--- a/Tests/Marketplace/copy_and_upload_packs.py
+++ b/Tests/Marketplace/copy_and_upload_packs.py
@@ -237,9 +237,10 @@ def verify_copy(successful_packs, pc_successful_packs_dict):
         pc_successful_packs_dict: The pack that were uploaded successfully in Prepare Content
 
     """
-    pc_successful_packs = {*pc_successful_packs_dict}
-    not_uploaded = [pack for pack in pc_successful_packs if pack not in successful_packs]
-    mistakenly_uploaded = [pack for pack in successful_packs if pack not in pc_successful_packs]
+    pc_successful_packs_names = {*pc_successful_packs_dict}
+    successful_packs_names = {pack.name for pack in successful_packs}
+    not_uploaded = [pack for pack in pc_successful_packs_names if pack not in successful_packs_names]
+    mistakenly_uploaded = [pack for pack in successful_packs_names if pack not in pc_successful_packs_names]
     error_str = "Mismatch in Prepare Content successful packs and Upload successful packs\n"
     error_str += f"Packs not copied: {', '.join(not_uploaded)}\n" if not_uploaded else ""
     error_str += f"Packs mistakenly copied: {', '.join(mistakenly_uploaded)}\n" if mistakenly_uploaded else ""

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -21,7 +21,7 @@ BUCKET_UPLOAD_TYPE = 'bucket_upload_flow'
 SDK_BUILD_TITLE = 'SDK Nightly Build'
 SDK_XSOAR_BUILD_TITLE = 'Demisto SDK Nightly - Run Against Cortex XSOAR'
 BUCKET_UPLOAD_BUILD_TITLE = 'Upload Packs To Marketplace Storage'
-PACKS_RESULTS_FILE = "failed_packs_prepare_content.json"
+PACKS_RESULTS_FILE = "packs_results.json"
 
 
 def get_faild_steps_list():


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed two issues in upload-flow:
- Slack notifier now notifies on successful packs, see Screenshot1
- verify copy uses pack names instead of pack object and therefore not failing the build, see Screenshot2 (before) and Screenshot3 (after)

## Screenshots
Screenshot1:
![image](https://user-images.githubusercontent.com/53565845/99242614-2628f580-2808-11eb-9054-8700b2e04afc.png)

Screenshot2:
![image](https://user-images.githubusercontent.com/53565845/99241242-41930100-2806-11eb-911d-d0a2fbc4b808.png)

Screenshot3:
![image](https://user-images.githubusercontent.com/53565845/99242655-36d96b80-2808-11eb-8977-fbed5bcfefb1.png)

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
