### PR TITLE
Mail Listener v2 - revert removal of last_fetch from last run

### DIFF
--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -189,9 +189,12 @@ def fetch_incidents(client: IMAPClient,
         next_run: This will be last_run in the next fetch-incidents
         incidents: Incidents that will be created in Demisto
     """
+    uid_to_fetch_from = last_run.get('last_uid', 1)
     # time_to_fetch_from is required only for the first fetch, as after that we will use UID to fetch from
     time_to_fetch_from = parse(f'{first_fetch_time} UTC') if not last_run else None
-    uid_to_fetch_from = last_run.get('last_uid', 1)
+    if uid_to_fetch_from == 1 and last_run.get('last_fetch'):
+        # for back compatibility, if an instance was using the timestamp and was upgraded to use UID
+        time_to_fetch_from = datetime.fromisoformat(last_run.get('last_fetch'))
     mails_fetched, messages, uid_to_fetch_from = fetch_mails(
         client=client,
         include_raw_body=include_raw_body,

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -194,7 +194,7 @@ def fetch_incidents(client: IMAPClient,
     time_to_fetch_from = parse(f'{first_fetch_time} UTC') if not last_run else None
     if uid_to_fetch_from == 1 and last_run.get('last_fetch'):
         # for back compatibility, if an instance was using the timestamp and was upgraded to use UID
-        time_to_fetch_from = datetime.fromisoformat(last_run.get('last_fetch'))
+        time_to_fetch_from = datetime.fromisoformat(last_run.get('last_fetch', ''))
     mails_fetched, messages, uid_to_fetch_from = fetch_mails(
         client=client,
         include_raw_body=include_raw_body,

--- a/Packs/MailListener/ReleaseNotes/1_0_2.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Mail Listener v2
+- Reverted removal of the last fetch timestamp stored in the fetch incidents flow.

--- a/Packs/MailListener/ReleaseNotes/1_0_2.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Mail Listener v2
-- Reverted removal of the last fetch timestamp stored in the fetch incidents flow.
+- Reverted a change made in `1.0.1` which would remove the last fetch timestamp stored in the fetch incidents flow.

--- a/Packs/MailListener/pack_metadata.json
+++ b/Packs/MailListener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mail Listener",
     "description": "Listen to a mailbox, enable incident triggering via e-mail",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
revert removal of the `last_fetch` attribute from the last run object which stored the last fetch timestamp done in https://github.com/demisto/content/pull/10223
using it only for the first fetch after upgrading (when the last uid is `1`) and after that will use only the uid as criterion to fetch from

## Does it break backward compatibility?
   - [x] No
