### PR TITLE
fix validate.sh for contributions

### DIFF
--- a/Tests/scripts/validate.sh
+++ b/Tests/scripts/validate.sh
@@ -5,6 +5,8 @@ echo "CIRCLE_BRANCH: $CIRCLE_BRANCH CI: $CI DEMISTO_README_VALIDATION: $DEMISTO_
 
 if [[ $CIRCLE_BRANCH = master ]] || [[ -n "${NIGHTLY}" ]] || [[ -n "${BUCKET_UPLOAD}" ]] || [[ -n "${DEMISTO_SDK_NIGHTLY}" ]]; then
     demisto-sdk validate -a --post-commit --id-set --id-set-path $CIRCLE_ARTIFACTS/unified_id_set.json
+elif [[ $CIRCLE_BRANCH =~ pull/[0-9]+ ]]; then
+    demisto-sdk validate -g --post-commit --id-set --id-set-path ./Tests/id_set.json
 else
     demisto-sdk validate -g --post-commit --id-set --id-set-path $CIRCLE_ARTIFACTS/unified_id_set.json
 fi


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed the script validate.sh. In case the current branch is a contrib's, we change the file path of id_set creation (id_set file will be saved in the other path).

link to a PR includes a validate that works with the change: https://github.com/demisto/content/pull/11339

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
