### PR TITLE
add Carbon Black Enterprise Protection V2 to skip list

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3280,7 +3280,8 @@
         "Cisco Umbrella Test": "Issue 24338",
         "PhishlabsIOC_DRP-Test": "Issue 29589",
         "Archer-Test-Playbook": "Issue 26851",
-        "Carbon Black Live Response Test": "Issue 28237"
+        "Carbon Black Live Response Test": "Issue 28237",
+        "Carbon Black Enterprise Protection V2 Test": "Issue 32322"
     },
     "skipped_integrations": {
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/27846

## Description
add Carbon Black Enterprise Protection V2 to skip list - expired license.
