### PR TITLE
Add section_start and section_end helper functions

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -12,8 +12,10 @@
       - .npm/
     policy: pull
 
+
 .default-before_script:
   before_script:
+    - source .gitlab/helper_functions.sh
     - echo "=== Running before script ==="
     - git checkout $CI_COMMIT_BRANCH
     - git config diff.renameLimit 6000
@@ -25,43 +27,49 @@
     - source .circleci/content_release_vars.sh
     - export PATH="${PWD}/node_modules/.bin:${PATH}"
 
-    - echo "=== Creating new clean logs folder ==="
+    - section_start "Creating new clean logs folder" --collapsed
     - rm -rf $ARTIFACTS_FOLDER/logs
     - mkdir -p $ARTIFACTS_FOLDER/logs
+    - section_end "Creating new clean logs folder"
 
-    - echo "=== Granting execute permissions on files ==="
+    - section_start "Granting execute permissions on files" --collapsed
     - chmod +x ./Tests/scripts/*
     - chmod +x ./Tests/Marketplace/*
+    - section_end "Granting execute permissions on files"
 
-    - echo "=== Installing Virtualenv ==="
+    - section_start "Installing Virtualenv" --collapsed
     - |
-     if [ -f "./venv/bin/activate" ]; then
-       echo "found venv"
-     else
-      echo "installing venv"
-      NO_HOOKS=1 SETUP_PY2=yes .hooks/bootstrap >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
-     fi
-     venv/bin/pip3 install -r .circleci/build-requirements.txt >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
-     source ./venv/bin/activate
+      if [ -f "./venv/bin/activate" ]; then
+        echo "found venv"
+      else
+        echo "installing venv"
+        NO_HOOKS=1 SETUP_PY2=yes .hooks/bootstrap >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
+      fi
+    - venv/bin/pip3 install -r .circleci/build-requirements.txt >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
+    - source ./venv/bin/activate
     - |
       if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
         echo "Installing SDK from master branch" | tee --append $ARTIFACTS_FOLDER/logs/installations.log
         pip3 install git+https://github.com/demisto/demisto-sdk@master >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
       fi
-    - echo "========= Installing SSH keys ========"
+    - section_end "Installing Virtualenv"
+
+    - section_start "Installing SSH keys" --collapsed
     - eval $(ssh-agent -s)
     - chmod 400 $OREGON_CI_KEY
     - ssh-add $OREGON_CI_KEY
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
+    - section_end "Installing SSH keys"
 
-    - echo "========== Build Parameters =========="
+    - section_start "Build Parameters"
     - set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^GCS_MARKET_BUCKET=|^SLACK_CHANNEL="
     - python --version
     - python3 --version
     - node --version
     - npm --version
     - demisto-sdk --version
+    - section_end "Build Parameters"
 
 
 .default-job-settings:

--- a/.gitlab/helper_functions.sh
+++ b/.gitlab/helper_functions.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+DARK_CYAN="\e[38;2;1;189;189m"
+CLEAR="\e[0m"
+SECTION_START="\e[0Ksection_start:$(date +%s):section_id\r\e[0K${DARK_CYAN}section_header${CLEAR}"
+SECTION_END="\e[0Ksection_end:$(date +%s):section_id\r\e[0K"
+
+section_start() {
+    local section_header section_id start
+    start="$SECTION_START"
+    if [[ "$#" -eq 1 ]]; then
+        section_header="$1"
+        section_id="$(echo "$1" | tr -c '[:alnum:]\n\r' '_')"
+    elif [[ "$#" -eq 2 ]]; then
+        if [[ "$2" =~ -{0,2}collapsed ]]; then
+            start="${start/section_id/section_id[collapsed=true]}"
+            section_header="$1"
+            section_id="$(echo "$1" | tr -c '[:alnum:]\n\r' '_')"
+        else
+            section_header="$2"
+            section_id="$1"
+        fi
+    elif [[ "$#" -eq 3 && "$3" =~ /^-{0,2}collapsed$/ ]]; then
+        start="${start/section_id/section_id[collapsed=true]}"
+        section_header="$2"
+        section_id="$1"
+    else
+        echo "section_start should be called with 1-3 args but it was called with $#"
+        echo "acceptable usages:"
+        echo "    1. section_start \"<section-start-id>\" \"<section-header>\""
+        echo "    2. section_start \"<section-header>\""
+        echo "    3. section_start \"<section-start-id>\" \"<section-header>\" --collapse"
+        echo "    4. section_start \"<section-header>\" --collapse"
+        echo "where <section-start-id> is only alphanumeric characters and underscore and"
+        echo "--collapse indicates that you would like those log steps to be collapsed in the job log output by default"
+        exit 9
+    fi
+    start="$(echo "$start" | sed -e "s/section_id/$section_id/" -e "s/section_header/$section_header/")"
+    echo -e "$start"
+}
+
+section_end() {
+    local section_id end
+    if [[ "$#" -eq 1 ]]; then
+        section_id="$(echo "$1" | tr -c '[:alnum:]\n\r' '_')"
+    else
+        echo "section_end should be called with 1 arg but it was called with $#"
+        echo "acceptable usage:"
+        echo "    1. section_end \"<section-start-id>\""
+        echo "    2. section_start \"<section-header>\""
+        echo "where <section-start-id> or <section-header> is that of the section this marks the end of"
+        exit 9
+    fi
+    end="${SECTION_END/section_id/$section_id}"
+    echo -e "$end"
+}


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Enables the use of `section_start` and `section_end` bash functions for collapsible sections in GitLab job logs as detailed [here](https://docs.gitlab.com/ee/ci/jobs/index.html#custom-collapsible-sections).

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/117808988-43de9100-b266-11eb-8f47-ffabca66e7ce.png)

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
