### PR TITLE
Server min version bugfix

### DIFF
--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from datetime import datetime, timedelta
 
 from Tests.Marketplace.marketplace_services import Pack, Metadata, input_to_list, get_valid_bool, convert_price, \
-    get_higher_server_version, GCPConfig, BucketUploadFlow, PackStatus, load_json, \
+    get_updated_server_version, GCPConfig, BucketUploadFlow, PackStatus, load_json, \
     store_successful_and_failed_packs_in_ci_artifacts, PACKS_FOLDER
 
 CHANGELOG_DATA_INITIAL_VERSION = {
@@ -501,19 +501,19 @@ class TestHelperFunctions:
 
     @pytest.mark.parametrize("current_string_version,compared_content_item,expected_result",
                              [
-                                 ("1.2.3", {"fromversion": "2.1.0"}, "2.1.0"),
-                                 ("1.2.3", {"fromVersion": "2.1.0"}, "2.1.0"),
-                                 ("5.5.2", {"fromversion": "2.1.0"}, "5.5.2"),
-                                 ("5.5.2", {"fromVersion": "2.1.0"}, "5.5.2"),
+                                 ("1.2.3", {"fromversion": "2.1.0"}, "1.2.3"),
+                                 ("1.2.3", {"fromVersion": "2.1.0"}, "1.2.3"),
+                                 ("5.5.2", {"fromversion": "2.1.0"}, "2.1.0"),
+                                 ("5.5.2", {"fromVersion": "2.1.0"}, "2.1.0"),
                                  ("5.5.0", {}, "5.5.0"),
                                  ("1.0.0", {}, "1.0.0")
                              ])
-    def test_get_higher_server_version(self, current_string_version, compared_content_item, expected_result):
+    def test_get_updated_server_version(self, current_string_version, compared_content_item, expected_result):
         """ Tests the comparison of server versions (that are collected in collect_content_items function.
-            Higher server semantic version should be returned.
+            Lower server semantic version should be returned.
         """
-        result = get_higher_server_version(current_string_version=current_string_version,
-                                           compared_content_item=compared_content_item, pack_name="dummy")
+        result = get_updated_server_version(current_string_version=current_string_version,
+                                            compared_content_item=compared_content_item, pack_name="dummy")
 
         assert result == expected_result
 

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -192,7 +192,7 @@ class Pack(object):
         self._status = None
         self._public_storage_path = ""
         self._remove_files_list = []  # tracking temporary files, in order to delete in later step
-        self._sever_min_version = "1.0.0"  # initialized min version
+        self._server_min_version = "99.99.99"  # initialized min version
         self._latest_version = None  # pack latest version found in changelog
         self._support_type = None  # initialized in load_user_metadata function
         self._current_version = None  # initialized in load_user_metadata function
@@ -336,10 +336,10 @@ class Pack(object):
     def server_min_version(self):
         """ str: server min version according to collected items.
         """
-        if not self._sever_min_version or self._sever_min_version == "1.0.0":
+        if not self._server_min_version or self._server_min_version == "99.99.99":
             return Metadata.SERVER_DEFAULT_MIN_VERSION
         else:
-            return self._sever_min_version
+            return self._server_min_version
 
     @property
     def downloads_count(self):
@@ -1478,8 +1478,8 @@ class Pack(object):
                     logging.debug(
                         f"Iterating over {pack_file_path} file and collecting items of {self._pack_name} pack")
                     # updated min server version from current content item
-                    self._sever_min_version = get_updated_server_version(self._sever_min_version, content_item,
-                                                                         self._pack_name)
+                    self._server_min_version = get_updated_server_version(self._server_min_version, content_item,
+                                                                          self._pack_name)
 
                     if current_directory == PackFolders.SCRIPTS.value:
                         folder_collected_items.append({

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -2472,21 +2472,21 @@ def get_updated_server_version(current_string_version, compared_content_item, pa
     Returns:
         str: latest version between compared versions.
     """
-    higher_version_result = current_string_version
+    lower_version_result = current_string_version
 
     try:
-        compared_string_version = compared_content_item.get('fromversion') or compared_content_item.get(
-            'fromVersion') or "1.0.0"
+        compared_string_version = compared_content_item.get('fromversion') or \
+                                  compared_content_item.get('fromVersion') or "99.99.99"
         current_version, compared_version = LooseVersion(current_string_version), LooseVersion(compared_string_version)
 
-        if current_version < compared_version:
-            higher_version_result = compared_string_version
+        if current_version > compared_version:
+            lower_version_result = compared_string_version
     except Exception:
         content_item_name = compared_content_item.get('name') or compared_content_item.get(
             'display') or compared_content_item.get('id') or compared_content_item.get('details', '')
         logging.exception(f"{pack_name} failed in version comparison of content item {content_item_name}.")
     finally:
-        return higher_version_result
+        return lower_version_result
 
 
 def get_content_git_client(content_repo_path: str):

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -2475,8 +2475,8 @@ def get_updated_server_version(current_string_version, compared_content_item, pa
     lower_version_result = current_string_version
 
     try:
-        compared_string_version = compared_content_item.get('fromversion') or \
-                                  compared_content_item.get('fromVersion') or "99.99.99"
+        compared_string_version = compared_content_item.get('fromversion') or compared_content_item.get(
+            'fromVersion') or "99.99.99"
         current_version, compared_version = LooseVersion(current_string_version), LooseVersion(compared_string_version)
 
         if current_version > compared_version:

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1478,8 +1478,8 @@ class Pack(object):
                     logging.debug(
                         f"Iterating over {pack_file_path} file and collecting items of {self._pack_name} pack")
                     # updated min server version from current content item
-                    self._sever_min_version = get_higher_server_version(self._sever_min_version, content_item,
-                                                                        self._pack_name)
+                    self._sever_min_version = get_updated_server_version(self._sever_min_version, content_item,
+                                                                         self._pack_name)
 
                     if current_directory == PackFolders.SCRIPTS.value:
                         folder_collected_items.append({
@@ -2461,7 +2461,7 @@ def convert_price(pack_id, price_value_input=None):
         return 0
 
 
-def get_higher_server_version(current_string_version, compared_content_item, pack_name):
+def get_updated_server_version(current_string_version, compared_content_item, pack_name):
     """ Compares two semantic server versions and returns the higher version between them.
 
     Args:

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -141,25 +141,26 @@ def get_attachments_for_bucket_upload_flow(build_url, job_name, packs_results_fi
         }] + steps_fields
 
     if job_name and job_name == BucketUploadFlow.UPLOAD_JOB_NAME:
-        successful_packs, failed_packs, successful_private_packs_dict, _ = get_upload_data(
+        successful_packs, failed_packs, successful_private_packs, _ = get_upload_data(
             packs_results_file_path, BucketUploadFlow.UPLOAD_PACKS_TO_MARKETPLACE_STORAGE
         )
         if successful_packs:
             steps_fields += [{
                 "title": "Successful Packs:",
-                "value": "\n".join(sorted([pack_name for pack_name in {*successful_packs}])),
+                "value": "\n".join(sorted([pack_name for pack_name in {*successful_packs}], key=lambda s: s.lower())),
                 "short": False
             }]
         if failed_packs:
             steps_fields += [{
                 "title": "Failed Packs:",
-                "value": "\n".join(sorted([pack_name for pack_name in {*failed_packs}])),
+                "value": "\n".join(sorted([pack_name for pack_name in {*failed_packs}], key=lambda s: s.lower())),
                 "short": False
             }]
-        if successful_private_packs_dict:
+        if successful_private_packs:
             steps_fields += [{
                 "title": "Successful Private Packs:",
-                "value": "\n".join(sorted([pack_name for pack_name in {*successful_private_packs_dict}])),
+                "value": "\n".join(sorted([pack_name for pack_name in {*successful_private_packs}],
+                                          key=lambda s: s.lower())),
                 "short": False
             }]
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34430

## Description
The server minimum version of a pack will be **lowest** fromversion of the pack's content items.

Note:
1. All packs server minimum version is being computed during runtime (of upload-flow), so we expect some packs to change their min version.
2. If a pack was released as 6.0.0 (lowest fromversion is 6.0) and a 5.0 integration was added then the pack min server ver will change to 5.0.0.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 

## Correctness
- [Successful trigger test upload](https://app.circleci.com/pipelines/github/demisto/content/75057/workflows/9c5910b3-9aea-448e-a9fd-12aeffbde3f5)
- Base's server min version was changed from 5.5.0 to 5.0.0:
   <img src=https://user-images.githubusercontent.com/53565845/111908895-9fa94c80-8a63-11eb-8c35-57c8ecfd3625.png width=400>
- Slack msg:
   <img src=https://user-images.githubusercontent.com/53565845/111908977-ff9ff300-8a63-11eb-954b-f9b9097a6fdf.png width=400>

