### PR TITLE
Email-Indicator: Ignore known file extensions 

### DIFF
--- a/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail.py
@@ -1,0 +1,30 @@
+import demistomock as demisto
+from CommonServerPython import *  # lgtm [py/polluting-import]
+
+import re
+
+VALID_EXTENSION = '(?!\\S*\\.(?:jpg|png|gif|bmp|txt|pdf|xls|xlsx|doc|docx)(?:[\\s\\n\\r]|$))'
+VALID_ADDRESS_FORMAT = '[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}'
+VALID_ADDRESS_REGEX = VALID_EXTENSION + VALID_ADDRESS_FORMAT
+
+
+def verify_is_email(email_address) -> bool:
+    try:
+        return re.match(VALID_ADDRESS_REGEX, email_address, re.IGNORECASE) is not None
+    except Exception:
+        return False
+
+
+def main():
+    emails = argToList(demisto.args().get('input'))
+
+    list_results = [email_address for email_address in emails if verify_is_email(email_address)]
+
+    if list_results:
+        demisto.results(list_results)
+    else:
+        demisto.results('')
+
+
+if __name__ in ('__main__', 'builtin', 'builtins'):
+    main()

--- a/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail.yml
+++ b/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail.yml
@@ -1,0 +1,22 @@
+commonfields:
+  id: ExtractEmail
+  version: 5
+name: ExtractEmail
+script: '-'
+type: python
+tags:
+- indicator-format
+comment: Verifies that an email address is valid and only returns the address if it is valid..
+enabled: true
+args:
+- name: input
+  default: true
+  description: The Emails to process.
+  isArray: true
+scripttarget: 0
+subtype: python3
+runonce: false
+dockerimage: demisto/python3:3.9.4.18682
+fromversion: 5.5.0
+tests:
+  - ExtractEmail-Test

--- a/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmail/ExtractEmail_test.py
@@ -1,0 +1,49 @@
+from ExtractEmail import verify_is_email, main
+import pytest
+import demistomock as demisto
+
+# Bitcoin address, expected_output
+testdata = [
+    ('Xsoar@test.org.de', True),
+    ('Xsoar@test.uk', True),
+    ('Xsoar@test.uk.Png', False),
+    ('Xsoar@test.pNG', False),
+    ('Xsoar@test.new.Docx', False),
+    ('entry@id.com.GIF', False),
+    ('Xsoar@test.com', True),
+    ('Xsoar@test.BmP', False),
+    ('Xsoa r@ test.BmP', False),
+]
+
+
+@pytest.mark.parametrize('address,valid', testdata)
+def test_verify_is_email(address, valid):
+    """Verifies that email address that was auto-extracted via the Email regex is valid.
+    Given
+    - address.
+    When
+    - When there is an address that looks like a bitcoin address.
+    Then
+    - Checks if it's a bitcoin address or not
+    """
+    assert verify_is_email(address) is valid
+
+
+ARGS = {
+    'input': 'Xsoar@test.org.de, Xsoar@test.uk, Xsoar@xsoar.xlsx,Xsoar@xsoar.co.il,Xsoar@xsoar.bla.test'}
+EXPECTED_RESULTS = ['Xsoar@test.org.de', 'Xsoar@test.uk', 'Xsoar@xsoar.co.il', 'Xsoar@xsoar.bla.test']
+
+
+def test_main(mocker):
+    """Verifies that all valid addresses get returned.
+       Given
+       - addresses.
+       When
+       - When there are multiple addresses that looks like a bitcoin address.
+       Then
+       - Return all valid addresses
+       """
+    mocker.patch.object(demisto, 'args', return_value=ARGS)
+    mocker.patch.object(demisto, 'results')
+    main()
+    assert EXPECTED_RESULTS == demisto.results.call_args[0][0]

--- a/Packs/CommonScripts/Scripts/ExtractEmail/README.md
+++ b/Packs/CommonScripts/Scripts/ExtractEmail/README.md
@@ -1,0 +1,26 @@
+Verifies that an email address is valid and only returns the address if it is valid.
+
+## Script Data
+---
+
+| **Name** | **Description** |
+| --- | --- |
+| Script Type | python3 |
+| Tags | indicator-format |
+| Demisto Version | 5.5.0 |
+
+## Used In
+---
+This script is used in the following playbooks and scripts.
+* Extract Indicators - Generic
+
+## Inputs
+---
+
+| **Argument Name** | **Description** |
+| --- | --- |
+| input | The Emails to process. |
+
+## Outputs
+---
+There are no outputs for this script.

