### PR TITLE
AbuseIPDB - fix analysis report categories sum

### DIFF
--- a/Packs/AbuseDB/Integrations/AbuseDB/AbuseDB.py
+++ b/Packs/AbuseDB/Integrations/AbuseDB/AbuseDB.py
@@ -137,7 +137,7 @@ def analysis_to_entry(info, threshold=THRESHOLD, verbose=VERBOSE):
 
         if verbose:
             reports = sum([report_dict.get("categories") for report_dict in analysis.get("reports")], [])  # type: list
-            categories = set(reports)
+            categories = set(filter(lambda category_id: category_id in CATEGORIES_NAME.keys(), reports))
             abuse_ec["IP"]["Reports"] = {CATEGORIES_NAME[c]: reports.count(c) for c in categories}
 
         human_readable.append(abuse_ec['IP'])

--- a/Packs/AbuseDB/ReleaseNotes/1_0_1.md
+++ b/Packs/AbuseDB/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AbuseIPDB
+Fixed an issue where the ***ip*** command failed when unknown categories were returned.

--- a/Packs/AbuseDB/TestPlaybooks/playbook-AbuseIPDB-test.yml
+++ b/Packs/AbuseDB/TestPlaybooks/playbook-AbuseIPDB-test.yml
@@ -86,7 +86,7 @@ tasks:
         simple: "10"
       fullResponse: {}
       ip:
-        simple: ' 178.62.60.225'
+        simple: '178.62.60.225,103.99.110.181'
       long: {}
       retries: {}
       sampleSize: {}

--- a/Packs/AbuseDB/pack_metadata.json
+++ b/Packs/AbuseDB/pack_metadata.json
@@ -2,7 +2,7 @@
   "name": "AbuseIPDB",
   "description": "Central repository to report and identify IP addresses that have been associated with malicious activity online. Check the Detailed Information section for more information on how to configure the integration.",
   "support": "xsoar",
-  "currentVersion": "1.0.0",
+  "currentVersion": "1.0.1",
   "author": "Cortex XSOAR",
   "url": "https://www.paloaltonetworks.com/cortex",
   "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1867,13 +1867,11 @@
         },
         {
             "integrations": "AbuseIPDB",
-            "playbookID": "AbuseIPDB Test",
-            "nightly": true
+            "playbookID": "AbuseIPDB Test"
         },
         {
             "integrations": "AbuseIPDB",
-            "playbookID": "AbuseIPDB PopulateIndicators Test",
-            "nightly": true
+            "playbookID": "AbuseIPDB PopulateIndicators Test"
         },
         {
             "integrations": "LogRhythm",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
the IP address 103.99.110.181 returns the following category IDs in its analysis report: 0, 5, 15
the problematic category ID is 0, which is not in the list of [known categories](https://www.abuseipdb.com/categories)
removing it from the set of categories to count for the given report

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
