### PR TITLE
nightly running against bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,6 +415,13 @@ references:
         context: nightly_env
     - Create Instances:
         context: nightly_env
+    - Run Unit Testing And Lint:
+        context: nightly_env
+        requires:
+          - Setup Environment
+    - Run Validations:
+        requires:
+          - Setup Environment
     - Server Master:
         requires:
           - Create Instances

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,13 +415,6 @@ references:
         context: nightly_env
     - Create Instances:
         context: nightly_env
-    - Run Unit Testing And Lint:
-        context: nightly_env
-        requires:
-          - Setup Environment
-    - Run Validations:
-        requires:
-          - Setup Environment
     - Server Master:
         requires:
           - Create Instances

--- a/Tests/Marketplace/Tests/copy_and_upload_packs_test.py
+++ b/Tests/Marketplace/Tests/copy_and_upload_packs_test.py
@@ -153,6 +153,8 @@ class TestRegex:
          "CommonReports/1.0.1/CommonReports.zip"),
         (f"{BUILD_BASE_PATH}/{BUILD_PATTERN}/Whois/1.1.6/Whois.zip",
          "Whois/1.1.6/Whois.zip"),
+        (f"{BUILD_BASE_PATH}/{BUILD_PATTERN}/Blockade.io/1.0.0/Blockade.io.zip",
+         "Blockade.io/1.0.0/Blockade.io.zip"),
         (f"{GCPConfig.GCS_PUBLIC_URL}/oproxy-dev.appspot.com/wow/content/packs/TIM-wow_a/99.98.99/TIM-wow_a.zip",
          "TIM-wow_a/99.98.99/TIM-wow_a.zip")
     ])

--- a/Tests/Marketplace/Tests/search_and_install_packs_test.py
+++ b/Tests/Marketplace/Tests/search_and_install_packs_test.py
@@ -283,7 +283,11 @@ def test_install_nightly_packs_endless_loop(mocker):
     script.install_nightly_packs(client, 'my_host', packs_to_install)
 
 
-def test_latest_ver_regex():
+@pytest.mark.parametrize('path, latest_version', [
+    (f'{GCPConfig.STORAGE_BASE_PATH}/TestPack/1.0.1/TestPack.zip', '1.0.1'),
+    (f'{GCPConfig.STORAGE_BASE_PATH}/Blockade.io/1.0.1/Blockade.io.zip', '1.0.1')
+])
+def test_pack_path_version_regex(path, latest_version):
     """
        Given:
            - A path in GCS of a zipped pack.
@@ -292,9 +296,7 @@ def test_latest_ver_regex():
        Then:
            - Validate that the extracted version is the expected version.
    """
-    assert script.LATEST_VER_REGEX.findall(f'{GCPConfig.STORAGE_BASE_PATH}/TestPack/1.0.1/TestPack.zip')[0] == '1.0.1'
-    assert script.LATEST_VER_REGEX.findall(f'{GCPConfig.STORAGE_BASE_PATH}/Blockade.io/1.0.1/Blockade.io.zip')[0] ==\
-           '1.0.1'
+    assert script.PACK_PATH_VERSION_REGEX.findall(path)[0] == latest_version
 
 
 def test_get_latest_version_from_bucket(mocker):

--- a/Tests/Marketplace/Tests/search_and_install_packs_test.py
+++ b/Tests/Marketplace/Tests/search_and_install_packs_test.py
@@ -1,8 +1,9 @@
 import demisto_client
 import pytest
 import timeout_decorator
-
 import Tests.Marketplace.search_and_install_packs as script
+from Tests.Marketplace.marketplace_services import GCPConfig
+from google.cloud.storage import Blob
 
 BASE_URL = 'http://123-fake-api.com'
 API_KEY = 'test-api-key'
@@ -280,3 +281,33 @@ def test_install_nightly_packs_endless_loop(mocker):
         {'id': 'bad_integration2'},
     ]
     script.install_nightly_packs(client, 'my_host', packs_to_install)
