### PR TITLE
Marketplace: Remove Contrib Suffix

### DIFF
--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -992,6 +992,25 @@ class TestImagesUpload:
         assert len(expected_result) == len(integration_images)
         assert integration_images == expected_result
 
+    @pytest.mark.parametrize("display_name", [
+        'Integration Name (Developer Contribution)',
+        'Integration Name (Community Contribution) ',
+        'Integration Name',
+        'Integration Name (Partner Contribution)',
+        'Integration Name(Partner Contribution)'
+    ])
+    def test_remove_contrib_suffix_from_name(self, dummy_pack, display_name):
+        """
+           Given:
+               - Integration name.
+           When:
+               - Uploading integrations images to gcs.
+           Then:
+               - Validates that the contribution details were removed
+       """
+
+        assert "Integration Name" == dummy_pack.remove_contrib_suffix_from_name(display_name)
+
     def test_copy_and_upload_integration_images(self, mocker, dummy_pack):
         """
            Given:

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1811,7 +1811,7 @@ class Pack(object):
             return task_status, exists_in_index
 
     @staticmethod
-    def remove_contrib_suffix_from_name(display_name: str):
+    def remove_contrib_suffix_from_name(display_name: str) -> str:
         """ Removes the contribution details suffix from the integration's display name
         Args:
             display_name (str): The integration display name.

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1810,6 +1810,24 @@ class Pack(object):
         finally:
             return task_status, exists_in_index
 
+    @staticmethod
+    def remove_contrib_suffix_from_name(display_name: str):
+        """ Removes the contribution details suffix from the integration's display name
+        Args:
+            display_name (str): The integration display name.
+
+        Returns:
+            str: The display name without the contrib details suffix
+
+        """
+        contribution_suffixes = ('(Partner Contribution)', '(Developer Contribution)', '(Community Contribution)')
+        for suffix in contribution_suffixes:
+            index = display_name.find(suffix)
+            if index != -1:
+                display_name = display_name[:index].rstrip(' ')
+                break
+        return display_name
+
     def upload_integration_images(self, storage_bucket):
         """ Uploads pack integrations images to gcs.
 
@@ -1853,8 +1871,13 @@ class Pack(object):
                 else:
                     image_gcs_path = pack_image_blob.public_url
 
+                integration_name = image_data.get('display_name', '')
+
+                if self.support_type != Metadata.XSOAR_SUPPORT:
+                    integration_name = self.remove_contrib_suffix_from_name(integration_name)
+
                 uploaded_integration_images.append({
-                    'name': image_data.get('display_name', ''),
+                    'name': integration_name,
                     'imagePath': image_gcs_path
                 })
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/33761

## Description
Added a function to remove the contribution details from the integration display name.
**This modification takes place *after* the upload step and affects only the integration top-level entry in the parsed metadata file.**

## Screenshots
After changes:

<img width="1456" alt="Screen Shot 2021-02-24 at 17 31 49" src="https://user-images.githubusercontent.com/21142167/109024331-4f3e0980-76c6-11eb-855f-fc70c53d8c1f.png">
