### PR TITLE
ServiceDeskPlus - fixed args

### DIFF
--- a/Packs/ServiceDeskPlus/Integrations/ServiceDeskPlus/ServiceDeskPlus.py
+++ b/Packs/ServiceDeskPlus/Integrations/ServiceDeskPlus/ServiceDeskPlus.py
@@ -17,7 +17,7 @@ OAUTH = 'https://accounts.zoho.com/oauth/v2/token'
 
 REQUEST_FIELDS = ['subject', 'description', 'request_type', 'impact', 'status', 'mode', 'level', 'urgency', 'priority',
                   'service_category', 'requester', 'assets', 'site', 'group', 'technician', 'category', 'subcategory',
-                  'item', 'email_ids_to_notify', 'is_fcr', 'resources', 'udf_fields']
+                  'item', 'email_ids_to_notify', 'is_fcr', 'resources', 'udf_fields', 'update_reason']
 FIELDS_WITH_NAME = ['request_type', 'impact', 'status', 'mode', 'level', 'urgency', 'priority', 'service_category',
                     'requester', 'site', 'group', 'technician', 'category', 'subcategory', 'item']
 FIELDS_TO_IGNORE = ['has_draft', 'cancel_flag_comments']

--- a/Packs/ServiceDeskPlus/Integrations/ServiceDeskPlus/ServiceDeskPlus.yml
+++ b/Packs/ServiceDeskPlus/Integrations/ServiceDeskPlus/ServiceDeskPlus.yml
@@ -568,12 +568,6 @@ script:
       name: update_reason
       required: false
       secret: false
-    - default: false
-      description: Comments added while changing the request's status.
-      isArray: false
-      name: status_change_comments
-      required: false
-      secret: false
     deprecated: false
     description: Updates the specified request.
     execution: false
@@ -812,7 +806,7 @@ script:
     description: Closes the specified request.
     execution: false
     name: service-desk-plus-request-close
-  dockerimage: demisto/python3:3.8.6.12176
+  dockerimage: demisto/python3:3.9.1.14969
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/ServiceDeskPlus/ReleaseNotes/1_2_2.md
+++ b/Packs/ServiceDeskPlus/ReleaseNotes/1_2_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### Service Desk Plus
+- The *update_reason* argument in the ***service-desk-plus-request-update*** command now works as expected.
+- The *status_change_comments* argument was removed from the ***service-desk-plus-request-update*** command since it was unused.
+- Upgraded the Docker image to demisto/python3:3.9.1.14969.

--- a/Packs/ServiceDeskPlus/pack_metadata.json
+++ b/Packs/ServiceDeskPlus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Manage Engine Service Desk Plus",
     "description": "IT service management.",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://github.com/demisto/etc/issues/32208

## Description
- Updated the code to use the *update_reason* argument in the ***service-desk-plus-request-update*** command.
- The *status_change_comments* argument was removed from the ***service-desk-plus-request-update*** command - We don't get it in the response json and are not able to see it updating in the UI.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
