### PR TITLE
Fixed an issue when fetch-indicators command had a wrong default value for "indicator type"

### DIFF
--- a/Packs/FeedIntel471/Integrations/Intel471Actors/Intel471Actors.py
+++ b/Packs/FeedIntel471/Integrations/Intel471Actors/Intel471Actors.py
@@ -163,7 +163,7 @@ def main():
     params = {k: v for k, v in demisto.params().items() if v is not None}
     url = _create_url(**params)
     params['url'] = url
-    params['indicator_type'] = 'Threat Actor'
+    params['indicator_type'] = 'STIX Threat Actor'
     params['feed_name_to_config'] = {
         'actors': {
             'extractor': 'actors[*]',

--- a/Packs/FeedIntel471/ReleaseNotes/1_1_3.md
+++ b/Packs/FeedIntel471/ReleaseNotes/1_1_3.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Intel471 Actors Feed
-- Fixed an issue when ***fetch-indicators*** command had a wrong default value for "indicator type".
+- Fixed an issue where the ***fetch-indicators*** command had an incorrect default value for "indicator type".

--- a/Packs/FeedIntel471/ReleaseNotes/1_1_3.md
+++ b/Packs/FeedIntel471/ReleaseNotes/1_1_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Intel471 Actors Feed
+- Fixed an issue when ***fetch-indicators*** command had a wrong default value for "indicator type".

--- a/Packs/FeedIntel471/pack_metadata.json
+++ b/Packs/FeedIntel471/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Intel471 Feed",
     "description": "This pack fetches actors indicators and malware-related indicators from intel471",
     "support": "xsoar",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/36170

## Description
changed the default indicator_type from "Threat Actor" to "STIX Threat Actor" because there isn't a "Threat Actor" indicator type in our system.

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
