### PR TITLE
fixed author field in pack_metadata.json

### DIFF
--- a/Packs/FeedCyjax/pack_metadata.json
+++ b/Packs/FeedCyjax/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "This pack is used to pull indicators of compromise from the Cyjax Threat Intelligence Platform.",
     "support": "partner",
     "currentVersion": "1.0.0",
-    "author": "Jakub Orzol",
+    "author": "Cyjax",
     "url": "https://cyjax.com",
     "email": "devs@cyjax.com",
     "created": "2021-01-06T15:46:16Z",


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fix author field in pack_metadata to be the vendor name.


## Minimum version of Demisto
- [ ] 5.0.0
- [x] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

