### PR TITLE
fixed 6.0 'wait until server ready' step in upload packs flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1182,7 +1182,12 @@ jobs:
       - *attach_workspace
       - *add_ssh_keys
       - *prepare_environment
-      - *wait_until_server_ready
+      - run:
+          name: Wait until server ready
+          shell: /bin/bash
+          when: always
+          command: |
+            python3 ./Tests/scripts/wait_until_server_ready.py "Demisto 6.0"
       - run:
           name: Install Packs
           shell: /bin/bash


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
wait until server 6.0 is ready instead of server master.
