### PR TITLE
[tests] Removed VxStream from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1990,7 +1990,6 @@
                 "Lastline v2",
                 "WildFire-v2",
                 "SNDBOX",
-                "VxStream",
                 "McAfee Advanced Threat Defense"
             ],
             "playbookID": "Detonate File - Generic Test",
@@ -3268,7 +3267,6 @@
         "Test-BPA_Integration": "Issue 28236",
         "CanaryTools Test": "Issue 30796",
         "Generic Webhook - Test": "Issue 30797",
-        "VxStream Test": "Issue 29280",
         "PhishLabsIOC TestPlaybook": "Issue 30874",
         "Test-VulnDB": "Issue 30875",
         "Malware Domain List Active IPs Feed Test": "Issue 30878",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/23795

## Description
Removed **VxStream** from skipped and from **Detonate File - Generic Test** requirements.