### PR TITLE
Add json loads in case literal_eval fails

### DIFF
--- a/Tests/timestamp_replacer.py
+++ b/Tests/timestamp_replacer.py
@@ -213,8 +213,15 @@ class TimestampReplacer:
                 try:
                     content = OrderedDict(literal_eval(content))
                     self.modify_json_body(req, content)
+                    return
                 except Exception:
                     logging.exception(f'failed to run literal_eval on content {content}')
+                try:
+                    logging.info('parsing the request body with "literal_eval" failed - trying with "json.loads"')
+                    content = json.loads(content, object_pairs_hook=OrderedDict)
+                    self.modify_json_body(req, content)
+                except Exception:
+                    logging.exception(f'failed to run json.loads on content {content}')
 
     def modify_json_body(self, req: HTTPRequest, json_body: dict) -> None:
         """Modify the json body of a request by replacing any timestamp data with constant data
@@ -327,8 +334,16 @@ class TimestampReplacer:
                     content = OrderedDict(literal_eval(content))
                     json_keys = self.determine_problematic_keys(content)
                     self.json_keys.update(json_keys)
+                    return
                 except Exception:
-                    logging.exception(f'failed while parsing content: {content}')
+                    logging.exception(f'failed to run literal_eval content: {content}')
+                try:
+                    logging.info('parsing the request body with "literal_eval" failed - trying with "json.loads"')
+                    content = json.loads(content, object_pairs_hook=OrderedDict)
+                    json_keys = self.determine_problematic_keys(content)
+                    self.json_keys.update(json_keys)
+                except Exception:
+                    logging.exception(f'failed to run json.loads on content {content}')
 
     def determine_problematic_keys(self, content: dict) -> List[str]:
         """Given a json request body, return the keys (in dot notation) whose values are potentially timestamp data.


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Added an attempt to json.loads content in which literal_eval failed on.

## Screenshots
![image](https://user-images.githubusercontent.com/41257953/100544434-3dcb9980-325e-11eb-9190-4338151f2282.png)

![image](https://user-images.githubusercontent.com/41257953/100544446-50de6980-325e-11eb-88ba-8c5cd7eccd08.png)

