### PR TITLE
Avoid test contrib PR to trigger gh workflows

### DIFF
--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_contributor_pack:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content' && startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false
+    if: github.repository == 'demisto/content' && startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   handle_new_external_pr:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true
+    if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34742

## Description
This fix should avoid triggering github workflows for PRs created during test_integration run.

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
