### PR TITLE
remove Cylance Protect from unmockable list

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1847,11 +1847,6 @@
             "is_mockable": false
         },
         {
-            "integrations": "Cylance Protect",
-            "playbookID": "get_file_sample_by_hash_-_cylance_protect_-_test",
-            "timeout": 240
-        },
-        {
             "integrations": "QRadar",
             "playbookID": "test_Qradar",
             "fromversion": "5.5.0",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3487,7 +3487,6 @@
         "urlscan.io": "Uses data that comes in the headers",
         "CloudConvert": "has a command that uploads a file (!cloudconvert-upload)",
         "Symantec Messaging Gateway": "Test playbook uses a random string",
-        "Cylance Protect": "Test playbook (get_file_sample_by_hash_-_cylance_protect_-_test) downloads a file",
         "AlienVault OTX TAXII Feed": "Client from 'cabby' package generates uuid4 in the request",
         "Generic Webhook": "Does not send HTTP traffic",
         "Microsoft Endpoint Configuration Manager": "Uses Microsoft winRM",


### PR DESCRIPTION
remove Cylance Protect from the tests because it’s deprecated.