### PR TITLE
SDP TPB fix

### DIFF
--- a/Packs/ServiceDeskPlus/TestPlaybooks/playbook-Service_Desk_Plus.yml
+++ b/Packs/ServiceDeskPlus/TestPlaybooks/playbook-Service_Desk_Plus.yml
@@ -5,10 +5,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: f95b3bea-2c28-4f85-8ad2-dd41f6aa4760
+    taskid: 8bcd8273-82ac-4f37-9954-9fbca1f49c9a
     type: start
     task:
-      id: f95b3bea-2c28-4f85-8ad2-dd41f6aa4760
+      id: 8bcd8273-82ac-4f37-9954-9fbca1f49c9a
       version: -1
       name: ""
       iscommand: false
@@ -31,10 +31,10 @@ tasks:
     quietmode: 0
   "1":
     id: "1"
-    taskid: 12684003-ab9e-495d-8286-4c321b898a65
+    taskid: 6e4a355a-6908-4a65-8bc5-bfdfcbd63fe8
     type: regular
     task:
-      id: 12684003-ab9e-495d-8286-4c321b898a65
+      id: 6e4a355a-6908-4a65-8bc5-bfdfcbd63fe8
       version: -1
       name: service-desk-plus-request-create
       description: Create new requests
@@ -84,10 +84,10 @@ tasks:
     quietmode: 0
   "3":
     id: "3"
-    taskid: f9f1e44a-6fbc-472d-8d76-d86fac008844
+    taskid: 61cbc5ba-a3d0-4b75-a797-a4e24ad6da3f
     type: title
     task:
-      id: f9f1e44a-6fbc-472d-8d76-d86fac008844
+      id: 61cbc5ba-a3d0-4b75-a797-a4e24ad6da3f
       version: -1
       name: Done
       type: title
@@ -108,10 +108,10 @@ tasks:
     quietmode: 0
   "4":
     id: "4"
-    taskid: 87613ed2-81cd-47c3-8871-eb4f80ae0388
+    taskid: 3b0ecff1-24ec-482f-85ae-ef003ddde302
     type: regular
     task:
-      id: 87613ed2-81cd-47c3-8871-eb4f80ae0388
+      id: 3b0ecff1-24ec-482f-85ae-ef003ddde302
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -145,10 +145,10 @@ tasks:
     quietmode: 0
   "5":
     id: "5"
-    taskid: d0fabbce-9af0-4a26-8a3f-95216a6d57f8
+    taskid: 5f59d6e5-24be-4abf-9276-85b7438d9e33
     type: condition
     task:
-      id: d0fabbce-9af0-4a26-8a3f-95216a6d57f8
+      id: 5f59d6e5-24be-4abf-9276-85b7438d9e33
       version: -1
       name: Verify service-desk-plus-requests-list-output
       description: Check whether the values provided in arguments are equal. If either
@@ -185,10 +185,10 @@ tasks:
     quietmode: 0
   "8":
     id: "8"
-    taskid: f2ebc516-6d51-4bd4-827e-9981f57f26c2
+    taskid: ba37a356-eea7-4cca-b9be-f5ff418709c1
     type: regular
     task:
-      id: f2ebc516-6d51-4bd4-827e-9981f57f26c2
+      id: ba37a356-eea7-4cca-b9be-f5ff418709c1
       version: -1
       name: Generate Random Request Subject
       description: Generates random string
@@ -225,10 +225,10 @@ tasks:
     quietmode: 0
   "9":
     id: "9"
-    taskid: 2ad471d0-4461-418f-8a08-c4b38c1cf95e
+    taskid: e33893f4-ae7a-4aed-9b78-78c2fb95fa90
     type: title
     task:
-      id: 2ad471d0-4461-418f-8a08-c4b38c1cf95e
+      id: e33893f4-ae7a-4aed-9b78-78c2fb95fa90
       version: -1
       name: Test Requests-List
       type: title
@@ -252,10 +252,10 @@ tasks:
     quietmode: 0
   "10":
     id: "10"
-    taskid: ef02abe2-65ca-4d45-8690-ae813b6c3929
+    taskid: 53cd3879-e534-4e0c-a5f2-3308641b703c
     type: regular
     task:
-      id: ef02abe2-65ca-4d45-8690-ae813b6c3929
+      id: 53cd3879-e534-4e0c-a5f2-3308641b703c
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -289,10 +289,10 @@ tasks:
     quietmode: 0
   "11":
     id: "11"
