### PR TITLE
login in to docker for the lint command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ references:
         rm $GCS_PATH
 
         python3 Utils/merge_content_new_zip.py -f $FEATURE_BRANCH_NAME -b $successful_feature_branch_build
-        
+
         zip -j $CIRCLE_ARTIFACTS/uploadable_packs.zip $CIRCLE_ARTIFACTS/uploadable_packs/* || ((($? > 0)) && echo "failed to zip the uploadable packs, ignoring the failure" && exit 0)
         rm -rf $CIRCLE_ARTIFACTS/uploadable_packs
 
@@ -406,6 +406,8 @@ references:
           echo "Skipping validations when uploading to a test bucket."
           exit 0
         fi
+        # Login in to docker to avoid rate limiting
+        echo $DOCKER_READ_ONLY_PASSWORD | docker login --username $DOCKER_READ_ONLY_USER --password-stdin
 
         echo "demisto-sdk version: $(demisto-sdk --version)"
         echo "mypy version: $(mypy --version)"


### PR DESCRIPTION
Since lint command pulls a lot of docker images as part of it's flow, we need to run to login to docker during lint command to avoid docker rate limiting.
