### PR TITLE
Extract files bug

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -1,6 +1,7 @@
 id: Extract Indicators From File - Generic v2
 version: -1
-fromversion: 5.0.0
+contentitemexportablefields:
+  contentitemfields: {}
 name: Extract Indicators From File - Generic v2
 description: |-
   Extracts indicators from a file.
@@ -43,6 +44,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "1":
     id: "1"
     taskid: 7872ce6f-5e06-4c00-846b-6de0d54307b1
@@ -82,6 +85,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "2":
     id: "2"
     taskid: ae4c0ec9-1082-477b-8b41-dc412d1377e5
@@ -99,7 +104,6 @@ tasks:
       '#none#':
       - "4"
     scriptarguments:
-      append: {}
       key:
         simple: File
       value:
@@ -119,6 +123,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "3":
     id: "3"
     taskid: 832242ed-942e-4094-8cf4-003921e7ef7a
@@ -142,6 +148,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "4":
     id: "4"
     taskid: ab59c7dd-3e82-4efe-8e36-d3065d88a590
@@ -171,6 +179,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "5":
     id: "5"
     taskid: ec94113f-b87d-40e7-80da-93bfd4262a37
@@ -179,7 +189,8 @@ tasks:
       id: ec94113f-b87d-40e7-80da-93bfd4262a37
       version: -1
       name: Is there a text-based file?
-      description: Checks if there is a text-based file in context. Skips MSG and EML files.
+      description: Checks if there is a text-based file in context. Skips MSG and
+        EML files.
       type: condition
       iscommand: false
       brand: ""
@@ -313,6 +324,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "6":
     id: "6"
     taskid: 2fa182d1-a775-4c81-8e7d-d63474ec434b
@@ -438,7 +451,6 @@ tasks:
           accessor: EntryID
           transformers:
           - operator: uniq
-      maxFileSize: {}
     reputationcalc: 2
     separatecontext: false
     view: |-
@@ -451,6 +463,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "7":
     id: "7"
     taskid: 79feacf1-749d-4213-85ce-9b87809c59cf
@@ -510,6 +524,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "8":
     id: "8"
     taskid: f954fb51-0ed0-44d2-837a-64f852f3dd9d
@@ -551,8 +567,6 @@ tasks:
           accessor: EntryID
           transformers:
           - operator: uniq
-      maxImages: {}
-      userPassword: {}
     reputationcalc: 2
     separatecontext: false
     view: |-
@@ -565,12 +579,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "9":
     id: "9"
-    taskid: ea30b950-c393-43b3-8f33-1804d071bb4b
+    taskid: 5b8b3edf-fd03-46ea-8267-0f54b17e9567
     type: condition
     task:
-      id: ea30b950-c393-43b3-8f33-1804d071bb4b
+      id: 5b8b3edf-fd03-46ea-8267-0f54b17e9567
       version: -1
       name: Is there a Word file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
@@ -617,6 +633,14 @@ tasks:
                       value:
                         simple: docx
                     ignorecase: true
+                  - operator: containsString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: CDFV2
                 - - operator: isNotEqualString
                     left:
                       value:
@@ -695,6 +719,22 @@ tasks:
                       value:
                         simple: pptx
                     ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Extension
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xlsb
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Info
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xlsb
                 accessor: EntryID
                 transformers:
                 - operator: uniq
@@ -709,6 +749,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "10":
     id: "10"
     taskid: 371fb092-fd79-4550-8b2e-d3c945d2cc10
@@ -735,6 +777,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "11":
     id: "11"
     taskid: bccca988-5145-4391-8476-945618df7c72
@@ -873,6 +917,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "12":
     id: "12"
     taskid: 01853d00-5297-4e59-83fa-1aec87f7b3aa
@@ -949,6 +995,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "13":
     id: "13"
     taskid: 60827e91-7450-4f79-8e82-863488b15371
@@ -957,7 +1005,8 @@ tasks:
       id: 60827e91-7450-4f79-8e82-863488b15371
       version: -1
       name: Is Image OCR enabled?
-      description: Checks whether there is an active instance of the Image OCR integration enabled.
+      description: Checks whether there is an active instance of the Image OCR integration
+        enabled.
       type: condition
       iscommand: false
       brand: ""
@@ -995,6 +1044,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "14":
     id: "14"
     taskid: 19fe4f88-c55b-4f13-814c-1ad0aae31cae
@@ -1003,7 +1054,8 @@ tasks:
       id: 19fe4f88-c55b-4f13-814c-1ad0aae31cae
       version: -1
       name: Extract text from images
-      description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
+      description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract
+        to get reputation for indicators.
       script: '|||image-ocr-extract-text'
       type: regular
       iscommand: true
@@ -1055,7 +1107,6 @@ tasks:
           accessor: EntryID
           transformers:
           - operator: uniq
-      langs: {}
     reputationcalc: 2
     separatecontext: false
     view: |-
@@ -1068,12 +1119,14 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "15":
     id: "15"
-    taskid: b7677e2a-e24c-42f2-845e-0a0b8138222c
+    taskid: 36c6ef3c-b758-4f07-8d59-762cf68b7f39
     type: condition
     task:
-      id: b7677e2a-e24c-42f2-845e-0a0b8138222c
+      id: 36c6ef3c-b758-4f07-8d59-762cf68b7f39
       version: -1
       name: Is there another supported document type?
       description: |-
@@ -1183,6 +1236,14 @@ tasks:
                       value:
                         simple: text/rtf
                     ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: File.Extension
+                      iscontext: true
+                    right:
+                      value:
+                        simple: xlsb
                 accessor: EntryID
                 transformers:
                 - operator: uniq
@@ -1198,6 +1259,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
   "16":
     id: "16"
     taskid: 152dad0a-3204-4907-8bf3-a81f8f6af520
@@ -1312,7 +1375,6 @@ tasks:
           accessor: EntryID
           transformers:
           - operator: uniq
-      format: {}
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -1325,6 +1387,8 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
 view: |-
   {
     "linkLabelsPosition": {
@@ -1357,6 +1421,7 @@ inputs:
       root: File
   required: false
   description: The file from which to extract indicators.
+  playbookInputQuery:
 outputs:
 - contextPath: Domain.Name
   description: Extracted domains.
@@ -1394,4 +1459,24 @@ outputs:
   description: List of URLs that were extracted from the file.
   type: unknown
 tests:
+- Field polling test
+- test-domain-indicator
+- Calculate Severity - Generic v2 - Test
+- Wait Until Datetime - Test
+- Calculate Severity - Standard - Test
 - Extract Indicators From File - Generic v2 - Test
+- URL Enrichment - Generic v2 - Test
+- File Enrichment - Generic v2 - Test
+- Domain Enrichment - Generic v2 - Test
+- Account Enrichment - Generic v2.1 - Test
+- IP Enrichment - Generic v2 - Test
+- Detonate URL - Generic Test
+- Email Address Enrichment - Generic v2.1 - Test
+- Generic Polling Test
+- Send Investigation Summary Reports - Test
+- Detonate File - No Files test
+- Test Convert file hash to corresponding hashes
+- Detonate File - Generic Test
+- Endpoint Enrichment - Generic v2.1 - Test
+- Retrieve File from Endpoint - Generic V2 Test
+fromversion: 5.0.0

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "1.9.4",
+    "currentVersion": "1.9.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35710

## Description
The playbook was not handeling .xlsb files and was mistakenly classifying them as word files in 6.0.1 or as other convertable format in 6.2. This fix solves both cases.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