-    taskid: 3b5397be-7f6b-4316-8b0c-0aceb4e07d41
+    taskid: d1a55d2d-7683-4930-99ea-6dbf6baa2abb
     type: regular
     task:
-      id: 3b5397be-7f6b-4316-8b0c-0aceb4e07d41
+      id: d1a55d2d-7683-4930-99ea-6dbf6baa2abb
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -326,10 +326,10 @@ tasks:
     quietmode: 0
   "12":
     id: "12"
-    taskid: d44e9ce1-4c33-4c85-81c2-0d1b5f3b496f
+    taskid: f5aea6aa-aedd-43ad-a20a-8afe8b5072b8
     type: condition
     task:
-      id: d44e9ce1-4c33-4c85-81c2-0d1b5f3b496f
+      id: f5aea6aa-aedd-43ad-a20a-8afe8b5072b8
       version: -1
       name: Verify service-desk-plus-requests-list-output
       description: Check whether the values provided in arguments are equal. If either
@@ -363,10 +363,10 @@ tasks:
     quietmode: 0
   "13":
     id: "13"
-    taskid: b65da235-45a4-45ba-8053-aeb3d6247607
+    taskid: 4eb47152-e958-4d45-8fcc-e75316d72981
     type: condition
     task:
-      id: b65da235-45a4-45ba-8053-aeb3d6247607
+      id: 4eb47152-e958-4d45-8fcc-e75316d72981
       version: -1
       name: Verify service-desk-plus-requests-list-output
       description: Check whether the values provided in arguments are equal. If either
@@ -400,10 +400,10 @@ tasks:
     quietmode: 0
   "14":
     id: "14"
-    taskid: 603166e1-7650-46d5-81ff-a18ad82297fa
+    taskid: b8aa33e6-150d-43f8-91ea-51aa28422db2
     type: regular
     task:
-      id: 603166e1-7650-46d5-81ff-a18ad82297fa
+      id: b8aa33e6-150d-43f8-91ea-51aa28422db2
       version: -1
       name: Delete Context
       description: Delete field from context
@@ -436,10 +436,10 @@ tasks:
     quietmode: 0
   "15":
     id: "15"
-    taskid: c38fd479-0a62-4205-81b4-6fca22888b36
+    taskid: 5d68beb4-5dd2-4b13-ba08-f873fd9628cf
     type: regular
     task:
-      id: c38fd479-0a62-4205-81b4-6fca22888b36
+      id: 5d68beb4-5dd2-4b13-ba08-f873fd9628cf
       version: -1
       name: Requests Number
       description: Count an array size
@@ -469,10 +469,10 @@ tasks:
     quietmode: 0
   "16":
     id: "16"
-    taskid: 038b5799-1e3f-47d7-81b0-a86a89619108
+    taskid: fab849bc-668c-4e70-bedf-499bb9420d96
     type: regular
     task:
-      id: 038b5799-1e3f-47d7-81b0-a86a89619108
+      id: fab849bc-668c-4e70-bedf-499bb9420d96
       version: -1
       name: Save Request Id
       description: Sets a value into the context with the given context key
@@ -506,10 +506,10 @@ tasks:
     quietmode: 0
   "17":
     id: "17"
-    taskid: fb2a5fd1-058a-4129-8e81-41c95dc7136c
+    taskid: 1da9ef17-61f5-474b-a617-897e5253a739
     type: title
     task:
-      id: fb2a5fd1-058a-4129-8e81-41c95dc7136c
+      id: 1da9ef17-61f5-474b-a617-897e5253a739
       version: -1
       name: Test Assign, Update Commands
       type: title
@@ -533,10 +533,10 @@ tasks:
     quietmode: 0
   "18":
     id: "18"
-    taskid: 040c3c31-6fc6-487e-8a4b-4aecc4dd854b
+    taskid: db351a0f-06b7-4968-9173-b6af4378761a
     type: regular
     task:
-      id: 040c3c31-6fc6-487e-8a4b-4aecc4dd854b
+      id: db351a0f-06b7-4968-9173-b6af4378761a
       version: -1
       name: service-desk-plus-request-update
       description: Update the request with the given request id.
@@ -592,10 +592,10 @@ tasks:
     quietmode: 0
   "19":
     id: "19"
-    taskid: ade04c9c-c88a-46ea-85b6-2db12709d0a9
+    taskid: 23a3aa17-53dd-4820-898b-d0864a9b57a9
     type: regular
     task:
