### PR TITLE
XDR - added milliseconds to time calculation

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -1493,7 +1493,7 @@ def get_last_mirrored_in_time(args):
 
     else:  # handling 6.0 version
         last_mirrored_in_time = arg_to_timestamp(args.get('last_update'), 'last_update')
-        last_mirrored_in_timestamp = (last_mirrored_in_time - 120)
+        last_mirrored_in_timestamp = (last_mirrored_in_time - (120 * 1000))
 
     return last_mirrored_in_timestamp
 

--- a/Packs/CortexXDR/ReleaseNotes/3_0_6.md
+++ b/Packs/CortexXDR/ReleaseNotes/3_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+- Fixed an issue where a timestamp misconfiguration caused incidents to not update when using the incoming mirroring from XDR to XSOAR.

--- a/Packs/CortexXDR/ReleaseNotes/3_0_7.md
+++ b/Packs/CortexXDR/ReleaseNotes/3_0_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+- Fixed an issue where a timestamp misconfiguration caused incidents to not update when using the incoming mirroring from XDR to XSOAR.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "3.0.5",
+    "currentVersion": "3.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "3.0.6",
+    "currentVersion": "3.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35860

## Description
Added milliseconds calculation since the last_mirrored_in_time was not calculated correctly caused incidents to not update from XDR in the incoming mirroring


