### PR TITLE
Slack UT - removed skip 

### DIFF
--- a/Packs/Slack/Integrations/Slack/Slack_test.py
+++ b/Packs/Slack/Integrations/Slack/Slack_test.py
@@ -4246,7 +4246,6 @@ def test_unset_proxy_and_ssl(mocker):
     assert init_args['proxy'] is None
 
 
-# @pytest.mark.skip(reason="Test not stable, issue: 32385")
 def test_fail_connect_threads(mocker):
     import Slack
     mocker.patch.object(demisto, 'params', return_value={'unsecure': 'true', 'bot_token': '123'})

--- a/Packs/Slack/Integrations/Slack/Slack_test.py
+++ b/Packs/Slack/Integrations/Slack/Slack_test.py
@@ -4260,7 +4260,6 @@ def test_fail_connect_threads(mocker):
     assert threading.active_count() < 6  # we shouldn't have more than 5 threads (1 + 4 max size of executor)
 
 
-
 def test_slack_send_filter_one_mirro_tag(mocker):
     # When filtered_tags parameter contains the same tag as the entry tag - slack_send method should send the message
     import Slack

--- a/Packs/Slack/Integrations/Slack/Slack_test.py
+++ b/Packs/Slack/Integrations/Slack/Slack_test.py
@@ -4246,7 +4246,7 @@ def test_unset_proxy_and_ssl(mocker):
     assert init_args['proxy'] is None
 
 
-@pytest.mark.skip(reason="Test not stable, issue: 32385")
+# @pytest.mark.skip(reason="Test not stable, issue: 32385")
 def test_fail_connect_threads(mocker):
     import Slack
     mocker.patch.object(demisto, 'params', return_value={'unsecure': 'true', 'bot_token': '123'})
@@ -4258,6 +4258,7 @@ def test_fail_connect_threads(mocker):
         time.sleep(0.5)
     assert return_error_mock.call_count == 8
     assert threading.active_count() < 6  # we shouldn't have more than 5 threads (1 + 4 max size of executor)
+
 
 
 def test_slack_send_filter_one_mirro_tag(mocker):


### PR DESCRIPTION
Removed skip of `test_fail_connect_threads` ut as it passes.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/32385

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
