### PR TITLE
Unskipping Test Playbooks for PAN-OS

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3308,8 +3308,6 @@
         "Palo_Alto_Networks_Enterprise_DLP - Test": "Issue 32568",
         "JoeSecurityTestDetonation": "Issue 25650",
         "JoeSecurityTestPlaybook": "Issue 25649",
-        "PAN-OS Create Or Edit Rule Test": "Issue 26465",
-        "PAN-OS DAG Configuration Test": "Issue 19205",
         "Cortex Data Lake Test": "Issue 24346",
         "O365-SecurityAndCompliance-Test": "Issue 32364",
         "pyEWS_Test": "Issue 27942",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2397,7 +2397,7 @@
             "integrations": "palo_alto_networks_pan_os_edl_management"
         },
         {
-            "playbookID": "PAN-OS DAGd Configuration Test",
+            "playbookID": "PAN-OS DAG Configuration Test",
             "integrations": "Panorama",
             "instance_names": "palo_alto_panorama_9.0",
             "timeout": 1500

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2397,7 +2397,7 @@
             "integrations": "palo_alto_networks_pan_os_edl_management"
         },
         {
-            "playbookID": "PAN-OS DAG Configuration Test",
+            "playbookID": "PAN-OS DAGd Configuration Test",
             "integrations": "Panorama",
             "instance_names": "palo_alto_panorama_9.0",
             "timeout": 1500


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/26465 
fixes: https://github.com/demisto/etc/issues/19205

## Description
Unskipping PAN-OS -Create or edit rule and DAG configuration test playbooks 
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x ] No

## Must have
- [ ] Tests
- [ ] Documentation 
