### PR TITLE
Supporting new slack client

### DIFF
--- a/Tests/instance_notifier.py
+++ b/Tests/instance_notifier.py
@@ -1,14 +1,14 @@
-import json
 import argparse
+import json
 import logging
 
 import demisto_client
 from slackclient import SlackClient
 
+from Tests.configure_and_test_integration_instances import update_content_on_demisto_instance
 from Tests.scripts.utils.log_util import install_simple_logging
 from Tests.test_integration import __create_integration_instance, __delete_integrations_instances
 from demisto_sdk.commands.common.tools import str2bool
-from Tests.configure_and_test_integration_instances import update_content_on_demisto_instance
 
 SERVER_URL = "https://{}"
 
@@ -123,21 +123,26 @@ def slack_notifier(slack_token, secret_conf_path, server, user, password, build_
     # Failing instances list
     sc.api_call(
         "chat.postMessage",
-        channel="dmst-content-lab",
-        username="Instances nightly report",
-        as_user="False",
-        attachments=attachments,
-        text="You have {0} instances configurations".format(integrations_counter)
+        json={
+            'channel': 'dmst-content-lab',
+            'username': 'Instances nightly report',
+            'as_user': 'False',
+            'attachments': attachments,
+            'text': "You have {0} instances configurations".format(integrations_counter)
+        }
     )
 
     # Failing instances file
     sc.api_call(
         "chat.postMessage",
-        channel="dmst-content-lab",
-        username="Instances nightly report",
-        as_user="False",
-        text="Detailed list of failing instances could be found in the following link:\n"
-             "https://{}-60525392-gh.circle-artifacts.com/0/artifacts/failed_instances.txt".format(build_number)
+        json={
+            'channel': 'dmst-content-lab',
+            'username': 'Instances nightly report',
+            'as_user': 'False',
+            'text': "Detailed list of failing instances could be found in the following link:\n"
+                    "https://{}-60525392-gh.circle-artifacts.com/0/artifacts/failed_instances.txt".format(build_number)
+
+        }
     )
 
 

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -1,17 +1,17 @@
+import argparse
 import json
+import logging
 import os
 import re
 import sys
-import argparse
+
 import requests
-import logging
 from circleci.api import Api as circle_api
+from slack import WebClient as SlackClient
 
-from slackclient import SlackClient
-
+from Tests.Marketplace.marketplace_services import BucketUploadFlow, get_successful_and_failed_packs
 from Tests.scripts.utils.log_util import install_logging
 from demisto_sdk.commands.common.tools import str2bool, run_command
-from Tests.Marketplace.marketplace_services import BucketUploadFlow, get_successful_and_failed_packs
 
 DEMISTO_GREY_ICON = 'https://3xqz5p387rui1hjtdv1up7lw-wpengine.netdna-ssl.com/wp-content/' \
                     'uploads/2018/07/Demisto-Icon-Dark.png'
@@ -307,10 +307,10 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
         slack_client = SlackClient(slack_token)
         slack_client.api_call(
             "chat.postMessage",
-            channel="dmst-content-team",
-            username="Content CircleCI",
-            as_user="False",
-            attachments=content_team_attachments
+            json={'channel': 'dmst-content-team',
+                  'username': 'Content CircleCI',
+                  'as_user': 'False',
+                  'attachments': content_team_attachments}
         )
 
 

--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -1,45 +1,33 @@
 from __future__ import print_function
 
+import argparse
+import datetime
+import json
 import logging
 import os
 import re
-import sys
-import json
-import time
-import argparse
-import threading
 import subprocess
-from time import sleep
-import datetime
+import sys
+import threading
+import time
+from contextlib import contextmanager
 from distutils.version import LooseVersion
+from queue import Queue
+from time import sleep
 from typing import Union, Any
 
-import pytz
-
-from google.cloud import storage
-from google.api_core.exceptions import PreconditionFailed
-from queue import Queue
-from contextlib import contextmanager
-
-import urllib3
-import requests
 import demisto_client.demisto_api
-
-from Tests.scripts.utils.log_util import ParallelLoggingManager
-
-try:
-    """
-    Those dual-imports are required as Slack updated their sdk and it breaks BC.
-    `from slack import...` is for new slack and local runs.
-    `from slackclient import...` is for old slack and running in CircleCI (old slack in docker image)
-    """
-    from slack import WebClient as SlackClient  # New slack
-except ModuleNotFoundError:
-    from slackclient import SlackClient  # Old slack
+import pytz
+import requests
+import urllib3
+from google.api_core.exceptions import PreconditionFailed
+from google.cloud import storage
+from slack import WebClient as SlackClient
 
 from Tests.mock_server import MITMProxy, run_with_mock, RESULT
-from Tests.test_integration import Docker, check_integration
+from Tests.scripts.utils.log_util import ParallelLoggingManager
 from Tests.test_dependencies import get_used_integrations, get_tests_allocation_for_threads
+from Tests.test_integration import Docker, check_integration
 from demisto_sdk.commands.common.constants import FILTER_CONF, PB_Status
 from demisto_sdk.commands.common.tools import str2bool
 
@@ -289,11 +277,11 @@ def send_slack_message(slack, chanel, text, user_name, as_user):
     sc = SlackClient(slack)
     sc.api_call(
         "chat.postMessage",
-        channel=chanel,
-        username=user_name,
-        as_user=as_user,
-        text=text,
-        mrkdwn='true'
+        json={'channel': chanel,
+              'username': user_name,
+              'as_user': as_user,
+              'text': text,
+              'mrkdwn': 'true'}
     )
 
 
@@ -458,10 +446,12 @@ def notify_failed_test(slack, circle_ci, playbook_id, build_number, inc_id, serv
     if user_id:
         sc.api_call(
             "chat.postMessage",
-            channel=user_id,
-            username="Content CircleCI",
-            as_user="False",
-            text=text
+            json={
+                'channel': user_id,
+                'username': 'Content CircleCI',
+                'as_user': 'False',
+                'text': text
+            }
         )
 
 


### PR DESCRIPTION
In the latest sdk release the slack version was updated to 2.9.3 from 1.x.x which have some breaking changes.



This PR is about updating the usage of slack client to support 2.9.3 version according to this documentation

https://github.com/slackapi/python-slack-sdk/wiki/Migrating-to-2.x