### PR TITLE
Add a playback run after record

### DIFF
--- a/Tests/mock_server.py
+++ b/Tests/mock_server.py
@@ -177,13 +177,14 @@ class MITMProxy:
                  repo_folder=MOCKS_GIT_PATH,
                  tmp_folder=MOCKS_TMP_PATH,
                  ):
+        is_branch_master = branch_name == 'master'
         self.public_ip = public_ip
         self.current_folder = self.repo_folder = repo_folder
         self.tmp_folder = tmp_folder
         self.logging_module = logging_module
         self.build_number = build_number
         self.ami = AMIConnection(self.public_ip)
-        self.should_update_mock_repo = branch_name == 'master'
+        self.should_update_mock_repo = is_branch_master
         self.empty_files = []
         self.failed_tests_count = 0
         self.successful_tests_count = 0


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31887

## Description
After a successful record - run another playback run on this new 

## Screenshots:
### Successful playback logs:
![image](https://user-images.githubusercontent.com/41257953/102790479-293a7700-43ae-11eb-8c25-dcc19056a5b5.png)

### Failed playback logs:
![image](https://user-images.githubusercontent.com/41257953/102794645-5722ba00-43b4-11eb-91b2-b0d30fb8c2af.png)


## TODO
- [ ] Add a confluence page about how to solve failure cases and add it's link to the warning log
