### PR TITLE
Rasterize test failure fix

### DIFF
--- a/Packs/rasterize/TestPlaybooks/playbook-Rasterize_Test.yml
+++ b/Packs/rasterize/TestPlaybooks/playbook-Rasterize_Test.yml
@@ -388,7 +388,7 @@ tasks:
     task:
       id: 5533a172-35f4-4612-8221-ecba2c82d365
       version: -1
-      name: Rasterize URL to PNG (Github)
+      name: Rasterize URL to PNG (Google)
       description: Rasterize a URL into image or PDF
       script: '|||rasterize'
       type: regular
@@ -402,7 +402,7 @@ tasks:
       type:
         simple: png
       url:
-        simple: https://github.com
+        simple: https://google.com
       wait_time:
         simple: "5"
       width: {}
@@ -506,7 +506,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: github
+              simple: google
     view: |-
       {
         "position": {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3228,8 +3228,7 @@
         "Test-Detonate URL - Crowdstrike": "Issue 30879",
         "nexpose_test": "Issue 31019",
         "CuckooTest": "Issue 25601",
-        "Cisco Umbrella Test": "Issue 24338",
-        "Rasterize Test": "Issue 31463"
+        "Cisco Umbrella Test": "Issue 24338"
     },
     "skipped_integrations": {
         


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31463

## Description
- Fixed rasterize test playbook - now scanning google instead of github
- Removed rasterize test from skipped

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
