### PR TITLE
Supporting build hardening

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,9 @@ commands:
             echo "Host 10.0.*
               StrictHostKeyChecking no
               LogLevel ERROR
-              ProxyJump ec2-user@content-build-lb.demisto.works  # disable-secrets-detection
+              ProxyJump content-build@content-build-lb.demisto.works  # disable-secrets-detection
              Host content-build-lb.demisto.works
+              Port 43567
               UserKnownHostsFile /dev/null
               StrictHostKeyChecking no
               LogLevel ERROR" >> ~/.ssh/config
@@ -57,7 +58,7 @@ commands:
               # Capturing the port
               PORT=$(echo $IP_AND_PORT | grep -o -E "[0-9]{4}")
               echo "Opening a tunnel for ip $IP with port $PORT"
-              ssh -4 -o "ServerAliveInterval=15" -f -N "ec2-user@content-build-lb.demisto.works" -L "$PORT:$IP:443"  # disable-secrets-detection
+              ssh -4 -o "ServerAliveInterval=15" -f -N "content-build@content-build-lb.demisto.works" -L "$PORT:$IP:443"  # disable-secrets-detection
               echo "Waiting for tunnel to be established"
               until nc -z 127.0.0.1 $PORT -v; do
                 if [ $COUNT -ge << parameters.timeout >> ]; then

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,7 +1,7 @@
 flake8==3.8.3
 bandit==1.6.2
 demisto-py==2.0.22
-demisto-sdk==1.3.1
+git+https://github.com/demisto/demisto-sdk.git@d9a0c1adcb541a80bd87dddf1612d4981f3337bb
 pytest==6.2.1
 pytest-mock==3.4.0
 requests-mock==1.8.0


### PR DESCRIPTION
## Description:
- Changing LB port from 22 (default) to 43567.
- Changing LB ssh user from `ec2-user` to `content-build`
- Temporarily replaced the LB address, once this configuration can be merged into master - we will change it back to `content-build-lb.demisto.works` as the routing to the specific lb is done via route53 configuration.

## Related issues:
fixes: https://github.com/demisto/etc/issues/33859
