### PR TITLE
Microsoft Graph API - add note about in case unsupported top resource

### DIFF
--- a/Packs/MicrosoftGraphAPI/Integrations/MicrosoftGraphAPI/README.md
+++ b/Packs/MicrosoftGraphAPI/Integrations/MicrosoftGraphAPI/README.md
@@ -99,3 +99,9 @@ We can see that according to the [HTTP request](https://docs.microsoft.com/en-us
  - The resource is ***/applications***
  
 So in order to list all the applications using the integration, we would run the command: `!msgraph-api resource=/applications http_method=GET`
+
+## Notes
+- In order to limit the number of results returned from Microsoft Graph API, the default value of the *odata* command argument is `$top=10`.
+Some of the Graph APIs do not support the `top` resource, and in that case the following error message will be returned: `This resource does not support custom page sizes. Please retry without a page size argument.`
+In this case, you can modify the *odata* command argument to not include the `top` resource.
+For example, run the command with the *odata* command argument set to `$count=true` to include a count of the total number of items in a collection alongside the page of data values returned from Microsoft Graph.


### PR DESCRIPTION

## Status
- [x] Ready

## Description
some graph apis do not support the `top` resource, which is the default value of the `odata` command argument
added a note to the readme how to handle that case
