### PR TITLE
Updating index and metadata of packs with changed tags

### DIFF
--- a/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
+++ b/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
@@ -17,7 +17,7 @@ from Tests.scripts.collect_tests_and_content_packs import (
     create_filter_envs_file, get_from_version_and_to_version_bounderies,
     get_test_list_and_content_packs_to_install, is_documentation_changes_only,
     remove_ignored_tests, remove_tests_for_non_supported_packs)
-from Tests.scripts.utils.get_modified_files_for_testing import get_modified_files_for_testing
+from Tests.scripts.utils.get_modified_files_for_testing import get_modified_files_for_testing, ModifiedFiles
 from Tests.scripts.utils import content_packs_util
 
 from TestSuite import repo, test_tools
@@ -290,9 +290,12 @@ class TestChangedTestPlaybook:
 
         """
         test_path = 'Tests/scripts/infrastructure_tests/tests_data/mock_test_playbooks/fake_test_playbook.yml'
-        modified_files_list, modified_tests_list, changed_common, _, sample_tests, modified_metadata_list, _, _ = \
-            create_get_modified_files_ret(modified_files_list=[test_path], modified_tests_list=[test_path])
-        all_modified_files_paths = set(modified_files_list + modified_tests_list + changed_common + sample_tests)
+        modified_files_instance = create_get_modified_files_ret(modified_files_list=[test_path],
+                                                                modified_tests_list=[test_path])
+        all_modified_files_paths = set(modified_files_instance.modified_files
+                                       + modified_files_instance.modified_tests
+                                       + modified_files_instance.changed_common_files
+                                       + modified_files_instance.sample_tests)
         from_version, to_version = get_from_version_and_to_version_bounderies(all_modified_files_paths,
                                                                               MOCK_ID_SET)
 
@@ -567,17 +570,10 @@ A       Packs/Active_Directory_Query/Integrations/Active_Directory_Query/key.pem
 """
 
     def test_changed_runnable_test_non_mocked_get_modified_files(self):
-        (files_list,
-         tests_list,
-         all_tests,
-         is_conf_json,
-         sample_tests,
-         modified_metadata_list,
-         is_reputations_json,
-         is_indicator_json) = get_modified_files_for_testing(self.GIT_DIFF_RET)
-        assert len(sample_tests) == 0
+        modified_files_instance = get_modified_files_for_testing(self.GIT_DIFF_RET)
+        assert len(modified_files_instance.sample_tests) == 0
         assert 'Packs/Active_Directory_Query/Integrations/' \
-               'Active_Directory_Query/Active_Directory_Query.yml' in files_list
+               'Active_Directory_Query/Active_Directory_Query.yml' in modified_files_instance.modified_files
 
 
 class TestNoChange:
@@ -591,11 +587,11 @@ class TestNoChange:
 
 def create_get_modified_files_ret(modified_files_list=None, modified_tests_list=None, changed_common=None,
                                   is_conf_json=False, sample_tests=None, modified_metadata_list=None,
-                                  is_reputations_json=None, is_indicator_json=None):
+                                  is_reputations_json=None, is_indicator_json=None, is_landing_page_sections_json=None):
     """
     Returns return value for get_modified_files() to be used with a mocker patch
     """
