### PR TITLE
Remove Launch job details from conf.json

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1483,11 +1483,6 @@
             "fromversion": "5.0.0"
         },
         {
-            "integrations": "AnsibleTower",
-            "playbookID": "Launch Job - Ansible Tower",
-            "fromversion": "5.0.0"
-        },
-        {
             "integrations": "SplunkPy",
             "playbookID": "SplunkPySearch_Test",
             "memory_threshold": 200,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Ansible tower test playbook call Launch Job playbook as sub-playbook with specific parameters. Launch Job playbook was than added to conf.json in order the instance recognize him. This apperently was not needed, only insert the playbookName of the called sub-playbook on the test playbook. Removed Launch Job playbook details from conf.json

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
