### PR TITLE
bump back jira docker version because Outh1() was broken

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.yml
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.yml
@@ -354,7 +354,7 @@ script:
       will not update the current incident, it's here for debugging purposes.
     execution: false
     name: get-remote-data
-  dockerimage: demisto/oauthlib:1.0.0.16907
+  dockerimage: demisto/oauthlib:1.0.0.15507
   isfetch: true
   isremotesyncin: true
   runonce: false

--- a/Packs/Jira/ReleaseNotes/1_2_13.md
+++ b/Packs/Jira/ReleaseNotes/1_2_13.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Atlassian Jira v2
+- Downgraded the Docker image back to *demisto/oauthlib:1.0.0.15507* because the last image failed Oauth1 authentication.

--- a/Packs/Jira/ReleaseNotes/1_2_13.md
+++ b/Packs/Jira/ReleaseNotes/1_2_13.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Atlassian Jira v2
-- Downgraded the Docker image back to *demisto/oauthlib:1.0.0.15507* because the last image failed Oauth1 authentication.
+- Changed the Docker image to *demisto/oauthlib:1.0.0.15507* to handle Oauth1 authentication failures introduced by the previous update.

--- a/Packs/Jira/ReleaseNotes/1_2_13.md
+++ b/Packs/Jira/ReleaseNotes/1_2_13.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Atlassian Jira v2
-- Changed the Docker image to *demisto/oauthlib:1.0.0.15507* to handle Oauth1 authentication failures introduced by the previous update.
+- Changed the Docker image to *demisto/oauthlib:1.0.0.15507* to handle possible Oauth1 authentication failures introduced in Pack version 1.2.12.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Demisto incidents from projects.",
     "support": "xsoar",
-    "currentVersion": "1.2.12",
+    "currentVersion": "1.2.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
 Outh 1 flow broken with the new docker image:
 
<img width="557" alt="image" src="https://user-images.githubusercontent.com/19407287/110589283-db4c3880-817e-11eb-896a-353444bae793.png">


## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
