### PR TITLE
EmailAskUserResponse  - consider file entry as valid entry type to parse

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_3_47.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_3_47.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### EmailAskUserResponse
+- Fixed an issue where the script failed to parse the response in case the email had an image embedded in it.

--- a/Packs/CommonScripts/Scripts/script-EmailAskUserResponse.yml
+++ b/Packs/CommonScripts/Scripts/script-EmailAskUserResponse.yml
@@ -6,7 +6,7 @@ script: >
   var res = executeCommand("getEntry", {"id":args.responseEntryId});
 
 
-  if (res[0].Type==entryTypes.note) {
+  if (res[0].Type==entryTypes.note || res[0].Type==entryTypes.file) {
       text = res[0].Contents;
       text = text.replace(/<br\/?>/gi,'\n')
                   .replace(/\n/g,'__NL__')

--- a/Packs/CommonScripts/Scripts/script-EmailAskUserResponse.yml
+++ b/Packs/CommonScripts/Scripts/script-EmailAskUserResponse.yml
@@ -32,3 +32,5 @@ args:
   description: Entry ID where EmailAskUser will complete when user replies
 scripttarget: 0
 fromversion: 5.0.0
+tests:
+  - No test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.3.46",
+    "currentVersion": "1.3.47",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/37030

## Description
in case image is embedded in the email, it will return as file entry from the server but will still contain the answer, so it is ok to consider it as valid entry type to parse

## Does it break backward compatibility?
   - [x] No
