### PR TITLE
Add indent when saving json file

### DIFF
--- a/Tests/Marketplace/remove_existing_pack_from_private_id_set.py
+++ b/Tests/Marketplace/remove_existing_pack_from_private_id_set.py
@@ -45,7 +45,7 @@ def get_and_set_private_id_set_by_path(private_id_set_path, new_pack_name):
     private_id_set = remove_old_pack_from_private_id_set(private_id_set, new_pack_name)
 
     with open(private_id_set_path, 'w') as id_set_file:
-        json.dump(private_id_set, id_set_file)
+        json.dump(private_id_set, id_set_file, indent=4)
 
 
 def options_handler():
@@ -59,10 +59,9 @@ def options_handler():
 
 
 def main():
-    options = options_handler()
-    private_id_set_path = options.private_id_set_path
-    new_pack_name = options.new_pack_name
-    get_and_set_private_id_set_by_path(private_id_set_path, new_pack_name)
+    # options = options_handler()
+
+    get_and_set_private_id_set_by_path('private_id_set.json', 'IAM')
 
 
 if __name__ == '__main__':

--- a/Tests/Marketplace/remove_existing_pack_from_private_id_set.py
+++ b/Tests/Marketplace/remove_existing_pack_from_private_id_set.py
@@ -59,9 +59,10 @@ def options_handler():
 
 
 def main():
-    # options = options_handler()
-
-    get_and_set_private_id_set_by_path('private_id_set.json', 'IAM')
+    options = options_handler()
+    private_id_set_path = options.private_id_set_path
+    new_pack_name = options.new_pack_name
+    get_and_set_private_id_set_by_path(private_id_set_path, new_pack_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When using the script `remove_existing_pack_from_private_id_set.py` it saves the json file without indent, added `indent=4` solved it.

## Screenshots
before:
![image](https://user-images.githubusercontent.com/46249224/116399152-476b2480-a831-11eb-9c51-ce4849e65543.png)

after:
![image](https://user-images.githubusercontent.com/46249224/116399217-58b43100-a831-11eb-86ab-8a972935cf55.png)


## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
