### PR TITLE
Fixing urlscan bug

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -68,7 +68,7 @@ def http_request(method, url_suffix, json=None, wait=0, retries=0):
 
         response_json = r.json()
         error_description = response_json.get('description')
-        should_continue_on_blacklisted_urls = argToBoolean(demisto.args().get('continue_on_blacklisted_urls'))
+        should_continue_on_blacklisted_urls = argToBoolean(demisto.args().get('continue_on_blacklisted_urls', False))
         if should_continue_on_blacklisted_urls and error_description == BLACKLISTED_URL_ERROR_MESSAGE:
             response_json['url_is_blacklisted'] = True
             requested_url = JSON.loads(json)['url']

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -195,7 +195,7 @@ def format_results(uuid):
     file_context = makehash()
     url_cont = makehash()
 
-    LIMIT = int(demisto.args().get('limit'))
+    LIMIT = int(demisto.args().get('limit', 20))
     if 'certificates' in scan_lists:
         cert_md = []
         cert_ec = []

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -41,8 +41,8 @@ def http_request(method, url_suffix, json=None, wait=0, retries=0):
             'Content-Type': 'application/json',
             'Accept': 'application/json'
         }
-    LOG('requesting https request with method: {}, url: {}, data: {}'.format(method, BASE_URL + url_suffix, json))
-    LOG.print_log()
+    demisto.debug(
+        'requesting https request with method: {}, url: {}, data: {}'.format(method, BASE_URL + url_suffix, json))
     r = requests.request(
         method,
         BASE_URL + url_suffix,
@@ -130,26 +130,22 @@ def poll(target, step, args=(), kwargs=None, timeout=60,
     # According to the doc - The most efficient approach would be to wait at least 10 seconds before starting to poll
     time.sleep(10)
     while True:
-        LOG('Number of Polling attempts: {}'.format(tries))
-        LOG.print_log()
+        demisto.debug('Number of Polling attempts: {}'.format(tries))
         try:
             val = target(*args, **kwargs)
             last_item = val
         except ignore_exceptions as e:
             last_item = e
-            LOG('Polling request failed with exception {}'.format(str(e)))
-            LOG.print_log()
+            demisto.debug('Polling request failed with exception {}'.format(str(e)))
         else:
             if check_success(val):
                 return val
-        LOG('Polling request returned False')
-        LOG.print_log()
+        demisto.debug('Polling request returned False')
         values.put(last_item)
         tries += 1
         if max_time is not None and time.time() >= max_time:
             demisto.results('The operation timed out. Please try again with a longer timeout period.')
-            LOG('The operation timed out.')
-            LOG.print_log()
+            demisto.debug('The operation timed out.')
             return False
         time.sleep(step)  # pylint: disable=sleep-exists
         step = step_function(step)
@@ -177,8 +173,7 @@ def urlscan_submit_url():
 
 def format_results(uuid):
     response = urlscan_submit_request(uuid)
-    LOG('urlscan_submit_request response: {}'.format(response))
-    LOG.print_log()
+    demisto.debug('urlscan_submit_request response: {}'.format(response))
     scan_data = response.get('data', {})
     scan_lists = response.get('lists', {})
     scan_tasks = response.get('task', {})
@@ -550,7 +545,9 @@ def format_http_transaction_list():
 
 
 """COMMAND FUNCTIONS"""
-if __name__ in ('__main__', '__builtin__', 'builtins'):
+
+
+def main():
     try:
         handle_proxy()
         if demisto.command() == 'test-module':
@@ -575,3 +572,7 @@ if __name__ in ('__main__', '__builtin__', 'builtins'):
         LOG(e)
         LOG.print_log(False)
         return_error(e.message)
+
+
+if __name__ in ('__main__', '__builtin__', 'builtins'):
+    main()

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -16,7 +16,8 @@ configuration:
   required: false
   type: 8
 - defaultvalue: '1'
-  display: URL Threshold. Minimum number of positive results from urlscan.io to consider the URL malicious.
+  display: URL Threshold. Minimum number of positive results from urlscan.io to consider
+    the URL malicious.
   name: url_threshold
   required: false
   type: 0
@@ -32,7 +33,8 @@ script:
   commands:
   - arguments:
     - default: true
-      description: A parameter for which to search (as a string), for example an IP address, file name, SHA256 hash, URL, domain, and so on.
+      description: A parameter for which to search (as a string), for example an IP
+        address, file name, SHA256 hash, URL, domain, and so on.
       isArray: false
       name: searchParameter
       required: true
@@ -88,7 +90,8 @@ script:
       secret: false
     - default: false
       defaultValue: '60'
-      description: The amount of time (in seconds) to wait for the scan ID result before timeout. Default is 60.
+      description: The amount of time (in seconds) to wait for the scan ID result
+        before timeout. Default is 60.
       isArray: false
       name: timeout
       required: false
@@ -101,15 +104,22 @@ script:
       secret: false
     - default: false
       defaultValue: '20'
-      description: The maximum number of Limits the returned list of Certificates, IP's and ASN's
+      description: The maximum number of Limits the returned list of Certificates,
+        IP's and ASN's
       isArray: false
       name: limit
       required: false
       secret: false
-    - default: false
-      description: Determines whether a scan should continue if one of the URLs is blacklisted.
-      isArray: false
+    - auto: PREDEFINED
+      default: false
+      description: Determines whether a scan should continue if one of the URLs is
+        blacklisted.
+      isArray: true
       name: continue_on_blacklisted_urls
+      predefined:
+      - 'true'
+      - 'false'
+      defaultValue: 'false'
       required: false
       secret: false
     deprecated: true
@@ -195,7 +205,8 @@ script:
       secret: false
     - default: false
       defaultValue: '60'
-      description: The amount of time (in seconds) to wait for the scan ID result before timeout. Default is 60.
+      description: The amount of time (in seconds) to wait for the scan ID result
+        before timeout. Default is 60.
       isArray: false
       name: timeout
       required: false
@@ -215,7 +226,8 @@ script:
       secret: false
     - default: false
       defaultValue: '5'
-      description: The amount of time (in seconds) to wait between tries if the API rate limit is exceeded.
+      description: The amount of time (in seconds) to wait between tries if the API
+        rate limit is exceeded.
       isArray: false
       name: wait
       required: false
@@ -227,10 +239,16 @@ script:
       name: retries
       required: false
       secret: false
-    - default: false
-      description: Determines whether a scan should continue if one of the URLs is blacklisted.
-      isArray: false
+    - auto: PREDEFINED
+      default: false
+      description: Determines whether a scan should continue if one of the URLs is
+        blacklisted.
+      isArray: true
       name: continue_on_blacklisted_urls
+      predefined:
+      - 'true'
+      - 'false'
+      defaultValue: 'false'
       required: false
       secret: false
     deprecated: false
@@ -328,7 +346,8 @@ script:
       secret: false
     - default: false
       defaultValue: '20'
-      description: The maximum number of results to return to the War Room. Maximum is 100. Default is 20.
+      description: The maximum number of results to return to the War Room. Maximum
+        is 100. Default is 20.
       isArray: false
       name: limit
       required: false
@@ -340,7 +359,8 @@ script:
       required: true
       secret: false
     deprecated: true
-    description: Returns the HTTP transaction list for the specified URL. Do not use this command in conjunction with the urlscan-get-http-transactions script.
+    description: Returns the HTTP transaction list for the specified URL. Do not use
+      this command in conjunction with the urlscan-get-http-transactions script.
     execution: false
     name: urlscan-get-http-transaction-list
     outputs:
@@ -348,7 +368,8 @@ script:
       description: The URL address that was scanned.
       type: string
     - contextPath: URLScan.httpTransaction
-      description: A link to the HTTP transaction made during the search for the specified URL.
+      description: A link to the HTTP transaction made during the search for the specified
+        URL.
       type: string
   - arguments:
     - default: false
@@ -369,7 +390,8 @@ script:
       required: true
       secret: false
     deprecated: true
-    description: Polls the urlscan service regarding the results of the specified URI.
+    description: Polls the urlscan service regarding the results of the specified
+      URI.
     execution: false
     name: urlscan-poll-uri
   - arguments:
@@ -383,12 +405,13 @@ script:
     description: Returns the results page for the specified UUID.
     execution: false
     name: urlscan-get-result-page
+  feed: false
   isfetch: false
   longRunning: false
   longRunningPort: false
   runonce: false
-  script: ''
-  type: python
+  script: '-'
   subtype: python2
+  type: python
 defaultEnabled: false
 fromversion: 5.0.0

--- a/Packs/UrlScan/Integrations/UrlScan/Urlscan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/Urlscan_test.py
@@ -2,8 +2,10 @@ import pytest
 import demistomock as demisto
 import json
 
+
 RETURN_ERROR_TARGET = 'UrlScan.return_error'
 SCAN_URL = 'https://urlscan.io/api/v1/scan/'
+RESULT_URL = 'https://urlscan.io/api/v1/result/'
 
 
 @pytest.mark.parametrize('continue_on_blacklisted_urls', [(True), (False)])
@@ -29,3 +31,13 @@ def test_continue_on_blacklisted_error_arg(mocker, requests_mock, continue_on_bl
         assert return_error_mock.call_count == 0
     else:
         assert return_error_mock.call_count == 1
+
+
+def test_endless_loop_on_failed_response(requests_mock, mocker):
+    from UrlScan import format_results
+    mocker.patch(RETURN_ERROR_TARGET)
+
+    with open('./test_data/capitalne.json', 'r') as f:
+        response_data = json.loads(f.read())
+    requests_mock.get(RESULT_URL + 'uuid', status_code=200, json=response_data)
+    format_results('uuid')

--- a/Packs/UrlScan/Integrations/UrlScan/Urlscan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/Urlscan_test.py
@@ -1,3 +1,5 @@
+import time
+from threading import Thread
 import pytest
 import demistomock as demisto
 import json
@@ -34,10 +36,21 @@ def test_continue_on_blacklisted_error_arg(mocker, requests_mock, continue_on_bl
 
 
 def test_endless_loop_on_failed_response(requests_mock, mocker):
+    """
+    Given
+    - Some uuid
+    When
+    - Running format results on it
+    Then
+    - Assert it does not enter an endless loop
+    """
     from UrlScan import format_results
     mocker.patch(RETURN_ERROR_TARGET)
 
     with open('./test_data/capitalne.json', 'r') as f:
         response_data = json.loads(f.read())
     requests_mock.get(RESULT_URL + 'uuid', status_code=200, json=response_data)
-    format_results('uuid')
+    thread = Thread(target=format_results, args=('uuid', ))
+    thread.start()
+    time.sleep(10)
+    assert not thread.is_alive(), 'format_results method have probably entered an endless loop'

--- a/Packs/UrlScan/Integrations/UrlScan/test_data/capitalne.json
+++ b/Packs/UrlScan/Integrations/UrlScan/test_data/capitalne.json
@@ -1,0 +1,208 @@
+{
+  "data": {
+    "requests": [
+      {
+        "request": {
+          "requestId": "72681F21205D1F1483083AAC32DBA719",
+          "loaderId": "72681F21205D1F1483083AAC32DBA719",
+          "documentURL": "http://capitalne.com/",
+          "request": {
+            "url": "http://capitalne.com/",
+            "method": "GET",
+            "headers": {
+              "Upgrade-Insecure-Requests": "1",
+              "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)"
+            },
+            "mixedContentType": "none",
+            "initialPriority": "VeryHigh",
+            "referrerPolicy": "no-referrer-when-downgrade"
+          },
+          "timestamp": 6731750.150596,
+          "wallTime": 1595517675.009059,
+          "initiator": {
+            "type": "other"
+          },
+          "type": "Document",
+          "frameId": "DD6EADE429B73140FAE4117A7D1AC2A4",
+          "hasUserGesture": false
+        },
+        "response": {
+          "encodedDataLength": 0,
+          "dataLength": 0,
+          "failed": {
+            "requestId": "72681F21205D1F1483083AAC32DBA719",
+            "timestamp": 6731766.66642,
+            "type": "Document",
+            "errorText": "net::ERR_EMPTY_RESPONSE",
+            "canceled": false
+          }
+        }
+      },
+      {
+        "request": {},
+        "requests": [],
+        "response": {
+          "encodedDataLength": 0,
+          "dataLength": 0,
+          "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "size": 0
+        }
+      }
+    ],
+    "cookies": [],
+    "console": [],
+    "links": [],
+    "timing": {
+      "beginNavigation": "2020-07-23T15:21:15.008Z",
+      "frameStartedLoading": "2020-07-23T15:21:31.534Z",
+      "frameNavigated": "2020-07-23T15:21:31.534Z",
+      "loadEventFired": "2020-07-23T15:21:31.534Z",
+      "frameStoppedLoading": "2020-07-23T15:21:31.535Z",
+      "domContentEventFired": "2020-07-23T15:21:31.535Z"
+    },
+    "globals": []
+  },
+  "stats": {
+    "resourceStats": [],
+    "protocolStats": [],
+    "tlsStats": [],
+    "serverStats": [],
+    "domainStats": [
+      {
+        "count": 0,
+        "ips": [],
+        "domain": "capitalne.com",
+        "size": 0,
+        "encodedSize": 0,
+        "countries": [],
+        "index": 0,
+        "initiators": [
+          null
+        ]
+      }
+    ],
+    "regDomainStats": [
+      {
+        "count": 0,
+        "ips": [],
+        "regDomain": "capitalne.com",
+        "size": 0,
+        "encodedSize": 0,
+        "countries": [],
+        "index": 0,
+        "subDomains": [
+          {
+            "domain": "",
+            "failed": true
+          }
+        ]
+      }
+    ],
+    "secureRequests": 0,
+    "securePercentage": 0,
+    "IPv6Percentage": null,
+    "uniqCountries": 0,
+    "totalLinks": 0,
+    "malicious": 0,
+    "adBlocked": 0,
+    "ipStats": []
+  },
+  "meta": {
+    "processors": {
+      "wappa": {
+        "state": "done",
+        "data": []
+      },
+      "rdns": {
+        "state": "done",
+        "data": []
+      },
+      "asn": {
+        "state": "done",
+        "data": []
+      },
+      "geoip": {
+        "state": "done",
+        "data": []
+      },
+      "done": {
+        "state": "done",
+        "data": {
+          "state": "done"
+        }
+      }
+    }
+  },
+  "task": {
+    "uuid": "8fb2fc51-7653-46b4-bbb0-a4cde38e549d",
+    "time": "2020-07-23T15:21:14.776Z",
+    "url": "http://capitalne.com",
+    "visibility": "public",
+    "options": {
+      "useragent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) "
+    },
+    "method": "api",
+    "source": "0c422ee9",
+    "tags": [],
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)",
+    "reportURL": "https://urlscan.io/result/8fb2fc51-7653-46b4-bbb0-a4cde38e549d/",
+    "domURL": "https://urlscan.io/dom/8fb2fc51-7653-46b4-bbb0-a4cde38e549d/"
+  },
+  "page": {
+    "url": "http://capitalne.com",
+    "domain": "capitalne.com"
+  },
+  "lists": {
+    "ips": [],
+    "countries": [],
+    "asns": [],
+    "domains": [
+      "capitalne.com"
+    ],
+    "servers": [],
+    "urls": [
+      "http://capitalne.com/"
+    ],
+    "linkDomains": [],
+    "certificates": [],
+    "hashes": [
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    ]
+  },
+  "verdicts": {
+    "overall": {
+      "score": 0,
+      "categories": [],
+      "brands": [],
+      "tags": [],
+      "malicious": false,
+      "hasVerdicts": 0
+    },
+    "urlscan": {
+      "score": 0,
+      "categories": [],
+      "brands": [],
+      "tags": [],
+      "detectionDetails": [],
+      "malicious": false
+    },
+    "engines": {
+      "score": 0,
+      "malicious": [],
+      "benign": [],
+      "maliciousTotal": 0,
+      "benignTotal": 0,
+      "verdicts": [],
+      "enginesTotal": 0
+    },
+    "community": {
+      "score": 0,
+      "votes": [],
+      "votesTotal": 0,
+      "votesMalicious": 0,
+      "votesBenign": 0,
+      "tags": [],
+      "categories": []
+    }
+  }
+}

--- a/Packs/UrlScan/ReleaseNotes/1_0_6.md
+++ b/Packs/UrlScan/ReleaseNotes/1_0_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### urlscan.io
-- Fixed a bug where exceeding quota limit caused timeout exception
+- Fixed a bug where exceeding the quota limit caused a timeout exception.

--- a/Packs/UrlScan/ReleaseNotes/1_0_6.md
+++ b/Packs/UrlScan/ReleaseNotes/1_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Fixed a bug where exceeding quota limit caused timeout exception

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "urlscan.io",
     "description": "Urlscan.io reputation",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3399,9 +3399,11 @@
         "Lastline v2",
         "TruSTAR",
         "SlackV2",
-        "VulnDB"
+        "VulnDB",
+        "urlscan.io"
     ],
     "unmockable_integrations": {
+        "urlscan.io": "Uses data that comes in the headers",
         "QRadar_v2": "Test playbook 'test playbook - QRadarCorrelations' has multiple branches",
         "CloudConvert": "has a command that uploads a file (!cloudconvert-upload)",
         "EWS v2": "Fetches bytes data (!ews-get-items-from-folder)",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes https://github.com/demisto/etc/issues/31551

## Description
This PR fixes the urlscan bug:
- Removes two endless loops
- Uses api-key in all requests to enjoy the extended rate limit
- Added logs for better debugging


## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
