### PR TITLE
killing prints manager

### DIFF
--- a/Documentation/common_server_docs.py
+++ b/Documentation/common_server_docs.py
@@ -237,7 +237,7 @@ def create_ps_documentation(path, origin, language):
 
 
 def main(argv):
-    install_logging('Common Server Documentation.log')
+    install_logging('Common_Server_Documentation.log')
     js_doc, is_error_js = create_js_documentation('./Documentation/commonServerJsDoc.json', 'CommonServerJs',
                                                   'javascript')
     py_doc, is_error_py = create_py_documentation('./Packs/Base/Scripts/CommonServerPython/CommonServerPython.py',

--- a/Tests/Marketplace/configure_and_install_packs.py
+++ b/Tests/Marketplace/configure_and_install_packs.py
@@ -23,7 +23,7 @@ def options_handler():
 
 
 def main():
-    install_logging('Install Packs.log')
+    install_logging('Install_Packs.log')
     options = options_handler()
 
     # Get the host by the ami env

--- a/Tests/Marketplace/copy_and_upload_packs.py
+++ b/Tests/Marketplace/copy_and_upload_packs.py
@@ -301,7 +301,7 @@ def options_handler():
 
 
 def main():
-    install_logging('Copy and Upload Packs.log')
+    install_logging('Copy_and_Upload_Packs.log')
     options = options_handler()
     packs_artifacts_path = options.artifacts_path
     extract_destination_path = options.extract_path

--- a/Tests/Marketplace/normalize_gcs_paths.py
+++ b/Tests/Marketplace/normalize_gcs_paths.py
@@ -81,7 +81,7 @@ def normalize_pack_integration_urls(pack, original_base_path):
 
 
 def main():
-    install_logging('Prepare Content Packs For Testing.log')
+    install_logging('Prepare_Content_Packs_For_Testing.log')
     option = option_handler()
     storage_bucket_name = option.bucket_name
     service_account = option.service_account

--- a/Tests/Marketplace/packs_dependencies.py
+++ b/Tests/Marketplace/packs_dependencies.py
@@ -46,7 +46,7 @@ def calculate_single_pack_dependencies(pack: str, dependency_graph: object) -> T
         all_level_dependencies: A list with all dependencies names
         pack: The pack name
     """
-    install_logging('Calculate Packs Dependencies.log', include_process_name=True)
+    install_logging('Calculate_Packs_Dependencies.log', include_process_name=True)
     first_level_dependencies = {}
     all_level_dependencies = []
     try:
@@ -157,7 +157,7 @@ def main():
     packs dependencies. The logic of pack dependency is identical to sdk find-dependencies command.
 
     """
-    install_logging('Calculate Packs Dependencies.log', include_process_name=True)
+    install_logging('Calculate_Packs_Dependencies.log', include_process_name=True)
     option = option_handler()
     output_path = option.output_path
     id_set_path = option.id_set_path

--- a/Tests/Marketplace/private_build_prepare_for_testing.py
+++ b/Tests/Marketplace/private_build_prepare_for_testing.py
@@ -56,7 +56,7 @@ def upload_premium_pack_to_private_testing_bucket(premium_pack, private_testing_
 
 
 def main():
-    install_logging('Prepare Content Packs For Testing.log')
+    install_logging('Prepare_Content_Packs_For_Testing.log')
     packs_dir = '/home/runner/work/content-private/content-private/content/artifacts/packs'
     temp_dir = '/home/runner/work/content-private/content-private/content/temp-dir'
     if not os.path.exists(packs_dir):

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -903,7 +903,7 @@ def store_successful_and_failed_packs_in_ci_artifacts(circle_artifacts_path, suc
 
 
 def main():
-    install_logging('Prepare Content Packs For Testing.log')
+    install_logging('Prepare_Content_Packs_For_Testing.log')
     option = option_handler()
     packs_artifacts_path = option.artifacts_path
     extract_destination_path = option.extract_path

--- a/Tests/Marketplace/zip_packs.py
+++ b/Tests/Marketplace/zip_packs.py
@@ -206,7 +206,7 @@ def get_latest_pack_zip_from_blob(pack, blobs):
 
 
 def main():
-    install_logging('Zip Content Packs From GCS.log')
+    install_logging('Zip_Content_Packs_From_GCS.log')
     option = option_handler()
     storage_bucket_name = option.bucket_name
     zip_path = option.zip_path

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -22,8 +22,8 @@ from Tests.scripts.utils.log_util import install_logging
 from paramiko.client import SSHClient, AutoAddPolicy
 import demisto_client
 from ruamel import yaml
-from demisto_sdk.commands.common.tools import print_error, print_warning, print_color, LOG_COLORS, run_threads_list, \
-    run_command, get_yaml, str2bool, format_version, find_type
+from demisto_sdk.commands.common.tools import run_threads_list, run_command, get_yaml,\
+    str2bool, format_version, find_type
 from demisto_sdk.commands.common.constants import FileType
 from Tests.test_integration import __get_integration_config, __test_integration_instance, \
     __disable_integrations_instances
@@ -436,7 +436,7 @@ def change_placeholders_to_values(placeholders_map, config_item):
     return json.loads(item_as_string)
 
 
-def set_integration_params(integrations, secret_params, instance_names, placeholders_map):
+def set_integration_params(integrations, secret_params, instance_names, placeholders_map, logging_module=logging):
     """
     For each integration object, fill in the parameter values needed to configure an instance from
     the secret_params taken from our secret configuration file. Because there may be a number of
@@ -459,6 +459,7 @@ def set_integration_params(integrations, secret_params, instance_names, placehol
             configuration values.
         placeholders_map: (dict)
              Dict that holds the real values to be replaced for each placeholder.
+        logging_module (Union[ParallelLoggingManager,logging]): The logging module to use
 
     Returns:
         (bool): True if integrations params were filled with secret configuration values, otherwise false
@@ -485,9 +486,9 @@ def set_integration_params(integrations, secret_params, instance_names, placehol
                                                for optional_integration in integration_params]
                     failed_match_instance_msg = 'There are {} instances of {}, please select one of them by using' \
                                                 ' the instance_name argument in conf.json. The options are:\n{}'
-                    print_error(failed_match_instance_msg.format(len(integration_params),
-                                                                 integration['name'],
-                                                                 '\n'.join(optional_instance_names)))
+                    logging_module.error(failed_match_instance_msg.format(len(integration_params),
+                                                                          integration['name'],
+                                                                          '\n'.join(optional_instance_names)))
                     return False
 
             integration['params'] = matched_integration_params.get('params', {})
@@ -810,75 +811,6 @@ def report_tests_status(preupdate_fails, postupdate_fails, preupdate_success, po
     return testing_status
 
 
-def set_marketplace_gcp_bucket_for_build(client, prints_manager, branch_name, ci_build_number, is_nightly, is_private):
-    """Sets custom marketplace GCP bucket based on branch name and build number
-
-    Args:
-        client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object
-        branch_name (str): GitHub branch name
-        ci_build_number (str): CI build number
-        is_nightly: Whether this is a nightly build
-        is_private: Whether this is a private build
-
-    Returns:
-        response_data: The response data
-        status_code: The response status code
-    """
-    host = client.api_client.configuration.host
-    installed_content_message = \
-        '\nMaking "POST" request to server - "{}" to set GCP bucket server configuration.'.format(host)
-    prints_manager.add_print_job(installed_content_message, print_color, 0, LOG_COLORS.GREEN)
-
-    # make request to update server configs
-    # disable-secrets-detection-start
-    server_configuration = {
-        'content.pack.verify': 'false',
-        'marketplace.initial.sync.delay': '0',
-        'content.pack.ignore.missing.warnings.contentpack': 'true'
-    }
-    if is_private:
-        server_configuration['marketplace.bootstrap.bypass.url'] = 'https://storage.googleapis.com/marketplace-ci-build'
-        server_configuration['marketplace.gcp.path'] = f'content/builds/{branch_name}/{ci_build_number}/content/packs'
-        server_configuration['jobs.marketplacepacks.schedule'] = '1m'
-        server_configuration[
-            'marketplace.premium.gateway.service.url'] = 'https://xsoar-premium-content-team-gateway.demisto.works'
-    elif not is_nightly:
-        server_configuration['marketplace.bootstrap.bypass.url'] = \
-            f'https://storage.googleapis.com/marketplace-ci-build/content/builds/{branch_name}/{ci_build_number}'
-    error_msg = "Failed to set GCP bucket server config - with status code "
-    # disable-secrets-detection-end
-    return update_server_configuration(client, server_configuration, error_msg)
-
-
-def set_docker_hardening_for_build(client, prints_manager):
-    """Sets docker hardening configuration
-
-    Args:
-        client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object
-
-    Returns:
-        response_data: The response data
-        status_code: The response status code
-    """
-    host = client.api_client.configuration.host
-    installed_content_message = \
-        '\nMaking "POST" request to server - "{}" to set docker hardening server configuration.'.format(host)
-    prints_manager.add_print_job(installed_content_message, print_color, 0, LOG_COLORS.GREEN)
-
-    # make request to update server configs
-    server_configuration = {
-        'docker.cpu.limit': '1.0',
-        'docker.run.internal.asuser': 'true',
-        'limit.docker.cpu': 'true',
-        'python.pass.extra.keys': '--memory=1g##--memory-swap=-1##--pids-limit=256##--ulimit=nofile=1024:8192'
-    }
-    error_msg = "Failed to set docker hardening server config - with status code "
-
-    return update_server_configuration(client, server_configuration, error_msg)
-
-
 def get_env_conf():
     if Build.run_environment == Running.CIRCLECI_RUN:
         return get_json_file(Build.env_results_path)
@@ -923,7 +855,7 @@ def get_json_file(path):
         return json.loads(json_file.read())
 
 
-def configure_servers_and_restart(build, prints_manager=None):
+def configure_servers_and_restart(build):
     if LooseVersion(build.server_numeric_version) >= LooseVersion('5.5.0'):
         configurations = DOCKER_HARDENING_CONFIGURATION
         configure_types = ['docker hardening']
@@ -939,11 +871,7 @@ def configure_servers_and_restart(build, prints_manager=None):
         if manual_restart:
             input('restart your server and then press enter.')
         else:
-            if prints_manager:
-                prints_manager.add_print_job('Done restarting servers.\nSleeping for 1 minute...', print_warning, 0)
-                prints_manager.execute_thread_prints(0)
-            else:
-                logging.info('Done restarting servers. Sleeping for 1 minute')
+            logging.info('Done restarting servers. Sleeping for 1 minute')
             sleep(60)
 
 
@@ -1204,10 +1132,8 @@ def update_content_till_v6(build: Build):
     run_threads_list(threads_list)
 
 
-def disable_instances(build: Build, all_module_instances, prints_manager=None):
-    __disable_integrations_instances(build.servers[0].client, all_module_instances, prints_manager)
-    if prints_manager:
-        prints_manager.execute_thread_prints(0)
+def disable_instances(build: Build, all_module_instances):
+    __disable_integrations_instances(build.servers[0].client, all_module_instances)
 
 
 def create_nightly_test_pack():

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1237,7 +1237,7 @@ def set_marketplace_url(servers, branch_name, ci_build_number):
 
 
 def main():
-    install_logging('Install Content And Configure Integrations On Server.log')
+    install_logging('Install_Content_And_Configure_Integrations_On_Server.log')
     build = Build(options_handler())
 
     configure_servers_and_restart(build)

--- a/Tests/instance_notifier.py
+++ b/Tests/instance_notifier.py
@@ -1,13 +1,13 @@
 import json
 import argparse
+import logging
 
 import demisto_client
 from slackclient import SlackClient
 
 from Tests.scripts.utils.log_util import install_simple_logging
 from Tests.test_integration import __create_integration_instance, __delete_integrations_instances
-from Tests.test_content import ParallelPrintsManager
-from demisto_sdk.commands.common.tools import str2bool, print_color, print_error, LOG_COLORS, print_warning
+from demisto_sdk.commands.common.tools import str2bool
 from Tests.configure_and_test_integration_instances import update_content_on_demisto_instance
 
 SERVER_URL = "https://{}"
@@ -46,8 +46,6 @@ def test_instances(secret_conf_path, server, username, password):
     failed_integrations = []
     integrations_counter = 0
 
-    prints_manager = ParallelPrintsManager(1)
-
     content_installation_client = demisto_client.configure(base_url=server, username=username, password=password,
                                                            verify_ssl=False)
     install_new_content(content_installation_client, server)
@@ -66,24 +64,20 @@ def test_instances(secret_conf_path, server, username, password):
         if has_integration:
             instance_id, failure_message, _ = __create_integration_instance(
                 server, username, password, integration_name, integration_instance_name,
-                integration_params, is_byoi, prints_manager, validate_test=validate_test)
+                integration_params, is_byoi, validate_test=validate_test)
             if failure_message == 'No configuration':
-                prints_manager.add_print_job(
-                    "Warning: skipping {} as it exists in content-test-conf conf.json but not in content repo\n".format(
-                        integration_name), print_warning, 0)
+                logging.warning(
+                    f"skipping {integration_name} as it exists in content-test-conf conf.json but not in content repo")
                 continue
             if not instance_id:
-                prints_manager.add_print_job(
-                    'Failed to create instance of {} with message: {}\n'.format(integration_name, failure_message),
-                    print_error, 0)
+                logging.error(
+                    f'Failed to create instance of {integration_name} with message: {failure_message}')
                 failed_integrations.append("{} {} - devops comments: {}".format(
                     integration_name, product_description, devops_comments))
             else:
                 instance_ids.append(instance_id)
-                prints_manager.add_print_job('Create integration {} succeed\n'.format(integration_name), print_color, 0,
-                                             message_color=LOG_COLORS.GREEN)
-                __delete_integrations_instances(c, instance_ids, prints_manager)
-            prints_manager.execute_thread_prints(0)
+                logging.success(f'Create integration {integration_name} succeed')
+                __delete_integrations_instances(c, instance_ids)
 
     return failed_integrations, integrations_counter
 
@@ -121,7 +115,7 @@ def get_attachments(secret_conf_path, server, user, password, build_url):
 
 
 def slack_notifier(slack_token, secret_conf_path, server, user, password, build_url, build_number):
-    print_color("Starting Slack notifications about instances", LOG_COLORS.GREEN)
+    logging.info("Starting Slack notifications about instances")
     attachments, integrations_counter = get_attachments(secret_conf_path, server, user, password, build_url)
 
     sc = SlackClient(slack_token)
@@ -161,4 +155,4 @@ if __name__ == "__main__":
         with open("./Tests/is_build_passed_{}.txt".format(env_results[0]["Role"].replace(' ', '')), 'a'):
             pass
     else:
-        print_error("Not instance tests build, stopping Slack Notifications about instances")
+        logging.error("Not instance tests build, stopping Slack Notifications about instances")

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -7,11 +7,11 @@ import signal
 import string
 import time
 import unicodedata
+from pprint import pformat
+
 import urllib3
 import demisto_client.demisto_api
 from subprocess import call, Popen, PIPE, check_call, check_output, CalledProcessError, STDOUT
-from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
-    LOG_COLORS
 
 VALID_FILENAME_CHARS = '-_.() %s%s' % (string.ascii_letters, string.digits)
 PROXY_PROCESS_INIT_TIMEOUT = 20
@@ -171,19 +171,20 @@ class MITMProxy:
         process (Popen): object representation of the Proxy process (used to track the proxy process status).
         empty_files (list): List of playbooks that have empty mock files (indicating no usage of mock mechanism).
         rerecorded_tests (list): List of playbook ids that failed on mock playback but succeeded on new recording.
-        debug (bool): enable debug prints - redirect.
     """
 
     PROXY_PORT = '9997'
     MOCKS_TMP_PATH = '/tmp/Mocks/'
     MOCKS_GIT_PATH = 'content-test-data/'
 
-    def __init__(self, public_ip,
-                 repo_folder=MOCKS_GIT_PATH, tmp_folder=MOCKS_TMP_PATH, debug=False):
+    def __init__(self,
+                 public_ip,
+                 logging_manager,
+                 repo_folder=MOCKS_GIT_PATH, tmp_folder=MOCKS_TMP_PATH):
         self.public_ip = public_ip
         self.current_folder = self.repo_folder = repo_folder
         self.tmp_folder = tmp_folder
-        self.debug = debug
+        self.logging_manager = logging_manager
 
         self.ami = AMIConnection(self.public_ip)
 
@@ -197,18 +198,17 @@ class MITMProxy:
         self.rerecorded_tests = []
         silence_output(self.ami.call, ['mkdir', '-p', tmp_folder], stderr='null')
 
-    @staticmethod
-    def configure_proxy_in_demisto(username, password, server, proxy=''):
+    def configure_proxy_in_demisto(self, username, password, server, proxy=''):
         client = demisto_client.configure(base_url=server, username=username,
                                           password=password, verify_ssl=False)
-
+        self.logging_manager.debug('Adding proxy server configurations')
         system_conf_response = demisto_client.generic_request_func(
             self=client,
             path='/system/config',
             method='GET'
         )
         system_conf = ast.literal_eval(system_conf_response[0]).get('sysConf', {})
-
+        self.logging_manager.debug(f'Server configurations before proxy server configurations:\n{pformat(system_conf)}')
         http_proxy = https_proxy = proxy
         if proxy:
             http_proxy = 'http://' + proxy
@@ -223,6 +223,7 @@ class MITMProxy:
         }
         response = demisto_client.generic_request_func(self=client, path='/system/config',
                                                        method='POST', body=data)
+        self.logging_manager.debug(f'Server configurations before proxy server configurations:\n{pformat(response)}')
 
         return response
 
@@ -245,46 +246,42 @@ class MITMProxy:
         """Set the temp folder as the current folder (the one used to store mock and log files)."""
         self.current_folder = self.tmp_folder
 
-    def move_mock_file_to_repo(self, playbook_id, thread_index=0, prints_manager=None):
+    def move_mock_file_to_repo(self, playbook_id):
         """Move the mock and log files of a (successful) test playbook run from the temp folder to the repo folder
 
         Args:
             playbook_id (string): ID of the test playbook of which the files should be moved.
-            thread_index (int): Index of the relevant thread, to make printing readable.
-            prints_manager (ParallelPrintsManager): Prints manager to synchronize parallel prints.
         """
         src_filepath = os.path.join(self.tmp_folder, get_mock_file_path(playbook_id))
         src_files = os.path.join(self.tmp_folder, get_folder_path(playbook_id) + '*')
         dst_folder = os.path.join(self.repo_folder, get_folder_path(playbook_id))
 
         if not self.has_mock_file(playbook_id):
-            prints_manager.add_print_job('Mock file not created!', print, thread_index)
+            self.logging_manager.info('Mock file not created!')
         elif self.get_mock_file_size(src_filepath) == '0':
-            prints_manager.add_print_job('Mock file is empty, ignoring.', print, thread_index)
+            self.logging_manager.info('Mock file is empty, ignoring.')
             self.empty_files.append(playbook_id)
         else:
             # Move to repo folder
-            prints_manager.add_print_job(
-                'Moving "{}" files to "{}" directory'.format(src_files, dst_folder), print, thread_index
-            )
+            self.logging_manager.debug(f'Moving "{src_files}" files to "{dst_folder}" directory')
             self.ami.call(['mkdir', '--parents', dst_folder])
             self.ami.call(['mv', src_files, dst_folder])
 
-    def clean_mock_file(self, playbook_id, path=None, thread_index=0, prints_manager=None):
-        prints_manager.add_print_job(f'clean_mock_file was called for test "{playbook_id}"', print, thread_index)
+    def clean_mock_file(self, playbook_id, path=None):
+        self.logging_manager.debug(f'clean_mock_file was called for test "{playbook_id}"')
         path = path or self.current_folder
         problem_keys_filepath = os.path.join(path, get_folder_path(playbook_id), 'problematic_keys.json')
-        prints_manager.add_print_job(f'problem_keys_filepath="{problem_keys_filepath}"', print, thread_index)
+        self.logging_manager.debug(f'problem_keys_filepath="{problem_keys_filepath}"')
         problem_key_file_exists = ["[", "-f", problem_keys_filepath, "]"]
         if not self.ami.call(problem_key_file_exists) == 0:
             err_msg = 'Error: The problematic_keys.json file was not written to the file path' \
-                      ' "{}" when recording the "{}" test playbook'.format(problem_keys_filepath, playbook_id)
-            prints_manager.add_print_job(err_msg, print_error, thread_index)
+                      f' "{problem_keys_filepath}" when recording the "{playbook_id}" test playbook'
+            self.logging_manager.error.add_print_job(err_msg)
             return
         problem_keys = json.loads(self.ami.check_output(['cat', problem_keys_filepath]))
 
         # is there data in problematic_keys.json that needs whitewashing?
-        prints_manager.add_print_job('checking if there is data to whitewash', print, thread_index)
+        self.logging_manager.debug('checking if there is data to whitewash')
         needs_whitewashing = False
         for val in problem_keys.values():
             if val:
@@ -298,75 +295,62 @@ class MITMProxy:
             command = 'mitmdump -ns ~/timestamp_replacer.py '
             log_file = os.path.join(path, get_log_file_path(playbook_id, record=True))
             # Handle proxy log output
-            debug_opt = f' >>{log_file} 2>&1' if not self.debug else ''
+            debug_opt = f' | sudo tee -a {log_file}'
             options = f'--set script_mode=clean --set keys_filepath={problem_keys_filepath}'
             if options.strip():
                 command += options
             command += ' -r {} -w {}{}'.format(mock_file_path, cleaned_mock_filepath, debug_opt)
             command = "source .bash_profile && {}".format(command)
-            prints_manager.add_print_job(f'command to clean mockfile:\n\t{command}', print, thread_index)
+            self.logging_manager.debug(f'command to clean mockfile:\n\t{command}')
             split_command = command.split()
-            prints_manager.add_print_job('Let\'s try and clean the mockfile from timestamp data!', print, thread_index)
+            self.logging_manager.debug('Let\'s try and clean the mockfile from timestamp data!')
             try:
                 check_output(self.ami.add_ssh_prefix(split_command, ssh_options='-t'), stderr=STDOUT)
             except CalledProcessError as e:
-                cleaning_err_msg = 'There may have been a problem when filtering timestamp data from the mock file.'
-                prints_manager.add_print_job(cleaning_err_msg, print_error, thread_index)
+                self.logging_manager.error(
+                    'There may have been a problem when filtering timestamp data from the mock file.')
                 err_msg = f'command `{command}` exited with return code [{e.returncode}]'
                 err_msg = f'{err_msg} and the output of "{e.output}"' if e.output else err_msg
                 if e.stderr:
                     err_msg += f'STDERR: {e.stderr}'
-                prints_manager.add_print_job(err_msg, print_error, thread_index)
+                self.logging_manager.error(err_msg)
             else:
-                prints_manager.add_print_job('Success!', print_color, thread_index, LOG_COLORS.GREEN)
+                self.logging_manager.debug('Success!')
 
             # verify cleaned mock is different than original
-            verify_diff_start_msg = 'verifying cleaned mock file is different than the original mock file'
-            prints_manager.add_print_job(verify_diff_start_msg, print, thread_index)
-            diff_cmd = 'diff -sq {} {}'.format(cleaned_mock_filepath, mock_file_path)
+            self.logging_manager.debug('verifying cleaned mock file is different than the original mock file')
+            diff_cmd = f'diff -sq {cleaned_mock_filepath} {mock_file_path}'
             try:
                 diff_cmd_output = self.ami.check_output(diff_cmd.split()).decode().strip()
-                prints_manager.add_print_job(f'diff_cmd_output={diff_cmd_output}', print, thread_index)
+                self.logging_manager.debug(f'diff_cmd_output={diff_cmd_output}')
                 if diff_cmd_output.endswith('are identical'):
-                    identical_msg = 'cleaned mock file and original mock file are identical... ' \
-                                    'uh oh looks like cleaning didn\'t work properly'
-                    prints_manager.add_print_job(identical_msg, print_warning, thread_index)
+                    self.logging_manager.debug('cleaned mock file and original mock file are identical')
                 else:
-                    prints_manager.add_print_job(
-                        'looks like the cleaning process did something!',
-                        print_color,
-                        thread_index,
-                        LOG_COLORS.GREEN
-                    )
+                    self.logging_manager.debug('looks like the cleaning process did something!')
 
-            except CalledProcessError as e:
-                err_msg = 'command `{}` exited with return code [{}]'.format(diff_cmd, e.returncode)
-                err_msg = '{} and the output of "{}"'.format(err_msg, e.output) if e.output else err_msg
-                prints_manager.add_print_job(err_msg, print_error, thread_index)
+            except CalledProcessError:
+                self.logging_manager.exception(f'command `{diff_cmd}` failed')
 
-            prints_manager.add_print_job('Replace old mock with cleaned one.', print, thread_index)
-            mv_cmd = 'mv {} {}'.format(cleaned_mock_filepath, mock_file_path)
+            self.logging_manager.debug('Replace old mock with cleaned one.')
+            mv_cmd = f'mv {cleaned_mock_filepath} {mock_file_path}'
             self.ami.call(mv_cmd.split())
         else:
-            empty_msg = '"problematic_keys.json" dictionary values were empty - ' \
-                        'no data to whitewash from the mock file.'
-            prints_manager.add_print_job(empty_msg, print, thread_index)
+            self.logging_manager.debug('"problematic_keys.json" dictionary values were empty - '
+                                       'no data to whitewash from the mock file.')
 
-    def start(self, playbook_id, path=None, record=False, thread_index=0, prints_manager=None):
+    def start(self, playbook_id, path=None, record=False):
         """Start the proxy process and direct traffic through it.
 
         Args:
             playbook_id (string): ID of the test playbook to run.
             path (string): path override for the mock/log files.
             record (bool): Select proxy mode (record/playback)
-            thread_index (int): Index of the relevant thread, to make printing readable.
-            prints_manager (ParallelPrintsManager): Prints manager to synchronize parallel prints.
         """
         if self.process:
             raise Exception("Cannot start proxy - already running.")
 
         path = path or self.current_folder
-
+        self.logging_manager.info(f'Attempting to start proxy in {"record" if record else "playback"} mode')
         # Create mock files directory
         silence_output(self.ami.call, ['mkdir', os.path.join(path, get_folder_path(playbook_id))], stderr='null')
 
@@ -402,7 +386,7 @@ class MITMProxy:
 
         log_file = os.path.join(path, get_log_file_path(playbook_id, record))
         # Handle proxy log output
-        debug_opt = " >{} 2>&1".format(log_file) if not self.debug else ''
+        debug_opt = f" | sudo tee -a {log_file}"
 
         # all mitmproxy/mitmdump commands should have the 'source .bash_profile && ' prefix to ensure the PATH
         # is correct when executing the command over ssh
@@ -416,8 +400,10 @@ class MITMProxy:
         self.process = Popen(self.ami.add_ssh_prefix(command, "-t"), stdout=PIPE, stderr=PIPE)
         self.process.poll()
         if self.process.returncode is not None:
-            print_error("Proxy process terminated unexpectedly.\nExit code: {}\noutputs:\nSTDOUT\n{}\n\nSTDERR\n{}"
-                        .format(self.process.returncode, self.process.stdout.read(), self.process.stderr.read()))
+            self.logging_manager.exception("Proxy process terminated unexpectedly.\n"
+                                           f"Exit code: {self.process.returncode}\noutputs:\n"
+                                           f"STDOUT\n{self.process.stdout.read()}"
+                                           f"\n\nSTDERR\n{self.process.stderr.read()}")
         log_file_exists = False
         seconds_since_init = 0
         # Make sure process is up and running
@@ -427,36 +413,29 @@ class MITMProxy:
             time.sleep(PROXY_PROCESS_INIT_INTERVAL)
             seconds_since_init += PROXY_PROCESS_INIT_INTERVAL
         if not log_file_exists:
-            self.stop(thread_index, prints_manager)
+            self.stop()
             raise Exception("Proxy process took to long to go up.")
-        proxy_up_message = 'Proxy process up and running. Took {} seconds'.format(seconds_since_init)
-        prints_manager.add_print_job(proxy_up_message, print, thread_index)
+        self.logging_manager.debug(f'Proxy process up and running. Took {seconds_since_init} seconds')
 
         # verify that mitmdump process is listening on port 9997
         try:
-            prints_manager.add_print_job('verifying that mitmdump is listening on port 9997', print, thread_index)
+            self.logging_manager.debug('verifying that mitmdump is listening on port 9997')
             lsof_cmd = ['sudo', 'lsof', '-iTCP:9997', '-sTCP:LISTEN']
             lsof_cmd_output = self.ami.check_output(lsof_cmd).decode().strip()
-            prints_manager.add_print_job(f'lsof_cmd_output={lsof_cmd_output}', print, thread_index)
-        except CalledProcessError as e:
-            cleaning_err_msg = 'No process listening on port 9997'
-            prints_manager.add_print_job(cleaning_err_msg, print_error, thread_index)
-            err_msg = f'command `{command}` exited with return code [{e.returncode}]'
-            err_msg += f'{err_msg} and the output of "{e.output}"' if e.output else err_msg
-            prints_manager.add_print_job(err_msg, print_error, thread_index)
+            self.logging_manager.debug(f'lsof_cmd_output={lsof_cmd_output}')
+        except CalledProcessError:
+            self.logging_manager.error('No process listening on port 9997')
 
-    def stop(self, thread_index=0, prints_manager=None):
+    def stop(self):
         if not self.process:
             raise Exception("Cannot stop proxy - not running.")
 
-        prints_manager.add_print_job('proxy.stop() was called', print, thread_index)
+        self.logging_manager.info('proxy.stop() was called')
         self.process.send_signal(signal.SIGINT)  # Terminate proxy process
         self.ami.call(["rm", "-rf", "/tmp/_MEI*"])  # Clean up temp files
 
         # Handle logs
-        if self.debug:
-            prints_manager.add_print_job('proxy outputs:', print, thread_index)
-            prints_manager.add_print_job(f'{self.process.stdout.read()}', print, thread_index)
-            prints_manager.add_print_job(f'{self.process.stderr.read()}', print, thread_index)
+        self.logging_manager.debug(
+            f'proxy outputs:\n{self.process.stdout.read().decode()}\n{self.process.stderr.read().decode()}')
 
         self.process = None

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -162,7 +162,7 @@ class MITMProxy:
     """Manager for MITM Proxy and the mock file structure.
 
     Attributes:
-        demisto_api_key: API key for demisto API.
+        logging_manager: Logging module to use
         public_ip (string): The IP of the AMI instance.
         repo_folder (string): path to the local clone of the content-test-data git repo.
         tmp_folder (string): path to a temporary folder for log/mock files before pushing to git.
@@ -223,7 +223,7 @@ class MITMProxy:
         }
         response = demisto_client.generic_request_func(self=client, path='/system/config',
                                                        method='POST', body=data)
-        self.logging_manager.debug(f'Server configurations before proxy server configurations:\n{pformat(response)}')
+        self.logging_manager.debug(f'Server configurations response:\n{pformat(response)}')
 
         return response
 
@@ -422,7 +422,7 @@ class MITMProxy:
             self.logging_manager.debug('verifying that mitmdump is listening on port 9997')
             lsof_cmd = ['sudo', 'lsof', '-iTCP:9997', '-sTCP:LISTEN']
             lsof_cmd_output = self.ami.check_output(lsof_cmd).decode().strip()
-            self.logging_manager.debug(f'lsof_cmd_output={lsof_cmd_output}')
+            self.logging_manager.debug(f'{lsof_cmd_output=}')
         except CalledProcessError:
             self.logging_manager.error('No process listening on port 9997')
 

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -6,10 +6,10 @@ import zipfile
 from time import sleep
 from ruamel import yaml
 from typing import List
+import logging
 
 from Tests.scripts.utils.log_util import install_simple_logging
-from demisto_sdk.commands.common.tools import print_error, find_type
-from Tests.test_content import ParallelPrintsManager
+from demisto_sdk.commands.common.tools import find_type
 from Tests.configure_and_test_integration_instances import Build, configure_servers_and_restart, \
     get_tests, \
     get_changed_integrations, configure_server_instances, instance_testing, disable_instances, \
@@ -32,12 +32,11 @@ def install_private_testing_pack(build: Build, test_pack_zip_path: str):
                           pack_path=test_pack_zip_path)
 
 
-def install_packs_private(build: Build, prints_manager: ParallelPrintsManager, pack_ids: list = None) -> bool:
+def install_packs_private(build: Build, pack_ids: list = None) -> bool:
     """
     Wrapper for the search and install packs function.
 
     :param build: Build object containing the build settings.
-    :param prints_manager: PrintsManager object used for reporting status. Will be deprecated.
     :param pack_ids: Optional, list of packs to install. List contains pack id and version requested.
     :return: Boolean indicating if the installation was successful.
     """
@@ -49,9 +48,8 @@ def install_packs_private(build: Build, prints_manager: ParallelPrintsManager, p
                                                                            pack_ids, server.client)
             if not flag:
                 raise Exception('Failed to search and install packs.')
-        except Exception as exc:
-            prints_manager.add_print_job(str(exc), print_error, 0)
-            prints_manager.execute_thread_prints(0)
+        except Exception:
+            logging.exception('Failed to search and install packs.')
             installed_content_packs_successfully = False
 
     return installed_content_packs_successfully
@@ -115,13 +113,12 @@ def write_test_pack_zip(tests_file_paths: set, path_to_content: str,
 def main():
     install_simple_logging()
     build = Build(options_handler())
-    prints_manager = ParallelPrintsManager(1)
 
-    configure_servers_and_restart(build, prints_manager)
+    configure_servers_and_restart(build)
     #  Get a list of the test we need to run.
     tests_for_iteration = get_tests(build)
     #  Installing the packs.
-    installed_content_packs_successfully = install_packs_private(build, prints_manager)
+    installed_content_packs_successfully = install_packs_private(build)
     #  Get a list of the integrations that have changed.
     new_integrations, modified_integrations = get_changed_integrations(build)
     #  Configuring the instances which are used in testing.

--- a/Tests/private_build/run_content_tests_private.py
+++ b/Tests/private_build/run_content_tests_private.py
@@ -219,11 +219,9 @@ def run_private_test_scenario(tests_settings: SettingsTester, t: dict, default_t
     test_to_version = t.get('toversion', '99.99.99')
 
     if not (LooseVersion(test_from_version) <= LooseVersion(server_numeric_version) <= LooseVersion(test_to_version)):
-        logging.info(f'\n------ Test {test_message} start ------')
         warning_message = f'Test {test_message} ignored due to version mismatch ' \
                           f'(test versions: {test_from_version}-{test_to_version})'
         logging.warning(warning_message)
-        logging.info(f'------ Test {test_message} end ------\n')
         return
 
     placeholders_map = {'%%SERVER_HOST%%': server}

--- a/Tests/private_build/run_content_tests_private.py
+++ b/Tests/private_build/run_content_tests_private.py
@@ -382,7 +382,7 @@ def manage_tests(tests_settings: SettingsTester):
 
 
 def main():
-    install_logging('Run Tests.log')
+    install_logging('Run_Tests.log')
     tests_settings = options_handler()
     manage_tests(tests_settings)
 

--- a/Tests/private_build/run_content_tests_private.py
+++ b/Tests/private_build/run_content_tests_private.py
@@ -2,23 +2,20 @@ from __future__ import print_function
 import sys
 import time
 import argparse
-import traceback
 from time import sleep
-import datetime
 from distutils.version import LooseVersion
 from typing import Any
 
+import logging
 import urllib3
 import demisto_client.demisto_api
-from demisto_client.demisto_api.rest import ApiException
 
-from Tests.scripts.utils.log_util import install_simple_logging
+from Tests.scripts.utils.log_util import install_logging
 from Tests.test_integration import Docker, check_integration, disable_all_integrations
 from demisto_sdk.commands.common.constants import PB_Status
-from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
-    LOG_COLORS, str2bool
+from demisto_sdk.commands.common.tools import str2bool
 
-from Tests.test_content import SettingsTester, ParallelPrintsManager, DataKeeperTester, \
+from Tests.test_content import SettingsTester, DataKeeperTester, \
     print_test_summary, update_test_msg, turn_off_telemetry, \
     create_result_files, get_all_tests, get_instances_ips_and_names, get_server_numeric_version, \
     initialize_queue_and_executed_tests_set, get_test_records_of_given_test_names, \
@@ -58,8 +55,7 @@ def options_handler():
 def run_test_logic(tests_settings: Any, c: Any, failed_playbooks: list,
                    integrations: list, playbook_id: str, succeed_playbooks: list, test_message: str,
                    test_options: dict, slack: Any, circle_ci: str, build_number: str, server_url: str,
-                   demisto_user: str, demisto_pass: str, build_name: str,
-                   prints_manager: Any, thread_index: int = 0) -> bool:
+                   demisto_user: str, demisto_pass: str, build_name: str) -> bool:
     """
     run_test_logic handles the testing of the integration by triggering check_integration. afterwards
     it will check the status of the test and report success or add the failed test to the list of
@@ -82,27 +78,20 @@ def run_test_logic(tests_settings: Any, c: Any, failed_playbooks: list,
     :param demisto_user: Username of the demisto user running the tests.
     :param demisto_pass: Password of the demisto user running the tests.
     :param build_name: Name of the build. (Nightly, etc.)
-    :param prints_manager: PrintsManager object used in reporting. Will be deprecated.
-    :param thread_index: Integer indicating what thread the test is running on.
     :return: Boolean indicating if the test was successful.
     """
     status, inc_id = check_integration(c, server_url, demisto_user, demisto_pass, integrations, playbook_id,
-                                       prints_manager, test_options, thread_index=thread_index)
+                                       options=test_options)
     if status == PB_Status.COMPLETED:
-        prints_manager.add_print_job('PASS: {} succeed'.format(test_message), print_color,
-                                     thread_index,
-                                     message_color=LOG_COLORS.GREEN)
+        logging.success(f'PASS: {test_message} succeed')
         succeed_playbooks.append(playbook_id)
 
     elif status == PB_Status.NOT_SUPPORTED_VERSION:
-        not_supported_version_message = 'PASS: {} skipped - not supported version'.format(
-            test_message)
-        prints_manager.add_print_job(not_supported_version_message, print, thread_index)
+        logging.info(f'PASS: {test_message} skipped - not supported version')
         succeed_playbooks.append(playbook_id)
 
     else:
-        error_message = 'Failed: {} failed'.format(test_message)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+        logging.error(f'Failed: {test_message} failed')
         playbook_id_with_mock = playbook_id
         playbook_id_with_mock += " (Mock Disabled)"
         failed_playbooks.append(playbook_id_with_mock)
@@ -118,8 +107,7 @@ def run_test_logic(tests_settings: Any, c: Any, failed_playbooks: list,
 def run_test(tests_settings: SettingsTester, demisto_user: str, demisto_pass: str,
              failed_playbooks: list, integrations: list, playbook_id: str, succeed_playbooks: list,
              test_message: str, test_options: dict, slack: str, circle_ci: str, build_number: str,
-             server_url: str, build_name: str, prints_manager: ParallelPrintsManager,
-             thread_index: int = 0) -> None:
+             server_url: str, build_name: str) -> None:
     """
     Wrapper for the run_test_logic function. Helps by indicating when the test is starting and ending.
 
@@ -139,22 +127,16 @@ def run_test(tests_settings: SettingsTester, demisto_user: str, demisto_pass: st
     :param build_number: The build number of the CI run. Used in slack message.
     :param server_url: The FQDN of the server tests are being ran on.
     :param build_name: Name of the build. (Nightly, etc.)
-    :param prints_manager: PrintsManager object used in reporting. Will be deprecated.
-    :param thread_index: Integer indicating what thread the test is running on.
     :return: No object is returned.
     """
     start_message = f'------ Test {test_message} start ------'
     client = demisto_client.configure(base_url=server_url, username=demisto_user, password=demisto_pass,
                                       verify_ssl=False)
-    prints_manager.add_print_job(start_message + ' (Private Build Test)', print, thread_index,
-                                 include_timestamp=True)
+    logging.info(start_message + ' (Private Build Test)')
     run_test_logic(tests_settings, client, failed_playbooks, integrations, playbook_id,
                    succeed_playbooks, test_message, test_options, slack, circle_ci, build_number,
-                   server_url, demisto_user, demisto_pass, build_name, prints_manager,
-                   thread_index=thread_index)
-    prints_manager.add_print_job('------ Test %s end ------\n' % (test_message,), print,
-                                 thread_index,
-                                 include_timestamp=True)
+                   server_url, demisto_user, demisto_pass, build_name)
+    logging.info(f'------ Test {test_message} end ------\n')
 
     return
 
@@ -164,8 +146,7 @@ def run_private_test_scenario(tests_settings: SettingsTester, t: dict, default_t
                               skipped_integration: set, filtered_tests: list, skipped_tests: set, secret_params: dict,
                               failed_playbooks: list, playbook_skipped_integration: set, succeed_playbooks: list,
                               slack: str, circle_ci: str, build_number: str, server: str, build_name: str,
-                              server_numeric_version: str, demisto_user: str, demisto_pass: str, demisto_api_key: str,
-                              prints_manager: ParallelPrintsManager, thread_index: int = 0):
+                              server_numeric_version: str, demisto_user: str, demisto_pass: str, demisto_api_key: str):
     """
     Checks to see if test should run given the scenario. If the test should run, it will collect the
     integrations which are required to run the test.
@@ -194,8 +175,6 @@ def run_private_test_scenario(tests_settings: SettingsTester, t: dict, default_t
     :param demisto_user: Username of the demisto user running the tests.
     :param demisto_pass: Password of the demisto user running the tests.
     :param demisto_api_key: API key for the demisto instance.
-    :param prints_manager: PrintsManager object used in reporting. Will be deprecated.
-    :param thread_index: Integer indicating what thread the test is running on.
     :return:
     """
     playbook_id = t['playbookID']
@@ -240,19 +219,16 @@ def run_private_test_scenario(tests_settings: SettingsTester, t: dict, default_t
     test_to_version = t.get('toversion', '99.99.99')
 
     if not (LooseVersion(test_from_version) <= LooseVersion(server_numeric_version) <= LooseVersion(test_to_version)):
-        prints_manager.add_print_job(f'\n------ Test {test_message} start ------', print, thread_index,
-                                     include_timestamp=True)
-        warning_message = 'Test {} ignored due to version mismatch (test versions: {}-{})'.format(test_message,
-                                                                                                  test_from_version,
-                                                                                                  test_to_version)
-        prints_manager.add_print_job(warning_message, print_warning, thread_index)
-        prints_manager.add_print_job(f'------ Test {test_message} end ------\n', print, thread_index,
-                                     include_timestamp=True)
+        logging.info(f'\n------ Test {test_message} start ------')
+        warning_message = f'Test {test_message} ignored due to version mismatch ' \
+                          f'(test versions: {test_from_version}-{test_to_version})'
+        logging.warning(warning_message)
+        logging.info(f'------ Test {test_message} end ------\n')
         return
 
     placeholders_map = {'%%SERVER_HOST%%': server}
     are_params_set = set_integration_params(demisto_api_key, integrations, secret_params, instance_names_conf,
-                                            playbook_id, prints_manager, placeholders_map, thread_index=thread_index)
+                                            playbook_id, placeholders_map)
     if not are_params_set:
         failed_playbooks.append(playbook_id)
         return
@@ -260,12 +236,11 @@ def run_private_test_scenario(tests_settings: SettingsTester, t: dict, default_t
     test_message = update_test_msg(integrations, test_message)
     run_test(tests_settings, demisto_user, demisto_pass, failed_playbooks, integrations,
              playbook_id, succeed_playbooks, test_message, test_options, slack, circle_ci,
-             build_number, server, build_name, prints_manager, thread_index=thread_index)
+             build_number, server, build_name)
 
 
 def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: set,
-                    tests_data_keeper: DataKeeperTester, prints_manager: ParallelPrintsManager,
-                    thread_index: int = 0):
+                    tests_data_keeper: DataKeeperTester):
     """
     Main function used to handle the testing process. Starts by turning off telemetry and disabling
     any left over tests. Afterwards it will create a test queue object which then is used to run the
@@ -275,14 +250,11 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
     :param server_ip: IP address of the server. Will be formatted before use.
     :param all_tests: All tests currently in the test conf.
     :param tests_data_keeper: Object containing all the test results. Used by report tests function.
-    :param prints_manager: PrintsManager object used in reporting. Will be deprecated.
-    :param thread_index: Integer indicating what thread the test is running on.
     :return: No object is returned, just updates the tests_data_keep object.
     """
     server = SERVER_URL.format(server_ip)
     server_numeric_version = tests_settings.serverNumericVersion
-    start_message = "Executing tests with the server {} - and the server ip {}".format(server, server_ip)
-    prints_manager.add_print_job(start_message, print, thread_index)
+    logging.info(f"Executing tests with the server {server} - and the server ip {server_ip}")
     slack = tests_settings.slack
     circle_ci = tests_settings.circleci
     build_number = tests_settings.buildNumber
@@ -305,8 +277,7 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
     filtered_tests = extract_filtered_tests()
 
     if not tests or len(tests) == 0:
-        prints_manager.add_print_job('no integrations are configured for test', print, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
+        logging.info('no integrations are configured for test')
         return
     xsoar_client = demisto_client.configure(base_url=server, username=demisto_user,
                                             password=demisto_pass, verify_ssl=False)
@@ -320,18 +291,17 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
     skipped_integration = set([])
     playbook_skipped_integration = set([])
 
-    disable_all_integrations(xsoar_client, prints_manager, thread_index=thread_index)
-    prints_manager.execute_thread_prints(thread_index)
+    disable_all_integrations(xsoar_client)
     #  Private builds do not use mocking. Here we copy the mocked test list to the unmockable list.
     private_tests = get_test_records_of_given_test_names(tests_settings, all_tests)
     try:
         # first run the mock tests to avoid mockless side effects in container
-        prints_manager.add_print_job("\nRunning private tests", print, thread_index)
+        logging.info("\nRunning private tests")
         executed_in_current_round, private_tests_queue = initialize_queue_and_executed_tests_set(private_tests)
         while not private_tests_queue.empty():
             t = private_tests_queue.get()
             executed_in_current_round = update_round_set_and_sleep_if_round_completed(
-                executed_in_current_round, prints_manager, t, thread_index)
+                executed_in_current_round, t)
             run_private_test_scenario(tests_settings, t, default_test_timeout, skipped_tests_conf,
                                       nightly_integrations, skipped_integrations_conf,
                                       skipped_integration,
@@ -339,18 +309,10 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
                                       failed_playbooks, playbook_skipped_integration,
                                       succeed_playbooks, slack, circle_ci, build_number, server,
                                       build_name, server_numeric_version, demisto_user,
-                                      demisto_pass, demisto_api_key, prints_manager,
-                                      thread_index=thread_index)
-            prints_manager.execute_thread_prints(thread_index)
+                                      demisto_pass, demisto_api_key)
 
-    except Exception as exc:
-        if exc.__class__ == ApiException:
-            error_message = exc.body
-        else:
-            error_message = f'~~ Thread {thread_index + 1} failed ~~\n{str(exc)}\n{traceback.format_exc()}'
-        prints_manager.add_print_job(error_message, print_error, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
-        failed_playbooks.append(f'~~ Thread {thread_index + 1} failed ~~')
+    except Exception:
+        logging.exception('~~ Thread Failed ~~')
         raise
 
     finally:
@@ -359,9 +321,7 @@ def execute_testing(tests_settings: SettingsTester, server_ip: str, all_tests: s
 
 
 def update_round_set_and_sleep_if_round_completed(executed_in_current_round: set,
-                                                  prints_manager: ParallelPrintsManager,
-                                                  t: dict,
-                                                  thread_index: int) -> set:
+                                                  t: dict) -> set:
     """
     Checks if the string representation of the current test configuration is already in
     the executed_in_current_round set.
@@ -375,19 +335,15 @@ def update_round_set_and_sleep_if_round_completed(executed_in_current_round: set
         executed_in_current_round: A set containing the string representation of all tests
         configuration as they appear
         in conf.json file that were already executed in the current round
-        prints_manager: ParallelPrintsManager object
         t: test configuration as it appears in conf.json file
-        thread_index: Currently executing thread
 
     Returns:
         A new executed_in_current_round set which contains only the current tests configuration if a
         round was completed else it just adds the new test to the set.
     """
     if str(t) in executed_in_current_round:
-        prints_manager.add_print_job(
-            'all tests in the queue were executed, sleeping for 30 seconds to let locked tests get unlocked.',
-            print,
-            thread_index)
+        logging.info(
+            'all tests in the queue were executed, sleeping for 30 seconds to let locked tests get unlocked.')
         executed_in_current_round = set()
         time.sleep(30)
     executed_in_current_round.add(str(t))
@@ -406,17 +362,14 @@ def manage_tests(tests_settings: SettingsTester):
     tests_settings.serverNumericVersion = get_server_numeric_version(tests_settings.serverVersion,
                                                                      tests_settings.is_local_run)
     instances_ips = get_instances_ips_and_names(tests_settings)
-    number_of_instances = len(instances_ips)
-    prints_manager = ParallelPrintsManager(number_of_instances)
     tests_data_keeper = DataKeeperTester()
 
     for ami_instance_name, ami_instance_ip in instances_ips:
         if ami_instance_name == tests_settings.serverVersion:
-            print_color("Starting private testing for {}".format(ami_instance_name), LOG_COLORS.GREEN)
-            print("Starts tests with server url - https://{}".format(ami_instance_ip))
+            logging.info(f"Starting private testing for {ami_instance_name}")
+            logging.info(f"Starts tests with server url - https://{ami_instance_ip}")
             all_tests = get_all_tests(tests_settings)
-            execute_testing(tests_settings, ami_instance_ip, all_tests, tests_data_keeper,
-                            prints_manager, thread_index=0)
+            execute_testing(tests_settings, ami_instance_ip, all_tests, tests_data_keeper)
             sleep(8)
 
     print_test_summary(tests_data_keeper, tests_settings.isAMI)
@@ -429,8 +382,7 @@ def manage_tests(tests_settings: SettingsTester):
 
 
 def main():
-    install_simple_logging()
-    print("Time is: {}\n\n\n".format(datetime.datetime.now()))
+    install_logging('Run Tests.log')
     tests_settings = options_handler()
     manage_tests(tests_settings)
 

--- a/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/tests/test_configure_and_test_integration_instances_private.py
@@ -8,7 +8,6 @@ from Tests.private_build.configure_and_test_integration_instances_private import
     find_needed_test_playbook_paths, install_private_testing_pack, write_test_pack_zip,\
     install_packs_private
 import Tests.Marketplace.search_and_install_packs as script
-from Tests.test_content import ParallelPrintsManager
 
 
 class ServerMock:
@@ -170,7 +169,6 @@ def test_install_packs_private(mocker):
     Then: Collect the pack ID from the packs to install file, update the license, and upload the pack.
     """
 
-    prints_manager = ParallelPrintsManager(len(BuildMock().servers))
     mocker.patch('Tests.Marketplace.search_and_install_packs.open', return_value=StringIO('HelloWorld\nTEST'))
     mocker.patch('Tests.Marketplace.search_and_install_packs.search_pack_and_its_dependencies')
 
@@ -186,6 +184,5 @@ def test_install_packs_private(mocker):
     mock_build = BuildMock()
     mock_build.test_pack_path = 'content/artifacts/packs'
     mock_build.pack_ids_to_install = ['TestPack']
-    test_results = install_packs_private(build=mock_build, prints_manager=prints_manager,
-                                         pack_ids=['TEST'])
+    test_results = install_packs_private(build=mock_build, pack_ids=['TEST'])
     assert test_results is True

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -99,11 +99,10 @@ class TestConf(object):
                 pack = tools.get_pack_name(int_path)
                 if pack:
                     packs.add(pack)
-            except TypeError as e:
+            except TypeError:
                 err_msg = f'Error occurred when trying to determine the pack of integration "{integration}"'
                 err_msg += f' with path "{int_path}"' if int_path else ''
-                err_msg += f'\nERROR: "{e}"'
-                tools.print_color(err_msg, tools.LOG_COLORS.YELLOW)
+                logging.exception(err_msg)
         return packs
 
     def get_test_playbooks_configured_with_integration(self, integration_id):

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1252,7 +1252,7 @@ def create_test_file(is_nightly, skip_save=False, path_to_pack=''):
 
 
 if __name__ == "__main__":
-    install_logging('Collect Tests And Content Packs.log')
+    install_logging('Collect_Tests_And_Content_Packs.log')
     logging.info("Starting creation of test filter file")
 
     parser = argparse.ArgumentParser(description='Utility CircleCI usage')

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -4,11 +4,13 @@ import re
 import sys
 import argparse
 import requests
+import logging
 from circleci.api import Api as circle_api
 
 from slackclient import SlackClient
 
-from demisto_sdk.commands.common.tools import str2bool, run_command, LOG_COLORS, print_color, print_error
+from Tests.scripts.utils.log_util import install_logging
+from demisto_sdk.commands.common.tools import str2bool, run_command
 
 DEMISTO_GREY_ICON = 'https://3xqz5p387rui1hjtdv1up7lw-wpengine.netdna-ssl.com/wp-content/' \
                     'uploads/2018/07/Demisto-Icon-Dark.png'
@@ -82,14 +84,14 @@ def get_failing_unit_tests_file_data():
         failing_ut_list = None
         file_name = './artifacts/failed_lint_report.txt'
         if os.path.isfile(file_name):
-            print('Extracting lint_report')
+            logging.info('Extracting lint_report')
             with open(file_name, 'r') as failed_unittests_file:
                 failing_ut = failed_unittests_file.readlines()
                 failing_ut_list = [line.strip('\n') for line in failing_ut]
         else:
-            print('Did not find failed_lint_report.txt file')
-    except Exception as err:
-        print_error(f'Error getting failed_lint_report.txt file: \n {err}')
+            logging.info('Did not find failed_lint_report.txt file')
+    except Exception:
+        logging.exception('Error getting failed_lint_report.txt file')
     return failing_ut_list
 
 
@@ -162,8 +164,7 @@ def get_attachments_for_bucket_upload_flow(build_url, job_name, packs_results_fi
                 pass
 
     if job_name and job_name != 'Upload Packs To Marketplace' and color == 'good':
-        print_color('On bucket upload flow we are not notifying on jobs that are not Upload Packs. exiting...',
-                    LOG_COLORS.NATIVE)
+        logging.info('On bucket upload flow we are not notifying on jobs that are not Upload Packs. exiting...')
         sys.exit(0)
 
     container_build_url = build_url + '#queue-placeholder/containers/0'
@@ -195,7 +196,7 @@ def get_attachments_for_all_steps(build_url, build_title):
 
 def get_attachments_for_test_playbooks(build_url, env_results_file_name):
     if not env_results_file_name or not os.path.exists(env_results_file_name):
-        print_error('When running slack notifier for nightly build, provide env_results_file')
+        logging.critical('When running slack notifier for nightly build, provide env_results_file')
         sys.exit(0)
     with open(env_results_file_name, 'r') as env_results_file_content:
         env_results = json.load(env_results_file_content)
@@ -230,21 +231,21 @@ def get_attachments_for_test_playbooks(build_url, env_results_file_name):
 def get_fields():
     failed_tests = []
     if os.path.isfile('./Tests/failed_tests.txt'):
-        print('Extracting failed_tests')
+        logging.info('Extracting failed_tests')
         with open('./Tests/failed_tests.txt', 'r') as failed_tests_file:
             failed_tests = failed_tests_file.readlines()
             failed_tests = [line.strip('\n') for line in failed_tests]
 
     skipped_tests = []
     if os.path.isfile('./Tests/skipped_tests.txt'):
-        print('Extracting skipped_tests')
+        logging.info('Extracting skipped_tests')
         with open('./Tests/skipped_tests.txt', 'r') as skipped_tests_file:
             skipped_tests = skipped_tests_file.readlines()
             skipped_tests = [line.strip('\n') for line in skipped_tests]
 
     skipped_integrations = []
     if os.path.isfile('./Tests/skipped_integrations.txt'):
-        print('Extracting skipped_integrations')
+        logging.info('Extracting skipped_integrations')
         with open('./Tests/skipped_integrations.txt', 'r') as skipped_integrations_file:
             skipped_integrations = skipped_integrations_file.readlines()
             skipped_integrations = [line.strip('\n') for line in skipped_integrations]
@@ -286,21 +287,21 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
     branch_name = branch_name_reg.group(1)
 
     if branch_name == 'master':
-        print("Extracting build status")
+        logging.info("Extracting build status")
         if test_type == UNITTESTS_TYPE:
-            print_color("Starting Slack notifications about nightly build - unit tests", LOG_COLORS.GREEN)
+            logging.info("Starting Slack notifications about nightly build - unit tests")
             content_team_attachments = get_attachments_for_unit_test(build_url)
         elif test_type == SDK_UNITTESTS_TYPE:
-            print_color("Starting Slack notifications about SDK nightly build - unit tests", LOG_COLORS.GREEN)
+            logging.info("Starting Slack notifications about SDK nightly build - unit tests")
             content_team_attachments = get_attachments_for_unit_test(build_url, is_sdk_build=True)
         elif test_type == 'test_playbooks':
-            print_color("Starting Slack notifications about nightly build - tests playbook", LOG_COLORS.GREEN)
+            logging.info("Starting Slack notifications about nightly build - tests playbook")
             content_team_attachments, _ = get_attachments_for_test_playbooks(build_url, env_results_file_name)
         elif test_type == SDK_FAILED_STEPS_TYPE:
-            print_color('Starting Slack notifications about SDK nightly build - test playbook', LOG_COLORS.GREEN)
+            logging.info('Starting Slack notifications about SDK nightly build - test playbook')
             content_team_attachments = get_attachments_for_all_steps(build_url, build_title=SDK_BUILD_TITLE)
         elif test_type == BUCKET_UPLOAD_TYPE:
-            print_color('Starting Slack notifications about upload to production bucket build', LOG_COLORS.GREEN)
+            logging.info('Starting Slack notifications about upload to production bucket build')
             content_team_attachments = get_attachments_for_bucket_upload_flow(
                 build_url=build_url, job_name=job_name, packs_results_file_path=packs_results_file
             )
@@ -308,8 +309,8 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
             content_team_attachments = get_attachments_for_all_steps(build_url, build_title=SDK_XSOAR_BUILD_TITLE)
         else:
             raise NotImplementedError('The test_type parameter must be only \'test_playbooks\' or \'unittests\'')
-        print('Content team attachments:\n', content_team_attachments)
-        print("Sending Slack messages to #content-team")
+        logging.info(f'Content team attachments:\n{content_team_attachments}')
+        logging.info("Sending Slack messages to #content-team")
         slack_client = SlackClient(slack_token)
         slack_client.api_call(
             "chat.postMessage",
@@ -321,6 +322,7 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
 
 
 def main():
+    install_logging('Slack Notifier.log')
     options = options_handler()
     nightly = options.nightly
     url = options.url
@@ -338,7 +340,7 @@ def main():
     elif test_type in (SDK_UNITTESTS_TYPE, SDK_FAILED_STEPS_TYPE, SDK_RUN_AGAINST_FAILED_STEPS_TYPE):
         slack_notifier(url, slack, test_type)
     else:
-        print_color("Not nightly build, stopping Slack Notifications about Content build", LOG_COLORS.RED)
+        logging.error("Not nightly build, stopping Slack Notifications about Content build")
 
 
 if __name__ == '__main__':

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -322,7 +322,7 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
 
 
 def main():
-    install_logging('Slack Notifier.log')
+    install_logging('Slack_Notifier.log')
     options = options_handler()
     nightly = options.nightly
     url = options.url

--- a/Tests/scripts/update_conf_json.py
+++ b/Tests/scripts/update_conf_json.py
@@ -76,7 +76,7 @@ def load_test_data_from_conf_json():
 
 
 def generate_pack_tests_configuration(pack_name, existing_test_playbooks):
-    install_logging('Update Tests step.log', include_process_name=True)
+    install_logging('Update_Tests_step.log', include_process_name=True)
     pack_integrations = []
     pack_test_playbooks = []
 
@@ -123,7 +123,7 @@ def update_new_conf_json(future):
 
 
 def main():
-    install_logging('Update Tests step.log', include_process_name=True)
+    install_logging('Update_Tests_step.log', include_process_name=True)
     existing_test_playbooks = load_test_data_from_conf_json()
     with ProcessPool(max_workers=os.cpu_count(), max_tasks=100) as pool:
         for pack_name in os.listdir(PACKS_DIR):

--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -145,6 +145,7 @@ class ParallelLoggingManager:
     >>> logging_manager.critical('critical message', real_time=True)
     >>> logging_manager.success('success message', real_time=True)
     """
+
     def __init__(self, log_file_name):
         """
         Initializes the logging manager:
@@ -172,6 +173,7 @@ class ParallelLoggingManager:
         self.real_time_logger.addHandler(self.file_handler)
         self.real_time_logger.addHandler(self.console_handler)
         self.real_time_logger.setLevel(logging.DEBUG)
+        self.real_time_logger.propagate = False
         self.loggers = {}
         self.listeners = {}
         self.logs_lock = Lock()
@@ -187,8 +189,8 @@ class ParallelLoggingManager:
         log_queue = queue.Queue(-1)
         queue_handler = QueueHandler(log_queue)
         queue_handler.setLevel(logging.DEBUG)
-
         logger = logging.getLogger(thread_name)
+        logger.propagate = False
         logger.setLevel(logging.DEBUG)
         logger.addHandler(queue_handler)
         listener = QueueListener(log_queue, self.console_handler, self.file_handler, respect_handler_level=True)

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -59,7 +59,7 @@ def download_cloud_init_logs_from_server(ip: str) -> None:
 
 
 def main():
-    install_logging('Wait Until Server Ready.log')
+    install_logging('Wait_Until_Server_Ready.log')
     global SETUP_TIMEOUT
     instance_name_to_wait_on = sys.argv[1]
     ready_ami_list = []

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -9,7 +9,6 @@ import time
 import argparse
 import threading
 import subprocess
-import traceback
 from time import sleep
 import datetime
 from distutils.version import LooseVersion
@@ -24,10 +23,8 @@ from contextlib import contextmanager
 import urllib3
 import requests
 import demisto_client.demisto_api
-from demisto_client.demisto_api.rest import ApiException
 
-
-from Tests.scripts.utils.log_util import install_simple_logging
+from Tests.scripts.utils.log_util import ParallelLoggingManager
 
 try:
     """
@@ -43,8 +40,9 @@ from Tests.mock_server import MITMProxy, AMIConnection
 from Tests.test_integration import Docker, check_integration, disable_all_integrations
 from Tests.test_dependencies import get_used_integrations, get_tests_allocation_for_threads
 from demisto_sdk.commands.common.constants import FILTER_CONF, PB_Status
-from demisto_sdk.commands.common.tools import print_color, print_error, print_warning, \
-    LOG_COLORS, str2bool
+from demisto_sdk.commands.common.tools import str2bool
+
+logging_manager: ParallelLoggingManager = None
 
 # Disable insecure warnings
 urllib3.disable_warnings()
@@ -122,51 +120,6 @@ class SettingsTester:
         return tests_to_run
 
 
-class PrintJob:
-    def __init__(self, message_to_print, print_function_to_execute, message_color=None):
-        self.print_function_to_execute = print_function_to_execute
-        self.message_to_print = message_to_print
-        self.message_color = message_color
-
-    def execute_print(self):
-        if self.message_color:
-            self.print_function_to_execute(self.message_to_print, self.message_color)
-        else:
-            self.print_function_to_execute(self.message_to_print)
-
-
-class ParallelPrintsManager:
-
-    def __init__(self, number_of_threads):
-        self.threads_print_jobs = [[] for i in range(number_of_threads)]
-        self.print_lock = threading.Lock()
-        self.threads_last_update_times = [time.time() for i in range(number_of_threads)]
-
-    def should_update_thread_status(self, thread_index):
-        current_time = time.time()
-        thread_last_update = self.threads_last_update_times[thread_index]
-        return current_time - thread_last_update > 300
-
-    def add_print_job(self, message_to_print, print_function_to_execute, thread_index, message_color=None,
-                      include_timestamp=False):
-        if include_timestamp:
-            message_to_print = f'[{datetime.datetime.now(datetime.timezone.utc)}] {message_to_print}'
-
-        print_job = PrintJob(message_to_print, print_function_to_execute, message_color=message_color)
-        self.threads_print_jobs[thread_index].append(print_job)
-        if self.should_update_thread_status(thread_index):
-            print("Thread {} is still running.".format(thread_index))
-            self.threads_last_update_times[thread_index] = time.time()
-
-    def execute_thread_prints(self, thread_index):
-        self.print_lock.acquire()
-        prints_to_execute = self.threads_print_jobs[thread_index]
-        for print_job in prints_to_execute:
-            print_job.execute_print()
-        self.print_lock.release()
-        self.threads_print_jobs[thread_index] = []
-
-
 class DataKeeperTester:
 
     def __init__(self):
@@ -200,13 +153,15 @@ class DataKeeperTester:
             self.empty_files.append(playbook_id)
 
 
-def print_test_summary(tests_data_keeper: DataKeeperTester, is_ami: bool = True):
+def print_test_summary(tests_data_keeper: DataKeeperTester, is_ami: bool = True, logging_module=logging) -> None:
     """
     Takes the information stored in the tests_data_keeper and prints it in a human readable way.
+    Args:
+        tests_data_keeper: object containing test statuses.
+        is_ami: indicating if the server running the tests is an AMI or not.
+        logging_module: Logging module to use for test_summary
 
-    :param tests_data_keeper: DataKeeperTester object containing test statuses.
-    :param is_ami: Boolean indicating if the server running the tests is an AMI or not.
-    :return: None.
+
     """
     succeed_playbooks = tests_data_keeper.succeeded_playbooks
     failed_playbooks = tests_data_keeper.failed_playbooks
@@ -222,51 +177,40 @@ def print_test_summary(tests_data_keeper: DataKeeperTester, is_ami: bool = True)
     rerecorded_count = len(rerecorded_tests) if is_ami else 0
     empty_mocks_count = len(empty_files) if is_ami else 0
     unmocklable_integrations_count = len(unmocklable_integrations)
-    print('\nTEST RESULTS:')
-    tested_playbooks_message = '\t Number of playbooks tested - ' + str(succeed_count + failed_count)
-    print(tested_playbooks_message)
-    succeeded_playbooks_message = '\t Number of succeeded tests - ' + str(succeed_count)
-    print_color(succeeded_playbooks_message, LOG_COLORS.GREEN)
-
-    if failed_count > 0:
-        failed_tests_message = '\t Number of failed tests - ' + str(failed_count) + ':'
-        print_error(failed_tests_message)
-        for playbook_id in failed_playbooks:
-            print_error('\t - ' + playbook_id)
-
+    logging_module.info('TEST RESULTS:')
+    logging_module.info(f'Number of playbooks tested - {succeed_count + failed_count}')
+    logging_module.success(f'Number of succeeded tests - {succeed_count}')
+    if succeed_count:
+        logging_module.success(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in succeed_playbooks]))
+    if failed_count:
+        logging_module.error(f'Number of failed tests - {failed_count}:')
+        logging_module.error(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in failed_playbooks]))
     if rerecorded_count > 0:
-        recording_warning = '\t Tests with failed playback and successful re-recording - ' + str(rerecorded_count) + ':'
-        print_warning(recording_warning)
-        for playbook_id in rerecorded_tests:
-            print_warning('\t - ' + playbook_id)
+        logging_module.warning(f'Tests with failed playback and successful re-recording - {rerecorded_count}')
+        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in rerecorded_tests]))
 
     if empty_mocks_count > 0:
-        empty_mock_successes_msg = '\t Successful tests with empty mock files - ' + str(empty_mocks_count) + ':'
-        print(empty_mock_successes_msg)
-        proxy_explanation = '\t (either there were no http requests or no traffic is passed through the proxy.\n' \
-                            '\t Investigate the playbook and the integrations.\n' \
-                            '\t If the integration has no http traffic, add to unmockable_integrations in conf.json)'
-        print(proxy_explanation)
-        for playbook_id in empty_files:
-            print('\t - ' + playbook_id)
+        logging_module.info(f'Successful tests with empty mock files - {empty_mocks_count}:\n')
+        proxy_explanation = \
+            '\t\t\t\t\t\t (either there were no http requests or no traffic is passed through the proxy.\n' \
+            '\t\t\t\t\t\t Investigate the playbook and the integrations.\n' \
+            '\t\t\t\t\t\t If the integration has no http traffic, add to unmockable_integrations in conf.json)'
+        logging_module.info(proxy_explanation)
+        logging_module.info(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in empty_files]))
 
     if len(skipped_integration) > 0:
-        skipped_integrations_warning = '\t Number of skipped integration - ' + str(len(skipped_integration)) + ':'
-        print_warning(skipped_integrations_warning)
-        for playbook_id in skipped_integration:
-            print_warning('\t - ' + playbook_id)
+        logging_module.warning(f'Number of skipped integration - {len(skipped_integration):}')
+        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_integration]))
 
     if skipped_count > 0:
-        skipped_tests_warning = '\t Number of skipped tests - ' + str(skipped_count) + ':'
-        print_warning(skipped_tests_warning)
-        for playbook_id in skipped_tests:
-            print_warning('\t - ' + playbook_id)
+        logging_module.warning(f'Number of skipped tests - {skipped_count}:')
+        logging_module.warning(''.join([f'\n\t\t\t\t\t\t - {playbook_id}' for playbook_id in skipped_tests]))
 
     if unmocklable_integrations_count > 0:
-        unmockable_warning = '\t Number of unmockable integrations - ' + str(unmocklable_integrations_count) + ':'
-        print_warning(unmockable_warning)
-        for playbook_id, reason in unmocklable_integrations.items():
-            print_warning('\t - ' + playbook_id + ' - ' + reason)
+        logging_module.warning(f'Number of unmockable integrations - {unmocklable_integrations_count}:')
+        logging_module.warning(
+            ''.join([f'\n\t\t\t\t\t\t - {playbook_id} - {reason}' for playbook_id, reason in
+                     unmocklable_integrations.items()]))
 
 
 def update_test_msg(integrations, test_message):
@@ -291,19 +235,19 @@ def turn_off_telemetry(xsoar_client):
                                                                path='/telemetry?status=notelemetry')
 
     if status_code != 200:
-        print_error('Request to turn off telemetry failed with status code "{}"\n{}'.format(status_code, body))
+        logging_manager.critical(f'Request to turn off telemetry failed with status code "{status_code}"\n{body}',
+                                 real_time=True)
         sys.exit(1)
 
 
-def reset_containers(server, demisto_user, demisto_pass, prints_manager, thread_index):
-    prints_manager.add_print_job('Resetting containers', print, thread_index)
+def reset_containers(server, demisto_user, demisto_pass):
+    logging_manager.info('Resetting containers')
     client = demisto_client.configure(base_url=server, username=demisto_user, password=demisto_pass, verify_ssl=False)
     body, status_code, _ = demisto_client.generic_request_func(self=client, method='POST',
                                                                path='/containers/reset')
     if status_code != 200:
-        error_msg = 'Request to reset containers failed with status code "{}"\n{}'.format(status_code, body)
-        prints_manager.add_print_job(error_msg, print_error, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
+        logging_manager.error(f'Request to reset containers failed with status code "{status_code}"\n{body}')
+        logging_manager.execute_logs()
         sys.exit(1)
     sleep(10)
 
@@ -347,30 +291,25 @@ def send_slack_message(slack, chanel, text, user_name, as_user):
 def run_test_logic(conf_json_test_details, tests_queue, tests_settings, c, demisto_user, demisto_pass,
                    failed_playbooks, integrations, playbook_id, succeed_playbooks, test_message,
                    test_options, slack, circle_ci, build_number, server_url,
-                   build_name, prints_manager, thread_index=0, is_mock_run=False):
+                   build_name, is_mock_run=False):
     with acquire_test_lock(integrations,
                            test_options.get('timeout'),
-                           prints_manager,
-                           thread_index,
                            tests_settings.conf_path) as lock:
         if lock:
             status, inc_id = check_integration(c, server_url, demisto_user, demisto_pass, integrations,
-                                               playbook_id, prints_manager, test_options,
-                                               is_mock_run, thread_index=thread_index)
+                                               playbook_id, logging_manager, test_options,
+                                               is_mock_run)
             # c.api_client.pool.close()
             if status == PB_Status.COMPLETED:
-                prints_manager.add_print_job('PASS: {} succeed'.format(test_message), print_color,
-                                             thread_index, message_color=LOG_COLORS.GREEN)
+                logging_manager.success(f'PASS: {test_message} succeed')
                 succeed_playbooks.append(playbook_id)
 
             elif status == PB_Status.NOT_SUPPORTED_VERSION:
-                not_supported_version_message = 'PASS: {} skipped - not supported version'.format(test_message)
-                prints_manager.add_print_job(not_supported_version_message, print, thread_index)
+                logging_manager.info(f'PASS: {test_message} skipped - not supported version')
                 succeed_playbooks.append(playbook_id)
 
             else:
-                error_message = 'Failed: {} failed'.format(test_message)
-                prints_manager.add_print_job(error_message, print_error, thread_index)
+                logging_manager.error(f'Failed: {test_message} failed')
                 playbook_id_with_mock = playbook_id
                 if not is_mock_run:
                     playbook_id_with_mock += " (Mock Disabled)"
@@ -389,20 +328,18 @@ def run_test_logic(conf_json_test_details, tests_queue, tests_settings, c, demis
 # run the test using a real instance, record traffic.
 def run_and_record(conf_json_test_details, tests_queue, tests_settings, c, demisto_user, demisto_pass,
                    proxy, failed_playbooks, integrations, playbook_id, succeed_playbooks, test_message,
-                   test_options, slack, circle_ci, build_number, server_url, build_name, prints_manager,
-                   thread_index=0):
+                   test_options, slack, circle_ci, build_number, server_url, build_name):
     proxy.set_tmp_folder()
-    proxy.start(playbook_id, record=True, thread_index=thread_index, prints_manager=prints_manager)
+    proxy.start(playbook_id, record=True)
     succeed = run_test_logic(conf_json_test_details, tests_queue, tests_settings, c, demisto_user, demisto_pass,
                              failed_playbooks, integrations, playbook_id, succeed_playbooks,
                              test_message, test_options, slack, circle_ci, build_number, server_url,
-                             build_name, prints_manager, thread_index=thread_index,
-                             is_mock_run=True)
-    proxy.stop(thread_index=thread_index, prints_manager=prints_manager)
+                             build_name, is_mock_run=True)
+    proxy.stop()
     if succeed:
         proxy.successful_rerecord_count += 1
-        proxy.clean_mock_file(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
-        proxy.move_mock_file_to_repo(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
+        proxy.clean_mock_file(playbook_id)
+        proxy.move_mock_file_to_repo(playbook_id)
     else:
         proxy.failed_rerecord_count += 1
         proxy.failed_rerecord_tests.append(playbook_id)
@@ -412,51 +349,42 @@ def run_and_record(conf_json_test_details, tests_queue, tests_settings, c, demis
 
 def mock_run(conf_json_test_details, tests_queue, tests_settings, c, demisto_user, demisto_pass, proxy,
              failed_playbooks, integrations, playbook_id, succeed_playbooks, test_message, test_options,
-             slack, circle_ci, build_number, server_url, build_name, start_message, prints_manager,
-             thread_index=0):
+             slack, circle_ci, build_number, server_url, build_name, start_message):
     rerecord = False
 
     if proxy.has_mock_file(playbook_id):
-        start_mock_message = '{} (Mock: Playback)'.format(start_message)
-        prints_manager.add_print_job(start_mock_message, print, thread_index, include_timestamp=True)
-        proxy.start(playbook_id, thread_index=thread_index, prints_manager=prints_manager)
+        logging_manager.info(f'{start_message} (Mock: Playback)')
+        proxy.start(playbook_id)
         # run test
         status, _ = check_integration(c, server_url, demisto_user, demisto_pass, integrations,
-                                      playbook_id, prints_manager, test_options,
-                                      is_mock_run=True, thread_index=thread_index)
+                                      playbook_id, logging_manager, test_options,
+                                      is_mock_run=True)
         # use results
-        proxy.stop(thread_index=thread_index, prints_manager=prints_manager)
+        proxy.stop()
         if status == PB_Status.COMPLETED:
             proxy.successful_tests_count += 1
-            succeed_message = 'PASS: {} succeed'.format(test_message)
-            prints_manager.add_print_job(succeed_message, print_color, thread_index, LOG_COLORS.GREEN)
+            logging_manager.success(f'PASS: {test_message} succeed')
             succeed_playbooks.append(playbook_id)
-            end_mock_message = f'------ Test {test_message} end ------\n'
-            prints_manager.add_print_job(end_mock_message, print, thread_index, include_timestamp=True)
+            logging_manager.info(f'------ Test {test_message} end ------\n')
             return
 
         if status == PB_Status.NOT_SUPPORTED_VERSION:
-            not_supported_version_message = 'PASS: {} skipped - not supported version'.format(test_message)
-            prints_manager.add_print_job(not_supported_version_message, print, thread_index)
+            logging_manager.info(f'PASS: {test_message} skipped - not supported version')
             succeed_playbooks.append(playbook_id)
-            end_mock_message = f'------ Test {test_message} end ------\n'
-            prints_manager.add_print_job(end_mock_message, print, thread_index, include_timestamp=True)
+            logging_manager.info(f'------ Test {test_message} end ------\n')
             return
 
         if status == PB_Status.FAILED_DOCKER_TEST:
-            error_message = 'Failed: {} failed'.format(test_message)
-            prints_manager.add_print_job(error_message, print_error, thread_index)
+            logging_manager.error(f'Failed: {test_message} failed')
             failed_playbooks.append(playbook_id)
-            end_mock_message = f'------ Test {test_message} end ------\n'
-            prints_manager.add_print_job(end_mock_message, print, thread_index, include_timestamp=True)
+            logging_manager.info(f'------ Test {test_message} end ------\n')
             return
         proxy.failed_tests_count += 1
         mock_failed_message = "Test failed with mock, recording new mock file. (Mock: Recording)"
-        prints_manager.add_print_job(mock_failed_message, print, thread_index)
+        logging_manager.info(mock_failed_message)
         rerecord = True
     else:
-        mock_recording_message = start_message + ' (Mock: Recording)'
-        prints_manager.add_print_job(mock_recording_message, print, thread_index, include_timestamp=True)
+        logging_manager.info(f'{start_message} (Mock: Recording)')
 
     # Mock recording - no mock file or playback failure.
     c = demisto_client.configure(base_url=c.api_client.configuration.host,
@@ -464,37 +392,33 @@ def mock_run(conf_json_test_details, tests_queue, tests_settings, c, demisto_use
     succeed = run_and_record(conf_json_test_details, tests_queue, tests_settings, c, demisto_user,
                              demisto_pass, proxy, failed_playbooks, integrations, playbook_id,
                              succeed_playbooks, test_message, test_options, slack, circle_ci,
-                             build_number, server_url, build_name, prints_manager, thread_index=thread_index)
+                             build_number, server_url, build_name)
 
     if rerecord and succeed:
         proxy.rerecorded_tests.append(playbook_id)
-    test_end_message = f'------ Test {test_message} end ------\n'
-    prints_manager.add_print_job(test_end_message, print, thread_index, include_timestamp=True)
+    logging_manager.info(f'------ Test {test_message} end ------\n')
 
 
 def run_test(conf_json_test_details, tests_queue, tests_settings, demisto_user, demisto_pass, proxy, failed_playbooks,
              integrations, unmockable_integrations, playbook_id, succeed_playbooks, test_message, test_options,
-             slack, circle_ci, build_number, server_url, build_name, prints_manager, is_ami=True, thread_index=0):
+             slack, circle_ci, build_number, server_url, build_name, is_ami=True):
     start_message = f'------ Test {test_message} start ------'
     client = demisto_client.configure(base_url=server_url, username=demisto_user, password=demisto_pass,
                                       verify_ssl=False)
 
     if not is_ami or (not integrations or has_unmockable_integration(integrations,
                                                                      unmockable_integrations)):
-        prints_manager.add_print_job(start_message + ' (Mock: Disabled)', print, thread_index,
-                                     include_timestamp=True)
+        logging_manager.info(f'------ Test {test_message} start ------')
         run_test_logic(conf_json_test_details, tests_queue, tests_settings, client, demisto_user,
                        demisto_pass, failed_playbooks, integrations, playbook_id,
                        succeed_playbooks, test_message, test_options, slack, circle_ci,
-                       build_number, server_url, build_name, prints_manager, thread_index=thread_index)
-        prints_manager.add_print_job('------ Test %s end ------\n' % (test_message,), print, thread_index,
-                                     include_timestamp=True)
+                       build_number, server_url, build_name)
+        logging_manager.info(f'------ Test {test_message} end ------\n')
 
         return
     mock_run(conf_json_test_details, tests_queue, tests_settings, client, demisto_user, demisto_pass,
              proxy, failed_playbooks, integrations, playbook_id, succeed_playbooks, test_message,
-             test_options, slack, circle_ci, build_number, server_url, build_name, start_message,
-             prints_manager, thread_index=thread_index)
+             test_options, slack, circle_ci, build_number, server_url, build_name, start_message)
 
 
 def http_request(url, params_dict=None):
@@ -583,8 +507,7 @@ def change_placeholders_to_values(placeholders_map, config_item):
     return json.loads(item_as_string)
 
 
-def set_integration_params(demisto_api_key, integrations, secret_params, instance_names, playbook_id,
-                           prints_manager, placeholders_map, thread_index=0):
+def set_integration_params(demisto_api_key, integrations, secret_params, instance_names, playbook_id, placeholders_map):
     for integration in integrations:
         integration_params = [change_placeholders_to_values(placeholders_map, item) for item
                               in secret_params if item['name'] == integration['name']]
@@ -604,7 +527,7 @@ def set_integration_params(demisto_api_key, integrations, secret_params, instanc
                     error_msg = FAILED_MATCH_INSTANCE_MSG.format(playbook_id, len(integration_params),
                                                                  integration['name'],
                                                                  '\n'.join(optional_instance_names))
-                    prints_manager.add_print_job(error_msg, print_error, thread_index)
+                    logging_manager.error(error_msg)
                     return False
 
             integration['params'] = matched_integration_params.get('params', {})
@@ -665,8 +588,7 @@ def run_test_scenario(tests_queue, tests_settings, t, proxy, default_test_timeou
                       nightly_integrations, skipped_integrations_conf, skipped_integration, is_nightly, filtered_tests,
                       skipped_tests, secret_params, failed_playbooks, playbook_skipped_integration,
                       unmockable_integrations, succeed_playbooks, slack, circle_ci, build_number, server, build_name,
-                      server_numeric_version, demisto_user, demisto_pass, demisto_api_key,
-                      prints_manager, thread_index=0, is_ami=True):
+                      server_numeric_version, demisto_user, demisto_pass, demisto_api_key, is_ami=True):
     playbook_id = t['playbookID']
     nightly_test = t.get('nightly', False)
     integrations_conf = t.get('integrations', [])
@@ -699,11 +621,9 @@ def run_test_scenario(tests_queue, tests_settings, t, proxy, default_test_timeou
     # Skip nightly test
     skip_nightly_test = (nightly_test or is_nightly_integration) and not is_nightly
     if skip_nightly_test:
-        prints_manager.add_print_job(f'\n------ Test {test_message} start ------', print, thread_index,
-                                     include_timestamp=True)
-        prints_manager.add_print_job('Skip test', print, thread_index)
-        prints_manager.add_print_job(f'------ Test {test_message} end ------\n', print, thread_index,
-                                     include_timestamp=True)
+        logging_manager.info(f'------ Test {test_message} start ------')
+        logging_manager.warning(f'------ Test {test_message} start ------')
+        logging_manager.info(f'------ Test {test_message} end ------\n')
         return
 
     # Skip test that appear in the skip section
@@ -720,19 +640,17 @@ def run_test_scenario(tests_queue, tests_settings, t, proxy, default_test_timeou
     test_to_version = t.get('toversion', '99.99.99')
 
     if not (LooseVersion(test_from_version) <= LooseVersion(server_numeric_version) <= LooseVersion(test_to_version)):
-        prints_manager.add_print_job(f'\n------ Test {test_message} start ------', print, thread_index,
-                                     include_timestamp=True)
-        warning_message = 'Test {} ignored due to version mismatch (test versions: {}-{})'.format(test_message,
-                                                                                                  test_from_version,
-                                                                                                  test_to_version)
-        prints_manager.add_print_job(warning_message, print_warning, thread_index)
-        prints_manager.add_print_job(f'------ Test {test_message} end ------\n', print, thread_index,
-                                     include_timestamp=True)
+        logging_manager.info(f'------ Test {test_message} start ------')
+
+        warning_message = \
+            f'Test {test_message} ignored due to version mismatch (test versions: {test_from_version}-{test_to_version})'
+        logging_manager.warning(warning_message)
+        logging_manager.info(f'------ Test {test_message} end ------\n')
         return
 
     placeholders_map = {'%%SERVER_HOST%%': server}
     are_params_set = set_integration_params(demisto_api_key, integrations, secret_params, instance_names_conf,
-                                            playbook_id, prints_manager, placeholders_map, thread_index=thread_index)
+                                            playbook_id, placeholders_map)
     if not are_params_set:
         failed_playbooks.append(playbook_id)
         return
@@ -749,8 +667,8 @@ def run_test_scenario(tests_queue, tests_settings, t, proxy, default_test_timeou
 
     run_test(t, tests_queue, tests_settings, demisto_user, demisto_pass, proxy, failed_playbooks,
              integrations, unmockable_integrations, playbook_id, succeed_playbooks, test_message,
-             test_options, slack, circle_ci, build_number, server, build_name, prints_manager,
-             is_ami, thread_index=thread_index)
+             test_options, slack, circle_ci, build_number, server, build_name,
+             is_ami)
 
 
 def load_env_results_json():
@@ -841,12 +759,15 @@ def get_json_file(path):
         return json.loads(json_file.read())
 
 
-def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_tests_names,
-                    tests_data_keeper, prints_manager, thread_index=0, is_ami=True):
+def execute_testing(tests_settings,
+                    server_ip,
+                    mockable_tests_names,
+                    unmockable_tests_names,
+                    tests_data_keeper,
+                    is_ami=True):
     server = SERVER_URL.format(server_ip)
     server_numeric_version = tests_settings.serverNumericVersion
-    start_message = "Executing tests with the server {} - and the server ip {}".format(server, server_ip)
-    prints_manager.add_print_job(start_message, print, thread_index)
+    logging_manager.info(f'Executing tests with the server {server} - and the server ip {server_ip}', real_time=True)
     is_nightly = tests_settings.nightly
     is_memory_check = tests_settings.memCheck
     slack = tests_settings.slack
@@ -871,8 +792,7 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
     filtered_tests = extract_filtered_tests()
 
     if not tests or len(tests) == 0:
-        prints_manager.add_print_job('no integrations are configured for test', print, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
+        logging_manager.info('no integrations are configured for test', real_time=True)
         return
     xsoar_client = demisto_client.configure(base_url=server, username=demisto_user,
                                             password=demisto_pass, verify_ssl=False)
@@ -884,7 +804,7 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
     if is_ami:
         ami = AMIConnection(server_ip)
         ami.clone_mock_data()
-        proxy = MITMProxy(server_ip)
+        proxy = MITMProxy(server_ip, logging_manager)
 
     failed_playbooks = []
     succeed_playbooks = []
@@ -892,8 +812,8 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
     skipped_integration = set([])
     playbook_skipped_integration = set([])
 
-    disable_all_integrations(xsoar_client, prints_manager, thread_index=thread_index)
-    prints_manager.execute_thread_prints(thread_index)
+    disable_all_integrations(xsoar_client, logging_manager)
+    logging_manager.execute_logs()
     mockable_tests = get_test_records_of_given_test_names(tests_settings, mockable_tests_names)
     unmockable_tests = get_test_records_of_given_test_names(tests_settings, unmockable_tests_names)
 
@@ -913,58 +833,48 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
             while not mockable_tests_queue.empty():
                 t = mockable_tests_queue.get()
                 executed_in_current_round = update_round_set_and_sleep_if_round_completed(executed_in_current_round,
-                                                                                          prints_manager,
-                                                                                          t,
-                                                                                          thread_index,
-                                                                                          mockable_tests_queue)
+                                                                                          t)
                 run_test_scenario(mockable_tests_queue, tests_settings, t, proxy, default_test_timeout,
                                   skipped_tests_conf, nightly_integrations, skipped_integrations_conf,
-                                  skipped_integration, is_nightly, filtered_tests, skipped_tests, secret_params, failed_playbooks,
+                                  skipped_integration, is_nightly, filtered_tests, skipped_tests, secret_params,
+                                  failed_playbooks,
                                   playbook_skipped_integration, unmockable_integrations, succeed_playbooks, slack,
                                   circle_ci, build_number, server, build_name, server_numeric_version, demisto_user,
-                                  demisto_pass, demisto_api_key, prints_manager, thread_index=thread_index)
+                                  demisto_pass, demisto_api_key)
+                logging_manager.execute_logs()
             proxy.configure_proxy_in_demisto(username=demisto_user, password=demisto_pass, server=server)
 
             # reset containers after clearing the proxy server configuration
-            reset_containers(server, demisto_user, demisto_pass, prints_manager, thread_index)
+            reset_containers(server, demisto_user, demisto_pass)
 
-        prints_manager.add_print_job("\nRunning mock-disabled tests", print, thread_index)
+        logging_manager.info("Running mock-disabled tests\n", real_time=True)
         executed_in_current_round, unmockable_tests_queue = initialize_queue_and_executed_tests_set(unmockable_tests)
         while not unmockable_tests_queue.empty():
             t = unmockable_tests_queue.get()
             executed_in_current_round = update_round_set_and_sleep_if_round_completed(executed_in_current_round,
-                                                                                      prints_manager,
-                                                                                      t,
-                                                                                      thread_index,
-                                                                                      unmockable_tests_queue)
+                                                                                      t)
             run_test_scenario(unmockable_tests_queue, tests_settings, t, proxy, default_test_timeout,
                               skipped_tests_conf, nightly_integrations, skipped_integrations_conf, skipped_integration,
                               is_nightly, filtered_tests, skipped_tests, secret_params,
                               failed_playbooks, playbook_skipped_integration, unmockable_integrations,
                               succeed_playbooks, slack, circle_ci, build_number, server, build_name,
-                              server_numeric_version, demisto_user, demisto_pass, demisto_api_key,
-                              prints_manager, thread_index, is_ami)
-            prints_manager.execute_thread_prints(thread_index)
+                              server_numeric_version, demisto_user, demisto_pass, demisto_api_key, is_ami)
+            logging_manager.execute_logs()
 
-    except Exception as exc:
-        if exc.__class__ == ApiException:
-            error_message = exc.body
-        else:
-            error_message = f'~~ Thread {thread_index + 1} failed ~~\n{str(exc)}\n{traceback.format_exc()}'
-        prints_manager.add_print_job(error_message, print_error, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
-        failed_playbooks.append(f'~~ Thread {thread_index + 1} failed ~~')
+    except Exception:
+        logging_manager.exception('~~ Thread failed ~~')
+        logging_manager.execute_logs()
         raise
 
     finally:
+        logging_manager.execute_logs()
         tests_data_keeper.add_tests_data(succeed_playbooks, failed_playbooks, skipped_tests,
                                          skipped_integration, unmockable_integrations)
         if is_ami:
             tests_data_keeper.add_proxy_related_test_data(proxy)
 
             if build_name == 'master':
-                updating_mocks_msg = "Pushing new/updated mock files to mock git repo."
-                prints_manager.add_print_job(updating_mocks_msg, print, thread_index)
+                logging_manager.info("Pushing new/updated mock files to mock git repo.")
                 ami.upload_mock_files(build_name, build_number)
 
         if playbook_skipped_integration and build_name == 'master':
@@ -1000,14 +910,11 @@ def execute_testing(tests_settings, server_ip, mockable_tests_names, unmockable_
             current_file_blob.compose([current_file_blob, new_file_blob])
             new_file_blob.delete()
         except Exception:
-            prints_manager.add_print_job("Failed to save proxy metrics", print, thread_index)
+            logging_manager.exception("Failed to save proxy metrics")
 
 
 def update_round_set_and_sleep_if_round_completed(executed_in_current_round: set,
-                                                  prints_manager: ParallelPrintsManager,
-                                                  t: dict,
-                                                  thread_index: int,
-                                                  unmockable_tests_queue: Queue) -> set:
+                                                  t: dict) -> set:
     """
     Checks if the string representation of the current test configuration is already in
     the executed_in_current_round set.
@@ -1018,20 +925,15 @@ def update_round_set_and_sleep_if_round_completed(executed_in_current_round: set
     Args:
         executed_in_current_round: A set containing the string representation of all tests configuration as they appear
         in conf.json file that were already executed in the current round
-        prints_manager: ParallelPrintsManager object
         t: test configuration as it appears in conf.json file
-        thread_index: Currently executing thread
-        unmockable_tests_queue: The queue of remaining tests
 
     Returns:
         A new executed_in_current_round set which contains only the current tests configuration if a round was completed
         else it just adds the new test to the set.
     """
     if str(t) in executed_in_current_round:
-        prints_manager.add_print_job(
-            'all tests in the queue were executed, sleeping for 30 seconds to let locked tests get unlocked.',
-            print,
-            thread_index)
+        logging_manager.info(
+            'all tests in the queue were executed, sleeping for 30 seconds to let locked tests get unlocked.')
         executed_in_current_round = set()
         time.sleep(30)
     executed_in_current_round.add(str(t))
@@ -1085,20 +987,17 @@ def manage_tests(tests_settings):
     instances_ips = get_instances_ips_and_names(tests_settings)
     is_nightly = tests_settings.nightly
     number_of_instances = len(instances_ips)
-    prints_manager = ParallelPrintsManager(number_of_instances)
     tests_data_keeper = DataKeeperTester()
 
     if tests_settings.server:
         # If the user supplied a server - all tests will be done on that server.
         server_ip = tests_settings.server
-        print_color("Starting tests for {}".format(server_ip), LOG_COLORS.GREEN)
-        print("Starts tests with server url - https://{}".format(server_ip))
+        logging_manager.info(f"Starts tests with server url - https://{server_ip}", real_time=True)
         all_tests = get_all_tests(tests_settings)
         mockable_tests = []
-        print(tests_settings.specific_tests_to_run)
+        logging_manager.info(tests_settings.specific_tests_to_run, real_time=True)
         unmockable_tests = tests_settings.specific_tests_to_run if tests_settings.specific_tests_to_run else all_tests
-        execute_testing(tests_settings, server_ip, mockable_tests, unmockable_tests, tests_data_keeper, prints_manager,
-                        thread_index=0, is_ami=False)
+        execute_testing(tests_settings, server_ip, mockable_tests, unmockable_tests, tests_data_keeper, is_ami=False)
 
     elif tests_settings.isAMI:
         # Running tests in AMI configuration.
@@ -1118,20 +1017,18 @@ def manage_tests(tests_settings):
                     unmockable_tests = [test for test in all_unmockable_tests_list
                                         if test in tests_allocation_for_instance]
                     mockable_tests = [test for test in tests_allocation_for_instance if test not in unmockable_tests]
-                    print_color("Starting tests for {}".format(ami_instance_name), LOG_COLORS.GREEN)
-                    print("Starts tests with server url - https://{}".format(ami_instance_ip))
+                    logging_manager.info(f"Starts tests with server url - https://{ami_instance_ip}",
+                                         real_time=True)
 
                     if number_of_instances == 1:
                         execute_testing(tests_settings, current_instance, mockable_tests, unmockable_tests,
-                                        tests_data_keeper, prints_manager, thread_index=0, is_ami=True)
+                                        tests_data_keeper, is_ami=True)
                     else:
                         thread_kwargs = {
                             "tests_settings": tests_settings,
                             "server_ip": current_instance,
                             "mockable_tests_names": mockable_tests,
                             "unmockable_tests_names": unmockable_tests,
-                            "thread_index": current_thread_index,
-                            "prints_manager": prints_manager,
                             "tests_data_keeper": tests_data_keeper,
                         }
                         t = threading.Thread(target=execute_testing, kwargs=thread_kwargs)
@@ -1145,13 +1042,12 @@ def manage_tests(tests_settings):
         else:
             for ami_instance_name, ami_instance_ip in instances_ips:
                 if ami_instance_name == tests_settings.serverVersion:
-                    print_color("Starting tests for {}".format(ami_instance_name), LOG_COLORS.GREEN)
-                    print("Starts tests with server url - https://{}".format(ami_instance_ip))
+                    logging_manager.info(f"Starts tests with server url - https://{ami_instance_ip}", real_time=True)
                     all_tests = get_all_tests(tests_settings)
                     unmockable_tests = get_unmockable_tests(tests_settings)
                     mockable_tests = [test for test in all_tests if test not in unmockable_tests]
                     execute_testing(tests_settings, ami_instance_ip, mockable_tests, unmockable_tests,
-                                    tests_data_keeper, prints_manager, thread_index=0, is_ami=True)
+                                    tests_data_keeper, is_ami=True)
                     sleep(8)
 
     else:
@@ -1160,18 +1056,19 @@ def manage_tests(tests_settings):
         # 1. When someone from Server wants to trigger a content build on their branch.
         # 2. When someone from content wants to run tests on a specific build.
         server_numeric_version = '99.99.98'  # assume latest
-        print("Using server version: {} (assuming latest for non-ami)".format(server_numeric_version))
+        logging_manager.info(f"Using server version: {server_numeric_version} (assuming latest for non-ami)",
+                             real_time=True)
         instance_ip = instances_ips[0][1]
         all_tests = get_all_tests(tests_settings)
         execute_testing(tests_settings, instance_ip, [], all_tests,
-                        tests_data_keeper, prints_manager, thread_index=0, is_ami=False)
+                        tests_data_keeper, is_ami=False)
 
     print_test_summary(tests_data_keeper, tests_settings.isAMI)
+    logging_manager.execute_logs()
     create_result_files(tests_data_keeper)
 
     if tests_data_keeper.failed_playbooks:
-        tests_failed_msg = "Some tests have failed. Not destroying instances."
-        print(tests_failed_msg)
+        logging_manager.critical("Some tests have failed. Not destroying instances.", real_time=True)
         sys.exit(1)
 
 
@@ -1193,25 +1090,22 @@ def add_pr_comment(comment):
                 res = requests.post(issue_url, json={'body': comment}, headers=headers, verify=False)
                 handle_github_response(res)
         else:
-            print_warning('Add pull request comment failed: There is more then one open pull request for branch {}.'
-                          .format(branch_name))
-    except Exception as e:
-        print_warning('Add pull request comment failed: {}'.format(e))
+            logging_manager.warning('Add pull request comment failed: There is more then one open pull '
+                                    f'request for branch {branch_name}.', real_time=True)
+    except Exception:
+        logging_manager.exception('Add pull request comment failed')
 
 
 def handle_github_response(response):
     res_dict = response.json()
     if not res_dict.ok:
-        print_warning('Add pull request comment failed: {}'.
-                      format(res_dict.get('message')))
+        logging_manager.error(f'Add pull request comment failed: {res_dict.get("message")}', real_time=True)
     return res_dict
 
 
 @contextmanager
 def acquire_test_lock(integrations_details: list,
                       test_timeout: int,
-                      prints_manager: ParallelPrintsManager,
-                      thread_index: int,
                       conf_json_path: str) -> None:
     """
     This is a context manager that handles all the locking and unlocking of integrations.
@@ -1222,59 +1116,47 @@ def acquire_test_lock(integrations_details: list,
     Args:
         integrations_details: test integrations details
         test_timeout: test timeout in seconds
-        prints_manager: ParallelPrintsManager object
-        thread_index: The index of the thread that executes the unlocking
         conf_json_path: Path to conf.json file
     Yields:
         A boolean indicating the lock attempt result
     """
     locked = safe_lock_integrations(test_timeout,
-                                    prints_manager,
                                     integrations_details,
-                                    thread_index,
                                     conf_json_path)
     try:
         yield locked
+    except Exception:
+        logging_manager.exception('Failed with test lock')
     finally:
         if not locked:
             return
-        safe_unlock_integrations(prints_manager, integrations_details, thread_index)
-        prints_manager.execute_thread_prints(thread_index)
+        safe_unlock_integrations(integrations_details)
 
 
-def safe_unlock_integrations(prints_manager: ParallelPrintsManager, integrations_details: list, thread_index: int):
+def safe_unlock_integrations(integrations_details: list):
     """
     This integration safely unlocks the test's integrations.
     If an unexpected error occurs - this method will log it's details and other tests execution will continue
     Args:
-        prints_manager: ParallelPrintsManager object
         integrations_details: Details of the currently executed test
-        thread_index: The index of the thread that executes the unlocking
     """
     try:
         # executing the test could take a while, re-instancing the storage client
         storage_client = storage.Client()
-        unlock_integrations(integrations_details, prints_manager, storage_client, thread_index)
-    except Exception as e:
-        prints_manager.add_print_job(f'attempt to unlock integration failed for unknown reason.\nError: {e}',
-                                     print_warning,
-                                     thread_index,
-                                     include_timestamp=True)
+        unlock_integrations(integrations_details, storage_client)
+    except Exception:
+        logging_manager.exception('attempt to unlock integration failed for unknown reason.')
 
 
 def safe_lock_integrations(test_timeout: int,
-                           prints_manager: ParallelPrintsManager,
                            integrations_details: list,
-                           thread_index: int,
                            conf_json_path: str) -> bool:
     """
     This integration safely locks the test's integrations and return it's result
     If an unexpected error occurs - this method will log it's details and return False
     Args:
         test_timeout: Test timeout in seconds
-        prints_manager: ParallelPrintsManager object
         integrations_details: test integrations details
-        thread_index: The index of the thread that executes the unlocking
         conf_json_path: Path to conf.json file
 
     Returns:
@@ -1289,16 +1171,12 @@ def safe_lock_integrations(test_timeout: int,
         print_msg = f'Attempting to lock integrations {integration_names}, with timeout {test_timeout}'
     else:
         print_msg = 'No integrations to lock'
-    prints_manager.add_print_job(print_msg, print, thread_index, include_timestamp=True)
+    logging_manager.info(print_msg)
     try:
         storage_client = storage.Client()
-        locked = lock_integrations(filtered_integrations_details, test_timeout, storage_client, prints_manager,
-                                   thread_index)
-    except Exception as e:
-        prints_manager.add_print_job(f'attempt to lock integration failed for unknown reason.\nError: {e}',
-                                     print_warning,
-                                     thread_index,
-                                     include_timestamp=True)
+        locked = lock_integrations(filtered_integrations_details, test_timeout, storage_client)
+    except Exception:
+        logging_manager.exception('attempt to lock integration failed for unknown reason.')
         locked = False
     return locked
 
@@ -1323,25 +1201,21 @@ def workflow_still_running(workflow_id: str) -> bool:
                                                      headers={'Accept': 'application/json'},
                                                      auth=(CIRCLE_STATUS_TOKEN, ''))
             workflow_details_response.raise_for_status()
-        except Exception as e:
-            print(f'Failed to get circleci response about workflow with id {workflow_id}, error is: {e}')
+        except Exception:
+            logging_manager.exception(f'Failed to get circleci response about workflow with id {workflow_id}.')
             return True
         return workflow_details_response.json().get('status') not in ('canceled', 'success', 'failed')
 
 
 def lock_integrations(integrations_details: list,
                       test_timeout: int,
-                      storage_client: storage.Client,
-                      prints_manager: ParallelPrintsManager,
-                      thread_index: int) -> bool:
+                      storage_client: storage.Client) -> bool:
     """
     Locks all the test's integrations
     Args:
         integrations_details: List of current test's integrations
         test_timeout: Test timeout in seconds
         storage_client: The GCP storage client
-        prints_manager: ParallelPrintsManager object
-        thread_index: The index of the thread that executes the unlocking
 
     Returns:
         True if all the test's integrations were successfully locked, else False
@@ -1356,13 +1230,10 @@ def lock_integrations(integrations_details: list,
         workflow_id, build_number, lock_timeout = lock_file.download_as_string().decode().split(':')
         if not lock_expired(lock_file, lock_timeout) and workflow_still_running(workflow_id):
             # there is a locked integration for which the lock is not expired - test cannot be executed at the moment
-            prints_manager.add_print_job(
+            logging_manager.info(
                 f'Could not lock integration {integration}, another lock file was exist with '
                 f'build number: {build_number}, timeout: {lock_timeout}, last update at {lock_file.updated}.\n'
-                f'Delaying test execution',
-                print,
-                thread_index,
-                include_timestamp=True)
+                f'Delaying test execution')
             return False
     integrations_generation_number = {}
     # Gathering generation number with which the new file will be created,
@@ -1372,8 +1243,7 @@ def lock_integrations(integrations_details: list,
             integrations_generation_number[integration] = existing_integrations_lock_files[integration].generation
         else:
             integrations_generation_number[integration] = 0
-    return create_lock_files(integrations_generation_number, prints_manager,
-                             storage_client, integrations_details, test_timeout, thread_index)
+    return create_lock_files(integrations_generation_number, storage_client, integrations_details, test_timeout)
 
 
 def get_integrations_list(test_integrations: list) -> list:
@@ -1390,11 +1260,9 @@ def get_integrations_list(test_integrations: list) -> list:
 
 
 def create_lock_files(integrations_generation_number: dict,
-                      prints_manager: ParallelPrintsManager,
                       storage_client: storage.Client,
                       integrations_details: list,
-                      test_timeout: int,
-                      thread_index: int) -> bool:
+                      test_timeout: int) -> bool:
     """
     This method tries to create a lock files for all integrations specified in 'integrations_generation_number'.
     Each file should contain <circle-ci-build-number>:<test-timeout>
@@ -1403,11 +1271,9 @@ def create_lock_files(integrations_generation_number: dict,
     If for any of the integrations, the lock file creation will fail- the already created files will be cleaned.
     Args:
         integrations_generation_number: A dict in the form of {<integration-name>:<integration-generation>}
-        prints_manager: ParallelPrintsManager object
         storage_client: The GCP storage client
         integrations_details: List of current test's integrations
         test_timeout: The time out
-        thread_index:
 
     Returns:
 
@@ -1419,37 +1285,27 @@ def create_lock_files(integrations_generation_number: dict,
         try:
             blob.upload_from_string(f'{WORKFLOW_ID}:{CIRCLE_BUILD_NUM}:{test_timeout + 30}',
                                     if_generation_match=generation_number)
-            prints_manager.add_print_job(f'integration {integration} locked',
-                                         print,
-                                         thread_index,
-                                         include_timestamp=True)
+            logging_manager.info(f'integration {integration} locked')
             locked_integrations.append(integration)
         except PreconditionFailed:
             # if this exception occurs it means that another build has locked this integration
             # before this build managed to do it.
             # we need to unlock all the integrations we have already locked and try again later
-            prints_manager.add_print_job(
+            logging_manager.warning(
                 f'Could not lock integration {integration}, Create file with precondition failed.'
-                f'delaying test execution.',
-                print_warning,
-                thread_index,
-                include_timestamp=True)
-            unlock_integrations(integrations_details, prints_manager, storage_client, thread_index)
+                f'delaying test execution.')
+            unlock_integrations(integrations_details, storage_client)
             return False
     return True
 
 
 def unlock_integrations(integrations_details: list,
-                        prints_manager: ParallelPrintsManager,
-                        storage_client: storage.Client,
-                        thread_index: int) -> None:
+                        storage_client: storage.Client) -> None:
     """
     Delete all integration lock files for integrations specified in 'locked_integrations'
     Args:
         integrations_details: List of current test's integrations
-        prints_manager: ParallelPrintsManager object
         storage_client: The GCP storage client
-        thread_index: The index of the thread that executes the unlocking
     """
     locked_integrations = get_integrations_list(integrations_details)
     locked_integration_blobs = get_locked_integrations(locked_integrations, storage_client)
@@ -1459,16 +1315,10 @@ def unlock_integrations(integrations_details: list,
             _, build_number, _ = lock_file.download_as_string().decode().split(':')
             if build_number == CIRCLE_BUILD_NUM:
                 lock_file.delete(if_generation_match=lock_file.generation)
-                prints_manager.add_print_job(
-                    f'Integration {integration} unlocked',
-                    print,
-                    thread_index,
-                    include_timestamp=True)
+                logging_manager.info(
+                    f'Integration {integration} unlocked')
         except PreconditionFailed:
-            prints_manager.add_print_job(f'Could not unlock integration {integration} precondition failure',
-                                         print_warning,
-                                         thread_index,
-                                         include_timestamp=True)
+            logging_manager.error(f'Could not unlock integration {integration} precondition failure')
 
 
 def get_locked_integrations(integrations: list, storage_client: storage.Client) -> dict:
@@ -1510,16 +1360,9 @@ def lock_expired(lock_file: storage.Blob, lock_timeout: str) -> bool:
 
 
 def main():
-    install_simple_logging()
-    print("Time is: {}\n\n\n".format(datetime.datetime.now()))
+    global logging_manager
+    logging_manager = ParallelLoggingManager('Run Tests.log')
     tests_settings = options_handler()
-
-    # should be removed after solving: https://github.com/demisto/etc/issues/21383
-    # -------------
-    if 'master' in tests_settings.serverVersion.lower():
-        print('[{}] sleeping for 30 secs'.format(datetime.datetime.now()))
-        sleep(45)
-    # -------------
     manage_tests(tests_settings)
 
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -1171,7 +1171,7 @@ def safe_lock_integrations(test_timeout: int,
         print_msg = f'Attempting to lock integrations {integration_names}, with timeout {test_timeout}'
     else:
         print_msg = 'No integrations to lock'
-    logging_manager.info(print_msg)
+    logging_manager.debug(print_msg)
     try:
         storage_client = storage.Client()
         locked = lock_integrations(filtered_integrations_details, test_timeout, storage_client)
@@ -1230,7 +1230,7 @@ def lock_integrations(integrations_details: list,
         workflow_id, build_number, lock_timeout = lock_file.download_as_string().decode().split(':')
         if not lock_expired(lock_file, lock_timeout) and workflow_still_running(workflow_id):
             # there is a locked integration for which the lock is not expired - test cannot be executed at the moment
-            logging_manager.info(
+            logging_manager.warning(
                 f'Could not lock integration {integration}, another lock file was exist with '
                 f'build number: {build_number}, timeout: {lock_timeout}, last update at {lock_file.updated}.\n'
                 f'Delaying test execution')
@@ -1285,7 +1285,7 @@ def create_lock_files(integrations_generation_number: dict,
         try:
             blob.upload_from_string(f'{WORKFLOW_ID}:{CIRCLE_BUILD_NUM}:{test_timeout + 30}',
                                     if_generation_match=generation_number)
-            logging_manager.info(f'integration {integration} locked')
+            logging_manager.debug(f'integration {integration} locked')
             locked_integrations.append(integration)
         except PreconditionFailed:
             # if this exception occurs it means that another build has locked this integration
@@ -1315,7 +1315,7 @@ def unlock_integrations(integrations_details: list,
             _, build_number, _ = lock_file.download_as_string().decode().split(':')
             if build_number == CIRCLE_BUILD_NUM:
                 lock_file.delete(if_generation_match=lock_file.generation)
-                logging_manager.info(
+                logging_manager.debug(
                     f'Integration {integration} unlocked')
         except PreconditionFailed:
             logging_manager.error(f'Could not unlock integration {integration} precondition failure')

--- a/Tests/test_integration.py
+++ b/Tests/test_integration.py
@@ -19,8 +19,6 @@ from demisto_client.demisto_api import DefaultApi
 from demisto_client.demisto_api.rest import ApiException
 from demisto_client.demisto_api.models.incident import Incident
 from demisto_sdk.commands.common.constants import PB_Status
-from demisto_sdk.commands.common.tools import (LOG_COLORS, print_color,
-                                               print_error, print_warning)
 
 from Tests.tools import update_server_configuration
 
@@ -136,11 +134,12 @@ class Docker:
         return cmd
 
     @classmethod
-    def _parse_stats_result(cls, stats_lines):
+    def _parse_stats_result(cls, stats_lines, logging_module=logging):
         """Parses the docker statics str and converts to Mib.
 
             Args:
                 stats_lines (str): String that contains docker stats.
+                logging_module: The logging module that should be used.
             Returns:
                 list: List of dictionaries with parsed docker container statistics.
 
@@ -165,8 +164,8 @@ class Docker:
                     'container_name': container_stat.get(cls.CONTAINER_NAME),
                     'container_id': container_stat.get(cls.CONTAINER_ID)
                 })
-        except Exception as e:
-            print_warning("Failed in parsing docker stats result, returned empty list. Additional info: {}".format(e))
+        except Exception:
+            logging_module.exception("Failed in parsing docker stats result, returned empty list.")
         finally:
             return stats_result
 
@@ -188,12 +187,12 @@ class Docker:
         return stdout, stderr
 
     @classmethod
-    def get_image_for_container_id(cls, server_ip, container_id):
+    def get_image_for_container_id(cls, server_ip, container_id, logging_module=logging):
         cmd = cls._build_ssh_command(server_ip, "sudo docker inspect -f {{.Config.Image}} " + container_id,
                                      force_tty=False)
         stdout, stderr = cls.run_shell_command(cmd)
         if stderr:
-            print_warning("Received stderr from docker inspect command. Additional information: {}".format(stderr))
+            logging_module.warning(f"Received stderr from docker inspect command. Additional information: {stderr}")
         res = stdout or ""
         return res.strip()
 
@@ -220,12 +219,13 @@ class Docker:
             return [cls.DEFAULT_PYTHON2_IMAGE, cls.DEFAULT_PYTHON3_IMAGE]
 
     @classmethod
-    def docker_stats(cls, server_ip, docker_images):
+    def docker_stats(cls, server_ip, docker_images, logging_module=logging):
         """ Executes docker stats command and greps all containers with prefix of docker images names.
 
             Args:
                 server_ip (str): Remote machine ip to connect using ssh.
                 docker_images (set): Set of docker images to check their resource usage.
+                logging_module: The logging module that should be used.
 
             Returns:
                 list: List of dictionaries with parsed container memory statistics.
@@ -234,33 +234,35 @@ class Docker:
         stdout, stderr = cls.run_shell_command(cmd)
 
         if stderr:
-            print_warning("Failed running docker stats command. Additional information: {}".format(stderr))
+            logging_module.warning(f"Failed running docker stats command. Additional information: {stderr}")
             return []
 
-        return cls._parse_stats_result(stdout)
+        return cls._parse_stats_result(stdout, logging_module)
 
     @classmethod
-    def kill_container(cls, server_ip, container_name):
+    def kill_container(cls, server_ip, container_name, logging_module):
         """ Executes docker kill command on remote machine using ssh.
 
             Args:
                 server_ip (str): The remote server ip address.
                 container_name (str): The container name to kill
+                logging_module: The logging module to use
 
         """
         cmd = cls._build_kill_cmd(server_ip, container_name)
         _, stderr = cls.run_shell_command(cmd)
 
         if stderr:
-            print_warning("Failed killing container: {}\nAdditional information: {}".format(container_name, stderr))
+            logging_module.debug(f"Failed killing container: {container_name}\nAdditional information: {stderr}")
 
     @classmethod
-    def get_docker_pid_info(cls, server_ip, container_id):
+    def get_docker_pid_info(cls, server_ip, container_id, logging_module):
         """Executes docker exec ps command on remote machine using ssh.
 
             Args:
                 server_ip (str): The remote server ip address.
                 container_id (str): Docker container id.
+                logging_module: The logging module to use
 
             Returns:
                 str: output of executed command.
@@ -271,14 +273,19 @@ class Docker:
         if stderr:
             ignored_warning_message = "Connection to {} closed".format(server_ip)
             if ignored_warning_message not in stderr:
-                print_warning("Failed getting pid info for container id: {}.\nAdditional information: {}".
-                              format(container_id, stderr))
+                logging_module.debug(f"Failed getting pid info for container id: {container_id}.\n"
+                                     f"Additional information: {stderr}")
 
         return stdout
 
     @classmethod
-    def check_resource_usage(cls, server_url, docker_images, def_memory_threshold, def_pid_threshold,
-                             docker_thresholds):
+    def check_resource_usage(cls,
+                             server_url,
+                             docker_images,
+                             def_memory_threshold,
+                             def_pid_threshold,
+                             docker_thresholds,
+                             logging_module):
         """
         Executes docker stats command on remote machine and returns error message in case of exceeding threshold.
 
@@ -288,13 +295,14 @@ class Docker:
             def_memory_threshold (int): Memory threshold of specific docker container, in Mib.
             def_pids_threshold (int): PIDs threshold of specific docker container, in Mib.
             docker_thresholds: thresholds per docker image
+            logging_module: The logging module that should be used.
 
         Returns:
             str: The error message. Empty in case that resource check passed.
 
         """
         server_ip = server_url.lstrip("https://")
-        containers_stats = cls.docker_stats(server_ip, docker_images)
+        containers_stats = cls.docker_stats(server_ip, docker_images, logging_module)
         error_message = ""
 
         for container_stat in containers_stats:
@@ -304,15 +312,17 @@ class Docker:
             memory_usage = container_stat['memory_usage']
             pids_usage = container_stat['pids']
             image_full = cls.get_image_for_container_id(server_ip,
-                                                        container_id)  # get full name (ex: demisto/slack:1.0.0.4978)
+                                                        container_id,
+                                                        logging_module)  # get full name (ex: demisto/slack:1.0.0.4978)
             image_name = image_full.split(':')[0]  # just the name such as demisto/slack
 
             memory_threshold = (docker_thresholds.get(image_full, {}).get('memory_threshold') or docker_thresholds.get(
                 image_name, {}).get('memory_threshold') or def_memory_threshold)
             pid_threshold = (docker_thresholds.get(image_full, {}).get('pid_threshold')
                              or docker_thresholds.get(image_name, {}).get('pid_threshold') or def_pid_threshold)
-            print("Checking container: {} (image: {}) for memory: {} pid: {} thresholds ...".format(
-                container_name, image_full, memory_threshold, pid_threshold))
+            logging_module.debug(
+                f"Checking container: {container_name} "
+                f"(image: {image_full}) for memory: {memory_threshold} pid: {pid_threshold} thresholds ...")
             if memory_usage > memory_threshold:
                 error_message += ('Failed docker resource test. Docker container {} exceeded the memory threshold, '
                                   'configured: {} MiB and actual memory usage is {} MiB.\n'
@@ -326,14 +336,14 @@ class Docker:
                                   'Fix container pid usage or add `pid_threshold` key to failed test '
                                   'in conf.json with value that is greater than {}\n'
                                   .format(container_name, pid_threshold, pids_usage, pids_usage))
-                additional_pid_info = cls.get_docker_pid_info(server_ip, container_id)
+                additional_pid_info = cls.get_docker_pid_info(server_ip, container_id, logging_module)
                 if additional_pid_info:
                     error_message += 'Additional pid information:\n{}'.format(additional_pid_info)
                 failed_memory_test = True
 
             if failed_memory_test:
                 # killing current container in case of memory resource test failure
-                cls.kill_container(server_ip, container_name)
+                cls.kill_container(server_ip, container_name, logging_module)
 
         return error_message
 
@@ -341,18 +351,15 @@ class Docker:
 # ----- Functions ----- #
 
 # get integration configuration
-def __get_integration_config(client, integration_name, prints_manager=None, thread_index=0):
+def __get_integration_config(client, integration_name, logging_module=logging):
     body = {
         'page': 0, 'size': 100, 'query': 'name:' + integration_name
     }
     try:
         res_raw = demisto_client.generic_request_func(self=client, path='/settings/integration/search',
                                                       method='POST', body=body)
-    except ApiException as conn_error:
-        if prints_manager:
-            prints_manager.add_print_job(conn_error.body, print, thread_index)
-        else:
-            logging.exception(f'failed to get integration {integration_name} configuration')
+    except ApiException:
+        logging_module.exception(f'failed to get integration {integration_name} configuration')
         return None
 
     res = ast.literal_eval(res_raw[0])
@@ -361,11 +368,7 @@ def __get_integration_config(client, integration_name, prints_manager=None, thre
     total_sleep = 0
     while 'configurations' not in res:
         if total_sleep == TIMEOUT:
-            error_message = f"Timeout - failed to get integration {integration_name} configuration. Error: {res}"
-            if prints_manager:
-                prints_manager.add_print_job(error_message, print_error, thread_index)
-            else:
-                logging.error(error_message)
+            logging_module.error(f"Timeout - failed to get integration {integration_name} configuration. Error: {res}")
             return None
 
         time.sleep(SLEEP_INTERVAL)
@@ -375,29 +378,20 @@ def __get_integration_config(client, integration_name, prints_manager=None, thre
     match_configurations = [x for x in all_configurations if x['name'] == integration_name]
 
     if not match_configurations or len(match_configurations) == 0:
-        if prints_manager:
-            prints_manager.add_print_job('integration was not found', print_error, thread_index)
-        else:
-            logging.error('integration was not found')
+        logging_module.error('integration was not found')
         return None
 
     return match_configurations[0]
 
 
 # __test_integration_instance
-def __test_integration_instance(client, module_instance, prints_manager=None, thread_index=0):
+def __test_integration_instance(client, module_instance, logging_module=logging):
     connection_retries = 3
     response_code = 0
     integration_of_instance = module_instance.get('brand', '')
     instance_name = module_instance.get('name', '')
-    if prints_manager:
-        prints_manager.add_print_job(
-            f'Running "test-module" for instance "{instance_name}" of integration "{integration_of_instance}".',
-            print_warning,
-            thread_index)
-    else:
-        logging.info(
-            f'Running "test-module" for instance "{instance_name}" of integration "{integration_of_instance}".')
+    logging_module.info(
+        f'Running "test-module" for instance "{instance_name}" of integration "{integration_of_instance}".')
     for i in range(connection_retries):
         try:
             response_data, response_code, _ = demisto_client.generic_request_func(self=client, method='POST',
@@ -405,28 +399,15 @@ def __test_integration_instance(client, module_instance, prints_manager=None, th
                                                                                   body=module_instance,
                                                                                   _request_timeout=120)
             break
-        except ApiException as conn_err:
-            if prints_manager:
-                error_msg = 'Failed to test integration instance, error trying to communicate with demisto server: ' \
-                            f'{conn_err.body} '
-                prints_manager.add_print_job(error_msg, print_error, thread_index)
-            else:
-                logging.exception(
-                    'Failed to test integration instance, error trying to communicate with demisto server')
+        except ApiException:
+            logging_module.exception(
+                'Failed to test integration instance, error trying to communicate with demisto server')
             return False, None
         except urllib3.exceptions.ReadTimeoutError:
-            warning_msg = f"Could not connect. Trying to connect for the {i + 1} time"
-            if prints_manager:
-                prints_manager.add_print_job(warning_msg, print_warning, thread_index)
-            else:
-                logging.warning(warning_msg)
+            logging_module.warning(f"Could not connect. Trying to connect for the {i + 1} time")
 
     if int(response_code) != 200:
-        test_failed_msg = f'Integration-instance test ("Test" button) failed. Bad status code: {response_code}'
-        if prints_manager:
-            prints_manager.add_print_job(test_failed_msg, print_error, thread_index)
-        else:
-            logging.error(test_failed_msg)
+        logging_module.error(f'Integration-instance test ("Test" button) failed. Bad status code: {response_code}')
         return False, None
 
     result_object = ast.literal_eval(response_data)
@@ -435,19 +416,16 @@ def __test_integration_instance(client, module_instance, prints_manager=None, th
         server_url = client.api_client.configuration.host
         test_failed_msg = f'Test integration failed - server: {server_url}.'
         test_failed_msg += f'\nFailure message: {failure_message}' if failure_message else ' No failure message.'
-        if prints_manager:
-            prints_manager.add_print_job(test_failed_msg, print_error, thread_index)
-        else:
-            logging.error(test_failed_msg)
+        logging_module.error(test_failed_msg)
     return success, failure_message
 
 
-def __set_server_keys(client, prints_manager, integration_params, integration_name):
+def __set_server_keys(client, logging_manager, integration_params, integration_name):
     """Adds server configuration keys using the demisto_client.
 
     Args:
         client (demisto_client): The configured client to use.
-        prints_manager (ParallelPrintsManager): Print manager object.
+        logging_manager (ParallelLoggingManager): logging manager object.
         integration_params (dict): The values to use for an integration's parameters to configure an instance.
         integration_name (str): The name of the integration which the server configurations keys are related to.
 
@@ -455,8 +433,7 @@ def __set_server_keys(client, prints_manager, integration_params, integration_na
     if 'server_keys' not in integration_params:
         return
 
-    prints_manager.add_print_job('Setting server keys for integration: {}'.format(integration_name),
-                                 print_color, 0, LOG_COLORS.GREEN)
+    logging_manager.debug(f'Setting server keys for integration: {integration_name}')
 
     data = {
         'data': {},
@@ -469,18 +446,18 @@ def __set_server_keys(client, prints_manager, integration_params, integration_na
     update_server_configuration(
         client=client,
         server_configuration=integration_params.get('server_keys'),
-        error_msg='Failed to set server keys'
+        error_msg='Failed to set server keys',
+        logging_manager=logging_manager
     )
 
 
-def __delete_integration_instance_if_determined_by_name(client, instance_name, prints_manager, thread_index=0):
+def __delete_integration_instance_if_determined_by_name(client, instance_name, logging_manager):
     """Deletes integration instance by it's name.
 
     Args:
         client (demisto_client): The configured client to use.
         instance_name (str): The name of the instance to delete.
-        prints_manager (ParallelPrintsManager): Print manager object.
-        thread_index: The index of the thread running the execution.
+        logging_manager (ParallelLoggingManager): logging manager object.
 
     Notes:
         This function is needed when the name of the instance is pre-defined in the tests configuration, and the test
@@ -494,34 +471,30 @@ def __delete_integration_instance_if_determined_by_name(client, instance_name, p
                                                        path='/settings/integration/search',
                                                        body={'size': 1000})
         int_instances = ast.literal_eval(int_resp[0])
-    except ApiException as conn_err:
-        error_message = 'Failed to delete integrations instance, error trying to communicate with demisto server: ' \
-                        '{} '.format(conn_err.body)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except ApiException:
+        logging_manager.exception(
+            'Failed to delete integrations instance, error trying to communicate with demisto server')
         return
     if int(int_resp[1]) != 200:
-        error_message = 'Get integration instance failed with status code: {}'.format(int_resp[1])
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+        logging_manager.error(f'Get integration instance failed with status code: {int_resp[1]}')
         return
     if 'instances' not in int_instances:
-        prints_manager.add_print_job("No integrations instances found to delete", print, thread_index)
+        logging_manager.info('No integrations instances found to delete')
         return
 
     for instance in int_instances['instances']:
         if instance.get('name') == instance_name:
-            prints_manager.add_print_job(f'Deleting integration instance {instance_name} since it is defined by name',
-                                         print_color, thread_index, message_color=LOG_COLORS.GREEN)
-            __delete_integration_instance(client, instance.get('id'), prints_manager, thread_index)
+            logging_manager.info(f'Deleting integration instance {instance_name} since it is defined by name')
+            __delete_integration_instance(client, instance.get('id'), logging_manager)
 
 
 # return instance name if succeed, None otherwise
 def __create_integration_instance(server, username, password, integration_name, integration_instance_name,
-                                  integration_params, is_byoi, prints_manager, validate_test=True, thread_index=0):
+                                  integration_params, is_byoi, logging_manager=logging, validate_test=True):
 
     # get configuration config (used for later rest api
     integration_conf_client = demisto_client.configure(base_url=server, username=username, password=password, verify_ssl=False)
-    configuration = __get_integration_config(integration_conf_client, integration_name, prints_manager,
-                                             thread_index=thread_index)
+    configuration = __get_integration_config(integration_conf_client, integration_name, logging_manager)
     if not configuration:
         return None, 'No configuration', None
 
@@ -531,14 +504,13 @@ def __create_integration_instance(server, username, password, integration_name, 
 
     if 'integrationInstanceName' in integration_params:
         instance_name = integration_params['integrationInstanceName']
-        __delete_integration_instance_if_determined_by_name(integration_conf_client, instance_name, prints_manager, thread_index)
+        __delete_integration_instance_if_determined_by_name(integration_conf_client, instance_name, logging_manager)
     else:
-        instance_name = '{}_test_{}'.format(integration_instance_name.replace(' ', '_'), str(uuid.uuid4()))
+        instance_name = f'{integration_instance_name.replace(" ", "_")}_test_{uuid.uuid4()}'
 
-    start_message = 'Configuring instance for {} (instance name: {}, ' \
-                    'validate "Test": {})'.format(integration_name, instance_name, validate_test)
-    prints_manager.add_print_job(start_message, print, thread_index)
-
+    logging_manager.info(
+        f'Configuring instance for {integration_name} (instance name: {instance_name}, validate "Test": {validate_test})'
+    )
     # define module instance
     module_instance = {
         'brand': configuration['name'],
@@ -555,7 +527,7 @@ def __create_integration_instance(server, username, password, integration_name, 
     }
 
     # set server keys
-    __set_server_keys(integration_conf_client, prints_manager, integration_params, configuration['name'])
+    __set_server_keys(integration_conf_client, logging_manager, integration_params, configuration['name'])
 
     # set module params
     for param_conf in module_configuration:
@@ -583,17 +555,15 @@ def __create_integration_instance(server, username, password, integration_name, 
         res = demisto_client.generic_request_func(self=integration_conf_client, method='PUT',
                                                   path='/settings/integration',
                                                   body=module_instance)
-    except ApiException as conn_err:
-        error_message = 'Error trying to create instance for integration: {0}:\n {1}'.format(
-            integration_name, conn_err.body
-        )
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except ApiException:
+        error_message = f'Error trying to create instance for integration: {integration_name}'
+        logging_manager.exception(error_message)
         return None, error_message, None
 
     if res[1] != 200:
-        error_message = 'create instance failed with status code ' + str(res[1])
-        prints_manager.add_print_job(error_message, print_error, thread_index)
-        prints_manager.add_print_job(pformat(res[0]), print_error, thread_index)
+        error_message = f'create instance failed with status code  {res[1]}'
+        logging_manager.error(error_message)
+        logging_manager.error(pformat(res[0]))
         return None, error_message, None
 
     integration_config = ast.literal_eval(res[0])
@@ -602,16 +572,15 @@ def __create_integration_instance(server, username, password, integration_name, 
     # test integration
     refreshed_client = demisto_client.configure(base_url=server, username=username, password=password, verify_ssl=False)
     if validate_test:
-        test_succeed, failure_message = __test_integration_instance(refreshed_client, module_instance, prints_manager,
-                                                                    thread_index=thread_index)
+        test_succeed, failure_message = __test_integration_instance(refreshed_client, module_instance, logging_manager)
     else:
-        print_warning(
-            "Skipping test validation for integration: {} (it has test_validate set to false)".format(integration_name)
+        logging_manager.debug(
+            f"Skipping test validation for integration: {integration_name} (it has test_validate set to false)"
         )
         test_succeed = True
 
     if not test_succeed:
-        __disable_integrations_instances(refreshed_client, [module_instance], prints_manager, thread_index=thread_index)
+        __disable_integrations_instances(refreshed_client, [module_instance], logging_manager)
         return None, failure_message, None
 
     docker_image = Docker.get_integration_image(integration_config)
@@ -619,7 +588,7 @@ def __create_integration_instance(server, username, password, integration_name, 
     return module_instance, '', docker_image
 
 
-def __disable_integrations_instances(client, module_instances, prints_manager=None, thread_index=0):
+def __disable_integrations_instances(client, module_instances, logging_module=logging):
     for configured_instance in module_instances:
         # tested with POSTMAN, this is the minimum required fields for the request.
         module_instance = {
@@ -632,49 +601,21 @@ def __disable_integrations_instances(client, module_instances, prints_manager=No
             res = demisto_client.generic_request_func(self=client, method='PUT',
                                                       path='/settings/integration',
                                                       body=module_instance)
-        except ApiException as conn_err:
-            if prints_manager:
-                error_message = 'Failed to disable integration instance, error trying to communicate with demisto' \
-                                f' server: {conn_err.body}'
-                prints_manager.add_print_job(error_message, print_error, thread_index)
-            else:
-                logging.exception('Failed to disable integration instance')
+        except ApiException:
+            logging_module.exception('Failed to disable integration instance')
             return
 
         if res[1] != 200:
-            error_message = f'disable instance failed with status code {res[1]}'
-            if prints_manager:
-                prints_manager.add_print_job(error_message, print_error, thread_index)
-                prints_manager.add_print_job(pformat(res), print_error, thread_index)
-            else:
-                logging.error(f'disable instance failed, Error: {pformat(res)}')
-
-
-def __enable_integrations_instances(client, module_instances):
-    for configured_instance in module_instances:
-        # tested with POSTMAN, this is the minimum required fields for the request.
-        module_instance = {
-            key: configured_instance[key] for key in ['id', 'brand', 'name', 'data', 'isIntegrationScript', ]
-        }
-        module_instance['enable'] = "true"
-        module_instance['version'] = -1
-
-        try:
-            res = demisto_client.generic_request_func(self=client, method='PUT',
-                                                      path='/settings/integration',
-                                                      body=module_instance)
-            if res[1] != 200:
-                print_error('Enabling instance failed with status code ' + str(res[1]) + '\n' + pformat(res))
-        except ApiException as conn_err:
-            print_error(
-                'Failed to enable integration instance, error trying to communicate with demisto '
-                'server: {} '.format(conn_err.body)
-            )
+            logging_module.error(f'disable instance failed, Error: {pformat(res)}')
 
 
 # create incident with given name & playbook, and then fetch & return the incident
-def __create_incident_with_playbook(client: DefaultApi, name, playbook_id, integrations, prints_manager,
-                                    thread_index=0) -> Tuple[Optional[Incident], int]:
+def __create_incident_with_playbook(client: DefaultApi,
+                                    name,
+                                    playbook_id,
+                                    integrations,
+                                    logging_manager,
+                                    ) -> Tuple[Optional[Incident], int]:
     # create incident
     create_incident_request = demisto_client.demisto_api.CreateIncidentRequest()
     create_incident_request.create_investigation = True
@@ -683,8 +624,8 @@ def __create_incident_with_playbook(client: DefaultApi, name, playbook_id, integ
 
     try:
         response = client.create_incident(create_incident_request=create_incident_request)
-    except ApiException as err:
-        prints_manager.add_print_job(str(err.body), print_error, thread_index)
+    except ApiException:
+        logging_manager.exception(f'Failed to create incident with name {name} for playbook {playbook_id}')
 
     try:
         inc_id = response.id
@@ -694,11 +635,12 @@ def __create_incident_with_playbook(client: DefaultApi, name, playbook_id, integ
     if inc_id == 'incCreateErr':
         integration_names = [integration['name'] for integration in integrations if
                              'name' in integration]
-        error_message = 'Failed to create incident for integration names: {} and playbookID: {}.' \
+        error_message = f'Failed to create incident for integration names: {integration_names} ' \
+                        f'and playbookID: {playbook_id}.' \
                         'Possible reasons are:\nMismatch between playbookID in conf.json and ' \
                         'the id of the real playbook you were trying to use,' \
-                        'or schema problems in the TestPlaybook.'.format(str(integration_names), playbook_id)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+                        'or schema problems in the TestPlaybook.'
+        logging_manager.error(error_message)
         return None, -1
 
     # get incident
@@ -718,14 +660,11 @@ def __create_incident_with_playbook(client: DefaultApi, name, playbook_id, integ
             incidents = client.search_incidents(filter=search_filter)
             found_incidents = incidents.total
             incident_search_responses.append(incidents)
-        except ApiException as err:
-            prints_manager.add_print_job(err.body, print, thread_index)
+        except ApiException:
+            logging_manager.exception(f'Searching incident with id {inc_id} failed')
         if time.time() > timeout:
-            error_message = 'Got timeout for searching incident with id {}'.format(inc_id)
-            prints_manager.add_print_job(error_message, print_error, thread_index)
-            prints_manager.add_print_job(
-                'Incident search responses: {}'.format(str(incident_search_responses)), print, thread_index
-            )
+            logging_manager.error(f'Got timeout for searching incident with id {inc_id}')
+            logging_manager.error(f'Incident search responses: {incident_search_responses}')
             return None, -1
 
         time.sleep(10)
@@ -734,15 +673,15 @@ def __create_incident_with_playbook(client: DefaultApi, name, playbook_id, integ
 
 
 # returns current investigation playbook state - 'inprogress'/'failed'/'completed'
-def __get_investigation_playbook_state(client, inv_id, prints_manager, thread_index=0):
+def __get_investigation_playbook_state(client, inv_id, logging_manager):
     try:
         investigation_playbook_raw = demisto_client.generic_request_func(self=client, method='GET',
                                                                          path='/inv-playbook/' + inv_id)
         investigation_playbook = ast.literal_eval(investigation_playbook_raw[0])
-    except ApiException as conn_err:
-        error_message = 'Failed to get investigation playbook state, error trying to communicate with demisto ' \
-                        'server: {} '.format(conn_err.body)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except ApiException:
+        logging_manager.exception(
+            'Failed to get investigation playbook state, error trying to communicate with demisto server'
+        )
         return PB_Status.FAILED
 
     try:
@@ -753,7 +692,7 @@ def __get_investigation_playbook_state(client, inv_id, prints_manager, thread_in
 
 
 # return True if delete-incident succeeded, False otherwise
-def __delete_incident(client: DefaultApi, incident: Incident, prints_manager, thread_index=0):
+def __delete_incident(client: DefaultApi, incident: Incident, logging_manager):
     try:
         body = {
             'ids': [incident.id],
@@ -762,51 +701,43 @@ def __delete_incident(client: DefaultApi, incident: Incident, prints_manager, th
         }
         res = demisto_client.generic_request_func(self=client, method='POST',
                                                   path='/incident/batchDelete', body=body)
-    except ApiException as conn_err:
-        error_message = 'Failed to delete incident, error trying to communicate with demisto server: {} ' \
-                        ''.format(conn_err.body)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except ApiException:
+        logging_manager.exception('Failed to delete incident, error trying to communicate with demisto server')
         return False
 
     if int(res[1]) != 200:
-        error_message = 'delete incident failed\nStatus code' + str(res[1])
-        prints_manager.add_print_job(error_message, print_error, thread_index)
-        prints_manager.add_print_job(pformat(res), print_error, thread_index)
+        logging_manager.error(f'delete incident failed with Status code {res[1]}')
+        logging_manager.error(pformat(res))
         return False
 
     return True
 
 
 # return True if delete-integration-instance succeeded, False otherwise
-def __delete_integration_instance(client, instance_id, prints_manager, thread_index=0):
+def __delete_integration_instance(client, instance_id, logging_manager=logging):
     try:
         res = demisto_client.generic_request_func(self=client, method='DELETE',
                                                   path='/settings/integration/' + urllib.parse.quote(
                                                       instance_id))
-    except ApiException as conn_err:
-        error_message = 'Failed to delete integration instance, error trying to communicate with demisto ' \
-                        'server: {} '.format(conn_err.body)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except ApiException:
+        logging_manager.exception('Failed to delete integration instance, error trying to communicate with demisto.')
         return False
     if int(res[1]) != 200:
-        error_message = 'delete integration instance failed\nStatus code' + str(res[1])
-        prints_manager.add_print_job(error_message, print_error, thread_index)
-        prints_manager.add_print_job(pformat(res), print_error, thread_index)
+        logging_manager.error(f'delete integration instance failed\nStatus code {res[1]}')
+        logging_manager.error(pformat(res))
         return False
     return True
 
 
 # delete all integration instances, return True if all succeed delete all
-def __delete_integrations_instances(client, module_instances, prints_manager, thread_index=0):
+def __delete_integrations_instances(client, module_instances, logging_manager=logging):
     succeed = True
     for module_instance in module_instances:
-        succeed = __delete_integration_instance(client, module_instance['id'], thread_index=thread_index,
-                                                prints_manager=prints_manager) and succeed
+        succeed = __delete_integration_instance(client, module_instance['id'], logging_manager) and succeed
     return succeed
 
 
-def __print_investigation_error(client, playbook_id, investigation_id, prints_manager, color=LOG_COLORS.RED,
-                                thread_index=0):
+def __print_investigation_error(client, playbook_id, investigation_id, logging_manager):
     try:
         empty_json = {"pageSize": 1000}
         res = demisto_client.generic_request_func(self=client, method='POST',
@@ -815,27 +746,20 @@ def __print_investigation_error(client, playbook_id, investigation_id, prints_ma
         if res and int(res[1]) == 200:
             resp_json = ast.literal_eval(res[0])
             entries = resp_json['entries']
-            prints_manager.add_print_job('Playbook {} has failed:'.format(playbook_id), print_color, thread_index,
-                                         message_color=color)
+            logging_manager.error(f'Playbook {playbook_id} has failed:')
             for entry in entries:
                 if entry['type'] == ENTRY_TYPE_ERROR and entry['parentContent']:
-                    prints_manager.add_print_job('- Task ID: {}'.format(entry['taskId']), print_color, thread_index,
-                                                 message_color=color)
+                    logging_manager.error(f'- Task ID: {entry["taskId"]}')
                     # Checks for passwords and replaces them with "******"
                     parent_content = re.sub(
                         r' (P|p)assword="[^";]*"', ' password=******', entry['parentContent'])
-                    prints_manager.add_print_job('  Command: {}'.format(parent_content), print_color,
-                                                 thread_index, message_color=color)
-                    body_contents_str = '  Body:\n{}\n'.format(entry['contents'])
-                    prints_manager.add_print_job(body_contents_str, print_color,
-                                                 thread_index, message_color=color)
+                    logging_manager.error(f'  Command: {parent_content}')
+                    logging_manager.error(f'  Body:\n{entry["contents"]}')
         else:
-            prints_manager.add_print_job(f'Failed getting entries for investigation: {investigation_id}. Res: {res}',
-                                         print_error, thread_index)
-    except ApiException as conn_err:
-        error_message = 'Failed to print investigation error, error trying to communicate with demisto ' \
-                        'server: {} '.format(conn_err.body)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+            logging_manager.error(f'Failed getting entries for investigation: {investigation_id}. Res: {res}')
+    except ApiException:
+        logging_manager.exception(
+            'Failed to print investigation error, error trying to communicate with demisto server')
 
 
 # Configure integrations to work with mock
@@ -859,7 +783,7 @@ def configure_proxy_unsecure(integration_params):
 # 4. if test pass - delete incident & instance
 # return playbook status
 def check_integration(client, server_url, demisto_user, demisto_pass, integrations, playbook_id,
-                      prints_manager, options=None, is_mock_run=False, thread_index=0):
+                      logging_module=logging, options=None, is_mock_run=False):
     options = options if options is not None else {}
     # create integrations instances
     module_instances = []
@@ -884,38 +808,36 @@ def check_integration(client, server_url, demisto_user, demisto_pass, integratio
                                                                                        integration_name,
                                                                                        integration_instance_name,
                                                                                        integration_params,
-                                                                                       is_byoi, prints_manager,
-                                                                                       validate_test=validate_test,
-                                                                                       thread_index=thread_index)
+                                                                                       is_byoi, logging_module,
+                                                                                       validate_test=validate_test)
         if module_instance is None:
             failure_message = failure_message if failure_message else 'No failure message could be found'
-            msg = 'Failed to create instance: {}'.format(failure_message)
-            prints_manager.add_print_job(msg, print_error, thread_index)  # disable-secrets-detection
-            __delete_integrations_instances(client, module_instances, prints_manager, thread_index=thread_index)
+            logging_module.error(f'Failed to create instance: {failure_message}')
+            __delete_integrations_instances(client, module_instances, logging_module)
             return False, -1
 
         module_instances.append(module_instance)
         if docker_image:
             test_docker_images.update(docker_image)
 
-        prints_manager.add_print_job('Create integration {} succeed'.format(integration_name), print, thread_index)
+        logging_module.info(f'Create integration {integration_name} succeed')
 
     # create incident with playbook
-    incident, inc_id = __create_incident_with_playbook(client, 'inc_{}'.format(playbook_id, ),
-                                                       playbook_id, integrations, prints_manager,
-                                                       thread_index=thread_index)
+    incident, inc_id = __create_incident_with_playbook(client,
+                                                       f'inc_{playbook_id}',
+                                                       playbook_id,
+                                                       integrations,
+                                                       logging_module)
 
     if not incident:
         return False, -1
 
     investigation_id = incident.investigation_id
     if investigation_id is None or len(investigation_id) == 0:
-        incident_id_not_found_msg = 'Failed to get investigation id of incident:' + incident
-        prints_manager.add_print_job(incident_id_not_found_msg, print_error, thread_index)  # disable-secrets-detection
+        logging.error(f'Failed to get investigation id of incident: {incident}')
         return False, -1
 
-    prints_manager.add_print_job('Investigation URL: {}/#/WorkPlan/{}'.format(server_url, investigation_id), print,
-                                 thread_index)
+    logging_module.info(f'Investigation URL: {server_url}/#/WorkPlan/{investigation_id}')
 
     timeout_amount = options['timeout'] if 'timeout' in options else DEFAULT_TIMEOUT
     timeout = time.time() + timeout_amount
@@ -928,8 +850,7 @@ def check_integration(client, server_url, demisto_user, demisto_pass, integratio
 
         try:
             # fetch status
-            playbook_state = __get_investigation_playbook_state(client, investigation_id, prints_manager,
-                                                                thread_index=thread_index)
+            playbook_state = __get_investigation_playbook_state(client, investigation_id, logging_module)
         except demisto_client.demisto_api.rest.ApiException:
             playbook_state = 'Pending'
             client = demisto_client.configure(base_url=client.api_client.configuration.host,
@@ -938,26 +859,18 @@ def check_integration(client, server_url, demisto_user, demisto_pass, integratio
         if playbook_state in (PB_Status.COMPLETED, PB_Status.NOT_SUPPORTED_VERSION):
             break
         if playbook_state == PB_Status.FAILED:
-            if is_mock_run:
-                prints_manager.add_print_job(playbook_id + ' failed with error/s', print_warning, thread_index)
-                __print_investigation_error(client, playbook_id, investigation_id, prints_manager,
-                                            LOG_COLORS.YELLOW, thread_index=thread_index)
-            else:
-                prints_manager.add_print_job(playbook_id + ' failed with error/s', print_error, thread_index)
-                __print_investigation_error(client, playbook_id, investigation_id, prints_manager,
-                                            thread_index=thread_index)
+            logging_module.error(f'{playbook_id} failed with error/s')
+            __print_investigation_error(client, playbook_id, investigation_id, logging_module)
             break
         if time.time() > timeout:
-            prints_manager.add_print_job(playbook_id + ' failed on timeout', print_error, thread_index)
+            logging_module.error(f'{playbook_id} failed on timeout')
             break
 
         if i % DEFAULT_INTERVAL == 0:
-            loop_number_message = 'loop no. {}, playbook state is {}'.format(
-                i / DEFAULT_INTERVAL, playbook_state)
-            prints_manager.add_print_job(loop_number_message, print, thread_index)
+            logging_module.info(f'loop no. {i / DEFAULT_INTERVAL}, playbook state is {playbook_state}')
         i = i + 1
 
-    __disable_integrations_instances(client, module_instances, prints_manager, thread_index=thread_index)
+    __disable_integrations_instances(client, module_instances, logging_module)
 
     if test_docker_images:
         memory_threshold = options.get('memory_threshold', Docker.DEFAULT_CONTAINER_MEMORY_USAGE)
@@ -966,27 +879,27 @@ def check_integration(client, server_url, demisto_user, demisto_pass, integratio
                                                     docker_images=test_docker_images,
                                                     def_memory_threshold=memory_threshold,
                                                     def_pid_threshold=pids_threshold,
-                                                    docker_thresholds=docker_thresholds)
+                                                    docker_thresholds=docker_thresholds,
+                                                    logging_module=logging_module)
 
         if error_message:
-            prints_manager.add_print_job(error_message, print_error, thread_index)
+            logging_module.error(error_message)
             return PB_Status.FAILED_DOCKER_TEST, inc_id
     else:
-        prints_manager.add_print_job("Skipping docker container memory resource check for test {}".format(playbook_id),
-                                     print_warning, thread_index)
+        logging_module.debug(f"Skipping docker container memory resource check for test {playbook_id}")
 
     test_pass = playbook_state in (PB_Status.COMPLETED, PB_Status.NOT_SUPPORTED_VERSION)
     if test_pass:
         # delete incident
-        __delete_incident(client, incident, prints_manager, thread_index=thread_index)
+        __delete_incident(client, incident, logging_module)
 
         # delete integration instance
-        __delete_integrations_instances(client, module_instances, prints_manager, thread_index=thread_index)
+        __delete_integrations_instances(client, module_instances, logging_module)
 
     return playbook_state, inc_id
 
 
-def disable_all_integrations(dem_client, prints_manager, thread_index=0):
+def disable_all_integrations(dem_client, logging_manager=logging):
     """
     Disable all enabled integrations. Should be called at start of test loop to start out clean
 
@@ -999,24 +912,20 @@ def disable_all_integrations(dem_client, prints_manager, thread_index=0):
                                                        path='/settings/integration/search',
                                                        body=body)
         int_instances = ast.literal_eval(int_resp[0])
-    except requests.exceptions.RequestException as conn_err:
-        error_message = 'Failed to disable all integrations, error trying to communicate with demisto server: ' \
-                        '{} '.format(conn_err)
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+    except requests.exceptions.RequestException:
+        logging_manager.exception('Failed to disable all integrations, error trying to communicate with demisto server')
         return
     if int(int_resp[1]) != 200:
-        error_message = 'Get all integration instances failed with status code: {}'.format(int_resp[1])
-        prints_manager.add_print_job(error_message, print_error, thread_index)
+        logging_manager.error(f'Get all integration instances failed with status code: {int_resp[1]}')
         return
     if 'instances' not in int_instances:
-        prints_manager.add_print_job("No integrations instances found to disable all", print, thread_index)
+        logging_manager.info("No integrations instances found to disable all")
         return
     to_disable = []
     for instance in int_instances['instances']:
         if instance.get('enabled') == 'true' and instance.get("isIntegrationScript"):
-            add_to_disable_message = "Adding to disable list. Name: {}. Brand: {}".format(instance.get("name"),
-                                                                                          instance.get("brand"))
-            prints_manager.add_print_job(add_to_disable_message, print, thread_index)
+            logging_manager.debug(
+                f'Adding to disable list. Name: {instance.get("name")}. Brand: {instance.get("brand")}')
             to_disable.append(instance)
     if len(to_disable) > 0:
-        __disable_integrations_instances(dem_client, to_disable, prints_manager, thread_index=thread_index)
+        __disable_integrations_instances(dem_client, to_disable, logging_manager)

--- a/Tests/tests/test_integration_test.py
+++ b/Tests/tests/test_integration_test.py
@@ -1,6 +1,6 @@
 import pytest
+
 from Tests.test_integration import __print_investigation_error
-from Tests.test_content import ParallelPrintsManager
 import demisto_client
 
 
@@ -24,11 +24,9 @@ def test_print_investigation_error(command, output, mocker):
     - Ensure message sent to print manager contains "pass word="123123!""
 
     """
-    prints_manager = ParallelPrintsManager(1)
     body = {'entries': [{'type': 4, 'parentContent': command, 'taskId': '12', 'contents': '2'}]}
     mocker.patch.object(demisto_client, "generic_request_func", return_value=[str(body), '200'])
-
+    logging_manager = mocker.MagicMock()
     client = demisto_client
-    __print_investigation_error(client, '', '', prints_manager)
-    prints_to_execute = prints_manager.threads_print_jobs[0]
-    assert prints_to_execute[2].message_to_print == output
+    __print_investigation_error(client, '', '', logging_manager)
+    logging_manager.error.assert_any_call(output)

--- a/Tests/tools.py
+++ b/Tests/tools.py
@@ -5,26 +5,33 @@ from pprint import pformat
 import demisto_client
 
 
-def update_server_configuration(client, server_configuration, error_msg):
+def update_server_configuration(client, server_configuration, error_msg, logging_manager=None):
     """updates server configuration
 
     Args:
         client (demisto_client): The configured client to use.
         server_configuration (dict): The server configuration to be added
         error_msg (str): The error message
+        logging_manager: Logging manager object
 
     Returns:
         response_data: The response data
         status_code: The response status code
     """
-    logging.debug(f'Updating server configurations with {pformat(server_configuration)}')
+    if logging_manager:
+        logging_manager.debug(f'Updating server configurations with {pformat(server_configuration)}')
+    else:
+        logging.debug(f'Updating server configurations with {pformat(server_configuration)}')
     system_conf_response = demisto_client.generic_request_func(
         self=client,
         path='/system/config',
         method='GET'
     )
     system_conf = ast.literal_eval(system_conf_response[0]).get('sysConf', {})
-    logging.debug(f'Current server configurations are {pformat(system_conf)}')
+    if logging_manager:
+        logging_manager.debug(f'Current server configurations are {pformat(system_conf)}')
+    else:
+        logging.debug(f'Current server configurations are {pformat(system_conf)}')
     system_conf.update(server_configuration)
     data = {
         'data': system_conf,
@@ -35,12 +42,22 @@ def update_server_configuration(client, server_configuration, error_msg):
 
     try:
         result_object = ast.literal_eval(response_data)
-        logging.debug(f'Updated server configurations with response: {pformat(result_object)}')
+        if logging_manager:
+            logging_manager.debug(f'Updated server configurations with response: {pformat(result_object)}')
+        else:
+            logging.debug(f'Updated server configurations with response: {pformat(result_object)}')
     except ValueError as err:
-        logging.exception('failed to parse response from demisto. response is {}.\nError:\n{}'.format(response_data, err))
+        if logging_manager:
+            logging_manager.exception(
+                f'failed to parse response from demisto. response is {response_data}.\nError:\n{err}')
+        else:
+            logging.exception(f'failed to parse response from demisto. response is {response_data}.\nError:\n{err}')
         return
 
     if status_code >= 300 or status_code < 200:
         message = result_object.get('message', '')
-        logging.error(f'{error_msg} {status_code}\n{message}')
+        if logging_manager:
+            logging_manager.error(f'{error_msg} {status_code}\n{message}')
+        else:
+            logging.error(f'{error_msg} {status_code}\n{message}')
     return response_data, status_code

--- a/Utils/release_notes_generator.py
+++ b/Utils/release_notes_generator.py
@@ -456,7 +456,7 @@ def create_content_descriptor(release_notes, version, asset_id, github_token):
 
 
 def main():
-    install_logging('Build Content Descriptor.log')
+    install_logging('Build_Content_Descriptor.log')
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('version', help='Release version')
     arg_parser.add_argument('git_sha1', help='commit sha1 to compare changes with')


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29261

## Description
This PR is about removing the ParallelPrintsManager and the different print methods from the build's steps (`print_error`, `print_warning` etc.)

In addition:
- Moved all the docker limit logs to debug file
- Moved most of the proxy prints to the debug file and added the stdout of the process.
- Since the test playbook step in private builds has one thread only - replaced the PrintsManager with logging (instead of loggingManager) 
- added logging to the slack notifier step
- Replaced as many `.format` strings with f-string

## Open design questions:
1. what logs should be visible on the console and what logs should appear in the file only:
    - Should the locking logs appear?
    - Should the proxy logs appear?

## When reviewing:
Open the `Run Tests.log` file from artifacts to see the difference between the two

Successful nightly build link - https://app.circleci.com/pipelines/github/demisto/content/46984/workflows/d1173e83-dbbd-4a93-ac86-6353c418adb8/jobs/201386
Successful instance testing build link - https://app.circleci.com/pipelines/github/demisto/content/47455/workflows/66684f44-bd75-422f-833d-f1fa395e8a38/jobs/203070
Successful private build link - https://github.com/demisto/content-private/runs/1469317268