### PR TITLE
Support mitmdump service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,11 @@ references:
         export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
         zip -P $PSWD $CIRCLE_ARTIFACTS/ServerLogs.zip $CIRCLE_ARTIFACTS/server*.log || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
         rm -f $CIRCLE_ARTIFACTS/server*.log
+        if [ -f $CIRCLE_ARTIFACTS/logs/Run_Tests.log ];
+        then
+            zip -P $PSWD $CIRCLE_ARTIFACTS/logs/Run_Tests.zip $CIRCLE_ARTIFACTS/logs/Run_Tests.log
+            rm -f $CIRCLE_ARTIFACTS/logs/Run_Tests.log
+        fi
       when: always
 
   persist_to_workspace: &persist_to_workspace

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -383,6 +383,7 @@ def mock_run(conf_json_test_details, tests_queue, tests_settings, c, demisto_use
             logging_manager.info(f'------ Test {test_message} end ------\n')
             return
         proxy.failed_tests_count += 1
+        proxy.get_mitmdump_service_status()
         logging_manager.warning("Test failed with mock, recording new mock file. (Mock: Recording)")
         rerecord = True
     else:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/30765

## Related PRs:
https://github.com/demisto/content-test-conf/pull/1041

## Description

* ### Supporting mitmdump service
    - Before starting the service creates a file named `/home/ec2-user/mitmdump_rc` which will be used by the service's start.
    - using `start` and `stop` commands to start and stop the service

* ### Added polling mechanism 
    - with timeout that waits until the mitmdump is ready and gets last in case it failed to start using `systemctl status mitmdump` command

* ### Copying the `timestamp_replacer.py` script only once in the `MITMProxy` init.

### The changes to the file `Tests/test_content.py` are only there tomporary and should be removed once [this](https://github.com/demisto/content-test-conf/pull/1041) PR is merged