### PR TITLE
Fix collect_tests_and_content_packs.py 

### DIFF
--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1175,6 +1175,11 @@ def get_from_version_and_to_version_bounderies(all_modified_files_paths: set,
             max_to_version = max(max_to_version, LooseVersion(to_version))
 
     for artifacts in id_set.values():
+
+        # Ignore the Packs list in the ID set
+        if isinstance(artifacts, dict):
+            break
+
         for artifact_dict in artifacts:
             for artifact_details in artifact_dict.values():
                 if artifact_details.get('file_path') in all_modified_files_paths:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://app.circleci.com/pipelines/github/demisto/content/64799/workflows/b561145c-1494-4b87-935e-8595ad971722/jobs/267676

## Description
Fix `collect_tests_and_content_packs.py` - Failed because it runs on all ID set, and Packs are in dictionary and not in list.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
