### PR TITLE
MS Teams Management Test - increase sleep time to alone cloned team to get created

### DIFF
--- a/Packs/MicrosoftTeams/TestPlaybooks/Microsoft_Teams_Management_-_Test.yml
+++ b/Packs/MicrosoftTeams/TestPlaybooks/Microsoft_Teams_Management_-_Test.yml
@@ -1401,7 +1401,7 @@ tasks:
       - "11"
     scriptarguments:
       seconds:
-        simple: "10"
+        simple: "30"
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/33410

## Description
clone team action might take some time, increasing the sleep time to allow it to be created successfully
