### PR TITLE
check_contributor_pack failing on contributions

### DIFF
--- a/Utils/request_contributor_review.py
+++ b/Utils/request_contributor_review.py
@@ -145,18 +145,32 @@ def check_pack_and_request_review(pr_number, github_token=None, verify_ssl=True)
                     reviewers.add(github_user)
                     print(f"Found {github_user} default reviewer of pack {pack}")
 
-            if reviewers:
-                pack_files = {file for file in modified_files if file.startswith(PACKS_FOLDER)
-                              and Path(file).parts[1] == pack}
-                tag_user_on_pr(reviewers=reviewers, pr_number=pr_number, pack=pack, pack_files=pack_files,
-                               github_token=github_token, verify_ssl=verify_ssl)
-            else:
-                print(f"{pack} pack No reviewers were found.")
+            check_reviewers(reviewers=reviewers, pr_author=pr_author, version=pack_metadata.get('currentVersion'),
+                            modified_files=modified_files, pack=pack, pr_number=pr_number, github_token=github_token,
+                            verify_ssl=verify_ssl)
 
         elif pack_metadata.get('support') == XSOAR_SUPPORT:
             print(f"Skipping check of {pack} pack supported by {XSOAR_SUPPORT}")
         else:
             print(f"{pack} pack has no default github reviewer")
+
+
+def check_reviewers(reviewers, pr_author, version, modified_files, pack, pr_number, github_token, verify_ssl):
+    if reviewers:
+        if pr_author != 'xsoar-bot' or version != '1.0.0':
+            pack_files = {file for file in modified_files if file.startswith(PACKS_FOLDER)
+                          and Path(file).parts[1] == pack}
+            tag_user_on_pr(
+                reviewers=reviewers,
+                pr_number=pr_number,
+                pack=pack,
+                pack_files=pack_files,
+                github_token=github_token,
+                verify_ssl=verify_ssl
+            )
+
+    else:
+        print(f"{pack} pack No reviewers were found.")
 
 
 def main():

--- a/Utils/tests/check_pack_and_request_review_test.py
+++ b/Utils/tests/check_pack_and_request_review_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from Utils.request_contributor_review import check_reviewers
+
+
+@pytest.mark.parametrize('pr_author,version,reviewers,call_count', [('xsoar-bot', '1.0.0', ['reviewer'], 0),
+                                                                    ('xsoar-bot', '1.0.2', ['reviewer'], 1),
+                                                                    ('xsoar-bot', '1.0.0', [], 0)])
+def test_check_reviewers(mocker, pr_author, version, reviewers, call_count):
+    """
+       Given
+        - pr_author - author of thr pr
+        - version - pack version taken from pack_metadata
+        - reviewers - pack reviewers
+
+       When
+       - calling check_pack_and_request_review function at the request_contributor_review
+
+       Then
+       - validating that tag_user_on_pr function called only when the pack is not new,
+       or it is was not opened by 'xsoar-bot'
+    """
+    check_reviewers_mock = mocker.patch('Utils.request_contributor_review.tag_user_on_pr')
+
+    check_reviewers(reviewers=reviewers, pr_author=pr_author, version=version,
+                    modified_files=['Pack/TestPack/file1'], pack='TestPack', pr_number='1', github_token='github_token',
+                    verify_ssl=True)
+    assert check_reviewers_mock.call_count == call_count


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34428

## Description
Added check, to ask review only if contributor pr was not open by xsoar bot and it is new pack. 

## Must have
- [x] Tests
- [ ] Documentation 
