### PR TITLE
Added pid_threshold to phishing tests in conf.json

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2059,7 +2059,8 @@
                 "Demisto REST API",
                 "Rasterize"
             ],
-            "memory_threshold": 115
+            "memory_threshold": 115,
+            "pid_threshold": 5
         },
         {
             "playbookID": "Phishing - Core - Test - Incident Starter",
@@ -2071,7 +2072,8 @@
                 "Demisto REST API",
                 "Rasterize"
             ],
-            "memory_threshold": 100
+            "memory_threshold": 100,
+            "pid_threshold": 5
         },
         {
             "integrations": "duo",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26784
fixes: https://github.com/demisto/etc/issues/26783

## Description
Added `pid_threshold` to try and prevent phishing tests from randomly failing with the error that the integration instances are disabled, following ItayK's suggestion https://panw-global.slack.com/archives/G011E63JXPB/p1606639527468400


