### PR TITLE
docker login with read only creds and leave instances logged in

### DIFF
--- a/Tests/scripts/destroy_instances.py
+++ b/Tests/scripts/destroy_instances.py
@@ -7,7 +7,6 @@ import sys
 import Tests.scripts.awsinstancetool.aws_functions as aws_functions
 
 from Tests.scripts.utils.log_util import install_logging
-from demisto_sdk.commands.test_content.tools import is_redhat_instance
 
 
 def main():
@@ -47,15 +46,6 @@ def main():
 
         except subprocess.CalledProcessError:
             logging.exception(f'Failed downloading server logs from server {env["InstanceDNS"]}')
-
-        try:
-            container_engine_type = 'podman' if is_redhat_instance(env["InstanceDNS"]) else 'docker'
-            logging.debug(f'logging out of {container_engine_type} on server for server {env["InstanceDNS"]}')
-            subprocess.check_output(
-                f'ssh -o StrictHostKeyChecking=no {env["SSHuser"]}@{env["InstanceDNS"]} '
-                f'cd /home/demisto && sudo -u demisto {container_engine_type} logout'.split())
-        except Exception:
-            logging.exception(f'Could not log out of {container_engine_type} on {env["InstanceDNS"]}')
 
         if time_to_live:
             logging.info(f'Skipping - Time to live was set to {time_to_live} minutes')

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -64,8 +64,8 @@ def docker_login(ip: str) -> None:
     Args:
         ip: The ip of the server that should be logged in
     """
-    docker_username = os.environ.get('DOCKERHUB_USER')
-    docker_password = os.environ.get('DOCKERHUB_PASSWORD')
+    docker_username = os.environ.get('DOCKER_READ_ONLY_USER')
+    docker_password = os.environ.get('DOCKER_READ_ONLY_PASSWORD')
     container_engine_type = 'podman' if is_redhat_instance(ip) else 'docker'
     try:
         check_output(


### PR DESCRIPTION
## Description:
- Using docker credentials with read only permissions.
- Leaving the instances logged in to docker when build finishes.