### PR TITLE
Mail Sender pop3 beta - bug fix from contrib

### DIFF
--- a/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.py
+++ b/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.py
@@ -212,7 +212,7 @@ def parse_mail_parts(parts):
             attachments.extend(part_attachments)
         elif not is_attachment:
             if headers.get('content-transfer-encoding') == 'base64':
-                text = base64.b64decode(part._payload).decode('utf-8')
+                text = base64.b64decode(part._payload).decode('utf-8', 'replace')
             elif headers.get('content-transfer-encoding') == 'quoted-printable':
                 str_utf8 = part._payload.decode('cp1252')
                 str_utf8 = str_utf8.encode('utf-8')

--- a/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.py
+++ b/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.py
@@ -104,13 +104,13 @@ class TextExtractHtmlParser(HTMLParser):
         self._texts = []  # type: list
         self._ignore = False
 
-    def handle_starttag(self, tag, attrs):
+    def handle_starttag(self, tag, _):
         if tag in ('p', 'br') and not self._ignore:
             self._texts.append('\n')
         elif tag in ('script', 'style'):
             self._ignore = True
 
-    def handle_startendtag(self, tag, attrs):
+    def handle_startendtag(self, tag, _):
         if tag in ('br', 'tr') and not self._ignore:
             self._texts.append('\n')
 

--- a/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3_test.py
+++ b/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3_test.py
@@ -1,3 +1,6 @@
+# -*- coding: iso-8859-1 -*-
+import base64
+
 from MailListener_POP3 import parse_mail_parts
 
 
@@ -22,3 +25,29 @@ def test_parse_mail_parts():
 
     body, html, attachments = parse_mail_parts(parts)
     assert body == 'El Nio'
+
+
+def test_base64_mail_decode():
+    """
+    Given
+    - base64 email data which could not be decoded into utf-8
+    When
+    - Email contains special characters
+    Then
+    - run parse_mail_parts method
+    - Validate that no exception is thrown
+    - Validate The result body
+    """
+    class MockEmailPart:
+        pass
+
+    test_payload = 'Foo\xbbBar=='
+    base_64_encoded_test_payload = base64.b64encode(test_payload)
+
+    part = MockEmailPart()
+    part._headers = [['content-transfer-encoding', 'base64']]
+    part._payload = base_64_encoded_test_payload
+    parts = [part]
+
+    body, html, attachments = parse_mail_parts(parts)
+    assert body.replace(u'\uFFFD', '?') == 'Foo?Bar=='

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_2.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_2.md
@@ -1,5 +1,4 @@
 
 #### Integrations
 ##### MailListener - POP3 Beta
-- Fixed an issue where some email messages caused fetch incidents process to fail.
-
+- Fixed an issue where decoding non-UTF-8 characters caused ***fetch-incidents*** to fail on some emails.

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_2.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_2.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### MailListener - POP3 Beta
+- Fixed an issue where some email messages caused fetch incidents process to fail.
+

--- a/Packs/MailListener_-_POP3/pack_metadata.json
+++ b/Packs/MailListener_-_POP3/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MailListener - POP3 (Beta)",
     "description": "Listen to a mailbox, enable incident triggering via e-mail",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34065

## Description
non-utf-8 characters will now be replaced by the u+fffd character filler.


## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [X] Tests
- [X] Documentation 

Failing UT before the change: https://app.circleci.com/pipelines/github/demisto/content/69605/workflows/16554cfe-0c29-4fd5-b4d3-cd76acff9036/jobs/287218

Waiting for sample email for PB