### PR TITLE
don't clone mock during the build

### DIFF
--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -82,7 +82,6 @@ class AMIConnection:
     REMOTE_MACHINE_USER = 'ec2-user'
     REMOTE_HOME = f'/home/{REMOTE_MACHINE_USER}/'
     LOCAL_SCRIPTS_DIR = '/home/circleci/project/Tests/scripts/'
-    CLONE_MOCKS_SCRIPT = 'clone_mocks.sh'
     UPLOAD_MOCKS_SCRIPT = 'upload_mocks.sh'
 
     def __init__(self, public_ip):
@@ -151,9 +150,6 @@ class AMIConnection:
 
     def upload_mock_files(self, build_name, build_number):
         self.run_script(self.UPLOAD_MOCKS_SCRIPT, build_name, build_number)
-
-    def clone_mock_data(self):
-        self.run_script(self.CLONE_MOCKS_SCRIPT)
 
 
 class MITMProxy:

--- a/Tests/scripts/clone_mocks.sh
+++ b/Tests/scripts/clone_mocks.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-if [[ ! -d "content-test-data" ]]; then
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
-    git clone git@github.com:demisto/content-test-data.git
-  else
-    cd content-test-data && git reset --hard && git pull -r
-fi

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -789,7 +789,6 @@ def execute_testing(tests_settings,
     proxy = None
     if is_ami:
         ami = AMIConnection(server_ip)
-        ami.clone_mock_data()
         proxy = MITMProxy(server_ip, logging_manager)
 
     failed_playbooks = []


### PR DESCRIPTION
No need to clone mock during the build since it is done in the server initialization.