### PR TITLE
FireEye HX - handle alert parse with event_values as list

### DIFF
--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -2390,7 +2390,7 @@ def parse_alert_to_incident(alert):
 
     indicator = ''
     if isinstance(event_values, dict):
-        indicator = event_values.get(event_indicator)
+        indicator = event_values.get(event_indicator, '')
 
     incident_name = '{event_type_parsed}: {indicator}'.format(
         event_type_parsed=re.sub("([a-z])([A-Z])", "\g<1> \g<2>", event_type).title(),

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -2373,6 +2373,7 @@ def fetch_incidents():
         demisto.setLastRun({'min_id': min_id})
 
 
+@logger
 def parse_alert_to_incident(alert):
 
     event_type = alert.get('event_type')

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -37,6 +37,7 @@ def set_proxies():
 GLOBAL VARS
 
 """
+TOKEN = ''
 SERVER_URL = demisto.params()['server']
 USERNAME = demisto.params()['credentials']['identifier']
 PASSWORD = demisto.params()['credentials']['password']
@@ -2586,58 +2587,64 @@ EXECUTION
 """
 
 
-set_proxies()
+def main():
+    global TOKEN
+    set_proxies()
 
-command = demisto.command()
-LOG('Running command "{}"'.format(command))
+    command = demisto.command()
+    LOG('Running command "{}"'.format(command))
 
-# ask for a token using user credentials
-TOKEN = get_token()
+    # ask for a token using user credentials
+    TOKEN = get_token()
 
-try:
-    if command == 'test-module':
-        # token generated - credentials are valid
-        demisto.results('ok')
-    elif command == 'fetch-incidents':
-        fetch_incidents()
-    elif command == 'fireeye-hx-get-alerts':
-        get_alerts()
-    elif command == 'fireeye-hx-cancel-containment':
-        containment_cancellation()
-    elif command == 'fireeye-hx-host-containment':
-        containment()
-    elif command == 'fireeye-hx-create-indicator':
-        create_indicator()
-    elif command == 'fireeye-hx-get-indicator':
-        get_indicator()
-        get_indicator_conditions()
-    elif command == 'fireeye-hx-get-indicators':
-        get_indicators()
-    elif command == 'fireeye-hx-suppress-alert':
-        suppress_alert()
-    elif command == 'fireeye-hx-get-host-information':
-        get_host_information()
-    elif command == 'fireeye-hx-get-alert':
-        get_alert()
-    elif command == 'fireeye-hx-file-acquisition':
-        file_acquisition()
-    elif command == 'fireeye-hx-delete-file-acquisition':
-        delete_file_acquisition()
-    elif command == 'fireeye-hx-data-acquisition':
-        data_acquisition()
-    elif command == 'fireeye-hx-delete-data-acquisition':
-        delete_data_acquisition()
-    elif command == 'fireeye-hx-search':
-        start_search()
-    elif command == 'fireeye-hx-get-host-set-information':
-        get_host_set_information()
-    elif command == 'fireeye-hx-append-conditions':
-        append_conditions()
-    elif command == 'fireeye-hx-get-all-hosts-information':
-        get_hosts_information()
-except ValueError as e:
-    LOG(e)
-    LOG.print_log()
-    return_error(e)
-finally:
-    logout()
+    try:
+        if command == 'test-module':
+            # token generated - credentials are valid
+            demisto.results('ok')
+        elif command == 'fetch-incidents':
+            fetch_incidents()
+        elif command == 'fireeye-hx-get-alerts':
+            get_alerts()
+        elif command == 'fireeye-hx-cancel-containment':
+            containment_cancellation()
+        elif command == 'fireeye-hx-host-containment':
+            containment()
+        elif command == 'fireeye-hx-create-indicator':
+            create_indicator()
+        elif command == 'fireeye-hx-get-indicator':
+            get_indicator()
+            get_indicator_conditions()
+        elif command == 'fireeye-hx-get-indicators':
+            get_indicators()
+        elif command == 'fireeye-hx-suppress-alert':
+            suppress_alert()
+        elif command == 'fireeye-hx-get-host-information':
+            get_host_information()
+        elif command == 'fireeye-hx-get-alert':
+            get_alert()
+        elif command == 'fireeye-hx-file-acquisition':
+            file_acquisition()
+        elif command == 'fireeye-hx-delete-file-acquisition':
+            delete_file_acquisition()
+        elif command == 'fireeye-hx-data-acquisition':
+            data_acquisition()
+        elif command == 'fireeye-hx-delete-data-acquisition':
+            delete_data_acquisition()
+        elif command == 'fireeye-hx-search':
+            start_search()
+        elif command == 'fireeye-hx-get-host-set-information':
+            get_host_set_information()
+        elif command == 'fireeye-hx-append-conditions':
+            append_conditions()
+        elif command == 'fireeye-hx-get-all-hosts-information':
+            get_hosts_information()
+    except ValueError as e:
+        LOG(e)
+        LOG.print_log()
+        return_error(e)
+    finally:
+        logout()
+
+
+if __name__ in ('__main__', '__builtin__', 'builtins'):
+    main()

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -2387,9 +2387,13 @@ def parse_alert_to_incident(alert):
     event_indicator = event_indicators_map.get(event_type)
     event_indicator = 'No Indicator' if not event_indicator else event_indicator
 
+    indicator = ''
+    if isinstance(event_values, dict):
+        indicator = event_values.get(event_indicator)
+
     incident_name = '{event_type_parsed}: {indicator}'.format(
         event_type_parsed=re.sub("([a-z])([A-Z])", "\g<1> \g<2>", event_type).title(),
-        indicator=event_values.get(event_indicator)
+        indicator=indicator
     )
 
     incident = {

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -2643,8 +2643,6 @@ def main():
         elif command == 'fireeye-hx-get-all-hosts-information':
             get_hosts_information()
     except ValueError as e:
-        LOG(e)
-        LOG.print_log()
         return_error(e)
     finally:
         logout()

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX_test.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX_test.py
@@ -1,0 +1,30 @@
+import demistomock as demisto
+
+
+def test_parse_alert_to_incident(mocker):
+    """
+    Given:
+        - Alert with event_values as list
+
+    When:
+        - Parsing the alert
+
+    Then:
+        - Ensure parsing does not fail
+        - Verify parsed alert returned as expected
+    """
+    mocker.patch.object(
+        demisto,
+        'params',
+        return_value={
+            'server': 'server',
+            'credentials': {
+                'identifier': 'identifier',
+                'password': 'password'
+            },
+            'insecure': False,
+            'version': 'v3'
+        }
+    )
+    from FireEyeHX import parse_alert_to_incident
+    assert parse_alert_to_incident({'event_values': []}) == {'name': 'New Event: ', 'rawJSON': '{"event_values": []}'}

--- a/Packs/FireEyeHX/ReleaseNotes/1_0_8.md
+++ b/Packs/FireEyeHX/ReleaseNotes/1_0_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### FireEye HX
+- Improved alert parsing as part of the fetch incidents flow.

--- a/Packs/FireEyeHX/pack_metadata.json
+++ b/Packs/FireEyeHX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye HX",
     "description": "FireEye Endpoint Security is an integrated solution that detects what others miss and protects endpoint against known and unknown threats. The HX Demisto integration provides access to information about endpoints, acquisitions, alerts, indicators, and containment. Customers can extract critical data and effectively operate security operations automated playbook",
     "support": "xsoar",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3267,7 +3267,6 @@
         "Cisco Umbrella Test": "Issue 24338",
         "PhishlabsIOC_DRP-Test": "Issue 29589",
         "Akamai_WAF-Test": "Issue 31900",
-        "FireEye HX Test": "Issue 24935",
         "Carbon Black Enterprise Protection V2 Test": "Issue 27846"
     },
     "skipped_integrations": {


### PR DESCRIPTION
## Status
- [x] Ready

fixes https://github.com/demisto/etc/issues/31972
fixes https://github.com/demisto/etc/issues/24935

## Description
handle the case where `event_values ` property in the alert object is a list


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

see failing test at https://app.circleci.com/pipelines/github/demisto/content/54054/workflows/cd44cfae-b6da-46a6-8d9d-62343b05b480/jobs/227246