+
+
+def test_latest_ver_regex():
+    """
+       Given:
+           - A path in GCS of a zipped pack.
+       When:
+           - Extracting the version from the path.
+       Then:
+           - Validate that the extracted version is the expected version.
+   """
+    assert script.LATEST_VER_REGEX.findall(f'{GCPConfig.STORAGE_BASE_PATH}/TestPack/1.0.1/TestPack.zip')[0] == '1.0.1'
+    assert script.LATEST_VER_REGEX.findall(f'{GCPConfig.STORAGE_BASE_PATH}/Blockade.io/1.0.1/Blockade.io.zip')[0] ==\
+           '1.0.1'
+
+
+def test_get_latest_version_from_bucket(mocker):
+    """
+       Given:
+           - An id of a pack and the bucket.
+       When:
+           - Getting the latest version of the pack in the bucket.
+       Then:
+           - Validate that the version is the one we expect for.
+   """
+    dummy_prod_bucket = mocker.MagicMock()
+    first_blob = Blob(f'{GCPConfig.STORAGE_BASE_PATH}/TestPack/1.0.0/TestPack.zip', dummy_prod_bucket)
+    second_blob = Blob(f'{GCPConfig.STORAGE_BASE_PATH}/TestPack/1.0.1/TestPack.zip', dummy_prod_bucket)
+    dummy_prod_bucket.list_blobs.return_value = [first_blob, second_blob]
+    assert script.get_latest_version_from_bucket('TestPack', dummy_prod_bucket) == '1.0.1'

--- a/Tests/Marketplace/copy_and_upload_packs.py
+++ b/Tests/Marketplace/copy_and_upload_packs.py
@@ -15,8 +15,8 @@ from Tests.Marketplace.marketplace_services import init_storage_client, Pack, Pa
 from Tests.Marketplace.upload_packs import extract_packs_artifacts, print_packs_summary, load_json, \
     get_packs_summary
 
-LATEST_ZIP_REGEX = re.compile(fr'^{GCPConfig.GCS_PUBLIC_URL}/[\w./-]+/content/packs/([A-Za-z0-9-_]+/\d+\.\d+\.\d+/'
-                              r'[A-Za-z0-9-_]+\.zip$)')
+LATEST_ZIP_REGEX = re.compile(fr'^{GCPConfig.GCS_PUBLIC_URL}/[\w./-]+/content/packs/([A-Za-z0-9-_.]+/\d+\.\d+\.\d+/'
+                              r'[A-Za-z0-9-_.]+\.zip$)')
 
 
 def get_pack_names(target_packs: str) -> set:

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -30,7 +30,7 @@ from Tests.test_integration import __get_integration_config, __test_integration_
 from Tests.test_content import extract_filtered_tests, get_server_numeric_version
 from Tests.update_content_data import update_content
 from Tests.Marketplace.search_and_install_packs import search_and_install_packs_and_their_dependencies, \
-    install_all_content_packs, upload_zipped_packs
+    install_all_content_packs, upload_zipped_packs, install_all_content_packs_for_nightly
 from Tests.tools import update_server_configuration
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
@@ -157,6 +157,7 @@ class Build:
         self.tests_to_run = self.fetch_tests_list(options.tests_to_run)
         self.content_root = options.content_root
         self.pack_ids_to_install = self.fetch_pack_ids_to_install(options.pack_ids_to_install)
+        self.service_account = options.service_account if options.service_account else None
 
     @staticmethod
     def fetch_tests_list(tests_to_run_path: str):
@@ -224,6 +225,16 @@ def options_handler():
                         default='./Tests/filter_file.txt')
     parser.add_argument('-pl', '--pack_ids_to_install', help='Path to the packs to install file.',
                         default='./Tests/content_packs_to_install.txt')
+    # disable-secrets-detection-start
+    parser.add_argument('-sa', '--service_account',
+                        help=("Path to gcloud service account, is for circleCI usage. "
+                              "For local development use your personal account and "
+                              "authenticate using Google Cloud SDK by running: "
+                              "`gcloud auth application-default login` and leave this parameter blank. "
+                              "For more information go to: "
+                              "https://googleapis.dev/python/google-api-core/latest/auth.html"),
+                        required=False)
+    # disable-secrets-detection-end
     options = parser.parse_args()
 
     return options
@@ -1036,12 +1047,14 @@ def get_pack_ids_to_install():
         #  END CHANGE ON LOCAL RUN  #
 
 
