### PR TITLE
fixing error in Enum extension

### DIFF
--- a/Tests/scripts/utils/get_modified_files_for_testing.py
+++ b/Tests/scripts/utils/get_modified_files_for_testing.py
@@ -7,18 +7,13 @@ from enum import Enum
 from typing import Dict, Set, Optional, Tuple, List
 
 import demisto_sdk.commands.common.constants as constants
+from demisto_sdk.commands.common.constants import FileType
 from demisto_sdk.commands.common import tools
 
 from Tests.scripts.utils.collect_helpers import (
     COMMON_YML_LIST,
     is_pytest_file, checked_type, SECRETS_WHITE_LIST,
 )
-
-
-class FileType(constants.FileType, Enum):
-    CONF_JSON = "confjson"
-    METADATA = "metadata"
-    WHITE_LIST = 'whitelist'
 
 
 def resolve_type(file_path: str) -> Optional[FileType]:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
So far, using a Python 3.9 docker on the private repo caused errors due to the fact we are extending Enums in a way that has been made illegal in Python 3.9.
This issue is now fixed.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
