### PR TITLE
Increased phishing tests pid threshold to 80

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2118,7 +2118,7 @@
                 "Rasterize"
             ],
             "memory_threshold": 115,
-            "pid_threshold": 60
+            "pid_threshold": 80
         },
         {
             "playbookID": "Phishing - Core - Test - Incident Starter",
@@ -2131,7 +2131,7 @@
                 "Rasterize"
             ],
             "memory_threshold": 100,
-            "pid_threshold": 60
+            "pid_threshold": 80
         },
         {
             "integrations": "duo",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/26784

## Description
Increased phishing tests pid threshold to 80 according to recommendation in the failing build (it used to be 60):
![image](https://user-images.githubusercontent.com/43602124/107145847-13c4e080-694d-11eb-8a92-519973a38317.png)
