### PR TITLE
fixing the encryption of private packs

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -775,7 +775,9 @@ class Pack(object):
         except Exception:
             logging.exception(f"Failed in zipping {self._pack_name} folder")
         finally:
-            return task_status, zip_pack_path
+            # If the pack needs to be encrypted, it is initially at a different location than this final path
+            final_path_to_zipped_pack = f"{self._pack_path}.zip"
+            return task_status, final_path_to_zipped_pack
 
     def detect_modified(self, content_repo, index_folder_path, current_commit_hash, previous_commit_hash):
         """ Detects pack modified files.


### PR DESCRIPTION
## Status 
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31741

## Description
Due to regression, the encryption of private packs was not working as expected.
This issue is now fixed.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
