### PR TITLE
Playbook was not calling the proper incident type

### DIFF
--- a/Packs/PANOStoCDLMonitoring/Playbooks/PANOStoCDLMonitoring-cron_job.yml
+++ b/Packs/PANOStoCDLMonitoring/Playbooks/PANOStoCDLMonitoring-cron_job.yml
@@ -2643,7 +2643,7 @@ tasks:
       travelmaplink: {}
       triggeredsecurityprofile: {}
       type:
-        simple: CDL - FW logging - action required
+        simple: PAN-OS logging to Cortex Data Lake - Action Required
       uniquebiometricdatabreached: {}
       uniqueidentificationnumberbreached: {}
       uniqueports: {}


### PR DESCRIPTION
Playbook opens an incident type "CDL - FW logging - action required" while this incident type does not exist anymore. It should call the new incident type instead "PAN-OS logging to Cortex Data Lake - Action Required"

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
