### PR TITLE
Make JiraV2 respect issueJson field again.

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -462,9 +462,9 @@ def get_issue_fields(issue_creating=False, mirroring=False, **issue_args):
     :param issue_args: issue argument
     """
     issue = {}  # type: dict
-    if 'issue_json' in issue_args:
+    if 'issueJson' in issue_args:
         try:
-            issue = json.loads(issue_args['issue_json'])
+            issue = json.loads(issue_args['issueJson'])
         except TypeError as te:
             demisto.debug(str(te))
             return_error("issueJson must be in a valid json format")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
✔️  Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: 01789341

## Description
The command parameter is called `issueJson`. 
Since it has been renamed to `issue_json` here, the parameter is now ignored completely, which can (and does) break Playbooks relying on the parameter.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No, your content update does!

