### PR TITLE
Arcsight ESM v2 - fix wrong query returned in invalid viewer query id error message

### DIFF
--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -239,7 +239,7 @@ def test():
     if events_query_viewer_id:
         fields, results = get_query_viewer_results(events_query_viewer_id)
         if 'Event ID' not in fields or 'Start Time' not in fields:
-            return_error('Query "{}" must contain "Start Time" and "Event ID" fields'.format(cases_query_viewer_id))
+            return_error('Query "{}" must contain "Start Time" and "Event ID" fields'.format(events_query_viewer_id))
 
     if cases_query_viewer_id:
         fields, results = get_query_viewer_results(cases_query_viewer_id)

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ArcSight ESM v2
-- Improved the error message in case an invalid *Query Viewer ID* was entered.
+- Improved error message that is returned when an invalid *Query Viewer ID* is entered.

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ArcSight ESM v2
-- Improved error message in case invalid Query Viewer ID was given.
+- Improved the error message in case an invalid *Query Viewer ID* was entered.

--- a/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_0_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ArcSight ESM v2
+- Improved error message in case invalid Query Viewer ID was given.

--- a/Packs/ArcSightESM/pack_metadata.json
+++ b/Packs/ArcSightESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ArcSight ESM",
     "description": "ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
In case invalid viewer query ID was given as parameter for the fetch, the wrong query (cases query viewer id) was returned in the error message

## Does it break backward compatibility?
   - [x] No