-      id: ade04c9c-c88a-46ea-85b6-2db12709d0a9
+      id: 23a3aa17-53dd-4820-898b-d0864a9b57a9
       version: -1
       name: service-desk-plus-request-assign
       description: Assignes the request with the given request id to a technician/group
@@ -627,10 +627,10 @@ tasks:
     quietmode: 0
   "20":
     id: "20"
-    taskid: ad3e3b78-a6a2-49a8-8982-e70d146ff3d8
+    taskid: b876ee62-e524-4326-9b8e-9418c83abfe8
     type: regular
     task:
-      id: ad3e3b78-a6a2-49a8-8982-e70d146ff3d8
+      id: b876ee62-e524-4326-9b8e-9418c83abfe8
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -666,10 +666,10 @@ tasks:
     quietmode: 0
   "21":
     id: "21"
-    taskid: 0bb15d90-7ae0-4ba9-8066-50670c8dd9c3
+    taskid: 6821dc02-02e5-457f-8984-99a6897ee9c9
     type: condition
     task:
-      id: 0bb15d90-7ae0-4ba9-8066-50670c8dd9c3
+      id: 6821dc02-02e5-457f-8984-99a6897ee9c9
       version: -1
       name: Verify assign
       description: Check whether the values provided in arguments are equal. If either
@@ -703,10 +703,10 @@ tasks:
     quietmode: 0
   "24":
     id: "24"
-    taskid: b05e62b0-c94f-4905-84d0-427e89eff2d6
+    taskid: 4de058e9-46b4-4c89-856d-2e014b10823e
     type: condition
     task:
-      id: b05e62b0-c94f-4905-84d0-427e89eff2d6
+      id: 4de058e9-46b4-4c89-856d-2e014b10823e
       version: -1
       name: Verify update
       description: Check whether the values provided in arguments are equal. If either
@@ -740,10 +740,10 @@ tasks:
     quietmode: 0
   "25":
     id: "25"
-    taskid: efa14364-6bf9-4d50-8b30-a255f7c69383
+    taskid: 86fcb304-ce33-49b7-9bda-a40724a9a949
     type: condition
     task:
-      id: efa14364-6bf9-4d50-8b30-a255f7c69383
+      id: 86fcb304-ce33-49b7-9bda-a40724a9a949
       version: -1
       name: Verify update
       description: Check whether the values provided in arguments are equal. If either
@@ -777,10 +777,10 @@ tasks:
     quietmode: 0
   "26":
     id: "26"
-    taskid: 5d5aa47a-6143-4a61-899f-42b2f85fcf51
+    taskid: 48adffd1-1db6-428a-8226-bd85d4b611e8
     type: regular
     task:
-      id: 5d5aa47a-6143-4a61-899f-42b2f85fcf51
+      id: 48adffd1-1db6-428a-8226-bd85d4b611e8
       version: -1
       name: service-desk-plus-request-close
       description: Close the existing request with the given request id
@@ -813,10 +813,10 @@ tasks:
     quietmode: 0
   "27":
     id: "27"
-    taskid: 8d535541-8825-449a-803e-f3ddb9c3201d
+    taskid: e2e44bea-25be-45e2-be3b-2b9ee636f47f
     type: title
     task:
-      id: 8d535541-8825-449a-803e-f3ddb9c3201d
+      id: e2e44bea-25be-45e2-be3b-2b9ee636f47f
       version: -1
       name: Test Close and Delete commands
       type: title
@@ -840,10 +840,10 @@ tasks:
     quietmode: 0
   "28":
     id: "28"
-    taskid: cc5a25da-9c6e-4092-8f74-be936766f6a5
+    taskid: 8ed60cae-00bc-47a0-8392-b39c6910716c
     type: regular
     task:
-      id: cc5a25da-9c6e-4092-8f74-be936766f6a5
+      id: 8ed60cae-00bc-47a0-8392-b39c6910716c
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -877,10 +877,10 @@ tasks:
     quietmode: 0
   "29":
     id: "29"
-    taskid: 4f4a7b44-2d25-4f03-852e-0f60d3ac9031
+    taskid: 84165d45-95b3-4c2d-97dd-138b565a47fa
     type: condition
     task:
-      id: 4f4a7b44-2d25-4f03-852e-0f60d3ac9031
+      id: 84165d45-95b3-4c2d-97dd-138b565a47fa
       version: -1
       name: Verify closed
       description: Check whether the values provided in arguments are equal. If either
@@ -914,10 +914,10 @@ tasks:
     quietmode: 0
   "30":
     id: "30"
