### PR TITLE
fixing validation

### DIFF
--- a/Tests/scripts/validate_premium_packs.py
+++ b/Tests/scripts/validate_premium_packs.py
@@ -193,6 +193,8 @@ def verify_server_paid_packs_by_index(server_paid_packs: list, index_data_packs:
                                                             outer_packs_name="index packs")
 
     logging.info("Verifying all premium index packs are in the server")
+    # Removing HelloWorldPremium since it currently isn't on the page of premium packs, by design
+    index_data_packs.remove('HelloWorldPremium')
     all_index_packs_in_server = verify_outer_contains_inner(inner_packs=index_data_packs,
                                                             outer_packs=server_paid_packs,
                                                             inner_packs_name="index packs",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Not validating that `HelloWorldPremium` is on the premium server packs page. 
It isn't there, by design (for now) since we reduced its price to 0.