### PR TITLE
Logs aren't return as we expect from common server python

### DIFF
--- a/Packs/Base/ReleaseNotes/1_6_3.md
+++ b/Packs/Base/ReleaseNotes/1_6_3.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed an issue when logs returned unexpected message.

--- a/Packs/Base/ReleaseNotes/1_6_3.md
+++ b/Packs/Base/ReleaseNotes/1_6_3.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Fixed an issue when logs returned unexpected message.
+- Internal code improvements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -1111,6 +1111,7 @@ class IntegrationLogger(object):
                 demisto.debug(text)
         else:
             demisto.info(text)
+        return text
 
     def add_replace_strs(self, *args):
         '''
@@ -4389,7 +4390,7 @@ def return_error(message, error='', outputs=None):
     if is_debug_mode() and not is_server_handled and any(sys.exc_info()):  # Checking that an exception occurred
         message = "{}\n\n{}".format(message, traceback.format_exc())
 
-    LOG(message)
+    message = LOG(message)
     if error:
         LOG(str(error))
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -1035,7 +1035,7 @@ def test_exception_in_return_error(mocker):
 
     expected = {'EntryContext': None, 'Type': 4, 'ContentsFormat': 'text', 'Contents': 'Message'}
     mocker.patch.object(demisto, 'results')
-    mocker.patch.object(IntegrationLogger, '__call__')
+    mocker.patch.object(IntegrationLogger, '__call__', return_value='Message')
     with raises(SystemExit, match='0'):
         return_error("Message", error=ValueError("Error!"))
     results = demisto.results.call_args[0][0]

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.6.2",
+    "currentVersion": "1.6.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: demisto/etc#32401

## Description
The log is filtered in info but not in the Content part.
For more information please look at the issue.

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
