### PR TITLE
Improved nightly packs installation error handling

### DIFF
--- a/Tests/Marketplace/Tests/search_and_install_packs_test.py
+++ b/Tests/Marketplace/Tests/search_and_install_packs_test.py
@@ -242,11 +242,9 @@ def test_not_find_malformed_pack_id():
     When
     - Run find_malformed_pack_id command.
     Then
-    - Ensure Exception is returned with the error message.
+    - Ensure an empty list is returned.
     """
-    with pytest.raises(Exception, match='The request to install packs has failed. '
-                                        'Reason: This is an error message without pack ID'):
-        script.find_malformed_pack_id('This is an error message without pack ID')
+    assert script.find_malformed_pack_id('This is an error message without pack ID') == []
 
 
 @timeout_decorator.timeout(3)

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -390,11 +390,12 @@ def get_latest_version_from_bucket(pack_id: str, production_bucket: Bucket) -> s
 
     """
     pack_bucket_path = os.path.join(GCPConfig.STORAGE_BASE_PATH, pack_id)
-    # Adding the '/' in the end of the prefix to search for the exact pack id
     logging.debug(f'Trying to get latest version for pack {pack_id} from bucket path {pack_bucket_path}')
+    # Adding the '/' in the end of the prefix to search for the exact pack id
     pack_versions_paths = [f.name for f in production_bucket.list_blobs(prefix=f'{pack_bucket_path}/') if
                            f.name.endswith('.zip')]
     pack_versions = [LooseVersion(PACK_PATH_VERSION_REGEX.findall(path)[0]) for path in pack_versions_paths]
+    logging.debug(f'Found the following zips for {pack_id} pack: {pack_versions}')
     if pack_versions:
         pack_latest_version = max(pack_versions).vstring
         return pack_latest_version


### PR DESCRIPTION
* In case all packs installation fails - log and raise the original error instead of raising a new one in `find_malformed_pack_id` method.
* Before running max on server versions returned from bucket - validate there are versions to avoid unclear exception and continue installing packs without that pack
* Added some logs

## Screenshots of current errors:
![image](https://user-images.githubusercontent.com/41257953/102449177-64e6e100-403c-11eb-8526-d174ec49c7e5.png)
![image](https://user-images.githubusercontent.com/41257953/102449219-75975700-403c-11eb-8d6e-8151696dd234.png)
