### PR TITLE
Allowing server scripts to continue when one of the step fails

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -84,6 +84,7 @@ create-instances:
   stage: run-instances
   dependencies:
     - create-instances
+  allow_failure: true
   script:
     - *download_demisto_conf
     - export TEMP=$(cat $ARTIFACTS_FOLDER/filter_envs.json | jq ".\"$INSTANCE_ROLE\"")


### PR DESCRIPTION
When test playbook part fails (in nightly for example), the gitlab job stops execution and skips the instance destruction, and slack notification.