--- a/Packs/CommonScripts/TestPlaybooks/playbook-ExtractEmail-Test.yml
+++ b/Packs/CommonScripts/TestPlaybooks/playbook-ExtractEmail-Test.yml
@@ -1,0 +1,295 @@
+id: ExtractEmail-Test
+version: -1
+name: ExtractEmail-Test
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 714157a4-ac77-4c5a-8f2e-ca308ac57d1f
+    type: start
+    task:
+      id: 714157a4-ac77-4c5a-8f2e-ca308ac57d1f
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+      description: ''
+    nexttasks:
+      '#none#':
+      - "1"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "1":
+    id: "1"
+    taskid: 55f37b4b-0b10-4e76-89f4-c5172a8762a7
+    type: regular
+    task:
+      id: 55f37b4b-0b10-4e76-89f4-c5172a8762a7
+      version: -1
+      name: DeleteContext
+      description: Delete field from context
+      scriptName: DeleteContext
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "5"
+    scriptarguments:
+      all:
+        simple: "yes"
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "4":
+    id: "4"
+    taskid: 49a3eb12-b277-477a-84e6-39b878c6fe83
+    type: title
+    task:
+      id: 49a3eb12-b277-477a-84e6-39b878c6fe83
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+      description: ''
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "5":
+    id: "5"
+    taskid: b0f2b0ee-bd7c-4d80-8e90-5956f2fd645c
+    type: regular
+    task:
+      id: b0f2b0ee-bd7c-4d80-8e90-5956f2fd645c
+      version: -1
+      name: ExtractEmail
+      description: Verifies that an email address is valid and only returns the address
+        if so.
+      scriptName: ExtractEmail
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "7"
+      - "8"
+    scriptarguments:
+      input:
+        simple: Xsoar@xsoar.com, xsoar@test.net.bla
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "6":
+    id: "6"
+    taskid: c99055c4-1d15-466c-8d56-bcabec710ac2
+    type: regular
+    task:
+      id: c99055c4-1d15-466c-8d56-bcabec710ac2
+      version: -1
+      name: Verify only  Xsoar@Xsoar.com was extracted
+      description: Verify given entry contains a string
+      scriptName: VerifyHumanReadableContains
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      humanReadableEntryId:
+        complex:
+          root: lastCompletedTaskEntries
+          transformers:
+          - operator: atIndex
+            args:
+              index:
+                value:
+                  simple: "0"
+      substring:
+        simple: ' Xsoar@Xsoar.com'
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 895
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "7":
+    id: "7"
+    taskid: 84e63a8c-ac14-4664-898c-f772625bb9bd
+    type: regular
+    task:
+      id: 84e63a8c-ac14-4664-898c-f772625bb9bd
+      version: -1
+      name: Verify Xsoar@xsoar.com was extracted
+      description: Verify given entry contains a string
+      scriptName: VerifyHumanReadableContains
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "9"
+    scriptarguments:
+      humanReadableEntryId:
+        complex:
+          root: lastCompletedTaskEntries
+          transformers:
+          - operator: atIndex
+            args:
+              index:
+                value:
+                  simple: "0"
+      substring:
+        simple: Xsoar@xsoar.com
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "8":
+    id: "8"
+    taskid: e49b53a6-986e-4e50-8e95-9d92fa38b554
+    type: regular
+    task:
+      id: e49b53a6-986e-4e50-8e95-9d92fa38b554
+      version: -1
+      name: Verify xsoar@test.net.bla was extracted
+      description: Verify given entry contains a string
+      scriptName: VerifyHumanReadableContains
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "9"
+    scriptarguments:
+      humanReadableEntryId:
+        complex:
+          root: lastCompletedTaskEntries
+          transformers:
+          - operator: atIndex
+            args:
+              index:
+                value:
+                  simple: "1"
+      substring:
+        simple: xsoar@test.net.bla
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+  "9":
+    id: "9"
+    taskid: 17fbdf9e-6297-43fa-87a7-fd8c08ce3cd5
+    type: regular
+    task:
+      id: 17fbdf9e-6297-43fa-87a7-fd8c08ce3cd5
+      version: -1
+      name: ExtractEmail-Invalid
+      description: Verifies that an email address is valid and only returns the address
+        if so.
+      scriptName: ExtractEmail
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
+    scriptarguments:
+      input:
+        simple: Xsoar@Xsoar.png, Xsoar@Xsoar.BMP, Xsoar@Xsoar.com
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 1085,
+        "width": 810,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []
+fromversion: 5.5.0
+description: ''

--- a/Packs/CommonScripts/TestPlaybooks/playbook-ExtractEmail-Test.yml
+++ b/Packs/CommonScripts/TestPlaybooks/playbook-ExtractEmail-Test.yml
@@ -128,7 +128,7 @@ tasks:
     task:
       id: c99055c4-1d15-466c-8d56-bcabec710ac2
       version: -1
-      name: Verify only  Xsoar@Xsoar.com was extracted
+      name: Verify only Xsoar@Xsoar.com was extracted
       description: Verify given entry contains a string
       scriptName: VerifyHumanReadableContains
       type: regular
@@ -148,7 +148,7 @@ tasks:
                 value:
                   simple: "0"
       substring:
-        simple: ' Xsoar@Xsoar.com'
+        simple: 'Xsoar@Xsoar.com'
     separatecontext: false
     view: |-
       {

--- a/Packs/CommonTypes/IndicatorTypes/reputation-email.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-email.json
@@ -21,7 +21,7 @@
   "file": false,
   "updateAfter": 0,
   "mergeContext": false,
-  "formatScript": "",
+  "formatScript": "ExtractEmail",
   "contextPath": "Account.Email(val.Address \u0026\u0026 val.Address === obj.Address)",
   "contextValue": "Address",
   "excludedBrands": [],


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: link to the issue

## Description
Added formatting script for Email indicator extraction to avoid known file extractions from being considered as a possible domain.
Added tpb
Set the new script as the formatting script in reputation-email.json

## Screenshots
extractIndicator:
<img width="992" alt="Screen Shot 2021-05-13 at 20 22 39" src="https://user-images.githubusercontent.com/21142167/118163243-720cce00-b42a-11eb-8553-c46ca2b418f9.png">

## Minimum version of Cortex XSOAR
- [X] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [X] Tests
- [X] Documentation 

