### PR TITLE
Jira fix create ticket HR

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -529,7 +529,7 @@ def create_issue_command():
     j_res = jira_req('POST', url, json.dumps(issue), resp_type='json')
 
     md_and_context = generate_md_context_create_issue(j_res, project_key=demisto.getArg('projectKey'),
-                                                      project_name=demisto.getArg('issueTypeName'))
+                                                      project_name=demisto.getArg('projectName'))
     human_readable = tableToMarkdown(demisto.command(), md_and_context['md'], "")
     contents = j_res
     outputs = md_and_context['context']

--- a/Packs/Jira/Integrations/JiraV2/JiraV2.yml
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.yml
@@ -354,7 +354,7 @@ script:
       will not update the current incident, it's here for debugging purposes.
     execution: false
     name: get-remote-data
-  dockerimage: demisto/oauthlib:1.0.0.15507
+  dockerimage: demisto/oauthlib:1.0.0.16907
   isfetch: true
   isremotesyncin: true
   runonce: false

--- a/Packs/Jira/ReleaseNotes/1_2_12.md
+++ b/Packs/Jira/ReleaseNotes/1_2_12.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Atlassian Jira v2
+- Fixed ann issue where *issue type* was printed under *project name* place in ***jira-create-issue*** war room response

--- a/Packs/Jira/ReleaseNotes/1_2_12.md
+++ b/Packs/Jira/ReleaseNotes/1_2_12.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Atlassian Jira v2
-- Fixed an issue where *issue type* was printed under *project name* place in ***jira-create-issue*** war room response.
+ - Fixed an issue where the *issue type* was printed instead of the *project name* in the war room response of the ***jira-create-issue*** command.
 - Updated the docker image to demisto/oauthlib:1.0.0.16907.

--- a/Packs/Jira/ReleaseNotes/1_2_12.md
+++ b/Packs/Jira/ReleaseNotes/1_2_12.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Atlassian Jira v2
- - Fixed an issue where the *issue type* was printed instead of the *project name* in the war room response of the ***jira-create-issue*** command.
-- Updated the docker image to demisto/oauthlib:1.0.0.16907.
+- Fixed an issue where the *issue type* was printed instead of the *project name* in the war room response of the ***jira-create-issue*** command.
+- Updated the Docker image to: *demisto/oauthlib:1.0.0.16907*.

--- a/Packs/Jira/ReleaseNotes/1_2_12.md
+++ b/Packs/Jira/ReleaseNotes/1_2_12.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Atlassian Jira v2
-- Fixed ann issue where *issue type* was printed under *project name* place in ***jira-create-issue*** war room response
+- Fixed an issue where *issue type* was printed under *project name* place in ***jira-create-issue*** war room response.
+- Updated the docker image to demisto/oauthlib:1.0.0.16907.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Demisto incidents from projects.",
     "support": "xsoar",
-    "currentVersion": "1.2.11",
+    "currentVersion": "1.2.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34425

## Description
In the HR entry, under project name we should get the project name and not `issueTypeName`

## Screenshots
Paste here any images that will help the reviewer

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - x] No

## Must have
- [ ] Tests
- [ ] Documentation 
