### PR TITLE
Export Indicators - pop instead of del indicator value

### DIFF
--- a/Packs/ExportIndicators/Integrations/ExportIndicators/ExportIndicators.py
+++ b/Packs/ExportIndicators/Integrations/ExportIndicators/ExportIndicators.py
@@ -449,7 +449,7 @@ def json_format_single_indicator(indicator: dict):
     json_format_indicator = {
         "indicator": indicator.get("value")
     }
-    del indicator["value"]
+    indicator.pop("value", None)
 
     json_format_indicator["value"] = indicator
     return json_format_indicator

--- a/Packs/ExportIndicators/Integrations/ExportIndicators/ExportIndicators.yml
+++ b/Packs/ExportIndicators/Integrations/ExportIndicators/ExportIndicators.yml
@@ -272,7 +272,7 @@ script:
       On-Demand).
     execution: false
     name: eis-update
-  dockerimage: demisto/teams:1.0.0.7832
+  dockerimage: demisto/teams:1.0.0.14318
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Export Indicators Service
 - Fixed an issue where processing an indicator without value would raise an exception.
+- Upgraded the Docker image to demisto/teams:1.0.0.14318.

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Export Indicators Service
+- Fixed an issue where processing an indicator without value would raise an exception.

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_1.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Export Indicators Service
-- Fixed an issue where processing an indicator without value would raise an exception.
+- Fixed an issue where processing an indicator without a value would raise an exception.
 - Upgraded the Docker image to demisto/teams:1.0.0.14318.

--- a/Packs/ExportIndicators/pack_metadata.json
+++ b/Packs/ExportIndicators/pack_metadata.json
@@ -1,18 +1,18 @@
 {
-  "name": "Export Indicators",
-  "description": "Use the Export Indicators Service integration to provide an endpoint with a list of indicators as a service for the system indicators.",
-  "support": "xsoar",
-  "currentVersion": "1.0.0",
-  "author": "Cortex XSOAR",
-  "url": "https://www.paloaltonetworks.com/cortex",
-  "email": "",
-  "created": "2020-03-09T16:04:45Z",
-  "categories": [
-    "Data Enrichment & Threat Intelligence"
-  ],
-  "tags": [],
-  "useCases": [],
-  "keywords": [
-    "Export Indicators"
-  ]
+    "name": "Export Indicators",
+    "description": "Use the Export Indicators Service integration to provide an endpoint with a list of indicators as a service for the system indicators.",
+    "support": "xsoar",
+    "currentVersion": "1.0.1",
+    "author": "Cortex XSOAR",
+    "url": "https://www.paloaltonetworks.com/cortex",
+    "email": "",
+    "created": "2020-03-09T16:04:45Z",
+    "categories": [
+        "Data Enrichment & Threat Intelligence"
+    ],
+    "tags": [],
+    "useCases": [],
+    "keywords": [
+        "Export Indicators"
+    ]
 }


### PR DESCRIPTION
## Status
- [x] Ready

Fixes https://github.com/demisto/etc/issues/31588

## Description
in the indicator object does not have the `value` field, a `KeyError` would be raised:
```
Traceback (most recent call last):
  File "<string>", line 5938, in route_list_values
  File "<string>", line 5780, in get_outbound_ioc_values
  File "<string>", line 5362, in refresh_outbound_context
  File "<string>", line 5697, in create_values_for_returned_dict
  File "<string>", line 5601, in create_json_out_format
  File "<string>", line 5611, in json_format_single_indicator
KeyError: 'value'
```
changed the `del` to `pop` with `None` as default value to avoid the `KeyError`


## Does it break backward compatibility?
   - [x] No
