### PR TITLE
[Project Manager] Limit workflow execution to demisto/content

### DIFF
--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false
+    if: github.repository == 'demisto/content' && startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/project_manager_daily.yml
+++ b/.github/workflows/project_manager_daily.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   manage_project_board:
     runs-on: ubuntu-latest
+    if: github.repository == 'demisto/content'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/.github/workflows/project_manager_hourly.yml
+++ b/.github/workflows/project_manager_hourly.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   manage_project_board:
     runs-on: ubuntu-latest
+    if: github.repository == 'demisto/content'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/33603

## Description
Limited the execution of the project manager workflows to `demisto/content` only.
Also limited execution of `Check contributor packs` workflow to `demisto/content` only.