### PR TITLE
Proofpoint Protection Server v2 - adjust smart search from and to params to pps on prem v8.14.2

### DIFF
--- a/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2.py
+++ b/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2.py
@@ -140,12 +140,14 @@ def test_module(client: Client) -> str:
 def smart_search(client: Client, args: Dict[str, Any]) -> CommandResults:
     assert (start_time := parse(args.get('start_time', '24 hours'), settings={'RETURN_AS_TIMEZONE_AWARE': True})), \
         f"Failed parsing start time: {args.get('start_time')}"
-    assert (end_time := parse(args.get('end_time', 'now'), settings={'RETURN_AS_TIMEZONE_AWARE': True})), \
-        f"Failed parsing end time: {args.get('end_time')}"
+    if end_time := args.get('end_time'):
+        assert (end_time := parse(end_time, settings={'RETURN_AS_TIMEZONE_AWARE': True})), \
+            f"Failed parsing start time: {end_time}"
+        end_time = end_time.strftime("%Y-%m-%dT%H:%M:%S%z")
     result = client.smart_search_request(
         action=args.get('action'),
         from_=start_time.strftime("%Y-%m-%dT%H:%M:%S%z"),
-        to=end_time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        to=end_time,
         virus=args.get('virus'),
         env_from=args.get('sender'),
         env_rcpt=args.get('recipient'),

--- a/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2.py
+++ b/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2.py
@@ -138,13 +138,14 @@ def test_module(client: Client) -> str:
 
 
 def smart_search(client: Client, args: Dict[str, Any]) -> CommandResults:
-    assert (start_time := parse(args.get('start_time', '24 hours'))), \
+    assert (start_time := parse(args.get('start_time', '24 hours'), settings={'RETURN_AS_TIMEZONE_AWARE': True})), \
         f"Failed parsing start time: {args.get('start_time')}"
-    assert (end_time := parse(args.get('end_time', 'now'))), f"Failed parsing end time: {args.get('end_time')}"
+    assert (end_time := parse(args.get('end_time', 'now'), settings={'RETURN_AS_TIMEZONE_AWARE': True})), \
+        f"Failed parsing end time: {args.get('end_time')}"
     result = client.smart_search_request(
         action=args.get('action'),
-        from_=start_time.isoformat(),
-        to=end_time.isoformat(),
+        from_=start_time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        to=end_time.strftime("%Y-%m-%dT%H:%M:%S%z"),
         virus=args.get('virus'),
         env_from=args.get('sender'),
         env_rcpt=args.get('recipient'),

--- a/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2_test.py
+++ b/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2_test.py
@@ -35,10 +35,18 @@ def test_smart_search(requests_mock, client):
         - Verify command outputs are as expected
     """
     args = {
-        'action': 'accept'
+        'action': 'accept',
+        'start_time': '2021-02-08T08:12:30-05:00',
+        'end_time': '2021-02-08T09:12:30-05:00',
+    }
+    params = {
+        'action': 'accept',
+        'from': '2021-02-08T08:12:30-0500',
+        'to': '2021-02-08T09:12:30-0500',
+        'count': '100',
     }
     api_response = load_test_data('./test_data/smart_search_response.json')
-    requests_mock.get(SERVER_URL + '/pss/filter?' + urlencode(args), json=api_response)
+    requests_mock.get(SERVER_URL + '/pss/filter?' + urlencode(params), json=api_response)
     result = smart_search(client=client, args=args)
     assert result.outputs == api_response.get('result')
 

--- a/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2_test.py
+++ b/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/ProofpointProtectionServerV2_test.py
@@ -37,12 +37,10 @@ def test_smart_search(requests_mock, client):
     args = {
         'action': 'accept',
         'start_time': '2021-02-08T08:12:30-05:00',
-        'end_time': '2021-02-08T09:12:30-05:00',
     }
     params = {
         'action': 'accept',
         'from': '2021-02-08T08:12:30-0500',
-        'to': '2021-02-08T09:12:30-0500',
         'count': '100',
     }
     api_response = load_test_data('./test_data/smart_search_response.json')

--- a/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/README.md
+++ b/Packs/ProofpointServerProtection/Integrations/ProofpointProtectionServerV2/README.md
@@ -1,6 +1,9 @@
 Proofpoint email security appliance.
 
-This integration was integrated and tested with version 8.16.2 of Proofpoint Protection Server.
+This integration was integrated and tested with the following versions of Proofpoint Protection Server:
+- Cloud 8.16.2
+- On-promise 8.14.2
+
 ## Authentication
 An administrator must have a role that includes access to a specific REST API. 
 

--- a/Packs/ProofpointServerProtection/ReleaseNotes/2_0_3.md
+++ b/Packs/ProofpointServerProtection/ReleaseNotes/2_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Proofpoint Protection Server v2
+- Fixed an issue where the *start_time* and *end_time* arguments of the ***proofpoint-pps-smart-search*** command were not handled properly for Proofpoint on-premise appliance version 8.14.2.

--- a/Packs/ProofpointServerProtection/pack_metadata.json
+++ b/Packs/ProofpointServerProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Protection Server",
     "description": "Proofpoint email security appliance.",
     "support": "xsoar",
-    "currentVersion": "2.0.2",
+    "currentVersion": "2.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/33754

## Description
removed the `:` from the timezone sent in the `to` and `from` params in the smart search api

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
