### PR TITLE
Wrong content for the no_logs_str

### DIFF
--- a/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
+++ b/Packs/PANOStoCDLMonitoring/Scripts/PANOStoCortexDataLakeMonitoring/PANOStoCortexDataLakeMonitoring.py
@@ -51,7 +51,7 @@ def query_cdl(fw_monitor_list: list) -> CommandResults:
     :param fw_monitor_list: list of FWs serials
     :return: CommandResults object containing the serials which sent logs and that did not.
     """
-    no_logs_str = "### Logs table\n**No entries.**\n"
+    no_logs_str = "### Logs traffic table\n**No entries.**\n"
     firewalls_with_logs = []
     firewalls_without_logs = []
     start_time = datetime.utcnow() - timedelta(hours=12)  # Looking for the last 12 hours of logs


### PR DESCRIPTION
When API call has been modified back to cdl-query-traffic-logs, the no_logs_str should have been modified back to "Logs traffic table".

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ X] No

## Must have
- [ ] Tests
- [ ] Documentation 
