### PR TITLE
Splunk - handle notable raw fields where key equals value

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -200,6 +200,14 @@ def notable_to_incident(event):
     else:
         incident["occurred"] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S.0+00:00')
     event = replace_keys(event) if REPLACE_FLAG else event
+    for key, val in event.items():
+        # if notable event raw fields were sent in double quotes (e.g. "DNS Destination") and the field does not exist
+        # in the event, then splunk returns the field with the key as value (e.g. ("DNS Destination", "DNS Destination")
+        # so we go over the fields, and check if the key equals the value and set the value to be empty string
+        if key == val:
+            demisto.debug('Found notable event raw field [{}] with key that equals the value - replacing the value '
+                          'with empty string'.format(key))
+            event[key] = ''
     incident["rawJSON"] = json.dumps(event)
     labels = []
     if demisto.get(demisto.params(), 'parseNotableEventsRaw'):

--- a/Packs/SplunkPy/ReleaseNotes/1_2_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Fixed an issue where a notable event raw field that was provided wrapped in double quotes was returned with the key as the value in the incident metadata if it did not exist in the notable event.
+- Fixed an issue where providing a raw field which is wrapped in double quotes in a notable event, would return with the key set as the value in the incident metadata if it did not exist.

--- a/Packs/SplunkPy/ReleaseNotes/1_2_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where a notable event raw field that was provided wrapped in double quotes was returned with the key as the value in the incident metadata if it did not exist in the notable event.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SplunkPy",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/31548

## Description
if a notable event raw field was provided in the `extractFields` integration parameter wrapped in double quotes, and the field does not exist in the event, then splunk returns it anyway with the value equals the key
added iteration over the event keys to check for that, and replace value with empty string in that case

## Does it break backward compatibility?
   - [x] No
