### PR TITLE
CSP GetRemoteDataResponse Bugfix

### DIFF
--- a/Packs/Base/ReleaseNotes/1_7_14.md
+++ b/Packs/Base/ReleaseNotes/1_7_14.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Deleted mirroring logging in **GetRemoteDataResponse** class that used an invalid key. 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -5894,7 +5894,6 @@ class GetRemoteDataResponse:
         :rtype: ``list``
         """
         if self.mirrored_object:
-            demisto.info('Updating object {}'.format(self.mirrored_object["id"]))
             return [self.mirrored_object] + self.entries
 
 

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.7.13",
+    "currentVersion": "1.7.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Not every mirrored object uses the `id` field to store its unique identifier, e.g. Splunk uses the `event_id` field.

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
