### PR TITLE
ServiceNow raise error on non implemented command

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -9,6 +9,8 @@ from CommonServerPython import *
 # disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
+COMMAND_NOT_IMPLEMENTED_MSG = 'Command not implemented'
+
 TICKET_STATES = {
     'incident': {
         '1': '1 - New',
@@ -2201,7 +2203,9 @@ def main():
             md_, ec_, raw_response, ignore_auto_extract = commands[command](client, args)
             return_outputs(md_, ec_, raw_response, ignore_auto_extract=ignore_auto_extract)
         else:
-            raise NotImplementedError(f'Command "{command}" is not implemented.')
+            raise_exception = True
+            raise NotImplementedError(f'{COMMAND_NOT_IMPLEMENTED_MSG}: {demisto.command()}')
+
     except Exception as err:
         LOG(err)
         LOG.print_log()

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -2336,7 +2336,7 @@ script:
       the current incident, and should be used for debugging purposes.
     execution: false
     name: get-remote-data
-  dockerimage: demisto/python3:3.8.6.12176
+  dockerimage: demisto/python3:3.8.6.13358
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/ServiceNow/ReleaseNotes/1_3_12.md
+++ b/Packs/ServiceNow/ReleaseNotes/1_3_12.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### ServiceNow v2
+- Fixed an issue where unsupported commands were not handled correctly.
+- Upgraded the Docker image to demisto/oauthlib:1.0.0.13983.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "1.3.11",
+    "currentVersion": "1.3.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/30696

## Description
Server requires for mirroring integrations to raise an exception for un-implemented commands.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
