### PR TITLE
Increased phishing tests threshold

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2066,7 +2066,7 @@
                 "Rasterize"
             ],
             "memory_threshold": 115,
-            "pid_threshold": 5
+            "pid_threshold": 60
         },
         {
             "playbookID": "Phishing - Core - Test - Incident Starter",
@@ -2079,7 +2079,7 @@
                 "Rasterize"
             ],
             "memory_threshold": 100,
-            "pid_threshold": 5
+            "pid_threshold": 60
         },
         {
             "integrations": "duo",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: demisto/etc#26784
fixes: demisto/etc#26783

## Description
Increased `pid_threshold` to 60 which is above 57 as suggested in the failed build:
https://app.circleci.com/pipelines/github/demisto/content/55041/workflows/dbb478cc-9d66-43c3-9c25-72c6f6d85ff5/jobs/231331

![image](https://user-images.githubusercontent.com/43602124/103075726-df7fa580-45d4-11eb-867b-eb3a05e0e34e.png)

