### PR TITLE
ThreatConnect v2- Removed and fixed arguments

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.py
@@ -2022,7 +2022,7 @@ def create_document_group():
     if not owner:
         return_error('You must specify an owner in the command, or by using the Organization parameter.')
 
-    security_label = demisto.args().get('securityLabel')
+    security_label = demisto.args().get('security_label')
     description = demisto.args().get('description')
 
     # open a file handle for a local file and read the contents thereof

--- a/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnect_v2/ThreatConnect_v2.yml
@@ -1112,9 +1112,6 @@ script:
       description: The active DNS indicator (only for hosts).
     - name: whoisActive
       description: The active indicator (only for hosts).
-    - name: updatedValues
-      description: A comma-separated list of field:value pairs to update. For example, "rating=3",
-        "confidence=42", and "description=helloWorld".
     - name: falsePositive
       auto: PREDEFINED
       predefined:

--- a/Packs/ThreatConnect/ReleaseNotes/2_0_11.md
+++ b/Packs/ThreatConnect/ReleaseNotes/2_0_11.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### ThreatConnect v2
+- Fixed an issue where the *security_label* argument was not used correctly in the ***tc-create-document-group*** command.
+- Removed the *updatedValues* argument from the ***tc-update-indicator*** since it is not in use.

--- a/Packs/ThreatConnect/ReleaseNotes/2_0_11.md
+++ b/Packs/ThreatConnect/ReleaseNotes/2_0_11.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### ThreatConnect v2
 - Fixed an issue where the *security_label* argument was not used correctly in the ***tc-create-document-group*** command.
-- Removed the *updatedValues* argument from the ***tc-update-indicator*** since it is not in use.
+- Removed the *updatedValues* argument from the ***tc-update-indicator*** command since it is not in use.

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "2.0.10",
+    "currentVersion": "2.0.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://github.com/demisto/etc/issues/32208

## Description
- Updated the code in ***tc-create-document-group*** command to use the *security_label* argument correctly.
- Removed the *updatedValues* argument from the ***tc-update-indicator*** since it is not in use and the customer can use the regular args instead.
## Screenshots

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
