### PR TITLE
Copy and upload - copy index.json from dedicated blob

### DIFF
--- a/Tests/Marketplace/copy_and_upload_packs.py
+++ b/Tests/Marketplace/copy_and_upload_packs.py
@@ -80,8 +80,9 @@ def copy_index(index_folder_path: str, build_index_blob: Blob, build_index_gener
             else:
                 logging.error("Failed copying index.zip from build index - blob does not exist.")
                 sys.exit(1)
+            copied_index_json_blob = build_bucket.blob(prod_index_json_storage_path)
             copied_index_json = build_bucket.copy_blob(
-                blob=build_index_blob, destination_bucket=production_bucket, new_name=prod_index_json_storage_path
+                blob=copied_index_json_blob, destination_bucket=production_bucket, new_name=prod_index_json_storage_path
             )
             if copied_index_json.exists():
                 logging.success(f"Finished uploading {GCPConfig.INDEX_NAME}.json to storage.")


### PR DESCRIPTION
## Status
- [x] Ready

## Description
fixed an issue where the `index.zip` was copied to be `index.json` due to using the `index.zip` blob
created a new blob for the `index.json` to copy from
