### PR TITLE
Adding RC process ID + PID fields

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -239,6 +239,8 @@ def process_timeline(detection_id):
                 'SHA256': image['sha256'],
                 'StartTime': get_time_str(get_time_obj(process['started_at'])),
                 'CommandLine': process['command_line']['attributes']['command_line'],
+                'ID': process['native_id'],
+                'PID': process['operating_system_pid'],
             })
 
         elif activity['attributes']['type'] == 'network_connection_activity_occurred':

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
@@ -406,6 +406,12 @@ script:
     - contextPath: Process.CommandLine
       description: Process command line
       type: string
+    - contextPath: Process.ID
+      description: ID of process in EDR solution
+      type: string
+    - contextPath: Process.PID
+      description: System PID
+      type: number
     description: Get a detection by unique identifier.
   isfetch: true
   runonce: false


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: N/A

## Description
Adding two return fields to Red Canary function `!redcanary-get-detection`. The fields are:
 - Process.ID
 - Process.PID
 
The the contents of these two fields was already being returned by the API call made by the integration (`native_id` & `operating_system_pid`). They required mapping to use.

Ref RC API: https://ritoplz.my.redcanary.co/openapi/v3/docs/index.html#definition-activity_timelines.ActivityOccurred 

## Screenshots
N/A

## Minimum version of Cortex XSOAR
N/A

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
