### PR TITLE
SDK - run with hash of fix

### DIFF
--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,7 +1,7 @@
 flake8==3.8.3
 bandit==1.6.2
 demisto-py==2.0.22
-demisto-sdk==1.2.14
+git+https://github.com/demisto/demisto-sdk.git@568f3ab01c628d42ea3e46aa02608c822e95b008
 pytest==6.2.1
 pytest-mock==3.4.0
 requests-mock==1.8.0


### PR DESCRIPTION
I will change the hash to 1.2.15 when I will see that it is ok.

fix: https://app.circleci.com/pipelines/github/demisto/content/58736/workflows/127bc7e7-b183-45f8-a2b3-b178df38521d/jobs/245342

related pr: https://github.com/demisto/demisto-sdk/pull/1011