### PR TITLE
SumoLogic - set last fetch to now time for agg records

### DIFF
--- a/Packs/SumoLogic/Integrations/integration-SumoLogic.yml
+++ b/Packs/SumoLogic/Integrations/integration-SumoLogic.yml
@@ -238,22 +238,33 @@ script:
                 }
             }
 
-            if (params.fetchRecords && s.records) {
-                for (var i=0; i<s.records.length; i++) {
-                    var incident = {name: 'Incident from SumoLogic',
-                        details: JSON.stringify(s.records[i]), labels: [], rawJSON: JSON.stringify(s.records[i])};
-                    var props = Object.getOwnPropertyNames(s.records[i]);
-                    for (var j=0; j<props.length; j++) {
-                        if (props[j] !== '_raw') {
-                            incident.labels.push({type: props[j], value: s.records[i][props[j]]});
+            if (params.fetchRecords) {
+                var updatedCurrentFetch = currentFetch;
+                if (s.records) {
+                    for (var i=0; i<s.records.length; i++) {
+                        var incident = {name: 'Incident from SumoLogic',
+                            details: JSON.stringify(s.records[i]), labels: [], rawJSON: JSON.stringify(s.records[i])};
+                        var props = Object.getOwnPropertyNames(s.records[i]);
+                        for (var j=0; j<props.length; j++) {
+                            if (props[j] !== '_raw') {
+                                incident.labels.push({type: props[j], value: s.records[i][props[j]]});
+                            }
                         }
+                        var recordDate = new Date("{0}T{1}".format(s.records[i].date, s.records[i].time));
+                        var recordDateEpoch = Math.ceil(recordDate);
+                        if (recordDateEpoch >= updatedCurrentFetch){
+                            updatedCurrentFetch = recordDateEpoch + 1
+                        }
+                        incidents.push(incident);
                     }
-                    var recordDate = new Date("{0}T{1}".format(s.records[i].date, s.records[i].time));
-                    var recordDateEpoch = Math.ceil(recordDate);
-                    if (recordDateEpoch >= currentFetch){
-                        currentFetch = recordDateEpoch + 1
-                    }
-                    incidents.push(incident);
+                }
+
+                // if no records were fetched, then we set the currentFetch to now time as in later runs we could send
+                // a big query with old timestamp that could cause a timeout
+                if (updatedCurrentFetch === currentFetch) {
+                    currentFetch = now;
+                } else {
+                    currentFetch = updatedCurrentFetch;
                 }
             }
             setLastRun({time: currentFetch});

--- a/Packs/SumoLogic/ReleaseNotes/1_0_4.md
+++ b/Packs/SumoLogic/ReleaseNotes/1_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SumoLogic
-- Improved the integration to set the last fetch time as now time when fetching aggregate records to avoid timeouts for big queries.
+- Fixed an issue with ***fetch-incidents***, which caused timeouts for large queries.

--- a/Packs/SumoLogic/ReleaseNotes/1_0_4.md
+++ b/Packs/SumoLogic/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SumoLogic
+- Improved the integration to set the last fetch time as now time when fetching aggregate records to avoid timeouts for big queries.

--- a/Packs/SumoLogic/pack_metadata.json
+++ b/Packs/SumoLogic/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SumoLogic",
     "description": "Cloud-based service for logs & metrics management",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
https://github.com/demisto/etc/issues/32021

## Description
in https://github.com/demisto/content/pull/9208 we modified the last fetch to not be now time
this seem to cause timeouts when fetching aggregate records with big queries


## Does it break backward compatibility?
   - [x] No
