### PR TITLE
PANOStoCortexDataLakeMonitoring - Fixed an issue with the querying of…

### DIFF
--- a/Packs/PANOStoCDLMonitoring/ReleaseNotes/1_0_1.md
+++ b/Packs/PANOStoCDLMonitoring/ReleaseNotes/1_0_1.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### PANOStoCortexDataLakeMonitoring
+- Fixed an issue with the querying of the Cortex Data Lake table.

--- a/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
+++ b/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
@@ -60,7 +60,7 @@ def query_cdl(fw_monitor_list: list) -> CommandResults:
     for current_fw in fw_monitor_list:
         query['query'] = f'log_source_id = \'{current_fw}\''
 
-        query_result = demisto.executeCommand("cdl-query-logs", query)
+        query_result = demisto.executeCommand("cdl-query-traffic-logs", query)
         if is_error(query_result):
             raise Exception(f'Querying logs in Cortex Data Lake failed. {query_result[0]["Contents"]}')
 

--- a/Packs/PANOStoCDLMonitoring/pack_metadata.json
+++ b/Packs/PANOStoCDLMonitoring/pack_metadata.json
@@ -2,7 +2,7 @@
   "name": "PAN-OS to Cortex Data Lake Monitoring",
   "description": "Monitor the PAN-OS FW log upload to the Cortex Data Lake in a reoccurring job. The key pre-requisite is the configuration of the Cortex Data Lake integration.",
   "support": "community",
-  "currentVersion": "1.0.0",
+  "currentVersion": "1.0.1",
   "fromversion": "6.0.0",
   "author": "Brice RENAUD",
   "url": "",


### PR DESCRIPTION
… the Cortex Data Lake table

per feedback from the contributor

## Desc
a table needs to be provided to the `cdl-query-logs` cmd. we can either add it as an arg to the PB, or by default query the traffic table. I opt for the quicker win sol, we can always enhance this pack upon request.

## Status
- [x] Ready


## Minimum version of Demisto
- [x] 6.0.0

## Does it break backward compatibility?
   - [x] No