### PR TITLE
Writing create-instances job

### DIFF
--- a/.circleci/build-requirements.txt
+++ b/.circleci/build-requirements.txt
@@ -9,6 +9,5 @@ pyminizip===0.2.4
 google-cloud-storage==1.29.0
 google-cloud-bigquery==1.26.1
 prettytable==0.7.2
-circleci==1.2.2
 boto3==1.16.39
 mock-open==1.4.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,3 +85,80 @@ stages:
   - create-instances
   - run-instances
   - upload-to-marketplace
+
+create-instances:
+  stage: create-instances
+  script:
+    - |
+      demisto-sdk create-id-set -o ./Tests/id_set.json
+      cp ./Tests/id_set.json $ARTIFACTS_FOLDER
+    - python3 Utils/release_notes_generator.py $CONTENT_VERSION $CI_COMMIT_SHA $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
+    - ./Documentation/commonServerDocs.sh
+    -  demisto-sdk create-content-artifacts -a $ARTIFACTS_FOLDER --cpus 8 --content_version $CONTENT_VERSION
+    - |
+      gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY" > auth.out 2>&1
+      echo "successfully activated google cloud service account"
+    - successful_feature_branch_build=$(gsutil ls "gs://xsoar-ci-artifacts/content/$FEATURE_BRANCH_NAME/*" | tail -n 1 | grep -o -E "content/$FEATURE_BRANCH_NAME/[0-9]*")
+    - echo $successful_feature_branch_build
+    - python3 Utils/merge_content_new_zip.py -f $FEATURE_BRANCH_NAME -b $successful_feature_branch_build
+    - zip -j $ARTIFACTS_FOLDER/uploadable_packs.zip $ARTIFACTS_FOLDER/uploadable_packs/* || ((($? > 0)) && echo "failed to zip the uploadable packs, ignoring the failure" && exit 0)
+    - rm -rf $ARTIFACTS_FOLDER/uploadable_packs
+    - python3 ./Tests/scripts/update_conf_json.py
+    - cp "./Tests/conf.json" "$ARTIFACTS_FOLDER/conf.json"
+    - |
+      if [ -n "${INSTANCE_TESTS}" ];
+        then
+          echo "Skipping - not running in INSTANCE_TESTS build"
+        else
+          [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
+          python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
+      fi
+    - python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $ARTIFACTS_FOLDER/packs_dependencies.json
+    - |
+      if [[ -n "${CONTRIB_BRANCH}" || -n "${DEMISTO_SDK_NIGHTLY}" ]] ; then
+        echo "Skipping Preparing Content Packs For Testing since nightly instances uses production bucket"
+      else
+        ./Tests/scripts/prepare_content_packs_for_testing.sh "$GCS_MARKET_BUCKET"
+      fi
+    - |
+      if [[ -n "${DEMISTO_SDK_NIGHTLY}" ]] || [[ $CI_COMMIT_BRANCH != master ]] && [[ $CI_COMMIT_BRANCH != 20\.* ]] && [[ $CI_COMMIT_BRANCH != 21\.* ]]; then
+        echo "Skipping packs download to artifact on non master or release branch"
+      else
+        ZIP_FOLDER=$(mktemp -d)
+        python3 ./Tests/Marketplace/zip_packs.py -b 'marketplace-dist' -z $ZIP_FOLDER -a $ARTIFACTS_FOLDER -s $GCS_MARKET_KEY
+      fi
+    - |
+      if [ -n "${DEMISTO_SDK_NIGHTLY}" ];
+        then
+          echo "Skipping - not running in INSTANCE_TESTS build"
+        else
+          ./Tests/scripts/upload_artifacts.sh
+      fi
+    - |
+      if [ -n "${DEMISTO_SDK_NIGHTLY}" ];
+        then
+          echo "Skipping - not running in INSTANCE_TESTS build"
+        else
+          [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=300
+          if [ -n "${NIGHTLY}" ] ;
+            then
+              export IFRA_ENV_TYPE=Nightly # disable-secrets-detection
+          elif [ -n "${INSTANCE_TESTS}" ] ;
+            then
+              export IFRA_ENV_TYPE="Server 5.5" # disable-secrets-detection
+          elif [[ -n "${CONTRIB_BRANCH}" || -n "${DEMISTO_SDK_NIGHTLY}" ]] ;
+            then
+              export IFRA_ENV_TYPE="Server Master" # disable-secrets-detection
+          elif [ -n "${BUCKET_UPLOAD}" ] ;
+            then
+              export IFRA_ENV_TYPE="Bucket-Upload" # disable-secrets-detection
+          else
+            export IFRA_ENV_TYPE=Content-Env # disable-secrets-detection
+          fi
+        python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile "$ARTIFACTS_FOLDER/env_results.json"
+      fi
+  artifacts:
+    expire_in: 48 hrs
+    paths:
+      - /builds/xsoar/content/artifacts/*
+    when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,87 @@
+default:
+  image: docker-io.artifactory.pan.local/devdemisto/gitlab-content-ci:1.0.0.18863
+  cache:
+    key:
+      files:
+       - "dev-requirements-py3.txt"
+       - "package-lock.json"
+    paths:
+      - venv/
+      - node_modules/
+    when: always
+  before_script:
+    - echo "=== Running before script ==="
+    - git checkout $CI_COMMIT_BRANCH
+    - mkdir -p -m 777 $ARTIFACTS_FOLDER/
+    - |
+      if [[ -f "$BASH_ENV" ]]; then
+        source "$BASH_ENV"
+      fi
+    - echo "=== Creating new clean logs folder ==="
+    - rm -rf $ARTIFACTS_FOLDER/logs
+    - mkdir -p $ARTIFACTS_FOLDER/logs
+    - echo "=== Granting execute permissions on files ==="
+    - chmod +x ./Tests/scripts/*
+    - chmod +x ./Tests/lastest_server_build_scripts/*
+    - chmod +x ./Tests/Marketplace/*
+    - echo "=== Installing Virtualenv ==="
+    - |
+     if [ -f "./venv/bin/activate" ]; then
+       echo "found venv"
+     else
+      echo "installing venv"
+      NO_HOOKS=1 SETUP_PY2=yes .hooks/bootstrap
+     fi
+     venv/bin/pip3 install -r .circleci/build-requirements.txt
+     venv/bin/pip2 install -r dev-requirements-py2.txt
+     source ./venv/bin/activate
+    - git config diff.renameLimit 6000
+    - export PATH="${PWD}/node_modules/.bin:${PATH}"
+    - |
+      if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
+        echo "Installing SDK"
+        pip3 install git+https://github.com/demisto/demisto-sdk@master
+      fi
+    - echo "========= Installing SSH keys ========"
+    - 'command -v ssh-agent >/dev/null || ( apt-get update -y && apt-get install openssh-client -y )'
+    - eval $(ssh-agent -s)
+    - chmod 400 $OREGON_CI_KEY
+    - ssh-add $OREGON_CI_KEY
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+
+    - echo "======= Download configuration ========"
+    - ./Tests/scripts/download_demisto_conf.sh
+
+    - echo "========== Build Parameters =========="
+    - set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^GCS_MARKET_BUCKET=|^SLACK_CHANNEL="
+    - python --version
+    - python3 --version
+    - node --version
+    - npm --version
+    - demisto-sdk --version
+
+
+variables:
+  CONTENT_VERSION: "21.3.2"
+  SERVER_VERSION: "6.0.0"
+  GIT_SHA1: "6fee942518c6b2275a6cb61c1824574171cf58f9" # guardrails-disable-line disable-secrets-detection
+  DONT_CACHE_LAST_RESPONSE: "true"
+  GCS_MARKET_BUCKET: "marketplace-dist"
+  SLACK_CHANNEL: "dmst-content-team"
+  DEMISTO_README_VALIDATION: "true"
+  ARTIFACTS_FOLDER: "/builds/xsoar/content/artifacts"
+  BASH_ENV: "/builds/xsoar/content/artifacts/bash_env"
+  PYTHONPATH: "/builds/xsoar/content"
+  FEATURE_BRANCH_NAME: "v4.5.0"
+# Gitlab CI/CD uses shallow fetch with default depth of 50, these arguments are used to override it
+# See here for more about that https://docs.gitlab.com/ee/ci/pipelines/settings.html#git-shallow-clone  # disable-secrets-detection
+  GIT_STRATEGY: clone
+  GIT_DEPTH: 0
+
+
+stages:
+  - unittests-and-validations
+  - create-instances
+  - run-instances
+  - upload-to-marketplace

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -305,8 +305,7 @@ def id_set__get_integration_file_path(id_set, integration_id):
     for integration in id_set.get('integrations', []):
         if integration_id in integration.keys():
             return integration[integration_id]['file_path']
-        else:
-            logging.critical(f'Could not find integration "{integration}" in the id_set')
+    logging.critical(f'Could not find integration "{integration_id}" in the id_set')
 
 
 def check_if_fetch_incidents_is_tested(missing_ids, integration_ids, id_set, conf, tests_set):
@@ -1290,7 +1289,7 @@ def create_filter_envs_file(from_version: str, to_version: str, documentation_ch
             'Server 6.0': False,
         }
     logging.info("Creating filter_envs.json with the following envs: {}".format(envs_to_test))
-    with open("./Tests/filter_envs.json", "w") as filter_envs_file:
+    with open("./artifacts/filter_envs.json", "w") as filter_envs_file:
         json.dump(envs_to_test, filter_envs_file)
 
 
@@ -1348,11 +1347,11 @@ def create_test_file(is_nightly, skip_save=False, path_to_pack=''):
 
     if not skip_save:
         logging.info("Creating filter_file.txt")
-        with open("./Tests/filter_file.txt", "w") as filter_file:
+        with open("./artifacts/filter_file.txt", "w") as filter_file:
             filter_file.write(tests_string)
         # content_packs_to_install.txt is not used in nightly build
         logging.info("Creating content_packs_to_install.txt")
-        with open("./Tests/content_packs_to_install.txt", "w") as content_packs_to_install:
+        with open("./artifacts/content_packs_to_install.txt", "w") as content_packs_to_install:
             content_packs_to_install.write(packs_to_install_string)
 
     if is_nightly:

--- a/Tests/scripts/prepare_content_packs_for_testing.sh
+++ b/Tests/scripts/prepare_content_packs_for_testing.sh
@@ -3,28 +3,26 @@
 # exit on errors
 set -e
 
-CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown}
-CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM:-00000}
-CIRCLE_ARTIFACTS=${CIRCLE_ARTIFACTS}
-PACK_ARTIFACTS=$CIRCLE_ARTIFACTS/content_packs.zip
-ID_SET=$CIRCLE_ARTIFACTS/id_set.json
+CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH:-unknown}
+CI_BUILD_ID=${CI_BUILD_ID:-00000}
+ARTIFACTS_FOLDER=${ARTIFACTS_FOLDER}
+PACK_ARTIFACTS=$ARTIFACTS_FOLDER/content_packs.zip
+ID_SET=$ARTIFACTS_FOLDER/id_set.json
 EXTRACT_FOLDER=$(mktemp -d)
 
-if [[ -z "$GCS_MARKET_KEY" ]]; then
+if [[ ! -f "$GCS_MARKET_KEY" ]]; then
     echo "GCS_MARKET_KEY not set aborting!"
     exit 1
 fi
 
 echo "Preparing content packs for testing ..."
 
-KF=$(mktemp)
-echo "$GCS_MARKET_KEY" > "$KF"
-gcloud auth activate-service-account --key-file="$KF" > auth.out 2>&1
+gcloud auth activate-service-account --key-file="$GCS_MARKET_KEY" > auth.out 2>&1
 echo "Auth loaded successfully."
 
 # ====== BUILD CONFIGURATION ======
 GCS_BUILD_BUCKET="marketplace-ci-build"
-BUILD_BUCKET_PATH="content/builds/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM"
+BUILD_BUCKET_PATH="content/builds/$CI_COMMIT_BRANCH/$CI_BUILD_ID"
 TARGET_PATH="$BUILD_BUCKET_PATH/content/packs"
 CONTENT_FULL_TARGET_PATH="$GCS_BUILD_BUCKET/$BUILD_BUCKET_PATH/content"
 BUCKET_FULL_TARGET_PATH="$GCS_BUILD_BUCKET/$BUILD_BUCKET_PATH"
@@ -40,15 +38,15 @@ if [[ "$GCS_MARKET_BUCKET" == "marketplace-dist" ]]; then
   SOURCE_PATH="content"
 else
   # ====== UPDATING TESTING BUCKET ======
-  SOURCE_PATH="upload-flow/builds/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM/content"
+  SOURCE_PATH="upload-flow/builds/$CI_COMMIT_BRANCH/$CI_BUILD_ID/content"
   echo "Copying production bucket files at: gs://marketplace-dist/content to testing bucket at path: gs://$GCS_MARKET_BUCKET/$SOURCE_PATH ..."
-  gsutil -m cp -r "gs://marketplace-dist/content" "gs://$GCS_MARKET_BUCKET/$SOURCE_PATH" > "$CIRCLE_ARTIFACTS/logs/Prepare Content Packs For Testing.log" 2>&1
+  gsutil -m cp -r "gs://marketplace-dist/content" "gs://$GCS_MARKET_BUCKET/$SOURCE_PATH" > "$ARTIFACTS_FOLDER/logs/Prepare Content Packs For Testing.log" 2>&1
   echo "Finished copying successfully."
   # ====== UPDATING TESTING BUCKET ======
 fi
 
 echo "Copying master files at: gs://$GCS_MARKET_BUCKET/$SOURCE_PATH to target path: gs://$CONTENT_FULL_TARGET_PATH ..."
-gsutil -m cp -r "gs://$GCS_MARKET_BUCKET/$SOURCE_PATH" "gs://$CONTENT_FULL_TARGET_PATH" > "$CIRCLE_ARTIFACTS/logs/Prepare Content Packs For Testing.log" 2>&1
+gsutil -m cp -r "gs://$GCS_MARKET_BUCKET/$SOURCE_PATH" "gs://$CONTENT_FULL_TARGET_PATH" > "$ARTIFACTS_FOLDER/logs/Prepare Content Packs For Testing.log" 2>&1
 echo "Finished copying successfully."
 
 if [ ! -n "${BUCKET_UPLOAD}" ]; then
@@ -62,7 +60,7 @@ if [ ! -n "${BUCKET_UPLOAD}" ]; then
       echo "Did not get content packs to update in the bucket."
     else
       echo "Updating the following content packs: $CONTENT_PACKS_TO_INSTALL ..."
-      python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p $CONTENT_PACKS_TO_INSTALL -o true -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt false --id_set_path $ID_SET -bu false -c $CIRCLE_BRANCH -f false
+      python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $ARTIFACTS_FOLDER/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s "$GCS_MARKET_KEY" -n $CI_BUILD_ID -p $CONTENT_PACKS_TO_INSTALL -o true -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt false --id_set_path $ID_SET -bu false -c $CI_COMMIT_BRANCH -f false
       echo "Finished updating content packs successfully."
     fi
   fi
@@ -85,7 +83,7 @@ else
     PACKS_LIST="all"
     IS_FORCE_UPLOAD=false
   fi
-  python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $CIRCLE_ARTIFACTS/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s $KF -n $CIRCLE_BUILD_NUM -p "$PACKS_LIST" -o $OVERRIDE_ALL_PACKS -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt $REMOVE_PBS -i $ID_SET -bu $BUCKET_UPLOAD_FLOW -pb "$GCS_PRIVATE_BUCKET" -c $CIRCLE_BRANCH -f $IS_FORCE_UPLOAD
+  python3 ./Tests/Marketplace/upload_packs.py -a $PACK_ARTIFACTS -d $ARTIFACTS_FOLDER/packs_dependencies.json -e $EXTRACT_FOLDER -b $GCS_BUILD_BUCKET -s "$GCS_MARKET_KEY" -n $CI_BUILD_ID -p "$PACKS_LIST" -o $OVERRIDE_ALL_PACKS -sb $TARGET_PATH -k $PACK_SIGNING_KEY -rt $REMOVE_PBS -i $ID_SET -bu $BUCKET_UPLOAD_FLOW -pb "$GCS_PRIVATE_BUCKET" -c $CI_COMMIT_BRANCH -f $IS_FORCE_UPLOAD
   echo "Finished updating content packs successfully."
 fi
 

--- a/Tests/scripts/upload_artifacts.sh
+++ b/Tests/scripts/upload_artifacts.sh
@@ -4,10 +4,8 @@
 set -e
 
 # Build uploads artifacts dir to artifacts bucket
-
-CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown}
-ARTIFACTS_DIR=${ARTIFACTS_DIR:-artifacts}
-CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+BRANCH=${CI_COMMIT_BRANCH:-unknown}
+ARTIFACTS_DIR=${ARTIFACTS_FOLDER:-artifacts}
 
 if [[ ! -d "$ARTIFACTS_DIR" ]]; then
     echo "Directory [$ARTIFACTS_DIR] not found. Nothing to upload. Skipping!"
@@ -19,12 +17,12 @@ if [[ -z "$(ls -A ${ARTIFACTS_DIR})" ]]; then
     exit 0
 fi
 
-if [[ "$CIRCLE_BRANCH" =~ pull/[0-9]+ ]]; then
+if [[ "$BRANCH" =~ pull/[0-9]+ ]]; then
     echo "Running on remote fork. Skipping!"
     exit 0
 fi
 
-if [[ -z "$CIRCLE_BUILD_NUM" ]]; then
+if [[ -z "$CI_BUILD_ID" ]]; then
     echo "CIRCLE_BUILD_NUM not set aborting!"
     exit 1
 fi
@@ -34,12 +32,12 @@ if [[ -z "$GCS_ARTIFACTS_BUCKET" ]]; then
     exit 1
 fi
 
-if [[ -z "$GCS_ARTIFACTS_KEY" ]]; then
+if [[ ! -f "$GCS_ARTIFACTS_KEY" ]]; then
     echo "GCS_ARTIFACTS_KEY not set aborting!"
     exit 1
 fi
 
-echo "$GCS_ARTIFACTS_KEY"  | gcloud auth activate-service-account --key-file=- > auth.out 2>&1
-TARGET_PATH="content/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM/$CIRCLE_NODE_INDEX"
+cat "$GCS_ARTIFACTS_KEY"  | gcloud auth activate-service-account --key-file=- > auth.out 2>&1
+TARGET_PATH="content/$BRANCH/$CI_BUILD_ID"
 echo "auth loaded. uploading files at: $ARTIFACTS_DIR to target path: $TARGET_PATH ..."
 gsutil -m cp -r "$ARTIFACTS_DIR" "gs://$GCS_ARTIFACTS_BUCKET/$TARGET_PATH"

--- a/Tests/scripts/utils/get_modified_files_for_testing.py
+++ b/Tests/scripts/utils/get_modified_files_for_testing.py
@@ -3,7 +3,7 @@ This class replaces the old get_modified_files_for_testing function in collect_t
 """
 import glob
 import os
-from enum import Enum
+from demisto_sdk.commands.common.constants import FileType
 from typing import Dict, Set, Optional
 
 import demisto_sdk.commands.common.constants as constants
@@ -12,13 +12,6 @@ from Tests.scripts.utils.collect_helpers import (
     is_pytest_file, checked_type, SECRETS_WHITE_LIST, LANDING_PAGE_SECTIONS_JSON_PATH,
 )
 from demisto_sdk.commands.common import tools
-
-
-class FileType(constants.FileType, Enum):
-    CONF_JSON = "confjson"
-    METADATA = "metadata"
-    WHITE_LIST = 'whitelist'
-    LANDING_PAGE_SECTIONS_JSON = 'landingPage_sections.json'
 
 
 class ModifiedFiles:

--- a/Utils/merge_content_new_zip.py
+++ b/Utils/merge_content_new_zip.py
@@ -6,7 +6,7 @@ import argparse
 import shutil
 
 
-ARTIFACTS_PATH = '/home/circleci/project/artifacts/'
+ARTIFACTS_PATH = os.environ.get('ARTIFACTS_FOLDER')
 STORAGE_BUCKET_NAME = 'xsoar-ci-artifacts'
 FILES_TO_REMOVE = ['content-descriptor.json', 'doc-CommonServer.json', 'doc-howto.json', 'reputations.json',
                    'tools-o365.zip', 'tools-exchange.zip', 'tools-winpmem.zip']
@@ -28,18 +28,13 @@ def download_zip_file_from_gcp(current_feature_branch_zip_file_path, zip_destina
     Returns:
         The new path of the zip file.
     """
-
-    file_path = "creds.json"
-    json_content = json.loads(os.environ.get('GCS_ARTIFACTS_KEY'))
-    with open(file_path, "w") as file:
-        json.dump(json_content, file)
+    file_path = os.environ.get('GCS_ARTIFACTS_KEY')
     os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = file_path
     storage_client = storage.Client()
 
     storage_bucket = storage_client.bucket(STORAGE_BUCKET_NAME)
 
     index_blob = storage_bucket.blob(current_feature_branch_zip_file_path)
-    os.remove(file_path)
     if not os.path.exists(zip_destination_path):
         os.mkdir(zip_destination_path)
     index_blob.download_to_filename(f'{zip_destination_path}/{zip_name}.zip')
@@ -80,7 +75,7 @@ def get_feature_branch_zip_file_path(feature_branch_build_path, zip_name):
 
     """
     current_feature_branch_zip_file_path = f'{feature_branch_build_path}/0/{zip_name}.zip'
-    zip_destination_path = f'{ARTIFACTS_PATH}feature_{zip_name}_zip'
+    zip_destination_path = f'{ARTIFACTS_PATH}/feature_{zip_name}_zip'
     feature_zip_file_path = download_zip_file_from_gcp(current_feature_branch_zip_file_path, zip_destination_path,
                                                        zip_name)
     return feature_zip_file_path, zip_destination_path

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,7 +1,7 @@
 flake8==3.8.3
 bandit==1.6.2
 demisto-py==2.0.22
-demisto-sdk==1.3.4
+git+https://github.com/demisto/demisto-sdk.git@1921b8c7ea832e0d7268c62703ad60413cd00cca
 pytest==6.2.1
 pytest-mock==3.4.0
 requests-mock==1.8.0


### PR DESCRIPTION
## Description:
This is the create instances job.
It contains pretty much the same flow as in circle with the following changes:
- The paths of the files that needs to be used in later jobs is changed to the artifacts folder.
- `GCS_ARTIFACTS_KEY` and `GCS_ARTIFACTS_KEY` env variables now contains the **path** to the files containing the service account and not the content of the json file, this simplifies things when authenticating to GCP.
- `CIRCLE_BUILD_NUM` will. be replaced by `CI_BUILD_ID`
- `CIRCLE_WORKFLOW_ID` will be replaced by `CI_PIPELINE_ID`
- `CIRCLE_BRANCH` will be replaced by `CI_COMMIT_BRANCH`
- The `$CIRCLE_NODE_INDEX` does not exist in gitlab which brings up the question of whether to maintain the circle upload path: `content/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM/$CIRCLE_NODE_INDEX` (where CIRCLE_NODE_INDEX = 0) or just remove it (which could be a bit simpler but break BC) @glicht @guyfreund 
- Since the build's image runs on python 3.9 which does not support Enum extension - a small fix for the sdk has been implemented as well [here](https://github.com/demisto/demisto-sdk/pull/1140).
## Related issues:
fixes: https://github.com/demisto/etc/issues/35417

## Build example:
https://code-stage.pan.run/xsoar/content/-/jobs/11263021

