### PR TITLE
O365 Security And Compliance - send device_code instead of code

### DIFF
--- a/Packs/EWS/Integrations/SecurityAndCompliance/SecurityAndCompliance.ps1
+++ b/Packs/EWS/Integrations/SecurityAndCompliance/SecurityAndCompliance.ps1
@@ -501,7 +501,7 @@ class OAuth2DeviceCodeClient {
                 "URI" = "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
                 "Method" = "Post"
                 "Headers" = (New-Object "System.Collections.Generic.Dictionary[[String],[String]]").Add("Content-Type", "application/x-www-form-urlencoded")
-                "Body" = "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&code=$($this.device_code)&client_id=$($this.application_id)"
+                "Body" = "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=$($this.device_code)&client_id=$($this.application_id)"
                 "NoProxy" = !$this.proxy
                 "SkipCertificateCheck" = $this.insecure
             }

--- a/Packs/EWS/ReleaseNotes/1_6_2.md
+++ b/Packs/EWS/ReleaseNotes/1_6_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### O365 - Security And Compliance - Content Search (beta)
+- Fixed an issue where the request body for getting an access token was not sent as expected.

--- a/Packs/EWS/pack_metadata.json
+++ b/Packs/EWS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "EWS",
     "description": "Exchange Web Services and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.6.1",
+    "currentVersion": "1.6.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/32274

## Description
according to https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#authenticating-the-user, `device_code` should be sent in the request body

## Does it break backward compatibility?
   - [x] No
