### PR TITLE
Add ability to set debug logging via test conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,7 +361,7 @@ references:
         zip -P $PSWD -j $CIRCLE_ARTIFACTS/Logs.zip $CIRCLE_ARTIFACTS/server*.log || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
         rm -f $CIRCLE_ARTIFACTS/server*.log
         zip -P $PSWD -j $CIRCLE_ARTIFACTS/InstanceLogs.zip $CIRCLE_ARTIFACTS/integration-instance*.log || ((($? > 0)) && echo "Didn’t find any instance logs, skipping this stage" && exit 0)
-                rm -f $CIRCLE_ARTIFACTS/integration-instance*.log
+        rm -f $CIRCLE_ARTIFACTS/integration-instance*.log
       when: always
 
   persist_to_workspace: &persist_to_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,8 @@ references:
         export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
         zip -P $PSWD -j $CIRCLE_ARTIFACTS/Logs.zip $CIRCLE_ARTIFACTS/server*.log || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
         rm -f $CIRCLE_ARTIFACTS/server*.log
+        zip -P $PSWD -j $CIRCLE_ARTIFACTS/InstanceLogs.zip $CIRCLE_ARTIFACTS/integration-instance*.log || ((($? > 0)) && echo "Didn’t find any instance logs, skipping this stage" && exit 0)
+                rm -f $CIRCLE_ARTIFACTS/integration-instance*.log
       when: always
 
   persist_to_workspace: &persist_to_workspace

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -11,7 +11,7 @@ from urlparse import urlparse
 from requests.utils import quote  # type: ignore
 
 
-""" POLLING FUNCTIONS"""
+""" POLLING FUNCTIONS """
 try:
     from Queue import Queue
 except ImportError:

--- a/Packs/UrlScan/ReleaseNotes/1_0_8.md
+++ b/Packs/UrlScan/ReleaseNotes/1_0_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Testing

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "urlscan.io",
     "description": "Urlscan.io reputation",
     "support": "xsoar",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -651,6 +651,10 @@ def set_integration_instance_parameters(integration_configuration,
         'version': 0
     }
 
+    # Add instance logging if applicable
+    if 'integrationLogLevel' in integration_params:
+        module_instance['integrationLogLevel'] = integration_params['integrationLogLevel']
+
     # set server keys
     __set_server_keys(client, integration_params, integration_configuration['name'])
 

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -652,8 +652,8 @@ def set_integration_instance_parameters(integration_configuration,
     }
 
     # Add instance logging if applicable
-    if 'integrationLogLevel' in integration_params:
-        module_instance['integrationLogLevel'] = integration_params['integrationLogLevel']
+    if 'integration_log_level' in integration_params:
+        module_instance['integrationLogLevel'] = integration_params['integration_log_level']
 
     # set server keys
     __set_server_keys(client, integration_params, integration_configuration['name'])


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: Internal

## Description
Goal is to be able to set in the test conf the following: 
```json
{
            "name": "urlscan.io",
            "params": {
                "url": "https://urlscan.io/api/v1/",
                "apikey": "REDACTED",
                "insecure": "false",
                "proxy": "false"
            },
            "integration_log_level": "Verbose"
        }
```

The instance should be configured with the Integration Log Level set and while running tests, the logs will be sent to a dedicated log file with verbose detailing.