### PR TITLE
Some build refractoring

### DIFF
--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -226,7 +226,7 @@ def install_nightly_packs(client: demisto_client,
             else:
                 result_object = ast.literal_eval(response_data)
                 message = result_object.get('message', '')
-                raise Exception(f'Failed to install packs - with status code {status_code}\n{message}\n')
+                raise Exception(f'Failed to install packs on server {host}- with status code {status_code}\n{message}\n')
             break
 
         except Exception as e:
@@ -241,7 +241,7 @@ def install_nightly_packs(client: demisto_client,
                 logging.exception(
                     f'The pack {malformed_pack_id} has failed to install even though it was not in the installation list')
                 raise
-            logging.warning(f'The request to install packs has failed, retrying without {malformed_pack_id}')
+            logging.warning(f'The request to install packs on server {host} has failed, retrying without {malformed_pack_id}')
             # Remove the malformed pack from the pack to install list.
             packs_to_install = [pack for pack in packs_to_install if pack['id'] not in malformed_pack_id]
             request_data = {
@@ -481,7 +481,7 @@ def upload_zipped_packs(client: demisto_client,
                                                                    header_params=header_params, files=files)
 
         if 200 <= status_code < 300:
-            logging.info(f'All packs from file {pack_path} were successfully installed!')
+            logging.info(f'All packs from file {pack_path} were successfully installed on server {host}')
         else:
             result_object = ast.literal_eval(response_data)
             message = result_object.get('message', '')

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -131,7 +131,7 @@ def main():
     all_module_instances.extend(brand_new_integrations)
     successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
     #  Done running tests so we are disabling the instances.
-    disable_instances(build, all_module_instances)
+    disable_instances(build)
     #  Gather tests to add to test pack
     test_playbooks_from_id_set = build.id_set.get('TestPlaybooks', [])
     tests_to_add_to_test_pack = find_needed_test_playbook_paths(test_playbooks=test_playbooks_from_id_set,

--- a/Tests/private_build/run_content_tests_private.py
+++ b/Tests/private_build/run_content_tests_private.py
@@ -11,7 +11,7 @@ import urllib3
 import demisto_client.demisto_api
 
 from Tests.scripts.utils.log_util import install_logging
-from Tests.test_integration import Docker, check_integration, disable_all_integrations
+from Tests.test_integration import Docker, check_integration
 from demisto_sdk.commands.common.constants import PB_Status
 from demisto_sdk.commands.common.tools import str2bool
 
@@ -289,7 +289,6 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
     skipped_integration = set([])
     playbook_skipped_integration = set([])
 
-    disable_all_integrations(xsoar_client)
     #  Private builds do not use mocking. Here we copy the mocked test list to the unmockable list.
     private_tests = get_test_records_of_given_test_names(tests_settings, all_tests)
     try:

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -182,38 +182,44 @@ def print_test_summary(tests_data_keeper: DataKeeperTester,
     unmocklable_integrations_count = len(unmocklable_integrations)
     logging_module.info('TEST RESULTS:')
     logging_module.info(f'Number of playbooks tested - {succeed_count + failed_count}')
-    logging_module.success(f'Number of succeeded tests - {succeed_count}')
-    if succeed_count:
-        logging_module.success(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in succeed_playbooks]))
     if failed_count:
         logging_module.error(f'Number of failed tests - {failed_count}:')
-        logging_module.error(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in failed_playbooks]))
+        logging_module.error('Failed Tests: {}'.format(
+                             ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in failed_playbooks])))
+    if succeed_count:
+        logging_module.success(f'Number of succeeded tests - {succeed_count}')
+        logging_module.success('Successful Tests: {}'.format(
+                               ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in succeed_playbooks])))
     if rerecorded_count > 0:
-        logging_module.warning(f'Tests with failed playback and successful re-recording - {rerecorded_count}')
-        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in rerecorded_tests]))
+        logging_module.warning(f'Number of tests with failed playback and successful re-recording - {rerecorded_count}')
+        logging_module.warning('Tests with failed playback and successful re-recording: {}'.format(
+                               ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in rerecorded_tests])))
 
     if empty_mocks_count > 0:
-        logging_module.info(f'Successful tests with empty mock files - {empty_mocks_count}:\n')
+        logging_module.info(f'Successful tests with empty mock files count- {empty_mocks_count}:\n')
         proxy_explanation = \
