### PR TITLE
CrowdStrike Falcon - call http_request args positional in case of 403

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -30,8 +30,8 @@ FETCH_TIME = demisto.params().get('fetch_time', '3 days')
 BYTE_CREDS = '{name}:{password}'.format(name=CLIENT_ID, password=SECRET).encode('utf-8')
 # Headers to be sent in requests
 HEADERS = {
-    'Content-Type': 'application/json',
-    'Accept': 'application/json',
+    # 'Content-Type': 'application/json',
+    # 'Accept': 'application/json',
     'Authorization': 'Basic {}'.format(base64.b64encode(BYTE_CREDS).decode())
 }
 # Note: True life time of token is actually 30 mins
@@ -216,7 +216,15 @@ def http_request(method, url_suffix, params=None, data=None, files=None, headers
                 LOG(err_msg)
                 token = get_token(new_token=True)
                 headers['Authorization'] = 'Bearer {}'.format(token)
-                return http_request(method, url_suffix, params, data, headers, safe, get_token_flag=False)
+                return http_request(
+                    method=method,
+                    url_suffix=url_suffix,
+                    params=params,
+                    data=data,
+                    headers=headers,
+                    safe=safe,
+                    get_token_flag=False
+                )
             elif safe:
                 return None
             return_error(err_msg)

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -30,8 +30,8 @@ FETCH_TIME = demisto.params().get('fetch_time', '3 days')
 BYTE_CREDS = '{name}:{password}'.format(name=CLIENT_ID, password=SECRET).encode('utf-8')
 # Headers to be sent in requests
 HEADERS = {
-    # 'Content-Type': 'application/json',
-    # 'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
     'Authorization': 'Basic {}'.format(base64.b64encode(BYTE_CREDS).decode())
 }
 # Note: True life time of token is actually 30 mins

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -2061,7 +2061,7 @@ script:
     - contextPath: CrowdStrike.Incidents.fine_score
       description: The incident score.
       type: Number
-  dockerimage: demisto/python3:3.8.6.13358
+  dockerimage: demisto/python3:3.8.6.14516
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_11.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_11.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### CrowdStrike Falcon
-- Fixed an issue where unsupported media type was sent.
+- Fixed an issue where an unsupported media type was sent.
 - Upgraded the Docker image to demisto/python3:3.8.6.14516.

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_11.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_11.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### CrowdStrike Falcon
+- Fixed an issue where unsupported media type was sent.
+- Upgraded the Docker image to demisto/python3:3.8.6.14516.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.2.10",
+    "currentVersion": "1.2.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/32072

## Description
in case of 403, `http_request` was called again with `headers` passed to `files` which led to `415 - Unsupported Media Type`

## Does it break backward compatibility?
   - [x] No
