### PR TITLE
Using thread index when running mocked integrations

### DIFF
--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -484,7 +484,7 @@ def run_test(conf_json_test_details, tests_queue, tests_settings, demisto_user, 
         run_test_logic(conf_json_test_details, tests_queue, tests_settings, client, demisto_user,
                        demisto_pass, failed_playbooks, integrations, playbook_id,
                        succeed_playbooks, test_message, test_options, slack, circle_ci,
-                       build_number, server_url, build_name, prints_manager)
+                       build_number, server_url, build_name, prints_manager, thread_index=thread_index)
         prints_manager.add_print_job('------ Test %s end ------\n' % (test_message,), print, thread_index,
                                      include_timestamp=True)
 


### PR DESCRIPTION
I'd hate to point out names, but it seems like someone forgot to send the thread_index to the `run_test_logic` method when running unmockable integrations.

Which messed up the prints in the nightly build because all threads used the same thread index (0) during their execution
![image](https://user-images.githubusercontent.com/41257953/99371443-92b6f980-28c7-11eb-81b8-289ae2f2bb59.png)
