### PR TITLE
McAfee ESM v2 - handle search timeout

### DIFF
--- a/Packs/McAfee_ESM/Integrations/McAfee_ESM_v2/McAfee_ESM_v2.py
+++ b/Packs/McAfee_ESM/Integrations/McAfee_ESM_v2/McAfee_ESM_v2.py
@@ -486,14 +486,14 @@ class McAfeeESMClient(BaseClient):
                                 f'AlarmEvent(val.ID && val.ID == obj.ID)': context_entry}, result
 
     def complete_search(self):
-        time_out = self.args.get('timeOut', 30)
+        time_out = int(self.args.get('timeOut', 30))
         interval = min(10, time_out)
         search_id = self.__search()
         i = 0
         while not self.__generic_polling(search_id):
             i += 1
             time.sleep(interval)  # pylint: disable=sleep-exists
-            if i * interval == time_out:
+            if i * interval >= time_out:
                 raise DemistoException(f'Search: {search_id} time out.')
 
         return self.__search_fetch_result(search_id)
@@ -563,7 +563,9 @@ class McAfeeESMClient(BaseClient):
 
             except DemistoException as error:
                 if not expected_errors(error):
-                    raise error
+                    raise
+                else:
+                    result_ready = True
         result = table_times_set(result, self.difference)
         entry: List = [{}] * len(result['rows'])
         headers = [str(field.get('name')).replace('.', '') for field in result['columns']]

--- a/Packs/McAfee_ESM/Integrations/McAfee_ESM_v2/McAfee_ESM_v2.yml
+++ b/Packs/McAfee_ESM/Integrations/McAfee_ESM_v2/McAfee_ESM_v2.yml
@@ -921,7 +921,7 @@ script:
     - contextPath: McAfeeESM.Watchlist.name
       description: The name of the watchlist.
       type: string
-  dockerimage: demisto/python3:3.8.5.11789
+  dockerimage: demisto/python3:3.8.6.13358
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
+++ b/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### McAfee ESM v2
+- Fixed 2 issues in the ***esm-search*** command: 
+  - The *timeout* argument was not handled properly.
+  - The command did not return results if the limit passed in products of 50 (e.g. 100).

--- a/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
+++ b/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
@@ -1,6 +1,5 @@
 
 #### Integrations
 ##### McAfee ESM v2
-- Fixed 2 issues in the ***esm-search*** command: 
-  - The *timeout* argument was not handled properly.
-  - The command did not return results if the limit passed in products of 50 (e.g. 100).
+- Fixed an issue where the *timeout* argument was not handled correctly in the **esm-search** command.
+- Fixed an issue where no results returned if the *limit* was set to a product of 50 (e.g. 100) in the **esm-search** command.

--- a/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
+++ b/Packs/McAfee_ESM/ReleaseNotes/1_1_2.md
@@ -3,3 +3,4 @@
 ##### McAfee ESM v2
 - Fixed an issue where the *timeout* argument was not handled correctly in the **esm-search** command.
 - Fixed an issue where no results returned if the *limit* was set to a product of 50 (e.g. 100) in the **esm-search** command.
+- Upgraded the Docker image to demisto/python3:3.8.6.13358.

--- a/Packs/McAfee_ESM/TestPlaybooks/McAfee_ESM_v2_-_Test.yml
+++ b/Packs/McAfee_ESM/TestPlaybooks/McAfee_ESM_v2_-_Test.yml
@@ -353,7 +353,8 @@ tasks:
       limit:
         simple: "30"
       queryType: {}
-      timeOut: {}
+      timeOut:
+        simple: "30"
       timeRange:
         simple: CURRENT_YEAR
     separatecontext: false

--- a/Packs/McAfee_ESM/pack_metadata.json
+++ b/Packs/McAfee_ESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "McAfee ESM",
     "description": "Run queries and receive alarms from Intel Security ESM.",
     "support": "xsoar",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/30986

## Description
- cast timeout to int
- handle 400 status code as result ready

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
see failing test in https://app.circleci.com/pipelines/github/demisto/content/46986/workflows/079ca85b-cc66-4c49-b996-72e08cc3d312/jobs/201393
