### PR TITLE
Add transform_results arg to cdl-query-logs

### DIFF
--- a/Packs/CortexDataLake/.secrets-ignore
+++ b/Packs/CortexDataLake/.secrets-ignore
@@ -43,3 +43,5 @@ eujea0rudykqgbvianr5lqfgrykbufbamkeyizdw1npk96zax5c4h8sbxs1kgqx31nwp5jsfsgif8ior
 cbdf1f3cccd949e6e96c425b3d7ccc463b956f002f694472e4d24a12ff2cea4d
 PetZR587UGE/wOkxgS2b+zF364WTmJ29VnV2gihfJZM=
 t6dTRzTObu15RCxw6Nk7SPFXe83uxr06yPMC5Px1p8c=
+203.0.113.1
+198.51.100.20

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
@@ -787,6 +787,7 @@ def query_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[
     """
     query = args.get('query', '')
     limit = args.get('limit', '')
+    transform_results = argToBoolean(args.get('transform_results', 'Yes'))
 
     if 'limit' not in query.lower():
         query += f' LIMIT {limit}'
@@ -794,10 +795,10 @@ def query_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[
     records, raw_results = client.query_loggings(query)
 
     table_name = get_table_name(query)
-    transformed_results = [common_context_transformer(record) for record in records]
-    human_readable = tableToMarkdown('Logs ' + table_name + ' table', transformed_results, removeNull=True)
+    output_results = records if not transform_results else [common_context_transformer(record) for record in records]
+    human_readable = tableToMarkdown('Logs ' + table_name + ' table', output_results, removeNull=True)
     ec = {
-        'CDL.Logging': transformed_results
+        'CDL.Logging': output_results
     }
     return human_readable, ec, raw_results
 

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.py
@@ -787,7 +787,7 @@ def query_logs_command(args: dict, client: Client) -> Tuple[str, Dict[str, List[
     """
     query = args.get('query', '')
     limit = args.get('limit', '')
-    transform_results = argToBoolean(args.get('transform_results', 'Yes'))
+    transform_results = argToBoolean(args.get('transform_results', 'true'))
 
     if 'limit' not in query.lower():
         query += f' LIMIT {limit}'

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
@@ -232,11 +232,15 @@ script:
       - weeks
       required: false
       secret: false
-    - default: false
-      defaultValue: 'Yes'
-      description: If set to No query results are not mapped into the standard command context. Default is Yes.
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'true'
+      description: If set to false query results are not mapped into the standard command context. Default is true.
       isArray: false
       name: transform_results
+      predefined:
+      - 'true'
+      - 'false'
       required: false
       secret: false
     deprecated: false

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake.yml
@@ -232,6 +232,13 @@ script:
       - weeks
       required: false
       secret: false
+    - default: false
+      defaultValue: 'Yes'
+      description: If set to No query results are not mapped into the standard command context. Default is Yes.
+      isArray: false
+      name: transform_results
+      required: false
+      secret: false
     deprecated: false
     description: Runs a query on the threat table according to preset queries.
     execution: false

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
@@ -133,3 +133,71 @@ def test_get_table_name():
     assert get_table_name(query) == 'firewall.threat'
     query = 'Wrongly formmated query'
     assert get_table_name(query) == 'Unrecognized table name'
+
+
+def test_query_logs_command_transform_results():
+    from CortexDataLake import query_logs_command
+    cdl_record = {
+        'action': {'value': 'allow'},
+        'app': 'web-browsing',
+        'protocol': {'value': 'tcp'},
+        'dest_ip': {'value': '198.51.100.20'},
+        'rule_matched': 'Allow-All',
+        'characteristics_of_app': [
+            "able-to-transfer-file",
+            "has-known-vulnerability",
+            "tunnel-other-application",
+            "prone-to-misuse",
+            "is-saas"
+        ],
+        'log_source_name': 'ngfw1',
+        'is_nat': False,
+        'nat_dest_port': 80,
+        'nat_dest': {'value': '198.51.100.20'},
+        'nat_source': {'value': '203.0.113.1'},
+        'source_ip': {'value': '203.0.113.1'},
+        'app_category': 'networking',
+        'source_location': '203.0.113.0-203.0.113.255',
+        'dest_location': '198.51.100.0-198.51.255',
+        'count': 100,
+    }
+
+    class MockClient():
+        def query_loggings(self, query):
+            return [cdl_record], []
+
+    # test with no transform_results options, should transform to common context
+    _, results_no_xform, _ = query_logs_command({'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`'}, MockClient())
+    assert results_no_xform == {'CDL.Logging': [{
+        'Action': 'allow',
+        'App': 'web-browsing',
+        'Protocol': 'tcp',
+        'DestinationIP': '198.51.100.20',
+        'RuleMatched': 'Allow-All',
+        'CharacteristicOfApp': [
+            "able-to-transfer-file",
+            "has-known-vulnerability",
+            "tunnel-other-application",
+            "prone-to-misuse",
+            "is-saas"
+        ],
+        'LogSourceName': 'ngfw1',
+        'IsNat': False,
+        'NatDestinationPort': 80,
+        'NatDestination': '198.51.100.20',
+        'NatSource': '203.0.113.1',
+        'SourceIP': '203.0.113.1',
+        'AppCategory': 'networking',
+        'SourceLocation': '203.0.113.0-203.0.113.255',
+        'DestinationLocation': '198.51.100.0-198.51.255',
+        'FileSHA256': None,
+        'FileName': None,
+        'TimeGenerated': None
+    }]}
+
+    # test with transform_results options, should transform to common context
+    _, results_xform, _ = query_logs_command(
+        {'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`', 'transform_results': 'No'},
+        MockClient()
+    )
+    assert results_xform == {'CDL.Logging': [cdl_record]}

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
@@ -197,7 +197,7 @@ def test_query_logs_command_transform_results():
 
     # test with transform_results options, should transform to common context
     _, results_xform, _ = query_logs_command(
-        {'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`', 'transform_results': 'No'},
+        {'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`', 'transform_results': 'false'},
         MockClient()
     )
     assert results_xform == {'CDL.Logging': [cdl_record]}

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/CortexDataLake_test.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from CommonServerPython import parse_date_range
 
 HUMAN_READABLE_TIME_FROM_EPOCH_TIME_TEST_CASES = [(1582210145000000, False, '2020-02-20T14:49:05'),
@@ -23,6 +24,11 @@ QUERY_TIMESTAMPS_TEST_CASES = [
         'Both start/end time and time range'
     )
 ]
+
+
+def load_test_data(json_path):
+    with open(json_path) as f:
+        return json.load(f)
 
 
 @pytest.mark.parametrize('epoch_time, utc_time, expected_response', HUMAN_READABLE_TIME_FROM_EPOCH_TIME_TEST_CASES)
@@ -135,69 +141,32 @@ def test_get_table_name():
     assert get_table_name(query) == 'Unrecognized table name'
 
 
-def test_query_logs_command_transform_results():
+def test_query_logs_command_transform_results_1():
+    """
+    Given:
+        - a list of CDL query results
+    When
+        - running query_logs_command function
+    Then
+        - if transform_results is not specified, CDL query results are mapped into the CDL common context (test 1)
+        - if transform_results is set to false, CDL query results are returned unaltered (test 2)
+    """
     from CortexDataLake import query_logs_command
-    cdl_record = {
-        'action': {'value': 'allow'},
-        'app': 'web-browsing',
-        'protocol': {'value': 'tcp'},
-        'dest_ip': {'value': '198.51.100.20'},
-        'rule_matched': 'Allow-All',
-        'characteristics_of_app': [
-            "able-to-transfer-file",
-            "has-known-vulnerability",
-            "tunnel-other-application",
-            "prone-to-misuse",
-            "is-saas"
-        ],
-        'log_source_name': 'ngfw1',
-        'is_nat': False,
-        'nat_dest_port': 80,
-        'nat_dest': {'value': '198.51.100.20'},
-        'nat_source': {'value': '203.0.113.1'},
-        'source_ip': {'value': '203.0.113.1'},
-        'app_category': 'networking',
-        'source_location': '203.0.113.0-203.0.113.255',
-        'dest_location': '198.51.100.0-198.51.255',
-        'count': 100,
-    }
+
+    cdl_records = load_test_data('./test_data/test_query_logs_command_transform_results_original.json')
+    cdl_records_xform = load_test_data('./test_data/test_query_logs_command_transform_results_xformed.json')
 
     class MockClient():
         def query_loggings(self, query):
-            return [cdl_record], []
+            return cdl_records, []
 
-    # test with no transform_results options, should transform to common context
-    _, results_no_xform, _ = query_logs_command({'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`'}, MockClient())
-    assert results_no_xform == {'CDL.Logging': [{
-        'Action': 'allow',
-        'App': 'web-browsing',
-        'Protocol': 'tcp',
-        'DestinationIP': '198.51.100.20',
-        'RuleMatched': 'Allow-All',
-        'CharacteristicOfApp': [
-            "able-to-transfer-file",
-            "has-known-vulnerability",
-            "tunnel-other-application",
-            "prone-to-misuse",
-            "is-saas"
-        ],
-        'LogSourceName': 'ngfw1',
-        'IsNat': False,
-        'NatDestinationPort': 80,
-        'NatDestination': '198.51.100.20',
-        'NatSource': '203.0.113.1',
-        'SourceIP': '203.0.113.1',
-        'AppCategory': 'networking',
-        'SourceLocation': '203.0.113.0-203.0.113.255',
-        'DestinationLocation': '198.51.100.0-198.51.255',
-        'FileSHA256': None,
-        'FileName': None,
-        'TimeGenerated': None
-    }]}
+    # test 1, with no transform_results options, should transform to common context
+    _, results_xform, _ = query_logs_command({'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`'}, MockClient())
+    assert results_xform == {'CDL.Logging': cdl_records_xform}
 
-    # test with transform_results options, should transform to common context
-    _, results_xform, _ = query_logs_command(
+    # test 2, with transform_results options, should transform to common context
+    _, results_noxform, _ = query_logs_command(
         {'limit': '1', 'query': 'SELECT * FROM `firewall.traffic`', 'transform_results': 'false'},
         MockClient()
     )
-    assert results_xform == {'CDL.Logging': [cdl_record]}
+    assert results_noxform == {'CDL.Logging': cdl_records}

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
@@ -70,7 +70,8 @@ Runs a query on the Cortex logging service.
 | --- | --- | --- |
 | query | A free-text SQL query. For example, query="SELECT * FROM \`firewall.traffic\` limit 10". There are multiple tables in Loggings, for example: threat, traffic, and so on. Refer to the Cortex Logging service schema reference for the full list. | Optional |
 | limit | The number of logs to return. Default is 10 | Optional | 
- 
+| transform_results | If set to No query results are not mapped into the standard command context. Default is Yes. | Optional | 
+
 
 
 ##### Context Output

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/README.md
@@ -70,7 +70,7 @@ Runs a query on the Cortex logging service.
 | --- | --- | --- |
 | query | A free-text SQL query. For example, query="SELECT * FROM \`firewall.traffic\` limit 10". There are multiple tables in Loggings, for example: threat, traffic, and so on. Refer to the Cortex Logging service schema reference for the full list. | Optional |
 | limit | The number of logs to return. Default is 10 | Optional | 
-| transform_results | If set to No query results are not mapped into the standard command context. Default is Yes. | Optional | 
+| transform_results | If set to false query results are not mapped into the standard command context. Default is true. | Optional | 
 
 
 
@@ -1247,4 +1247,3 @@ against. That is, log types must be fully qualified and the instance ID is a par
 `<instanceID>.firewall.traffic`
 However in this integration the instance ID is added automatically to the query so the name `firewall.traffic` is a valid table name
 * The SQL syntex supported for queries is `csql`
-

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/test_data/test_query_logs_command_transform_results_original.json
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/test_data/test_query_logs_command_transform_results_original.json
@@ -1,0 +1,24 @@
+[{
+    "action": {"value": "allow"},
+    "app": "web-browsing",
+    "protocol": {"value": "tcp"},
+    "dest_ip": {"value": "198.51.100.20"},
+    "rule_matched": "Allow-All",
+    "characteristics_of_app": [
+        "able-to-transfer-file",
+        "has-known-vulnerability",
+        "tunnel-other-application",
+        "prone-to-misuse",
+        "is-saas"
+    ],
+    "log_source_name": "ngfw1",
+    "is_nat": false,
+    "nat_dest_port": 80,
+    "nat_dest": {"value": "198.51.100.20"},
+    "nat_source": {"value": "203.0.113.1"},
+    "source_ip": {"value": "203.0.113.1"},
+    "app_category": "networking",
+    "source_location": "203.0.113.0-203.0.113.255",
+    "dest_location": "198.51.100.0-198.51.255",
+    "count": 100
+}]

--- a/Packs/CortexDataLake/Integrations/CortexDataLake/test_data/test_query_logs_command_transform_results_xformed.json
+++ b/Packs/CortexDataLake/Integrations/CortexDataLake/test_data/test_query_logs_command_transform_results_xformed.json
@@ -1,0 +1,26 @@
+[{
+    "Action": "allow",
+    "App": "web-browsing",
+    "Protocol": "tcp",
+    "DestinationIP": "198.51.100.20",
+    "RuleMatched": "Allow-All",
+    "CharacteristicOfApp": [
+        "able-to-transfer-file",
+        "has-known-vulnerability",
+        "tunnel-other-application",
+        "prone-to-misuse",
+        "is-saas"
+    ],
+    "LogSourceName": "ngfw1",
+    "IsNat": false,
+    "NatDestinationPort": 80,
+    "NatDestination": "198.51.100.20",
+    "NatSource": "203.0.113.1",
+    "SourceIP": "203.0.113.1",
+    "AppCategory": "networking",
+    "SourceLocation": "203.0.113.0-203.0.113.255",
+    "DestinationLocation": "198.51.100.0-198.51.255",
+    "FileSHA256": null,
+    "FileName": null,
+    "TimeGenerated": null
+}]

--- a/Packs/CortexDataLake/ReleaseNotes/1_2_9.md
+++ b/Packs/CortexDataLake/ReleaseNotes/1_2_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cortex Data Lake
+- Addes transform_results argument in cdl-query-logs command

--- a/Packs/CortexDataLake/ReleaseNotes/1_2_9.md
+++ b/Packs/CortexDataLake/ReleaseNotes/1_2_9.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Cortex Data Lake
-- Addes transform_results argument in cdl-query-logs command
+- Added transform_results argument in cdl-query-logs command.

--- a/Packs/CortexDataLake/pack_metadata.json
+++ b/Packs/CortexDataLake/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Data Lake",
     "description": "Palo Alto Networks Cortex Data Lake provides cloud-based, centralized log storage and aggregation for your on premise, virtual (private cloud and public cloud) firewalls, for Prisma Access, and for cloud-delivered services such as Cortex XDR",
     "support": "xsoar",
-    "currentVersion": "1.2.8",
+    "currentVersion": "1.2.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Current implementation of `cdl-query-logs` command automatically maps results from CDL API into a context common to all Log types. See [here](https://github.com/demisto/content/blob/master/Packs/CortexDataLake/Integrations/CortexDataLake/README.md#context-example) for an example.
This mapping is fine as long as no special CDL query functions are used that could modify the results fields. When the results field are modified via the query, the context mapping does not collect fields falling outside common mapping.

Example:

The query: 
```
SELECT source_ip.value AS src_ip,log_source_id,vsys,COUNT(*) AS count FROM `firewall.traffic` WHERE dest_ip.value="54.240.251.124" AND source_user is NULL AND action.id=0 AND log_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY) AND protocol.value=LOWER("TCP") AND dest_port=443 GROUP BY log_source_id, vsys, src_ip
```

Returns:
```
	{
		"count": 3,
		"log_source_id": "007055000130601",
		"src_ip": "10.0.5.25",
		"vsys": "vsys1"
	}
```

But when mapped to common context all the fields are `null` and custom fields are dropped:
```
	{
		"App": null,
		"TimeGenerated": null,
		"SourceIP": null,
		"DestinationLocation": null,
		"FileSHA256": null,
		"FileName": null,
		"RuleMatched": null,
		"LogSourceName": null,
		"NatDestination": null,
		"NatDestinationPort": null,
		"CharacteristicOfApp": null,
		"SourceLocation": null,
		"DestinationIP": null,
		"Action": null,
		"IsNat": null,
		"Protocol": null,
		"NatSource": null,
		"AppCategory": null
	}
```

### Changes
This PR adds a new bool argument to `cdl-query-logs` called `transform_results` to control the mapping of results to the common context:
- if set to `Yes` (default) the current behaviour is applied (map to common context)
- if set to `No`, mapping is skipped and unaltered CDL records are returned in `CDL.Logging`, a behaviour similar to `splunk-search`.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
