### PR TITLE
CortexXDR IR: updated field type to match the actual type in the incident field

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -2185,7 +2185,7 @@ def convert_type(items: List, conversion_map: Dict[str, Any]):
             if key in item:
                 try:
                     item[key] = convert_to(item[key])
-                except TypeError:
+                except (TypeError, ValueError):
                     demisto.error(f'could not convert key {key} to type {convert_to}. value: {item[key]}')
 
     return items

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -1784,3 +1784,58 @@ def test_create_account_context_user_is_none():
     account_context = create_account_context(endpoints_list)
 
     assert account_context == []
+
+
+class TestConvertType:
+    @staticmethod
+    def test_sanity():
+        from CortexXDRIR import convert_type
+        items = [
+            {'key1': 1, 'key2': 2},
+            {'key1': 3, 'key2': 4},
+        ]
+
+        expected = [
+            {'key1': '1', 'key2': 2},
+            {'key1': '3', 'key2': 4},
+        ]
+        assert expected == convert_type(items, {'key1': str})
+
+    @staticmethod
+    def test_missing_key():
+        from CortexXDRIR import convert_type
+        items = [
+            {'key1': 1, 'key2': 2},
+            {'key1': 3, 'key2': 4},
+        ]
+        assert items == convert_type(items, {'key3': str})
+
+    @staticmethod
+    def test_cant_convert_ignore_value_error(capfd):
+        from CortexXDRIR import convert_type
+        items = [
+            {'key1': '', 'key2': 2},
+            {'key1': '3', 'key2': 4},
+        ]
+
+        expected = [
+            {'key1': '', 'key2': 2},
+            {'key1': 3, 'key2': 4},
+        ]
+        with capfd.disabled():
+            assert expected == convert_type(items, {'key1': int})
+
+    @staticmethod
+    def test_cant_convert_ignore_type_error(capfd):
+        from CortexXDRIR import convert_type
+        items = [
+            {'key1': '', 'key2': 2},
+            {'key1': 3, 'key2': 4},
+        ]
+
+        expected = [
+            {'key1': [], 'key2': 2},
+            {'key1': 3, 'key2': 4},
+        ]
+        with capfd.disabled():
+            assert expected == convert_type(items, {'key1': list})

--- a/Packs/CortexXDR/ReleaseNotes/2_8_4.md
+++ b/Packs/CortexXDR/ReleaseNotes/2_8_4.md
@@ -2,5 +2,5 @@
 #### Integrations
 ##### Palo Alto Networks Cortex XDR - Investigation and Response
 - **Breaking Changes:**
-  - Changed the type of the **detectiontimestamp** field in the **alerts** incident field to string.
+  - Changed the type of the **Detection Timestamp** field in the **XDR Alerts** incident field to string.
   - Changed the type of the **Network Remote Port** field in the **XDR Network Artifacts** incident field to string.

--- a/Packs/CortexXDR/ReleaseNotes/2_8_4.md
+++ b/Packs/CortexXDR/ReleaseNotes/2_8_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+- **Breaking Changes:**
+  - Changed the type of the **detectiontimestamp** field in the **alerts** incident field to string.
+  - Changed the type of the **Network Remote Port** field in the **XDR Network Artifacts** incident field to string.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "This Content Pack automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "2.8.3",
+    "currentVersion": "2.8.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/33352

## Description
- **Breaking Changes:**
  - Changed the type of the **Detection Timestamp** field in the **XDR Alerts** incident field to string.
  - Changed the type of the **Network Remote Port** field in the **XDR Network Artifacts** incident field to string.

## Screenshots
before (orange - number):
![image](https://user-images.githubusercontent.com/30797606/106806790-0c61b680-6671-11eb-914a-8bc352bcb140.png)

after (green - string):
![image](https://user-images.githubusercontent.com/30797606/106806491-b7be3b80-6670-11eb-9a54-3e78c2937478.png)

## Does it break backward compatibility?
   - [X] Yes
       - Further details: see RN
   - [ ] No

@David-BMS @dorsha - FYI