-            '\t\t\t\t\t\t (either there were no http requests or no traffic is passed through the proxy.\n' \
-            '\t\t\t\t\t\t Investigate the playbook and the integrations.\n' \
-            '\t\t\t\t\t\t If the integration has no http traffic, add to unmockable_integrations in conf.json)'
+            '\t\t\t\t\t\t\t (either there were no http requests or no traffic is passed through the proxy.\n' \
+            '\t\t\t\t\t\t\t Investigate the playbook and the integrations.\n' \
+            '\t\t\t\t\t\t\t If the integration has no http traffic, add to unmockable_integrations in conf.json)'
         logging_module.info(proxy_explanation)
-        logging_module.info(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in empty_files]))
+        logging_module.info('Successful tests with empty mock files: {}'.format(
+                            ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in empty_files])))
 
     if len(skipped_integration) > 0:
         logging_module.warning(f'Number of skipped integration - {len(skipped_integration):}')
-        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_integration]))
+        logging_module.warning('Skipped integration: {}'.format(
+                               ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_integration])))
 
     if skipped_count > 0:
         logging_module.warning(f'Number of skipped tests - {skipped_count}:')
-        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_tests]))
+        logging_module.warning('Skipped tests: {}'.format(
+                               ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_tests])))
 
     if unmocklable_integrations_count > 0:
         logging_module.warning(f'Number of unmockable integrations - {unmocklable_integrations_count}:')
-        logging_module.warning(
-            ''.join([f'\n\t\t\t\t\t\t - {playbook_id} - {reason}' for playbook_id, reason in
-                     unmocklable_integrations.items()]))
+        logging_module.warning('Unmockable integrations: {}'.format(
+                               ''.join([f'\n\t\t\t\t\t\t\t - {playbook_id} - {reason}' for playbook_id, reason in
+                                        unmocklable_integrations.items()])))
 
 
 def update_test_msg(integrations, test_message):

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -810,7 +810,6 @@ def execute_testing(tests_settings,
     skipped_integration = set([])
     playbook_skipped_integration = set([])
 
-    logging_manager.execute_logs()
     mockable_tests = get_test_records_of_given_test_names(tests_settings, mockable_tests_names)
     unmockable_tests = get_test_records_of_given_test_names(tests_settings, unmockable_tests_names)
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -38,7 +38,7 @@ except ModuleNotFoundError:
     from slackclient import SlackClient  # Old slack
 
 from Tests.mock_server import MITMProxy, AMIConnection
-from Tests.test_integration import Docker, check_integration, disable_all_integrations
+from Tests.test_integration import Docker, check_integration
 from Tests.test_dependencies import get_used_integrations, get_tests_allocation_for_threads
 from demisto_sdk.commands.common.constants import FILTER_CONF, PB_Status
 from demisto_sdk.commands.common.tools import str2bool
@@ -810,7 +810,6 @@ def execute_testing(tests_settings,
     skipped_integration = set([])
     playbook_skipped_integration = set([])
 
-    disable_all_integrations(xsoar_client, logging_manager)
     logging_manager.execute_logs()
     mockable_tests = get_test_records_of_given_test_names(tests_settings, mockable_tests_names)
     unmockable_tests = get_test_records_of_given_test_names(tests_settings, unmockable_tests_names)

--- a/Tests/tests/configure_and_test_integration_instances_test.py
+++ b/Tests/tests/configure_and_test_integration_instances_test.py
@@ -1,4 +1,4 @@
-from Tests.configure_and_test_integration_instances import configure_old_and_new_integrations
+from Tests.configure_and_test_integration_instances import configure_modified_and_new_integrations
 
 
 def test_configure_old_and_new_integrations(mocker):
@@ -19,9 +19,9 @@ def test_configure_old_and_new_integrations(mocker):
 
     mocker.patch('Tests.configure_and_test_integration_instances.configure_integration_instance',
                  side_effect=configure_integration_instance_mocker)
-    old_modules_instances, new_modules_instances = configure_old_and_new_integrations(
+    old_modules_instances, new_modules_instances = configure_modified_and_new_integrations(
         build=mocker.MagicMock(servers=['server1']),
-        old_integrations_to_configure=['old_integration1', 'old_integration2'],
+        modified_integrations_to_configure=['old_integration1', 'old_integration2'],
         new_integrations_to_configure=['new_integration1', 'new_integration2'],
         demisto_client=None
     )


### PR DESCRIPTION
## Description

- refactored the main method of `Tests/configure_and_test_integration_instances.py` to be more readable (no logic change there, just separating the code to smaller functions)
- Moved the disabling of the integrations from the beginning of the test playbooks step to the end of the content installation and configuration
- Removed the 45 seconds sleep in the beginning of `Tests/test_content.py` as it seems the related issue is solved

### Related issues:
https://github.com/demisto/etc/issues/30511
https://github.com/demisto/etc/issues/30292