-    return (
+    return ModifiedFiles(
         modified_files_list if modified_files_list is not None else [],
         modified_tests_list if modified_tests_list is not None else [],
         changed_common if changed_common is not None else [],
@@ -603,7 +599,8 @@ def create_get_modified_files_ret(modified_files_list=None, modified_tests_list=
         sample_tests if sample_tests is not None else [],
         modified_metadata_list if modified_metadata_list is not None else [],
         is_reputations_json if is_reputations_json is not None else [],
-        is_indicator_json if is_indicator_json is not None else []
+        is_indicator_json if is_indicator_json is not None else [],
+        is_landing_page_sections_json if is_landing_page_sections_json is not None else False
     )
 
 

--- a/Tests/scripts/utils/collect_helpers.py
+++ b/Tests/scripts/utils/collect_helpers.py
@@ -61,6 +61,8 @@ COMMON_YML_LIST = ["scripts/script-CommonIntegration.yml", "scripts/script-Commo
 # secrets white list file to be ignored in tests to prevent full tests running each time it is updated
 SECRETS_WHITE_LIST = 'secrets_white_list.json'
 
+LANDING_PAGE_SECTIONS_JSON_PATH = 'Tests/Marketplace/landingPage_sections.json'
+
 
 def checked_type(file_path: str, regex_list: Iterable[str]) -> bool:
     """

--- a/Tests/scripts/utils/tests/test_get_modified_files_for_testing.py
+++ b/Tests/scripts/utils/tests/test_get_modified_files_for_testing.py
@@ -36,92 +36,64 @@ class TestGetModifiedFilesForTesting:
             return_value=[yml_file],
         )
         mock_get_dict_from_yaml(mocker, {"category": "cat"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == [yml_file]
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == [yml_file]
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_yaml_file(self, mocker):
         diff_line = "M      Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml"
         mock_get_dict_from_yaml(mocker, {"category": "c"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == [
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == [
             "Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml"
         ]
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_non_relevant_file(self):
         diff_line = "A       Packs/HelloWorld/Integrations/HelloWorld/cert.pem"
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_test_file(self):
         diff_line = (
             "M       Packs/HelloWorld/Integrations/HelloWorld/connection_test.py"
         )
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_renamed_file(self, mocker):
         diff_line = (
@@ -129,91 +101,65 @@ class TestGetModifiedFilesForTesting:
             "Packs/NewHelloWorld/Integrations/HelloWorld/NewHelloWorld.yml"
         )
         mock_get_dict_from_yaml(mocker, {"category": "c"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == [
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == [
             "Packs/NewHelloWorld/Integrations/HelloWorld/NewHelloWorld.yml"
         ]
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_test_playbook(self, mocker):
         diff_line = "M Packs/HelloWorld/TestPlaybooks/HelloWorld.yml"
         mock_get_dict_from_yaml(mocker, {"tasks": "c"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == ["Packs/HelloWorld/TestPlaybooks/HelloWorld.yml"]
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == ["Packs/HelloWorld/TestPlaybooks/HelloWorld.yml"]
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_no_file_path(self):
         diff_line = ""
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_common_yml_file(self, mocker):
         diff_line = "M    scripts/script-CommonIntegration.yml"
         mock_get_dict_from_yaml(mocker, {"script": "cat"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == ["scripts/script-CommonIntegration.yml"]
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == ["scripts/script-CommonIntegration.yml"]
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_common_py_file(self, mocker):
         diff_line = "M    Packs/Base/Scripts/CommonServerPython/CommonServerPython.py"
@@ -224,26 +170,20 @@ class TestGetModifiedFilesForTesting:
             ],
         )
         mock_get_dict_from_yaml(mocker, {"script": "cat"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == [
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == [
             "Packs/Base/Scripts/CommonServerPython/CommonServerPython.yml"
         ]
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     @pytest.mark.parametrize(
         "path",
@@ -255,133 +195,96 @@ class TestGetModifiedFilesForTesting:
     def test_reputations_list(self, path: str, mocker):
         diff_line = f"M {path}"
         mock_get_dict_from_yaml(mocker, {"regex": "bla"}, "json")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is True
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is True
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_conf(self, mocker):
         diff_line = "M Tests/conf.json"
         mock_get_dict_from_yaml(mocker, {}, "json")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is True
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is True
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_docs(self):
         diff_line = "A Packs/HelloWorld/README.md"
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_metadata(self, mocker):
         diff_line = "M Packs/HelloWorld/pack_metadata.json"
         mock_get_dict_from_yaml(mocker, {}, "json")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == {"HelloWorld"}
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == {"HelloWorld"}
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_indicator_fields(self, mocker):
         diff_line = "M Packs/HelloWorld/IndicatorFields/sample-field.json"
         mock_get_dict_from_yaml(mocker, {"id": "indicator-sample-field"}, "json")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is True
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is True
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_secrets_whitelist(self, mocker):
         mock_get_dict_from_yaml(mocker, {"files": []}, "json")
         diff_line = "M Tests/secrets_white_list.json"
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     @pytest.mark.parametrize(
         "file_path",
@@ -400,24 +303,18 @@ class TestGetModifiedFilesForTesting:
         """
         diff_line = "M Tests/Util/Scripts/new_script.py"
         py_file = "Tests/Util/Scripts/new_script.py"
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == []
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == [py_file]
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == []
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == [py_file]
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False
 
     def test_name_not_same_as_folder(self, mocker):
         """
@@ -438,21 +335,14 @@ class TestGetModifiedFilesForTesting:
             return_value=[yml_file],
         )
         mock_get_dict_from_yaml(mocker, {"category": "cat"}, "yml")
-        (
-            modified_files_list,
-            modified_tests_list,
-            changed_common,
-            is_conf_json,
-            sample_tests,
-            modified_metadata_list,
-            is_reputations_json,
-            is_indicator_json,
-        ) = get_modified_files_for_testing(diff_line)
-        assert modified_files_list == [yml_file]
-        assert modified_tests_list == []
-        assert changed_common == []
-        assert is_conf_json is False
-        assert sample_tests == []
-        assert modified_metadata_list == set()
-        assert is_reputations_json is False
-        assert is_indicator_json is False
+        modified_files_instance = get_modified_files_for_testing(diff_line)
+
+        assert modified_files_instance.modified_files == [yml_file]
+        assert modified_files_instance.modified_tests == []
+        assert modified_files_instance.changed_common_files == []
+        assert modified_files_instance.is_conf_json is False
+        assert modified_files_instance.sample_tests == []
+        assert modified_files_instance.modified_metadata == set()
+        assert modified_files_instance.is_reputations_json is False
+        assert modified_files_instance.is_indicator_json is False
+        assert modified_files_instance.is_landing_page_sections_json is False


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/34750

## Description
Added a method `get_packs_from_landing_page`, that parses the diff of the landing page sections file into modified packs.
These will be added to the packs that should be installed and in the `Prepare Content Packs For Testing` it's metadata will be updated with the newest and the packs will be installed on the server instances.

In addition -  modified the `get_modified_files_for_testing` method to return a class instead of tuple to make refactoring of that method a bit easier (no need to update all the places this method is called if there is a need to edit its output.

Most of this PR is about modifying the unittests to support this change.

