### PR TITLE
not updating index on force upload flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,6 @@ parameters:
   bucket_upload:
     type: string
     default: ""
-  force_previous_commit:
-    type: string
-    default: ""
 
 references:
   environment: &environment
@@ -72,7 +69,6 @@ references:
       FORCE_PACK_UPLOAD_PARAMETER: << pipeline.parameters.force_pack_upload >>
       PACKS_TO_UPLOAD_PARAMETER: << pipeline.parameters.packs_to_upload >>
       BUCKET_UPLOAD_PARAMETER: << pipeline.parameters.bucket_upload >>
-      FORCE_PREVIOUS_COMMIT_PARAMETER: << pipeline.parameters.force_previous_commit >>
 
   container_config: &container_config
     docker:
@@ -137,10 +133,6 @@ references:
         then
             echo "export BUCKET_UPLOAD=$BUCKET_UPLOAD_PARAMETER" >> $BASH_ENV
         fi
-        if [ -n "${FORCE_PREVIOUS_COMMIT_PARAMETER}" ];
-        then
-            echo "export FORCE_PREVIOUS_COMMIT=$FORCE_PREVIOUS_COMMIT_PARAMETER" >> $BASH_ENV
-        fi
 
         echo "=== sourcing $BASH_ENV ==="
         source $BASH_ENV
@@ -169,7 +161,7 @@ references:
         fi
 
         echo "========== Build Parameters =========="
-        set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^NON_AMI_RUN=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^FORCE_PREVIOUS_COMMIT="
+        set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^NON_AMI_RUN=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD="
         python --version
         python3 --version
         demisto-sdk --version

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -241,7 +241,7 @@ def clean_non_existing_packs(index_folder_path: str, private_packs: list, storag
 
 def upload_index_to_storage(index_folder_path: str, extract_destination_path: str, index_blob: Any,
                             build_number: str, private_packs: list, current_commit_hash: str,
-                            index_generation: int, is_private: bool = False):
+                            index_generation: int, is_private: bool = False, force_upload: bool = False):
     """
     Upload updated index zip to cloud storage.
 
@@ -253,15 +253,26 @@ def upload_index_to_storage(index_folder_path: str, extract_destination_path: st
     :param current_commit_hash: last commit hash of head.
     :param index_generation: downloaded index generation.
     :param is_private: Indicates if upload is private.
+    :param force_upload: Indicates if force upload or not.
     :returns None.
 
     """
-    with open(os.path.join(index_folder_path, f"{GCPConfig.INDEX_NAME}.json"), "w+") as index_file:
+    index_json_file_path = os.path.join(index_folder_path, f"{GCPConfig.INDEX_NAME}.json")
+
+    if force_upload:
+        # If we force upload we don't want to update the commit in the index.json file, this is to be able to identify
+        # all changed packs in the next upload
+        commit = load_json(index_json_file_path).get('commit')
+    else:
+        # Otherwise, update the index with the current commit hash (the commit of the upload)
+        commit = current_commit_hash
+
+    with open(index_json_file_path, "w+") as index_file:
         index = {
             'revision': build_number,
             'modified': datetime.utcnow().strftime(Metadata.DATE_FORMAT),
             'packs': private_packs,
-            'commit': current_commit_hash
+            'commit': commit
         }
         json.dump(index, index_file, indent=4)
 
@@ -459,7 +470,7 @@ def get_content_git_client(content_repo_path: str):
 
 
 def get_recent_commits_data(content_repo: Any, index_folder_path: str, is_bucket_upload_flow: bool,
-                            force_previous_commit: str, is_private_build: bool = False, circle_branch: str = "master"):
+                            is_private_build: bool = False, circle_branch: str = "master"):
     """ Returns recent commits hashes (of head and remote master)
 
     Args:
@@ -467,25 +478,14 @@ def get_recent_commits_data(content_repo: Any, index_folder_path: str, is_bucket
         index_folder_path (str): the path to the local index folder
         is_bucket_upload_flow (bool): indicates whether its a run of bucket upload flow or regular build
         is_private_build (bool): indicates whether its a run of private build or not
-        force_previous_commit (str): if exists, this should be the commit to diff with
         circle_branch (str): CircleCi branch of current build
 
     Returns:
         str: last commit hash of head.
         str: previous commit depending on the flow the script is running
     """
-    head_commit = content_repo.head.commit.hexsha
-    if force_previous_commit:
-        try:
-            previous_commit = content_repo.commit(force_previous_commit).hexsha
-            logging.info(f"Using force commit hash {previous_commit} to diff with.")
-            return head_commit, previous_commit
-        except Exception as e:
-            logging.critical(f'Force commit {force_previous_commit} does not exist in content repo. Additional '
-                             f'info:\n {e}')
-            sys.exit(1)
-    return head_commit, get_previous_commit(content_repo, index_folder_path, is_bucket_upload_flow, is_private_build,
-                                            circle_branch)
+    return content_repo.head.commit.hexsha, get_previous_commit(content_repo, index_folder_path, is_bucket_upload_flow,
+                                                                is_private_build, circle_branch)
 
 
 def update_index_with_priced_packs(private_storage_bucket: Any, extract_destination_path: str,
@@ -729,9 +729,9 @@ def option_handler():
     parser.add_argument('-rt', '--remove_test_playbooks', type=str2bool,
                         help='Should remove test playbooks from content packs or not.', default=True)
     parser.add_argument('-bu', '--bucket_upload', help='is bucket upload build?', type=str2bool, required=True)
-    parser.add_argument('-fc', '--force_previous_commit', help='A commit to be used as the previous commit to diff with')
     parser.add_argument('-pb', '--private_bucket_name', help="Private storage bucket name", required=False)
     parser.add_argument('-c', '--circle_branch', help="CircleCi branch of current build", required=True)
+    parser.add_argument('-f', '--force_upload', help="is force upload build?", type=str2bool, required=True)
     # disable-secrets-detection-end
     return parser.parse_args()
 
@@ -918,9 +918,9 @@ def main():
     storage_base_path = option.storage_base_path
     remove_test_playbooks = option.remove_test_playbooks
     is_bucket_upload_flow = option.bucket_upload
-    force_previous_commit = option.force_previous_commit
     private_bucket_name = option.private_bucket_name
     circle_branch = option.circle_branch
+    force_upload = option.force_upload
 
     # google cloud storage client initialized
     storage_client = init_storage_client(service_account)
@@ -936,8 +936,7 @@ def main():
     # content repo client initialized
     content_repo = get_content_git_client(CONTENT_ROOT_PATH)
     current_commit_hash, previous_commit_hash = get_recent_commits_data(content_repo, index_folder_path,
-                                                                        is_bucket_upload_flow, force_previous_commit,
-                                                                        circle_branch)
+                                                                        is_bucket_upload_flow, circle_branch)
 
     # detect packs to upload
     pack_names = get_packs_names(target_packs, previous_commit_hash)