-    taskid: 81b6fdb8-8bd8-44ea-80de-fc66f6e65924
+    taskid: b4950040-8f05-4453-b6e4-02a366e5b57d
     type: regular
     task:
-      id: 81b6fdb8-8bd8-44ea-80de-fc66f6e65924
+      id: b4950040-8f05-4453-b6e4-02a366e5b57d
       version: -1
       name: service-desk-plus-request-delete
       description: Delete the request with the given id.
@@ -946,10 +946,10 @@ tasks:
     quietmode: 0
   "31":
     id: "31"
-    taskid: 627b7a97-41b9-470a-8c96-22666944d292
+    taskid: 8f9b8a99-63ed-4af8-9f48-87f26c0faf91
     type: regular
     task:
-      id: 627b7a97-41b9-470a-8c96-22666944d292
+      id: 8f9b8a99-63ed-4af8-9f48-87f26c0faf91
       version: -1
       name: Delete Context
       description: Delete field from context
@@ -982,10 +982,10 @@ tasks:
     quietmode: 0
   "32":
     id: "32"
-    taskid: b289f753-b2ab-4f6d-8de9-61b4798b66a7
+    taskid: 61713e93-652f-4657-8b7d-7d1e1c4c8daf
     type: regular
     task:
-      id: b289f753-b2ab-4f6d-8de9-61b4798b66a7
+      id: 61713e93-652f-4657-8b7d-7d1e1c4c8daf
       version: -1
       name: Generate Random Request Subject
       description: Generates random string
@@ -1022,10 +1022,10 @@ tasks:
     quietmode: 0
   "33":
     id: "33"
-    taskid: 9f454c7b-ca7b-420b-8a69-03e24950f168
+    taskid: a7ce1992-6810-4bfd-affc-e4524270b03c
     type: regular
     task:
-      id: 9f454c7b-ca7b-420b-8a69-03e24950f168
+      id: a7ce1992-6810-4bfd-affc-e4524270b03c
       version: -1
       name: service-desk-plus-request-create
       description: Create new requests
@@ -1075,10 +1075,10 @@ tasks:
     quietmode: 0
   "34":
     id: "34"
-    taskid: 5a50e00b-ecec-4670-884b-adfa018e6da7
+    taskid: e0087d21-0f2d-4a5a-a54c-8d0cd6273b8d
     type: regular
     task:
-      id: 5a50e00b-ecec-4670-884b-adfa018e6da7
+      id: e0087d21-0f2d-4a5a-a54c-8d0cd6273b8d
       version: -1
       name: Save Request Id
       description: Sets a value into the context with the given context key
@@ -1112,10 +1112,10 @@ tasks:
     quietmode: 0
   "35":
     id: "35"
-    taskid: fd67e209-c1c7-43f7-8cc4-a7acd44a9f75
+    taskid: ed8d6381-2c5d-434f-adfe-3de2b33c1f6b
     type: title
     task:
-      id: fd67e209-c1c7-43f7-8cc4-a7acd44a9f75
+      id: ed8d6381-2c5d-434f-adfe-3de2b33c1f6b
       version: -1
       name: Create 2 New Requests
       type: title
@@ -1139,10 +1139,10 @@ tasks:
     quietmode: 0
   "36":
     id: "36"
-    taskid: 30d93ab0-5f72-4295-8e69-39c51eceba91
+    taskid: d0baee53-43a2-4567-897e-d5eaf331ef68
     type: regular
     task:
-      id: 30d93ab0-5f72-4295-8e69-39c51eceba91
+      id: d0baee53-43a2-4567-897e-d5eaf331ef68
       version: -1
       name: Generate Random Request Subject
       description: Generates random string
@@ -1179,10 +1179,10 @@ tasks:
     quietmode: 0
   "37":
     id: "37"
-    taskid: d2575191-02ad-435a-830a-39b66e6ad358
+    taskid: 51c18817-c84d-468f-9a7a-b7eb16b2fb39
     type: regular
     task:
-      id: d2575191-02ad-435a-830a-39b66e6ad358
+      id: 51c18817-c84d-468f-9a7a-b7eb16b2fb39
       version: -1
       name: service-desk-plus-request-create
       description: Create new requests
@@ -1232,10 +1232,10 @@ tasks:
     quietmode: 0
   "38":
     id: "38"
-    taskid: 83dae9cc-fac3-485c-853a-1cb0e5135d76
+    taskid: d3330c05-d2b6-4c8d-944c-9f243e31fdea
     type: regular
     task:
