### PR TITLE
CrowdStrike Falcon - pass missing args in retry when encountering 403

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -222,8 +222,12 @@ def http_request(method, url_suffix, params=None, data=None, files=None, headers
                     params=params,
                     data=data,
                     headers=headers,
+                    files=files,
+                    json=json,
                     safe=safe,
-                    get_token_flag=False
+                    get_token_flag=False,
+                    status_code=status_code,
+                    no_json=no_json,
                 )
             elif safe:
                 return None

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -2061,7 +2061,7 @@ script:
     - contextPath: CrowdStrike.Incidents.fine_score
       description: The incident score.
       type: Number
-  dockerimage: demisto/python3:3.8.6.14516
+  dockerimage: demisto/python3:3.9.1.14969
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_12.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_2_12.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### CrowdStrike Falcon
+- Fixed an issue where an unsupported media type was sent.
+- Upgraded the Docker image to demisto/python3:3.9.1.14969.

--- a/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
+++ b/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
@@ -910,7 +910,7 @@ tasks:
         simple: 15dbb9d8f06b45fe9f61eb46e829d986
       raw: {}
       script_name:
-        simple: LongerThanFiveMinutes
+        simple: 301Seconds
       timeout:
         simple: "400"
     separatecontext: false

--- a/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
+++ b/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
@@ -910,7 +910,7 @@ tasks:
         simple: 15dbb9d8f06b45fe9f61eb46e829d986
       raw: {}
       script_name:
-        simple: MoreThanFiveMinutes
+        simple: LongerThanFiveMinutes
       timeout:
         simple: "400"
     separatecontext: false

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.2.11",
+    "currentVersion": "1.2.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3357,8 +3357,7 @@
         "Lastline v2": "Temporary skipping, due to quota issues, in order to merge a PR",
         "AttackIQFireDrill": "License issues #29774",
         "CrowdStrike Falcon Intel v2": "License issues #32473",
-        "CrowdStrikeMalquery": "License issues #32473",
-        "CrowdstrikeFalcon": "License issues #32473"
+        "CrowdStrikeMalquery": "License issues #32473"
     },
     "nightly_integrations": [
         "Lastline v2",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/32072

## Description
in case 403 occurred, not all args (`files` in this case) were passed on the second call to `http_request`

## Does it break backward compatibility?
   - [x] No
