### PR TITLE
Fixed [Test-Failure] Test-Detonate URL - Crowdstrike

### DIFF
--- a/Packs/CrowdStrikeFalconSandbox/.secrets-ignore
+++ b/Packs/CrowdStrikeFalconSandbox/.secrets-ignore
@@ -1,0 +1,1 @@
+https://www.google.co.il

--- a/Packs/CrowdStrikeFalconSandbox/TestPlaybooks/playbook-Detonate_URL_-_Crowdstrike_Test.yml
+++ b/Packs/CrowdStrikeFalconSandbox/TestPlaybooks/playbook-Detonate_URL_-_Crowdstrike_Test.yml
@@ -84,7 +84,7 @@ tasks:
       key:
         simple: URL.Data
       value:
-        simple: https://www.google.com
+        simple: https://www.google.co.il
     separatecontext: false
     view: |-
       {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3272,7 +3272,6 @@
         "Test-VulnDB": "Issue 30875",
         "Malware Domain List Active IPs Feed Test": "Issue 30878",
         "urlscan_malicious_Test": "Issue 20111",
-        "Test-Detonate URL - Crowdstrike": "Issue 30879",
         "nexpose_test": "Issue 31019",
         "CuckooTest": "Issue 25601",
         "Cisco Umbrella Test": "Issue 24338",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3271,7 +3271,6 @@
         "PhishLabsIOC TestPlaybook": "Issue 30874",
         "Test-VulnDB": "Issue 30875",
         "Malware Domain List Active IPs Feed Test": "Issue 30878",
-        "urlscan_malicious_Test": "Issue 20111",
         "nexpose_test": "Issue 31019",
         "CuckooTest": "Issue 25601",
         "Cisco Umbrella Test": "Issue 24338",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/30879

## Description
I changed google.com because it failed and it's a crowdstrike bug because it also failed in the UI

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
