### PR TITLE
Microsoft Teams - improve error handling in the channel mirror loop

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1303,8 +1303,9 @@ def channel_mirror_loop():
     """
     while True:
         found_channel_to_mirror: bool = False
-        integration_context = get_integration_context()
+        integration_context = {}
         try:
+            integration_context = get_integration_context()
             teams: list = json.loads(integration_context.get('teams', '[]'))
             for team in teams:
                 mirrored_channels = team.get('mirrored_channels', [])

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -343,7 +343,7 @@ script:
     - contextPath: MicrosoftTeams.CreateMeeting.participantDisplayName
       description: The display name of the participants.
       type: String
-  dockerimage: demisto/teams:1.0.0.19066
+  dockerimage: demisto/teams:1.0.0.19340
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Microsoft Teams
 - Improved handling of failure in deserializing objects from the integration cache.
-- - Updated the Docker image to: *demisto/teams:1.0.0.19340*.
+- Updated the Docker image to: *demisto/teams:1.0.0.19340*.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Microsoft Teams
 - Improved handling of failure in deserializing objects from the integration cache.
+- - Updated the Docker image to: *demisto/teams:1.0.0.19340*.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_1_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Teams
+- Improved handling of failure in deserializing objects from the integration cache.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/36924

## Description
move the integration context get call to the try-except block to better handle failures in the call

## Does it break backward compatibility?
   - [x] No
