### PR TITLE
Mail Listener v2 - fetch emails from the day before the last fetch

### DIFF
--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -246,7 +246,7 @@ def fetch_mails(client: IMAPClient,
             continue
         # The search query filters emails by day, not by exact date
         email_message_object = Email(message_bytes, include_raw_body, save_file, mail_id)
-        if not first_fetch_time or email_message_object.date > first_fetch_time:
+        if email_message_object.date > first_fetch_time:
             mails_fetched.append(email_message_object)
     return mails_fetched, messages
 
@@ -291,7 +291,7 @@ def generate_search_query(latest_created_time: Optional[datetime],
         # Removing Parenthesis and quotes
         messages_query = messages_query.strip('()').replace('"', '')
     # Creating a list of the OR query words
-    messages_query_list = messages_query.split() + ['SINCE', latest_created_time]  # type: ignore[list-item]
+    messages_query_list = messages_query.split() + ['SINCE', latest_created_time - timedelta(days=1)]  # type: ignore[list-item]
     return messages_query_list
 
 

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2_test.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 
 MAIL_STRING = """Delivered-To: to@test1.com
@@ -90,7 +90,7 @@ def test_generate_search_query():
                                                                                             'FROM',
                                                                                             'domain2.com',
                                                                                             'SINCE',
-                                                                                            now]
+                                                                                            now - timedelta(days=1)]
 
 
 def test_generate_labels():

--- a/Packs/MailListener/ReleaseNotes/1_0_1.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Mail Listener v2
+Fixed an issue where some emails were not fetched.
+Note: After installing this integration version, there might be duplicate emails fetched for the first fetch.

--- a/Packs/MailListener/ReleaseNotes/1_0_1.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Mail Listener v2
-Fixed an issue where some emails were not fetched.
+Fixed an issue where some emails were not fetched due to timezone mismatch.

--- a/Packs/MailListener/ReleaseNotes/1_0_1.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_1.md
@@ -2,4 +2,3 @@
 #### Integrations
 ##### Mail Listener v2
 Fixed an issue where some emails were not fetched.
-Note: After installing this integration version, there might be duplicate emails fetched for the first fetch.

--- a/Packs/MailListener/pack_metadata.json
+++ b/Packs/MailListener/pack_metadata.json
@@ -1,17 +1,17 @@
 {
-  "name": "Mail Listener",
-  "description": "Listen to a mailbox, enable incident triggering via e-mail",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-07-27T14:21:48Z",
-  "categories": [
-    "Messaging"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": [],
-  "dependencies": {}
+    "name": "Mail Listener",
+    "description": "Listen to a mailbox, enable incident triggering via e-mail",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-07-27T14:21:48Z",
+    "categories": [
+        "Messaging"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": [],
+    "dependencies": {}
 }


### PR DESCRIPTION
## Status
- [x] Ready

## Description
the IMAP client uses the `SINCE` operator which searches disregarding time and timezone see https://imapclient.readthedocs.io/en/2.1.0/api.html#imapclient.IMAPClient.search and https://tools.ietf.org/html/rfc3501 (page 51)
this means that there could be a case where emails wont be fetched (depends on the timezone)

the suggested fix is always to look one day back and by that bypass any timezone issue

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
