### PR TITLE
Unmocking integration with random uuid

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3247,7 +3247,7 @@
         "Cisco Umbrella Test": "Issue 24338"
     },
     "skipped_integrations": {
-        
+
         "_comment1": "~~~ NO INSTANCE ~~~",
         "Forcepoint": "instance issues. Issue 28043",
         "ZeroFox": "Issue 29284",
@@ -3330,11 +3330,11 @@
         "AWS - Athena - Beta": "Issue 19834",
         "SNDBOX": "Issue 28826",
         "Workday": "License expired Issue: 29595",
-        
+
         "_comment2": "~~~ UNSTABLE ~~~",
         "Tenable.sc": "unstable instance",
         "ThreatConnect v2": "unstable instance",
-        
+
         "_comment3": "~~~ QUOTA ISSUES ~~~",
         "Joe Security": "Issue 25650",
         "XFE_v2": "Required proper instance, otherwise we get quota errors",
@@ -3342,7 +3342,7 @@
         "Google Resource Manager": "Cannot create projects because have reached allowed quota.",
         "Looker": "Warehouse 'DEMO_WH' cannot be resumed because resource monitor 'LIMITER' has exceeded its quota.",
         "Ipstack": "Issue 26266",
-        
+
         "_comment4": "~~~ OTHER ~~~",
         "XFE": "We have the new integration XFE_v2, so no need to test the old one because they use the same quote",
         "Endace": "Issue 24304",
@@ -3367,6 +3367,8 @@
         "VulnDB"
     ],
     "unmockable_integrations": {
+        "CloudConvert": "has a command that uploads a file (!cloudconvert-upload)",
+        "EWS v2": "Fetches bytes data (!ews-get-items-from-folder)",
         "jira-v2": "has a command that uploads a file ( !jira-issue-upload-file)",
         "Rundeck": "has a command that uploads a file (!rundeck-adhoc-script-run)",
         "ServiceDeskPlus": "Playbook uses a random string and verifying the response contain it",
@@ -3529,7 +3531,7 @@
         "Mail Listener v2"
     ],
     "docker_thresholds": {
-        
+
         "_comment": "Add here docker images which are specific to an integration and require a non-default threshold (such as rasterize or ews). That way there is no need to define this multiple times. You can specify full image name with version or without.",
         "images": {
             "demisto/chromium": {


### PR DESCRIPTION
Test playbook uses random string to create a policy and there is no command to delete a policy so there is no way to test create a policy without a random uuid.
