### PR TITLE
Panorama - added 2 commands by Alex

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -1,3 +1,5 @@
+import shutil
+
 from CommonServerPython import *
 
 ''' IMPORTS '''
@@ -286,29 +288,30 @@ def prepare_security_rule_params(api_action: str = None, rulename: str = None, s
         # application always must be specified and the default should be any
         application = ['any']
 
+    # flake8: noqa
     rulename = rulename if rulename else ('demisto-' + (str(uuid.uuid4()))[:8])
     params = {
         'type': 'config',
         'action': api_action,
         'key': API_KEY,
         'element': add_argument_open(action, 'action', False)
-                + add_argument_target(target, 'target')
-                + add_argument_open(description, 'description', False)
-                + add_argument_list(source, 'source', True, True)
-                + add_argument_list(destination, 'destination', True, True)
-                + add_argument_list(application, 'application', True)
-                + add_argument_list(category, 'category', True)
-                + add_argument_open(source_user, 'source-user', True)
-                + add_argument_list(from_, 'from', True, True)  # default from will always be any
-                + add_argument_list(to, 'to', True, True)  # default to will always be any
-                + add_argument_list(service, 'service', True, True)
-                + add_argument_yes_no(negate_source, 'negate-source')
-                + add_argument_yes_no(negate_destination, 'negate-destination')
-                + add_argument_yes_no(disable, 'disabled')
-                + add_argument_yes_no(disable_server_response_inspection, 'disable-server-response-inspection', True)
-                + add_argument(log_forwarding, 'log-setting', False)
-                + add_argument_list(tags, 'tag', True)
-                + add_argument_profile_setting(profile_setting, 'profile-setting')
+                   + add_argument_target(target, 'target')
+                   + add_argument_open(description, 'description', False)
+                   + add_argument_list(source, 'source', True, True)
+                   + add_argument_list(destination, 'destination', True, True)
+                   + add_argument_list(application, 'application', True)
+                   + add_argument_list(category, 'category', True)
+                   + add_argument_open(source_user, 'source-user', True)
+                   + add_argument_list(from_, 'from', True, True)  # default from will always be any
+                   + add_argument_list(to, 'to', True, True)  # default to will always be any
+                   + add_argument_list(service, 'service', True, True)
+                   + add_argument_yes_no(negate_source, 'negate-source')
+                   + add_argument_yes_no(negate_destination, 'negate-destination')
+                   + add_argument_yes_no(disable, 'disabled')
+                   + add_argument_yes_no(disable_server_response_inspection, 'disable-server-response-inspection', True)
+                   + add_argument(log_forwarding, 'log-setting', False)
+                   + add_argument_list(tags, 'tag', True)
+                   + add_argument_profile_setting(profile_setting, 'profile-setting')
     }
     if DEVICE_GROUP:
         if not PRE_POST:
@@ -4441,9 +4444,12 @@ def panorama_get_logs_command(args: dict):
 ''' Security Policy Match'''
 
 
-def build_policy_match_query(application: Optional[str] = None, category: Optional[str] = None, destination: Optional[str] = None,
-                             destination_port: Optional[str] = None, from_: Optional[str] = None, to_: Optional[str] = None,
-                             protocol: Optional[str] = None, source: Optional[str] = None, source_user: Optional[str] = None):
+def build_policy_match_query(application: Optional[str] = None, category: Optional[str] = None,
+                             destination: Optional[str] = None,
+                             destination_port: Optional[str] = None, from_: Optional[str] = None,
+                             to_: Optional[str] = None,
+                             protocol: Optional[str] = None, source: Optional[str] = None,
+                             source_user: Optional[str] = None):
     query = '<test><security-policy-match>'
     if from_:
         query += f'<from>{from_}</from>'
@@ -5723,16 +5729,15 @@ def apply_security_profile(xpath: str, profile_name: str) -> Dict:
 
 
 def apply_security_profile_command(profile_name: str, profile_type: str, rule_name: str, pre_post: str = None):
-
     if DEVICE_GROUP:  # Panorama instance
         if not pre_post:
             raise Exception('Please provide the pre_post argument when applying profiles to rules in '
                             'Panorama instance.')
-        xpath = f"{XPATH_RULEBASE}{pre_post}/security/rules/entry[@name='{rule_name}']/profile-setting/"\
+        xpath = f"{XPATH_RULEBASE}{pre_post}/security/rules/entry[@name='{rule_name}']/profile-setting/" \
                 f"profiles/{profile_type}"
 
     else:  # firewall instance
-        xpath = f"{XPATH_RULEBASE}rulebase/security/rules/entry[@name='{rule_name}']/profile-setting/"\
+        xpath = f"{XPATH_RULEBASE}rulebase/security/rules/entry[@name='{rule_name}']/profile-setting/" \
                 f"profiles/{profile_type}"
 
     apply_security_profile(xpath, profile_name)
@@ -5753,7 +5758,6 @@ def get_ssl_decryption_rules(xpath: str) -> Dict:
 
 
 def get_ssl_decryption_rules_command(pre_post: str):
-
     content = []
     if DEVICE_GROUP:
         if not pre_post:
@@ -5896,7 +5900,6 @@ def get_anti_spyware_best_practice() -> Dict:
 
 
 def get_anti_spyware_best_practice_command():
-
     result = get_anti_spyware_best_practice()
     spyware_profile = result.get('response', {}).get('result', {}).get('spyware').get('entry', [])
     strict_profile = next(item for item in spyware_profile if item['@name'] == 'strict')
@@ -5951,7 +5954,6 @@ def get_file_blocking_best_practice() -> Dict:
 
 
 def get_file_blocking_best_practice_command():
-
     results = get_file_blocking_best_practice()
     file_blocking_profile = results.get('response', {}).get('result', {}).get('file-blocking', {}).get('entry', [])
 
@@ -5989,7 +5991,6 @@ def get_antivirus_best_practice() -> Dict:
 
 
 def get_antivirus_best_practice_command():
-
     results = get_antivirus_best_practice()
     antivirus_profile = results.get('response', {}).get('result', {}).get('virus', {})
     strict_profile = antivirus_profile.get('entry', {})
@@ -6026,7 +6027,6 @@ def get_vulnerability_protection_best_practice() -> Dict:
 
 
 def get_vulnerability_protection_best_practice_command():
-
     results = get_vulnerability_protection_best_practice()
     vulnerability_protection = results.get('response', {}).get('result', {}).get('vulnerability', {}).get('entry', [])
     strict_profile = next(item for item in vulnerability_protection if item['@name'] == 'strict')
@@ -6102,7 +6102,6 @@ def prettify_wildfire_rules(rules: Dict) -> List:
 
 
 def get_wildfire_best_practice_command():
-
     result = get_wildfire_best_practice()
     wildfire_profile = result.get('response', {}).get('result', {}).get('wildfire-analysis', {})
     best_practice = wildfire_profile.get('entry', {}).get('rules', {}).get('entry', {})
@@ -6154,7 +6153,7 @@ def set_xpath_wildfire(template: str = None) -> str:
     """
     if template:
         xpath_wildfire = f"/config/devices/entry[@name='localhost.localdomain']/template/entry[@name=" \
-            f"'{template}']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting/wildfire"
+                         f"'{template}']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting/wildfire"
 
     else:
         xpath_wildfire = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting"
@@ -6163,7 +6162,6 @@ def set_xpath_wildfire(template: str = None) -> str:
 
 @logger
 def get_wildfire_system_config(template: str) -> Dict:
-
     params = {
         'action': 'get',
         'type': 'config',
@@ -6181,7 +6179,7 @@ def get_wildfire_update_schedule(template: str) -> Dict:
         'action': 'get',
         'type': 'config',
         'xpath': f"/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='{template}']"
-        f"/config/devices/entry[@name='localhost.localdomain']/deviceconfig/system/update-schedule/wildfire",
+                 f"/config/devices/entry[@name='localhost.localdomain']/deviceconfig/system/update-schedule/wildfire",
         'key': API_KEY
     }
     result = http_request(URL, 'GET', params=params)
@@ -6190,7 +6188,6 @@ def get_wildfire_update_schedule(template: str) -> Dict:
 
 
 def get_wildfire_configuration_command(template: str):
-
     file_size = []
     result = get_wildfire_system_config(template)
     system_config = result.get('response', {}).get('result', {}).get('wildfire', {})
@@ -6234,7 +6231,7 @@ def enforce_wildfire_system_config(template: str) -> Dict:
         'action': 'set',
         'type': 'config',
         'xpath': f"/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='{template}']/"
-        f"config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting",
+                 f"config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting",
         'key': API_KEY,
         'element': '<wildfire><file-size-limit><entry name="pe"><size-limit>10</size-limit></entry>'
                    '<entry name="apk"><size-limit>30</size-limit></entry><entry name="pdf">'
@@ -6256,7 +6253,7 @@ def enforce_wildfire_schedule(template: str) -> Dict:
         'action': 'set',
         'type': 'config',
         'xpath': f"/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='{template}']/config/"
-        f"devices/entry[@name='localhost.localdomain']/deviceconfig/system/update-schedule/wildfire",
+                 f"devices/entry[@name='localhost.localdomain']/deviceconfig/system/update-schedule/wildfire",
         'key': API_KEY,
         'element': '<recurring><every-min><action>download-and-install</action></every-min></recurring>'
     }
@@ -6267,7 +6264,6 @@ def enforce_wildfire_schedule(template: str) -> Dict:
 
 
 def enforce_wildfire_best_practice_command(template: str):
-
     enforce_wildfire_system_config(template)
     enforce_wildfire_schedule(template)
 
@@ -6278,7 +6274,6 @@ def enforce_wildfire_best_practice_command(template: str):
 
 @logger
 def url_filtering_block_default_categories(profile_name: str) -> Dict:
-
     params = {
         'action': 'set',
         'type': 'config',
@@ -6295,13 +6290,11 @@ def url_filtering_block_default_categories(profile_name: str) -> Dict:
 
 
 def url_filtering_block_default_categories_command(profile_name: str):
-
     url_filtering_block_default_categories(profile_name)
     return_results(f'The default categories to block has been set successfully to {profile_name}')
 
 
 def get_url_filtering_best_practice_command():
-
     best_practice = {
         '@name': 'best-practice', 'credential-enforcement': {
             'mode': {'disabled': False},
@@ -6393,7 +6386,6 @@ def create_antivirus_best_practice_profile_command(profile_name: str):
 
 @logger
 def create_anti_spyware_best_practice_profile(profile_name: str) -> Dict:
-
     params = {
         'action': 'set',
         'type': 'config',
@@ -6423,7 +6415,6 @@ def create_anti_spyware_best_practice_profile_command(profile_name: str):
 
 @logger
 def create_vulnerability_best_practice_profile(profile_name: str) -> Dict:
-
     params = {
         'action': 'set',
         'type': 'config',
@@ -6477,7 +6468,6 @@ def create_vulnerability_best_practice_profile_command(profile_name: str):
 
 @logger
 def create_url_filtering_best_practice_profile(profile_name: str) -> Dict:
-
     params = {
         'action': 'set',
         'type': 'config',
@@ -6660,6 +6650,77 @@ def initialize_instance(args: Dict[str, str], params: Dict[str, str]):
                              DEVICE_GROUP + "\']/"
     else:
         XPATH_RULEBASE = f"/config/devices/entry[@name=\'localhost.localdomain\']/vsys/entry[@name=\'{VSYS}\']/"
+
+
+def panorama_upload_content_update_file_command():
+    category = demisto.args()['category']
+    upload = demisto.args()['entryID']
+    try:
+        filePath = demisto.getFilePath(upload)['path']
+        fileName = demisto.getFilePath(upload)['name']
+    except Exception:
+        return_error("File was not found")
+    try:
+        shutil.copy(filePath, fileName)
+    except Exception:
+        raise Exception('Failed to prepare file for upload.')
+    try:
+        with open(fileName, 'rb') as file:
+            url = URL
+            payload = {}  # type: ignore
+            files = {'file': file}
+            headers = {}  # type: ignore
+            params = {'type': 'import', 'category': category, 'key': API_KEY}
+            response = requests.request("POST", url, data=payload, headers=headers, params=params, files=files,
+                                        verify=False)
+            demisto.debug(response.text.encode('utf8'))
+    finally:
+        shutil.rmtree(fileName, ignore_errors=True)
+
+
+@logger
+def panorama_install_file_content_update(version: str, category: str):
+    params = {
+        'type': 'op',
+        'cmd': (
+            f'<request><{category}><upgrade><install><file>{version}</file></install></upgrade></{category}></request>'),
+        'key': API_KEY
+    }
+    result = http_request(
+        URL,
+        'GET',
+        params=params
+    )
+    return result
+
+
+def panorama_install_file_content_update_command():
+    if DEVICE_GROUP:
+        raise Exception('Content download status is only supported on Firewall (not Panorama).')
+    version = demisto.args()['version_name']
+    category = demisto.args()['category']
+    result = panorama_install_file_content_update(version, category)
+
+    if 'result' in result['response']:
+        # installation has been given a jobid
+        content_install_info = {
+            'JobID': result['response']['result']['job'],
+            'Status': 'Pending'
+        }
+        entry_context = {"Panorama.Content.Install(val.JobID == obj.JobID)": content_install_info}
+        human_readable = tableToMarkdown('Result:', content_install_info, ['JobID', 'Status'], removeNull=True)
+
+        demisto.results({
+            'Type': entryTypes['note'],
+            'ContentsFormat': formats['json'],
+            'Contents': result,
+            'ReadableContentsFormat': formats['markdown'],
+            'HumanReadable': human_readable,
+            'EntryContext': entry_context
+        })
+    else:
+        # no content install took place
+        demisto.results(result['response']['msg'])
 
 
 def main():
@@ -7012,6 +7073,12 @@ def main():
 
         elif demisto.command() == 'panorama-create-wildfire-best-practice-profile':
             create_wildfire_best_practice_profile_command(**args)
+
+        elif demisto.command() == 'panorama-upload-content-update-file':
+            panorama_upload_content_update_file_command()
+
+        elif demisto.command() == 'panorama-install-file-content-update':
+            panorama_install_file_content_update_command()
 
         else:
             raise NotImplementedError(f'Command {demisto.command()} was not implemented.')

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -6657,10 +6657,12 @@ def panorama_upload_content_update_file_command(args: dict):
     entry_id = args['entryID']
     file_path = demisto.getFilePath(entry_id)['path']
     file_name = demisto.getFilePath(entry_id)['name']
+
     try:
-        shutil.copy(file_path, file_name)  # todo understand why doing this?
+        shutil.copy(file_path, file_name)
     except Exception:
         raise Exception('Failed to prepare file for upload.')
+
     try:
         with open(file_name, 'rb') as file:
             payload = {}  # type: ignore
@@ -6669,7 +6671,7 @@ def panorama_upload_content_update_file_command(args: dict):
             params = {'type': 'import', 'category': category, 'key': API_KEY}
             response = requests.request("POST", URL, data=payload, headers=headers, params=params, files=files,
                                         verify=False)
-            demisto.debug(response.text.encode('utf8'))  # todo add explanation
+            demisto.debug(response.text.encode('utf8'))
     finally:
         shutil.rmtree(file_name, ignore_errors=True)
 
@@ -6691,8 +6693,6 @@ def panorama_install_file_content_update(version: str, category: str):
 
 
 def panorama_install_file_content_update_command(args: dict):
-    if DEVICE_GROUP:  # todo understand that
-        raise Exception('Content download status is only supported on Firewall (not Panorama).')
     version = args['version_name']
     category = args['category']
     result = panorama_install_file_content_update(version, category)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -4400,6 +4400,41 @@ script:
     description: Creates a WildFire analysis best practice profile.
     execution: false
     name: panorama-create-wildfire-best-practice-profile
+  - name: panorama-upload-content-update-file
+    arguments:
+    - name: entryID
+      required: true
+      description: Entry id of the file to upload
+    - name: category
+      required: true
+      auto: PREDEFINED
+      predefined:
+        - wildfire
+        - anti-virus
+        - content
+      description: 'File type '
+    description: Uploads content file to Panorama
+  - name: panorama-install-file-content-update
+    arguments:
+      - name: version_name
+        required: true
+        description: Update name to install on Panorama.
+      - name: category
+        required: true
+        auto: PREDEFINED
+        predefined:
+          - wildfire
+          - anti-virus
+          - content
+        description: File type.
+    outputs:
+      - contextPath: Panorama.Content.Install.JobID
+        description: JobID of the installation.
+        type: string
+      - contextPath: Content.Install.Status
+        description: Installation status.
+        type: string
+    description: Installs specific content update file.
   dockerimage: demisto/python3:3.9.1.14969
   feed: false
   isfetch: false

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -4412,13 +4412,13 @@ script:
         - wildfire
         - anti-virus
         - content
-      description: 'File type '
+      description: The file type
     description: Uploads content file to Panorama
   - name: panorama-install-file-content-update
     arguments:
       - name: version_name
         required: true
-        description: Update name to install on Panorama.
+        description: Update file name to be installed on Panorama
       - name: category
         required: true
         auto: PREDEFINED
@@ -4426,7 +4426,7 @@ script:
           - wildfire
           - anti-virus
           - content
-        description: File type.
+        description: The file type
     outputs:
       - contextPath: Panorama.Content.Install.JobID
         description: JobID of the installation.

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -1,29 +1,186 @@
+This integration supports both Palo Alto Networks Panorama and Palo Alto Networks Firewall. You can create separate instances of each integration, and they are not necessarily related or dependent on one another.
 Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.
-This integration was integrated and tested with version xx of Panorama
+This integration was integrated and tested with version 8.1.0 and 9.0.1 of Palo Alto Firewall, Palo Alto Panorama
+
+## Panorama Playbook
+* **PanoramaCommitConfiguration** : Based on the playbook input, the Playbook will commit the configuration to Palo Alto Firewall, or push the configuration from Panorama to predefined device groups of firewalls. The integration is available from Demisto v3.0, but playbook uses the GenericPooling sub-playbook, which is only available from Demisto v4.0.
+* **Panorama Query Logs** : Wraps several commands (listed below) with genericPolling to enable a complete flow to query the following log types: traffic, threat, URL, data-filtering, and Wildfire.
+   * [panorama-query-logs](#panorama-query-logs)
+   * [panorama-check-logs-status](#panorama-check-logs-status)
+   * [panorama-get-logs](#panorama-get-logs)
+* PAN-OS DAG Configuration
+* PAN-OS EDL Setup
+
+## Use Cases
+* Create custom security rules in Palo Alto Networks PAN-OS.
+* Creating and updating address objects, address-groups, custom URL categories, URL filtering objects.
+* Use the URL Filtering category information from Palo Alto Networks to enrich URLs by checking the *use_url_filtering* parameter. A valid license for the Firewall is required.
+* Get URL Filtering category information from Palo Alto - Request Change is a known Palo Alto limitation.
+* Add URL filtering objects including overrides to Palo Alto Panorama and Firewall.
+* Committing configuration to Palo Alto FW and to Panorama, and pushing configuration from Panorama to Pre-Defined Device-Groups of Firewalls.
+* Block IP addresses using registered IP tags from PAN-OS without committing the PAN-OS instance. First you have to create a registered IP tag, DAG, and security rule, and commit the instance. You can then register additional IP addresses to the tag without committing the instance.
+
+   i. Create a registered IP tag and add the necessary IP addresses by running the [panorama-register-ip-tag](#panorama-register-ip-tag) command.
+   
+   ii. Create a dynamic address group (DAG), by running the [panorama-create-address-group](#panorama-create-address-group) command. Specify values for the following arguments: type="dynamic", match={ tagname }.
+   
+   iii. Create a security rule using the DAG created in the previous step, by running the [panorama-create-rule](#panorama-create-rule) command.
+   
+   iv. Commit the PAN-OS instance by running the PanoramaCommitConfiguration playbook.
+   
+   v. You can now register IP addresses to, or unregister IP addresses from, the IP tag by running the [panorama-register-ip-tag](#panorama-register-ip-tag) command, or [panorama-unregister-ip-tag command](#panorama-unregister-ip-tag), respectively, without committing the PAN-OS instance.
+
+* Create a predefined security profiles with the best practices by Palo Alto Networks.
+* Get security profiles best practices as defined by Palo Alto Networks. For more inforamtion about Palo Alto Networks best practices, visit [Palo Alto Networks best practices](https://docs.paloaltonetworks.com/best-practices/9-0/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles).
+* Apply security profiles to specific rule.
+* Set default categories to block in the URL filtering profile.
+* Enforce WildFire best practice.
+   
+   i. Set file upload to the maximum size.
+   ii. WildFire Update Schedule is set to download and install updates every minute.
+   iii. All file types are forwarded.
+
+## Known Limitations
+* Maximum commit queue length is 3. Running numerous Panorama commands simultaneously might cause errors.
+* After you run `panorama-create-` commands and the object is not committed, then the `panorama-edit` commands or `panorama-get` commands might not run correctly.
+* URL Filtering `request change` of a URL is not available via the API. Instead, you need to use the https://urlfiltering.paloaltonetworks.com website.
+* If you do not specify a vsys (Firewall instances) or a device group (Panorama instances), you will only be able to execute certain commands.
+   * [panorama-get-url-category](#panorama-get-url-category)
+   * [panorama-commit](#panorama-commit)
+   * [panorama-push-to-device-group](#panorama-push-to-device-group)
+   * [panorama-register-ip-tag](#panorama-register-ip-tag)
+   * [panorama-unregister-ip-tag](#panorama-unregister-ip-tag)
+   * [panorama-query-logs](#panorama-query-logs)
+   * [panorama-check-logs-status](#panorama-check-logs-status)
+   * [panorama-get-logs](#panorama-get-logs)
+
 ## Configure Panorama on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
 2. Search for Panorama.
 3. Click **Add instance** to create and configure a new integration instance.
 
-    | **Parameter** | **Description** | **Required** |
-    | --- | --- | --- |
-    | server | Server URL \(e.g., https://192.168.0.1\) | True |
-    | port | Port \(e.g 443\) | False |
-    | key | API Key | True |
-    | device_group | Device group - Panorama instances only \(write shared for Shared location\) | False |
-    | vsys | Vsys - Firewall instances only | False |
-    | template | Template - Panorama instances only | False |
-    | use_url_filtering | Use URL Filtering for auto enrichment | False |
-    | additional_suspicious | URL Filtering Additional suspicious categories. CSV list of categories that will be considered suspicious. | False |
-    | additional_malicious | URL Filtering Additional malicious categories. CSV list of categories that will be considered malicious. | False |
-    | insecure | Trust any certificate \(not secure\) | False |
-    | proxy | Use system proxy settings | False |
+| **Parameter** | **Description** | **Required** |
+| --- | --- | --- |
+| server | Server URL \(e.g., https://192.168.0.1\) | True |
+| port | Port \(e.g 443\) | False |
+| key | API Key | True |
+| device_group | Device group - Panorama instances only \(write shared for Shared location\) | False |
+| vsys | Vsys - Firewall instances only | False |
+| template | Template - Panorama instances only | False |
+| use_url_filtering | Use URL Filtering for auto enrichment | False |
+| additional_suspicious | URL Filtering Additional suspicious categories. CSV list of categories that will be considered suspicious. | False |
+| additional_malicious | URL Filtering Additional malicious categories. CSV list of categories that will be considered malicious. | False |
+| insecure | Trust any certificate \(not secure\) | False |
+| proxy | Use system proxy settings | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
+   
+
 ## Commands
-You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
+You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
+
+1. [Run any command supported in the Panorama API: panorama](#panorama)
+2. [Get pre-defined threats list from a Firewall or Panorama and stores as a JSON file in the context: panorama-get-predefined-threats-list](#panorama-get-predefined-threats-list)
+3. [Commit a configuration: panorama-commit](#panorama-commit)
+4. [Pushes rules from PAN-OS to the configured device group: panorama-push-to-device-group](#panorama-push-to-device-group)
+5. [Returns a list of addresses: panorama-list-addresses](#panorama-list-addresses)
+6. [Returns address details for the supplied address name: panorama-get-address](#panorama-get-address)
+7. [Creates an address object: panorama-create-address](#panorama-create-address)
+8. [Delete an address object: panorama-delete-address](#panorama-delete-address)
+9. [Returns a list of address groups: panorama-list-address-groups](#panorama-list-address-groups)
+10. [Get details for the specified address group: panorama-get-address-group](#panorama-get-address-group)
+11. [Creates a static or dynamic address group: panorama-create-address-group](#panorama-create-address-group)
+12. [Sets a vulnerability signature to block mode: panorama-block-vulnerability](#panorama-block-vulnerability)
+13. [Deletes an address group: panorama-delete-address-group](#panorama-delete-address-group)
+14. [Edits a static or dynamic address group: panorama-edit-address-group](#panorama-edit-address-group)
+15. [Returns a list of addresses: panorama-list-services](#panorama-list-services)
+16. [Returns service details for the supplied service name: panorama-get-service](#panorama-get-service)
+17. [Creates a service: panorama-create-service](#panorama-create-service)
+18. [Deletes a service: panorama-delete-service](#panorama-delete-service)
+19. [Returns a list of service groups: panorama-list-service-groups](#panorama-list-service-groups)
+20. [Returns details for the specified service group: panorama-get-service-group](#panorama-get-service-group)
+21. [Creates a service group: panorama-create-service-group](#panorama-create-service-group)
+22. [Deletes a service group: panorama-delete-service-group](#panorama-delete-service-group)
+23. [Edit a service group: panorama-edit-service-group](#panorama-edit-service-group)
+24. [Returns information for a custom URL category: panorama-get-custom-url-category](#panorama-get-custom-url-category)
+25. [Creates a custom URL category: panorama-create-custom-url-category](#panorama-create-custom-url-category)
+26. [Deletes a custom URL category: panorama-delete-custom-url-category](#panorama-delete-custom-url-category)
+27. [Adds or removes sites to and from a custom URL category: panorama-edit-custom-url-category](#panorama-edit-custom-url-category)
+28. [Gets a URL category from URL Filtering: panorama-get-url-category](#panorama-get-url-category)
+29. [Gets a URL information: url](#url)
+30. [Returns a URL category from URL Filtering in the cloud: panorama-get-url-category-from-cloud](#panorama-get-url-category-from-cloud)
+31. [Returns a URL category from URL Filtering on the host: panorama-get-url-category-from-host](#panorama-get-url-category-from-host)
+32. [Returns information for a URL filtering rule: panorama-get-url-filter](#panorama-get-url-filter)
+33. [Creates a URL filtering rule: panorama-create-url-filter](#panorama-create-url-filter)
+34. [Edit a URL filtering rule: panorama-edit-url-filter](#panorama-edit-url-filter)
+35. [Deletes a URL filtering rule: panorama-delete-url-filter](#panorama-delete-url-filter)
+36. [Returns a list of external dynamic lists: panorama-list-edls](#panorama-list-edls)
+37. [Returns information for an external dynamic list: panorama-get-edl](#panorama-get-edl)
+38. [Creates an external dynamic list: panorama-create-edl](#panorama-create-edl)
+39. [Modifies an element of an external dynamic list: panorama-edit-edl](#panorama-edit-edl)
+40. [Deletes an external dynamic list: panorama-delete-edl](#panorama-delete-edl)
+41. [Refreshes the specified external dynamic list: panorama-refresh-edl](#panorama-refresh-edl)
+42. [Creates a policy rule: panorama-create-rule](#panorama-create-rule)
+43. [Creates a custom block policy rule: panorama-custom-block-rule](#panorama-custom-block-rule)
+44. [Changes the location of a policy rule: panorama-move-rule](#panorama-move-rule)
+45. [Edits a policy rule: panorama-edit-rule](#panorama-edit-rule)
+46. [Deletes a policy rule: panorama-delete-rule](#panorama-delete-rule)
+47. [Returns a list of applications: panorama-list-applications](#panorama-list-applications)
+48. [Returns commit status for a configuration: panorama-commit-status](#panorama-commit-status)
+49. [Returns the push status for a configuration: panorama-push-status](#panorama-push-status)
+50. [Returns information for a Panorama PCAP file: panorama-get-pcap](#panorama-get-pcap)
+51. [Returns a list of all PCAP files by PCAP type: panorama-list-pcaps](#panorama-list-pcaps)
+52. [Registers IP addresses to a tag: panorama-register-ip-tag](#panorama-register-ip-tag)
+53. [Unregisters IP addresses from a tag: panorama-unregister-ip-tag](#panorama-unregister-ip-tag)
+54. [Registers Users to a tag: panorama-register-user-tag](#panorama-register-user-tag)
+55. [Unregisters Users from a tag: panorama-unregister-user-tag](#panorama-unregister-user-tag)
+56. [Deprecated. Queries traffic logs: panorama-query-traffic-logs](#panorama-query-traffic-logs)
+57. [Deprecated. Checks the query status of traffic logs: panorama-check-traffic-logs-status](#panorama-check-traffic-logs-status)
+58. [Deprecated. Retrieves traffic log query data by job id: panorama-get-traffic-logs](#panorama-get-traffic-logs)
+59. [Returns a list of predefined Security Rules: panorama-list-rules](#panorama-list-rules)
+60. [Query logs in Panorama: panorama-query-logs](#panorama-query-logs)
+61. [Checks the status of a logs query: panorama-check-logs-status](#panorama-check-logs-status)
+62. [Retrieves the data of a logs query: panorama-get-logs](#panorama-get-logs)
+63. [Checks whether a session matches the specified security policy: panorama-security-policy-match](#panorama-security-policy-match)
+64. [Lists the static routes of a virtual router: panorama-list-static-routes](#panorama-list-static-routes)
+65. [Returns the specified static route of a virtual router: panorama-get-static-route](#panorama-get-static-route)
+66. [Adds a static route: panorama-add-static-route](#panorama-add-static-route)
+67. [Deletes a static route: panorama-delete-static-route](#panorama-delete-static-route)
+68. [Show firewall device software version: panorama-show-device-version](#panorama-show-device-version)
+69. [Downloads the latest content update: panorama-download-latest-content-update](#panorama-download-latest-content-update)
+70. [Checks the download status of a content update: panorama-content-update-download-status](#panorama-content-update-download-status)
+71. [Installs the latest content update: panorama-install-latest-content-update](#panorama-install-latest-content-update)
+72. [Gets the installation status of the content update: panorama-content-update-install-status](#panorama-content-update-install-status)
+73. [Checks the PAN-OS software version from the repository: panorama-check-latest-panos-software](#panorama-check-latest-panos-software)
+74. [Downloads the target PAN-OS software version to install on the target device: panorama-download-panos-version](#panorama-download-panos-version)
+75. [Gets the download status of the target PAN-OS software: panorama-download-panos-status](#panorama-download-panos-status)
+76. [Installs the target PAN-OS version on the specified target device: panorama-install-panos-version](#panorama-install-panos-version)
+77. [Gets the installation status of the PAN-OS software: panorama-install-panos-status](#panorama-install-panos-status)
+78. [Reboots the Firewall device: panorama-device-reboot](#panorama-device-reboot)
+79. [Gets location information for an IP address: panorama-show-location-ip](#panorama-show-location-ip)
+80. [Gets information about available PAN-OS licenses and their statuses: panorama-get-licenses](#panorama-get-licenses)
+81. [Gets information for the specified security profile: panorama-get-security-profiles](#panorama-get-security-profiles)
+82. [Apply a security profile to specific rules or rules with a specific tag: panorama-apply-security-profile](#panorama-apply-security-profile)
+83. [Get SSL decryption rules: panorama-get-ssl-decryption-rules](#panorama-get-ssl-decryption-rules)
+84. [Retrieves the Wildfire configuration: panorama-get-wildfire-configuration](#panorama-get-wildfire-configuration)
+85. [Set default categories to block in the URL filtering profile: panorama-url-filtering-block-default-categories](#panorama-url-filtering-block-default-categories)
+86. [Get anti-spyware best practices: panorama-get-anti-spyware-best-practice](#panorama-get-anti-spyware-best-practice)
+87. [Get file-blocking best practices: panorama-get-file-blocking-best-practice](#panorama-get-file-blocking-best-practice)
+88. [Get anti-virus best practices: panorama-get-antivirus-best-practice](#panorama-get-antivirus-best-practice)
+89. [Get vulnerability-protection best practices: panorama-get-vulnerability-protection-best-practice](#panorama-get-vulnerability-protection-best-practice)
+90. [View WildFire best practices: panorama-get-wildfire-best-practice](#panorama-get-wildfire-best-practice)
+91. [View URL Filtering best practices: panorama-get-url-filtering-best-practice](#panorama-get-url-filtering-best-practice)
+92. [Enforces wildfire best practices to upload files to the maximum size, forwards all file types, and updates the schedule: panorama-enforce-wildfire-best-practice](#panorama-enforce-wildfire-best-practice)
+93. [Creates an antivirus best practice profile: panorama-create-antivirus-best-practice-profile](#panorama-create-antivirus-best-practice-profile)
+94. [Creates an Anti-Spyware best practice profile: panorama-create-anti-spyware-best-practice-profile](#panorama-create-anti-spyware-best-practice-profile)
+95. [Creates a vulnerability protection best practice profile: panorama-create-vulnerability-best-practice-profile](#panorama-create-vulnerability-best-practice-profile)
+96. [Creates a URL filtering best practice profile: panorama-create-url-filtering-best-practice-profile](#panorama-create-url-filtering-best-practice-profile)
+97. [Creates a file blocking best practice profile: panorama-create-file-blocking-best-practice-profile](#panorama-create-file-blocking-best-practice-profile)
+98. [Creates a WildFire analysis best practice profile: panorama-create-wildfire-best-practice-profile](#panorama-create-wildfire-best-practice-profile)
+
+
 ### panorama
 ***
 Run any command supported in the API.
@@ -36,10 +193,10 @@ Run any command supported in the API.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| action | Action to be taken, such as show, get, set, edit, delete, rename, clone, move, override, multi-move, multi-clone, or complete. Possible values are: set, edit, delete, rename, clone, move, override, muti-move, multi-clone, complete, show, get. | Optional | 
+| action | Action to be taken, such as show, get, set, edit, delete, rename, clone, move, override, multi-move, multi-clone, or complete. | Optional | 
 | category | Category parameter. For example, when exporting a configuration file, use "category=configuration". | Optional | 
 | cmd | Specifies the xml structure that defines the command. Used for operation commands. | Optional | 
-| command | Run a command. For example, command =&lt;show&gt;&lt;arp&gt;&lt;entry name='all'/&gt;&lt;/arp&gt;&lt;/show&gt;. | Optional | 
+| command | Run a command. For example, command =&lt;show&gt;&lt;arp&gt;&lt;entry name='all'/&gt;&lt;/arp&gt;&lt;/show&gt; | Optional | 
 | dst | Specifies a destination. | Optional | 
 | element | Used to define a new value for an object. | Optional | 
 | to | End time (used when cloning an object). | Optional | 
@@ -47,13 +204,13 @@ Run any command supported in the API.
 | key | Sets a key value. | Optional | 
 | log-type | Retrieves log types. For example, log-type=threat for threat logs. | Optional | 
 | where | Specifies the type of a move operation (for example, where=after, where=before, where=top, where=bottom). | Optional | 
-| period | Time period. For example, period=last-24-hrs. | Optional | 
-| xpath | xpath location. For example, xpath=/config/predefined/application/entry[@name='hotmail']. | Optional | 
+| period | Time period. For example, period=last-24-hrs | Optional | 
+| xpath | xpath location. For example, xpath=/config/predefined/application/entry[@name='hotmail'] | Optional | 
 | pcap-id | PCAP ID included in the threat log. | Optional | 
 | serialno | Specifies the device serial number. | Optional | 
 | reporttype | Chooses the report type, such as dynamic, predefined or custom. | Optional | 
 | reportname | Report name. | Optional | 
-| type | Request type (e.g. export, import, log, config). Default is keygen,config,commit,op,report,log,import,export,user-id,version. | Optional | 
+| type | Request type (e.g. export, import, log, config). | Optional | 
 | search-time | The time that the PCAP was received on the firewall. Used for threat PCAPs. | Optional | 
 | target | Target number of the firewall. Use only on a Panorama instance. | Optional | 
 | job-id | Job ID. | Optional | 
@@ -64,16 +221,10 @@ Run any command supported in the API.
 
 There is no context output for this command.
 
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
-
 
 ### panorama-get-predefined-threats-list
 ***
-Gets the predefined threats list from a Firewall or Panorama and stores it as a JSON file in the context.
+Gets the pre-defined threats list from a Firewall or Panorama and stores as a JSON file in the context.
 
 
 #### Base Command
@@ -93,26 +244,23 @@ Gets the predefined threats list from a Firewall or Panorama and stores it as a 
 | File.Size | number | File size. | 
 | File.Name | string | File name. | 
 | File.Type | string | File type. | 
-| File.Info | string | File information. | 
+| File.Info | string | File info. | 
 | File.Extension | string | File extension. | 
-| File.EntryID | string | File entry ID. | 
+| File.EntryID | string | File entryID. | 
 | File.MD5 | string | MD5 hash of the file. | 
 | File.SHA1 | string | SHA1 hash of the file. | 
 | File.SHA256 | string | SHA256 hash of the file. | 
-| File.SHA512 | string | SHA512 hash of the file. | 
-| File.SSDeep | string | SSDeep hash of the file. | 
+| File.SHA512 | string | SHA512 hash of the file. |
+| File.SSDeep | string | SSDeep hash of the file. |
 
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-get-predefined-threats-list```
 
 
 ### panorama-commit
 ***
-Commits a configuration to the Palo Alto firewall or Panorama, but does not validate if the commit was successful. Committing to Panorama does not push the configuration to the firewalls. To push the configuration, run the panorama-push-to-device-group command.
+Commits a configuration to Palo Alto Firewall or Panorama, but does not validate if the commit was successful. Committing to Panorama does not push the configuration to the Firewalls. To push the configuration, run the panorama-push-to-device-group command.
 
 
 #### Base Command
@@ -127,14 +275,30 @@ There are no input arguments for this command.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | Panorama.Commit.JobID | number | Job ID to commit. | 
-| Panorama.Commit.Status | string | Commit status. | 
+| Panorama.Commit.Status | string | Commit status | 
 
 
 #### Command Example
-``` ```
+```!panorama-commit```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Commit": {
+            "JobID": "113198",
+            "Status": "Pending"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Commit:
+>|JobID|Status|
+>|---|---|
+>| 113198 | Pending |
 
 
 ### panorama-push-to-device-group
@@ -162,11 +326,14 @@ Pushes rules from PAN-OS to the configured device group.
 
 
 #### Command Example
-``` ```
+```!panorama-push-to-device-group ```
 
 #### Human Readable Output
 
-
+>### Push to Device Group Status:
+>|JobID|Status|
+>|---|---|
+>| 113198 | Pending |
 
 ### panorama-list-addresses
 ***
@@ -198,10 +365,34 @@ Returns a list of addresses.
 
 
 #### Command Example
-``` ```
+```!panorama-list-addresses```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Addresses": [
+            {
+                "IP_Netmask": "10.10.10.1/24",
+                "Name": "Demisto address"
+            },
+            {
+                "Description": "a",
+                "IP_Netmask": "1.1.1.1",
+                "Name": "test1"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Addresses:
+>|Name|IP_Netmask|IP_Range|FQDN|
+>|---|---|---|---|
+>| Demisto address | 10.10.10.1/24 |  |  |
+>| test1 | 1.1.1.1 |  |  |
 
 
 ### panorama-get-address
@@ -234,10 +425,26 @@ Returns address details for the supplied address name.
 
 
 #### Command Example
-``` ```
+```!panorama-get-address name="Demisto address"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Addresses": {
+            "IP_Netmask": "10.10.10.1/24",
+            "Name": "Demisto address"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Address:
+>|Name|IP_Netmask|
+>|---|---|
+>| Demisto address | 10.10.10.1/24 |
 
 
 ### panorama-create-address
@@ -255,8 +462,8 @@ Creates an address object.
 | name | New address name. | Required | 
 | description | New address description. | Optional | 
 | fqdn | FQDN of the new address. | Optional | 
-| ip_netmask | IP Netmask of the new address. For example, 10.10.10.10/24. | Optional | 
-| ip_range | IP range of the new address IP. For example, 10.10.10.0-10.10.10.255. | Optional | 
+| ip_netmask | IP Netmask of the new address. For example, 10.10.10.10/24 | Optional | 
+| ip_range | IP range of the new address IP. For example, 10.10.10.0-10.10.10.255 | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
 | tag | The tag for the new address. | Optional | 
 
@@ -275,11 +482,24 @@ Creates an address object.
 
 
 #### Command Example
-``` ```
+```!panorama-create-address name="address_test_pb" description="just a desc" ip_range="10.10.10.9-10.10.10.10"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Addresses": {
+            "Description": "just a desc",
+            "IP_Range": "10.10.10.9-10.10.10.10",
+            "Name": "address_test_pb"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Address was created successfully.
 
 ### panorama-delete-address
 ***
@@ -306,11 +526,22 @@ Delete an address object
 
 
 #### Command Example
-``` ```
+```!panorama-delete-address name="address_test_pb"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Addresses": {
+            "Name": "address_test_pb"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Address was deleted successfully.
 
 ### panorama-list-address-groups
 ***
@@ -342,10 +573,55 @@ Returns a list of address groups.
 
 
 #### Command Example
-``` ```
+```!panorama-list-address-groups```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "AddressGroups": [
+            {
+                "Match": "2.2.2.2",
+                "Name": "a_g_1",
+                "Type": "dynamic"
+            },
+            {
+                "Addresses": [
+                    "Demisto address",
+                    "test3",
+                    "test_demo3"
+                ],
+                "Name": "Demisto group",
+                "Type": "static"
+            },
+            {
+                "Description": "jajja",
+                "Match": "4.4.4.4",
+                "Name": "dynamic2",
+                "Type": "dynamic"
+            },
+            {
+                "Addresses": [
+                    "test4",
+                    "test2"
+                ],
+                "Name": "static2",
+                "Type": "static"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Address groups:
+>|Name|Type|Addresses|Match|Description|Tags|
+>|---|---|---|---|---|---|
+>| a_g_1 | dynamic |  | 2.2.2.2 |  |  |
+>| Demisto group | static | Demisto address,<br/>test3,<br/>test_demo3 |  |  |  |
+>| dynamic2 | dynamic |  | 4.4.4.4 | jajja |  |
+>| static2 | static | test4,<br/>test2 |  |  |  |
 
 
 ### panorama-get-address-group
@@ -378,11 +654,14 @@ Get details for the specified address group
 
 
 #### Command Example
-``` ```
+```!panorama-get-address-group name=suspicious_address_group ```
 
 #### Human Readable Output
 
-
+>### Address groups:
+>|Name|Type|Addresses|Match|Description|
+>|---|---|---|---|---|
+>| suspicious_address_group | dynamic | 1.1.1.1 | this ip is very bad |
 
 ### panorama-create-address-group
 ***
@@ -397,8 +676,8 @@ Creates a static or dynamic address group.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Address group name. | Required | 
-| type | Address group type. Possible values are: dynamic, static. | Required | 
-| match | Dynamic Address group match. e.g: "1.1.1.1 or 2.2.2.2". | Optional | 
+| type | Address group type. | Required | 
+| match | Dynamic Address group match. e.g: "1.1.1.1 or 2.2.2.2" | Optional | 
 | addresses | Static address group list of addresses. | Optional | 
 | description | Address group description. | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
@@ -419,11 +698,25 @@ Creates a static or dynamic address group.
 
 
 #### Command Example
-``` ```
+```!panorama-create-address-group name=suspicious_address_group type=dynamic match=1.1.1.1 description="this ip is very bad"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "AddressGroups": {
+            "Description": "this ip is very bad",
+            "Match": "1.1.1.1",
+            "Name": "suspicious_address_group",
+            "Type": "dynamic"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Address group was created successfully.
 
 ### panorama-block-vulnerability
 ***
@@ -437,7 +730,7 @@ Sets a vulnerability signature to block mode.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| drop_mode | Type of session rejection. Possible values are: "drop", "alert", "block-ip", "reset-both", "reset-client", and "reset-server". Default is "drop". Possible values are: drop, alert, block-ip, reset-both, reset-client, reset-server. | Optional | 
+| drop_mode | Type of session rejection. Possible values are: "drop", "alert", "block-ip", "reset-both", "reset-client", and "reset-server".' Default is "drop". | Optional | 
 | vulnerability_profile | Name of vulnerability profile. | Required | 
 | threat_id | Numerical threat ID. | Required | 
 
@@ -451,11 +744,11 @@ Sets a vulnerability signature to block mode.
 
 
 #### Command Example
-``` ```
+```!panorama-block-vulnerability threat_id=18250 vulnerability_profile=name```
 
 #### Human Readable Output
 
-
+>Threat with ID 18250 overridden.
 
 ### panorama-delete-address-group
 ***
@@ -482,11 +775,12 @@ Deletes an address group.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-address-group name="dynamic_address_group_test_pb3"```
+
 
 #### Human Readable Output
 
-
+>Address group was deleted successfully
 
 ### panorama-edit-address-group
 ***
@@ -501,7 +795,7 @@ Edits a static or dynamic address group.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the address group to edit. | Required | 
-| type | Address group type. Possible values are: static, dynamic. | Required | 
+| type | Address group type. | Required | 
 | match | Address group new match. For example, '1.1.1.1 and 2.2.2.2'. | Optional | 
 | element_to_add | Element to add to the list of the static address group. Only existing Address objects can be added. | Optional | 
 | element_to_remove | Element to remove from the list of the static address group. Only existing Address objects can be removed. | Optional | 
@@ -520,13 +814,6 @@ Edits a static or dynamic address group.
 | Panorama.AddressGroups.Addresses | string | Static Address group addresses. | 
 | Panorama.AddressGroups.DeviceGroup | String | Device group for the address group \(Panorama instances\). | 
 | Panorama.AddressGroups.Tags | String | Address group tags. | 
-
-
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
 
 
 ### panorama-list-services
@@ -559,10 +846,39 @@ Returns a list of addresses.
 
 
 #### Command Example
-``` ```
+```!panorama-list-services```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Services": [
+            {
+                "Description": "rgfg",
+                "DestinationPort": "55",
+                "Name": "demisto_service1",
+                "Protocol": "tcp",
+                "SourcePort": "567-569"
+            },
+            {
+                "Description": "mojo",
+                "DestinationPort": "55",
+                "Name": "demi_service_test_pb",
+                "Protocol": "sctp",
+                "SourcePort": "60"
+            },
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Services:
+>|Name|Protocol|SourcePort|DestinationPort|Description|
+>|---|---|---|---|---|
+>| demisto_service1 | tcp | 567-569 | 55 | rgfg |
+>| demi_service_test_pb | sctp | 60 | 55 | mojo |
 
 
 ### panorama-get-service
@@ -595,10 +911,14 @@ Returns service details for the supplied service name.
 
 
 #### Command Example
-``` ```
+```!panorama-get-service name=demisto_service1 ```
 
 #### Human Readable Output
 
+>### Address
+>|Name|Protocol|SourcePort|DestinationPort|Description|
+>|---|---|---|---|---|
+>| demisto_service1 | tcp | 567-569 | 55 | rgfg |
 
 
 ### panorama-create-service
@@ -614,7 +934,7 @@ Creates a service.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name for the new service. | Required | 
-| protocol | Protocol for the new service. Possible values are: tcp, udp, sctp. | Required | 
+| protocol | Protocol for the new service. | Required | 
 | destination_port | Destination port  for the new service. | Required | 
 | source_port | Source port  for the new service. | Optional | 
 | description | Description for the new service. | Optional | 
@@ -636,11 +956,25 @@ Creates a service.
 
 
 #### Command Example
-``` ```
+```!panorama-create-service name=guy_ser3 protocol=udp destination_port=36 description=bfds```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Services": {
+            "Description": "bfds",
+            "DestinationPort": "36",
+            "Name": "guy_ser3",
+            "Protocol": "udp"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Service was created successfully.
 
 ### panorama-delete-service
 ***
@@ -667,11 +1001,22 @@ Deletes a service.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-service name=guy_ser3```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Services": {
+            "Name": "guy_ser3"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Service was deleted successfully.
 
 ### panorama-list-service-groups
 ***
@@ -700,10 +1045,36 @@ Returns a list of service groups.
 
 
 #### Command Example
-``` ```
+```!panorama-list-service-groups```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "ServiceGroups": [
+            {
+                "Name": "demisto_default_service_groups",
+                "Services": [
+                    "service-http",
+                    "service-https"
+                ]
+            },
+            {
+                "Name": "demisto_test_pb_service_group",
+                "Services": "serice_tcp_test_pb"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Service groups:
+>|Name|Services|
+>|---|---|
+>| demisto_default_service_groups | service-http,<br/>service-https |
+>| demisto_test_pb_service_group | serice_tcp_test_pb |
 
 
 ### panorama-get-service-group
@@ -733,10 +1104,29 @@ Returns details for the specified service group.
 
 
 #### Command Example
-``` ```
+```!panorama-get-service-group name=ser_group6```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "ServiceGroups": {
+            "Name": "ser_group6",
+            "Services": [
+                "serice_tcp_test_pb",
+                "demi_service_test_pb"
+            ]
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Service group:
+>|Name|Services|
+>|---|---|
+>| ser_group6 | serice_tcp_test_pb,<br/>demi_service_test_pb |
 
 
 ### panorama-create-service-group
@@ -768,10 +1158,7 @@ Creates a service group.
 
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-create-service-group name=lalush_sg4 services=`["demisto_service1","demi_service_test_pb"]```
 
 
 ### panorama-delete-service-group
@@ -799,10 +1186,7 @@ Deletes a service group.
 
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-delete-service-group name=lalush_sg4```
 
 
 ### panorama-edit-service-group
@@ -834,10 +1218,10 @@ Edit a service group.
 
 
 #### Command Example
-``` ```
+```!panorama-edit-service-group name=lalush_sg4 services_to_remove=`["serice_udp_test_pb","demisto_service1"] ```
 
 #### Human Readable Output
-
+>Service group was edited successfully
 
 
 ### panorama-get-custom-url-category
@@ -869,11 +1253,15 @@ Returns information for a custom URL category.
 
 
 #### Command Example
-``` ```
+```!panorama-get-custom-url-category name=my_personal_url_category```
+
 
 #### Human Readable Output
 
-
+>### Custom URL Category:
+>|Name|Sites|Description|
+>|---|---|
+>| my_personal_url_category | thepill.com,<br/>abortion.com | just a desc |
 
 ### panorama-create-custom-url-category
 ***
@@ -891,7 +1279,7 @@ Creates a custom URL category.
 | description | Description of the custom URL category to create. | Optional | 
 | sites | List of sites for the custom URL category. | Optional | 
 | device-group | The device group for which to return addresses for the custom URL category (Panorama instances). | Optional | 
-| type | The category type of the URL. Relevant from PAN-OS v9.x. Possible values are: URL List, Category Match. | Optional | 
+| type | The category type of the URL. Relevant from PAN-OS v9.x. | Optional | 
 | categories | The list of categories. Relevant from PAN-OS v9.x. | Optional | 
 
 
@@ -908,10 +1296,30 @@ Creates a custom URL category.
 
 
 #### Command Example
-``` ```
+```!panorama-create-custom-url-category name=suspicious_address_group sites=["thepill.com","abortion.com"] description=momo```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "CustomURLCategory": {
+            "Description": "momo",
+            "Name": "suspicious_address_group",
+            "Sites": [
+                "thepill.com",
+                "abortion.com"
+            ]
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Created Custom URL Category:
+>|Name|Sites|Description|
+>|---|---|---|
+>| suspicious_address_group | thepill.com,<br/>abortion.com | momo |
 
 
 ### panorama-delete-custom-url-category
@@ -939,11 +1347,22 @@ Deletes a custom URL category.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-custom-url-category name=suspicious_address_group```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "CustomURLCategory": {
+            "Name": "suspicious_address_group"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Custom URL category was deleted successfully.
 
 ### panorama-edit-custom-url-category
 ***
@@ -959,7 +1378,7 @@ Adds or removes sites to and from a custom URL category.
 | --- | --- | --- |
 | name | Name of the custom URL category to add or remove sites. | Required | 
 | sites | A comma separated list of sites to add to the custom URL category. | Optional | 
-| action | Adds or removes sites or categories. Can be "add",or "remove". Possible values are: add, remove. | Required | 
+| action | Adds or removes sites or categories. Can be "add",or "remove". | Required | 
 | categories | A comma separated list of categories to add to the custom URL category. | Optional | 
 
 
@@ -973,16 +1392,9 @@ Adds or removes sites to and from a custom URL category.
 | Panorama.CustomURLCategory.DeviceGroup | string | Device group for the Custom URL Category \(Panorama instances\). | 
 
 
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
-
-
 ### panorama-get-url-category
 ***
-Gets a URL category from URL filtering.
+Gets a URL category from URL Filtering.
 
 
 #### Base Command
@@ -1006,19 +1418,47 @@ Gets a URL category from URL filtering.
 | DBotScore.Type | String | The indicator type. | 
 | DBotScore.Indicator | String | The indicator that was tested. | 
 | URL.Data | String | The URL address. | 
-| URL.Category | String | The URL category. | 
+| URL.Category | String | The URL Category. | 
 
 
 #### Command Example
-``` ```
+```!panorama-get-url-category url="poker.com"```
+
+#### Context Example
+```json
+{
+    "DBotScore": {
+        "Indicator": "poker.com",
+        "Score": 1,
+        "Type": "url",
+        "Vendor": "PAN-OS"
+    },
+    "Panorama": {
+        "URLFilter": {
+            "Category": "gambling",
+            "URL": [
+                "poker.com"
+            ]
+        }
+    },
+    "URL": {
+        "Category": "gambling",
+        "Data": "poker.com"
+    }
+}
+```
 
 #### Human Readable Output
 
+>### URL Filtering:
+>|URL|Category|
+>|---|---|
+>| poker.com | gambling |
 
 
 ### url
 ***
-Gets a URL category from URL filtering.
+Gets a URL category from URL Filtering.
 
 
 #### Base Command
@@ -1035,7 +1475,7 @@ Gets a URL category from URL filtering.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.URLFilter.URL | string | The URL. | 
+| Panorama.URLFilter.URL | string | URL. | 
 | Panorama.URLFilter.Category | string | The URL category. | 
 | DBotScore.Vendor | String | The vendor used to calculate the score. | 
 | DBotScore.Score | Number | The actual score. | 
@@ -1043,13 +1483,6 @@ Gets a URL category from URL filtering.
 | DBotScore.Indicator | String | The indicator that was tested. | 
 | URL.Data | String | The URL address. | 
 | URL.Category | String | The URL category. | 
-
-
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
 
 
 ### panorama-get-url-category-from-cloud
@@ -1064,7 +1497,7 @@ Returns a URL category from URL filtering.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| url | The URL to check. | Required | 
+| url | URL to check. | Required | 
 
 
 #### Context Output
@@ -1072,19 +1505,23 @@ Returns a URL category from URL filtering.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | Panorama.URLFilter.URL | string | The URL. | 
-| Panorama.URLFilter.Category | string | The URL category. | 
+| Panorama.URLFilter.Category | string | URL category. | 
 
 
 #### Command Example
-``` ```
+```!panorama-get-url-category-from-cloud url=google.com ```
 
 #### Human Readable Output
 
+>### URL Filtering from cloud:
+>|URL|Category|
+>|---|---|
+>| google.com | search-engines |
 
 
 ### panorama-get-url-category-from-host
 ***
-Returns a URL category from URL filtering.
+Returns a URL category from URL Filtering.
 
 
 #### Base Command
@@ -1094,7 +1531,7 @@ Returns a URL category from URL filtering.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| url | The URL to check. | Required | 
+| url | URL to check. | Required | 
 
 
 #### Context Output
@@ -1106,11 +1543,14 @@ Returns a URL category from URL filtering.
 
 
 #### Command Example
-``` ```
+```!panorama-get-url-category-from-host url=google.com ```
 
 #### Human Readable Output
 
-
+>### URL Filtering from host:
+>|URL|Category|
+>|---|---|
+>| google.com | search-engines |
 
 ### panorama-get-url-filter
 ***
@@ -1142,11 +1582,15 @@ Returns information for a URL filtering rule.
 
 
 #### Command Example
-``` ```
+```!panorama-get-url-filter name=demisto_default_url_filter```
+
 
 #### Human Readable Output
 
-
+>### URL Filter:
+>|Name|Category|OverrideAllowList|Description|
+>|---|---|---|---|
+>| demisto_default_url_filter | {'Action': 'block', 'Name': u'abortion'},<br/>{'Action': 'block', 'Name': u'abuse-drugs'} | 888.com,<br/>777.com | gres |
 
 ### panorama-create-url-filter
 ***
@@ -1162,7 +1606,7 @@ Creates a URL filtering rule.
 | --- | --- | --- |
 | name | Name of the URL filter to create. | Required | 
 | url_category | URL categories. | Required | 
-| action | Action for the URL categories. Can be "allow", "block", "alert", "continue", or "override". Possible values are: allow, block, alert, continue, override. | Required | 
+| action | Action for the URL categories. Can be "allow", "block", "alert", "continue", or "override". | Required | 
 | override_allow_list | CSV list of URLs to exclude from the allow list. | Optional | 
 | override_block_list | CSV list of URLs to exclude from the blocked list. | Optional | 
 | description | URL Filter description. | Optional | 
@@ -1183,11 +1627,28 @@ Creates a URL filtering rule.
 
 
 #### Command Example
-``` ```
+```!panorama-create-url-filter action=block name=gambling_url url_category=gambling```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "URLFilter": {
+            "Category": [
+                {
+                    "Action": "block",
+                    "Name": "gambling"
+                }
+            ],
+            "Name": "gambling_url"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>URL Filter was created successfully.
 
 ### panorama-edit-url-filter
 ***
@@ -1202,9 +1663,9 @@ Edit a URL filtering rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the URL filter to edit. | Required | 
-| element_to_change | Element to change. Can be "override_allow_list", or "override_block_list". Possible values are: override_allow_list, override_block_list, description. | Required | 
+| element_to_change | Element to change. Can be "override_allow_list", or "override_block_list" | Required | 
 | element_value | Element value. Limited to one value. | Required | 
-| add_remove_element | Add or remove an element from the Allow List or Block List fields. Default is to 'add' the element_value to the list. Possible values are: add, remove. Default is add. | Optional | 
+| add_remove_element | Add or remove an element from the Allow List or Block List fields. Default is to 'add' the element_value to the list. | Optional | 
 
 
 #### Context Output
@@ -1221,11 +1682,12 @@ Edit a URL filtering rule.
 
 
 #### Command Example
-``` ```
+```!panorama-edit-url-filter name=demisto_default_url_filter element_to_change=override_allow_list element_value="poker.com" add_remove_element=add```
+
 
 #### Human Readable Output
 
-
+>URL Filter was edited successfully
 
 ### panorama-delete-url-filter
 ***
@@ -1240,7 +1702,7 @@ Deletes a URL filtering rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the URL filter rule to delete. | Required | 
-| device-group | The device group for which to return addresses for the URL filter (Panorama instances). | Optional | 
+| device-group | The device group for which to return addresses for the URL filter (Panorama instances) | Optional | 
 
 
 #### Context Output
@@ -1252,11 +1714,22 @@ Deletes a URL filtering rule.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-url-filter name=gambling_url```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "URLFilter": {
+            "Name": "gambling_url"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>URL Filter was deleted successfully.
 
 ### panorama-list-edls
 ***
@@ -1287,9 +1760,39 @@ Returns a list of external dynamic lists.
 
 
 #### Command Example
-``` ```
+```!panorama-list-edls```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "EDL": [
+            {
+                "Description": "6u4ju7",
+                "Name": "blabla3",
+                "Recurring": "hourly",
+                "Type": "url",
+                "URL": "lolo"
+            },
+            {
+                "Description": "ip",
+                "Name": "bad_ip_edl_demisot_web_server",
+                "Recurring": "five-minute",
+                "Type": "ip",
+                "URL": "http://192.168.1.15/files/very_bad_ip2.txt"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
+
+>### External Dynamic Lists:
+>|Name|Type|URL|Recurring|Description|
+>|---|---|---|---|---|
+>| blabla3 | url | lolo | hourly | 6u4ju7 |
+>| bad_ip_edl_demisot_web_server | ip | http://192.168.1.15/files/very_bad_ip2.txt | five-minute | ip |
 
 
 
@@ -1323,10 +1826,29 @@ Returns information for an external dynamic list
 
 
 #### Command Example
-``` ```
+```!panorama-get-edl name=test_pb_domain_edl_DONT_DEL```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "EDL": {
+            "Description": "new description3",
+            "Name": "test_pb_domain_edl_DONT_DEL",
+            "Recurring": "hourly",
+            "Type": "url",
+            "URL": "https://test_pb_task.not.real"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### External Dynamic List:
+>|Name|Type|URL|Recurring|Description|
+>|---|---|---|---|---|
+>| test_pb_domain_edl_DONT_DEL | url | https://test_pb_task.not.real | hourly | new description3 |
 
 
 ### panorama-create-edl
@@ -1343,8 +1865,8 @@ Creates an external dynamic list.
 | --- | --- | --- |
 | name | Name of the EDL. | Required | 
 | url | URL from which to pull the EDL. | Required | 
-| type | The type of EDL. Possible values are: ip, url, domain. | Required | 
-| recurring | Time interval for pulling and updating the EDL. Possible values are: five-minute, hourly. | Required | 
+| type | The type of EDL. | Required | 
+| recurring | Time interval for pulling and updating the EDL. | Required | 
 | certificate_profile | Certificate Profile name for the URL that was previously uploaded. to PAN OS. | Optional | 
 | description | Description of the EDL. | Optional | 
 | device-group | The device group for which to return addresses for the EDL (Panorama instances). | Optional | 
@@ -1364,11 +1886,25 @@ Creates an external dynamic list.
 
 
 #### Command Example
-``` ```
+```!panorama-create-edl name=new_EDL recurring="five-minute" type=url url="gmail.com"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "EDL": {
+            "Name": "new_EDL",
+            "Recurring": "five-minute",
+            "Type": "url",
+            "URL": "gmail.com"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>External Dynamic List was created successfully.
 
 ### panorama-edit-edl
 ***
@@ -1383,7 +1919,7 @@ Modifies an element of an external dynamic list.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the external dynamic list to edit. | Required | 
-| element_to_change | The element to change (“url”, “recurring”, “certificate_profile”, “description”). Possible values are: url, recurring, certificate_profile, description. | Required | 
+| element_to_change | The element to change (“url”, “recurring”, “certificate_profile”, “description”). | Required | 
 | element_value | The element value. | Required | 
 
 
@@ -1400,11 +1936,23 @@ Modifies an element of an external dynamic list.
 
 
 #### Command Example
-``` ```
+```!panorama-edit-edl name=test_pb_domain_edl_DONT_DEL element_to_change=description element_value="new description3"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "EDL": {
+            "Description": "new description3",
+            "Name": "test_pb_domain_edl_DONT_DEL"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>External Dynamic List was edited successfully
 
 ### panorama-delete-edl
 ***
@@ -1431,11 +1979,22 @@ Deletes an external dynamic list.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-edl name=new_EDL```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "EDL": {
+            "Name": "new_EDL"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>External Dynamic List was deleted successfully
 
 ### panorama-refresh-edl
 ***
@@ -1449,9 +2008,9 @@ Refreshes the specified external dynamic list.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| name | Name of the EDL. | Required | 
+| name | Name of the EDL | Required | 
 | device-group | The device group for which to return addresses for the EDL (Panorama instances). | Optional | 
-| edl_type | The type of the EDL. Required when refreshing an EDL object which is configured on Panorama. Possible values are: ip, url, domain. | Optional | 
+| edl_type | The type of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
 | location | The location of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
 | vsys | The Vsys of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
 
@@ -1461,11 +2020,11 @@ Refreshes the specified external dynamic list.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-refresh-edl name=test_pb_domain_edl_DONT_DEL ```
 
 #### Human Readable Output
 
-
+>Refreshed External Dynamic List successfully
 
 ### panorama-create-rule
 ***
@@ -1481,23 +2040,23 @@ Creates a policy rule.
 | --- | --- | --- |
 | rulename | Name of the rule to create. | Optional | 
 | description | Description of the rule to create. | Optional | 
-| action | Action for the rule. Can be "allow", "deny", or "drop". Possible values are: allow, deny, drop. | Required | 
+| action | Action for the rule. Can be "allow", "deny", or "drop". | Required | 
 | source | A comma-separated list of address object names, address group object names, or EDL object names. | Optional | 
 | destination | A comma-separated list of address object names, address group object names, or EDL object names. | Optional | 
 | source_zone | A comma-separated list of source zones. | Optional | 
 | destination_zone | A comma-separated list of destination zones. | Optional | 
-| negate_source | Whether to negate the source (address, address group). Can be "Yes" or "No". Possible values are: Yes, No. | Optional | 
-| negate_destination | Whether to negate the destination (address, address group). Can be "Yes" or "No". Possible values are: Yes, No. | Optional | 
+| negate_source | Whether to negate the source (address, address group). Can be "Yes" or "No". | Optional | 
+| negate_destination | Whether to negate the destination (address, address group). Can be "Yes" or "No". | Optional | 
 | service | Service object names for the rule (service object) to create. | Optional | 
-| disable | Whether to disable the rule. Can be "Yes" or "No" (default is "No"). Possible values are: Yes, No. Default is No. | Optional | 
-| application | A comma-separated list of application object namesfor the rule to create. Default is any. | Optional | 
-| source_user | Source user for the rule to create. Default is any. | Optional | 
-| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| disable | Whether to disable the rule. Can be "Yes" or "No" (default is "No"). | Optional | 
+| application | A comma-separated list of application object namesfor the rule to create. | Optional | 
+| source_user | Source user for the rule to create. | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
 | target | Specifies a target firewall for the rule (Panorama instances). | Optional | 
 | log_forwarding | Log forwarding profile. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 | tags | Rule tags to create. | Optional | 
-| category | A comma-separated list of URL categories. | Optional | 
+| category | A comma-separated list of URL categories. | Optional |
 | profile_setting | A profile setting group. | Optional | 
 
 
@@ -1518,16 +2077,32 @@ Creates a policy rule.
 | Panorama.SecurityRule.Target | string | Target firewall \(Panorama instances\). | 
 | Panorama.SecurityRule.LogForwarding | string | Log forwarding profile \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
-| Panorama.SecurityRules.Tags | String | Rule tags. | 
+| Panorama.SecurityRules.Tags | String | Rule tags. |
 | Panorama.SecurityRules.ProfileSetting | String | Profile setting group. | 
 
 
 #### Command Example
-``` ```
+```!panorama-create-rule rulename="block_bad_application" description="do not play at work" action="deny" application="fortnite"```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "SecurityRule": {
+            "Action": "deny",
+            "Application": "fortnite",
+            "Description": "do not play at work",
+            "Disabled": "No",
+            "Name": "block_bad_application",
+            "SourceUser": "any"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Rule configured successfully.
 
 ### panorama-custom-block-rule
 ***
@@ -1542,10 +2117,10 @@ Creates a custom block policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the custom block policy rule to create. | Optional | 
-| object_type | Object type to block in the policy rule. Can be "ip", "address-group", "edl", or "custom-url-category". Possible values are: ip, address-group, application, url-category, edl. | Required | 
+| object_type | Object type to block in the policy rule. Can be "ip", "address-group", "edl", or "custom-url-category". | Required | 
 | object_value | A comma-separated list of object values for the object_type argument. | Required | 
-| direction | Direction to block. Can be "to", "from", or "both". Default is "both". This argument is not applicable to the "custom-url-category" object_type. Possible values are: to, from, both. Default is both. | Optional | 
-| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| direction | Direction to block. Can be "to", "from", or "both". Default is "both". This argument is not applicable to the "custom-url-category" object_type. | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
 | target | Specifies a target firewall for the rule (Panorama instances). | Optional | 
 | log_forwarding | Log forwarding profile. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
@@ -1563,15 +2138,30 @@ Creates a custom block policy rule.
 | Panorama.SecurityRule.LogForwarding | string | Log forwarding profile \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
 | Panorama.SecurityRule.Tags | String | Rule tags. | 
-| Panorama.SecurityRules.ProfileSetting | String | Profile setting group. | 
 
 
 #### Command Example
-``` ```
+```!panorama-custom-block-rule object_type=application object_value=fortnite```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "SecurityRule": {
+            "Application": [
+                "fortnite"
+            ],
+            "Direction": "both",
+            "Disabled": false,
+            "Name": "demisto-9c9ed15a"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Object was blocked successfully.
 
 ### panorama-move-rule
 ***
@@ -1586,9 +2176,9 @@ Changes the location of a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to move. | Required | 
-| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. Possible values are: before, after, top, bottom. | Required | 
+| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. | Required | 
 | dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument. | Optional | 
-| pre_post | Rule location. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| pre_post | Rule location. Mandatory for Panorama instances. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 
 
@@ -1601,11 +2191,11 @@ Changes the location of a policy rule.
 
 
 #### Command Example
-``` ```
+```!panorama-move-rule rulename="test_rule3" where="bottom" ```
 
 #### Human Readable Output
 
-
+>Rule test_rule3 moved successfully
 
 ### panorama-edit-rule
 ***
@@ -1620,10 +2210,10 @@ Edits a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to edit. | Required | 
-| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag' or 'group_profile'. Possible values are: source, destination, application, action, category, description, disabled, target, log-forwarding, tag, profile-setting. | Required | 
+| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag' or 'profile-setting'. | Required | 
 | element_value | The new value for the parameter. | Required | 
-| pre_post | Pre-rule or post-rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
-| behaviour | Whether to replace, add, or remove the element_value from the current rule object value. Possible values are: replace, add, remove. Default is replace. | Optional | 
+| pre_post | Pre-rule or post-rule (Panorama instances). | Optional | 
+| behaviour | Whether to replace, add, or remove the element_value from the current rule object value. | Optional | 
 
 
 #### Context Output
@@ -1643,14 +2233,26 @@ Edits a policy rule.
 | Panorama.SecurityRule.Target | string | Target firewall \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
 | Panorama.SecurityRule.Tags | String | Tags for the rule. | 
-
+| Panorama.SecurityRules.ProfileSetting | String | Profile setting group. |
 
 #### Command Example
-``` ```
+```!panorama-edit-rule rulename="block_bad_application" element_to_change=action element_value=drop```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "SecurityRule": {
+            "Action": "drop",
+            "Name": "block_bad_application"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>Rule edited successfully.
 
 ### panorama-delete-rule
 ***
@@ -1665,7 +2267,7 @@ Deletes a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to delete. | Required | 
-| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 
 
@@ -1678,11 +2280,12 @@ Deletes a policy rule.
 
 
 #### Command Example
-``` ```
+```!panorama-delete-rule rulename=block_bad_application```
+
 
 #### Human Readable Output
 
-
+>Rule deleted successfully.
 
 ### panorama-list-applications
 ***
@@ -1696,7 +2299,7 @@ Returns a list of applications.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| predefined | Whether to list predefined applications or not. Possible values are: true, false. Default is false. | Optional | 
+| predefined | Whether to list predefined applications or not. | Optional | 
 
 
 #### Context Output
@@ -1713,10 +2316,30 @@ Returns a list of applications.
 
 
 #### Command Example
-``` ```
+```!panorama-list-applications```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Applications": {
+            "Description": "lala",
+            "Id": null,
+            "Name": "demisto_fw_app3",
+            "Risk": "1",
+            "SubCategory": "ip-protocol",
+            "Technology": "peer-to-peer"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Applications
+>|Id|Name|Risk|Category|SubCategory|Technology|Description|
+>|---|---|---|---|---|---|---|
+>|  | demisto_fw_app3 | 1 |  | ip-protocol | peer-to-peer | lala |
 
 
 ### panorama-commit-status
@@ -1745,11 +2368,14 @@ Returns commit status for a configuration.
 
 
 #### Command Example
-``` ```
+```!panorama-commit-status job_id=948 ```
 
 #### Human Readable Output
 
-
+>### Commit Status:
+>|JobID|Status|
+>|---|---|
+>| 948 | Pending |
 
 ### panorama-push-status
 ***
@@ -1778,11 +2404,14 @@ Returns the push status for a configuration.
 
 
 #### Command Example
-``` ```
+```!panorama-push-status job_id=951 ```
 
 #### Human Readable Output
 
-
+>### Push to Device Group Status:
+>|JobID|Status|Details|
+>|---|---|---|
+>| 951 | Completed | commit succeeded with warnings |
 
 ### panorama-get-pcap
 ***
@@ -1796,7 +2425,7 @@ Returns information for a Panorama PCAP file. The recommended maximum file size 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pcapType | Type of Packet Capture. Possible values are: application-pcap, filter-pcap, threat-pcap, dlp-pcap. | Required | 
+| pcapType | Type of Packet Capture. | Required | 
 | from | The file name for the PCAP type ('dlp-pcap', 'filters-pcap', or 'application-pcap'). | Optional | 
 | localName | The new name for the PCAP file after downloading. If this argument is not specified, the file name is the PCAP file name set in the firewall. | Optional | 
 | serialNo | Serial number for the request. For further information, see the Panorama XML API Documentation. | Optional | 
@@ -1815,20 +2444,17 @@ Returns information for a Panorama PCAP file. The recommended maximum file size 
 | File.Name | string | File name. | 
 | File.Type | string | File type. | 
 | File.Info | string | File info. | 
-| File.Extension | string | File extension. | 
+| File.Extenstion | string | File extension. | 
 | File.EntryID | string | FIle entryID. | 
 | File.MD5 | string | MD5 hash of the file. | 
 | File.SHA1 | string | SHA1 hash of the file. | 
 | File.SHA256 | string | SHA256 hash of the file. | 
-| File.SHA512 | string | SHA512 hash of the file. | 
-| File.SSDeep | string | SSDeep hash of the file. | 
+| File.SHA512 | string | SHA512 hash of the file. |
+| File.SSDeep | string | SSDeep hash of the file. |
 
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-get-pcap pcapType="filter-pcap" from=pcap_test ```
 
 
 ### panorama-list-pcaps
@@ -1843,7 +2469,7 @@ Returns a list of all PCAP files by PCAP type.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pcapType | Type of Packet Capture. Possible values are: application-pcap, filter-pcap, threat-pcap, dlp-pcap. | Required | 
+| pcapType | Type of Packet Capture. | Required | 
 | password | Password for Panorama. Relevant for the 'dlp-pcap' PCAP type. | Optional | 
 
 
@@ -1852,11 +2478,14 @@ Returns a list of all PCAP files by PCAP type.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-list-pcaps pcapType=“filter-pcap” ```
 
 #### Human Readable Output
 
-
+>### List of Pcaps:
+>|Pcap name|
+>|---|
+>| pcam_name |
 
 ### panorama-register-ip-tag
 ***
@@ -1872,7 +2501,7 @@ Registers IP addresses to a tag.
 | --- | --- | --- |
 | tag | Tag for which to register IP addresses. | Required | 
 | IPs | IP addresses to register. | Required | 
-| persistent | Whether the IP addresses remain registered to the tag after the device reboots ('true':persistent, 'false':non-persistent). Default is 'true'. Possible values are: true, false. Default is true. | Optional | 
+| persistent | Whether the IP addresses remain registered to the tag after the device reboots ('true':persistent, 'false':non-persistent). Default is 'true'. | Optional | 
 
 
 #### Context Output
@@ -1884,11 +2513,11 @@ Registers IP addresses to a tag.
 
 
 #### Command Example
-``` ```
+```!panorama-register-ip-tag tag=tag02 IPs=[“10.0.0.13”,“10.0.0.14”] ```
 
 #### Human Readable Output
 
-
+>Registered ip-tag successfully
 
 ### panorama-unregister-ip-tag
 ***
@@ -1911,10 +2540,11 @@ Unregisters IP addresses from a tag.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-unregister-ip-tag tag=tag02 IPs=["10.0.0.13","10.0.0.14"] ```
 
 #### Human Readable Output
 
+>Unregistered ip-tag successfully
 
 
 ### panorama-register-user-tag
@@ -1942,10 +2572,10 @@ Registers users to a tag. This command is only available for PAN-OS version 9.x 
 
 
 #### Command Example
-``` ```
+```!panorama-register-user-tag tag-tag02 Users=Username```
 
 #### Human Readable Output
-
+>Registered user-tag successfully
 
 
 ### panorama-unregister-user-tag
@@ -1960,7 +2590,7 @@ Unregisters users from a tag. This command is only available for PAN-OS version 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| tag | Tag from which to unregister users. | Required | 
+| tag | Tag from which to unregister Users. | Required | 
 | Users | A comma-separated list of users to unregister. | Required | 
 
 
@@ -1969,10 +2599,122 @@ Unregisters users from a tag. This command is only available for PAN-OS version 
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-unregister-user-tag tag-tag02 Users=Username ```
+
+#### Human Readable Output
+>Unregistered user-tag successfully
+
+
+### panorama-query-traffic-logs
+***
+Deprecated. Queries traffic logs.
+
+#### Base Command
+
+`panorama-query-traffic-logs`
+#### Input
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| query | Specifies the match criteria for the logs. This is similar to the query provided in the web interface under the Monitor tab when viewing the logs. | Optional |
+| number_of_logs | The number of logs to retrieve. Default is 100. Maximum is 5,000. | Optional |
+| direction | Whether logs are shown oldest first (forward) or newest first (backward). Default is backward. | Optional |
+| source | Source address for the query. | Optional |
+| destination | Destination address for the query. | Optional |
+| receive_time | Date and time after which logs were received, in the format: YYYY/MM/DD HH:MM:SS. | Optional |
+| application | Application for the query. | Optional |
+| to_port | Destination port for the query. | Optional |
+| action | Action for the query. | Optional |
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
+| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
+
+#### Command Example
+```!panorama-query-traffic-logs query="" number_of_logs="100" direction="backward" source="" destination="" receive_time="" application="" to_port="" action="allow"```
 
 #### Human Readable Output
 
+>### Query Traffic Logs:
+>|JobID|Status|
+>|---|---|
+>| 1858 | Pending |
+
+
+### panorama-check-traffic-logs-status
+***
+Deprecated. Checks the query status of traffic logs.
+
+#### Base Command
+
+`panorama-check-traffic-logs-status`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| job_id | Job ID of the query. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
+| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
+
+#### Command Example
+```!panorama-check-traffic-logs-status job_id="1865"```
+
+#### Human Readable Output
+
+>### Query Traffic Logs status:
+>|JobID|Status|
+>|---|---|
+>| 1858 | Pending |
+
+
+### panorama-get-traffic-logs
+***
+Deprecated. Retrieves traffic log query data by job id.
+
+#### Base Command
+
+`panorama-get-traffic-logs`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| job_id | Job ID of the query. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
+| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
+| Panorama.TrafficLogs.Logs.Action | string | Action of the traffic log. |
+| Panorama.TrafficLogs.Logs.ActionSource | string | Action source of the traffic log. |
+| Panorama.TrafficLogs.Logs.Application | string | Application of the traffic log. |
+| Panorama.TrafficLogs.Logs.Category | string | Category of the traffic log. |
+| Panorama.TrafficLogs.Logs.DeviceName | string | Device name of the traffic log. |
+| Panorama.TrafficLogs.Logs.Destination | string | Destination of the traffic log. |
+| Panorama.TrafficLogs.Logs.DestinationPort | string | Destination port of the traffic log. |
+| Panorama.TrafficLogs.Logs.FromZone | string | From zone of the traffic log. |
+| Panorama.TrafficLogs.Logs.Protocol | string | Protocol of the traffic log. |
+| Panorama.TrafficLogs.Logs.ReceiveTime | string | Receive time of the traffic log. |
+| Panorama.TrafficLogs.Logs.Rule | string | Rule of the traffic log. |
+| Panorama.TrafficLogs.Logs.SessionEndReason | string | Session end reason of the traffic log. |
+| Panorama.TrafficLogs.Logs.Source | string | Source of the traffic log. |
+| Panorama.TrafficLogs.Logs.SourcePort | string | Source port of the traffic log. |
+| Panorama.TrafficLogs.Logs.StartTime | string | Start time of the traffic log. |
+| Panorama.TrafficLogs.Logs.ToZone | string | To zone of the traffic log. |
+
+#### Command Example
+```!panorama-get-traffic-logs job_id="1865"```
 
 
 ### panorama-list-rules
@@ -1987,7 +2729,7 @@ Returns a list of predefined Security Rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pre_post | Rules location. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| pre_post | Rules location. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
 | tag | Tag for which to filter the rules. | Optional | 
 
@@ -2011,10 +2753,91 @@ Returns a list of predefined Security Rules.
 
 
 #### Command Example
-``` ```
+```!panorama-list-rules```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "SecurityRule": [
+            {
+                "Action": "drop",
+                "Application": "fortnite",
+                "Destination": "any",
+                "From": "any",
+                "Name": "demisto-7b6dc6e6",
+                "Service": "any",
+                "Source": "any",
+                "To": "any"
+            },
+            {
+                "Action": "drop",
+                "Application": "fortnite",
+                "Destination": "any",
+                "From": "any",
+                "Name": "demisto-125e5985",
+                "Service": "any",
+                "Source": "any",
+                "To": "any"
+            },
+            {
+                "Action": {
+                    "#text": "drop",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "Application": {
+                    "#text": "fortnite",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "Destination": {
+                    "#text": "any",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "From": {
+                    "#text": "any",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "Name": "demisto-9c9ed15a",
+                "Service": {
+                    "#text": "any",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "Source": {
+                    "#text": "any",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                },
+                "To": {
+                    "#text": "any",
+                    "@admin": "api",
+                    "@dirtyId": "2986",
+                    "@time": "2020/10/13 05:00:06"
+                }
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Security Rules:
+>|Name|Action|From|To|Service|
+>|---|---|---|---|---|
+>| demisto-7b6dc6e6 | drop | any | any | any |
+>| demisto-125e5985 | drop | any | any | any |
+>| demisto-9c9ed15a | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: drop | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any |
 
 
 ### panorama-query-logs
@@ -2029,7 +2852,7 @@ Query logs in Panorama.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| log-type | The log type. Can be "threat", "traffic", "wildfire", "url", or "data". Possible values are: threat, traffic, wildfire, url, data. | Required | 
+| log-type | The log type. Can be "threat", "traffic", "wildfire", "url", or "data". | Required | 
 | query | The query string by which to match criteria for the logs. This is similar to the query provided in the web interface under the Monitor tab when viewing the logs. | Optional | 
 | time-generated | The time that the log was generated from the timestamp and prior to it.<br/>e.g "2019/08/11 01:10:44". | Optional | 
 | addr-src | Source address. | Optional | 
@@ -2042,7 +2865,7 @@ Query logs in Panorama.
 | rule | Rule name, e.g "Allow all outbound". | Optional | 
 | url | URL, e.g "safebrowsing.googleapis.com". | Optional | 
 | filedigest | File hash (for WildFire logs only). | Optional | 
-| number_of_logs | Maximum number of logs to retrieve. If empty, the default is 100. The maximum is 5,000. Default is 100. | Optional | 
+| number_of_logs | Maximum number of logs to retrieve. If empty, the default is 100. The maximum is 5,000. | Optional | 
 
 
 #### Context Output
@@ -2055,11 +2878,14 @@ Query logs in Panorama.
 
 
 #### Command Example
-``` ```
+```!panorama-query-logs log-type=data query="( addr.src in 192.168.1.12 )" ```
 
 #### Human Readable Output
 
-
+>### Query Logs:
+>|JobID|Status|
+>|---|---|
+>| 678 | Pending |
 
 ### panorama-check-logs-status
 ***
@@ -2085,11 +2911,14 @@ Checks the status of a logs query.
 
 
 #### Command Example
-``` ```
+```!panorama-check-logs-status job_id=657 ```
 
 #### Human Readable Output
 
-
+>### Query Logs Status:
+>|JobID|Status|
+>|---|---|
+>| 657 | Completed |
 
 ### panorama-get-logs
 ***
@@ -2104,7 +2933,7 @@ Retrieves the data of a logs query.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | job_id | Job ID of the query. | Required | 
-| ignore_auto_extract | Whether to auto-enrich the War Room entry. If "true", entry is not auto-enriched. If "false", entry is auto-extracted. Default is "true". Default is true. | Optional | 
+| ignore_auto_extract | Whether to auto-enrich the War Room entry. If "true", entry is not auto-enriched. If "false", entry is auto-extracted. Default is "true". | Optional | 
 
 
 #### Context Output
@@ -2174,11 +3003,14 @@ enforce the policy. |
 
 
 #### Command Example
-``` ```
+```!panorama-get-logs job_id=678 ```
 
 #### Human Readable Output
 
-
+>### Query data Logs:
+>|TimeGenerated|SourceAddress|DestinationAddress|Application|Action|Rule|
+>|---|---|---|---|---|---|
+>| 2019/07/24 08:50:24 | 1.1.1.1 | 2.3.4.5 | web-browsing | deny | any - any accept |
 
 ### panorama-security-policy-match
 ***
@@ -2219,18 +3051,47 @@ Checks whether a session matches a specified security policy. This command is on
 | Panorama.SecurityPolicyMatch.QueryFields.Category | String | The category name. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Destination | String | The destination IP address. | 
 | Panorama.SecurityPolicyMatch.QueryFields.DestinationPort | Number | The destination port. | 
-| Panorama.SecurityPolicyMatch.QueryFields.From | String | The query fields from zone. | 
-| Panorama.SecurityPolicyMatch.QueryFields.To | String | The query fields to zone. | 
+| Panorama.SecurityPolicyMatch.QueryFields.From | String | The from zone. | 
+| Panorama.SecurityPolicyMatch.QueryFields.To | String | The to zone. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Protocol | String | The IP protocol value. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Source | String | The destination IP address. | 
 | Panorama.SecurityPolicyMatch.QueryFields.SourceUser | String | The source user. | 
 
 
 #### Command Example
-``` ```
+```!panorama-security-policy-match destination=1.2.3.4 protocol=1 source=2.3.4.5```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "SecurityPolicyMatch": {
+            "Query": "<test><security-policy-match><source>2.3.4.5</source><destination>1.2.3.4</destination><protocol>1</protocol></security-policy-match></test>",
+            "QueryFields": {
+                "Destination": "1.2.3.4",
+                "Protocol": "1",
+                "Source": "2.3.4.5"
+            },
+            "Rules": {
+                "Action": "allow",
+                "Category": "any",
+                "Destination": "any",
+                "From": "any",
+                "Name": "any - any accept",
+                "Source": "any",
+                "To": "any"
+            }
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Matching Security Policies:
+>|Name|Action|From|To|Source|Destination|
+>|---|---|---|---|---|---|
+>| any - any accept | allow | any | any | any | any |
 
 
 ### panorama-list-static-routes
@@ -2245,9 +3106,9 @@ Lists the static routes of a virtual router.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| virtual_router | The name of the virtual router for which to list the static routes. | Required | 
+| virtual_router | The name of the virtual router for which to list static routes. | Required | 
 | template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
-| show_uncommitted | Whether to show an uncommitted configuration. Default is "false". Possible values are: true, false. Default is false. | Optional | 
+| show_uncommitted | Whether to show an uncommitted configuration. Default is "false" | Optional | 
 
 
 #### Context Output
@@ -2256,20 +3117,51 @@ Lists the static routes of a virtual router.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-| Panorama.StaticRoutes.RouteTable | String | The route table of a static route. | 
+|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+|  Panorama.StaticRoutes.RouteTable | String | The route table of a static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 | Panorama.StaticRoutes.Uncommitted | Boolean | Whether the static route is committed. | 
 
 
 #### Command Example
-``` ```
+```!panorama-list-static-routes virtual_router=virtual_router_test_DONT_DELETE```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "StaticRoutes": [
+            {
+                "BFDprofile": "None",
+                "Destination": "2.3.4.5/32",
+                "Metric": 14,
+                "Name": "static_route_ip",
+                "NextHop": "3.3.3.3",
+                "RouteTable": "Unicast",
+                "VirtualRouter": "virtual_router_test_DONT_DELETE"
+            },
+            {
+                "Destination": "1.1.1.1/32",
+                "Metric": 1012,
+                "Name": "test_maya",
+                "NextHop": "3.3.3.3",
+                "VirtualRouter": "virtual_router_test_DONT_DELETE"
+            }
+        ]
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Displaying all Static Routes for the Virtual Router: virtual_router_test_DONT_DELETE
+>|Name|Destination|NextHop|RouteTable|Metric|BFDprofile|
+>|---|---|---|---|---|---|
+>| static_route_ip | 2.3.4.5/32 | 3.3.3.3 | Unicast | 14 | None |
+>| test_maya | 1.1.1.1/32 | 3.3.3.3 |  | 1012 |  |
 
 
 ### panorama-get-static-route
@@ -2286,7 +3178,7 @@ Returns the specified static route of a virtual router.
 | --- | --- | --- |
 | virtual_router | Name of the virtual router for which to display the static route. | Required | 
 | static_route | Name of the static route to display. | Required | 
-| template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
+| template | The template for which to run the command. Overrides the template parameter (Panorama instances). | Optional | 
 
 
 #### Context Output
@@ -2295,19 +3187,40 @@ Returns the specified static route of a virtual router.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 
 
 #### Command Example
-``` ```
+```!panorama-get-static-route static_route=static_route_ip virtual_router=virtual_router_test_DONT_DELETE```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "StaticRoutes": {
+            "BFDprofile": "None",
+            "Destination": "2.3.4.5/32",
+            "Metric": 14,
+            "Name": "static_route_ip",
+            "NextHop": "3.3.3.3",
+            "RouteTable": "Unicast",
+            "VirtualRouter": "virtual_router_test_DONT_DELETE"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Static route: static_route_ip
+>|BFDprofile|Destination|Metric|Name|NextHop|RouteTable|VirtualRouter|
+>|---|---|---|---|---|---|---|
+>| None | 2.3.4.5/32 | 14 | static_route_ip | 3.3.3.3 | Unicast | virtual_router_test_DONT_DELETE |
 
 
 ### panorama-add-static-route
@@ -2322,10 +3235,10 @@ Adds a static route.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| virtual_router | Virtual router to which the routes will be added. | Required | 
+| virtual_router | Virtual Router to which the routes will be added. | Required | 
 | static_route | The name of the static route to add. The argument is limited to a maximum of 31 characters, is case-sensitive, and supports letters, numbers, spaces, hyphens, and underscores. | Required | 
 | destination | The IP address and network mask in Classless Inter-domain Routing (CIDR) notation: ip_address/mask. For example, 192.168.0.1/24 for IPv4 or 2001:db8::/32 for IPv6). | Required | 
-| nexthop_type | The type for the next hop. Can be: "ip-address", "next-vr", "fqdn", or "discard". Possible values are: ip-address, next-vr, fqdn, discard. | Required | 
+| nexthop_type | The type for the nexthop. Can be: "ip-address", "next-vr", "fqdn" or "discard". | Required | 
 | nexthop_value | The next hop value. | Required | 
 | metric | The metric port for the static route (1-65535). | Optional | 
 | interface | The interface name in which to add the static route. | Optional | 
@@ -2338,20 +3251,33 @@ Adds a static route.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 
 
 #### Command Example
-``` ```
+```!panorama-add-static-route destination=2.3.4.5/32 nexthop_type="ip-address" nexthop_value=3.3.3.3 static_route=my_temp_route virtual_router=virtual_router_test_DONT_DELETE```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "StaticRoutes": {
+            "@code": "20",
+            "@status": "success",
+            "msg": "command succeeded"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>New uncommitted static route my_temp_route configuration added.
 
 ### panorama-delete-static-route
 ***
@@ -2367,30 +3293,42 @@ Deletes a static route.
 | --- | --- | --- |
 | route_name | The name of the static route to delete. | Required | 
 | virtual_router | The virtual router from which the routes will be deleted. | Required | 
-| template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
+| template | The template for to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.StaticRoutes.Name | String | The name of the static route to delete. | 
+| Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 | Panorama.StaticRoutes.Deleted | Boolean | Whether the static route was deleted. | 
 
 
 #### Command Example
-``` ```
+```!panorama-delete-static-route route_name=my_temp_route virtual_router=virtual_router_test_DONT_DELETE```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "StaticRoutes": {
+            "Deleted": true,
+            "Name": "my_temp_route"
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
-
+>The static route: my_temp_route was deleted. Changes are not committed.
 
 ### panorama-show-device-version
 ***
@@ -2411,17 +3349,37 @@ Show firewall device software version.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.Device.Info.Devicename | String | Device name of the PAN-OS. | 
+| Panorama.Device.Info.Devicename | String | Devicename of the PAN-OS. | 
 | Panorama.Device.Info.Model | String | Model of the PAN-OS. | 
 | Panorama.Device.Info.Serial | String | Serial number of the PAN-OS. | 
 | Panorama.Device.Info.Version | String | Version of the PAN-OS. | 
 
 
 #### Command Example
-``` ```
+```!panorama-show-device-version```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Device": {
+            "Info": {
+                "Devicename": "PA-VM",
+                "Model": "PA-VM",
+                "Serial": "000000000000000",
+                "Version": "8.1.7"
+            }
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### Device Version:
+>|Devicename|Model|Serial|Version|
+>|---|---|---|---|
+>| PA-VM | PA-VM | 000000000000000 | 8.1.7 |
 
 
 ### panorama-download-latest-content-update
@@ -2448,11 +3406,14 @@ Downloads the latest content update.
 
 
 #### Command Example
-``` ```
+```!panorama-download-latest-content-update ```
 
 #### Human Readable Output
 
-
+>### Content download:
+>|JobID|Status|
+>|---|---|
+>| 657 | Pending |
 
 ### panorama-content-update-download-status
 ***
@@ -2480,10 +3441,14 @@ Checks the download status of a content update.
 
 
 #### Command Example
-``` ```
+```!panorama-content-update-download-status job_id=678 ```
 
 #### Human Readable Output
 
+>### Content download status:
+>|JobID|Status|Details|
+>|---|---|---|
+>| 678 | Completed | download succeeded with warnings |
 
 
 ### panorama-install-latest-content-update
@@ -2510,10 +3475,14 @@ Installs the latest content update.
 
 
 #### Command Example
-``` ```
+```!panorama-install-latest-content-update ```
 
 #### Human Readable Output
 
+>### Result:
+>|JobID|Status|
+>|---|---|
+>| 878 | Pending |
 
 
 ### panorama-content-update-install-status
@@ -2542,10 +3511,14 @@ Gets the installation status of the content update.
 
 
 #### Command Example
-``` ```
+```!panorama-content-update-install-status job_id=878 ```
 
 #### Human Readable Output
 
+>### Content install status:
+>|JobID|Status|Details|
+>|---|---|---|
+>| 878 | Completed | installation succeeded with warnings |
 
 
 ### panorama-check-latest-panos-software
@@ -2568,10 +3541,7 @@ Checks the PAN-OS software version from the repository.
 There is no context output for this command.
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-check-latest-panos-software```
 
 
 ### panorama-download-panos-version
@@ -2599,11 +3569,14 @@ Downloads the target PAN-OS software version to install on the target device.
 
 
 #### Command Example
-``` ```
+```!panorama-download-panos-version target_version=1 ```
 
 #### Human Readable Output
 
-
+>### Result:
+>|JobID|Status|
+>|---|---|
+>| 111 | Pending |
 
 ### panorama-download-panos-status
 ***
@@ -2631,11 +3604,14 @@ Gets the download status of the target PAN-OS software.
 
 
 #### Command Example
-``` ```
+```!panorama-download-panos-status job_id=999```
 
 #### Human Readable Output
 
-
+>### PAN-OS download status:
+>|JobID|Status|Details|
+>|---|---|---|
+>| 999 | Completed | download succeeded with warnings |
 
 ### panorama-install-panos-version
 ***
@@ -2657,16 +3633,19 @@ Installs the target PAN-OS version on the specified target device.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.PANOS.Install.JobID | string | Job ID of the PAN-OS installation. | 
+| Panorama.PANOS.Install.JobID | string | Job ID from the PAN-OS installation. | 
 | Panorama.PANOS.Install.Status | String | Status of the PAN-OS installation. | 
 
 
 #### Command Example
-``` ```
+```!panorama-install-panos-version target_version=1 ```
 
 #### Human Readable Output
 
-
+>### PAN-OS Installation:
+>|JobID|Status|
+>|---|---|
+>| 111 | Pending |
 
 ### panorama-install-panos-status
 ***
@@ -2694,11 +3673,14 @@ Gets the installation status of the PAN-OS software.
 
 
 #### Command Example
-``` ```
+```!panorama-install-panos-status job_id=878 ```
 
 #### Human Readable Output
 
-
+>### PAN-OS installation status:
+>|JobID|Status|Details|
+>|---|---|---|
+>| 878 | Completed | installation succeeded with warnings |
 
 ### panorama-device-reboot
 ***
@@ -2712,7 +3694,7 @@ Reboots the Firewall device.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| target | The target device on which to reboot the firewall. | Optional | 
+| target | The target device for which to reboot the firewall. | Optional | 
 
 
 #### Context Output
@@ -2720,10 +3702,7 @@ Reboots the Firewall device.
 There is no context output for this command.
 
 #### Command Example
-``` ```
-
-#### Human Readable Output
-
+```!panorama-device-reboot ```
 
 
 ### panorama-show-location-ip
@@ -2746,16 +3725,36 @@ Gets location information for an IP address.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | Panorama.Location.IP.country_code | String | The IP address location country code. | 
-| Panorama.Location.IP.country_name | String | The IP address location country name. | 
+| Panorama.Location.IP.country_name | String | The IP addres location country name. | 
 | Panorama.Location.IP.ip_address | String | The IP address. | 
 | Panorama.Location.IP.Status | String | Whether the IP address was found. | 
 
 
 #### Command Example
-``` ```
+```!panorama-show-location-ip ip_address=8.8.8.8```
+
+#### Context Example
+```json
+{
+    "Panorama": {
+        "Location": {
+            "IP": {
+                "country_code": "US",
+                "country_name": "United States",
+                "ip_address": "8.8.8.8",
+                "status": "Found"
+            }
+        }
+    }
+}
+```
 
 #### Human Readable Output
 
+>### IP 8.8.8.8 location:
+>|ip_address|country_name|country_code|
+>|---|---|---|
+>| 8.8.8.8 | United States | US |
 
 
 ### panorama-get-licenses
@@ -2785,11 +3784,13 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-licences ```
 
 #### Human Readable Output
 
-
+>|Authcode|Description|Feature|Serial|Expired|Expires|Issued|
+>|---|---|---|---|---|---|---|
+>| I9805928  | NFR Support | NFR Support | 007DEMISTO1t | no | Never | November 25, 2019 |
 
 ### panorama-get-security-profiles
 ***
@@ -2803,7 +3804,7 @@ Gets information for the specified security profile.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| security_profile | The security profile for which to get information. Can be "data-filtering", "file-blocking", "spyware", "url-filtering", "virus", "vulnerability", or "wildfire-analysis". Possible values are: data-filtering, file-blocking, spyware, url-filtering, virus, vulnerability, wildfire-analysis. | Optional | 
+| security_profile | The security profile for which to get information. Can be "data-filtering", "file-blocking", "spyware", "url-filtering", "virus", "vulnerability", or "wildfire-analysis". | Optional | 
 
 
 #### Context Output
@@ -2812,7 +3813,7 @@ Gets information for the specified security profile.
 | --- | --- | --- |
 | Panorama.Spyware.Name | String | The profile name. | 
 | Panorama.Spyware.Rules.Action | String | The rule action. | 
-| Panorama.Spyware.Rules.Category | String | The category for which to apply the rule. | 
+| Panorama.Spyware.Rules.Cateogry | String | The category for which to apply the rule. | 
 | Panorama.Spyware.Rules.Name | String | The rule name. | 
 | Panorama.Spyware.Rules.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Spyware.Rules.Severity | String | The rule severity. | 
@@ -2830,7 +3831,7 @@ Gets information for the specified security profile.
 | Panorama.Vulnerability.Rules.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Vulnerability.Rules.Host | String | The rule host. | 
 | Panorama.Vulnerability.Rules.Name | String | The rule name. | 
-| Panorama.Vulnerability.Rules.Category | String | The category for which to apply the rule. | 
+| Panorama.Vulnerability.Rules.Cateogry | String | The category for which to apply the rule. | 
 | Panorama.Vulnerability.Rules.CVE | String | The CVE for which to apply the rule. | 
 | Panorama.Vulnerability.Rules.Action | String | The rule action. | 
 | Panorama.Vulnerability.Rules.Severity | String | The rule severity. | 
@@ -2856,11 +3857,13 @@ Gets information for the specified security profile.
 
 
 #### Command Example
-``` ```
+```!panorama-get-security-profiles security_profile=spyware ```
 
 #### Human Readable Output
 
-
+>|Name|Rules|
+>|---|---|
+>| best-practice  | {'Name': 'simple-critical', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'critical', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-high', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'high', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-medium', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'medium', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-informational', 'Action': {'default': None}, 'Category': 'any', 'Severity': 'informational', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-low', 'Action': {'default': None}, 'Category': 'any', 'Severity': 'low', 'Threat-name': 'any', 'Packet-capture': 'disable'} |
 
 ### panorama-apply-security-profile
 ***
@@ -2874,10 +3877,10 @@ Apply a security profile to specific rules or rules with a specific tag.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| profile_type | Security profile type. Can be 'data-filtering', 'file-blocking', 'spyware', 'url-filtering', 'virus, 'vulnerability', or wildfire-analysis.'. Possible values are: data-filtering, file-blocking, spyware, url-filtering, virus, vulnerability, wildfire-analysis. | Required | 
+| profile_type | Security profile type. Can be 'data-filtering', 'file-blocking', 'spyware', 'url-filtering', 'virus, 'vulnerability', or wildfire-analysis.' | Required | 
 | rule_name | The rule name to apply. | Required | 
 | profile_name | The profile name to apply to the rule. | Required | 
-| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
 
 
 #### Context Output
@@ -2885,10 +3888,10 @@ Apply a security profile to specific rules or rules with a specific tag.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-apply-security-profile profile_name=test profile_type=spyware rule_name=rule1 pre_post="pre-rulebase" ```
 
 #### Human Readable Output
-
+>The profile test has been applied to the rule rule1
 
 
 ### panorama-get-ssl-decryption-rules
@@ -2903,7 +3906,7 @@ Get SSL decryption rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
 
 
 #### Context Output
@@ -2926,11 +3929,13 @@ Get SSL decryption rules.
 
 
 #### Command Example
-``` ```
+```!panorama-get-ssl-decryption-rules pre_post="pre-rulebase" ```
 
 #### Human Readable Output
 
-
+>|Name|UUID|Target|Service|Category|Type|From|To|Source|Destenation|Action|Source-user|
+>|---|---|---|---|---|---|---|---|---|---|---|---|
+>| test | some_uuid | negate: no | any | member: any | ssl-forward-proxy: null | any | any | any | any | no-decrypt | any |
 
 ### panorama-get-wildfire-configuration
 ***
@@ -2957,10 +3962,20 @@ Retrieves the Wildfire configuration.
 
 
 #### Command Example
-``` ```
+```!panorama-get-wildfire-configuration template=WildFire ```
 
-#### Human Readable Output
 
+>### WildFire Configuration
+> Report Grayware File: yes
+>|Name|Size-limit|
+>|---|---|
+>| pe | 10 |
+>| apk | 30 |
+
+>### The updated schedule for Wildfire
+>|recurring|
+>|---|
+>| every-min: {"action": "download-and-install"} |
 
 
 ### panorama-url-filtering-block-default-categories
@@ -2983,11 +3998,11 @@ Set default categories to block in the URL filtering profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-url-filtering-block-default-categories profile_name=test ```
 
 #### Human Readable Output
 
-
+>The default categories to block has been set successfully to test
 
 ### panorama-get-anti-spyware-best-practice
 ***
@@ -3010,7 +4025,7 @@ There are no input arguments for this command.
 | Panorama.Spyware.BotentDomain.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Spyware.BotentDomain.Sinkhole.ipv4-address | String | The botnet domain IPv4 address. | 
 | Panorama.Spyware.BotentDomain.Sinkhole.ipv6-address | String | The Botnet domain IPv6 address. | 
-| Panorama.Spyware.Rule.Category | String | The rule category. | 
+| Panorama.Spyware.Rule.Cateogry | String | The rule category. | 
 | Panorama.Spyware.Rule.Action | String | The rule action. | 
 | Panorama.Spyware.Rule.Name | String | The rule name. | 
 | Panorama.Spyware.Rule.Severity | String | The rule severity. | 
@@ -3019,11 +4034,22 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-anti-spyware-best-practice ```
 
 #### Human Readable Output
 
+>### Anti Spyware Botnet-Domains Best Practice
+>|Name|Action|Packet-capture|ipv4-address|ipv6-address|
+>|---|---|---|---|---|
+>| default-paloalto-dns | sinkhole: null | disable |  |  |
+>| default-paloalto-cloud | allow: null | disable |  |  |
+>|  |  |  | pan-sinkhole-default-ip | ::1 |
 
+>### Anti Spyware Best Practice Rules
+>|Name|Severity|Action|Category|Threat-name|
+>|---|---|---|---|---|
+>| simple-critical | critical | reset-both: null | any | any |
+>| simple-high | high | reset-both: null | any | any |
 
 ### panorama-get-file-blocking-best-practice
 ***
@@ -3048,11 +4074,15 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-file-blocking-best-practice ```
 
 #### Human Readable Output
 
-
+>### File Blocking Profile Best Practice
+>|Name|Action|File-type|Aplication|
+>|---|---|---|---|
+>| Block all risky file types | block | 7z,<br/>bat,<br/>cab,<br/>chm,<br/>class,<br/>cpl | any |
+>| Block encrypted files | block | encrypted-rar,<br/>encrypted-zip| any |
 
 ### panorama-get-antivirus-best-practice
 ***
@@ -3076,11 +4106,15 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-antivirus-best-practice ```
 
 #### Human Readable Output
 
-
+>### Antivirus Best Practice Profile
+>|Name|Action|WildFire-action|
+>|---|---|---|
+>| http | default | default|
+>| smtp default | default |
 
 ### panorama-get-vulnerability-protection-best-practice
 ***
@@ -3100,7 +4134,7 @@ There are no input arguments for this command.
 | --- | --- | --- |
 | Panorama.Vulnerability.Rule.Action | String | The rule action. | 
 | Panorama.Vulnerability.Rule.CVE | String | The rule CVE. | 
-| Panorama.Vulnerability.Rule.Category | String | The rule category. | 
+| Panorama.Vulnerability.Rule.Cateogry | String | The rule category. | 
 | Panorama.Vulnerability.Rule.Host | String | The rule host. | 
 | Panorama.Vulnerability.Rule.Name | String | The rule name. | 
 | Panorama.Vulnerability.Rule.Severity | String | The rule severity. | 
@@ -3109,11 +4143,15 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-vulnerability-protection-best-practice ```
 
 #### Human Readable Output
 
-
+>### vulnerability Protection Best Practice Profile
+>|Name|Action|Host|Severity|Category|Threat-name|CVE|Vendor-id|
+>|---|---|---|---|---|---|---|---|
+>| simple-client-critical | reset-both: null | client | critical | any | any | any | any |
+>| simple-client-high | reset-both: null | client | high | any | any | any | any |
 
 ### panorama-get-wildfire-best-practice
 ***
@@ -3143,15 +4181,35 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-wildfire-best-practice ```
 
 #### Human Readable Output
 
+>### WildFire Best Practice Profile
+>|Name|Analysis|Aplication|File-type|
+>|---|---|---|---|
+>| default | public-cloud | any | any |
 
+>### Wildfire Best Practice Schedule
+>|Action|Recurring|
+>|---|---|
+>| download-and-install | every-minute |
+
+>### Wildfire SSL Decrypt Settings
+>|allow-forward-decrypted-content|
+>|---|
+>| yes |
+
+>### Wildfire System Settings
+>report-grayware-file: yes
+>|Name|File-size|
+>|---|---|
+>| pe | 10 |
+>| apk | 30 |
 
 ### panorama-get-url-filtering-best-practice
 ***
-View URL filtering best practices.
+View URL Filtering best practices.
 
 
 #### Base Command
@@ -3176,11 +4234,20 @@ There are no input arguments for this command.
 
 
 #### Command Example
-``` ```
+```!panorama-get-url-filtering-best-practice ```
 
 #### Human Readable Output
 
+>### URL Filtering Best Practice Profile Categories
+>|Category|DeviceGroup|Name|
+>|---|---|---|
+>| {'Name': 'abortion', 'Action': 'alert'},<br/>{'Name': 'abused-drugs', 'Action': 'alert'} | Demisto sales lab | best-practice |
 
+
+>### Best Practice Headers
+>|log-container-page-only|log-http-hdr-referer|log-http-hdr-user|log-http-hdr-xff|
+>|---|---|---|---|
+>| yes | yes | yes | yes |
 
 ### panorama-enforce-wildfire-best-practice
 ***
@@ -3202,11 +4269,11 @@ Enforces wildfire best practices to upload files to the maximum size, forwards a
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-enforce-wildfire-best-practice template=WildFire ```
 
 #### Human Readable Output
 
-
+>The schedule was updated according to the best practice. Recurring every minute with the action of "download and install" The file upload for all file types is set to the maximum size.
 
 ### panorama-create-antivirus-best-practice-profile
 ***
@@ -3228,11 +4295,11 @@ Creates an antivirus best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-antivirus-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
+>The profile test was created successfully.
 
 ### panorama-create-anti-spyware-best-practice-profile
 ***
@@ -3254,11 +4321,11 @@ Creates an Anti-Spyware best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-anti-spyware-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
+>The profile test was created successfully.
 
 ### panorama-create-vulnerability-best-practice-profile
 ***
@@ -3280,11 +4347,11 @@ Creates a vulnerability protection best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-vulnerability-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
+>The profile test was created successfully.
 
 ### panorama-create-url-filtering-best-practice-profile
 ***
@@ -3306,11 +4373,11 @@ Creates a URL filtering best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-url-filtering-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
+>The profile test was created successfully.
 
 ### panorama-create-file-blocking-best-practice-profile
 ***
@@ -3332,11 +4399,11 @@ Creates a file blocking best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-file-blocking-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
+>The profile test was created successfully.
 
 ### panorama-create-wildfire-best-practice-profile
 ***
@@ -3358,66 +4425,8 @@ Creates a WildFire analysis best practice profile.
 There is no context output for this command.
 
 #### Command Example
-``` ```
+```!panorama-create-wildfire-best-practice-profile profile_name=test ```
 
 #### Human Readable Output
 
-
-
-### panorama-upload-content-update-file
-***
-Uploads content file to Panorama
-
-
-#### Base Command
-
-`panorama-upload-content-update-file`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| entryID | Entry id of the file to upload. | Required | 
-| category | The file type. Possible values are: wildfire, anti-virus, content. | Required | 
-
-
-#### Context Output
-
-There is no context output for this command.
-
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
-
-
-### panorama-install-file-content-update
-***
-Installs specific content update file.
-
-
-#### Base Command
-
-`panorama-install-file-content-update`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| version_name | Update file name to be installed on Panorama. | Required | 
-| category | The file type. Possible values are: wildfire, anti-virus, content. | Required | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| Panorama.Content.Install.JobID | string | JobID of the installation. | 
-| Content.Install.Status | string | Installation status. | 
-
-
-#### Command Example
-``` ```
-
-#### Human Readable Output
-
-
+>The profile test was created successfully.

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -1,186 +1,29 @@
-This integration supports both Palo Alto Networks Panorama and Palo Alto Networks Firewall. You can create separate instances of each integration, and they are not necessarily related or dependent on one another.
 Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.
-This integration was integrated and tested with version 8.1.0 and 9.0.1 of Palo Alto Firewall, Palo Alto Panorama
-
-## Panorama Playbook
-* **PanoramaCommitConfiguration** : Based on the playbook input, the Playbook will commit the configuration to Palo Alto Firewall, or push the configuration from Panorama to predefined device groups of firewalls. The integration is available from Demisto v3.0, but playbook uses the GenericPooling sub-playbook, which is only available from Demisto v4.0.
-* **Panorama Query Logs** : Wraps several commands (listed below) with genericPolling to enable a complete flow to query the following log types: traffic, threat, URL, data-filtering, and Wildfire.
-   * [panorama-query-logs](#panorama-query-logs)
-   * [panorama-check-logs-status](#panorama-check-logs-status)
-   * [panorama-get-logs](#panorama-get-logs)
-* PAN-OS DAG Configuration
-* PAN-OS EDL Setup
-
-## Use Cases
-* Create custom security rules in Palo Alto Networks PAN-OS.
-* Creating and updating address objects, address-groups, custom URL categories, URL filtering objects.
-* Use the URL Filtering category information from Palo Alto Networks to enrich URLs by checking the *use_url_filtering* parameter. A valid license for the Firewall is required.
-* Get URL Filtering category information from Palo Alto - Request Change is a known Palo Alto limitation.
-* Add URL filtering objects including overrides to Palo Alto Panorama and Firewall.
-* Committing configuration to Palo Alto FW and to Panorama, and pushing configuration from Panorama to Pre-Defined Device-Groups of Firewalls.
-* Block IP addresses using registered IP tags from PAN-OS without committing the PAN-OS instance. First you have to create a registered IP tag, DAG, and security rule, and commit the instance. You can then register additional IP addresses to the tag without committing the instance.
-
-   i. Create a registered IP tag and add the necessary IP addresses by running the [panorama-register-ip-tag](#panorama-register-ip-tag) command.
-   
-   ii. Create a dynamic address group (DAG), by running the [panorama-create-address-group](#panorama-create-address-group) command. Specify values for the following arguments: type="dynamic", match={ tagname }.
-   
-   iii. Create a security rule using the DAG created in the previous step, by running the [panorama-create-rule](#panorama-create-rule) command.
-   
-   iv. Commit the PAN-OS instance by running the PanoramaCommitConfiguration playbook.
-   
-   v. You can now register IP addresses to, or unregister IP addresses from, the IP tag by running the [panorama-register-ip-tag](#panorama-register-ip-tag) command, or [panorama-unregister-ip-tag command](#panorama-unregister-ip-tag), respectively, without committing the PAN-OS instance.
-
-* Create a predefined security profiles with the best practices by Palo Alto Networks.
-* Get security profiles best practices as defined by Palo Alto Networks. For more inforamtion about Palo Alto Networks best practices, visit [Palo Alto Networks best practices](https://docs.paloaltonetworks.com/best-practices/9-0/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles).
-* Apply security profiles to specific rule.
-* Set default categories to block in the URL filtering profile.
-* Enforce WildFire best practice.
-   
-   i. Set file upload to the maximum size.
-   ii. WildFire Update Schedule is set to download and install updates every minute.
-   iii. All file types are forwarded.
-
-## Known Limitations
-* Maximum commit queue length is 3. Running numerous Panorama commands simultaneously might cause errors.
-* After you run `panorama-create-` commands and the object is not committed, then the `panorama-edit` commands or `panorama-get` commands might not run correctly.
-* URL Filtering `request change` of a URL is not available via the API. Instead, you need to use the https://urlfiltering.paloaltonetworks.com website.
-* If you do not specify a vsys (Firewall instances) or a device group (Panorama instances), you will only be able to execute certain commands.
-   * [panorama-get-url-category](#panorama-get-url-category)
-   * [panorama-commit](#panorama-commit)
-   * [panorama-push-to-device-group](#panorama-push-to-device-group)
-   * [panorama-register-ip-tag](#panorama-register-ip-tag)
-   * [panorama-unregister-ip-tag](#panorama-unregister-ip-tag)
-   * [panorama-query-logs](#panorama-query-logs)
-   * [panorama-check-logs-status](#panorama-check-logs-status)
-   * [panorama-get-logs](#panorama-get-logs)
-
+This integration was integrated and tested with version xx of Panorama
 ## Configure Panorama on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
 2. Search for Panorama.
 3. Click **Add instance** to create and configure a new integration instance.
 
-| **Parameter** | **Description** | **Required** |
-| --- | --- | --- |
-| server | Server URL \(e.g., https://192.168.0.1\) | True |
-| port | Port \(e.g 443\) | False |
-| key | API Key | True |
-| device_group | Device group - Panorama instances only \(write shared for Shared location\) | False |
-| vsys | Vsys - Firewall instances only | False |
-| template | Template - Panorama instances only | False |
-| use_url_filtering | Use URL Filtering for auto enrichment | False |
-| additional_suspicious | URL Filtering Additional suspicious categories. CSV list of categories that will be considered suspicious. | False |
-| additional_malicious | URL Filtering Additional malicious categories. CSV list of categories that will be considered malicious. | False |
-| insecure | Trust any certificate \(not secure\) | False |
-| proxy | Use system proxy settings | False |
+    | **Parameter** | **Description** | **Required** |
+    | --- | --- | --- |
+    | server | Server URL \(e.g., https://192.168.0.1\) | True |
+    | port | Port \(e.g 443\) | False |
+    | key | API Key | True |
+    | device_group | Device group - Panorama instances only \(write shared for Shared location\) | False |
+    | vsys | Vsys - Firewall instances only | False |
+    | template | Template - Panorama instances only | False |
+    | use_url_filtering | Use URL Filtering for auto enrichment | False |
+    | additional_suspicious | URL Filtering Additional suspicious categories. CSV list of categories that will be considered suspicious. | False |
+    | additional_malicious | URL Filtering Additional malicious categories. CSV list of categories that will be considered malicious. | False |
+    | insecure | Trust any certificate \(not secure\) | False |
+    | proxy | Use system proxy settings | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
-   
-
 ## Commands
-You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
+You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
-
-1. [Run any command supported in the Panorama API: panorama](#panorama)
-2. [Get pre-defined threats list from a Firewall or Panorama and stores as a JSON file in the context: panorama-get-predefined-threats-list](#panorama-get-predefined-threats-list)
-3. [Commit a configuration: panorama-commit](#panorama-commit)
-4. [Pushes rules from PAN-OS to the configured device group: panorama-push-to-device-group](#panorama-push-to-device-group)
-5. [Returns a list of addresses: panorama-list-addresses](#panorama-list-addresses)
-6. [Returns address details for the supplied address name: panorama-get-address](#panorama-get-address)
-7. [Creates an address object: panorama-create-address](#panorama-create-address)
-8. [Delete an address object: panorama-delete-address](#panorama-delete-address)
-9. [Returns a list of address groups: panorama-list-address-groups](#panorama-list-address-groups)
-10. [Get details for the specified address group: panorama-get-address-group](#panorama-get-address-group)
-11. [Creates a static or dynamic address group: panorama-create-address-group](#panorama-create-address-group)
-12. [Sets a vulnerability signature to block mode: panorama-block-vulnerability](#panorama-block-vulnerability)
-13. [Deletes an address group: panorama-delete-address-group](#panorama-delete-address-group)
-14. [Edits a static or dynamic address group: panorama-edit-address-group](#panorama-edit-address-group)
-15. [Returns a list of addresses: panorama-list-services](#panorama-list-services)
-16. [Returns service details for the supplied service name: panorama-get-service](#panorama-get-service)
-17. [Creates a service: panorama-create-service](#panorama-create-service)
-18. [Deletes a service: panorama-delete-service](#panorama-delete-service)
-19. [Returns a list of service groups: panorama-list-service-groups](#panorama-list-service-groups)
-20. [Returns details for the specified service group: panorama-get-service-group](#panorama-get-service-group)
-21. [Creates a service group: panorama-create-service-group](#panorama-create-service-group)
-22. [Deletes a service group: panorama-delete-service-group](#panorama-delete-service-group)
-23. [Edit a service group: panorama-edit-service-group](#panorama-edit-service-group)
-24. [Returns information for a custom URL category: panorama-get-custom-url-category](#panorama-get-custom-url-category)
-25. [Creates a custom URL category: panorama-create-custom-url-category](#panorama-create-custom-url-category)
-26. [Deletes a custom URL category: panorama-delete-custom-url-category](#panorama-delete-custom-url-category)
-27. [Adds or removes sites to and from a custom URL category: panorama-edit-custom-url-category](#panorama-edit-custom-url-category)
-28. [Gets a URL category from URL Filtering: panorama-get-url-category](#panorama-get-url-category)
-29. [Gets a URL information: url](#url)
-30. [Returns a URL category from URL Filtering in the cloud: panorama-get-url-category-from-cloud](#panorama-get-url-category-from-cloud)
-31. [Returns a URL category from URL Filtering on the host: panorama-get-url-category-from-host](#panorama-get-url-category-from-host)
-32. [Returns information for a URL filtering rule: panorama-get-url-filter](#panorama-get-url-filter)
-33. [Creates a URL filtering rule: panorama-create-url-filter](#panorama-create-url-filter)
-34. [Edit a URL filtering rule: panorama-edit-url-filter](#panorama-edit-url-filter)
-35. [Deletes a URL filtering rule: panorama-delete-url-filter](#panorama-delete-url-filter)
-36. [Returns a list of external dynamic lists: panorama-list-edls](#panorama-list-edls)
-37. [Returns information for an external dynamic list: panorama-get-edl](#panorama-get-edl)
-38. [Creates an external dynamic list: panorama-create-edl](#panorama-create-edl)
-39. [Modifies an element of an external dynamic list: panorama-edit-edl](#panorama-edit-edl)
-40. [Deletes an external dynamic list: panorama-delete-edl](#panorama-delete-edl)
-41. [Refreshes the specified external dynamic list: panorama-refresh-edl](#panorama-refresh-edl)
-42. [Creates a policy rule: panorama-create-rule](#panorama-create-rule)
-43. [Creates a custom block policy rule: panorama-custom-block-rule](#panorama-custom-block-rule)
-44. [Changes the location of a policy rule: panorama-move-rule](#panorama-move-rule)
-45. [Edits a policy rule: panorama-edit-rule](#panorama-edit-rule)
-46. [Deletes a policy rule: panorama-delete-rule](#panorama-delete-rule)
-47. [Returns a list of applications: panorama-list-applications](#panorama-list-applications)
-48. [Returns commit status for a configuration: panorama-commit-status](#panorama-commit-status)
-49. [Returns the push status for a configuration: panorama-push-status](#panorama-push-status)
-50. [Returns information for a Panorama PCAP file: panorama-get-pcap](#panorama-get-pcap)
-51. [Returns a list of all PCAP files by PCAP type: panorama-list-pcaps](#panorama-list-pcaps)
-52. [Registers IP addresses to a tag: panorama-register-ip-tag](#panorama-register-ip-tag)
-53. [Unregisters IP addresses from a tag: panorama-unregister-ip-tag](#panorama-unregister-ip-tag)
-54. [Registers Users to a tag: panorama-register-user-tag](#panorama-register-user-tag)
-55. [Unregisters Users from a tag: panorama-unregister-user-tag](#panorama-unregister-user-tag)
-56. [Deprecated. Queries traffic logs: panorama-query-traffic-logs](#panorama-query-traffic-logs)
-57. [Deprecated. Checks the query status of traffic logs: panorama-check-traffic-logs-status](#panorama-check-traffic-logs-status)
-58. [Deprecated. Retrieves traffic log query data by job id: panorama-get-traffic-logs](#panorama-get-traffic-logs)
-59. [Returns a list of predefined Security Rules: panorama-list-rules](#panorama-list-rules)
-60. [Query logs in Panorama: panorama-query-logs](#panorama-query-logs)
-61. [Checks the status of a logs query: panorama-check-logs-status](#panorama-check-logs-status)
-62. [Retrieves the data of a logs query: panorama-get-logs](#panorama-get-logs)
-63. [Checks whether a session matches the specified security policy: panorama-security-policy-match](#panorama-security-policy-match)
-64. [Lists the static routes of a virtual router: panorama-list-static-routes](#panorama-list-static-routes)
-65. [Returns the specified static route of a virtual router: panorama-get-static-route](#panorama-get-static-route)
-66. [Adds a static route: panorama-add-static-route](#panorama-add-static-route)
-67. [Deletes a static route: panorama-delete-static-route](#panorama-delete-static-route)
-68. [Show firewall device software version: panorama-show-device-version](#panorama-show-device-version)
-69. [Downloads the latest content update: panorama-download-latest-content-update](#panorama-download-latest-content-update)
-70. [Checks the download status of a content update: panorama-content-update-download-status](#panorama-content-update-download-status)
-71. [Installs the latest content update: panorama-install-latest-content-update](#panorama-install-latest-content-update)
-72. [Gets the installation status of the content update: panorama-content-update-install-status](#panorama-content-update-install-status)
-73. [Checks the PAN-OS software version from the repository: panorama-check-latest-panos-software](#panorama-check-latest-panos-software)
-74. [Downloads the target PAN-OS software version to install on the target device: panorama-download-panos-version](#panorama-download-panos-version)
-75. [Gets the download status of the target PAN-OS software: panorama-download-panos-status](#panorama-download-panos-status)
-76. [Installs the target PAN-OS version on the specified target device: panorama-install-panos-version](#panorama-install-panos-version)
-77. [Gets the installation status of the PAN-OS software: panorama-install-panos-status](#panorama-install-panos-status)
-78. [Reboots the Firewall device: panorama-device-reboot](#panorama-device-reboot)
-79. [Gets location information for an IP address: panorama-show-location-ip](#panorama-show-location-ip)
-80. [Gets information about available PAN-OS licenses and their statuses: panorama-get-licenses](#panorama-get-licenses)
-81. [Gets information for the specified security profile: panorama-get-security-profiles](#panorama-get-security-profiles)
-82. [Apply a security profile to specific rules or rules with a specific tag: panorama-apply-security-profile](#panorama-apply-security-profile)
-83. [Get SSL decryption rules: panorama-get-ssl-decryption-rules](#panorama-get-ssl-decryption-rules)
-84. [Retrieves the Wildfire configuration: panorama-get-wildfire-configuration](#panorama-get-wildfire-configuration)
-85. [Set default categories to block in the URL filtering profile: panorama-url-filtering-block-default-categories](#panorama-url-filtering-block-default-categories)
-86. [Get anti-spyware best practices: panorama-get-anti-spyware-best-practice](#panorama-get-anti-spyware-best-practice)
-87. [Get file-blocking best practices: panorama-get-file-blocking-best-practice](#panorama-get-file-blocking-best-practice)
-88. [Get anti-virus best practices: panorama-get-antivirus-best-practice](#panorama-get-antivirus-best-practice)
-89. [Get vulnerability-protection best practices: panorama-get-vulnerability-protection-best-practice](#panorama-get-vulnerability-protection-best-practice)
-90. [View WildFire best practices: panorama-get-wildfire-best-practice](#panorama-get-wildfire-best-practice)
-91. [View URL Filtering best practices: panorama-get-url-filtering-best-practice](#panorama-get-url-filtering-best-practice)
-92. [Enforces wildfire best practices to upload files to the maximum size, forwards all file types, and updates the schedule: panorama-enforce-wildfire-best-practice](#panorama-enforce-wildfire-best-practice)
-93. [Creates an antivirus best practice profile: panorama-create-antivirus-best-practice-profile](#panorama-create-antivirus-best-practice-profile)
-94. [Creates an Anti-Spyware best practice profile: panorama-create-anti-spyware-best-practice-profile](#panorama-create-anti-spyware-best-practice-profile)
-95. [Creates a vulnerability protection best practice profile: panorama-create-vulnerability-best-practice-profile](#panorama-create-vulnerability-best-practice-profile)
-96. [Creates a URL filtering best practice profile: panorama-create-url-filtering-best-practice-profile](#panorama-create-url-filtering-best-practice-profile)
-97. [Creates a file blocking best practice profile: panorama-create-file-blocking-best-practice-profile](#panorama-create-file-blocking-best-practice-profile)
-98. [Creates a WildFire analysis best practice profile: panorama-create-wildfire-best-practice-profile](#panorama-create-wildfire-best-practice-profile)
-
-
 ### panorama
 ***
 Run any command supported in the API.
@@ -193,10 +36,10 @@ Run any command supported in the API.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| action | Action to be taken, such as show, get, set, edit, delete, rename, clone, move, override, multi-move, multi-clone, or complete. | Optional | 
+| action | Action to be taken, such as show, get, set, edit, delete, rename, clone, move, override, multi-move, multi-clone, or complete. Possible values are: set, edit, delete, rename, clone, move, override, muti-move, multi-clone, complete, show, get. | Optional | 
 | category | Category parameter. For example, when exporting a configuration file, use "category=configuration". | Optional | 
 | cmd | Specifies the xml structure that defines the command. Used for operation commands. | Optional | 
-| command | Run a command. For example, command =&lt;show&gt;&lt;arp&gt;&lt;entry name='all'/&gt;&lt;/arp&gt;&lt;/show&gt; | Optional | 
+| command | Run a command. For example, command =&lt;show&gt;&lt;arp&gt;&lt;entry name='all'/&gt;&lt;/arp&gt;&lt;/show&gt;. | Optional | 
 | dst | Specifies a destination. | Optional | 
 | element | Used to define a new value for an object. | Optional | 
 | to | End time (used when cloning an object). | Optional | 
@@ -204,13 +47,13 @@ Run any command supported in the API.
 | key | Sets a key value. | Optional | 
 | log-type | Retrieves log types. For example, log-type=threat for threat logs. | Optional | 
 | where | Specifies the type of a move operation (for example, where=after, where=before, where=top, where=bottom). | Optional | 
-| period | Time period. For example, period=last-24-hrs | Optional | 
-| xpath | xpath location. For example, xpath=/config/predefined/application/entry[@name='hotmail'] | Optional | 
+| period | Time period. For example, period=last-24-hrs. | Optional | 
+| xpath | xpath location. For example, xpath=/config/predefined/application/entry[@name='hotmail']. | Optional | 
 | pcap-id | PCAP ID included in the threat log. | Optional | 
 | serialno | Specifies the device serial number. | Optional | 
 | reporttype | Chooses the report type, such as dynamic, predefined or custom. | Optional | 
 | reportname | Report name. | Optional | 
-| type | Request type (e.g. export, import, log, config). | Optional | 
+| type | Request type (e.g. export, import, log, config). Default is keygen,config,commit,op,report,log,import,export,user-id,version. | Optional | 
 | search-time | The time that the PCAP was received on the firewall. Used for threat PCAPs. | Optional | 
 | target | Target number of the firewall. Use only on a Panorama instance. | Optional | 
 | job-id | Job ID. | Optional | 
@@ -221,10 +64,16 @@ Run any command supported in the API.
 
 There is no context output for this command.
 
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
+
 
 ### panorama-get-predefined-threats-list
 ***
-Gets the pre-defined threats list from a Firewall or Panorama and stores as a JSON file in the context.
+Gets the predefined threats list from a Firewall or Panorama and stores it as a JSON file in the context.
 
 
 #### Base Command
@@ -244,23 +93,26 @@ Gets the pre-defined threats list from a Firewall or Panorama and stores as a JS
 | File.Size | number | File size. | 
 | File.Name | string | File name. | 
 | File.Type | string | File type. | 
-| File.Info | string | File info. | 
+| File.Info | string | File information. | 
 | File.Extension | string | File extension. | 
-| File.EntryID | string | File entryID. | 
+| File.EntryID | string | File entry ID. | 
 | File.MD5 | string | MD5 hash of the file. | 
 | File.SHA1 | string | SHA1 hash of the file. | 
 | File.SHA256 | string | SHA256 hash of the file. | 
-| File.SHA512 | string | SHA512 hash of the file. |
-| File.SSDeep | string | SSDeep hash of the file. |
+| File.SHA512 | string | SHA512 hash of the file. | 
+| File.SSDeep | string | SSDeep hash of the file. | 
 
 
 #### Command Example
-```!panorama-get-predefined-threats-list```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-commit
 ***
-Commits a configuration to Palo Alto Firewall or Panorama, but does not validate if the commit was successful. Committing to Panorama does not push the configuration to the Firewalls. To push the configuration, run the panorama-push-to-device-group command.
+Commits a configuration to the Palo Alto firewall or Panorama, but does not validate if the commit was successful. Committing to Panorama does not push the configuration to the firewalls. To push the configuration, run the panorama-push-to-device-group command.
 
 
 #### Base Command
@@ -275,30 +127,14 @@ There are no input arguments for this command.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | Panorama.Commit.JobID | number | Job ID to commit. | 
-| Panorama.Commit.Status | string | Commit status | 
+| Panorama.Commit.Status | string | Commit status. | 
 
 
 #### Command Example
-```!panorama-commit```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Commit": {
-            "JobID": "113198",
-            "Status": "Pending"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Commit:
->|JobID|Status|
->|---|---|
->| 113198 | Pending |
 
 
 ### panorama-push-to-device-group
@@ -326,14 +162,11 @@ Pushes rules from PAN-OS to the configured device group.
 
 
 #### Command Example
-```!panorama-push-to-device-group ```
+``` ```
 
 #### Human Readable Output
 
->### Push to Device Group Status:
->|JobID|Status|
->|---|---|
->| 113198 | Pending |
+
 
 ### panorama-list-addresses
 ***
@@ -365,34 +198,10 @@ Returns a list of addresses.
 
 
 #### Command Example
-```!panorama-list-addresses```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Addresses": [
-            {
-                "IP_Netmask": "10.10.10.1/24",
-                "Name": "Demisto address"
-            },
-            {
-                "Description": "a",
-                "IP_Netmask": "1.1.1.1",
-                "Name": "test1"
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Addresses:
->|Name|IP_Netmask|IP_Range|FQDN|
->|---|---|---|---|
->| Demisto address | 10.10.10.1/24 |  |  |
->| test1 | 1.1.1.1 |  |  |
 
 
 ### panorama-get-address
@@ -425,26 +234,10 @@ Returns address details for the supplied address name.
 
 
 #### Command Example
-```!panorama-get-address name="Demisto address"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Addresses": {
-            "IP_Netmask": "10.10.10.1/24",
-            "Name": "Demisto address"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Address:
->|Name|IP_Netmask|
->|---|---|
->| Demisto address | 10.10.10.1/24 |
 
 
 ### panorama-create-address
@@ -462,8 +255,8 @@ Creates an address object.
 | name | New address name. | Required | 
 | description | New address description. | Optional | 
 | fqdn | FQDN of the new address. | Optional | 
-| ip_netmask | IP Netmask of the new address. For example, 10.10.10.10/24 | Optional | 
-| ip_range | IP range of the new address IP. For example, 10.10.10.0-10.10.10.255 | Optional | 
+| ip_netmask | IP Netmask of the new address. For example, 10.10.10.10/24. | Optional | 
+| ip_range | IP range of the new address IP. For example, 10.10.10.0-10.10.10.255. | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
 | tag | The tag for the new address. | Optional | 
 
@@ -482,24 +275,11 @@ Creates an address object.
 
 
 #### Command Example
-```!panorama-create-address name="address_test_pb" description="just a desc" ip_range="10.10.10.9-10.10.10.10"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Addresses": {
-            "Description": "just a desc",
-            "IP_Range": "10.10.10.9-10.10.10.10",
-            "Name": "address_test_pb"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Address was created successfully.
+
 
 ### panorama-delete-address
 ***
@@ -526,22 +306,11 @@ Delete an address object
 
 
 #### Command Example
-```!panorama-delete-address name="address_test_pb"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Addresses": {
-            "Name": "address_test_pb"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Address was deleted successfully.
+
 
 ### panorama-list-address-groups
 ***
@@ -573,55 +342,10 @@ Returns a list of address groups.
 
 
 #### Command Example
-```!panorama-list-address-groups```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "AddressGroups": [
-            {
-                "Match": "2.2.2.2",
-                "Name": "a_g_1",
-                "Type": "dynamic"
-            },
-            {
-                "Addresses": [
-                    "Demisto address",
-                    "test3",
-                    "test_demo3"
-                ],
-                "Name": "Demisto group",
-                "Type": "static"
-            },
-            {
-                "Description": "jajja",
-                "Match": "4.4.4.4",
-                "Name": "dynamic2",
-                "Type": "dynamic"
-            },
-            {
-                "Addresses": [
-                    "test4",
-                    "test2"
-                ],
-                "Name": "static2",
-                "Type": "static"
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Address groups:
->|Name|Type|Addresses|Match|Description|Tags|
->|---|---|---|---|---|---|
->| a_g_1 | dynamic |  | 2.2.2.2 |  |  |
->| Demisto group | static | Demisto address,<br/>test3,<br/>test_demo3 |  |  |  |
->| dynamic2 | dynamic |  | 4.4.4.4 | jajja |  |
->| static2 | static | test4,<br/>test2 |  |  |  |
 
 
 ### panorama-get-address-group
@@ -654,14 +378,11 @@ Get details for the specified address group
 
 
 #### Command Example
-```!panorama-get-address-group name=suspicious_address_group ```
+``` ```
 
 #### Human Readable Output
 
->### Address groups:
->|Name|Type|Addresses|Match|Description|
->|---|---|---|---|---|
->| suspicious_address_group | dynamic | 1.1.1.1 | this ip is very bad |
+
 
 ### panorama-create-address-group
 ***
@@ -676,8 +397,8 @@ Creates a static or dynamic address group.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Address group name. | Required | 
-| type | Address group type. | Required | 
-| match | Dynamic Address group match. e.g: "1.1.1.1 or 2.2.2.2" | Optional | 
+| type | Address group type. Possible values are: dynamic, static. | Required | 
+| match | Dynamic Address group match. e.g: "1.1.1.1 or 2.2.2.2". | Optional | 
 | addresses | Static address group list of addresses. | Optional | 
 | description | Address group description. | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
@@ -698,25 +419,11 @@ Creates a static or dynamic address group.
 
 
 #### Command Example
-```!panorama-create-address-group name=suspicious_address_group type=dynamic match=1.1.1.1 description="this ip is very bad"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "AddressGroups": {
-            "Description": "this ip is very bad",
-            "Match": "1.1.1.1",
-            "Name": "suspicious_address_group",
-            "Type": "dynamic"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Address group was created successfully.
+
 
 ### panorama-block-vulnerability
 ***
@@ -730,7 +437,7 @@ Sets a vulnerability signature to block mode.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| drop_mode | Type of session rejection. Possible values are: "drop", "alert", "block-ip", "reset-both", "reset-client", and "reset-server".' Default is "drop". | Optional | 
+| drop_mode | Type of session rejection. Possible values are: "drop", "alert", "block-ip", "reset-both", "reset-client", and "reset-server". Default is "drop". Possible values are: drop, alert, block-ip, reset-both, reset-client, reset-server. | Optional | 
 | vulnerability_profile | Name of vulnerability profile. | Required | 
 | threat_id | Numerical threat ID. | Required | 
 
@@ -744,11 +451,11 @@ Sets a vulnerability signature to block mode.
 
 
 #### Command Example
-```!panorama-block-vulnerability threat_id=18250 vulnerability_profile=name```
+``` ```
 
 #### Human Readable Output
 
->Threat with ID 18250 overridden.
+
 
 ### panorama-delete-address-group
 ***
@@ -775,12 +482,11 @@ Deletes an address group.
 
 
 #### Command Example
-```!panorama-delete-address-group name="dynamic_address_group_test_pb3"```
-
+``` ```
 
 #### Human Readable Output
 
->Address group was deleted successfully
+
 
 ### panorama-edit-address-group
 ***
@@ -795,7 +501,7 @@ Edits a static or dynamic address group.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the address group to edit. | Required | 
-| type | Address group type. | Required | 
+| type | Address group type. Possible values are: static, dynamic. | Required | 
 | match | Address group new match. For example, '1.1.1.1 and 2.2.2.2'. | Optional | 
 | element_to_add | Element to add to the list of the static address group. Only existing Address objects can be added. | Optional | 
 | element_to_remove | Element to remove from the list of the static address group. Only existing Address objects can be removed. | Optional | 
@@ -814,6 +520,13 @@ Edits a static or dynamic address group.
 | Panorama.AddressGroups.Addresses | string | Static Address group addresses. | 
 | Panorama.AddressGroups.DeviceGroup | String | Device group for the address group \(Panorama instances\). | 
 | Panorama.AddressGroups.Tags | String | Address group tags. | 
+
+
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-list-services
@@ -846,39 +559,10 @@ Returns a list of addresses.
 
 
 #### Command Example
-```!panorama-list-services```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Services": [
-            {
-                "Description": "rgfg",
-                "DestinationPort": "55",
-                "Name": "demisto_service1",
-                "Protocol": "tcp",
-                "SourcePort": "567-569"
-            },
-            {
-                "Description": "mojo",
-                "DestinationPort": "55",
-                "Name": "demi_service_test_pb",
-                "Protocol": "sctp",
-                "SourcePort": "60"
-            },
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Services:
->|Name|Protocol|SourcePort|DestinationPort|Description|
->|---|---|---|---|---|
->| demisto_service1 | tcp | 567-569 | 55 | rgfg |
->| demi_service_test_pb | sctp | 60 | 55 | mojo |
 
 
 ### panorama-get-service
@@ -911,14 +595,10 @@ Returns service details for the supplied service name.
 
 
 #### Command Example
-```!panorama-get-service name=demisto_service1 ```
+``` ```
 
 #### Human Readable Output
 
->### Address
->|Name|Protocol|SourcePort|DestinationPort|Description|
->|---|---|---|---|---|
->| demisto_service1 | tcp | 567-569 | 55 | rgfg |
 
 
 ### panorama-create-service
@@ -934,7 +614,7 @@ Creates a service.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name for the new service. | Required | 
-| protocol | Protocol for the new service. | Required | 
+| protocol | Protocol for the new service. Possible values are: tcp, udp, sctp. | Required | 
 | destination_port | Destination port  for the new service. | Required | 
 | source_port | Source port  for the new service. | Optional | 
 | description | Description for the new service. | Optional | 
@@ -956,25 +636,11 @@ Creates a service.
 
 
 #### Command Example
-```!panorama-create-service name=guy_ser3 protocol=udp destination_port=36 description=bfds```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Services": {
-            "Description": "bfds",
-            "DestinationPort": "36",
-            "Name": "guy_ser3",
-            "Protocol": "udp"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Service was created successfully.
+
 
 ### panorama-delete-service
 ***
@@ -1001,22 +667,11 @@ Deletes a service.
 
 
 #### Command Example
-```!panorama-delete-service name=guy_ser3```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Services": {
-            "Name": "guy_ser3"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Service was deleted successfully.
+
 
 ### panorama-list-service-groups
 ***
@@ -1045,36 +700,10 @@ Returns a list of service groups.
 
 
 #### Command Example
-```!panorama-list-service-groups```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "ServiceGroups": [
-            {
-                "Name": "demisto_default_service_groups",
-                "Services": [
-                    "service-http",
-                    "service-https"
-                ]
-            },
-            {
-                "Name": "demisto_test_pb_service_group",
-                "Services": "serice_tcp_test_pb"
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Service groups:
->|Name|Services|
->|---|---|
->| demisto_default_service_groups | service-http,<br/>service-https |
->| demisto_test_pb_service_group | serice_tcp_test_pb |
 
 
 ### panorama-get-service-group
@@ -1104,29 +733,10 @@ Returns details for the specified service group.
 
 
 #### Command Example
-```!panorama-get-service-group name=ser_group6```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "ServiceGroups": {
-            "Name": "ser_group6",
-            "Services": [
-                "serice_tcp_test_pb",
-                "demi_service_test_pb"
-            ]
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Service group:
->|Name|Services|
->|---|---|
->| ser_group6 | serice_tcp_test_pb,<br/>demi_service_test_pb |
 
 
 ### panorama-create-service-group
@@ -1158,7 +768,10 @@ Creates a service group.
 
 
 #### Command Example
-```!panorama-create-service-group name=lalush_sg4 services=`["demisto_service1","demi_service_test_pb"]```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-delete-service-group
@@ -1186,7 +799,10 @@ Deletes a service group.
 
 
 #### Command Example
-```!panorama-delete-service-group name=lalush_sg4```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-edit-service-group
@@ -1218,10 +834,10 @@ Edit a service group.
 
 
 #### Command Example
-```!panorama-edit-service-group name=lalush_sg4 services_to_remove=`["serice_udp_test_pb","demisto_service1"] ```
+``` ```
 
 #### Human Readable Output
->Service group was edited successfully
+
 
 
 ### panorama-get-custom-url-category
@@ -1253,15 +869,11 @@ Returns information for a custom URL category.
 
 
 #### Command Example
-```!panorama-get-custom-url-category name=my_personal_url_category```
-
+``` ```
 
 #### Human Readable Output
 
->### Custom URL Category:
->|Name|Sites|Description|
->|---|---|
->| my_personal_url_category | thepill.com,<br/>abortion.com | just a desc |
+
 
 ### panorama-create-custom-url-category
 ***
@@ -1279,7 +891,7 @@ Creates a custom URL category.
 | description | Description of the custom URL category to create. | Optional | 
 | sites | List of sites for the custom URL category. | Optional | 
 | device-group | The device group for which to return addresses for the custom URL category (Panorama instances). | Optional | 
-| type | The category type of the URL. Relevant from PAN-OS v9.x. | Optional | 
+| type | The category type of the URL. Relevant from PAN-OS v9.x. Possible values are: URL List, Category Match. | Optional | 
 | categories | The list of categories. Relevant from PAN-OS v9.x. | Optional | 
 
 
@@ -1296,30 +908,10 @@ Creates a custom URL category.
 
 
 #### Command Example
-```!panorama-create-custom-url-category name=suspicious_address_group sites=["thepill.com","abortion.com"] description=momo```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "CustomURLCategory": {
-            "Description": "momo",
-            "Name": "suspicious_address_group",
-            "Sites": [
-                "thepill.com",
-                "abortion.com"
-            ]
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Created Custom URL Category:
->|Name|Sites|Description|
->|---|---|---|
->| suspicious_address_group | thepill.com,<br/>abortion.com | momo |
 
 
 ### panorama-delete-custom-url-category
@@ -1347,22 +939,11 @@ Deletes a custom URL category.
 
 
 #### Command Example
-```!panorama-delete-custom-url-category name=suspicious_address_group```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "CustomURLCategory": {
-            "Name": "suspicious_address_group"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Custom URL category was deleted successfully.
+
 
 ### panorama-edit-custom-url-category
 ***
@@ -1378,7 +959,7 @@ Adds or removes sites to and from a custom URL category.
 | --- | --- | --- |
 | name | Name of the custom URL category to add or remove sites. | Required | 
 | sites | A comma separated list of sites to add to the custom URL category. | Optional | 
-| action | Adds or removes sites or categories. Can be "add",or "remove". | Required | 
+| action | Adds or removes sites or categories. Can be "add",or "remove". Possible values are: add, remove. | Required | 
 | categories | A comma separated list of categories to add to the custom URL category. | Optional | 
 
 
@@ -1392,9 +973,16 @@ Adds or removes sites to and from a custom URL category.
 | Panorama.CustomURLCategory.DeviceGroup | string | Device group for the Custom URL Category \(Panorama instances\). | 
 
 
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
+
+
 ### panorama-get-url-category
 ***
-Gets a URL category from URL Filtering.
+Gets a URL category from URL filtering.
 
 
 #### Base Command
@@ -1418,47 +1006,19 @@ Gets a URL category from URL Filtering.
 | DBotScore.Type | String | The indicator type. | 
 | DBotScore.Indicator | String | The indicator that was tested. | 
 | URL.Data | String | The URL address. | 
-| URL.Category | String | The URL Category. | 
+| URL.Category | String | The URL category. | 
 
 
 #### Command Example
-```!panorama-get-url-category url="poker.com"```
-
-#### Context Example
-```json
-{
-    "DBotScore": {
-        "Indicator": "poker.com",
-        "Score": 1,
-        "Type": "url",
-        "Vendor": "PAN-OS"
-    },
-    "Panorama": {
-        "URLFilter": {
-            "Category": "gambling",
-            "URL": [
-                "poker.com"
-            ]
-        }
-    },
-    "URL": {
-        "Category": "gambling",
-        "Data": "poker.com"
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### URL Filtering:
->|URL|Category|
->|---|---|
->| poker.com | gambling |
 
 
 ### url
 ***
-Gets a URL category from URL Filtering.
+Gets a URL category from URL filtering.
 
 
 #### Base Command
@@ -1475,7 +1035,7 @@ Gets a URL category from URL Filtering.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.URLFilter.URL | string | URL. | 
+| Panorama.URLFilter.URL | string | The URL. | 
 | Panorama.URLFilter.Category | string | The URL category. | 
 | DBotScore.Vendor | String | The vendor used to calculate the score. | 
 | DBotScore.Score | Number | The actual score. | 
@@ -1483,6 +1043,13 @@ Gets a URL category from URL Filtering.
 | DBotScore.Indicator | String | The indicator that was tested. | 
 | URL.Data | String | The URL address. | 
 | URL.Category | String | The URL category. | 
+
+
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-get-url-category-from-cloud
@@ -1497,41 +1064,7 @@ Returns a URL category from URL filtering.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| url | URL to check. | Required | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| Panorama.URLFilter.URL | string | The URL. | 
-| Panorama.URLFilter.Category | string | URL category. | 
-
-
-#### Command Example
-```!panorama-get-url-category-from-cloud url=google.com ```
-
-#### Human Readable Output
-
->### URL Filtering from cloud:
->|URL|Category|
->|---|---|
->| google.com | search-engines |
-
-
-### panorama-get-url-category-from-host
-***
-Returns a URL category from URL Filtering.
-
-
-#### Base Command
-
-`panorama-get-url-category-from-host`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| url | URL to check. | Required | 
+| url | The URL to check. | Required | 
 
 
 #### Context Output
@@ -1543,14 +1076,41 @@ Returns a URL category from URL Filtering.
 
 
 #### Command Example
-```!panorama-get-url-category-from-host url=google.com ```
+``` ```
 
 #### Human Readable Output
 
->### URL Filtering from host:
->|URL|Category|
->|---|---|
->| google.com | search-engines |
+
+
+### panorama-get-url-category-from-host
+***
+Returns a URL category from URL filtering.
+
+
+#### Base Command
+
+`panorama-get-url-category-from-host`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| url | The URL to check. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Panorama.URLFilter.URL | string | The URL. | 
+| Panorama.URLFilter.Category | string | The URL category. | 
+
+
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
+
 
 ### panorama-get-url-filter
 ***
@@ -1582,15 +1142,11 @@ Returns information for a URL filtering rule.
 
 
 #### Command Example
-```!panorama-get-url-filter name=demisto_default_url_filter```
-
+``` ```
 
 #### Human Readable Output
 
->### URL Filter:
->|Name|Category|OverrideAllowList|Description|
->|---|---|---|---|
->| demisto_default_url_filter | {'Action': 'block', 'Name': u'abortion'},<br/>{'Action': 'block', 'Name': u'abuse-drugs'} | 888.com,<br/>777.com | gres |
+
 
 ### panorama-create-url-filter
 ***
@@ -1606,7 +1162,7 @@ Creates a URL filtering rule.
 | --- | --- | --- |
 | name | Name of the URL filter to create. | Required | 
 | url_category | URL categories. | Required | 
-| action | Action for the URL categories. Can be "allow", "block", "alert", "continue", or "override". | Required | 
+| action | Action for the URL categories. Can be "allow", "block", "alert", "continue", or "override". Possible values are: allow, block, alert, continue, override. | Required | 
 | override_allow_list | CSV list of URLs to exclude from the allow list. | Optional | 
 | override_block_list | CSV list of URLs to exclude from the blocked list. | Optional | 
 | description | URL Filter description. | Optional | 
@@ -1627,28 +1183,11 @@ Creates a URL filtering rule.
 
 
 #### Command Example
-```!panorama-create-url-filter action=block name=gambling_url url_category=gambling```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "URLFilter": {
-            "Category": [
-                {
-                    "Action": "block",
-                    "Name": "gambling"
-                }
-            ],
-            "Name": "gambling_url"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->URL Filter was created successfully.
+
 
 ### panorama-edit-url-filter
 ***
@@ -1663,9 +1202,9 @@ Edit a URL filtering rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the URL filter to edit. | Required | 
-| element_to_change | Element to change. Can be "override_allow_list", or "override_block_list" | Required | 
+| element_to_change | Element to change. Can be "override_allow_list", or "override_block_list". Possible values are: override_allow_list, override_block_list, description. | Required | 
 | element_value | Element value. Limited to one value. | Required | 
-| add_remove_element | Add or remove an element from the Allow List or Block List fields. Default is to 'add' the element_value to the list. | Optional | 
+| add_remove_element | Add or remove an element from the Allow List or Block List fields. Default is to 'add' the element_value to the list. Possible values are: add, remove. Default is add. | Optional | 
 
 
 #### Context Output
@@ -1682,12 +1221,11 @@ Edit a URL filtering rule.
 
 
 #### Command Example
-```!panorama-edit-url-filter name=demisto_default_url_filter element_to_change=override_allow_list element_value="poker.com" add_remove_element=add```
-
+``` ```
 
 #### Human Readable Output
 
->URL Filter was edited successfully
+
 
 ### panorama-delete-url-filter
 ***
@@ -1702,7 +1240,7 @@ Deletes a URL filtering rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the URL filter rule to delete. | Required | 
-| device-group | The device group for which to return addresses for the URL filter (Panorama instances) | Optional | 
+| device-group | The device group for which to return addresses for the URL filter (Panorama instances). | Optional | 
 
 
 #### Context Output
@@ -1714,22 +1252,11 @@ Deletes a URL filtering rule.
 
 
 #### Command Example
-```!panorama-delete-url-filter name=gambling_url```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "URLFilter": {
-            "Name": "gambling_url"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->URL Filter was deleted successfully.
+
 
 ### panorama-list-edls
 ***
@@ -1760,39 +1287,9 @@ Returns a list of external dynamic lists.
 
 
 #### Command Example
-```!panorama-list-edls```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "EDL": [
-            {
-                "Description": "6u4ju7",
-                "Name": "blabla3",
-                "Recurring": "hourly",
-                "Type": "url",
-                "URL": "lolo"
-            },
-            {
-                "Description": "ip",
-                "Name": "bad_ip_edl_demisot_web_server",
-                "Recurring": "five-minute",
-                "Type": "ip",
-                "URL": "http://192.168.1.15/files/very_bad_ip2.txt"
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
-
->### External Dynamic Lists:
->|Name|Type|URL|Recurring|Description|
->|---|---|---|---|---|
->| blabla3 | url | lolo | hourly | 6u4ju7 |
->| bad_ip_edl_demisot_web_server | ip | http://192.168.1.15/files/very_bad_ip2.txt | five-minute | ip |
 
 
 
@@ -1826,29 +1323,10 @@ Returns information for an external dynamic list
 
 
 #### Command Example
-```!panorama-get-edl name=test_pb_domain_edl_DONT_DEL```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "EDL": {
-            "Description": "new description3",
-            "Name": "test_pb_domain_edl_DONT_DEL",
-            "Recurring": "hourly",
-            "Type": "url",
-            "URL": "https://test_pb_task.not.real"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### External Dynamic List:
->|Name|Type|URL|Recurring|Description|
->|---|---|---|---|---|
->| test_pb_domain_edl_DONT_DEL | url | https://test_pb_task.not.real | hourly | new description3 |
 
 
 ### panorama-create-edl
@@ -1865,8 +1343,8 @@ Creates an external dynamic list.
 | --- | --- | --- |
 | name | Name of the EDL. | Required | 
 | url | URL from which to pull the EDL. | Required | 
-| type | The type of EDL. | Required | 
-| recurring | Time interval for pulling and updating the EDL. | Required | 
+| type | The type of EDL. Possible values are: ip, url, domain. | Required | 
+| recurring | Time interval for pulling and updating the EDL. Possible values are: five-minute, hourly. | Required | 
 | certificate_profile | Certificate Profile name for the URL that was previously uploaded. to PAN OS. | Optional | 
 | description | Description of the EDL. | Optional | 
 | device-group | The device group for which to return addresses for the EDL (Panorama instances). | Optional | 
@@ -1886,25 +1364,11 @@ Creates an external dynamic list.
 
 
 #### Command Example
-```!panorama-create-edl name=new_EDL recurring="five-minute" type=url url="gmail.com"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "EDL": {
-            "Name": "new_EDL",
-            "Recurring": "five-minute",
-            "Type": "url",
-            "URL": "gmail.com"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->External Dynamic List was created successfully.
+
 
 ### panorama-edit-edl
 ***
@@ -1919,7 +1383,7 @@ Modifies an element of an external dynamic list.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | name | Name of the external dynamic list to edit. | Required | 
-| element_to_change | The element to change (“url”, “recurring”, “certificate_profile”, “description”). | Required | 
+| element_to_change | The element to change (“url”, “recurring”, “certificate_profile”, “description”). Possible values are: url, recurring, certificate_profile, description. | Required | 
 | element_value | The element value. | Required | 
 
 
@@ -1936,23 +1400,11 @@ Modifies an element of an external dynamic list.
 
 
 #### Command Example
-```!panorama-edit-edl name=test_pb_domain_edl_DONT_DEL element_to_change=description element_value="new description3"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "EDL": {
-            "Description": "new description3",
-            "Name": "test_pb_domain_edl_DONT_DEL"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->External Dynamic List was edited successfully
+
 
 ### panorama-delete-edl
 ***
@@ -1979,22 +1431,11 @@ Deletes an external dynamic list.
 
 
 #### Command Example
-```!panorama-delete-edl name=new_EDL```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "EDL": {
-            "Name": "new_EDL"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->External Dynamic List was deleted successfully
+
 
 ### panorama-refresh-edl
 ***
@@ -2008,9 +1449,9 @@ Refreshes the specified external dynamic list.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| name | Name of the EDL | Required | 
+| name | Name of the EDL. | Required | 
 | device-group | The device group for which to return addresses for the EDL (Panorama instances). | Optional | 
-| edl_type | The type of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
+| edl_type | The type of the EDL. Required when refreshing an EDL object which is configured on Panorama. Possible values are: ip, url, domain. | Optional | 
 | location | The location of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
 | vsys | The Vsys of the EDL. Required when refreshing an EDL object which is configured on Panorama. | Optional | 
 
@@ -2020,11 +1461,11 @@ Refreshes the specified external dynamic list.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-refresh-edl name=test_pb_domain_edl_DONT_DEL ```
+``` ```
 
 #### Human Readable Output
 
->Refreshed External Dynamic List successfully
+
 
 ### panorama-create-rule
 ***
@@ -2040,23 +1481,23 @@ Creates a policy rule.
 | --- | --- | --- |
 | rulename | Name of the rule to create. | Optional | 
 | description | Description of the rule to create. | Optional | 
-| action | Action for the rule. Can be "allow", "deny", or "drop". | Required | 
+| action | Action for the rule. Can be "allow", "deny", or "drop". Possible values are: allow, deny, drop. | Required | 
 | source | A comma-separated list of address object names, address group object names, or EDL object names. | Optional | 
 | destination | A comma-separated list of address object names, address group object names, or EDL object names. | Optional | 
 | source_zone | A comma-separated list of source zones. | Optional | 
 | destination_zone | A comma-separated list of destination zones. | Optional | 
-| negate_source | Whether to negate the source (address, address group). Can be "Yes" or "No". | Optional | 
-| negate_destination | Whether to negate the destination (address, address group). Can be "Yes" or "No". | Optional | 
+| negate_source | Whether to negate the source (address, address group). Can be "Yes" or "No". Possible values are: Yes, No. | Optional | 
+| negate_destination | Whether to negate the destination (address, address group). Can be "Yes" or "No". Possible values are: Yes, No. | Optional | 
 | service | Service object names for the rule (service object) to create. | Optional | 
-| disable | Whether to disable the rule. Can be "Yes" or "No" (default is "No"). | Optional | 
-| application | A comma-separated list of application object namesfor the rule to create. | Optional | 
-| source_user | Source user for the rule to create. | Optional | 
-| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
+| disable | Whether to disable the rule. Can be "Yes" or "No" (default is "No"). Possible values are: Yes, No. Default is No. | Optional | 
+| application | A comma-separated list of application object namesfor the rule to create. Default is any. | Optional | 
+| source_user | Source user for the rule to create. Default is any. | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
 | target | Specifies a target firewall for the rule (Panorama instances). | Optional | 
 | log_forwarding | Log forwarding profile. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 | tags | Rule tags to create. | Optional | 
-| category | A comma-separated list of URL categories. | Optional |
+| category | A comma-separated list of URL categories. | Optional | 
 | profile_setting | A profile setting group. | Optional | 
 
 
@@ -2077,32 +1518,16 @@ Creates a policy rule.
 | Panorama.SecurityRule.Target | string | Target firewall \(Panorama instances\). | 
 | Panorama.SecurityRule.LogForwarding | string | Log forwarding profile \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
-| Panorama.SecurityRules.Tags | String | Rule tags. |
+| Panorama.SecurityRules.Tags | String | Rule tags. | 
 | Panorama.SecurityRules.ProfileSetting | String | Profile setting group. | 
 
 
 #### Command Example
-```!panorama-create-rule rulename="block_bad_application" description="do not play at work" action="deny" application="fortnite"```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "SecurityRule": {
-            "Action": "deny",
-            "Application": "fortnite",
-            "Description": "do not play at work",
-            "Disabled": "No",
-            "Name": "block_bad_application",
-            "SourceUser": "any"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Rule configured successfully.
+
 
 ### panorama-custom-block-rule
 ***
@@ -2117,10 +1542,10 @@ Creates a custom block policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the custom block policy rule to create. | Optional | 
-| object_type | Object type to block in the policy rule. Can be "ip", "address-group", "edl", or "custom-url-category". | Required | 
+| object_type | Object type to block in the policy rule. Can be "ip", "address-group", "edl", or "custom-url-category". Possible values are: ip, address-group, application, url-category, edl. | Required | 
 | object_value | A comma-separated list of object values for the object_type argument. | Required | 
-| direction | Direction to block. Can be "to", "from", or "both". Default is "both". This argument is not applicable to the "custom-url-category" object_type. | Optional | 
-| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
+| direction | Direction to block. Can be "to", "from", or "both". Default is "both". This argument is not applicable to the "custom-url-category" object_type. Possible values are: to, from, both. Default is both. | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
 | target | Specifies a target firewall for the rule (Panorama instances). | Optional | 
 | log_forwarding | Log forwarding profile. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
@@ -2138,30 +1563,15 @@ Creates a custom block policy rule.
 | Panorama.SecurityRule.LogForwarding | string | Log forwarding profile \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
 | Panorama.SecurityRule.Tags | String | Rule tags. | 
+| Panorama.SecurityRules.ProfileSetting | String | Profile setting group. | 
 
 
 #### Command Example
-```!panorama-custom-block-rule object_type=application object_value=fortnite```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "SecurityRule": {
-            "Application": [
-                "fortnite"
-            ],
-            "Direction": "both",
-            "Disabled": false,
-            "Name": "demisto-9c9ed15a"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Object was blocked successfully.
+
 
 ### panorama-move-rule
 ***
@@ -2176,9 +1586,9 @@ Changes the location of a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to move. | Required | 
-| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. | Required | 
+| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. Possible values are: before, after, top, bottom. | Required | 
 | dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument. | Optional | 
-| pre_post | Rule location. Mandatory for Panorama instances. | Optional | 
+| pre_post | Rule location. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 
 
@@ -2191,11 +1601,11 @@ Changes the location of a policy rule.
 
 
 #### Command Example
-```!panorama-move-rule rulename="test_rule3" where="bottom" ```
+``` ```
 
 #### Human Readable Output
 
->Rule test_rule3 moved successfully
+
 
 ### panorama-edit-rule
 ***
@@ -2210,10 +1620,10 @@ Edits a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to edit. | Required | 
-| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag' or 'profile-setting'. | Required | 
+| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag' or 'group_profile'. Possible values are: source, destination, application, action, category, description, disabled, target, log-forwarding, tag, profile-setting. | Required | 
 | element_value | The new value for the parameter. | Required | 
-| pre_post | Pre-rule or post-rule (Panorama instances). | Optional | 
-| behaviour | Whether to replace, add, or remove the element_value from the current rule object value. | Optional | 
+| pre_post | Pre-rule or post-rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
+| behaviour | Whether to replace, add, or remove the element_value from the current rule object value. Possible values are: replace, add, remove. Default is replace. | Optional | 
 
 
 #### Context Output
@@ -2233,26 +1643,14 @@ Edits a policy rule.
 | Panorama.SecurityRule.Target | string | Target firewall \(Panorama instances\). | 
 | Panorama.SecurityRule.DeviceGroup | string | Device group for the rule \(Panorama instances\). | 
 | Panorama.SecurityRule.Tags | String | Tags for the rule. | 
-| Panorama.SecurityRules.ProfileSetting | String | Profile setting group. |
+
 
 #### Command Example
-```!panorama-edit-rule rulename="block_bad_application" element_to_change=action element_value=drop```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "SecurityRule": {
-            "Action": "drop",
-            "Name": "block_bad_application"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->Rule edited successfully.
+
 
 ### panorama-delete-rule
 ***
@@ -2267,7 +1665,7 @@ Deletes a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to delete. | Required | 
-| pre_post | Pre rule or Post rule (Panorama instances). | Optional | 
+| pre_post | Pre rule or Post rule (Panorama instances). Possible values are: pre-rulebase, post-rulebase. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 
 
@@ -2280,12 +1678,11 @@ Deletes a policy rule.
 
 
 #### Command Example
-```!panorama-delete-rule rulename=block_bad_application```
-
+``` ```
 
 #### Human Readable Output
 
->Rule deleted successfully.
+
 
 ### panorama-list-applications
 ***
@@ -2299,7 +1696,7 @@ Returns a list of applications.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| predefined | Whether to list predefined applications or not. | Optional | 
+| predefined | Whether to list predefined applications or not. Possible values are: true, false. Default is false. | Optional | 
 
 
 #### Context Output
@@ -2316,30 +1713,10 @@ Returns a list of applications.
 
 
 #### Command Example
-```!panorama-list-applications```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Applications": {
-            "Description": "lala",
-            "Id": null,
-            "Name": "demisto_fw_app3",
-            "Risk": "1",
-            "SubCategory": "ip-protocol",
-            "Technology": "peer-to-peer"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Applications
->|Id|Name|Risk|Category|SubCategory|Technology|Description|
->|---|---|---|---|---|---|---|
->|  | demisto_fw_app3 | 1 |  | ip-protocol | peer-to-peer | lala |
 
 
 ### panorama-commit-status
@@ -2368,14 +1745,11 @@ Returns commit status for a configuration.
 
 
 #### Command Example
-```!panorama-commit-status job_id=948 ```
+``` ```
 
 #### Human Readable Output
 
->### Commit Status:
->|JobID|Status|
->|---|---|
->| 948 | Pending |
+
 
 ### panorama-push-status
 ***
@@ -2404,14 +1778,11 @@ Returns the push status for a configuration.
 
 
 #### Command Example
-```!panorama-push-status job_id=951 ```
+``` ```
 
 #### Human Readable Output
 
->### Push to Device Group Status:
->|JobID|Status|Details|
->|---|---|---|
->| 951 | Completed | commit succeeded with warnings |
+
 
 ### panorama-get-pcap
 ***
@@ -2425,7 +1796,7 @@ Returns information for a Panorama PCAP file. The recommended maximum file size 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pcapType | Type of Packet Capture. | Required | 
+| pcapType | Type of Packet Capture. Possible values are: application-pcap, filter-pcap, threat-pcap, dlp-pcap. | Required | 
 | from | The file name for the PCAP type ('dlp-pcap', 'filters-pcap', or 'application-pcap'). | Optional | 
 | localName | The new name for the PCAP file after downloading. If this argument is not specified, the file name is the PCAP file name set in the firewall. | Optional | 
 | serialNo | Serial number for the request. For further information, see the Panorama XML API Documentation. | Optional | 
@@ -2444,17 +1815,20 @@ Returns information for a Panorama PCAP file. The recommended maximum file size 
 | File.Name | string | File name. | 
 | File.Type | string | File type. | 
 | File.Info | string | File info. | 
-| File.Extenstion | string | File extension. | 
+| File.Extension | string | File extension. | 
 | File.EntryID | string | FIle entryID. | 
 | File.MD5 | string | MD5 hash of the file. | 
 | File.SHA1 | string | SHA1 hash of the file. | 
 | File.SHA256 | string | SHA256 hash of the file. | 
-| File.SHA512 | string | SHA512 hash of the file. |
-| File.SSDeep | string | SSDeep hash of the file. |
+| File.SHA512 | string | SHA512 hash of the file. | 
+| File.SSDeep | string | SSDeep hash of the file. | 
 
 
 #### Command Example
-```!panorama-get-pcap pcapType="filter-pcap" from=pcap_test ```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-list-pcaps
@@ -2469,7 +1843,7 @@ Returns a list of all PCAP files by PCAP type.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pcapType | Type of Packet Capture. | Required | 
+| pcapType | Type of Packet Capture. Possible values are: application-pcap, filter-pcap, threat-pcap, dlp-pcap. | Required | 
 | password | Password for Panorama. Relevant for the 'dlp-pcap' PCAP type. | Optional | 
 
 
@@ -2478,14 +1852,11 @@ Returns a list of all PCAP files by PCAP type.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-list-pcaps pcapType=“filter-pcap” ```
+``` ```
 
 #### Human Readable Output
 
->### List of Pcaps:
->|Pcap name|
->|---|
->| pcam_name |
+
 
 ### panorama-register-ip-tag
 ***
@@ -2501,7 +1872,7 @@ Registers IP addresses to a tag.
 | --- | --- | --- |
 | tag | Tag for which to register IP addresses. | Required | 
 | IPs | IP addresses to register. | Required | 
-| persistent | Whether the IP addresses remain registered to the tag after the device reboots ('true':persistent, 'false':non-persistent). Default is 'true'. | Optional | 
+| persistent | Whether the IP addresses remain registered to the tag after the device reboots ('true':persistent, 'false':non-persistent). Default is 'true'. Possible values are: true, false. Default is true. | Optional | 
 
 
 #### Context Output
@@ -2513,11 +1884,11 @@ Registers IP addresses to a tag.
 
 
 #### Command Example
-```!panorama-register-ip-tag tag=tag02 IPs=[“10.0.0.13”,“10.0.0.14”] ```
+``` ```
 
 #### Human Readable Output
 
->Registered ip-tag successfully
+
 
 ### panorama-unregister-ip-tag
 ***
@@ -2540,11 +1911,10 @@ Unregisters IP addresses from a tag.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-unregister-ip-tag tag=tag02 IPs=["10.0.0.13","10.0.0.14"] ```
+``` ```
 
 #### Human Readable Output
 
->Unregistered ip-tag successfully
 
 
 ### panorama-register-user-tag
@@ -2572,10 +1942,10 @@ Registers users to a tag. This command is only available for PAN-OS version 9.x 
 
 
 #### Command Example
-```!panorama-register-user-tag tag-tag02 Users=Username```
+``` ```
 
 #### Human Readable Output
->Registered user-tag successfully
+
 
 
 ### panorama-unregister-user-tag
@@ -2590,7 +1960,7 @@ Unregisters users from a tag. This command is only available for PAN-OS version 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| tag | Tag from which to unregister Users. | Required | 
+| tag | Tag from which to unregister users. | Required | 
 | Users | A comma-separated list of users to unregister. | Required | 
 
 
@@ -2599,122 +1969,10 @@ Unregisters users from a tag. This command is only available for PAN-OS version 
 There is no context output for this command.
 
 #### Command Example
-```!panorama-unregister-user-tag tag-tag02 Users=Username ```
-
-#### Human Readable Output
->Unregistered user-tag successfully
-
-
-### panorama-query-traffic-logs
-***
-Deprecated. Queries traffic logs.
-
-#### Base Command
-
-`panorama-query-traffic-logs`
-#### Input
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| query | Specifies the match criteria for the logs. This is similar to the query provided in the web interface under the Monitor tab when viewing the logs. | Optional |
-| number_of_logs | The number of logs to retrieve. Default is 100. Maximum is 5,000. | Optional |
-| direction | Whether logs are shown oldest first (forward) or newest first (backward). Default is backward. | Optional |
-| source | Source address for the query. | Optional |
-| destination | Destination address for the query. | Optional |
-| receive_time | Date and time after which logs were received, in the format: YYYY/MM/DD HH:MM:SS. | Optional |
-| application | Application for the query. | Optional |
-| to_port | Destination port for the query. | Optional |
-| action | Action for the query. | Optional |
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
-| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
-
-#### Command Example
-```!panorama-query-traffic-logs query="" number_of_logs="100" direction="backward" source="" destination="" receive_time="" application="" to_port="" action="allow"```
+``` ```
 
 #### Human Readable Output
 
->### Query Traffic Logs:
->|JobID|Status|
->|---|---|
->| 1858 | Pending |
-
-
-### panorama-check-traffic-logs-status
-***
-Deprecated. Checks the query status of traffic logs.
-
-#### Base Command
-
-`panorama-check-traffic-logs-status`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| job_id | Job ID of the query. | Required | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
-| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
-
-#### Command Example
-```!panorama-check-traffic-logs-status job_id="1865"```
-
-#### Human Readable Output
-
->### Query Traffic Logs status:
->|JobID|Status|
->|---|---|
->| 1858 | Pending |
-
-
-### panorama-get-traffic-logs
-***
-Deprecated. Retrieves traffic log query data by job id.
-
-#### Base Command
-
-`panorama-get-traffic-logs`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| job_id | Job ID of the query. | Required | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| Panorama.TrafficLogs.JobID | number | Job ID of the traffic logs query. | 
-| Panorama.TrafficLogs.Status | string | Status of the traffic logs query. | 
-| Panorama.TrafficLogs.Logs.Action | string | Action of the traffic log. |
-| Panorama.TrafficLogs.Logs.ActionSource | string | Action source of the traffic log. |
-| Panorama.TrafficLogs.Logs.Application | string | Application of the traffic log. |
-| Panorama.TrafficLogs.Logs.Category | string | Category of the traffic log. |
-| Panorama.TrafficLogs.Logs.DeviceName | string | Device name of the traffic log. |
-| Panorama.TrafficLogs.Logs.Destination | string | Destination of the traffic log. |
-| Panorama.TrafficLogs.Logs.DestinationPort | string | Destination port of the traffic log. |
-| Panorama.TrafficLogs.Logs.FromZone | string | From zone of the traffic log. |
-| Panorama.TrafficLogs.Logs.Protocol | string | Protocol of the traffic log. |
-| Panorama.TrafficLogs.Logs.ReceiveTime | string | Receive time of the traffic log. |
-| Panorama.TrafficLogs.Logs.Rule | string | Rule of the traffic log. |
-| Panorama.TrafficLogs.Logs.SessionEndReason | string | Session end reason of the traffic log. |
-| Panorama.TrafficLogs.Logs.Source | string | Source of the traffic log. |
-| Panorama.TrafficLogs.Logs.SourcePort | string | Source port of the traffic log. |
-| Panorama.TrafficLogs.Logs.StartTime | string | Start time of the traffic log. |
-| Panorama.TrafficLogs.Logs.ToZone | string | To zone of the traffic log. |
-
-#### Command Example
-```!panorama-get-traffic-logs job_id="1865"```
 
 
 ### panorama-list-rules
@@ -2729,7 +1987,7 @@ Returns a list of predefined Security Rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pre_post | Rules location. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
+| pre_post | Rules location. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
 | device-group | The device group for which to return addresses (Panorama instances). | Optional | 
 | tag | Tag for which to filter the rules. | Optional | 
 
@@ -2753,91 +2011,10 @@ Returns a list of predefined Security Rules.
 
 
 #### Command Example
-```!panorama-list-rules```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "SecurityRule": [
-            {
-                "Action": "drop",
-                "Application": "fortnite",
-                "Destination": "any",
-                "From": "any",
-                "Name": "demisto-7b6dc6e6",
-                "Service": "any",
-                "Source": "any",
-                "To": "any"
-            },
-            {
-                "Action": "drop",
-                "Application": "fortnite",
-                "Destination": "any",
-                "From": "any",
-                "Name": "demisto-125e5985",
-                "Service": "any",
-                "Source": "any",
-                "To": "any"
-            },
-            {
-                "Action": {
-                    "#text": "drop",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "Application": {
-                    "#text": "fortnite",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "Destination": {
-                    "#text": "any",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "From": {
-                    "#text": "any",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "Name": "demisto-9c9ed15a",
-                "Service": {
-                    "#text": "any",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "Source": {
-                    "#text": "any",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                },
-                "To": {
-                    "#text": "any",
-                    "@admin": "api",
-                    "@dirtyId": "2986",
-                    "@time": "2020/10/13 05:00:06"
-                }
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Security Rules:
->|Name|Action|From|To|Service|
->|---|---|---|---|---|
->| demisto-7b6dc6e6 | drop | any | any | any |
->| demisto-125e5985 | drop | any | any | any |
->| demisto-9c9ed15a | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: drop | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any | @admin: api<br/>@dirtyId: 2986<br/>@time: 2020/10/13 05:00:06<br/>#text: any |
 
 
 ### panorama-query-logs
@@ -2852,7 +2029,7 @@ Query logs in Panorama.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| log-type | The log type. Can be "threat", "traffic", "wildfire", "url", or "data". | Required | 
+| log-type | The log type. Can be "threat", "traffic", "wildfire", "url", or "data". Possible values are: threat, traffic, wildfire, url, data. | Required | 
 | query | The query string by which to match criteria for the logs. This is similar to the query provided in the web interface under the Monitor tab when viewing the logs. | Optional | 
 | time-generated | The time that the log was generated from the timestamp and prior to it.<br/>e.g "2019/08/11 01:10:44". | Optional | 
 | addr-src | Source address. | Optional | 
@@ -2865,7 +2042,7 @@ Query logs in Panorama.
 | rule | Rule name, e.g "Allow all outbound". | Optional | 
 | url | URL, e.g "safebrowsing.googleapis.com". | Optional | 
 | filedigest | File hash (for WildFire logs only). | Optional | 
-| number_of_logs | Maximum number of logs to retrieve. If empty, the default is 100. The maximum is 5,000. | Optional | 
+| number_of_logs | Maximum number of logs to retrieve. If empty, the default is 100. The maximum is 5,000. Default is 100. | Optional | 
 
 
 #### Context Output
@@ -2878,14 +2055,11 @@ Query logs in Panorama.
 
 
 #### Command Example
-```!panorama-query-logs log-type=data query="( addr.src in 192.168.1.12 )" ```
+``` ```
 
 #### Human Readable Output
 
->### Query Logs:
->|JobID|Status|
->|---|---|
->| 678 | Pending |
+
 
 ### panorama-check-logs-status
 ***
@@ -2911,14 +2085,11 @@ Checks the status of a logs query.
 
 
 #### Command Example
-```!panorama-check-logs-status job_id=657 ```
+``` ```
 
 #### Human Readable Output
 
->### Query Logs Status:
->|JobID|Status|
->|---|---|
->| 657 | Completed |
+
 
 ### panorama-get-logs
 ***
@@ -2933,7 +2104,7 @@ Retrieves the data of a logs query.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | job_id | Job ID of the query. | Required | 
-| ignore_auto_extract | Whether to auto-enrich the War Room entry. If "true", entry is not auto-enriched. If "false", entry is auto-extracted. Default is "true". | Optional | 
+| ignore_auto_extract | Whether to auto-enrich the War Room entry. If "true", entry is not auto-enriched. If "false", entry is auto-extracted. Default is "true". Default is true. | Optional | 
 
 
 #### Context Output
@@ -3003,14 +2174,11 @@ enforce the policy. |
 
 
 #### Command Example
-```!panorama-get-logs job_id=678 ```
+``` ```
 
 #### Human Readable Output
 
->### Query data Logs:
->|TimeGenerated|SourceAddress|DestinationAddress|Application|Action|Rule|
->|---|---|---|---|---|---|
->| 2019/07/24 08:50:24 | 1.1.1.1 | 2.3.4.5 | web-browsing | deny | any - any accept |
+
 
 ### panorama-security-policy-match
 ***
@@ -3051,47 +2219,18 @@ Checks whether a session matches a specified security policy. This command is on
 | Panorama.SecurityPolicyMatch.QueryFields.Category | String | The category name. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Destination | String | The destination IP address. | 
 | Panorama.SecurityPolicyMatch.QueryFields.DestinationPort | Number | The destination port. | 
-| Panorama.SecurityPolicyMatch.QueryFields.From | String | The from zone. | 
-| Panorama.SecurityPolicyMatch.QueryFields.To | String | The to zone. | 
+| Panorama.SecurityPolicyMatch.QueryFields.From | String | The query fields from zone. | 
+| Panorama.SecurityPolicyMatch.QueryFields.To | String | The query fields to zone. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Protocol | String | The IP protocol value. | 
 | Panorama.SecurityPolicyMatch.QueryFields.Source | String | The destination IP address. | 
 | Panorama.SecurityPolicyMatch.QueryFields.SourceUser | String | The source user. | 
 
 
 #### Command Example
-```!panorama-security-policy-match destination=1.2.3.4 protocol=1 source=2.3.4.5```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "SecurityPolicyMatch": {
-            "Query": "<test><security-policy-match><source>2.3.4.5</source><destination>1.2.3.4</destination><protocol>1</protocol></security-policy-match></test>",
-            "QueryFields": {
-                "Destination": "1.2.3.4",
-                "Protocol": "1",
-                "Source": "2.3.4.5"
-            },
-            "Rules": {
-                "Action": "allow",
-                "Category": "any",
-                "Destination": "any",
-                "From": "any",
-                "Name": "any - any accept",
-                "Source": "any",
-                "To": "any"
-            }
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Matching Security Policies:
->|Name|Action|From|To|Source|Destination|
->|---|---|---|---|---|---|
->| any - any accept | allow | any | any | any | any |
 
 
 ### panorama-list-static-routes
@@ -3106,9 +2245,9 @@ Lists the static routes of a virtual router.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| virtual_router | The name of the virtual router for which to list static routes. | Required | 
+| virtual_router | The name of the virtual router for which to list the static routes. | Required | 
 | template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
-| show_uncommitted | Whether to show an uncommitted configuration. Default is "false" | Optional | 
+| show_uncommitted | Whether to show an uncommitted configuration. Default is "false". Possible values are: true, false. Default is false. | Optional | 
 
 
 #### Context Output
@@ -3117,51 +2256,20 @@ Lists the static routes of a virtual router.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-|  Panorama.StaticRoutes.RouteTable | String | The route table of a static route. | 
+| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+| Panorama.StaticRoutes.RouteTable | String | The route table of a static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 | Panorama.StaticRoutes.Uncommitted | Boolean | Whether the static route is committed. | 
 
 
 #### Command Example
-```!panorama-list-static-routes virtual_router=virtual_router_test_DONT_DELETE```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "StaticRoutes": [
-            {
-                "BFDprofile": "None",
-                "Destination": "2.3.4.5/32",
-                "Metric": 14,
-                "Name": "static_route_ip",
-                "NextHop": "3.3.3.3",
-                "RouteTable": "Unicast",
-                "VirtualRouter": "virtual_router_test_DONT_DELETE"
-            },
-            {
-                "Destination": "1.1.1.1/32",
-                "Metric": 1012,
-                "Name": "test_maya",
-                "NextHop": "3.3.3.3",
-                "VirtualRouter": "virtual_router_test_DONT_DELETE"
-            }
-        ]
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Displaying all Static Routes for the Virtual Router: virtual_router_test_DONT_DELETE
->|Name|Destination|NextHop|RouteTable|Metric|BFDprofile|
->|---|---|---|---|---|---|
->| static_route_ip | 2.3.4.5/32 | 3.3.3.3 | Unicast | 14 | None |
->| test_maya | 1.1.1.1/32 | 3.3.3.3 |  | 1012 |  |
 
 
 ### panorama-get-static-route
@@ -3178,7 +2286,7 @@ Returns the specified static route of a virtual router.
 | --- | --- | --- |
 | virtual_router | Name of the virtual router for which to display the static route. | Required | 
 | static_route | Name of the static route to display. | Required | 
-| template | The template for which to run the command. Overrides the template parameter (Panorama instances). | Optional | 
+| template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
 
 
 #### Context Output
@@ -3187,40 +2295,19 @@ Returns the specified static route of a virtual router.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 
 
 #### Command Example
-```!panorama-get-static-route static_route=static_route_ip virtual_router=virtual_router_test_DONT_DELETE```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "StaticRoutes": {
-            "BFDprofile": "None",
-            "Destination": "2.3.4.5/32",
-            "Metric": 14,
-            "Name": "static_route_ip",
-            "NextHop": "3.3.3.3",
-            "RouteTable": "Unicast",
-            "VirtualRouter": "virtual_router_test_DONT_DELETE"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Static route: static_route_ip
->|BFDprofile|Destination|Metric|Name|NextHop|RouteTable|VirtualRouter|
->|---|---|---|---|---|---|---|
->| None | 2.3.4.5/32 | 14 | static_route_ip | 3.3.3.3 | Unicast | virtual_router_test_DONT_DELETE |
 
 
 ### panorama-add-static-route
@@ -3235,10 +2322,10 @@ Adds a static route.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| virtual_router | Virtual Router to which the routes will be added. | Required | 
+| virtual_router | Virtual router to which the routes will be added. | Required | 
 | static_route | The name of the static route to add. The argument is limited to a maximum of 31 characters, is case-sensitive, and supports letters, numbers, spaces, hyphens, and underscores. | Required | 
 | destination | The IP address and network mask in Classless Inter-domain Routing (CIDR) notation: ip_address/mask. For example, 192.168.0.1/24 for IPv4 or 2001:db8::/32 for IPv6). | Required | 
-| nexthop_type | The type for the nexthop. Can be: "ip-address", "next-vr", "fqdn" or "discard". | Required | 
+| nexthop_type | The type for the next hop. Can be: "ip-address", "next-vr", "fqdn", or "discard". Possible values are: ip-address, next-vr, fqdn, discard. | Required | 
 | nexthop_value | The next hop value. | Required | 
 | metric | The metric port for the static route (1-65535). | Optional | 
 | interface | The interface name in which to add the static route. | Optional | 
@@ -3251,33 +2338,20 @@ Adds a static route.
 | --- | --- | --- |
 | Panorama.StaticRoutes.Name | String | The name of the static route. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 
 
 #### Command Example
-```!panorama-add-static-route destination=2.3.4.5/32 nexthop_type="ip-address" nexthop_value=3.3.3.3 static_route=my_temp_route virtual_router=virtual_router_test_DONT_DELETE```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "StaticRoutes": {
-            "@code": "20",
-            "@status": "success",
-            "msg": "command succeeded"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->New uncommitted static route my_temp_route configuration added.
+
 
 ### panorama-delete-static-route
 ***
@@ -3293,42 +2367,30 @@ Deletes a static route.
 | --- | --- | --- |
 | route_name | The name of the static route to delete. | Required | 
 | virtual_router | The virtual router from which the routes will be deleted. | Required | 
-| template | The template for to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
+| template | The template to use to run the command. Overrides the template parameter (Panorama instances). | Optional | 
 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.StaticRoutes.Name | String | The name of the static route. | 
+| Panorama.StaticRoutes.Name | String | The name of the static route to delete. | 
 | Panorama.StaticRoutes.BFDProfile | String | The BFD profile of the static route. | 
-|  Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
-|  Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
-|  Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
-|  Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
+| Panorama.StaticRoutes.Destination | String | The destination of the static route. | 
+| Panorama.StaticRoutes.Metric | Number | The metric \(port\) of the static route. | 
+| Panorama.StaticRoutes.NextHop | String | The next hop of the static route. Can be an IP address, FQDN, or a virtual router. | 
+| Panorama.StaticRoutes.RouteTable | String | The route table of the static route. | 
 | Panorama.StaticRoutes.VirtualRouter | String | The virtual router to which the static router belongs. | 
-|  Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
+| Panorama.StaticRoutes.Template | String | The template in which the static route is defined \(Panorama instances only\). | 
 | Panorama.StaticRoutes.Deleted | Boolean | Whether the static route was deleted. | 
 
 
 #### Command Example
-```!panorama-delete-static-route route_name=my_temp_route virtual_router=virtual_router_test_DONT_DELETE```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "StaticRoutes": {
-            "Deleted": true,
-            "Name": "my_temp_route"
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->The static route: my_temp_route was deleted. Changes are not committed.
+
 
 ### panorama-show-device-version
 ***
@@ -3349,37 +2411,17 @@ Show firewall device software version.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.Device.Info.Devicename | String | Devicename of the PAN-OS. | 
+| Panorama.Device.Info.Devicename | String | Device name of the PAN-OS. | 
 | Panorama.Device.Info.Model | String | Model of the PAN-OS. | 
 | Panorama.Device.Info.Serial | String | Serial number of the PAN-OS. | 
 | Panorama.Device.Info.Version | String | Version of the PAN-OS. | 
 
 
 #### Command Example
-```!panorama-show-device-version```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Device": {
-            "Info": {
-                "Devicename": "PA-VM",
-                "Model": "PA-VM",
-                "Serial": "000000000000000",
-                "Version": "8.1.7"
-            }
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### Device Version:
->|Devicename|Model|Serial|Version|
->|---|---|---|---|
->| PA-VM | PA-VM | 000000000000000 | 8.1.7 |
 
 
 ### panorama-download-latest-content-update
@@ -3406,14 +2448,11 @@ Downloads the latest content update.
 
 
 #### Command Example
-```!panorama-download-latest-content-update ```
+``` ```
 
 #### Human Readable Output
 
->### Content download:
->|JobID|Status|
->|---|---|
->| 657 | Pending |
+
 
 ### panorama-content-update-download-status
 ***
@@ -3441,14 +2480,10 @@ Checks the download status of a content update.
 
 
 #### Command Example
-```!panorama-content-update-download-status job_id=678 ```
+``` ```
 
 #### Human Readable Output
 
->### Content download status:
->|JobID|Status|Details|
->|---|---|---|
->| 678 | Completed | download succeeded with warnings |
 
 
 ### panorama-install-latest-content-update
@@ -3475,14 +2510,10 @@ Installs the latest content update.
 
 
 #### Command Example
-```!panorama-install-latest-content-update ```
+``` ```
 
 #### Human Readable Output
 
->### Result:
->|JobID|Status|
->|---|---|
->| 878 | Pending |
 
 
 ### panorama-content-update-install-status
@@ -3511,14 +2542,10 @@ Gets the installation status of the content update.
 
 
 #### Command Example
-```!panorama-content-update-install-status job_id=878 ```
+``` ```
 
 #### Human Readable Output
 
->### Content install status:
->|JobID|Status|Details|
->|---|---|---|
->| 878 | Completed | installation succeeded with warnings |
 
 
 ### panorama-check-latest-panos-software
@@ -3541,7 +2568,10 @@ Checks the PAN-OS software version from the repository.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-check-latest-panos-software```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-download-panos-version
@@ -3569,14 +2599,11 @@ Downloads the target PAN-OS software version to install on the target device.
 
 
 #### Command Example
-```!panorama-download-panos-version target_version=1 ```
+``` ```
 
 #### Human Readable Output
 
->### Result:
->|JobID|Status|
->|---|---|
->| 111 | Pending |
+
 
 ### panorama-download-panos-status
 ***
@@ -3604,14 +2631,11 @@ Gets the download status of the target PAN-OS software.
 
 
 #### Command Example
-```!panorama-download-panos-status job_id=999```
+``` ```
 
 #### Human Readable Output
 
->### PAN-OS download status:
->|JobID|Status|Details|
->|---|---|---|
->| 999 | Completed | download succeeded with warnings |
+
 
 ### panorama-install-panos-version
 ***
@@ -3633,19 +2657,16 @@ Installs the target PAN-OS version on the specified target device.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| Panorama.PANOS.Install.JobID | string | Job ID from the PAN-OS installation. | 
+| Panorama.PANOS.Install.JobID | string | Job ID of the PAN-OS installation. | 
 | Panorama.PANOS.Install.Status | String | Status of the PAN-OS installation. | 
 
 
 #### Command Example
-```!panorama-install-panos-version target_version=1 ```
+``` ```
 
 #### Human Readable Output
 
->### PAN-OS Installation:
->|JobID|Status|
->|---|---|
->| 111 | Pending |
+
 
 ### panorama-install-panos-status
 ***
@@ -3673,14 +2694,11 @@ Gets the installation status of the PAN-OS software.
 
 
 #### Command Example
-```!panorama-install-panos-status job_id=878 ```
+``` ```
 
 #### Human Readable Output
 
->### PAN-OS installation status:
->|JobID|Status|Details|
->|---|---|---|
->| 878 | Completed | installation succeeded with warnings |
+
 
 ### panorama-device-reboot
 ***
@@ -3694,7 +2712,7 @@ Reboots the Firewall device.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| target | The target device for which to reboot the firewall. | Optional | 
+| target | The target device on which to reboot the firewall. | Optional | 
 
 
 #### Context Output
@@ -3702,7 +2720,10 @@ Reboots the Firewall device.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-device-reboot ```
+``` ```
+
+#### Human Readable Output
+
 
 
 ### panorama-show-location-ip
@@ -3725,36 +2746,16 @@ Gets location information for an IP address.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | Panorama.Location.IP.country_code | String | The IP address location country code. | 
-| Panorama.Location.IP.country_name | String | The IP addres location country name. | 
+| Panorama.Location.IP.country_name | String | The IP address location country name. | 
 | Panorama.Location.IP.ip_address | String | The IP address. | 
 | Panorama.Location.IP.Status | String | Whether the IP address was found. | 
 
 
 #### Command Example
-```!panorama-show-location-ip ip_address=8.8.8.8```
-
-#### Context Example
-```json
-{
-    "Panorama": {
-        "Location": {
-            "IP": {
-                "country_code": "US",
-                "country_name": "United States",
-                "ip_address": "8.8.8.8",
-                "status": "Found"
-            }
-        }
-    }
-}
-```
+``` ```
 
 #### Human Readable Output
 
->### IP 8.8.8.8 location:
->|ip_address|country_name|country_code|
->|---|---|---|
->| 8.8.8.8 | United States | US |
 
 
 ### panorama-get-licenses
@@ -3784,13 +2785,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-licences ```
+``` ```
 
 #### Human Readable Output
 
->|Authcode|Description|Feature|Serial|Expired|Expires|Issued|
->|---|---|---|---|---|---|---|
->| I9805928  | NFR Support | NFR Support | 007DEMISTO1t | no | Never | November 25, 2019 |
+
 
 ### panorama-get-security-profiles
 ***
@@ -3804,7 +2803,7 @@ Gets information for the specified security profile.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| security_profile | The security profile for which to get information. Can be "data-filtering", "file-blocking", "spyware", "url-filtering", "virus", "vulnerability", or "wildfire-analysis". | Optional | 
+| security_profile | The security profile for which to get information. Can be "data-filtering", "file-blocking", "spyware", "url-filtering", "virus", "vulnerability", or "wildfire-analysis". Possible values are: data-filtering, file-blocking, spyware, url-filtering, virus, vulnerability, wildfire-analysis. | Optional | 
 
 
 #### Context Output
@@ -3813,7 +2812,7 @@ Gets information for the specified security profile.
 | --- | --- | --- |
 | Panorama.Spyware.Name | String | The profile name. | 
 | Panorama.Spyware.Rules.Action | String | The rule action. | 
-| Panorama.Spyware.Rules.Cateogry | String | The category for which to apply the rule. | 
+| Panorama.Spyware.Rules.Category | String | The category for which to apply the rule. | 
 | Panorama.Spyware.Rules.Name | String | The rule name. | 
 | Panorama.Spyware.Rules.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Spyware.Rules.Severity | String | The rule severity. | 
@@ -3831,7 +2830,7 @@ Gets information for the specified security profile.
 | Panorama.Vulnerability.Rules.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Vulnerability.Rules.Host | String | The rule host. | 
 | Panorama.Vulnerability.Rules.Name | String | The rule name. | 
-| Panorama.Vulnerability.Rules.Cateogry | String | The category for which to apply the rule. | 
+| Panorama.Vulnerability.Rules.Category | String | The category for which to apply the rule. | 
 | Panorama.Vulnerability.Rules.CVE | String | The CVE for which to apply the rule. | 
 | Panorama.Vulnerability.Rules.Action | String | The rule action. | 
 | Panorama.Vulnerability.Rules.Severity | String | The rule severity. | 
@@ -3857,13 +2856,11 @@ Gets information for the specified security profile.
 
 
 #### Command Example
-```!panorama-get-security-profiles security_profile=spyware ```
+``` ```
 
 #### Human Readable Output
 
->|Name|Rules|
->|---|---|
->| best-practice  | {'Name': 'simple-critical', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'critical', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-high', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'high', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-medium', 'Action': {'reset-both': None}, 'Category': 'any', 'Severity': 'medium', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-informational', 'Action': {'default': None}, 'Category': 'any', 'Severity': 'informational', 'Threat-name': 'any', 'Packet-capture': 'disable'},<br/>{'Name': 'simple-low', 'Action': {'default': None}, 'Category': 'any', 'Severity': 'low', 'Threat-name': 'any', 'Packet-capture': 'disable'} |
+
 
 ### panorama-apply-security-profile
 ***
@@ -3877,10 +2874,10 @@ Apply a security profile to specific rules or rules with a specific tag.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| profile_type | Security profile type. Can be 'data-filtering', 'file-blocking', 'spyware', 'url-filtering', 'virus, 'vulnerability', or wildfire-analysis.' | Required | 
+| profile_type | Security profile type. Can be 'data-filtering', 'file-blocking', 'spyware', 'url-filtering', 'virus, 'vulnerability', or wildfire-analysis.'. Possible values are: data-filtering, file-blocking, spyware, url-filtering, virus, vulnerability, wildfire-analysis. | Required | 
 | rule_name | The rule name to apply. | Required | 
 | profile_name | The profile name to apply to the rule. | Required | 
-| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
+| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
 
 
 #### Context Output
@@ -3888,10 +2885,10 @@ Apply a security profile to specific rules or rules with a specific tag.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-apply-security-profile profile_name=test profile_type=spyware rule_name=rule1 pre_post="pre-rulebase" ```
+``` ```
 
 #### Human Readable Output
->The profile test has been applied to the rule rule1
+
 
 
 ### panorama-get-ssl-decryption-rules
@@ -3906,7 +2903,7 @@ Get SSL decryption rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. | Optional | 
+| pre_post | The location of the rules. Can be 'pre-rulebase' or 'post-rulebase'. Mandatory for Panorama instances. Possible values are: pre-rulebase, post-rulebase. | Optional | 
 
 
 #### Context Output
@@ -3929,13 +2926,11 @@ Get SSL decryption rules.
 
 
 #### Command Example
-```!panorama-get-ssl-decryption-rules pre_post="pre-rulebase" ```
+``` ```
 
 #### Human Readable Output
 
->|Name|UUID|Target|Service|Category|Type|From|To|Source|Destenation|Action|Source-user|
->|---|---|---|---|---|---|---|---|---|---|---|---|
->| test | some_uuid | negate: no | any | member: any | ssl-forward-proxy: null | any | any | any | any | no-decrypt | any |
+
 
 ### panorama-get-wildfire-configuration
 ***
@@ -3962,20 +2957,10 @@ Retrieves the Wildfire configuration.
 
 
 #### Command Example
-```!panorama-get-wildfire-configuration template=WildFire ```
+``` ```
 
+#### Human Readable Output
 
->### WildFire Configuration
-> Report Grayware File: yes
->|Name|Size-limit|
->|---|---|
->| pe | 10 |
->| apk | 30 |
-
->### The updated schedule for Wildfire
->|recurring|
->|---|
->| every-min: {"action": "download-and-install"} |
 
 
 ### panorama-url-filtering-block-default-categories
@@ -3998,11 +2983,11 @@ Set default categories to block in the URL filtering profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-url-filtering-block-default-categories profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The default categories to block has been set successfully to test
+
 
 ### panorama-get-anti-spyware-best-practice
 ***
@@ -4025,7 +3010,7 @@ There are no input arguments for this command.
 | Panorama.Spyware.BotentDomain.Packet-capture | String | Whether packet capture is enabled. | 
 | Panorama.Spyware.BotentDomain.Sinkhole.ipv4-address | String | The botnet domain IPv4 address. | 
 | Panorama.Spyware.BotentDomain.Sinkhole.ipv6-address | String | The Botnet domain IPv6 address. | 
-| Panorama.Spyware.Rule.Cateogry | String | The rule category. | 
+| Panorama.Spyware.Rule.Category | String | The rule category. | 
 | Panorama.Spyware.Rule.Action | String | The rule action. | 
 | Panorama.Spyware.Rule.Name | String | The rule name. | 
 | Panorama.Spyware.Rule.Severity | String | The rule severity. | 
@@ -4034,22 +3019,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-anti-spyware-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### Anti Spyware Botnet-Domains Best Practice
->|Name|Action|Packet-capture|ipv4-address|ipv6-address|
->|---|---|---|---|---|
->| default-paloalto-dns | sinkhole: null | disable |  |  |
->| default-paloalto-cloud | allow: null | disable |  |  |
->|  |  |  | pan-sinkhole-default-ip | ::1 |
 
->### Anti Spyware Best Practice Rules
->|Name|Severity|Action|Category|Threat-name|
->|---|---|---|---|---|
->| simple-critical | critical | reset-both: null | any | any |
->| simple-high | high | reset-both: null | any | any |
 
 ### panorama-get-file-blocking-best-practice
 ***
@@ -4074,15 +3048,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-file-blocking-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### File Blocking Profile Best Practice
->|Name|Action|File-type|Aplication|
->|---|---|---|---|
->| Block all risky file types | block | 7z,<br/>bat,<br/>cab,<br/>chm,<br/>class,<br/>cpl | any |
->| Block encrypted files | block | encrypted-rar,<br/>encrypted-zip| any |
+
 
 ### panorama-get-antivirus-best-practice
 ***
@@ -4106,15 +3076,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-antivirus-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### Antivirus Best Practice Profile
->|Name|Action|WildFire-action|
->|---|---|---|
->| http | default | default|
->| smtp default | default |
+
 
 ### panorama-get-vulnerability-protection-best-practice
 ***
@@ -4134,7 +3100,7 @@ There are no input arguments for this command.
 | --- | --- | --- |
 | Panorama.Vulnerability.Rule.Action | String | The rule action. | 
 | Panorama.Vulnerability.Rule.CVE | String | The rule CVE. | 
-| Panorama.Vulnerability.Rule.Cateogry | String | The rule category. | 
+| Panorama.Vulnerability.Rule.Category | String | The rule category. | 
 | Panorama.Vulnerability.Rule.Host | String | The rule host. | 
 | Panorama.Vulnerability.Rule.Name | String | The rule name. | 
 | Panorama.Vulnerability.Rule.Severity | String | The rule severity. | 
@@ -4143,15 +3109,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-vulnerability-protection-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### vulnerability Protection Best Practice Profile
->|Name|Action|Host|Severity|Category|Threat-name|CVE|Vendor-id|
->|---|---|---|---|---|---|---|---|
->| simple-client-critical | reset-both: null | client | critical | any | any | any | any |
->| simple-client-high | reset-both: null | client | high | any | any | any | any |
+
 
 ### panorama-get-wildfire-best-practice
 ***
@@ -4181,35 +3143,15 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-wildfire-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### WildFire Best Practice Profile
->|Name|Analysis|Aplication|File-type|
->|---|---|---|---|
->| default | public-cloud | any | any |
 
->### Wildfire Best Practice Schedule
->|Action|Recurring|
->|---|---|
->| download-and-install | every-minute |
-
->### Wildfire SSL Decrypt Settings
->|allow-forward-decrypted-content|
->|---|
->| yes |
-
->### Wildfire System Settings
->report-grayware-file: yes
->|Name|File-size|
->|---|---|
->| pe | 10 |
->| apk | 30 |
 
 ### panorama-get-url-filtering-best-practice
 ***
-View URL Filtering best practices.
+View URL filtering best practices.
 
 
 #### Base Command
@@ -4234,20 +3176,11 @@ There are no input arguments for this command.
 
 
 #### Command Example
-```!panorama-get-url-filtering-best-practice ```
+``` ```
 
 #### Human Readable Output
 
->### URL Filtering Best Practice Profile Categories
->|Category|DeviceGroup|Name|
->|---|---|---|
->| {'Name': 'abortion', 'Action': 'alert'},<br/>{'Name': 'abused-drugs', 'Action': 'alert'} | Demisto sales lab | best-practice |
 
-
->### Best Practice Headers
->|log-container-page-only|log-http-hdr-referer|log-http-hdr-user|log-http-hdr-xff|
->|---|---|---|---|
->| yes | yes | yes | yes |
 
 ### panorama-enforce-wildfire-best-practice
 ***
@@ -4269,11 +3202,11 @@ Enforces wildfire best practices to upload files to the maximum size, forwards a
 There is no context output for this command.
 
 #### Command Example
-```!panorama-enforce-wildfire-best-practice template=WildFire ```
+``` ```
 
 #### Human Readable Output
 
->The schedule was updated according to the best practice. Recurring every minute with the action of "download and install" The file upload for all file types is set to the maximum size.
+
 
 ### panorama-create-antivirus-best-practice-profile
 ***
@@ -4295,11 +3228,11 @@ Creates an antivirus best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-antivirus-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
 
 ### panorama-create-anti-spyware-best-practice-profile
 ***
@@ -4321,11 +3254,11 @@ Creates an Anti-Spyware best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-anti-spyware-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
 
 ### panorama-create-vulnerability-best-practice-profile
 ***
@@ -4347,11 +3280,11 @@ Creates a vulnerability protection best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-vulnerability-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
 
 ### panorama-create-url-filtering-best-practice-profile
 ***
@@ -4373,11 +3306,11 @@ Creates a URL filtering best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-url-filtering-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
 
 ### panorama-create-file-blocking-best-practice-profile
 ***
@@ -4399,11 +3332,11 @@ Creates a file blocking best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-file-blocking-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
 
 ### panorama-create-wildfire-best-practice-profile
 ***
@@ -4425,8 +3358,66 @@ Creates a WildFire analysis best practice profile.
 There is no context output for this command.
 
 #### Command Example
-```!panorama-create-wildfire-best-practice-profile profile_name=test ```
+``` ```
 
 #### Human Readable Output
 
->The profile test was created successfully.
+
+
+### panorama-upload-content-update-file
+***
+Uploads content file to Panorama
+
+
+#### Base Command
+
+`panorama-upload-content-update-file`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| entryID | Entry id of the file to upload. | Required | 
+| category | The file type. Possible values are: wildfire, anti-virus, content. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
+
+
+### panorama-install-file-content-update
+***
+Installs specific content update file.
+
+
+#### Base Command
+
+`panorama-install-file-content-update`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| version_name | Update file name to be installed on Panorama. | Required | 
+| category | The file type. Possible values are: wildfire, anti-virus, content. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Panorama.Content.Install.JobID | string | JobID of the installation. | 
+| Content.Install.Status | string | Installation status. | 
+
+
+#### Command Example
+``` ```
+
+#### Human Readable Output
+
+

--- a/Packs/PAN-OS/ReleaseNotes/1_6_13.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_6_13.md
@@ -1,4 +1,6 @@
 
 #### Integrations
 ##### Palo Alto Networks PAN-OS
-- Added two commands *panorama-install-file-content-update* and *panorama-upload-content-update-file* 
+- Added 2 commands:
+    * ***panorama-install-file-content-update***
+    * ***panorama-upload-content-update-file***

--- a/Packs/PAN-OS/ReleaseNotes/1_6_13.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_6_13.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Added two commands *panorama-install-file-content-update* and *panorama-upload-content-update-file* 

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.6.12",
+    "currentVersion": "1.6.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/content/pull/10879
related: https://github.com/demisto/content/pull/9150

## Description
@apekarovsky's pack description: This content pack is set to be a "toolbox" for organisations with "Air Gap" networks. There are currently two use-cases in this "toolbox".
One is indicators "reputation" query from internal , air gapped network. This is done by getting the indicators across the "Air Gap" by using unidirectional diode that can pass UDP traffic. The answer will return as a JSON Feed file and will be transferred back in via another unidirectional diode that can pass files.
The second use-case is automating "Offline Panorama content updates" like AV, Apps and threats or even Wildfire content updates. External network Panorama will pull the content updates forward them to XSOAR. Then they will be checked for threats and moved by a unidirectional diode into the internal network where they will be automatically installed on the Panorama server and pushed to the firewalls.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
