### PR TITLE
Added fields for Sentinel and JIRA integration. Check also request in description

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -144,6 +144,9 @@ def get_update_incident_request_data(client, args):
     status = args.get('status')
     classification = args.get('classification')
     classification_reason = args.get('classification_reason')
+    owner_email = args.get('owner_email')
+    labels = args.get('labels')
+
 
     if not title:
         title = result.get('properties', {}).get('title')
@@ -153,6 +156,14 @@ def get_update_incident_request_data(client, args):
         severity = result.get('properties', {}).get('severity')
     if not status:
         status = result.get('properties', {}).get('status')
+    if not owner_email:
+        owner_email = result.get('properties', {}).get('owner_email')
+    if not labels:
+        labels_formatted = result.get('properties', {}).get('labels')
+    else:
+        labels_formatted = []
+        for item in labels:
+            labels_formatted.append({"labelName": item})
 
     inc_data = {
         'etag': result.get('etag'),
@@ -163,6 +174,10 @@ def get_update_incident_request_data(client, args):
             'status': status,
             'classification': classification,
             'classificationReason': classification_reason
+            "labels": labels_formatted,
+            "owner": {
+                "email": owner_email
+                }
         }
     }
     remove_nulls_from_dictionary(inc_data['properties'])

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -307,6 +307,7 @@ script:
       default: false
       description: The reason the incident was closed. Required when updating the status
         to Closed.
+    - default: false
       isArray: false
       name: classification
       predefined:
@@ -314,12 +315,14 @@ script:
       - FalsePositive
       - TruePositive
       - Undetermined
+      name: owner_email
       required: false
       secret: false
     - auto: PREDEFINED
       default: false
       description: The classification reason the incident was closed with. Required
         when updating the status to Closed and the classification is determined.
+    - default: false
       isArray: false
       name: classification_reason
       predefined:
@@ -327,6 +330,7 @@ script:
       - IncorrectAlertLogic
       - SuspiciousActivity
       - SuspiciousButExpected
+      name: labels
       required: false
       secret: false
     deprecated: false

--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -452,6 +452,11 @@ def get_issue_fields(issue_creating=False, **issue_args):
     if issue_args.get('description'):
         issue['fields']['description'] = issue_args['description']
 
+    if issue_args.get('components'):
+        issue['fields']['components'] = [{"name": issue_args['components']}]
+
+    if issue_args.get('security'):
+        issue['fields']['security'] = {"name": issue_args['security']}
     if issue_args.get('labels'):
         issue['fields']['labels'] = issue_args['labels'].split(",")
 

--- a/Packs/Jira/Integrations/JiraV2/JiraV2.yml
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.yml
@@ -297,6 +297,17 @@ script:
         command to get the user's Account ID.
     - name: status
       description: The name of the status.
+      isArray: false
+    - default: false
+      isArray: false
+      name: components
+      required: false
+      secret: false
+    - default: false
+      isArray: false
+      name: security
+      required: false
+      secret: false
     outputs:
     - contextPath: Ticket.Id
       description: The ID of the ticket.


### PR DESCRIPTION
1. added "security" and "components" field for JIRA
2. added "owner" and "labels" fields for Sentinel
REQUEST: please add "environment" for JIRA

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When updating jira and sentinel tickets/incidents using the commands, we noticed some fields were missing. With these changes (plus the one I requested), we should be able to add the changes we need when using the update command for both integrations.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
