### PR TITLE
Slack: Don't fail invite if user in channel

### DIFF
--- a/Packs/Slack/Integrations/Slack/Slack.py
+++ b/Packs/Slack/Integrations/Slack/Slack.py
@@ -422,7 +422,9 @@ def invite_users_to_conversation(conversation_id: str, users_to_invite: list):
             send_slack_request_sync(CHANNEL_CLIENT, 'conversations.invite', body=body)
         except SlackApiError as e:
             message = str(e)
-            if message.find('cant_invite_self') == -1:
+            if "already_in_channel" in message:
+                continue
+            elif message.find('cant_invite_self') == -1:
                 raise
 
 

--- a/Packs/Slack/Integrations/Slack/Slack.yml
+++ b/Packs/Slack/Integrations/Slack/Slack.yml
@@ -223,7 +223,8 @@ script:
     name: mirror-investigation
   - arguments:
     - default: true
-      description: "The message content. When mentioning another slack user, make sure to do so in the following format: <@user_name>."
+      description: "The message content. When mentioning another slack user, make\
+        \ sure to do so in the following format: <@user_name>."
       isArray: false
       name: message
       required: false
@@ -527,7 +528,7 @@ script:
     - contextPath: Slack.User.Email
       description: The email address of the user.
       type: String
-  dockerimage: demisto/slack:1.0.0.12666
+  dockerimage: demisto/slack:1.0.0.17181
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/Slack/ReleaseNotes/1_3_17.md
+++ b/Packs/Slack/ReleaseNotes/1_3_17.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v2
+- Updated invite_users to not fail a list when a user is not part of the channel.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "1.3.16",
+    "currentVersion": "1.3.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
When adding a list of users to channel, we shouldn't fail an invite because the user is already part of the channel.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: no issue opened

## Description
Update the slack integration so if it's attempting to add a list of users to channel, and a user is already in the channel, it doesn't cause the rest of the list to fail.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [x] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
