### PR TITLE
Add dashboard to Shift Management

### DIFF
--- a/Packs/ShiftManagement/Dashboards/dashboard-Shift_Management_.json
+++ b/Packs/ShiftManagement/Dashboards/dashboard-Shift_Management_.json
@@ -1,0 +1,286 @@
+{
+    "id": "Shift Management ",
+    "version": -1,
+    "fromDate": "0001-01-01T00:00:00Z",
+    "toDate": "0001-01-01T00:00:00Z",
+    "period": {
+        "by": "",
+        "byTo": "",
+        "byFrom": "days",
+        "toValue": null,
+        "fromValue": 0,
+        "field": ""
+    },
+    "fromDateLicense": "0001-01-01T00:00:00Z",
+    "name": "Shift Management ",
+    "layout": [
+        {
+            "id": "d9611ff0-6567-11eb-8a01-3d3e84b71837",
+            "forceRange": false,
+            "x": 4,
+            "y": 0,
+            "i": "d9611ff0-6567-11eb-8a01-3d3e84b71837",
+            "w": 8,
+            "h": 6,
+            "widget": {
+                "id": "RolesPerShift",
+                "version": 2,
+                "modified": "2021-01-27T15:56:46.896877342Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.0",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "Roles Per Shift",
+                "prevName": "Roles Per Shift",
+                "dataType": "scripts",
+                "widgetType": "text",
+                "query": "GetRolesPerShift",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Roles per shift 24x7",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "01b89410-6568-11eb-8a01-3d3e84b71837",
+            "forceRange": false,
+            "x": 0,
+            "y": 0,
+            "i": "01b89410-6568-11eb-8a01-3d3e84b71837",
+            "w": 4,
+            "h": 1,
+            "widget": {
+                "id": "ShiftTimeLeft",
+                "version": 2,
+                "modified": "2021-01-27T15:56:46.896902249Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.0",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+                    "all"
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "Shift changes in",
+                "prevName": "Shift changes in",
+                "dataType": "scripts",
+                "widgetType": "duration",
+                "query": "TimeToNextShift",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Shows how much time left for the shift to ends.",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "0d9784d0-6568-11eb-8a01-3d3e84b71837",
+            "forceRange": false,
+            "x": 0,
+            "y": 1,
+            "i": "0d9784d0-6568-11eb-8a01-3d3e84b71837",
+            "w": 4,
+            "h": 3,
+            "widget": {
+                "id": "UsersOnCall",
+                "version": 2,
+                "modified": "2021-01-27T15:56:46.896954285Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.0",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "Users On-Call",
+                "prevName": "Users On-Call",
+                "dataType": "scripts",
+                "widgetType": "text",
+                "query": "GetUsersOnCall",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Details of the users that are currently on-call",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "1eb67410-6568-11eb-8a01-3d3e84b71837",
+            "forceRange": false,
+            "x": 0,
+            "y": 4,
+            "i": "1eb67410-6568-11eb-8a01-3d3e84b71837",
+            "w": 4,
+            "h": 2,
+            "widget": {
+                "id": "UsersOOO",
+                "version": 2,
+                "modified": "2021-01-27T15:56:46.896925186Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.0",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+                    "all"
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "Out of office users",
+                "prevName": "Out of office users",
+                "dataType": "scripts",
+                "widgetType": "text",
+                "query": "GetUsersOOO",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Details of the users that are currently out of office",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "2be64ed0-6568-11eb-8a01-3d3e84b71837",
+            "forceRange": false,
+            "x": 0,
+            "y": 6,
+            "i": "2be64ed0-6568-11eb-8a01-3d3e84b71837",
+            "w": 4,
+            "h": 2,
+            "widget": {
+                "id": "OnCallHoursPerUser",
+                "version": 2,
+                "modified": "2021-01-27T15:56:46.896844451Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.0",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "On-Call Hours Per User",
+                "prevName": "On-Call Hours Per User",
+                "dataType": "scripts",
+                "widgetType": "bar",
+                "query": "GetOnCallHoursPerUser",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Displays number of on-call hours per user.",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        }
+    ],
+    "fromVersion": "6.0.0",
+    "description": "",
+    "isPredefined": true
+}

--- a/Packs/ShiftManagement/Dashboards/dashboard-Shift_Management_.json
+++ b/Packs/ShiftManagement/Dashboards/dashboard-Shift_Management_.json
@@ -8,27 +8,133 @@
         "byTo": "",
         "byFrom": "days",
         "toValue": null,
-        "fromValue": 0,
+        "fromValue": 7,
         "field": ""
     },
     "fromDateLicense": "0001-01-01T00:00:00Z",
     "name": "Shift Management ",
     "layout": [
         {
-            "id": "d9611ff0-6567-11eb-8a01-3d3e84b71837",
+            "id": "f2efe220-656d-11eb-9cda-0739334e539c",
+            "forceRange": false,
+            "x": 0,
+            "y": 4,
+            "i": "f2efe220-656d-11eb-9cda-0739334e539c",
+            "w": 4,
+            "h": 3,
+            "widget": {
+                "id": "UsersOOO",
+                "version": 1,
+                "modified": "2021-02-02T15:45:30.423391738Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.1",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "Out of office users",
+                "prevName": "Out of office users",
+                "dataType": "scripts",
+                "widgetType": "text",
+                "query": "GetUsersOOO",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Details of the users that are currently out of office",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "19969900-656e-11eb-9cda-0739334e539c",
+            "forceRange": false,
+            "x": 0,
+            "y": 7,
+            "i": "19969900-656e-11eb-9cda-0739334e539c",
+            "w": 4,
+            "h": 2,
+            "widget": {
+                "id": "OnCallHoursPerUser",
+                "version": 1,
+                "modified": "2021-02-02T15:45:30.422883019Z",
+                "sortValues": null,
+                "packID": "ShiftManagement",
+                "itemVersion": "1.2.1",
+                "fromServerVersion": "5.5.0",
+                "toServerVersion": "",
+                "propagationLabels": [
+
+                ],
+                "packPropagationLabels": [
+                    "all"
+                ],
+                "vcShouldIgnore": false,
+                "vcShouldKeepItemLegacyProdMachine": false,
+                "commitMessage": "",
+                "shouldCommit": false,
+                "name": "On-Call Hours Per User",
+                "prevName": "On-Call Hours Per User",
+                "dataType": "scripts",
+                "widgetType": "bar",
+                "query": "GetOnCallHoursPerUser",
+                "sort": null,
+                "isPredefined": true,
+                "description": "Displays number of on-call hours per user.",
+                "dateRange": {
+                    "fromDate": "0001-01-01T00:00:00Z",
+                    "toDate": "0001-01-01T00:00:00Z",
+                    "period": {
+                        "by": "",
+                        "byTo": "",
+                        "byFrom": "",
+                        "toValue": null,
+                        "fromValue": null,
+                        "field": ""
+                    },
+                    "fromDateLicense": "0001-01-01T00:00:00Z"
+                },
+                "params": null,
+                "size": 0,
+                "category": ""
+            }
+        },
+        {
+            "id": "3bd1df70-656e-11eb-9cda-0739334e539c",
             "forceRange": false,
             "x": 4,
             "y": 0,
-            "i": "d9611ff0-6567-11eb-8a01-3d3e84b71837",
+            "i": "3bd1df70-656e-11eb-9cda-0739334e539c",
             "w": 8,
-            "h": 6,
+            "h": 7,
             "widget": {
                 "id": "RolesPerShift",
-                "version": 2,
-                "modified": "2021-01-27T15:56:46.896877342Z",
+                "version": 1,
+                "modified": "2021-02-02T15:45:30.422924316Z",
                 "sortValues": null,
                 "packID": "ShiftManagement",
-                "itemVersion": "1.2.0",
+                "itemVersion": "1.2.1",
                 "fromServerVersion": "5.5.0",
                 "toServerVersion": "",
                 "propagationLabels": [
@@ -68,24 +174,24 @@
             }
         },
         {
-            "id": "01b89410-6568-11eb-8a01-3d3e84b71837",
+            "id": "7b2878f0-656e-11eb-9cda-0739334e539c",
             "forceRange": false,
             "x": 0,
             "y": 0,
-            "i": "01b89410-6568-11eb-8a01-3d3e84b71837",
+            "i": "7b2878f0-656e-11eb-9cda-0739334e539c",
             "w": 4,
             "h": 1,
             "widget": {
                 "id": "ShiftTimeLeft",
-                "version": 2,
-                "modified": "2021-01-27T15:56:46.896902249Z",
+                "version": 1,
+                "modified": "2021-02-02T15:45:30.422963877Z",
                 "sortValues": null,
                 "packID": "ShiftManagement",
-                "itemVersion": "1.2.0",
+                "itemVersion": "1.2.1",
                 "fromServerVersion": "5.5.0",
                 "toServerVersion": "",
                 "propagationLabels": [
-                    "all"
+
                 ],
                 "packPropagationLabels": [
                     "all"
@@ -121,20 +227,20 @@
             }
         },
         {
-            "id": "0d9784d0-6568-11eb-8a01-3d3e84b71837",
+            "id": "8e1aefb0-656e-11eb-9cda-0739334e539c",
             "forceRange": false,
             "x": 0,
             "y": 1,
-            "i": "0d9784d0-6568-11eb-8a01-3d3e84b71837",
+            "i": "8e1aefb0-656e-11eb-9cda-0739334e539c",
             "w": 4,
             "h": 3,
             "widget": {
                 "id": "UsersOnCall",
-                "version": 2,
-                "modified": "2021-01-27T15:56:46.896954285Z",
+                "version": 1,
+                "modified": "2021-02-02T15:45:30.423453073Z",
                 "sortValues": null,
                 "packID": "ShiftManagement",
-                "itemVersion": "1.2.0",
+                "itemVersion": "1.2.1",
                 "fromServerVersion": "5.5.0",
                 "toServerVersion": "",
                 "propagationLabels": [
@@ -155,112 +261,6 @@
                 "sort": null,
                 "isPredefined": true,
                 "description": "Details of the users that are currently on-call",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "toDate": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byTo": "",
-                        "byFrom": "",
-                        "toValue": null,
-                        "fromValue": null,
-                        "field": ""
-                    },
-                    "fromDateLicense": "0001-01-01T00:00:00Z"
-                },
-                "params": null,
-                "size": 0,
-                "category": ""
-            }
-        },
-        {
-            "id": "1eb67410-6568-11eb-8a01-3d3e84b71837",
-            "forceRange": false,
-            "x": 0,
-            "y": 4,
-            "i": "1eb67410-6568-11eb-8a01-3d3e84b71837",
-            "w": 4,
-            "h": 2,
-            "widget": {
-                "id": "UsersOOO",
-                "version": 2,
-                "modified": "2021-01-27T15:56:46.896925186Z",
-                "sortValues": null,
-                "packID": "ShiftManagement",
-                "itemVersion": "1.2.0",
-                "fromServerVersion": "5.5.0",
-                "toServerVersion": "",
-                "propagationLabels": [
-                    "all"
-                ],
-                "packPropagationLabels": [
-                    "all"
-                ],
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "commitMessage": "",
-                "shouldCommit": false,
-                "name": "Out of office users",
-                "prevName": "Out of office users",
-                "dataType": "scripts",
-                "widgetType": "text",
-                "query": "GetUsersOOO",
-                "sort": null,
-                "isPredefined": true,
-                "description": "Details of the users that are currently out of office",
-                "dateRange": {
-                    "fromDate": "0001-01-01T00:00:00Z",
-                    "toDate": "0001-01-01T00:00:00Z",
-                    "period": {
-                        "by": "",
-                        "byTo": "",
-                        "byFrom": "",
-                        "toValue": null,
-                        "fromValue": null,
-                        "field": ""
-                    },
-                    "fromDateLicense": "0001-01-01T00:00:00Z"
-                },
-                "params": null,
-                "size": 0,
-                "category": ""
-            }
-        },
-        {
-            "id": "2be64ed0-6568-11eb-8a01-3d3e84b71837",
-            "forceRange": false,
-            "x": 0,
-            "y": 6,
-            "i": "2be64ed0-6568-11eb-8a01-3d3e84b71837",
-            "w": 4,
-            "h": 2,
-            "widget": {
-                "id": "OnCallHoursPerUser",
-                "version": 2,
-                "modified": "2021-01-27T15:56:46.896844451Z",
-                "sortValues": null,
-                "packID": "ShiftManagement",
-                "itemVersion": "1.2.0",
-                "fromServerVersion": "5.5.0",
-                "toServerVersion": "",
-                "propagationLabels": [
-
-                ],
-                "packPropagationLabels": [
-                    "all"
-                ],
-                "vcShouldIgnore": false,
-                "vcShouldKeepItemLegacyProdMachine": false,
-                "commitMessage": "",
-                "shouldCommit": false,
-                "name": "On-Call Hours Per User",
-                "prevName": "On-Call Hours Per User",
-                "dataType": "scripts",
-                "widgetType": "bar",
-                "query": "GetOnCallHoursPerUser",
-                "sort": null,
-                "isPredefined": true,
-                "description": "Displays number of on-call hours per user.",
                 "dateRange": {
                     "fromDate": "0001-01-01T00:00:00Z",
                     "toDate": "0001-01-01T00:00:00Z",

--- a/Packs/ShiftManagement/ReleaseNotes/1_2_2.md
+++ b/Packs/ShiftManagement/ReleaseNotes/1_2_2.md
@@ -1,0 +1,10 @@
+
+#### Dashboards
+##### New: Shift Management 
+-  (Available from Cortex XSOAR 6.0.0).
+
+#### Scripts
+##### GetUsersOOO
+- Fixed message description. 
+##### GetUsersOnCall
+- Fixed message description.

--- a/Packs/ShiftManagement/Scripts/GetUsersOOO/GetUsersOOO.py
+++ b/Packs/ShiftManagement/Scripts/GetUsersOOO/GetUsersOOO.py
@@ -45,7 +45,7 @@ def main():
     if users_list:
         hr = 'Out of office Team members\n' + tableToMarkdown('', users_list)
     else:
-        hr = 'Out of office Team members\nNo analysts is out of office today.'
+        hr = 'Out of office Team members\nNo team members are out of office today.'
 
     return_results({
         'Type': entryTypes['note'],

--- a/Packs/ShiftManagement/Scripts/GetUsersOnCall/GetUsersOnCall.py
+++ b/Packs/ShiftManagement/Scripts/GetUsersOnCall/GetUsersOnCall.py
@@ -47,7 +47,7 @@ def main():
             contents = filter_OOO_users(get_users_response[0], list_name)
 
         if contents == 'No data returned':
-            contents = 'On-Call Team members\nNo analysts were found on-call.'
+            contents = 'On-Call Team members\nNo team members were found on-call.'
         demisto.results({
             'Type': entryTypes['note'],
             'ContentsFormat': formats['markdown'],

--- a/Packs/ShiftManagement/Scripts/GetUsersOnCall/GetUsersOnCall.yml
+++ b/Packs/ShiftManagement/Scripts/GetUsersOnCall/GetUsersOnCall.yml
@@ -2,7 +2,9 @@ args:
 - auto: PREDEFINED
   default: true
   defaultValue: 'false'
-  description: Whether to retrieve all users, including users who are out of the office. If "true" will retrieve all users. If "false", will only retrieve users who are not out of office. Default is "false".
+  description: Whether to retrieve all users, including users who are out of the office.
+    If "true" will retrieve all users. If "false", will only retrieve users who are
+    not out of office. Default is "false".
   isArray: false
   name: include_OOO_users
   predefined:
@@ -31,5 +33,5 @@ tags:
 - widget
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.9.1.14969
+dockerimage: demisto/python3:3.9.1.15759
 fromversion: 5.5.0

--- a/Packs/ShiftManagement/pack_metadata.json
+++ b/Packs/ShiftManagement/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Shift Management",
     "description": "This pack's purpose is to provide a single interface for all those essential elements of Shift management and handover in one place.",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
@@ -35,20 +35,20 @@
             "mandatory": false,
             "display_name": "Zoom"
         },
-		"Slack": {
-		"mandatory": false,
+        "Slack": {
+            "mandatory": false,
             "display_name": "Slack"
-		},
-		"MicrosoftTeams": {
-		"mandatory": false,
+        },
+        "MicrosoftTeams": {
+            "mandatory": false,
             "display_name": "MicrosoftTeams"
-		}
+        }
     },
     "displayedImages": [
         "CommonScripts",
         "CommonTypes",
         "Zoom",
-		"Slack",
-		"MicrosoftTeams"
+        "Slack",
+        "MicrosoftTeams"
     ]
 }


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/content/pull/10750

## Description

Add dashboard to Shift Management.
Fixed GetUsersOnCall and GetUsersOOO scripts message description when there are no team members on call or when no team members out of office.  



## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
