### PR TITLE
Fixing mimecast test

### DIFF
--- a/Packs/Mimecast/TestPlaybooks/playbook-Mimecast_Test.yml
+++ b/Packs/Mimecast/TestPlaybooks/playbook-Mimecast_Test.yml
@@ -1044,7 +1044,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: http://urltest.com/malware.bin
+              simple: You have new held messages
     view: |-
       {
         "position": {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26906

## Description
The test tried to list message and then validate that a specific message is there while this message seems to have been deleted.

The validation will now look for another message that is currently there

