### PR TITLE
Fix: Avoid HTML template formatting if HTML body is not used

### DIFF
--- a/Packs/EWS/Integrations/EWSO365/EWSO365.py
+++ b/Packs/EWS/Integrations/EWSO365/EWSO365.py
@@ -1911,7 +1911,8 @@ def send_email(client: EWSClient, to, subject='', body="", bcc=None, cc=None, ht
         template_params = handle_template_params(templateParams)
         if template_params:
             body = body.format(**template_params)
-            htmlBody = htmlBody.format(**template_params)
+            if htmlBody:
+                htmlBody = htmlBody.format(**template_params)
 
         message = create_message(to, subject, body, bcc, cc, htmlBody, attachments, additionalHeader)
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold

## Description
By default the `htmlBody` defaults to `None` resulting in a formatting exception should a template be used. This commit introduces an additionnal check to ensure `htmlBody` is not `None`.

## Does it break backward compatibility?
   - [ ] Yes
   - [X] No
