### PR TITLE
Running with --network=host on RHEL instances

### DIFF
--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -41,7 +41,7 @@ NO_PROXY = ','.join([
     'oproxy.demisto.ninja',
     'oproxy-dev.demisto.ninja',
 ])
-NO_PROXY_CONFIG = {'python.pass.extra.keys': f'--env##no_proxy={NO_PROXY}'}  # noqa: E501
+NO_PROXY_CONFIG = {'python.pass.extra.keys': f'--env##no_proxy={NO_PROXY}##--network=host'}  # noqa: E501
 DOCKER_HARDENING_CONFIGURATION = {
     'docker.cpu.limit': '1.0',
     'docker.run.internal.asuser': 'true',

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -41,7 +41,7 @@ NO_PROXY = ','.join([
     'oproxy.demisto.ninja',
     'oproxy-dev.demisto.ninja',
 ])
-NO_PROXY_CONFIG = {'python.pass.extra.keys': f'--env##no_proxy={NO_PROXY}##--network=host'}  # noqa: E501
+NO_PROXY_CONFIG = {'python.pass.extra.keys': f'--env##no_proxy={NO_PROXY}'}  # noqa: E501
 DOCKER_HARDENING_CONFIGURATION = {
     'docker.cpu.limit': '1.0',
     'docker.run.internal.asuser': 'true',
@@ -881,6 +881,7 @@ def configure_servers_and_restart(build):
             if is_redhat_instance(server.internal_ip):
                 configurations.update(DOCKER_HARDENING_CONFIGURATION_FOR_PODMAN)
                 configurations.update(NO_PROXY_CONFIG)
+                configurations['python.pass.extra.keys'] += "##--network=slirp4netns:cidr=192.168.0.0/16"
             else:
                 configurations.update(DOCKER_HARDENING_CONFIGURATION)
             configure_types.append('docker hardening')


### PR DESCRIPTION
Adding `--network=host` on podman containers to solve the latest podman issue with the proxy.

Build example: https://app.circleci.com/pipelines/github/demisto/content/82083/workflows/c2837755-91c8-4258-a83b-84b6fdc17e3e/jobs/339270 (Follow `Thread-10` in the logs)