### PR TITLE
Making Upload Packs To Marketplace job aware that the instance was created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1035,6 +1035,7 @@ jobs:
           steps:
             - set-instance-role-env-variable:
                 instance_role: Server Master
+                instance_created: "true"
             - start-tunnel
             - run:
                 name: Upload Packs To Marketplace Storage


### PR DESCRIPTION
Otherwise the tunnel will not be created.