### PR TITLE
update docker threshold for powershell images

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3600,6 +3600,22 @@
             },
             "demisto/taxii2": {
                 "pid_threshold": 11
+            },
+            "demisto/pwsh-infocyte": {
+                "pid_threshold": 24,
+                "memory_threshold": 140
+            },
+            "demisto/pwsh-exchange": {
+                "pid_threshold": 24,
+                "memory_threshold": 140
+            },
+            "demisto/powershell": {
+                "pid_threshold": 24,
+                "memory_threshold": 140
+            },
+            "demisto/powershell-ubuntu": {
+                "pid_threshold": 24,
+                "memory_threshold": 140
             }
         }
     }


### PR DESCRIPTION
Since powershell images takes more resources than the python images - we need to update the thresholds. 