### PR TITLE
Removing package-lock.json from being part of cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ references:
 
   restore_cache: &restore_cache
     restore_cache:
-      key: virtualenv-venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
+      key: virtualenv-venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}
 
   destroy_instances: &destroy_instances
     run:
@@ -502,7 +502,7 @@ jobs:
           paths:
             - venv
             - node_modules
-          key: virtualenv-venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}-{{ checksum "package-lock.json" }}
+          key: virtualenv-venv-{{ checksum "dev-requirements-py2.txt" }}-{{ checksum "dev-requirements-py3.txt" }}-{{ checksum ".circleci/build-requirements.txt" }}
       - *get_contribution_pack
       - *add_ssh_keys
       - *persist_to_workspace


### PR DESCRIPTION
It seems like running `npm install .` changes the package-lock.json which makes the checksum of the file before running the `prepare Environment step be different from after.

That's making the CircleCi cache mechanism miss the cache key every time because it tries to restore different key then what it saves.

fixes: https://github.com/demisto/etc/issues/31882