### PR TITLE
remove CloudConvert from unmockable integrations

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3434,7 +3434,6 @@
         "AzureWAF": "Has a command that sends parameters in the path",
         "HashiCorp Vault": "Has a command that sends parameters in the path",
         "urlscan.io": "Uses data that comes in the headers",
-        "CloudConvert": "has a command that uploads a file (!cloudconvert-upload)",
         "Symantec Messaging Gateway": "Test playbook uses a random string",
         "Cylance Protect": "Test playbook (get_file_sample_by_hash_-_cylance_protect_-_test) downloads a file",
         "AlienVault OTX TAXII Feed": "Client from 'cabby' package generates uuid4 in the request",


### PR DESCRIPTION
fixed in https://github.com/demisto/demisto-sdk/pull/1126