### PR TITLE
Taxii Server - docker image update + TPB

### DIFF
--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -44,7 +44,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.17799
+  dockerimage: demisto/taxii-server:1.0.0.7844
   feed: false
   isfetch: false
   longRunning: true
@@ -54,5 +54,5 @@ script:
   subtype: python3
   type: python
 tests:
-- No test
+- TAXII_Feed_Test
 fromversion: 5.5.0

--- a/Packs/TAXIIServer/ReleaseNotes/1_0_3.md
+++ b/Packs/TAXIIServer/ReleaseNotes/1_0_3.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### TAXII Server
-- Fixed an issue where a new docker image caused the integration to fail.
+- Fixed an issue where a new Docker image caused the integration to fail.
 - Updated the Docker image to: *demisto/taxii-server:1.0.0.7844*.

--- a/Packs/TAXIIServer/ReleaseNotes/1_0_3.md
+++ b/Packs/TAXIIServer/ReleaseNotes/1_0_3.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### TAXII Server
+- Fixed an issue where a new docker image caused the integration to fail.
+- Updated the Docker image to: *demisto/taxii-server:1.0.0.7844*.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/32567

## Description
New docker image causes failures.
Downgraded.
Needs force merge.

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
