### PR TITLE
Searching indicators by server version in content integrations

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -6418,3 +6418,24 @@ class TableOrListWidget(BaseWidget):
             'total': len(self.data),
             'data': self.data
         })
+
+
+class SearchIndicatorsByVersion:
+    def __init__(self, page=0):
+        # searchAfter is available in searchIndicators from version 6.2.0
+        self._can_use_search_after = is_demisto_version_ge('6.2.0')
+        self._search_after_title = 'searchAfter'
+        self._search_after_param = None
+        self._page = page
+
+    def search_indicators_by_version(self, from_date=None, query='', size=100, to_date=None, value=''):
+        if self._can_use_search_after:
+            res = demisto.searchIndicators(fromDate=from_date, toDate=to_date, query=query, size=size, value=value, searchAfter=self._search_after_param)
+            if self._search_after_title in res and res[self._search_after_title] is not None:
+                self._search_after_param = res[self._search_after_title]
+
+        else:
+            res = demisto.searchIndicators(fromDate=from_date, toDate=to_date, query=query, size=size, page=self._page, value=value)
+            self._page += 1
+
+        return res

--- a/Packs/Base/Scripts/GetIndicatorsByQuery/GetIndicatorsByQuery.py
+++ b/Packs/Base/Scripts/GetIndicatorsByQuery/GetIndicatorsByQuery.py
@@ -113,14 +113,14 @@ def find_indicators_with_limit_loop(indicator_query: str, limit: int, total_fetc
     Finds indicators using while loop with demisto.searchIndicators, and returns result and last page
     """
     iocs: List[dict] = []
+    search_indicators = SearchIndicatorsByVersion(page=next_page)
     if not last_found_len:
         last_found_len = total_fetched
     while last_found_len == PAGE_SIZE and limit and total_fetched < limit:
-        fetched_iocs = demisto.searchIndicators(query=indicator_query, page=next_page, size=PAGE_SIZE).get('iocs')
+        fetched_iocs = search_indicators.search_indicators_by_version(query=indicator_query, size=PAGE_SIZE).get('iocs')
         iocs.extend(fetched_iocs)
         last_found_len = len(fetched_iocs)
         total_fetched += last_found_len
-        next_page += 1
     return list(map(lambda x: parse_ioc(x), iocs)), next_page
 
 

--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -187,8 +187,7 @@ def find_indicators_to_limit(indicator_query: str, limit: int, offset: int = 0) 
         next_page = 0
         offset_in_page = 0
 
-    # the second returned variable is the next page - it is implemented for a future use of repolling
-    iocs, _ = find_indicators_to_limit_loop(indicator_query, limit, next_page=next_page)
+    iocs = find_indicators_to_limit_loop(indicator_query, limit, next_page=next_page)
 
     # if offset in page is bigger than the amount of results returned return empty list
     if len(iocs) <= offset_in_page:
@@ -214,10 +213,11 @@ def find_indicators_to_limit_loop(indicator_query: str, limit: int, total_fetche
         (tuple): The iocs and the last page
     """
     iocs: List[dict] = []
+    search_indicators = SearchIndicatorsByVersion(page=next_page)
     if not last_found_len:
         last_found_len = total_fetched
     while last_found_len == PAGE_SIZE and limit and total_fetched < limit:
-        fetched_iocs = demisto.searchIndicators(query=indicator_query, page=next_page, size=PAGE_SIZE).get('iocs')
+        fetched_iocs = search_indicators.search_indicators_by_version(query=indicator_query, size=PAGE_SIZE).get('iocs')
         # In case the result from searchIndicators includes the key `iocs` but it's value is None
         fetched_iocs = fetched_iocs or []
 
@@ -226,8 +226,7 @@ def find_indicators_to_limit_loop(indicator_query: str, limit: int, total_fetche
                     for ioc in fetched_iocs)
         last_found_len = len(fetched_iocs)
         total_fetched += last_found_len
-        next_page += 1
-    return iocs, next_page
+    return iocs
 
 
 def ip_groups_to_cidrs(ip_range_groups: list):

--- a/Packs/FeedMitreAttack/Integrations/FeedMitreAttack/FeedMitreAttack.py
+++ b/Packs/FeedMitreAttack/Integrations/FeedMitreAttack/FeedMitreAttack.py
@@ -355,13 +355,15 @@ def search_command(client, args):
     return_list_md: List[Dict] = list()
     entries = list()
     all_indicators: List[Dict] = list()
-    page = 0
     size = 1000
-    raw_data = demisto.searchIndicators(query=f'type:"{client.indicatorType}"', page=page, size=size)
-    while len(raw_data.get('iocs', [])) > 0:
-        all_indicators.extend(raw_data.get('iocs', []))
-        page += 1
-        raw_data = demisto.searchIndicators(query=f'type:"{client.indicatorType}"', page=page, size=size)
+    # makes sure the loop runs at least ones
+    ioc_data = 1
+    search_indicators = SearchIndicatorsByVersion()
+
+    while len(ioc_data) > 0:
+        raw_data = search_indicators.search_indicators_by_version(query=f'type:"{client.indicatorType}"', size=size)
+        ioc_data = raw_data.get('iocs', [])
+        all_indicators.extend(ioc_data)
 
     for indicator in all_indicators:
         custom_fields = indicator.get('CustomFields', {})


### PR DESCRIPTION
Opening as draft, want your opinion first.

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Searching indicators by demisto version,
if the version is 6.2 or higher we will use the `searchAfter` param, otherwise, we will use paging.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
