### PR TITLE
FireEye ETP get-alerts Fix

### DIFF
--- a/Packs/FireEyeETP/Integrations/FireEyeETP/FireEyeETP.py
+++ b/Packs/FireEyeETP/Integrations/FireEyeETP/FireEyeETP.py
@@ -349,31 +349,31 @@ def get_message_command():
 
 def alert_readable_data_summery(alert):
     return {
-        'Alert ID': alert['id'],
-        'Alert Timestamp': alert['alert']['timestamp'],
-        'From': alert['email']['headers']['from'],
-        'Recipients': '{}|{}'.format(alert['email']['headers']['to'], alert['email']['headers']['cc']),
-        'Subject': alert['email']['headers']['subject'],
-        'MD5': alert['alert'].get('malware_md5'),
-        'URL/Attachment': alert['email']['attachment'],
-        'Email Status': alert['email']['status'],
-        'Email Accepted': alert['email']['timestamp']['accepted'],
-        'Threat Intel': alert['ati']
+        'Alert ID': alert.get('id'),
+        'Alert Timestamp': alert.get('alert').get('timestamp'),
+        'From': alert.get('email').get('headers').get('from'),
+        'Recipients': '{}|{}'.format(alert.get('email').get('headers').get('to'), alert.get('email').get('headers').get('cc')),
+        'Subject': alert.get('email').get('headers').get('subject'),
+        'MD5': alert.get('alert').get('malware_md5'),
+        'URL/Attachment': alert.get('email').get('attachment'),
+        'Email Status': alert.get('email').get('status'),
+        'Email Accepted': alert.get('email').get('timestamp').get('accepted'),
+        'Threat Intel': alert.get('ati')
     }
 
 
 def alert_readable_data(alert):
     return {
-        'Alert ID': alert['id'],
-        'Alert Timestamp': alert['alert']['timestamp'],
-        'From': alert['email']['headers']['from'],
-        'Recipients': '{}|{}'.format(alert['email']['headers']['to'], alert['email']['headers']['cc']),
-        'Subject': alert['email']['headers']['subject'],
-        'MD5': alert['alert'].get('malware_md5'),
-        'URL/Attachment': alert['email']['attachment'],
-        'Email Status': alert['email']['status'],
-        'Email Accepted': alert['email']['timestamp']['accepted'],
-        'Sevirity': alert['alert']['severity']
+        'Alert ID': alert.get('id'),
+        'Alert Timestamp': alert.get('alert').get('timestamp'),
+        'From': alert.get('email').get('headers').get('from'),
+        'Recipients': '{}|{}'.format(alert.get('email').get('headers').get('to'), alert.get('email').get('headers').get('cc')),
+        'Subject': alert.get('email').get('headers').get('subject'),
+        'MD5': alert.get('alert').get('malware_md5'),
+        'URL/Attachment': alert.get('email').get('attachment'),
+        'Email Status': alert.get('email').get('status'),
+        'Email Accepted': alert.get('email').get('timestamp').get('accepted'),
+        'Sevirity': alert.get('alert').get('severity')
     }
 
 

--- a/Packs/FireEyeETP/ReleaseNotes/1_0_2.md
+++ b/Packs/FireEyeETP/ReleaseNotes/1_0_2.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### FireEye ETP
+Fixed a bug in the **fireeye-etp-get-alerts** command in which directly accessing fields in the response
+ caused a *KeyError* exception.

--- a/Packs/FireEyeETP/ReleaseNotes/1_0_2.md
+++ b/Packs/FireEyeETP/ReleaseNotes/1_0_2.md
@@ -1,5 +1,4 @@
 
 #### Integrations
 ##### FireEye ETP
-Fixed a bug in the **fireeye-etp-get-alerts** command in which directly accessing fields in the response
- caused a *KeyError* exception.
+Fixed an issue in the ***fireeye-etp-get-alerts*** command where directly accessing fields in the response would cause a *KeyError* exception.

--- a/Packs/FireEyeETP/pack_metadata.json
+++ b/Packs/FireEyeETP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye ETP",
     "description": "FireEye Email Threat Prevention (ETP Cloud) is a cloud-based platform that protects against advanced email attacks.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/33864

## Description
Fixed a bug in the `fireeye-etp-get-alerts` command that was caused due to direct access to the response fields. This caused a `KeyError` exception when some fields were missing in the response.

Couldn't add UTs as we don't have an instance of the product.
