### PR TITLE
Fix Typo in should_lint_all.sh

### DIFF
--- a/Tests/scripts/should_lint_all.sh
+++ b/Tests/scripts/should_lint_all.sh
@@ -34,7 +34,7 @@ elif [ "$CI_COMMIT_BRANCH" == "master" ]; then
         fi
     fi
 else
-    DIFF_COMPARE=origin/master...${$CI_COMMIT_BRANCH}
+    DIFF_COMPARE=origin/master...${CI_COMMIT_BRANCH}
 fi
 
 # test if any of the lint libraries has been updated


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://app.circleci.com/pipelines/github/demisto/content/85585/workflows/1d119463-a1a5-4c85-a359-abfbabfce1d2/jobs/353678/parallel-runs/0/steps/0-108

## Description
Our CircleCI builds would not compute the diff correctly because there was a typo. Therefore we would get an error like the following.
```
./Tests/scripts/should_lint_all.sh: line 37: origin/master...${$CI_COMMIT_BRANCH}: bad substitution
fatal: bad revision ''
fatal: bad revision ''
fatal: bad revision ''
fatal: bad revision ''
fatal: bad revision ''
```

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A 
