### PR TITLE
Hod/proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,11 @@ references:
         echo "=== sourcing $BASH_ENV ==="
         source $BASH_ENV
         sudo mkdir -p -m 777 $CIRCLE_ARTIFACTS/
+
+        # Creating new clean logs folder
+        rm -rf $CIRCLE_ARTIFACTS/logs
         mkdir -p $CIRCLE_ARTIFACTS/logs
+
         chmod +x ./Tests/scripts/*
         chmod +x ./Tests/lastest_server_build_scripts/*
         chmod +x ./Tests/Marketplace/*
@@ -230,13 +234,8 @@ references:
         python3 ./Tests/scripts/destroy_instances.py $CIRCLE_ARTIFACTS ./env_results.json "$INSTANCE_ROLE" "$TIME_TO_LIVE"
 
         export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
-        zip -P $PSWD $CIRCLE_ARTIFACTS/ServerLogs.zip $CIRCLE_ARTIFACTS/server*.log || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
-        rm -f $CIRCLE_ARTIFACTS/server*.log
-        if [ -f $CIRCLE_ARTIFACTS/logs/Run_Tests.log ];
-        then
-            zip -P $PSWD $CIRCLE_ARTIFACTS/logs/Run_Tests.zip $CIRCLE_ARTIFACTS/logs/Run_Tests.log
-            rm -f $CIRCLE_ARTIFACTS/logs/Run_Tests.log
-        fi
+        zip -P $PSWD -j $CIRCLE_ARTIFACTS/Logs.zip $CIRCLE_ARTIFACTS/server*.log $CIRCLE_ARTIFACTS/logs/* || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
+        rm -f $CIRCLE_ARTIFACTS/server*.log $CIRCLE_ARTIFACTS/logs/Run_Tests.log $CIRCLE_ARTIFACTS/logs/Install_Content_And_Configure_Integrations_On_Server.log
       when: always
 
   persist_to_workspace: &persist_to_workspace

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -523,7 +523,9 @@ def set_integration_params(build,
             integration['validate_test'] = matched_integration_params.get('validate_test', True)
             if integration['name'] not in build.unmockable_integrations:
                 integration['params'].update({'proxy': True})
-        logging.debug(f'Configuring integration {integration["name"]}with params: {pformat(integration["params"])}')
+            else:
+                integration['params'].update({'proxy': False})
+        logging.debug(f'Configuring integration "{integration["name"]}" with params: {pformat(integration["params"])}')
 
     return True
 
@@ -1186,7 +1188,7 @@ def test_integration_with_mock(build: Build, instance: dict, pre_update: bool):
     """
     testing_client = build.servers[0].reconnect_client()
     integration_of_instance = instance.get('brand', '')
-    logging.debug(f'Integration {integration_of_instance} is mockable, running test-module with mitmproxy')
+    logging.debug(f'Integration "{integration_of_instance}" is mockable, running test-module with mitmproxy')
     has_mock_file = build.proxy.has_mock_file(integration_of_instance)
     success = False
     if has_mock_file:
@@ -1194,14 +1196,14 @@ def test_integration_with_mock(build: Build, instance: dict, pre_update: bool):
             success, _ = __test_integration_instance(testing_client, instance)
             result_holder[RESULT] = success
             if not success:
-                logging.warning(f'Running test-module for \'{integration_of_instance}\' has failed in playback mode')
+                logging.warning(f'Running test-module for "{integration_of_instance}" has failed in playback mode')
     if not success and pre_update:
-        logging.debug(f'Recording a mock file for integration {integration_of_instance}.')
+        logging.debug(f'Recording a mock file for integration "{integration_of_instance}".')
         with run_with_mock(build.proxy, integration_of_instance, record=True) as result_holder:
             success, _ = __test_integration_instance(testing_client, instance)
             result_holder[RESULT] = success
             if not success:
-                logging.debug(f'Record mode for integration {integration_of_instance} has failed.')
+                logging.debug(f'Record mode for integration "{integration_of_instance}" has failed.')
     return success
 
 

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -31,7 +31,7 @@ from Tests.test_content import extract_filtered_tests, get_server_numeric_versio
 from Tests.update_content_data import update_content
 from Tests.Marketplace.search_and_install_packs import search_and_install_packs_and_their_dependencies, \
     install_all_content_packs, upload_zipped_packs, install_all_content_packs_for_nightly
-from Tests.tools import update_server_configuration
+from Tests.tools import update_server_configuration, run_with_proxy_configured
 from demisto_sdk.commands.validate.validate_manager import ValidateManager
 
 MARKET_PLACE_MACHINES = ('master',)
@@ -170,9 +170,6 @@ class Build:
     def proxy(self):
         if not self._proxy:
             self._proxy = MITMProxy(self.servers[0].host.replace('https://', ''), logging_module=logging)
-            self._proxy.configure_proxy_in_demisto(proxy=self._proxy.ami.docker_ip + ':' + self._proxy.PROXY_PORT,
-                                                   username=self.username, password=self.password,
-                                                   server=self.servers[0].host)
         return self._proxy
 
     @staticmethod
@@ -1112,6 +1109,7 @@ def configure_modified_and_new_integrations(build: Build,
     return modified_modules_instances, new_modules_instances
 
 
+@run_with_proxy_configured
 def instance_testing(build: Build, all_module_instances, pre_update):
     update_status = 'Pre' if pre_update else 'Post'
     failed_tests = set()

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -17,6 +17,7 @@ from distutils.version import LooseVersion
 import logging
 from typing import List
 
+from Tests.mock_server import MITMProxy, run_with_mock, RESULT
 from Tests.scripts.utils.log_util import install_logging
 
 from paramiko.client import SSHClient, AutoAddPolicy
@@ -141,6 +142,7 @@ class Build:
     #  END CHANGE ON LOCAL RUN  #
 
     def __init__(self, options):
+        self._proxy = None
         self.git_sha1 = options.git_sha1
         self.branch_name = options.branch
         self.ci_build_number = options.build_number
@@ -155,6 +157,7 @@ class Build:
         conf = get_json_file(options.conf)
         self.tests = conf['tests']
         self.skipped_integrations_conf = conf['skipped_integrations']
+        self.unmockable_integrations = conf['unmockable_integrations']
         id_set_path = options.id_set_path if options.id_set_path else ID_SET_PATH
         self.id_set = get_id_set(id_set_path)
         self.test_pack_path = options.test_pack_path if options.test_pack_path else None
@@ -162,6 +165,15 @@ class Build:
         self.content_root = options.content_root
         self.pack_ids_to_install = self.fetch_pack_ids_to_install(options.pack_ids_to_install)
         self.service_account = options.service_account
+
+    @property
+    def proxy(self):
+        if not self._proxy:
+            self._proxy = MITMProxy(self.servers[0].host.replace('https://', ''), logging_module=logging)
+            self._proxy.configure_proxy_in_demisto(proxy=self._proxy.ami.docker_ip + ':' + self._proxy.PROXY_PORT,
+                                                   username=self.username, password=self.password,
+                                                   server=self.servers[0].host)
+        return self._proxy
 
     @staticmethod
     def fetch_tests_list(tests_to_run_path: str):
@@ -1110,13 +1122,24 @@ def instance_testing(build: Build, all_module_instances, pre_update):
         logging.info(f'Start of Instance Testing ("Test" button) ({update_status}-update)')
     else:
         logging.info(f'No integrations to configure for the chosen tests. ({update_status}-update)')
-
     for instance in all_module_instances:
         integration_of_instance = instance.get('brand', '')
         instance_name = instance.get('name', '')
         testing_client = build.servers[0].reconnect_client()
         # If there is a failure, __test_integration_instance will print it
-        success, _ = __test_integration_instance(testing_client, instance)
+        if integration_of_instance not in build.unmockable_integrations:
+            has_mock_file = build.proxy.has_mock_file(integration_of_instance)
+            success = False
+            if has_mock_file:
+                with run_with_mock(build.proxy, integration_of_instance) as result_holder:
+                    success, _ = __test_integration_instance(testing_client, instance)
+                    result_holder[RESULT] = success
+            if not success:
+                with run_with_mock(build.proxy, integration_of_instance, record=True) as result_holder:
+                    success, _ = __test_integration_instance(testing_client, instance)
+                    result_holder[RESULT] = success
+        else:
+            success, _ = __test_integration_instance(testing_client, instance)
         if not success:
             failed_tests.add((instance_name, integration_of_instance))
         else:
@@ -1332,6 +1355,7 @@ def main():
     build = Build(options_handler())
 
     configure_servers_and_restart(build)
+    disable_instances(build)
     installed_content_packs_successfully = install_packs_pre_update(build)
 
     new_integrations, modified_integrations = get_changed_integrations(build)
@@ -1345,7 +1369,6 @@ def main():
     successful_tests_post, failed_tests_post = test_integrations_post_update(build,
                                                                              new_module_instances,
                                                                              modified_module_instances)
-    disable_instances(build)
 
     success = report_tests_status(failed_tests_pre, failed_tests_post, successful_tests_pre, successful_tests_post,
                                   new_integrations)

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1125,14 +1125,18 @@ def configure_modified_and_new_integrations(build: Build,
     return modified_modules_instances, new_modules_instances
 
 
-@run_with_proxy_configured
-def instance_testing(build: Build, all_module_instances: list, pre_update: bool) -> Tuple[set, set]:
+def instance_testing(build: Build,
+                     all_module_instances: list,
+                     pre_update: bool,
+                     use_mock: bool = True) -> Tuple[set, set]:
     """
     Runs 'test-module' command for the instances detailed in `all_module_instances`
     Args:
         build: An object containing the current build info.
         all_module_instances: The integration instances that should be tested
         pre_update: Whether this instance testing is before or after the content update on the server.
+        use_mock: Whether to use mock while testing mockable integrations. Should be used mainly with
+        private content build which aren't using the mocks.
 
     Returns:
         A set of the successful tests containing the instance name and the integration name
@@ -1152,7 +1156,7 @@ def instance_testing(build: Build, all_module_instances: list, pre_update: bool)
         instance_name = instance.get('name', '')
         testing_client = build.servers[0].reconnect_client()
         # If there is a failure, __test_integration_instance will print it
-        if integration_of_instance not in build.unmockable_integrations:
+        if integration_of_instance not in build.unmockable_integrations and use_mock:
             logging.debug(f'Integration {integration_of_instance} is mockable, running test-module with mitmproxy')
             has_mock_file = build.proxy.has_mock_file(integration_of_instance)
             success = False
@@ -1292,6 +1296,7 @@ def set_marketplace_url(servers, branch_name, ci_build_number):
     sleep(60)
 
 
+@run_with_proxy_configured
 def test_integrations_post_update(build: Build, new_module_instances: list, modified_module_instances: list) -> tuple:
     """
     Runs 'test-module on all integrations for post-update check
@@ -1330,6 +1335,7 @@ def update_content_on_servers(build: Build) -> bool:
     return installed_content_packs_successfully
 
 
+@run_with_proxy_configured
 def configure_and_test_integrations_pre_update(build: Build, new_integrations, modified_integrations) -> tuple:
     """
     Configures integration instances that exist in the current version and for each integration runs 'test-module'.

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -15,7 +15,7 @@ from time import sleep
 from threading import Thread
 from distutils.version import LooseVersion
 import logging
-from typing import List
+from typing import List, Tuple
 
 from Tests.mock_server import MITMProxy, run_with_mock, RESULT
 from Tests.scripts.utils.log_util import install_logging
@@ -167,7 +167,12 @@ class Build:
         self.service_account = options.service_account
 
     @property
-    def proxy(self):
+    def proxy(self) -> MITMProxy:
+        """
+        A property method that should create and return a single proxy instance through out the build
+        Returns:
+            The single proxy instance that should be used in this build.
+        """
         if not self._proxy:
             self._proxy = MITMProxy(self.servers[0].host.replace('https://', ''), logging_module=logging)
         return self._proxy
@@ -1110,7 +1115,18 @@ def configure_modified_and_new_integrations(build: Build,
 
 
 @run_with_proxy_configured
-def instance_testing(build: Build, all_module_instances, pre_update):
+def instance_testing(build: Build, all_module_instances: list, pre_update: bool) -> Tuple[set, set]:
+    """
+    Runs 'test-module' command for the instances detailed in `all_module_instances`
+    Args:
+        build: An object containing the current build info.
+        all_module_instances: The integration instances that should be tested
+        pre_update: Whether this instance testing is before or after the content update on the server.
+
+    Returns:
+        A set of the successful tests containing the instance name and the integration name
+        A set of the failed tests containing the instance name and the integration name
+    """
     update_status = 'Pre' if pre_update else 'Post'
     failed_tests = set()
     successful_tests = set()

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -417,10 +417,10 @@ class MITMProxy:
 
     def get_mitmdump_service_status(self) -> None:
         """
-        Safely extract the current mitmdump status and logs it
+        Safely extract the current mitmdump status and last 50 log lines
         """
         try:
-            output = self.ami.check_output('systemctl status mitmdump'.split(), stderr=STDOUT)
+            output = self.ami.check_output('systemctl status mitmdump -n 50 -l'.split(), stderr=STDOUT)
             self.logging_module.debug(f'mitmdump service status output:\n{output.decode()}')
         except CalledProcessError as exc:
             self.logging_module.debug(f'mitmdump service status output:\n{exc.output.decode()}')

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -82,7 +82,6 @@ class AMIConnection:
     REMOTE_MACHINE_USER = 'ec2-user'
     REMOTE_HOME = f'/home/{REMOTE_MACHINE_USER}/'
     LOCAL_SCRIPTS_DIR = '/home/circleci/project/Tests/scripts/'
-    CLONE_MOCKS_SCRIPT = 'clone_mocks.sh'
 
     def __init__(self, public_ip):
         self.public_ip = public_ip
@@ -147,9 +146,6 @@ class AMIConnection:
 
         silence_output(self.check_call, ['chmod', '+x', remote_script_path], stdout='null')
         silence_output(self.check_call, [remote_script_path] + list(args), stdout='null')
-
-    def clone_mock_data(self):
-        self.run_script(self.CLONE_MOCKS_SCRIPT)
 
 
 class MITMProxy:
@@ -383,7 +379,7 @@ class MITMProxy:
             self.logging_module.debug('"problematic_keys.json" dictionary values were empty - '
                                       'no data to whitewash from the mock file.')
 
-    def start(self, playbook_or_integration_id, path=None, record=False):
+    def start(self, playbook_or_integration_id, path=None, record=False) -> None:
         """Start the proxy process and direct traffic through it.
 
         Args:

--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -462,7 +462,8 @@ class MITMProxy:
             try:
                 silence_output(self.ami.call,
                                ['mv', repo_problem_keys_path, current_problem_keys_path],
-                               stdout='null')
+                               stdout='null',
+                               stderr='null')
             except CalledProcessError as e:
                 self.logging_module.debug(f'Failed to move problematic_keys.json with exit code {e.returncode}')
 

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -132,7 +132,6 @@ def main():
     #  Adding the new integrations to the instance test list and testing them.
     all_module_instances.extend(brand_new_integrations)
     successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
-    #  Done running tests so we are disabling the instances.
     #  Gather tests to add to test pack
     test_playbooks_from_id_set = build.id_set.get('TestPlaybooks', [])
     tests_to_add_to_test_pack = find_needed_test_playbook_paths(test_playbooks=test_playbooks_from_id_set,

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -115,6 +115,8 @@ def main():
     build = Build(options_handler())
 
     configure_servers_and_restart(build)
+
+    disable_instances(build)
     #  Get a list of the test we need to run.
     tests_for_iteration = get_tests(build)
     #  Installing the packs.
@@ -131,7 +133,6 @@ def main():
     all_module_instances.extend(brand_new_integrations)
     successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
     #  Done running tests so we are disabling the instances.
-    disable_instances(build)
     #  Gather tests to add to test pack
     test_playbooks_from_id_set = build.id_set.get('TestPlaybooks', [])
     tests_to_add_to_test_pack = find_needed_test_playbook_paths(test_playbooks=test_playbooks_from_id_set,

--- a/Tests/private_build/configure_and_test_integration_instances_private.py
+++ b/Tests/private_build/configure_and_test_integration_instances_private.py
@@ -8,7 +8,7 @@ from ruamel import yaml
 from typing import List
 import logging
 
-from Tests.scripts.utils.log_util import install_simple_logging
+from Tests.scripts.utils.log_util import install_logging
 from demisto_sdk.commands.common.tools import find_type
 from Tests.configure_and_test_integration_instances import Build, configure_servers_and_restart, \
     get_tests, \
@@ -111,7 +111,7 @@ def write_test_pack_zip(tests_file_paths: set, path_to_content: str,
 
 
 def main():
-    install_simple_logging()
+    install_logging('Install Content And Configure Integrations On Server.log')
     build = Build(options_handler())
 
     configure_servers_and_restart(build)
@@ -128,10 +128,16 @@ def main():
         configure_server_instances(build, tests_for_iteration, new_integrations, modified_integrations)
 
     #  Running the instance tests (pushing the test button)
-    successful_tests_pre, failed_tests_pre = instance_testing(build, all_module_instances, pre_update=True)
+    successful_tests_pre, failed_tests_pre = instance_testing(build,
+                                                              all_module_instances,
+                                                              pre_update=True,
+                                                              use_mock=False)
     #  Adding the new integrations to the instance test list and testing them.
     all_module_instances.extend(brand_new_integrations)
-    successful_tests_post, failed_tests_post = instance_testing(build, all_module_instances, pre_update=False)
+    successful_tests_post, failed_tests_post = instance_testing(build,
+                                                                all_module_instances,
+                                                                pre_update=False,
+                                                                use_mock=False)
     #  Gather tests to add to test pack
     test_playbooks_from_id_set = build.id_set.get('TestPlaybooks', [])
     tests_to_add_to_test_pack = find_needed_test_playbook_paths(test_playbooks=test_playbooks_from_id_set,

--- a/Tests/scripts/clone_mocks.sh
+++ b/Tests/scripts/clone_mocks.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-if [[ ! -d "content-test-data" ]]; then
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
-    git clone git@github.com:demisto/content-test-data.git
-  else
-    cd content-test-data && git reset --hard && git pull -r
-fi

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -37,7 +37,7 @@ try:
 except ModuleNotFoundError:
     from slackclient import SlackClient  # Old slack
 
-from Tests.mock_server import MITMProxy, AMIConnection, run_with_mock, RESULT
+from Tests.mock_server import MITMProxy, run_with_mock, RESULT
 from Tests.test_integration import Docker, check_integration
 from Tests.test_dependencies import get_used_integrations, get_tests_allocation_for_threads
 from demisto_sdk.commands.common.constants import FILTER_CONF, PB_Status
@@ -788,7 +788,6 @@ def execute_testing(tests_settings,
 
     proxy = None
     if is_ami:
-        ami = AMIConnection(server_ip)
         proxy = MITMProxy(server_ip, logging_manager, build_number=build_number, branch_name=build_name)
 
     failed_playbooks = []

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -789,7 +789,6 @@ def execute_testing(tests_settings,
     proxy = None
     if is_ami:
         ami = AMIConnection(server_ip)
-        ami.clone_mock_data()
         proxy = MITMProxy(server_ip, logging_manager, build_number=build_number, branch_name=build_name)
 
     failed_playbooks = []

--- a/Tests/tools.py
+++ b/Tests/tools.py
@@ -73,11 +73,11 @@ def run_with_proxy_configured(function: Callable) -> Callable:
         function: Should be the instance_testing method.
     """
     @wraps(function)
-    def decorated(build, all_module_instances, pre_update):
+    def decorated(build, *args, **kwargs):
         build.proxy.configure_proxy_in_demisto(proxy=build.proxy.ami.docker_ip + ':' + build.proxy.PROXY_PORT,
                                                username=build.username, password=build.password,
                                                server=build.servers[0].host)
-        result = function(build, all_module_instances, pre_update)
+        result = function(build, *args, **kwargs)
         build.proxy.configure_proxy_in_demisto(proxy='',
                                                username=build.username, password=build.password,
                                                server=build.servers[0].host)

--- a/Tests/tools.py
+++ b/Tests/tools.py
@@ -2,6 +2,7 @@ import ast
 import logging
 from pprint import pformat
 from functools import wraps
+from typing import Callable
 
 import demisto_client
 
@@ -64,7 +65,13 @@ def update_server_configuration(client, server_configuration, error_msg, logging
     return response_data, status_code
 
 
-def run_with_proxy_configured(function):
+def run_with_proxy_configured(function: Callable) -> Callable:
+    """
+    This is a decorator for the 'instance_testing method`.
+    This decorator configures the proxy in the server before the instance_testing execution and removes it afterwards.
+    Args:
+        function: Should be the instance_testing method.
+    """
     @wraps(function)
     def decorated(build, all_module_instances, pre_update):
         build.proxy.configure_proxy_in_demisto(proxy=build.proxy.ami.docker_ip + ':' + build.proxy.PROXY_PORT,


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31693

## Description
This PR is about supporting running the proxy around the test-module on the content installation step.

This PR implements the following changes:
*  As result [this](https://github.com/demisto/content-test-conf/pull/1068) PR - there is no need to clone or pull from the content-test-data repo during the test execution since this will be done in the instance's creation to validate the content-test-data repo in the instances is updated for content installation.
* implemented a decorator that will wrap the **instance_testing** method. This decorator will configure proxy in the server before the instance testing and remove the proxy configuration after it.
* Running proxy with playback mode if a mock file exists for the integration, and if there is no mock file or the playback fails - will run the proxy in record mode.

## TBD:
- [x] Add proxy configuration for mockable integration
- [x] Add documentation
- [x] Run nightly with those changes - https://app.circleci.com/pipelines/github/demisto/content/53393/workflows/37f02cc8-3c64-49ec-8324-cc4afff9d1b2
- [x] Run private content build with those changes - https://github.com/demisto/content-private/runs/1575050599?check_suite_focus=true