-      id: 83dae9cc-fac3-485c-853a-1cb0e5135d76
+      id: d3330c05-d2b6-4c8d-944c-9f243e31fdea
       version: -1
       name: Save Request Id
       description: Sets a value into the context with the given context key
@@ -1269,10 +1269,10 @@ tasks:
     quietmode: 0
   "39":
     id: "39"
-    taskid: 265f62d2-5e4e-464a-8183-ff8941ef7e20
+    taskid: c449cd7f-8c86-4739-b2f1-9b9ca6cc8d59
     type: title
     task:
-      id: 265f62d2-5e4e-464a-8183-ff8941ef7e20
+      id: c449cd7f-8c86-4739-b2f1-9b9ca6cc8d59
       version: -1
       name: Test Requests Linking
       type: title
@@ -1296,10 +1296,10 @@ tasks:
     quietmode: 0
   "40":
     id: "40"
-    taskid: 5855c7bc-4626-41bb-8b08-26da7eeec92a
+    taskid: 0a3d25b3-0686-4d86-b674-8004381b1942
     type: regular
     task:
-      id: 5855c7bc-4626-41bb-8b08-26da7eeec92a
+      id: 0a3d25b3-0686-4d86-b674-8004381b1942
       version: -1
       name: service-desk-plus-link-request-modify
       description: Link or Unlink multiple commands
@@ -1333,10 +1333,10 @@ tasks:
     quietmode: 0
   "41":
     id: "41"
-    taskid: 97580aad-2077-4701-8a13-02746d24ff1e
+    taskid: d9009853-e02c-4b55-88eb-55c904b562ae
     type: condition
     task:
-      id: 97580aad-2077-4701-8a13-02746d24ff1e
+      id: d9009853-e02c-4b55-88eb-55c904b562ae
       version: -1
       name: Verify Linked Request
       description: Check whether the values provided in arguments are equal. If either
@@ -1370,10 +1370,10 @@ tasks:
     quietmode: 0
   "42":
     id: "42"
-    taskid: 5ee1b2ae-dbe8-47d6-8517-8ada36598684
+    taskid: 4111d8e5-0c05-4036-a344-3a1f406c24a0
     type: regular
     task:
-      id: 5ee1b2ae-dbe8-47d6-8517-8ada36598684
+      id: 4111d8e5-0c05-4036-a344-3a1f406c24a0
       version: -1
       name: service-desk-plus-linked-request-list
       description: Gets a list with all the linked requests under a request
@@ -1402,10 +1402,10 @@ tasks:
     quietmode: 0
   "43":
     id: "43"
-    taskid: a3ddbfea-1869-4edc-8091-a8d637721029
+    taskid: 8ec82991-95b9-47eb-8076-a1af29256a74
     type: regular
     task:
-      id: a3ddbfea-1869-4edc-8091-a8d637721029
+      id: 8ec82991-95b9-47eb-8076-a1af29256a74
       version: -1
       name: service-desk-plus-link-request-modify
       description: Link or Unlink multiple commands
@@ -1439,10 +1439,10 @@ tasks:
     quietmode: 0
   "44":
     id: "44"
-    taskid: 4aa12771-a36d-437a-8c75-082be0082f85
+    taskid: 6ac155a2-cc45-4da1-be33-76cacabb2b3c
     type: regular
     task:
-      id: 4aa12771-a36d-437a-8c75-082be0082f85
+      id: 6ac155a2-cc45-4da1-be33-76cacabb2b3c
       version: -1
       name: service-desk-plus-linked-request-list
       description: Gets a list with all the linked requests under a request
@@ -1471,10 +1471,10 @@ tasks:
     quietmode: 0
   "45":
     id: "45"
-    taskid: eaffb3b0-c77b-4432-8ed3-2459772e9daf
+    taskid: 773cc659-741c-464b-8901-3a1ae345dbeb
     type: condition
     task:
-      id: eaffb3b0-c77b-4432-8ed3-2459772e9daf
+      id: 773cc659-741c-464b-8901-3a1ae345dbeb
       version: -1
       name: Verify No Linked Request
       description: Check whether the values provided in arguments are equal. If either
@@ -1508,10 +1508,10 @@ tasks:
     quietmode: 0
   "46":
     id: "46"
-    taskid: 3b20552d-4a52-4165-8298-3f7309bd261d
+    taskid: 4ceea6f0-5a79-4048-a586-253440916c45
     type: title
     task:
