### PR TITLE
FireEye HX Test - use uri_name in append indicators only for custom category indicators

### DIFF
--- a/Packs/FireEyeHX/TestPlaybooks/playbook-FireEyeHX_Test.yml
+++ b/Packs/FireEyeHX/TestPlaybooks/playbook-FireEyeHX_Test.yml
@@ -439,11 +439,11 @@ tasks:
       - "13"
     scriptarguments:
       category:
-        simple: ${FireEyeHX.Indicators.[0].category.name}
+        simple: ${FireEyeHX.Indicators.[0].category.uri_name}
       condition:
         simple: example.abc,example.lol
       name:
-        simple: ${FireEyeHX.Indicators.[0].name}
+        simple: ${FireEyeHX.Indicators.[0].uri_name}
     separatecontext: false
     view: |-
       {
@@ -503,7 +503,8 @@ tasks:
       - "15"
     scriptarguments:
       alerted: {}
-      category: {}
+      category:
+        simple: Custom
       createdBy: {}
       limit: {}
       searchTerm: {}


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24935
