### PR TITLE
FW lists have been mixed-up during name refresh

### DIFF
--- a/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
+++ b/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
@@ -66,9 +66,9 @@ def query_cdl(fw_monitor_list: list) -> CommandResults:
 
         if query_result:
             if query_result[0]['HumanReadable'] == no_logs_str:
-                firewalls_with_logs.append(current_fw)
-            else:
                 firewalls_without_logs.append(current_fw)
+            else:
+                firewalls_with_logs.append(current_fw)
 
     all_results = [{'FirewallsWithLogsSent': firewalls_with_logs,
                     'FirewallsWithoutLogsSent': firewalls_without_logs}]


### PR DESCRIPTION
The two lists firewalls_without_logs and firewalls_with_logs have been inverted during code clean-up

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Demisto
- [ ] 5.0.0
- [ ] 5.5.0
- [ ] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
