### PR TITLE
removed problematic call to timezone

### DIFF
--- a/Packs/Base/ReleaseNotes/1_4_2.md
+++ b/Packs/Base/ReleaseNotes/1_4_2.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed a breaking change bug (only relevant to old *demisto/python3:latest* image).

--- a/Packs/Base/ReleaseNotes/1_4_2.md
+++ b/Packs/Base/ReleaseNotes/1_4_2.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Fixed a breaking change bug (only relevant to old *demisto/python3:latest* image).
+- Fixed an issue encountered when using *demisto/python3:latest* docker image. Automation/Integration was failing with an error: `'timezone' is not defined`.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -17,7 +17,7 @@ import traceback
 from random import randint
 import xml.etree.cElementTree as ET
 from collections import OrderedDict
-from datetime import tzinfo, datetime, timedelta
+from datetime import datetime, timedelta
 from abc import abstractmethod
 
 import demistomock as demisto
@@ -47,28 +47,13 @@ ZERO = timedelta(0)
 HOUR = timedelta(hours=1)
 
 
-class UTC(tzinfo):
-    """UTC"""
-
-    def utcoffset(self, dt):
-        return ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return ZERO
-
-
 if IS_PY3:
     STRING_TYPES = (str, bytes)  # type: ignore
     STRING_OBJ_TYPES = (str,)
-    TIMEZONE_UTC = timezone.utc
 
 else:
     STRING_TYPES = (str, unicode)  # type: ignore # noqa: F821
     STRING_OBJ_TYPES = STRING_TYPES  # type: ignore
-    TIMEZONE_UTC = UTC()
 # pylint: enable=undefined-variable
 
 
@@ -3924,7 +3909,7 @@ def arg_to_datetime(arg, arg_name=None, is_utc=True, required=False, settings=No
             ms = ms / 1000.0
 
         if is_utc:
-            return datetime.utcfromtimestamp(ms).replace(tzinfo=TIMEZONE_UTC)
+            return datetime.utcfromtimestamp(ms).replace(tzinfo=timezone.utc)
         else:
             return datetime.fromtimestamp(ms)
     if isinstance(arg, str):

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -3301,13 +3301,13 @@ def test_arg_to_timestamp_valid_inputs():
     Then
         ensure returned int which represents timestamp in milliseconds
     """
-    from CommonServerPython import arg_to_datetime, TIMEZONE_UTC
-    from datetime import datetime
-
     if sys.version_info.major == 2:
         # skip for python 2 - date
         assert True
         return
+
+    from CommonServerPython import arg_to_datetime
+    from datetime import datetime, timezone
 
     # hard coded date
     result = arg_to_datetime(
@@ -3315,7 +3315,7 @@ def test_arg_to_timestamp_valid_inputs():
         arg_name='foo'
     )
 
-    assert result == datetime(2020, 11, 10, 21, 43, 43, tzinfo=TIMEZONE_UTC)
+    assert result == datetime(2020, 11, 10, 21, 43, 43, tzinfo=timezone.utc)
 
     # relative dates also work
     result = arg_to_datetime(

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.4.1",
+    "currentVersion": "1.4.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31308

## Description
Removed timezone from the global space

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
