### PR TITLE
Earlier Upload-Flow trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1318,7 +1318,7 @@ workflows:
   bucket_upload:
     triggers:
       - schedule:
-          # should trigger every day at 10 AM & 10 PM UTC (12:00 PM & 00:00 AM Israel Time)
+          # should trigger every day at 9 AM & 9 PM UTC (11:00 PM & 11:00 AM Israel Time)
           cron: "0 9,21 * * *"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1319,7 +1319,7 @@ workflows:
     triggers:
       - schedule:
           # should trigger every day at 10 AM & 10 PM UTC (12:00 PM & 00:00 AM Israel Time)
-          cron: "0 10,22 * * *"
+          cron: "0 9,21 * * *"
           filters:
             branches:
               only:

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -9,7 +9,7 @@ import requests
 from circleci.api import Api as circle_api
 from slack import WebClient as SlackClient
 
-from Tests.Marketplace.marketplace_services import BucketUploadFlow, get_successful_and_failed_packs
+from Tests.Marketplace.marketplace_services import BucketUploadFlow, get_successful_and_failed_packs, PackStatus
 from Tests.scripts.utils.log_util import install_logging
 from demisto_sdk.commands.common.tools import str2bool, run_command
 
@@ -151,7 +151,7 @@ def get_attachments_for_bucket_upload_flow(build_url, job_name, packs_results_fi
         if failed_packs:
             steps_fields += [{
                 "title": "Failed Packs:",
-                "value": "\n".join([f"{pack_name}: {pack_data.get(BucketUploadFlow.STATUS)}"
+                "value": "\n".join([f"{pack_name}: {PackStatus[pack_data.get(BucketUploadFlow.STATUS)].value}"
                                     for pack_name, pack_data in failed_packs.items()]),
                 "short": False
             }]


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
- Triggered both uploads to 11 (AM & PM) to prevent race conditions with nightly.
- Fixed an issue in Slack notifier where failed pack status was the name of the enum and not its value.

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
