### PR TITLE
Modify display language to be consistent with the use of 'resolved" i…

### DIFF
--- a/Packs/CommonReports/Reports/report-MTTRbyIncidentType2Quar.json
+++ b/Packs/CommonReports/Reports/report-MTTRbyIncidentType2Quar.json
@@ -291,16 +291,16 @@
     "rowPos": 7,
     "columnPos": 1,
     "tableColumns": [
-     "Month closed",
+     "Month resolved",
      "Type",
      "# Incidents",
-     "Mean time to close (days)"
+     "Mean time to resolve (days)"
     ],
     "classes": "striped stackable small very compact",
     "readableHeaders": {
      "type": "Type",
-     "closed(m)": "Month closed",
-     "avg|openDuration / (3600*24)": "Mean time to close (days)",
+     "closed(m)": "Month resolved",
+     "avg|openDuration / (3600*24)": "Mean time to resolve (days)",
      "count|1": "# Incidents"
     }
    }

--- a/Packs/CommonReports/Reports/report-MTTRbyOwner2Quar.json
+++ b/Packs/CommonReports/Reports/report-MTTRbyOwner2Quar.json
@@ -292,15 +292,15 @@
     "columnPos": 1,
     "tableColumns": [
      "Owner",
-     "Month closed",
+     "Month resolved",
      "Total incidents",
-     "Mean time to close (days)"
+     "Mean time to resolve (days)"
     ],
     "classes": "striped stackable small very compact",
     "readableHeaders": {
      "owner": "Owner",
-     "closed(m)": "Month closed",
-     "avg|openDuration / (3600*24)": "Mean time to close (days)",
+     "closed(m)": "Month resolved",
+     "avg|openDuration / (3600*24)": "Mean time to resolve (days)",
      "count|1": "Total incidents"
     }
    }


### PR DESCRIPTION
…nstead of 'closed'

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Modifies the display language on the MTTR reports to be consistent as use the word resolve instead of close

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [X] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
