### PR TITLE
fixing legacy key handling

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -560,7 +560,7 @@ class Pack(object):
         pack_metadata['description'] = user_metadata.get('description') or pack_id
         pack_metadata['created'] = user_metadata.get('created', datetime.utcnow().strftime(Metadata.DATE_FORMAT))
         pack_metadata['updated'] = datetime.utcnow().strftime(Metadata.DATE_FORMAT)
-        pack_metadata['legacy'] = user_metadata.get('legacy', True)
+        pack_metadata['legacy'] = user_metadata.get('legacy', False)
         pack_metadata['support'] = user_metadata.get('support') or Metadata.XSOAR_SUPPORT
         pack_metadata['supportDetails'] = Pack._create_support_section(support_type=pack_metadata['support'],
                                                                        support_url=user_metadata.get('url'),


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/32381

## Description
To this point, all packs in the marketplace were marked as `legacy` in the index.
This will no longer be the case for future versions.