-      id: 3b20552d-4a52-4165-8298-3f7309bd261d
+      id: 4ceea6f0-5a79-4048-a586-253440916c45
       version: -1
       name: Test Resolution and Pickup
       type: title
@@ -1535,10 +1535,10 @@ tasks:
     quietmode: 0
   "47":
     id: "47"
-    taskid: de62b0d7-31de-4c4d-8a36-421b8f85df0b
+    taskid: 3fc815b6-5ac9-4cde-a880-42fdbba9af01
     type: regular
     task:
-      id: de62b0d7-31de-4c4d-8a36-421b8f85df0b
+      id: 3fc815b6-5ac9-4cde-a880-42fdbba9af01
       version: -1
       name: service-desk-plus-request-resolution-add
       description: Adds a resolution to the given request
@@ -1571,10 +1571,10 @@ tasks:
     quietmode: 0
   "48":
     id: "48"
-    taskid: fbdba70a-4c1d-4952-86bc-8cb3013a4bfa
+    taskid: 6ad3a2f9-8925-4371-a9d8-d74eae176ebd
     type: regular
     task:
-      id: fbdba70a-4c1d-4952-86bc-8cb3013a4bfa
+      id: 6ad3a2f9-8925-4371-a9d8-d74eae176ebd
       version: -1
       name: service-desk-plus-request-delete
       description: Delete the request with the given id.
@@ -1603,10 +1603,10 @@ tasks:
     quietmode: 0
   "49":
     id: "49"
-    taskid: 031f3ce4-9e32-4e5f-8924-75287facb569
+    taskid: b56a25d7-7b0d-4052-b962-d820d60b3dff
     type: regular
     task:
-      id: 031f3ce4-9e32-4e5f-8924-75287facb569
+      id: b56a25d7-7b0d-4052-b962-d820d60b3dff
       version: -1
       name: service-desk-plus-request-resolutions-list
       description: Gets the resolution to the given request
@@ -1635,10 +1635,10 @@ tasks:
     quietmode: 0
   "50":
     id: "50"
-    taskid: 7f99087e-253f-4964-8685-8a652d4a42ed
+    taskid: fe0f1093-692b-4b9b-8e3f-36780cc1e0a0
     type: condition
     task:
-      id: 7f99087e-253f-4964-8685-8a652d4a42ed
+      id: fe0f1093-692b-4b9b-8e3f-36780cc1e0a0
       version: -1
       name: Verify Resolution of Linked Request
       description: Check whether the values provided in arguments are equal. If either
@@ -1672,10 +1672,10 @@ tasks:
     quietmode: 0
   "51":
     id: "51"
-    taskid: 113e8176-4376-42bf-8de5-027a4449c760
+    taskid: ea47fb5a-631b-447d-bfa4-f718dc302592
     type: regular
     task:
-      id: 113e8176-4376-42bf-8de5-027a4449c760
+      id: ea47fb5a-631b-447d-bfa4-f718dc302592
       version: -1
       name: service-desk-plus-request-pickup
       description: Allows the technician to pickup the request with the given request
@@ -1705,10 +1705,10 @@ tasks:
     quietmode: 0
   "52":
     id: "52"
-    taskid: 909784d6-9ddf-413b-874d-0724e14c4721
+    taskid: c6183203-370d-4bd1-80c8-0c6b91165d91
     type: regular
     task:
-      id: 909784d6-9ddf-413b-874d-0724e14c4721
+      id: c6183203-370d-4bd1-80c8-0c6b91165d91
       version: -1
       name: service-desk-plus-requests-list
       description: View the details of requests. If no parameters are given the details
@@ -1742,10 +1742,10 @@ tasks:
     quietmode: 0
   "53":
     id: "53"
-    taskid: 679a7084-b285-41b0-8863-abc51f555fa3
+    taskid: 34b04763-8b1f-4ed4-90ae-edd11c3b1937
     type: condition
     task:
-      id: 679a7084-b285-41b0-8863-abc51f555fa3
+      id: 34b04763-8b1f-4ed4-90ae-edd11c3b1937
       version: -1
       name: Verify Pickup
       description: Check whether the values provided in arguments are equal. If either


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/29026

## Description
Update all tasks UUID as they were duplicated in a new contribution integration.
The test failed because a new contribution of SDP on-prem was added. In this integration, the original SDP TPB was copied resulting in two playbooks with identical task UUIDs. Therefore, when testing the original SDP test PB, it tried to access the on-prem instance and failed.
