### PR TITLE
SentinelOne v2 - use f-strings instead of concat in error processing

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -40,7 +40,7 @@ def http_request(method, url_suffix, params={}, data=None):
         try:
             errors = ''
             for error in res.json().get('errors'):
-                errors = '\n' + errors + error.get('detail')
+                errors += f"\n{error.get('detail', '')}"
             raise Exception(
                 f'Error in API call to Sentinel One [{res.status_code}] - [{res.reason}] \n'
                 f'Error details: [{errors}]'

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -1444,7 +1444,7 @@ script:
     description: Sends an uninstall command to all agents that match the input filter.
     execution: false
     name: sentinelone-uninstall-agent
-  dockerimage: demisto/python3:3.8.6.12176
+  dockerimage: demisto/python3:3.8.6.13358
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/SentinelOne/ReleaseNotes/1_0_5.md
+++ b/Packs/SentinelOne/ReleaseNotes/1_0_5.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### SentinelOne v2
 - Improved processing of error messages from the SentinelOne API. 
+- Upgraded the Docker image to demisto/python3:3.8.6.13358.

--- a/Packs/SentinelOne/ReleaseNotes/1_0_5.md
+++ b/Packs/SentinelOne/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SentinelOne v2
+- Improved processing of error messages from the SentinelOne API. 

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "End point protection",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
if error object did not contain the `detail` key, then `TypeError: can only concatenate str (not "NoneType") to str` would be raised

## Does it break backward compatibility?
   - [x] No

fixes: https://github.com/demisto/etc/issues/31409