### PR TITLE
MISP v2: fixed an issue with max attribute parameter after upgrade

### DIFF
--- a/Packs/MISP/Integrations/MISP_V2/MISP_V2.py
+++ b/Packs/MISP/Integrations/MISP_V2/MISP_V2.py
@@ -28,19 +28,21 @@ requests.packages.urllib3.disable_warnings()
 warnings.warn = warn
 
 ''' GLOBALS/PARAMS '''
-MISP_KEY = demisto.params().get('api_key')
-MISP_URL = demisto.params().get('url')
-USE_SSL = not demisto.params().get('insecure')
+PARAMS = demisto.params()
+MISP_KEY = PARAMS.get('api_key')
+MISP_URL = PARAMS.get('url')
+USE_SSL = not PARAMS.get('insecure')
 proxies = handle_proxy()  # type: ignore
 MISP_PATH = 'MISP.Event(obj.ID === val.ID)'
 MISP = ExpandedPyMISP(url=MISP_URL, key=MISP_KEY, ssl=USE_SSL, proxies=proxies)  # type: ExpandedPyMISP
-DATA_KEYS_TO_SAVE = demisto.params().get('context_select', [])
+DATA_KEYS_TO_SAVE = PARAMS.get('context_select', [])
 try:
-    MAX_ATTRIBUTES = int(demisto.params().get('attributes_limit', 1000))
+    MAX_ATTRIBUTES = int(PARAMS.get('attributes_limit') or 1000)
 except ValueError:
     return_error("Maximum attributes in event must be a positive number")
-if MAX_ATTRIBUTES < 1:
-    return_error("Maximum attributes in event must be a positive number")
+else:
+    if MAX_ATTRIBUTES < 1:
+        return_error("Maximum attributes in event must be a positive number")
 
 """
 dict format :

--- a/Packs/MISP/ReleaseNotes/1_0_7.md
+++ b/Packs/MISP/ReleaseNotes/1_0_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MISP v2
+- Fixed an issue where the integration failed on a TypeError.

--- a/Packs/MISP/pack_metadata.json
+++ b/Packs/MISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP",
     "description": "Malware information sharing platform and threat sharing.",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/36547

## Description
fixed an issue where the max_attribute conversion to int failed after upgrading the pack from version 1.0.4 (instance was configured on a version without that parameter).
a workaround for the bug is to open the instance configuration and save it.
