### PR TITLE
AlphaSOC NBA - Adjust default incident severity from 3 to 4

### DIFF
--- a/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
@@ -25,6 +25,7 @@ configuration:
   defaultvalue: "4"
   type: 0
   required: true
+  additionalinfo: "AlphaSOC alert severity: (1) info, (2) low, (3) medium, (4) high, (5) critical"
 - display: Include policy violations
   name: policy
   defaultvalue: "true"

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
@@ -22,7 +22,7 @@ configuration:
   required: true
 - display: Ignore events below severity
   name: severity
-  defaultvalue: "3"
+  defaultvalue: "4"
   type: 0
   required: true
 - display: Include policy violations

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_1.md
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlphaSOC Network Behavior Analytics
+- Adjust the default minimum severity from 3 to 4

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AlphaSOC Network Behavior Analytics",
     "description": "Retrieve alerts from the AlphaSOC Analytics Engine",
     "support": "partner",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "AlphaSOC",
     "url": "",
     "email": "support@alphasoc.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This PR changes the default minimum severity of incidents to retrieve. Certain user environments may generate significant amount of low or medium severity incidents which are then unnecessarily fetched by default.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

fixes: https://github.com/demisto/etc/issues/30283
