### PR TITLE
Removed date filtering from CDL test playbook

### DIFF
--- a/Packs/CortexDataLake/TestPlaybooks/Cortex_Data_Lake_Test.yml
+++ b/Packs/CortexDataLake/TestPlaybooks/Cortex_Data_Lake_Test.yml
@@ -475,8 +475,7 @@ tasks:
       source_user: {}
       start_time: {}
       sub_type: {}
-      time_range:
-        simple: 1 year
+      time_range: {}
       url_category: {}
       url_domain: {}
     separatecontext: false


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24346
## Description
The file_data table was queried with expired time filter, removing it allowed it to receive the old records and pass the playbook
