### PR TITLE
CS Streaming v2 - verify stored event object is no more than 1 mb

### DIFF
--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_15.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike Falcon Streaming v2
+- Added validation of the size of the stored event object in case storing sample events.

--- a/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_15.md
+++ b/Packs/CrowdStrikeFalconStreamingV2/ReleaseNotes/1_0_15.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CrowdStrike Falcon Streaming v2
-- Added validation of the size of the stored event object in case storing sample events.
+- Added support for stored event size validation in case storing sample events.

--- a/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
+++ b/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon Streaming",
     "description": "Use the CrowdStrike Falcon Stream v2 integration to stream detections and audit security events.",
     "support": "xsoar",
-    "currentVersion": "1.0.14",
+    "currentVersion": "1.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/32102

## Description
storing sample events only if the obj size is no more than 1mb

## Does it break backward compatibility?
   - [x] No
