### PR TITLE
Moving premium packs validation to after the upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -939,15 +939,6 @@ jobs:
             fi
             ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
       - run:
-          name: Validate Premium Packs
-          shell: /bin/bash
-          when: always
-          command: |
-            if [ -n "${NIGHTLY}" ] ;
-              then
-                  ./Tests/scripts/validate_premium_packs.sh "$INSTANCE_ROLE"
-            fi
-      - run:
           name: Run Tests - Demisto Master
           shell: /bin/bash
           when: always
@@ -1034,6 +1025,12 @@ jobs:
 
                   python3 ./Tests/Marketplace/copy_and_upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -pb "$GCS_MARKET_BUCKET" -bb "$GCS_BUILD_BUCKET" -s $GCS_PATH -n $CREATE_INSTANCES_JOB_NUMBER -c $CIRCLE_BRANCH
                   rm $GCS_PATH
+            - run:
+                name: Validate Premium Packs
+                shell: /bin/bash
+                when: always
+                command: |
+                  ./Tests/scripts/validate_premium_packs.sh "$INSTANCE_ROLE"
       - run:
           name: Slack Notifier
           shell: /bin/bash


### PR DESCRIPTION

## Related Issues
https://github.com/demisto/content/pull/9992

## Description
Bucket validations should be executed right after uploading to the bucket

