### PR TITLE
Updating demisto-client to not cache last response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ references:
     environment:
       CONTENT_VERSION: "20.12.1"
       SERVER_VERSION: "6.0.0"
+      # A flag for the demisto_client to not cache it's last response in order to avoid memory leaks
+      DONT_CACHE_LAST_RESPONSE: "true"
       GIT_SHA1: "758aee8a0dc3e5c905ebbab94a91bb4bf7931cf5" # guardrails-disable-line disable-secrets-detection
       NON_AMI_RUN: << pipeline.parameters.non_ami_run >>
       ARTIFACT_BUILD_NUM: << pipeline.parameters.artifact_build_num >>

--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -1,6 +1,6 @@
 flake8==3.8.3
 bandit==1.6.2
-demisto-py==2.0.19
+demisto-py==2.0.22
 requests==2.23.0
 PyYAML==5.3.1
 pylint==1.9.5

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,6 +1,6 @@
 flake8==3.8.3
 bandit==1.6.2
-demisto-py==2.0.21
+demisto-py==2.0.22
 demisto-sdk==1.2.12
 pytest==6.1.2
 pytest-mock==3.3.1


### PR DESCRIPTION
Updated client version and added env variable with which the client will not cache it's last response

##Related issues:
fixes: https://github.com/demisto/etc/issues/30292