### PR TITLE
fixing private packs legacy

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1652,8 +1652,11 @@ class Pack(object):
             self._partner_id = user_metadata.get('partnerId', "")
             self._partner_name = user_metadata.get('partnerName', "")
             self._content_commit_hash = user_metadata.get('contentCommitHash', "")
+            # Currently all content packs are legacy.
+            # Since premium packs cannot be legacy, we directly set this attribute to false.
+            self._legacy = False
 
-        # ===== Pack Statistics Attributes =====
+            # ===== Pack Statistics Attributes =====
         if not self._is_private_pack and statistics_handler:  # Public Content case
             self._pack_statistics_handler = mp_statistics.PackStatisticsHandler(
                 self._pack_name, statistics_handler.packs_statistics_df, statistics_handler.packs_download_count_desc,

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1656,7 +1656,7 @@ class Pack(object):
             # Since premium packs cannot be legacy, we directly set this attribute to false.
             self._legacy = False
 
-            # ===== Pack Statistics Attributes =====
+        # ===== Pack Statistics Attributes =====
         if not self._is_private_pack and statistics_handler:  # Public Content case
             self._pack_statistics_handler = mp_statistics.PackStatisticsHandler(
                 self._pack_name, statistics_handler.packs_statistics_df, statistics_handler.packs_download_count_desc,


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37026

## Description
All packs are essentially marked as `legacy: true` at the moment.
After this change, premium packs will be excluded from that logic, and will be `legacy: false`.