### PR TITLE
revert DBot Truth Bombs search rank exception

### DIFF
--- a/Packs/DBotTruthBombs/README.md
+++ b/Packs/DBotTruthBombs/README.md
@@ -15,3 +15,5 @@ This Content Pack packs heat:
 Let’s see Siri or Alexa top that!  
 
 Channel the power of positive posturing today.  Grab this content pack from our Cortex XSOAR Marketplace where you will find hundreds of content packs to help you automate and drastically reduce time spent handling your security incidents! 
+
+Published as part of April fool's.

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -617,10 +617,6 @@ class Pack(object):
             search_rank += 10
         if certification == Metadata.CERTIFIED:
             search_rank += 10
-
-        if name == 'DBot Truth Bombs':
-            search_rank += 50
-
         if content_items:
             integrations = content_items.get("integration")
             if isinstance(integrations, list):


### PR DESCRIPTION

## Status
- [x] Ready

## Description
1. remove search rank increment for DBot Truth Bombs pack
2. added note in DBot Truth Bombs pack that it was "Published as part of April fool's"

Prefer not to release a new version if possible 