### PR TITLE
Changed defaultclassifier and defaultmapperin values in the RubrikPol…

### DIFF
--- a/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.yml
+++ b/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.yml
@@ -37,8 +37,8 @@ configuration:
   required: false
   type: 0
 
-defaultclassifier: Rubrik Polaris Radar - Classification
-defaultmapperin: Rubrik Polaris Radar - Mapping
+defaultclassifier: c3e38fe1-e429-4836-8050-a8d399518fe8
+defaultmapperin: 97b3f7dc-5bdb-40c8-819b-8c1beb95cb09
 description: Create a new incident when a Polaris Radar anomaly event is detected
   and determine if any Sonar data classification hits were found on that object.
 display: Rubrik Polaris

--- a/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.yml
+++ b/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.yml
@@ -26,8 +26,8 @@ configuration:
   type: 13
 - defaultvalue: 1 hour
   display: First fetch time
-  additionalinfo: The time interval for the first fetch (retroactive). Examples
-    of supported values can be found at https://dateparser.readthedocs.io/en/latest/#relative-date.
+  additionalinfo: The time interval for the first fetch (retroactive). Examples of
+    supported values can be found at https://dateparser.readthedocs.io/en/latest/#relative-date.
   name: first_fetch
   required: false
   type: 0
@@ -46,7 +46,9 @@ name: RubrikPolaris
 script:
   commands:
   - arguments:
-    - description: The ID of the Polaris Event Series. When used in combination with "Rubrik Radar Anomaly" incidents, this value will automatically be looked up using the incident context. Otherwise it is a required value.
+    - description: The ID of the Polaris Event Series. When used in combination with
+        "Rubrik Radar Anomaly" incidents, this value will automatically be looked
+        up using the incident context. Otherwise it is a required value.
       name: activitySeriesId
     description: Check the Radar Event for updates.
     name: rubrik-radar-analysis-status
@@ -80,7 +82,7 @@ script:
     - contextPath: Rubrik.Radar.ActivitySeriesId
       description: The ID of the Rubrik Polaris Activity Series.
       type: String
-  dockerimage: demisto/python3:3.9.1.15759
+  dockerimage: demisto/python3:3.9.2.18414
   isfetch: true
   runonce: false
   script: ''

--- a/Packs/RubrikPolaris/ReleaseNotes/1_0_1.md
+++ b/Packs/RubrikPolaris/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Rubrik Polaris
+- Fixed an issue where the "Go to" links for the classifier and mapper in the integration instance settings didn't work after installation with the default values.

--- a/Packs/RubrikPolaris/pack_metadata.json
+++ b/Packs/RubrikPolaris/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "RubrikPolaris",
     "description": "Integration for Rubrik Polaris",
     "support": "partner",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Rubrik",
     "url": "https://www.rubrik.com/support/",
     "email": "support@rubrik.com",


### PR DESCRIPTION
…aris.yml integration metadata file to match the id's in the Classifer and Mapper files.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Modified defaultclassifier and defaultmapper in values in the integration yaml file to match the "id" values from the Classifier and Mapping files.  Originally these were set to the "name" values and the Go To links in the integration settings resulted in a "Not Found" error that required us to reselect the classification and mapping in the drop down menu.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
