### PR TITLE
Unmocking Qradar integrations

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3271,7 +3271,7 @@
         "Carbon Black Enterprise Protection V2 Test": "Issue 27846"
     },
     "skipped_integrations": {
-        
+
         "_comment1": "~~~ NO INSTANCE ~~~",
         "Forcepoint": "instance issues. Issue 28043",
         "ZeroFox": "Issue 29284",
@@ -3356,11 +3356,11 @@
         "SNDBOX": "Issue 28826",
         "Workday": "License expired Issue: 29595",
         "FireEyeFeed": "License expired Issue: 31838",
-        
+
         "_comment2": "~~~ UNSTABLE ~~~",
         "Tenable.sc": "unstable instance",
         "ThreatConnect v2": "unstable instance",
-        
+
         "_comment3": "~~~ QUOTA ISSUES ~~~",
         "Joe Security": "Issue 25650",
         "XFE_v2": "Required proper instance, otherwise we get quota errors",
@@ -3368,7 +3368,7 @@
         "Google Resource Manager": "Cannot create projects because have reached allowed quota.",
         "Looker": "Warehouse 'DEMO_WH' cannot be resumed because resource monitor 'LIMITER' has exceeded its quota.",
         "Ipstack": "Issue 26266",
-        
+
         "_comment4": "~~~ OTHER ~~~",
         "XFE": "We have the new integration XFE_v2, so no need to test the old one because they use the same quote",
         "Endace": "Issue 24304",
@@ -3393,6 +3393,7 @@
         "VulnDB"
     ],
     "unmockable_integrations": {
+        "QRadar_v2": "Test playbook 'test playbook - QRadarCorrelations' has multiple branches",
         "CloudConvert": "has a command that uploads a file (!cloudconvert-upload)",
         "EWS v2": "Fetches bytes data (!ews-get-items-from-folder)",
         "jira-v2": "has a command that uploads a file ( !jira-issue-upload-file)",
@@ -3557,7 +3558,7 @@
         "Mail Listener v2"
     ],
     "docker_thresholds": {
-        
+
         "_comment": "Add here docker images which are specific to an integration and require a non-default threshold (such as rasterize or ews). That way there is no need to define this multiple times. You can specify full image name with version or without.",
         "images": {
             "demisto/chromium": {


### PR DESCRIPTION
The correlation playbook cannot be run under mock for multiple branches.
![QRadar_-_Get_offense_correlations_v2_Mon_Dec_21_2020](https://user-images.githubusercontent.com/41257953/102745536-e30cf580-4364-11eb-98ce-40abae3e3d77.png)
