### PR TITLE
Add 'controller' parameter support to MISPv2 integration searches

### DIFF
--- a/Packs/MISP/Integrations/MISP_V2/MISP_V2.yml
+++ b/Packs/MISP/Integrations/MISP_V2/MISP_V2.yml
@@ -1924,7 +1924,7 @@ script:
     - contextPath: MISP.Event.Object.Description
       description: Description of the object.
       type: String
-  dockerimage: demisto/pymisp:1.0.0.52
+  dockerimage: demisto/pymisp:1.0.0.15999
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/MISP/ReleaseNotes/1_0_5.md
+++ b/Packs/MISP/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MISP v2
+- Add controller parameter

--- a/Packs/MISP/pack_metadata.json
+++ b/Packs/MISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP",
     "description": "Malware information sharing platform and threat sharing.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
This PR adds the 'controller' parameter in the search() api calls to PyMISP under the MISPv2 integration.

Right now, due to lack of this controller parameter XSOAR ends up performing all searches under the 'events' controller where searching for an attribute value results in entire events being pulled from MISP instead of the matching attribute. This has the side-effect of causing memory consumption issues when large events have one more more matching attributes resulting in hundreds of megabytes (or more) of events being pulled into XSOAR incidents. 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ x] 5.0.0
- [ x] 5.5.0
- [ x] 6.0.0

## Does it break backward compatibility?
   - [ x] Yes
       - Further details: Any work previously done by users that assumed entire events being pulled,parsed and processed in XSOAR might encounter issues, that said as far as I can tell this PR only results in reduction of response size from MISP.
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
