### PR TITLE
added count argument to splunk-results command

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -99,7 +99,7 @@ Returns the results of a previous Splunk search. This command can be used in con
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | sid | The ID of the search for which to return results. | Required | 
-| count | The maximum number of returned results per search. To retrieve all results, enter "0" (Not recommended). | Optional | 
+| limit | The maximum number of returned results per search. To retrieve all results, enter "0" (Not recommended). | Optional | 
 
 
 ##### Context Output
@@ -107,7 +107,7 @@ Returns the results of a previous Splunk search. This command can be used in con
 There is no context output for this command.
 
 ##### Command Example
-``` !splunk-results sid="1566221331.1186" count="200" ```
+``` !splunk-results sid="1566221331.1186" limit="200" ```
 
 ### Search for events
 ***

--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -99,6 +99,7 @@ Returns the results of a previous Splunk search. This command can be used in con
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | sid | The ID of the search for which to return results. | Required | 
+| count | The maximum number of returned results per search. To retrieve all results, enter "0". | Optional | 
 
 
 ##### Context Output
@@ -106,7 +107,7 @@ Returns the results of a previous Splunk search. This command can be used in con
 There is no context output for this command.
 
 ##### Command Example
-``` !splunk-results sid="1566221331.1186" ```
+``` !splunk-results sid="1566221331.1186" count="200" ```
 
 ### Search for events
 ***

--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -99,7 +99,7 @@ Returns the results of a previous Splunk search. This command can be used in con
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | sid | The ID of the search for which to return results. | Required | 
-| count | The maximum number of returned results per search. To retrieve all results, enter "0". | Optional | 
+| count | The maximum number of returned results per search. To retrieve all results, enter "0" (Not recommended). | Optional | 
 
 
 ##### Context Output

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -448,7 +448,7 @@ def splunk_job_create_command(service):
 def splunk_results_command(service):
     res = []
     sid = demisto.args().get('sid', '')
-    count = int(demisto.args().get('count'))
+    count = int(demisto.args().get('count', '100'))
     try:
         job = service.job(sid)
     except HTTPError as error:

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -448,6 +448,7 @@ def splunk_job_create_command(service):
 def splunk_results_command(service):
     res = []
     sid = demisto.args().get('sid', '')
+    count = int(demisto.args().get('count'))
     try:
         job = service.job(sid)
     except HTTPError as error:
@@ -456,7 +457,7 @@ def splunk_results_command(service):
         else:
             return_error(error.message, error)
     else:
-        for result in results.ResultsReader(job.results()):
+        for result in results.ResultsReader(job.results(count=count)):
             if isinstance(result, results.Message):
                 demisto.results({"Type": 1, "ContentsFormat": "json", "Contents": json.dumps(result.message)})
             elif isinstance(result, dict):

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -448,7 +448,7 @@ def splunk_job_create_command(service):
 def splunk_results_command(service):
     res = []
     sid = demisto.args().get('sid', '')
-    count = int(demisto.args().get('count', '100'))
+    limit = int(demisto.args().get('limit', '100'))
     try:
         job = service.job(sid)
     except HTTPError as error:
@@ -457,7 +457,7 @@ def splunk_results_command(service):
         else:
             return_error(error.message, error)
     else:
-        for result in results.ResultsReader(job.results(count=count)):
+        for result in results.ResultsReader(job.results(count=limit)):
             if isinstance(result, results.Message):
                 demisto.results({"Type": 1, "ContentsFormat": "json", "Contents": json.dumps(result.message)})
             elif isinstance(result, dict):

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -126,7 +126,7 @@ script:
       defaultValue: '100'
       description: The maximum number of returned results per search. To retrieve all results, enter "0" (Not recommended).
       isArray: false
-      name: count
+      name: limit
       required: false
       secret: false
     deprecated: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -122,6 +122,13 @@ script:
       name: sid
       required: true
       secret: false
+    - default: true
+      defaultValue: '100'
+      description: The maximum number of returned results per search. To retrieve all results, enter "0".
+      isArray: false
+      name: count
+      required: false
+      secret: false
     deprecated: false
     description: Returns the results of a previous Splunk search. You can use this command in conjunction with the splunk-job-create command.
     execution: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -122,9 +122,9 @@ script:
       name: sid
       required: true
       secret: false
-    - default: true
+    - default: false
       defaultValue: '100'
-      description: The maximum number of returned results per search. To retrieve all results, enter "0".
+      description: The maximum number of returned results per search. To retrieve all results, enter "0" (Not recommended).
       isArray: false
       name: count
       required: false

--- a/Packs/SplunkPy/ReleaseNotes/1_2_7.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Added the **count** argument to **splunk-results** command to control the number of returned results.

--- a/Packs/SplunkPy/ReleaseNotes/1_2_7.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_7.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Added the **limit** argument to **splunk-results** command to control the number of returned results.
+- Added support for the *limit* argument in the **splunk-results** command in order to control the number of returned results.

--- a/Packs/SplunkPy/ReleaseNotes/1_2_7.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_2_7.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Added the **count** argument to **splunk-results** command to control the number of returned results.
+- Added the **limit** argument to **splunk-results** command to control the number of returned results.

--- a/Packs/SplunkPy/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
+++ b/Packs/SplunkPy/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
@@ -287,6 +287,8 @@ tasks:
     scriptarguments:
       sid:
         simple: ${Splunk.Job}
+      count:
+        simple: "200"
     separatecontext: false
     view: |-
       {

--- a/Packs/SplunkPy/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
+++ b/Packs/SplunkPy/TestPlaybooks/playbook-SplunkPy-Test-V2.yml
@@ -287,7 +287,7 @@ tasks:
     scriptarguments:
       sid:
         simple: ${Splunk.Job}
-      count:
+      limit:
         simple: "200"
     separatecontext: false
     view: |-

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.2.6",
+    "currentVersion": "1.2.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/31663

## Description
Added the **count** argument to **splunk-results** command to control the number of returned results.

## Screenshots
![image](https://user-images.githubusercontent.com/53565845/104889524-01bbd780-5977-11eb-9cb0-357fba2e1ec2.png)


## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Documentation 
