### PR TITLE
Change Display name for Crowdstrike Falcon Intel Feed Integration

### DIFF
--- a/Packs/FeedCrowdstrikeFalconIntel/Integrations/FeedCrowdstrikeFalconIntel/FeedCrowdstrikeFalconIntel.yml
+++ b/Packs/FeedCrowdstrikeFalconIntel/Integrations/FeedCrowdstrikeFalconIntel/FeedCrowdstrikeFalconIntel.yml
@@ -175,7 +175,7 @@ script:
     description: Gets indicators from Crowdstrike Falcon Intel Feed.
     execution: false
     name: crowdstrike-falcon-intel-get-indicators
-  dockerimage: demisto/python3:3.8.6.12176
+  dockerimage: demisto/python3:3.9.1.15759
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedCrowdstrikeFalconIntel/Integrations/FeedCrowdstrikeFalconIntel/FeedCrowdstrikeFalconIntel.yml
+++ b/Packs/FeedCrowdstrikeFalconIntel/Integrations/FeedCrowdstrikeFalconIntel/FeedCrowdstrikeFalconIntel.yml
@@ -131,7 +131,7 @@ description: The CrowdStrike intelligence team tracks the activities of threat a
   groups and advanced persistent threats (APTs) to understand as much as possible
   about their known aliases, targets, methods, and more. This integration retrieves
   indicators from the Crowdstrike Falcon Intel Feed
-display: Crowdstrike Falcon Intel Feed
+display: Crowdstrike Falcon Intel Feed Actors
 name: Crowdstrike Falcon Intel Feed
 script:
   commands:

--- a/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Crowdstrike Falcon Intel Feed Actors
+- Change display name to Crowdstrike Falcon Intel Feed Actors.

--- a/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Crowdstrike Falcon Intel Feed Actors
 - Change display name to Crowdstrike Falcon Intel Feed Actors.
+- Updated docker image to the latest version.

--- a/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/1_0_4.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Crowdstrike Falcon Intel Feed Actors
-- Change display name to Crowdstrike Falcon Intel Feed Actors.
-- Updated docker image to the latest version.
+- Changed the integration's display name to *Crowdstrike Falcon Intel Feed Actors*.
+- Upgraded the Docker image to demisto/python3:3.9.1.15759.

--- a/Packs/FeedCrowdstrikeFalconIntel/pack_metadata.json
+++ b/Packs/FeedCrowdstrikeFalconIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Crowdstrike Falcon Intel Feed",
     "description": "CrowdStrike intelligence team are tracking the activities of threat actor groups and  advanced persistent threats (APTs) to understand as much as possible about their known aliases, targets, methods, and more. Use this pack to receive information on adversaries tracked by CrowdStrike, their target nations and industries, and research on their activities.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Change Display name for Crowdstrike Falcon Intel Feed Integration to : Crowdstrike Falcon Intel Feed Actors

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
