### PR TITLE
MISP V2 - nightly failure

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3524,7 +3524,7 @@
         "TAXIIFeed": "Cannot use proxy",
         "EWSO365": "oproxy dependent",
         "QRadar": "Playbooks has parallel steps which are causing inconsistent results",
-        "MISP V2": "Issue 26905"
+        "MISP V2": "Cleanup process isn't performed as expected."
     },
     "parallel_integrations": [
         "SNDBOX",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26905

## Description
I performed the following steps:
1. Cleanup instance from old results (reduce timeout).
2. Removed mock, Has it work as expected (Cleanup didn't performed has expected).

Now the cleanup process occur without any error.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No