### PR TITLE
Remove individual "uploadable_packs" zips

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,10 @@ references:
         rm $GCS_PATH
 
         python3 Utils/merge_content_new_zip.py -f $FEATURE_BRANCH_NAME -b $successful_feature_branch_build
+        
+        zip -j $CIRCLE_ARTIFACTS/uploadable_packs.zip $CIRCLE_ARTIFACTS/uploadable_packs/* || ((($? > 0)) && echo "failed to zip the uploadable packs, ignoring the failure" && exit 0)
+        rm -rf $CIRCLE_ARTIFACTS/uploadable_packs
+
 
   restore_cache: &restore_cache
     restore_cache:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
removed the individual pack zips from the artifacts.
now, there will be a single zip containing all those zip files.

if it fails to zip them, it will not fail the build (and will keep the individual zip files in the artifacts)

## Screenshots
before:
![image](https://user-images.githubusercontent.com/30797606/113254809-b8b9c500-92cf-11eb-87c1-dc640adea877.png)

after:

![image](https://user-images.githubusercontent.com/30797606/113255867-084cc080-92d1-11eb-8d02-2243d87cd0b4.png)
