### PR TITLE
Azure Compute Test Failure Fix

### DIFF
--- a/Packs/AzureCompute/TestPlaybooks/AzureComputeTest.yml
+++ b/Packs/AzureCompute/TestPlaybooks/AzureComputeTest.yml
@@ -165,7 +165,7 @@ tasks:
       retry-count:
         simple: "3"
       virtual_machine_name:
-        simple: TestOAuth
+        simple: TestOAuth2
     separatecontext: false
     view: |-
       {

--- a/Packs/AzureCompute/TestPlaybooks/AzureComputeTest.yml
+++ b/Packs/AzureCompute/TestPlaybooks/AzureComputeTest.yml
@@ -134,7 +134,7 @@ tasks:
       resource_group:
         simple: compute-integration
       virtual_machine_name:
-        simple: TestOAuth
+        simple: TestOAuth2
     separatecontext: false
     view: |-
       {

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3329,7 +3329,6 @@
         "TCPUtils-Test": "Issue 29677",
         "Polygon-Test": "Issue 29060",
         "AttackIQ - Test": "Issue 29774",
-        "Azure Compute - Test": "Issue 28056",
         "forcepoint test": "Issue 28043",
         "CanaryTools Test": "Issue 30796",
         "Test-VulnDB": "Issue 30875",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/28056

## Description
Azure compute V2 kept failing due to invalid VM.
Re-established a new VM and changed test-playbook to try to start-instance on the new VM name.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No