### PR TITLE
Adding support in release branches

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -2,10 +2,7 @@
   rules:
     - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/'
 
-.server-master-rule:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/'
-    - if: '$NIGHTLY'
+
 .download-configuration: &download_demisto_conf
   - echo "======= Download configuration ========"
   - ./Tests/scripts/download_demisto_conf.sh  >> $ARTIFACTS_FOLDER/logs/installations.log
@@ -134,6 +131,6 @@ server_6_0:
 server_master:
   extends:
     - .test_content_on_server_instances_base
-    - .server-master-rule
+    - .nightly-rule
   variables:
     INSTANCE_ROLE: "Server Master"

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -125,12 +125,18 @@ server_5_5:
 
 server_6_0:
   extends: .test_content_on_server_instances_base
+  #  No need to trigger in case of release branch
+  rules:
+    - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
   variables:
     INSTANCE_ROLE: "Server 6.0"
 
 server_master:
   extends:
     - .test_content_on_server_instances_base
-    - .nightly-rule
+  #  No need to trigger in case of release branch
+  rules:
+    - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
+    - if: '$NIGHTLY'
   variables:
     INSTANCE_ROLE: "Server Master"

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1298,7 +1298,8 @@ def create_filter_envs_file(from_version: str, to_version: str, documentation_ch
             'Server 5.0': False,
             'Server 6.0': False,
         }
-
+    # Releases are only relevant for non marketplace server versions, therefore - there is no need to create marketplace
+    # server in release branches.
     if is_release_branch():
         marketplace_server_keys = {key for key in envs_to_test.keys() if key not in {'Server 5.5', 'Server 5.0'}}
         for key in marketplace_server_keys:

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1264,6 +1264,16 @@ def get_from_version_and_to_version_bounderies(all_modified_files_paths: set,
     return min_from_version.vstring, max_to_version.vstring
 
 
+def is_release_branch():
+    """
+    Checks for the current build's branch
+    Returns:
+        True if the branch name under the 'CI_COMMIT_BRANCH' env variable is a release branch, else False.
+    """
+    branch_name = os.getenv('CI_COMMIT_BRANCH', '')
+    return re.match(r'[0-9]{2}\.[0-9]{1,2}\.[0-9]', branch_name)
+
+
 def create_filter_envs_file(from_version: str, to_version: str, documentation_changes_only: bool = False):
     """
     Create a file containing all the envs we need to run for the CI
@@ -1288,6 +1298,12 @@ def create_filter_envs_file(from_version: str, to_version: str, documentation_ch
             'Server 5.0': False,
             'Server 6.0': False,
         }
+
+    if is_release_branch():
+        marketplace_server_keys = {key for key in envs_to_test.keys() if key not in {'Server 5.5', 'Server 5.0'}}
+        for key in marketplace_server_keys:
+            envs_to_test[key] = False
+
     logging.info("Creating filter_envs.json with the following envs: {}".format(envs_to_test))
     with open("./artifacts/filter_envs.json", "w") as filter_envs_file:
         json.dump(envs_to_test, filter_envs_file)

--- a/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
+++ b/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from ruamel.yaml import YAML
@@ -1253,6 +1254,7 @@ def test_get_from_version_and_to_version_bounderies_modified_metadata():
     assert '99.99.99' in to_version
 
 
+@patch.dict('os.environ', {'CI_COMMIT_BRANCH': '21.12.0'})
 def test_is_release_branch_positive():
     """
     Given:
@@ -1262,11 +1264,11 @@ def test_is_release_branch_positive():
     Then:
         - Validate the response is positive.
     """
-    os.environ['CI_COMMIT_BRANCH'] = '21.12.0'
     assert is_release_branch()
 
 
-def test_is_release_branch_negative():
+@pytest.mark.parametrize('mocked_branch_name', ['some_branch_name', ''])
+def test_is_release_branch_negative(mocked_branch_name):
     """
     Given:
         - That branch name found from 'CI_COMMIT_BRANCH' env variable is a regular branch name or an empty value
@@ -1275,7 +1277,5 @@ def test_is_release_branch_negative():
     Then:
         - Validate the response is negative.
     """
-    os.environ['CI_COMMIT_BRANCH'] = 'some_branch_name'
-    assert not is_release_branch()
-    os.environ['CI_COMMIT_BRANCH'] = ''
-    assert not is_release_branch()
+    with patch.dict('os.environ', {'CI_COMMIT_BRANCH': mocked_branch_name}):
+        assert not is_release_branch()

--- a/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
+++ b/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
@@ -16,7 +16,7 @@ from Tests.scripts.collect_tests_and_content_packs import (
     PACKS_DIR, TestConf, collect_content_packs_to_install,
     create_filter_envs_file, get_from_version_and_to_version_bounderies,
     get_test_list_and_content_packs_to_install, is_documentation_changes_only,
-    remove_ignored_tests, remove_tests_for_non_supported_packs)
+    remove_ignored_tests, remove_tests_for_non_supported_packs, is_release_branch)
 from Tests.scripts.utils.get_modified_files_for_testing import get_modified_files_for_testing, ModifiedFiles
 from Tests.scripts.utils import content_packs_util
 
@@ -1251,3 +1251,31 @@ def test_get_from_version_and_to_version_bounderies_modified_metadata():
 
     assert '6.1.0' in from_version
     assert '99.99.99' in to_version
+
+
+def test_is_release_branch_positive():
+    """
+    Given:
+        - That branch name found from 'CI_COMMIT_BRANCH' env variable is a release branch.
+    When:
+        - running is_release_branch method.
+    Then:
+        - Validate the response is positive.
+    """
+    os.environ['CI_COMMIT_BRANCH'] = '21.12.0'
+    assert is_release_branch()
+
+
+def test_is_release_branch_negative():
+    """
+    Given:
+        - That branch name found from 'CI_COMMIT_BRANCH' env variable is a regular branch name or an empty value
+    When:
+        - running is_release_branch method.
+    Then:
+        - Validate the response is negative.
+    """
+    os.environ['CI_COMMIT_BRANCH'] = 'some_branch_name'
+    assert not is_release_branch()
+    os.environ['CI_COMMIT_BRANCH'] = ''
+    assert not is_release_branch()


### PR DESCRIPTION
Supporting release branches

No need to create and run server 6.0 and server Master builds in case of release branch.

## Related issues:
fixes: https://github.com/demisto/etc/issues/34303