### PR TITLE
BPA Playbook Fix

### DIFF
--- a/Packs/BPA/TestPlaybooks/playbook-BPA-test.yml
+++ b/Packs/BPA/TestPlaybooks/playbook-BPA-test.yml
@@ -135,7 +135,7 @@ tasks:
         simple: "10"
       dt:
         simple: PAN-OS-BPA.JobResults(val.Status!='complete').JobID
-    separatecontext: false
+    separatecontext: true
     loop:
       iscommand: false
       exitCondition: ""


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28406

## Description
Changed the context of the GenericPolling sub-task to be private. This should prevent the generic polling to finish the task before the creation of the BPA request has completed.
