### PR TITLE
Making 'vt-detonate test' unmockable since it uploads a file

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1685,7 +1685,8 @@
             ],
             "timeout": 1400,
             "fromversion": "5.5.0",
-            "nightly": true
+            "nightly": true,
+            "is_mockable": false
         },
         {
             "integrations": "Cisco ASA",


### PR DESCRIPTION
Making 'vt-detonate test' unmockable since it uploads a file