### PR TITLE
Add handle proxy to http api module

### DIFF
--- a/Packs/ApiModules/Scripts/HTTPFeedApiModule/HTTPFeedApiModule.py
+++ b/Packs/ApiModules/Scripts/HTTPFeedApiModule/HTTPFeedApiModule.py
@@ -96,6 +96,7 @@ class Client(BaseClient):
                 ignore_regex: '^#'
         """
         super().__init__(base_url=url, verify=not insecure, proxy=proxy)
+        handle_proxy()
         try:
             self.polling_timeout = int(polling_timeout)
         except (ValueError, TypeError):

--- a/Packs/FeedBlocklist_de/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedBlocklist_de/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Blocklist_de Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedBlocklist_de/pack_metadata.json
+++ b/Packs/FeedBlocklist_de/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "BlockList DE Feed",
     "description": "Indicators feed from BlockList DE",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedBruteForceBlocker/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedBruteForceBlocker/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### BruteForceBlocker Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedBruteForceBlocker/pack_metadata.json
+++ b/Packs/FeedBruteForceBlocker/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "BruteForce Feed",
     "description": "Indicators feed from BruteForceBlocker",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedCloudflare/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedCloudflare/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cloudflare Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedCloudflare/pack_metadata.json
+++ b/Packs/FeedCloudflare/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cloudflare Feed",
     "description": "Indicators feed from Cloudflare",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedDShield/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedDShield/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### DShield Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedDShield/pack_metadata.json
+++ b/Packs/FeedDShield/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DShield Feed",
     "description": "Indicators feed from DShield",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedFeodoTracker/ReleaseNotes/1_0_5.md
+++ b/Packs/FeedFeodoTracker/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Feodo Tracker Hashes Feed (Deprecated)
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedFeodoTracker/pack_metadata.json
+++ b/Packs/FeedFeodoTracker/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FeodoTracker Feed",
     "description": "Indicators feed from FeodoTracker",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedMalwareDomainList/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedMalwareDomainList/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Malware Domain List Active IPs Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedMalwareDomainList/pack_metadata.json
+++ b/Packs/FeedMalwareDomainList/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MalwareDomainList Feed",
     "description": "Indicators feed from MalwareDomainList",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedPlainText/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedPlainText/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Plain Text Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedPlainText/pack_metadata.json
+++ b/Packs/FeedPlainText/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Plain Text Feed",
     "description": "Fetches indicators from a plain text feed.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedSpamhaus/ReleaseNotes/1_0_3.md
+++ b/Packs/FeedSpamhaus/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Spamhaus Feed
+- The **Use system proxy settings** parameter now works as expected.

--- a/Packs/FeedSpamhaus/pack_metadata.json
+++ b/Packs/FeedSpamhaus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Spamhaus Feed",
     "description": "Use the Spamhaus feed integration to fetch indicators from the feed.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/32934

## Description
added a call to `handle_proxy` in the HttpApiModule.

manually tested the following configurations:
* proxy configured:
  * used the proxy only when enabled.
  * if enabled and MITM didn't run, failed with ProxyError.
* proxy isn't configured:
  * never used the proxy

