### PR TITLE
AutoFocus v2 - fix indicator type for the file cmd

### DIFF
--- a/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
@@ -1480,7 +1480,7 @@ def search_file_command(file):
     command_results = []
 
     for sha256 in file_list:
-        raw_res = search_indicator('sha256', sha256.lower())
+        raw_res = search_indicator('filehash', sha256.lower())
         if not raw_res.get('indicator'):
             raise ValueError('Invalid response for indicator')
 

--- a/Packs/AutoFocus/Integrations/AutofocusV2/README.md
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/README.md
@@ -26,7 +26,7 @@ For more information on activating the license see [Activating AutoFocus License
 ## Configure AutoFocus V2 on Demisto
 ---
 
-1. Navigate to **Settings** > **Integrations**** > **Servers & Services**.
+1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
 2. Search for AutoFocus V2.
 3. Click **Add instance** to create and configure a new integration instance.
 

--- a/Packs/AutoFocus/Integrations/FeedAutofocusDaily/README.md
+++ b/Packs/AutoFocus/Integrations/FeedAutofocusDaily/README.md
@@ -36,7 +36,7 @@ Note: This command does not create indicators within Cortex XSOAR.
 
 ##### Base Command
 
-`autofocus-get-indicators`
+`autofocus-daily-get-indicators`
 ##### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -50,7 +50,7 @@ Note: This command does not create indicators within Cortex XSOAR.
 There is no context output for this command.
 
 ##### Command Example
-```!autofocus-get-indicators limit=4```
+```!autofocus-daily-get-indicators limit=4```
 
 
 ##### Human Readable Output
@@ -63,4 +63,4 @@ There is no context output for this command.
 | demsito\<Span\>.com/some/aditional/path | URL |
 
 To bring the next batch of indicators run:
-`!autofocus-get-indicators limit=4 offset=4`
+`!autofocus-daily-get-indicators limit=4 offset=4`

--- a/Packs/AutoFocus/ReleaseNotes/1_1_11.md
+++ b/Packs/AutoFocus/ReleaseNotes/1_1_11.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Palo Alto Networks AutoFocus v2
+- Fixed an issue where the **file** command returned 404 status code.

--- a/Packs/AutoFocus/ReleaseNotes/1_1_11.md
+++ b/Packs/AutoFocus/ReleaseNotes/1_1_11.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### Palo Alto Networks AutoFocus v2
-- Fixed an issue where the **file** command returned 404 status code.
+- Fixed an issue where the **file** command returned a 404 status code.

--- a/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocus_V2_test.yml
+++ b/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocus_V2_test.yml
@@ -1909,7 +1909,7 @@ tasks:
       codeItemType: {}
       delay: {}
       file:
-        simple: 9040e9fda52931c9472c90ecad5b74295cdb9cf7b68e2b89219700f6a8bff5ac
+        simple: 9040e9fda52931c9472c90ecad5b74295cdb9cf7b68e2b89219700f6a8bff5ac,e3fce71af74414f5c632265de2f7ee1f287b97c3b086e5a54bb285e6997fae43
       long: {}
       maxRetries: {}
       md5: {}

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "1.1.10",
+    "currentVersion": "1.1.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
- fixed the indicator type to be `filehash` in the api query for the file command according to https://docs.paloaltonetworks.com/autofocus/autofocus-api/perform-direct-searches/get-threat-intelligence-card-summary.html
- fixed commad name in daily feed in the feed doc
- removed redundant `**` in the af v2 integration doc

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
