### PR TITLE
Humio/query allow timestamps

### DIFF
--- a/Packs/Humio/Integrations/Humio/Humio.py
+++ b/Packs/Humio/Integrations/Humio/Humio.py
@@ -77,7 +77,6 @@ def humio_query(client, args, headers):
         data["start"] = int(args.get("start"))
     except ValueError:
         data["start"] = args.get("start")
-
     try:
         data["end"] = int(args.get("end"))
     except ValueError:

--- a/Packs/Humio/Integrations/Humio/Humio.py
+++ b/Packs/Humio/Integrations/Humio/Humio.py
@@ -73,8 +73,15 @@ def test_module(client, headers=None):
 def humio_query(client, args, headers):
     data = {}
     data["queryString"] = args.get("queryString")
-    data["start"] = args.get("start")
-    data["end"] = args.get("end")
+    try:
+        data["start"] = int(args.get("start"))
+    except ValueError:
+        data["start"] = args.get("start")
+
+    try:
+        data["end"] = int(args.get("end"))
+    except ValueError:
+        data["end"] = args.get("end")
     data["isLive"] = args.get("isLive").lower() in ["true", "1", "t", "y", "yes"]
     data["timeZoneOffsetMinutes"] = int(args.get("timeZoneOffsetMinutes", 0))
     if args.get("arguments"):

--- a/Packs/Humio/Integrations/Humio/Humio.yml
+++ b/Packs/Humio/Integrations/Humio/Humio.yml
@@ -350,7 +350,7 @@ script:
       description: The notifier body template
       type: String
     description: Get notifier from Humio by id
-  dockerimage: demisto/python3:3.8.2.6981
+  dockerimage: demisto/python3:3.9.1.14969
   isfetch: true
   runonce: false
   subtype: python3

--- a/Packs/Humio/ReleaseNotes/1_0_3.md
+++ b/Packs/Humio/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Humio
+- Arguments "start" and "end" for the "humio_query" command can now be given as either a timestamp or a relative time duration.

--- a/Packs/Humio/pack_metadata.json
+++ b/Packs/Humio/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Humio",
     "description": "Instantly search live log data at scale. Create dashboards to visualize and analyze complex systems in real time",
     "support": "partner",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Humio",
     "url": "",
     "email": "integrations@humio.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: no issue created

## Description
The humio_query command didn't handle the case of the arguments "start" and "end" being given as timestamps. 
This PR updates the command so it tries to cast input to these arguments as an integer, and if it fails it defaults to treating them like strings, which is what was done previously.

## Screenshots
---

## Minimum version of Demisto
With this small change, I don't believe the minimum version has changed, but I can't seem to find info on what the minimum was previously given as.
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
