### PR TITLE
Supporting json bodies with single quotes

### DIFF
--- a/Tests/timestamp_replacer.py
+++ b/Tests/timestamp_replacer.py
@@ -1,4 +1,5 @@
 import json
+from ast import literal_eval
 import functools
 import urllib
 from collections import OrderedDict
@@ -110,11 +111,6 @@ class TimestampReplacer:
             print(f'urlencoded_form data = {req.urlencoded_form.items()}')
         print(f'hashed_data={ServerPlayback._hash(self, flow)}')
 
-    # @record_concurrently(
-    #     replaying=bool(
-    #         ctx.options.server_replay or (ctx.options.rfile and ctx.options.save_stream_file)
-    #     )
-    # )
     def request(self, flow: flow.Flow) -> None:
         self.count += 1
         if ctx.options.debug:
@@ -200,9 +196,10 @@ class TimestampReplacer:
                 content = req.raw_content.decode()
             else:
                 content = ''
+            print(f'cleaning json body: content={content}')
             json_data = content.startswith('{')
             if json_data:
-                content = json.loads(content, object_pairs_hook=OrderedDict)
+                content = OrderedDict(literal_eval(content))
                 self.modify_json_body(req, content)
 
     def modify_json_body(self, req: HTTPRequest, json_body: dict) -> None:
@@ -309,9 +306,10 @@ class TimestampReplacer:
                 content = req.raw_content.decode()
             else:
                 content = ''
+            print(f'handling json body: content={content}')
             json_data = content.startswith('{')
             if json_data:
-                content = json.loads(content, object_pairs_hook=OrderedDict)
+                content = OrderedDict(literal_eval(content))
                 json_keys = self.determine_problematic_keys(content)
                 self.json_keys.update(json_keys)
 


### PR DESCRIPTION
Currently the `timestamp_replacer.py script uses json.loads for all body types.

This can causes trouble when trying to parse json content's with single quotes with the following example exception:

```
Request(POST /api/policy/blockedsenders/delete-policy)
Addon error: Traceback (most recent call last):
File "/home/ec2-user/timestamp_replacer.py", line 125, in request
self.run_all_key_detections(req)
File "/home/ec2-user/timestamp_replacer.py", line 263, in run_all_key_detections
self.handle_json_body(req)
File "/home/ec2-user/timestamp_replacer.py", line 323, in handle_json_body
content = json.loads(content, object_pairs_hook=OrderedDict)
File "/usr/lib64/python3.7/json/__init__.py", line 361, in loads
return cls(**kw).decode(s)
File "/usr/lib64/python3.7/json/decoder.py", line 337, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "/usr/lib64/python3.7/json/decoder.py", line 353, in raw_decode
obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

So instead we will use `ast.literal_eval`.