### PR TITLE
fixing handling of premium packs' pack metadata

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1643,9 +1643,9 @@ class Pack(object):
         self._dependencies = self._parse_pack_dependencies(user_metadata.get('dependencies', {}), dependencies_data)
 
         # ===== Pack Private Attributes =====
-        self._is_private_pack = user_metadata.get('partnerId', False)
-        self._is_premium = True if self._is_private_pack else False
-        self._preview_only = True if self._is_private_pack else False
+        self._is_private_pack = 'partnerId' in user_metadata
+        self._is_premium = self._is_private_pack
+        self._preview_only = get_valid_bool(user_metadata.get('previewOnly', False))
         self._price = convert_price(pack_id=self._pack_name, price_value_input=user_metadata.get('price'))
         if self._is_private_pack:
             self._vendor_id = user_metadata.get('vendorId', "")


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold

## Description
Currently, packs are being shown as "Coming Soon" due to a small bug in pack metadata parsing, specifically the handling of the `previewOnly` metadata label.
This issue is now fixed.