### PR TITLE
Akamai WAF - add extended and include_elements args to networks list

### DIFF
--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -52,6 +52,8 @@ class Client(BaseClient):
         Args:
             search: Only list items that match the specified substring in any network list’s name or list of items.
             list_type: Filters the output to lists of only the given type of network lists if provided, either IP or GEO.
+            extended: Whether to return extended details in the response
+            include_elements: Whether to return all list items.
 
         Returns:
             Json response as dictionary
@@ -290,6 +292,8 @@ def get_network_lists_command(
         client: Client object with request
         search: Only list items that match the specified substring in any network list’s name or list of items.
         list_type: Filters the output to lists of only the given type of network lists if provided, either IP or GEO.
+        extended: Whether to return extended details in the response
+        include_elements: Whether to return all list items.
 
     Returns:
         human readable (markdown format), entry context and raw response

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -41,7 +41,12 @@ class Client(BaseClient):
         """
         return self.get_network_lists()
 
-    def get_network_lists(self, search: str = None, list_type: str = None) -> dict:
+    def get_network_lists(self,
+                          search: str = None,
+                          list_type: str = None,
+                          extended: bool = True,
+                          include_elements: bool = True
+                          ) -> dict:
         """
             Get network lists
         Args:
@@ -54,8 +59,8 @@ class Client(BaseClient):
         params = {
             "search": search,
             "listType": list_type,
-            "extended": True,
-            "includeElements": True
+            "extended": extended,
+            "includeElements": include_elements
         }
         return self._http_request(method='GET',
                                   url_suffix='/network-list/v2/network-lists',
@@ -272,8 +277,13 @@ def test_module_command(client: Client, *_) -> Tuple[None, None, str]:
 
 
 @logger
-def get_network_lists_command(client: Client, search: str = None, list_type: str = None) \
-        -> Tuple[object, dict, Union[List, Dict]]:
+def get_network_lists_command(
+        client: Client,
+        search: str = None,
+        list_type: str = None,
+        extended: str = 'true',
+        include_elements: str = 'true'
+) -> Tuple[object, dict, Union[List, Dict]]:
     """Get network lists
 
     Args:
@@ -284,8 +294,9 @@ def get_network_lists_command(client: Client, search: str = None, list_type: str
     Returns:
         human readable (markdown format), entry context and raw response
     """
-    raw_response: Dict = client.get_network_lists(search=search,
-                                                  list_type=list_type)
+    raw_response: Dict = client.get_network_lists(
+        search=search, list_type=list_type, extended=(extended == 'true'), include_elements=(include_elements == 'true')
+    )
     if raw_response:
         title = f'{INTEGRATION_NAME} - network lists'
         entry_context, human_readable_ec = get_network_lists_ec(raw_response.get('networkLists'))

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -45,7 +45,7 @@ class Client(BaseClient):
                           search: str = None,
                           list_type: str = None,
                           extended: bool = True,
-                          include_elements: bool = True
+                          include_elements: bool = True,
                           ) -> dict:
         """
             Get network lists

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -284,7 +284,7 @@ def get_network_lists_command(
         search: str = None,
         list_type: str = None,
         extended: str = 'true',
-        include_elements: str = 'true'
+        include_elements: str = 'true',
 ) -> Tuple[object, dict, Union[List, Dict]]:
     """Get network lists
 

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -62,7 +62,7 @@ class Client(BaseClient):
             "search": search,
             "listType": list_type,
             "extended": extended,
-            "includeElements": include_elements
+            "includeElements": include_elements,
         }
         return self._http_request(method='GET',
                                   url_suffix='/network-list/v2/network-lists',

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.py
@@ -39,7 +39,7 @@ class Client(BaseClient):
         Returns:
             Response dictionary
         """
-        return self.get_network_lists()
+        return self.get_network_lists(extended=False, include_elements=False)
 
     def get_network_lists(self,
                           search: str = None,

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
@@ -252,7 +252,7 @@ script:
     - auto: PREDEFINED
       default: false
       description: The environment type to activate the network list. Can be "STAGING"
-        OR 'PRODUCTION".
+        OR "PRODUCTION".
       isArray: false
       name: env
       predefined:

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
@@ -28,7 +28,8 @@ configuration:
   name: proxy
   required: false
   type: 8
-description: Use the Akamai WAF integration to manage common sets of lists used by various Akamai security products and features.
+description: Use the Akamai WAF integration to manage common sets of lists used by
+  various Akamai security products and features.
 display: Akamai WAF
 name: Akamai WAF
 script:
@@ -36,7 +37,8 @@ script:
   - arguments:
     - auto: PREDEFINED
       default: false
-      description: The network list type by which to filter the results. Can be "IP" or "GEO".
+      description: The network list type by which to filter the results. Can be "IP"
+        or "GEO".
       isArray: false
       name: list_type
       predefined:
@@ -50,8 +52,36 @@ script:
       name: search
       required: false
       secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'true'
+      description: When enabled, provides additional response data identifying who
+        created and updated the list and when, and the network list’s deployment status
+        in both STAGING and PRODUCTION environments. This data takes longer to provide.
+      isArray: false
+      name: extended
+      predefined:
+      - 'true'
+      - 'false'
+      required: false
+      secret: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: 'true'
+      description: If enabled, the response list includes all items. For large network
+        lists, this may slow responses and yield large response objects. The default
+        false value when listing more than one network list omits the network list’s
+        elements and only provides higher-level metadata.
+      isArray: false
+      name: include_elements
+      predefined:
+      - 'true'
+      - 'false'
+      required: false
+      secret: false
     deprecated: false
-    description: Returns a list of all network lists available for an authenticated user who belongs to a group.
+    description: Returns a list of all network lists available for an authenticated
+      user who belongs to a group.
     execution: false
     name: akamai-get-network-lists
     outputs:
@@ -213,14 +243,16 @@ script:
     name: akamai-delete-network-list
   - arguments:
     - default: false
-      description: ' A comma-seprated list of network list IDs to activate. For example: list (list1,list2). '
+      description: ' A comma-seprated list of network list IDs to activate. For example:
+        list (list1,list2). '
       isArray: true
       name: network_list_ids
       required: true
       secret: false
     - auto: PREDEFINED
       default: false
-      description: The environment type to activate the network list. Can be "STAGING" OR 'PRODUCTION".
+      description: The environment type to activate the network list. Can be "STAGING"
+        OR 'PRODUCTION".
       isArray: false
       name: env
       predefined:
@@ -286,7 +318,8 @@ script:
     name: akamai-remove-element-from-network-list
   - arguments:
     - default: false
-      description: ' A comma-separated list of network list IDs for which to get the activation status. For example: (support list - list1,list2).'
+      description: ' A comma-separated list of network list IDs for which to get the
+        activation status. For example: (support list - list1,list2).'
       isArray: true
       name: network_list_ids
       required: true

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
@@ -348,7 +348,7 @@ script:
     - contextPath: Akamai.NetworkLists.ActivationStatus.ProductionStatus
       description: The network list environment activation status.
       type: String
-  dockerimage: demisto/akamai:1.0.0.8883
+  dockerimage: demisto/akamai:1.0.0.13142
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
@@ -318,7 +318,7 @@ script:
     name: akamai-remove-element-from-network-list
   - arguments:
     - default: false
-      description: ' A comma-separated list of network list IDs for which to get the
+      description: 'A comma-separated list of network list IDs for which to get the
         activation status. For example: (support list - list1,list2).'
       isArray: true
       name: network_list_ids

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/Akamai_WAF.yml
@@ -243,8 +243,8 @@ script:
     name: akamai-delete-network-list
   - arguments:
     - default: false
-      description: ' A comma-seprated list of network list IDs to activate. For example:
-        list (list1,list2). '
+      description: 'A comma-separated list of network list IDs to activate. For example:
+        list (list1,list2).'
       isArray: true
       name: network_list_ids
       required: true

--- a/Packs/Akamai_WAF/Integrations/Akamai_WAF/README.md
+++ b/Packs/Akamai_WAF/Integrations/Akamai_WAF/README.md
@@ -69,6 +69,8 @@ Returns a list of all network lists available for an authenticated user who belo
 |--- |--- |--- |
 |list_type|The network list type by which to filter the results. Can be "IP" or "GEO".|Optional|
 |search|The query by which to search for list names and list items.|Optional|
+|extended|When enabled, provides additional response data identifying who created and updated the list and when, and the network list’s deployment status in both STAGING and PRODUCTION environments. This data takes longer to provide. Possible values are: true, false. Default is true.|Optional|
+|include_elements|If enabled, the response list includes all items. For large network lists, this may slow responses and yield large response objects. The default false value when listing more than one network list omits the network list’s elements and only provides higher-level metadata. Possible values are: true, false. Default is true.|Optional|
 
 ##### Context Output
 

--- a/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
+++ b/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Akamai WAF
+- Added the *extended* and *include_elements* arguments to the ***akamai-get-network-lists*** command.

--- a/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
+++ b/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Akamai WAF
-- Added the *extended* and *include_elements* arguments to the ***akamai-get-network-lists*** command.
+- Added support for *extended* and *include_elements* arguments in the ***akamai-get-network-lists*** command.
 - Upgraded the Docker image to demisto/akamai:1.0.0.13142.

--- a/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
+++ b/Packs/Akamai_WAF/ReleaseNotes/1_0_2.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Akamai WAF
 - Added the *extended* and *include_elements* arguments to the ***akamai-get-network-lists*** command.
+- Upgraded the Docker image to demisto/akamai:1.0.0.13142.

--- a/Packs/Akamai_WAF/pack_metadata.json
+++ b/Packs/Akamai_WAF/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Akamai WAF",
     "description": "Use the Akamai WAF integration to manage common sets of lists used by various Akamai security products and features.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/30729

## Description
Added `extended` and `include_elements` flags to the list networks command

## Does it break backward compatibility?
   - [x] No
