### PR TITLE
MCAS - add 1 to last fetch if incidents were fetched

### DIFF
--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
@@ -555,6 +555,9 @@ def fetch_incidents(client: Client, max_results: Optional[str], last_run: dict, 
     alerts = arrange_alerts_by_incident_type(alerts)
     incidents, fetch_start_time, last_fetch_id = alerts_to_incidents_and_fetch_start_from(
         alerts, fetch_start_time, last_run)
+    if incidents:
+        # since we use gte filter, we increase the latest event timestamp by 1 to avoid duplicates in the next fetch
+        fetch_start_time += 1
     next_run = {'last_fetch': fetch_start_time, 'last_fetch_id': last_fetch_id}
     return next_run, incidents
 

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
@@ -834,7 +834,7 @@ script:
     - contextPath: MicrosoftCloudAppSecurity.UsersAccounts.userGroups.usersCount
       description: The number of users in the user group.
       type: Number
-  dockerimage: demisto/python3:3.8.6.13358
+  dockerimage: demisto/python3:3.8.6.14516
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_13.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_13.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Microsoft Cloud App Security
+- Improved timestamp query to avoid duplicates in case of more than one alert occurred at the same time.
+- Upgraded the Docker image to demisto/python3:3.8.6.14516.

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_13.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/1_0_13.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Microsoft Cloud App Security
-- Improved timestamp query to avoid duplicates in case of more than one alert occurred at the same time.
+- Improved timestamp query in order to avoid duplicates in the case of more than one alert occurred at the same time.
 - Upgraded the Docker image to demisto/python3:3.8.6.14516.

--- a/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
+++ b/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Cloud App Security",
     "description": "Microsoft Cloud App Security Integration, a Cloud Access Security Broker that supports various deployment modes",
     "support": "xsoar",
-    "currentVersion": "1.0.12",
+    "currentVersion": "1.0.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/32013

## Description
since we use `date gte` filter, added `1` to last fetch timestamp in case incidents were fetched to avoid duplicates in the next fetch since if 2 or more alerts occurred in the same time we would fetch dups


## Does it break backward compatibility?
   - [x] No
