### PR TITLE
safely decode raw content in the timestamp replacer

### DIFF
--- a/Tests/timestamp_replacer.py
+++ b/Tests/timestamp_replacer.py
@@ -204,7 +204,11 @@ class TimestampReplacer:
         if req.method == 'POST':
             raw_content = req.raw_content
             if raw_content is not None:
-                content = req.raw_content.decode()
+                try:
+                    content = raw_content.decode()
+                except UnicodeDecodeError:
+                    logging.error('Failed to decode request content')
+                    content = ''
             else:
                 content = ''
             logging.info(f'cleaning json body: content={content}')
@@ -324,7 +328,11 @@ class TimestampReplacer:
         if req.method == 'POST':
             raw_content = req.raw_content
             if raw_content is not None:
-                content = req.raw_content.decode()
+                try:
+                    content = raw_content.decode()
+                except UnicodeDecodeError:
+                    logging.error('Failed to decode request content')
+                    content = ''
             else:
                 content = ''
             logging.info(f'handling json body: content={content}')


### PR DESCRIPTION
Some requests include an encoded file in the content.

Those requests cannot be decoded because some of the bytes aren't in the ascii charset.

![image](https://user-images.githubusercontent.com/41257953/100969068-2a108380-353b-11eb-9342-4d210d78ee02.png)


![image](https://user-images.githubusercontent.com/41257953/100969364-ac994300-353b-11eb-941d-713c651a341c.png)
