### PR TITLE
Supporting handling the clean up of the build

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -63,16 +63,17 @@ create-instances:
       if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
         echo "Skipping - not running in INSTANCE_TESTS build"
       else
-        echo "====== Uploading artifacts to GCP ======"
-        ./Tests/scripts/upload_artifacts.sh
+        echo "====== Creating instances ======"
+        [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=300
+        python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile "$ARTIFACTS_FOLDER/env_results.json"
       fi
+  after_script:
     - |
       if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
         echo "Skipping - not running in INSTANCE_TESTS build"
       else
-        echo "====== Creating instances ======"
-        [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=300
-        python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile "$ARTIFACTS_FOLDER/env_results.json"
+        echo "====== Uploading artifacts to GCP ======"
+        ./Tests/scripts/upload_artifacts.sh
       fi
 
 
@@ -84,7 +85,6 @@ create-instances:
   stage: run-instances
   dependencies:
     - create-instances
-  allow_failure: true
   script:
     - *download_demisto_conf
     - export TEMP=$(cat $ARTIFACTS_FOLDER/filter_envs.json | jq ".\"$INSTANCE_ROLE\"")
@@ -98,8 +98,12 @@ create-instances:
     - chmod 700 ~/.ssh/config
     - Tests/scripts/open_ssh_tunnel.sh
     - python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
-    - ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE"
+    - ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE" || EXIT_CODE=$?
     - ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE"
+    - exit $EXIT_CODE
+  after_script:
+    - source ./venv/bin/activate
+    - source $BASH_ENV
     - |
       if [ -f ./Tests/failed_tests.txt ]; then
         cp ./Tests/failed_tests.txt $ARTIFACTS_FOLDER/failed_tests.txt
@@ -109,9 +113,6 @@ create-instances:
         ./Tests/scripts/slack_notifier.sh 'test_playbooks' $ARTIFACTS_FOLDER/env_results.json
       fi
     - python3 ./Tests/scripts/destroy_instances.py $ARTIFACTS_FOLDER $ARTIFACTS_FOLDER/env_results.json "$INSTANCE_ROLE" "$TIME_TO_LIVE"
-    - export PSWD=$(jq .serverLogsZipPassword < $(cat secret_conf_path) | cut -d \" -f 2)
-    - zip -P $PSWD -j $ARTIFACTS_FOLDER/Logs.zip $ARTIFACTS_FOLDER/server*.log || ((($? > 0)) && echo "Didn’t find any server logs, skipping this stage" && exit 0)
-    - rm -f $ARTIFACTS_FOLDER/server*.log
 
 
 server_5_0:


### PR DESCRIPTION
## In this PR:
- Adding `after_script` to the flow to allow the instances jobs to destroy them.
- Moving some steps to that `after_script`
- Removing the password from the server logs as it's not necessary now that the build is isolated. 