### PR TITLE
AlphaSOC NBA - Pass minSeverity parameter to API

### DIFF
--- a/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/Integrations/integration-AlphaSOC_Network_Behavior_Analytics.yml
@@ -128,7 +128,8 @@ script:
 
 
     function createAlertsURL(follow) {
-        return SERVER + API_PATH_ALERTS + '?follow=' + follow + '&threats=all';
+        var severity = getSeverityThereshold();
+        return SERVER + API_PATH_ALERTS + '?follow=' + follow + '&threats=all&minSeverity=' + severity;
     }
 
 

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_2.md
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlphaSOC Network Behavior Analytics
+- Pass minSeverity parameter to AlphaSOC API

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AlphaSOC Network Behavior Analytics",
     "description": "Retrieve alerts from the AlphaSOC Analytics Engine",
     "support": "partner",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "AlphaSOC",
     "url": "",
     "email": "support@alphasoc.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The AlphaSOC API now supports an optional `minSeverity` parameter which allows to reduce the number of retrieved threats. This PR updates the integration so that it uses that parameter.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