-def nightly_install_packs(build, install_method=install_all_content_packs, pack_path=None):
+def nightly_install_packs(build, install_method=install_all_content_packs, pack_path=None, service_account=None):
     threads_list = []
 
     # For each server url we install pack/ packs
     for thread_index, server in enumerate(build.servers):
         kwargs = {'client': server.client, 'host': server.host}
+        if service_account:
+            kwargs['service_account'] = build.service_account
         if pack_path:
             kwargs['pack_path'] = pack_path
         threads_list.append(Thread(target=install_method, kwargs=kwargs))
@@ -1049,7 +1062,8 @@ def nightly_install_packs(build, install_method=install_all_content_packs, pack_
 
 
 def install_nightly_pack(build):
-    nightly_install_packs(build, install_method=install_all_content_packs)
+    nightly_install_packs(build, install_method=install_all_content_packs_for_nightly,
+                          service_account=build.service_account)
     create_nightly_test_pack()
     nightly_install_packs(build, install_method=upload_zipped_packs,
                           pack_path=f'{Build.test_pack_target}/test_pack.zip')

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -157,7 +157,7 @@ class Build:
         self.tests_to_run = self.fetch_tests_list(options.tests_to_run)
         self.content_root = options.content_root
         self.pack_ids_to_install = self.fetch_pack_ids_to_install(options.pack_ids_to_install)
-        self.service_account = options.service_account if options.service_account else None
+        self.service_account = options.service_account
 
     @staticmethod
     def fetch_tests_list(tests_to_run_path: str):
@@ -1054,7 +1054,7 @@ def nightly_install_packs(build, install_method=install_all_content_packs, pack_
     for thread_index, server in enumerate(build.servers):
         kwargs = {'client': server.client, 'host': server.host}
         if service_account:
-            kwargs['service_account'] = build.service_account
+            kwargs['service_account'] = service_account
         if pack_path:
             kwargs['pack_path'] = pack_path
         threads_list.append(Thread(target=install_method, kwargs=kwargs))

--- a/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
@@ -64,6 +64,7 @@ class BuildMock:
         self.id_set = {}
         self.test_pack_path = ''
         self.pack_ids_to_install = []
+        self.service_account = None
 
 
 def test_find_needed_test_playbook_paths():

--- a/Tests/scripts/install_content_and_test_integrations.sh
+++ b/Tests/scripts/install_content_and_test_integrations.sh
@@ -8,9 +8,14 @@ CONF_PATH="./Tests/conf.json"
 
 [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
 
+if [ "$IS_NIGHTLY" = true ]; then
+  GCS_PATH=$(mktemp)
+  echo $GCS_MARKET_KEY > $GCS_PATH
+fi
+
 PREVIOUS_JOB_NUMBER=`cat create_instances_build_num.txt`
 
-python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$PREVIOUS_JOB_NUMBER"
+python3 ./Tests/configure_and_test_integration_instances.py -u "$USERNAME" -p "$PASSWORD" -c "$CONF_PATH" -s "$SECRET_CONF_PATH" -g "$GIT_SHA1" --ami_env "$1" -n $IS_NIGHTLY --branch "$CIRCLE_BRANCH" --build-number "$PREVIOUS_JOB_NUMBER" -sa "$GCS_PATH"
 if [ -f ./Tests/test_pack.zip ]; then
   cp ./Tests/test_pack.zip $CIRCLE_ARTIFACTS
 fi

--- a/Tests/scripts/install_content_and_test_integrations.sh
+++ b/Tests/scripts/install_content_and_test_integrations.sh
@@ -6,9 +6,10 @@ set -e
 SECRET_CONF_PATH=$(cat secret_conf_path)
 CONF_PATH="./Tests/conf.json"
 
-[ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
+IS_NIGHTLY=false
 
-if [ "$IS_NIGHTLY" = true ]; then
+if [ -n "${NIGHTLY}" ]; then
+  IS_NIGHTLY=true
   GCS_PATH=$(mktemp)
   echo $GCS_MARKET_KEY > $GCS_PATH
 fi


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30824

## Description
- Nightly is now running against the production bucket and not against origin/master when retrieving the latest version of each pack. 
- Refactored the latest pack regex to also catch pack names that consist of a dot.


## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