@@ -1080,7 +1079,8 @@ def main():
     # finished iteration over content packs
     upload_index_to_storage(index_folder_path=index_folder_path, extract_destination_path=extract_destination_path,
                             index_blob=index_blob, build_number=build_number, private_packs=private_packs,
-                            current_commit_hash=current_commit_hash, index_generation=index_generation)
+                            current_commit_hash=current_commit_hash, index_generation=index_generation,
+                            force_upload=force_upload)
 
     # upload id_set.json to bucket
     upload_id_set(storage_bucket, id_set_path)

--- a/Tests/private_build/upload_packs_private.py
+++ b/Tests/private_build/upload_packs_private.py
@@ -424,8 +424,7 @@ def main():
         content_repo = get_content_git_client(CONTENT_ROOT_PATH)
         current_commit_hash, remote_previous_commit_hash = get_recent_commits_data(content_repo, index_folder_path,
                                                                                    is_bucket_upload_flow=False,
-                                                                                   is_private_build=True,
-                                                                                   force_previous_commit="")
+                                                                                   is_private_build=True)
     else:
         current_commit_hash, remote_previous_commit_hash = "", ""
         content_repo = None

--- a/Tests/scripts/prepare_content_packs_for_testing.sh
+++ b/Tests/scripts/prepare_content_packs_for_testing.sh
@@ -48,7 +48,7 @@ if [ ! -n "${NIGHTLY}" ] && [ ! -n "${BUCKET_UPLOAD}" ]; then
       echo "Did not get content packs to update in the bucket."
     else
       echo "Updating the following content packs: $CONTENT_PACKS_TO_INSTALL ..."
-      python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p $CONTENT_PACKS_TO_INSTALL -o true -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt false --id_set_path $ID_SET -bu false -c $CIRCLE_BRANCH
+      python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p $CONTENT_PACKS_TO_INSTALL -o true -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt false --id_set_path $ID_SET -bu false -c $CIRCLE_BRANCH -f false
       echo "Finished updating content packs successfully."
     fi
   fi
@@ -65,11 +65,13 @@ else
       REMOVE_PBS=true
       BUCKET_UPLOAD_FLOW=true
       GCS_PRIVATE_BUCKET="marketplace-dist-private"
+      IS_FORCE_UPLOAD=false
     if [ -n "${FORCE_PACK_UPLOAD}" ] && [ -n "${PACKS_TO_UPLOAD}" ]; then
       # In case the workflow is force upload, we override the forced packs
       echo "Force uploading to production the following packs: ${PACKS_TO_UPLOAD}"
       OVERRIDE_ALL_PACKS=true
       PACKS_LIST="${PACKS_TO_UPLOAD}"
+      IS_FORCE_UPLOAD=true
     else
       # In case of a regular upload flow, the upload_packs script will decide which pack to upload or not, thus it is
       # given with all the packs, we don't override packs to not force upload a pack
@@ -78,7 +80,7 @@ else
       PACKS_LIST="all"
     fi
   fi
-  python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p "$PACKS_LIST" -o $OVERRIDE_ALL_PACKS -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt $REMOVE_PBS --id_set_path $ID_SET -bu $BUCKET_UPLOAD_FLOW -fc "$FORCE_PREVIOUS_COMMIT" -pb "$GCS_PRIVATE_BUCKET" -c $CIRCLE_BRANCH
+  python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p "$PACKS_LIST" -o $OVERRIDE_ALL_PACKS -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt $REMOVE_PBS --id_set_path $ID_SET -bu $BUCKET_UPLOAD_FLOW -pb "$GCS_PRIVATE_BUCKET" -c $CIRCLE_BRANCH -f $IS_FORCE_UPLOAD
   echo "Finished updating content packs successfully."
 fi
 

--- a/Utils/trigger_force_upload_pack_to_production.sh
+++ b/Utils/trigger_force_upload_pack_to_production.sh
@@ -7,7 +7,6 @@ fi
 
 _circle_token=$1
 _packs=$2
-_force_previous_commit=$3
 
 trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
@@ -16,8 +15,7 @@ post_data=$(cat <<-EOF
   "branch": "master",
   "parameters": {
     "force_pack_upload": "true",
-    "packs_to_upload": "${_packs}",
-    "force_previous_commit": "${_force_previous_commit}"
+    "packs_to_upload": "${_packs}"
   }
 }
 EOF


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
- Now, when force uploading, we don't update the index with the commit of the upload, we leave it as it is.
- Deleted all the logic related to `force_commit_hash` as it has no effect.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
