### PR TITLE
Running a record mode in post update instead of pre update

### DIFF
--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1197,7 +1197,7 @@ def test_integration_with_mock(build: Build, instance: dict, pre_update: bool):
             result_holder[RESULT] = success
             if not success:
                 logging.warning(f'Running test-module for "{integration_of_instance}" has failed in playback mode')
-    if not success and pre_update:
+    if not success and not pre_update:
         logging.debug(f'Recording a mock file for integration "{integration_of_instance}".')
         with run_with_mock(build.proxy, integration_of_instance, record=True) as result_holder:
             success, _ = __test_integration_instance(testing_client, instance)


### PR DESCRIPTION
Running test-module in record mode after playback mode failure in post-update instead of pre-update