### PR TITLE
Adds support for Vsys to panorama-get-logs and Panorama Query Logs

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -4355,6 +4355,8 @@ def prettify_log(log: dict):
         pretty_log['TimeGenerated'] = log['time_generated']
     if 'url_category_list' in log:
         pretty_log['URLCategoryList'] = log['url_category_list']
+    if 'vsys' in log:
+        pretty_log['Vsys'] = log['vsys']
 
     return pretty_log
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -3212,6 +3212,9 @@ script:
     - contextPath: Panorama.Monitor.Logs.BytesSent
       description: Log bytes sent.
       type: String
+    - contextPath: Panorama.Monitor.Logs.Vsys
+      description: Vsys on the firewall that generated the log.
+      type: String
   - arguments:
     - default: false
       description: The application name.

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -2999,6 +2999,7 @@ enforce the policy. |
 | Panorama.Monitor.Logs.Bytes | String | Total log bytes. | 
 | Panorama.Monitor.Logs.BytesReceived | String | Log bytes received. | 
 | Panorama.Monitor.Logs.BytesSent | String | Log bytes sent. | 
+| Panorama.Monitor.Logs.Vsys | String | Vsys on the firewall that generated the log. | 
 
 
 #### Command Example

--- a/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs.yml
@@ -540,6 +540,9 @@ outputs:
 - contextPath: Panorama.Monitor.Logs.URLCategoryList
   description: A list of the URL filtering categories that the firewall used to enforce policy.
   type: string
+- contextPath: Panorama.Monitor.Logs.Vsys
+  description: Vsys on the firewall that generated the log.
+  type: string
 - contextPath: Panorama.Monitor.JobID
   description: Job ID of the log query.
 - contextPath: Panorama.Monitor.Status

--- a/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs_README.md
+++ b/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs_README.md
@@ -78,6 +78,7 @@ This playbook does not use any scripts.
 | Panorama.Monitor.Logs.ToZone | The zone to which the session was sent. | string |
 | Panorama.Monitor.Logs.TimeGenerated | The time that the log was generated on the dataplane. | string |
 | Panorama.Monitor.Logs.URLCategoryList | The list of URL filtering categories that the firewall used to enforce policy. | string |
+| Panorama.Monitor.Logs.Vsys | Vsys on the firewall that generated the log. | string |
 | Panorama.Monitor.JobID | The job ID of the log query. | unknown |
 | Panorama.Monitor.Status | The status of the log query. | string |
 | Panorama.Monitor.Message | The message of the log query. | string |

--- a/Packs/PAN-OS/ReleaseNotes/1_6_8.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_6_8.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Added Panorama.Monitor.Logs.Vsys output field in panorama-get-logs command
+
+#### Playbooks
+##### Panorama Query Logs
+- Added Panorama.Monitor.Logs.Vsys in the subplaybook outputs

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.6.7",
+    "currentVersion": "1.6.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
*No open issue*

## Description
With the current version of the PAN-OS integration the *vsys* of PAN-OS/Panorama logs is not exported by panorama-get-logs and Panorama Query Logs subplaybook.
With this PR the *vsys* field from PAN-OS/Panorama logs is correctly exported by panorama-get-logs command and by Panorama Query Logs subplaybook.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
