### PR TITLE
fix default contentCommitHash

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -586,7 +586,7 @@ class Pack(object):
             pack_metadata['premium'] = True
             pack_metadata['vendorId'] = user_metadata.get('vendorId')
             pack_metadata['vendorName'] = user_metadata.get('vendorName')
-            pack_metadata['contentCommitHash'] = user_metadata.get('contentCommitHash')
+            pack_metadata['contentCommitHash'] = user_metadata.get('contentCommitHash', "")
             if user_metadata.get('previewOnly'):
                 pack_metadata['previewOnly'] = True
         pack_metadata['serverMinVersion'] = user_metadata.get('serverMinVersion') or server_min_version


### PR DESCRIPTION
Fixed the default value of `contentCommitHash` when it does not exist in user_pack_metadata
