### PR TITLE
Checkpoint Firewall v2 - pass the host id to the request properly in the delete-host cmd

### DIFF
--- a/Packs/CheckpointFirewall/Integrations/CheckPointFirewall_v2/CheckPointFirewall_v2.py
+++ b/Packs/CheckpointFirewall/Integrations/CheckPointFirewall_v2/CheckPointFirewall_v2.py
@@ -442,12 +442,12 @@ def checkpoint_delete_host_command(client: Client, identifier) -> CommandResults
         client (Client): CheckPoint client.
         identifier(str): uid or name.
     """
-    identifier = argToList(identifier)
+    identifiers_list = argToList(identifier)
     readable_output = ''
     printable_result = {}
     result = []
-    for index, item in enumerate(identifier):
-        current_result = client.delete_host(item[1])
+    for item in identifiers_list:
+        current_result = client.delete_host(item)
         result.append(current_result)
         printable_result = {'message': current_result.get('message')}
         current_readable_output = tableToMarkdown('CheckPoint data for deleting host:',

--- a/Packs/CheckpointFirewall/Integrations/CheckPointFirewall_v2/CheckPointFirewall_v2_test.py
+++ b/Packs/CheckpointFirewall/Integrations/CheckPointFirewall_v2/CheckPointFirewall_v2_test.py
@@ -62,6 +62,7 @@ def test_checkpoint_delete_host_command(mocker):
     mocked_client.delete_host.return_value = util_load_json('test_data/delete_object.json')
     result = checkpoint_delete_host_command(mocked_client, 'host 1').outputs
     assert result.get('message') == 'OK'
+    assert mocked_client.delete_host.call_args[0][0] == 'host 1'
 
 
 def test_checkpoint_list_groups_command(mocker):

--- a/Packs/CheckpointFirewall/ReleaseNotes/2_0_4.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/2_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Check Point Firewall v2
+- Fixed an issue in the ***checkpoint-host-delete*** command in which the *identifier* argument was not processed properly.

--- a/Packs/CheckpointFirewall/pack_metadata.json
+++ b/Packs/CheckpointFirewall/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Check Point Firewall",
     "description": "Manage Check Point firewall via API",
     "support": "xsoar",
-    "currentVersion": "2.0.3",
+    "currentVersion": "2.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
fixed an issue where only the second char in the host id would be passed to the request func


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
