### PR TITLE
[Dev-Task] add "(Community Contributed)" to release notes

### DIFF
--- a/Tests/scripts/infrastructure_tests/release_notes_generator_test.py
+++ b/Tests/scripts/infrastructure_tests/release_notes_generator_test.py
@@ -226,6 +226,46 @@ class TestGenerateReleaseNotesSummary:
         assert '### FakePack2 Pack v1.1.0' in rn_summary
         assert '### FakePack2 Pack v1.1.0 (Partner Supported)' not in rn_summary
 
+    def test_updated_community_pack(self):
+        """
+        Given
+        - A repository of two packs updates and release notes:
+          - FakePack1 with version 2.0.0 metadata "supports" field has value "community"
+          - FakePack2 version 1.1.0
+
+        When
+        - Generating a release notes summary file.
+
+        Then
+        - Ensure release notes generator creates a valid summary, by checking:
+          - the output of get_release_notes_dict() is a valid dict of (pack_name, dict(pack_version, release_note)).
+          - the release notes summary contains two packs with the following:
+            - FakePack1 with version 2.0.0 and has the string "(Community Supported)" after the version
+            - FakePack2 with version 1.1.0 DOES NOT have the string "(Community Supported)" after the version
+        """
+        release_notes_files = [
+            os.path.join(TEST_DATA_PATH, 'FakePack1', 'ReleaseNotes', '1_1_0.md'),
+            os.path.join(TEST_DATA_PATH, 'FakePack1', 'ReleaseNotes', '2_0_0.md'),
+            os.path.join(TEST_DATA_PATH, 'FakePack2', 'ReleaseNotes', '1_1_0.md'),
+        ]
+
+        rn_dict, _ = get_release_notes_dict(release_notes_files)
+
+        packs_metadta_dict = {
+            'FakePack1': {'support': 'community'},
+            'FakePack2': {'support': 'xsoar'}
+        }
+
+        assert '2.0.0' in rn_dict['FakePack1'].keys()
+        assert '1.1.0' in rn_dict['FakePack2'].keys()
+
+        rn_summary = generate_release_notes_summary({}, rn_dict, packs_metadta_dict, self._version, self._asset_id, self._outfile)
+
+        assert VERSION in rn_summary and ASSET_ID in rn_summary  # summary title
+        assert '### FakePack1 Pack v2.0.0 (Community Supported)' in rn_summary
+        assert '### FakePack2 Pack v1.1.0' in rn_summary
+        assert '### FakePack2 Pack v1.1.0 (Community Supported)' not in rn_summary
+
     def test_release_notes_summary_with_empty_lines_in_rn(self):
         """
         Given

--- a/Utils/release_notes_generator.py
+++ b/Utils/release_notes_generator.py
@@ -195,8 +195,16 @@ def get_pack_metadata(pack_path):
     return pack_metadata
 
 
+def is_support_type_in_metadata(metadata, support_type):
+    return metadata and metadata.get('support') == support_type
+
+
 def is_partner_supported_in_metadata(metadata):
-    return metadata and metadata.get('support') == 'partner'
+    return is_support_type_in_metadata(metadata, 'partner')
+
+
+def is_community_supported_in_metadata(metadata):
+    return is_support_type_in_metadata(metadata, 'community')
 
 
 def get_pack_path_from_release_note(file_path):
@@ -283,8 +291,12 @@ def aggregate_release_notes(pack_name: str, pack_versions_dict: dict, pack_metad
 
     """
     pack_release_notes, latest_version = merge_version_blocks(pack_versions_dict)
-    partner = ' (Partner Supported)' if is_partner_supported_in_metadata(pack_metadata) else ''
-    return (f'### {pack_name} Pack v{latest_version}{partner}\n'
+    pack_version_title = latest_version
+    if is_partner_supported_in_metadata(pack_metadata):
+        pack_version_title += ' (Partner Supported)'
+    elif is_community_supported_in_metadata(pack_metadata):
+        pack_version_title += ' (Community Supported)'
+    return (f'### {pack_name} Pack v{pack_version_title}\n'
             f'{pack_release_notes}')
 
 


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/28079

## Description
When creating release notes, packs that are "Community Contributed" will now have (Community Contributed) tag in the title, after the version number.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
