### PR TITLE
CircleCI config - set docker heap env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,9 @@ references:
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
+        environment:
+          MAX_HEAP_SIZE: 2048m
+          HEAP_NEWSIZE: 512m
 
   workspace_root: &workspace_root
     /home/circleci/


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
https://github.com/demisto/etc/issues/30292

## Description
setting the docker heap env vars as suggested in https://discuss.circleci.com/t/using-official-docker-images/13196