### PR TITLE
SumoLogic - store now - 1 min in case no records were fetched

### DIFF
--- a/Packs/SumoLogic/Integrations/integration-SumoLogic.yml
+++ b/Packs/SumoLogic/Integrations/integration-SumoLogic.yml
@@ -259,10 +259,11 @@ script:
                     }
                 }
 
-                // if no records were fetched, then we set the currentFetch to now time as in later runs we could send
-                // a big query with old timestamp that could cause a timeout
+                // if no records were fetched, then we set the currentFetch to (now time - 1 minute) as in
+                // later runs we could send a big query with old timestamp that could cause a timeout
+                // we are setting to (now - 1 minute) to avoid missing events
                 if (updatedCurrentFetch === currentFetch) {
-                    currentFetch = now;
+                    currentFetch = now - (60 * 1000);
                 } else {
                     currentFetch = updatedCurrentFetch;
                 }

--- a/Packs/SumoLogic/ReleaseNotes/1_0_5.md
+++ b/Packs/SumoLogic/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SumoLogic
+- Improved the last fetched record timestamp to avoid missing records.

--- a/Packs/SumoLogic/pack_metadata.json
+++ b/Packs/SumoLogic/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SumoLogic",
     "description": "Cloud-based service for logs & metrics management",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
if no records were fetched, we stored the now time
this could led to missing events in case of non synced clocks
modified to store the now time minus 1 minute

## Does it break backward compatibility?
   - [x] No
