### PR TITLE
SplunkPy Basic Auth

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1086,7 +1086,8 @@ def main():
         'app': demisto.params().get('app', '-'),
         'username': demisto.params()['authentication']['identifier'],
         'password': demisto.params()['authentication']['password'],
-        'verify': VERIFY_CERTIFICATE
+        'verify': VERIFY_CERTIFICATE,
+        'basic': True
     }
 
     if use_requests_handler:

--- a/Packs/SplunkPy/ReleaseNotes/1_3_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/1_3_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where authentication would fail behind a load balancer.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "1.3.0",
+    "currentVersion": "1.3.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34169

## Description
Authentication fails behind a load balancer since the connection is authenticated for specific servers. Added the basic=true flag to ensure auth with every request.
