### PR TITLE
Removing the use of basic_config to support python3.7

### DIFF
--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -99,10 +99,24 @@ def install_logging(log_file_name: str, include_process_name=False) -> str:
     fh.setFormatter(formatter)
     ch.setLevel(logging.INFO)
     fh.setLevel(logging.DEBUG)
+    configure_root_logger(ch, fh)
+    return log_file_path
+
+
+def configure_root_logger(ch: logging.StreamHandler, fh: logging.FileHandler) -> None:
+    """
+    - Configures the root logger with DEBUG level
+    - Removes existing handlers from the root logger and adds the console handler and the file handler.
+    Args:
+        ch: StreamHandler to add to the root logger
+        fh: FileHandler to add to the root logger
+    """
     logging.root.setLevel(logging.DEBUG)
+    for h in logging.root.handlers[:]:
+        logging.root.removeHandler(h)
+        h.close()
     logging.root.addHandler(ch)
     logging.root.addHandler(fh)
-    return log_file_path
 
 
 def install_simple_logging():

--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -99,9 +99,9 @@ def install_logging(log_file_name: str, include_process_name=False) -> str:
     fh.setFormatter(formatter)
     ch.setLevel(logging.INFO)
     fh.setLevel(logging.DEBUG)
-    logging.basicConfig(level=logging.DEBUG,
-                        handlers=[ch, fh],
-                        force=True)
+    logging.root.setLevel(logging.DEBUG)
+    logging.root.addHandler(ch)
+    logging.root.addHandler(fh)
     return log_file_path
 
 


### PR DESCRIPTION
The use of `basicConfig` with the `force` flag is not supported in python3.7.
Since the sdk build uses some files that uses this logging feature - its best to modify the root logger directly and thus support both 3.7 and 3.8 python versions.
