### PR TITLE
SplunkPy: fixed human readable header parsing

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1602,11 +1602,12 @@ def build_search_human_readable(args, parsed_search_results):
         if not isinstance(parsed_search_results[0], dict):
             headers = "results"
         else:
-            search_for_table_args = re.search(' table (?P<table>.*)(\|)?', args.get('query', ''))
+            search_for_table_args = re.search(r' table (?P<table>.*)(\|)?', args.get('query', ''))
             if search_for_table_args:
                 table_args = search_for_table_args.group('table')
                 table_args = table_args if '|' not in table_args else table_args.split(' |')[0]
-                chosen_fields = [field for field in re.split(' |,', table_args) if field]
+                chosen_fields = [field.strip('"')
+                                 for field in re.findall(r'((?:".*?")|(?:[^\s,]+))', table_args) if field]
 
                 headers = update_headers_from_field_names(parsed_search_results, chosen_fields)
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -1003,3 +1003,34 @@ def test_get_cim_mapping_field_command(mocker):
         'Asset Data': ASSET,
         'Identity Data': IDENTITY
     }
+
+
+def test_build_search_human_readable(mocker):
+    """
+    Given:
+        table headers in query
+
+    When:
+        building a human readable table as part of splunk-search
+
+    Then:
+        Test headers are calculated correctly:
+            * comma-separated, space-separated
+            * support commas and spaces inside header values (if surrounded with parenthesis)
+
+    """
+    func_patch = mocker.patch('SplunkPy.update_headers_from_field_names')
+    results = [
+        {'ID': 1, 'Header with space': 'h1', 'header3': 1, 'header_without_space': '1234'},
+        {'ID': 2, 'Header with space': 'h2', 'header3': 2, 'header_without_space': '1234'},
+    ]
+    args = {
+        'query': 'something | table ID "Header with space" header3 header_without_space '
+                 'comma,separated "Single,Header,with,Commas" | something else'
+    }
+    expected_headers = ['ID', 'Header with space', 'header3', 'header_without_space',
+                        'comma', 'separated', 'Single,Header,with,Commas']
+
+    splunk.build_search_human_readable(args, results)
+    headers = func_patch.call_args[0][1]
+    assert headers == expected_headers

--- a/Packs/SplunkPy/ReleaseNotes/2_0_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_0_1.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Fixed an issue where headers containing spaces were not displayed in the human readable of the ***splunk-search*** command.
+- Fixed an issue where headers containing spaces were not displayed in the human readable output of the ***splunk-search*** command.

--- a/Packs/SplunkPy/ReleaseNotes/2_0_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where headers containing spaces were not displayed in the human readable of the ***splunk-search*** command.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35835

## Description
fixed the human-readable header parsing to support headers with spaces

## Screenshots
before the fix:
![image](https://user-images.githubusercontent.com/30797606/115138192-68629700-a033-11eb-94c7-e2e8bc0b5649.png)

