### PR TITLE
Added option to EDL Intgeration for appending a slash at the end of URLs

### DIFF
--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -65,7 +65,7 @@ configuration:
   type: 8
 - additionalinfo: If selected, a slash will be appended to URLs composed only of an hostname.
     For example, 'www.example.com' would become 'www.example.com/'
-  defaultvalue: 'true'
+  defaultvalue: 'false'
   display: Add Slash to URLs
   name: url_add_slash
   required: false

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -63,6 +63,13 @@ configuration:
   name: url_port_stripping
   required: false
   type: 8
+- additionalinfo: If selected, a slash will be appended to URLs composed only of an hostname.
+    For example, 'www.example.com' would become 'www.example.com/'
+  defaultvalue: 'true'
+  display: Add Slash to URLs
+  name: url_add_slash
+  required: false
+  type: 8
 - additionalinfo: If selected, any URL entry that is not compliant with PAN-OS EDL
     URL format is dropped instead of being rewritten.
   display: PAN-OS URL Format Drop Invalid Entries
@@ -154,7 +161,7 @@ script:
     description: Updates values stored in the EDL (only available On-Demand).
     execution: false
     name: edl-update
-  dockerimage: demisto/teams:1.0.0.16907
+  dockerimage: demisto/teams:1.0.0.19245
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/EDL/Integrations/EDL/EDL_test.py
+++ b/Packs/EDL/Integrations/EDL/EDL_test.py
@@ -224,15 +224,15 @@ class TestHelperFunctions:
             {'value': '*.domain.com', 'indicator_type': 'URL'},
         ]
 
-        request_args = RequestArguments(query='', drop_invalids=True, url_port_stripping=True)
+        request_args = RequestArguments(query='', drop_invalids=True, url_port_stripping=True, url_add_slash=True)
         returned_dict, num_of_indicators = create_values_for_returned_dict(iocs, request_args)
         returned_output = returned_dict.get(EDL_VALUES_KEY, '').split('\n')
         assert '2603:1006:1400::/40' in returned_output
         assert '2002:ac8:b8d:0:0:0:0:0' in returned_output
         assert 'demisto.com/rest/of/path' in returned_output  # port stripping
         assert 'panw.com/path' in returned_output
-        assert '*.domain.com' in returned_output
-        assert 'domain.com' in returned_output  # PAN-OS URLs
+        assert '*.domain.com/' in returned_output
+        assert 'domain.com/' in returned_output  # PAN-OS URLs
         assert num_of_indicators == 6
 
     @pytest.mark.validate_basic_authentication

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks PAN-OS EDL Service",
     "description": "This integration provides External Dynamic List (EDL) as a service for the system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "1.0.14",
+    "currentVersion": "1.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
*No issue*

## Description
This PR adds an option to the Palo Alto Networks EDL integration to append a slash at the end of hostname only URLs.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
