### PR TITLE
context validation fix - added pack ignore

### DIFF
--- a/Packs/TaniumThreatResponse/.pack-ignore
+++ b/Packs/TaniumThreatResponse/.pack-ignore
@@ -1,2 +1,2 @@
 [file:TaniumThreatResponse.yml]
-ignore=IN126
+ignore=IN126,IN136

--- a/Packs/XMatters/.pack-ignore
+++ b/Packs/XMatters/.pack-ignore
@@ -1,4 +1,5 @@
-xMatters-Test.yml
+[file:xMatters-Test.yml]
+ignore=auto-test
 
 [file:xMatters.yml]
 ignore=IN136


### PR DESCRIPTION
## Status
- [x] Ready


## Description
Adding .pack_ignore in order to pass validation in https://github.com/demisto/demisto-sdk/pull/1077


## Minimum version of Demisto
- [x] 5.0.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
