### PR TITLE
GitHub - bump docker image

### DIFF
--- a/Packs/GitHub/Integrations/GitHub/GitHub.yml
+++ b/Packs/GitHub/Integrations/GitHub/GitHub.yml
@@ -2613,7 +2613,7 @@ script:
     - contextPath: GitHub.ActionsUsage.WorkflowUsage
       description: GitHub action worflow usage on different OS.
       type: Unknown
-  dockerimage: demisto/pyjwt3:1.0.0.10828
+  dockerimage: demisto/pyjwt3:1.0.0.16907
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/GitHub/ReleaseNotes/1_1_10.md
+++ b/Packs/GitHub/ReleaseNotes/1_1_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### GitHub
+- Updated the Docker image to: *demisto/pyjwt3:1.0.0.16907*.

--- a/Packs/GitHub/pack_metadata.json
+++ b/Packs/GitHub/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GitHub",
     "description": "Integration to GitHub API",
     "support": "xsoar",
-    "currentVersion": "1.1.9",
+    "currentVersion": "1.1.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
https://github.com/demisto/etc/issues/33818

## Description
no code changes are required since the `algorithm` to use in the encoding is mentioned in line 53: 
```py
jwt_token = jwt.encode(payload, private_key, algorithm='RS256')
```

## Does it break backward compatibility?
   - [x] No
