### PR TITLE
Carbon Black EDR - rm severity and target_value as optional values for the sort_field arg

### DIFF
--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
@@ -570,16 +570,14 @@ script:
           secret: false
         - auto: PREDEFINED
           default: false
-          defaultValue: severity
+          defaultValue: first_event_time
           description: Field by which to sort the results. Can be "first_event_time",
-            "last_event_time", "severity", or "target_value".
+            or "last_event_time".
           isArray: false
           name: sort_field
           predefined:
             - first_event_time
             - last_event_time
-            - severity
-            - target_value
           required: false
           secret: false
         - auto: PREDEFINED

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
@@ -1815,7 +1815,7 @@ script:
         - contextPath: CarbonBlackEEDR.SearchProcess.results.scriptload_count
           description: The cumulative count of loaded scripts since process tracking started.
           type: Number
-  dockerimage: demisto/python3:3.8.6.12176
+  dockerimage: demisto/python3:3.8.6.13358
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_1.md
+++ b/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_1.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### VMware Carbon Black Enterprise EDR
 - Removed invalid fields for the *sort_field* argument in the **cb-eedr-list-alerts** command.
+- Upgraded the Docker image to demisto/python3:3.8.6.13358.

--- a/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_1.md
+++ b/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VMware Carbon Black Enterprise EDR
+- Removed invalid fields for the *sort_field* argument in the **cb-eedr-list-alerts** command.

--- a/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
+++ b/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Carbon Black Cloud Enterprise EDR",
     "description": "Advanced threat hunting and incident response solution.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/30871

## Description
removed 2 invalid values to sort by and replaced the default value with valid one


## Does it break backward compatibility?
   - [x] No
