### PR TITLE
Elasticsearch v2: fixed incident labels representation

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
@@ -56,7 +56,7 @@ def get_timestamp_first_fetch(last_fetch):
     Returns:
         (num).The formatted timestamp
     """
-    # this theorticly shouldn't happen but just in case
+    # this theoretically shouldn't happen but just in case
     if str(last_fetch).isdigit():
         return int(last_fetch)
 
@@ -464,8 +464,9 @@ def incident_label_maker(source):
         (list).The labels.
     """
     labels = []
-    for field in source.keys():
-        labels.append({'type': str(field), 'value': str(source.get(field))})
+    for field, value in source.items():
+        encoded_value = value if isinstance(value, str) else json.dumps(value)
+        labels.append({'type': str(field), 'value': encoded_value})
 
     return labels
 

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -286,7 +286,7 @@ script:
     execution: false
     name: get-mapping-fields
     description: Returns the schema of the index to fetch from. This commmand should be used for debugging purposes.
-  dockerimage: demisto/elasticsearch:1.0.0.12410
+  dockerimage: demisto/elasticsearch:1.0.0.14274
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -12,8 +12,7 @@ configuration:
   name: credentials
   required: false
   type: 9
-- defaultvalue: 'false'
-  display: Trust any certificate (not secure)
+- display: Trust any certificate (not secure)
   name: insecure
   required: false
   type: 8

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -655,3 +655,52 @@ class GetMappingFields(unittest.TestCase):
         gmf = GetMapping()
         server_response = gmf.fetch_json('http://someurl.com/' + 'index' + '/_mapping')
         self.assertEqual(server_response, MOC_ES7_SERVER_RESPONSE)
+
+
+class TestIncidentLabelMaker(unittest.TestCase):
+    def test_sanity(self):
+        from Elasticsearch_v2 import incident_label_maker
+
+        sources = {
+            'first_name': 'John',
+            'sur_name': 'Snow',
+        }
+        expected_labels = [
+            {
+                'type': 'first_name',
+                'value': 'John'
+            },
+            {
+                'type': 'sur_name',
+                'value': 'Snow'
+            },
+        ]
+
+        labels = incident_label_maker(sources)
+        self.assertEquals(labels, expected_labels)
+
+    def test_complex_value(self):
+        from Elasticsearch_v2 import incident_label_maker
+
+        sources = {
+            'name': 'Ash',
+            'action': 'catch',
+            'targets': ['Pikachu', 'Charmander', 'Squirtle', 'Bulbasaur'],
+        }
+        expected_labels = [
+            {
+                'type': 'name',
+                'value': 'Ash',
+            },
+            {
+                'type': 'action',
+                'value': 'catch',
+            },
+            {
+                'type': 'targets',
+                'value': '["Pikachu", "Charmander", "Squirtle", "Bulbasaur"]',
+            },
+        ]
+
+        labels = incident_label_maker(sources)
+        self.assertEquals(labels, expected_labels)

--- a/Packs/Elasticsearch/ReleaseNotes/1_1_4.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_1_4.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Elasticsearch v2
 - Fixed an issue where JSON incident labels were not saved properly.
+- Upgraded the Docker image to demisto/elasticsearch:1.0.0.14274.

--- a/Packs/Elasticsearch/ReleaseNotes/1_1_4.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_1_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Elasticsearch v2
+- Fixed an issue where JSON incident labels were not saved properly.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.1.3",
+    "currentVersion": "1.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/33177

## Description
fixed incident labels representation.
in the case of JSON values, we returned `{'is_ok': True}` instead of `{"is_ok": true}`.

## Screenshots
screenshots with the fix posted in the issue.
