### PR TITLE
Collect tests only in relevant files

### DIFF
--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1071,10 +1071,6 @@ def get_test_list_and_content_packs_to_install(files_string, branch_name, minimu
     if modified_files_with_relevant_tests:
         tests, packs_to_install = find_tests_and_content_packs_for_modified_files(modified_files_with_relevant_tests,
                                                                                   conf, id_set)
-    # for pack in modified_metadata_list:
-    #     pack_tests = get_tests_for_pack(tools.pack_name_to_path(pack))
-    #     packs_to_install.add(pack)
-    #     tests = tests.union(pack_tests)
 
     # Adding a unique test for a json file.
     if is_reputations_json:


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31064

## Description
We should not collect tests based on changes for the metadata file, only for changes in relevant files like py/yml/etc...
Delete the part of the code that added all Pack's tests after a change in metadata file.

## Screenshots
**Before** my fix in collect tests, the build looks like this: (with a minor change in CommonScripts/AddKeyToList.py):
https://app.circleci.com/pipelines/github/demisto/content/50016/workflows/44eca69c-16b2-44cf-b109-94132b1e1d61/jobs/212942
<img width="1436" alt="Screen Shot 2020-12-07 at 13 00 56" src="https://user-images.githubusercontent.com/71635916/101343163-40487780-388c-11eb-8de1-b3252abe218c.png">

**After** my fix in collect tests , the build looks like this: (with a minor change in CommonScripts/AddKeyToList.py):
https://app.circleci.com/pipelines/github/demisto/content/50017/workflows/5f5dfe24-f6ae-4857-9a37-d829ff0bc83a/jobs/212945
<img width="1419" alt="Screen Shot 2020-12-07 at 13 01 51" src="https://user-images.githubusercontent.com/71635916/101343241-61a96380-388c-11eb-8aa2-fc0eef3146ee.png">

So, seems like only relevant tests were collected, and not all Pack’s tests.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
