### PR TITLE
Upload flow hidden rn bugfix

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1229,6 +1229,11 @@ class Pack(object):
                 changelog = {
                     Pack.PACK_INITIAL_VERSION: version_changelog
                 }
+            elif self._hidden:
+                logging.warning(f"Pack {self._pack_name} is deprecated. Skipping release notes handling.")
+                task_status = True
+                not_updated_build = True
+                return task_status, not_updated_build
             else:
                 logging.error(f"No release notes found for: {self._pack_name}")
                 task_status = False


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/33340

## Description
Handled the case where pack is deprecated while handling RN.

## Successful Run:
CCI: https://app.circleci.com/pipelines/github/demisto/content/65312/workflows/05506509-c3d8-4692-89d4-44497c1b8da8
Bucket: https://console.cloud.google.com/storage/browser/marketplace-ci-build/content/builds/upload-flow-hidden-rn-bugfix/269737
Server Configuration: https://storage.googleapis.com/marketplace-ci-build/content/builds/upload-flow-hidden-rn-bugfix/269737

## Screenshots
![image](https://user-images.githubusercontent.com/53565845/106636485-a7cc2c00-658a-11eb-9e4b-f917823af2f1.png)

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
