### PR TITLE
Archer v2 - increase last run by 1 sec if no records were fetched

### DIFF
--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.py
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.py
@@ -1189,6 +1189,10 @@ def fetch_incidents(
             demisto.debug(
                 f'The newly fetched incident is older than last fetch. {incident_created_time=} {next_fetch=}'
             )
+    if next_fetch == last_fetch_time:
+        # if no incidents were fetched we increase the next fetch by 1 second to avoid a case where we might hit the
+        # the fetch limit and the next fetch will stuck and the next fetch time wont will not advance
+        next_fetch += timedelta(seconds=1)
     demisto.debug(f'Going out fetch incidents with {next_fetch=}, {len(incidents)=}')
     return incidents, next_fetch
 

--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.yml
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.yml
@@ -566,7 +566,7 @@ script:
     description: prints Archer's integration cache.
     execution: false
     name: archer-print-cache
-  dockerimage: demisto/python3:3.9.4.18682
+  dockerimage: demisto/python3:3.9.5.20070
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2_test.py
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2_test.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from CommonServerPython import DemistoException
@@ -576,7 +576,8 @@ class TestArcherV2:
         )
         mocker.patch.object(client, 'search_records', return_value=([record], {}))
         incidents, next_fetch = fetch_incidents(client, params, last_fetch, '305')
-        assert last_fetch == next_fetch
+        assert last_fetch != next_fetch
+        assert next_fetch == last_fetch + timedelta(seconds=1)
         assert not incidents, 'Should not get new incidents.'
 
     def test_fetch_got_exact_same_time(self, mocker):
@@ -605,7 +606,8 @@ class TestArcherV2:
         )
         mocker.patch.object(client, 'search_records', return_value=([record], {}))
         incidents, next_fetch = fetch_incidents(client, params, last_fetch, '305')
-        assert last_fetch == next_fetch
+        assert last_fetch != next_fetch
+        assert next_fetch == last_fetch + timedelta(seconds=1)
         assert not incidents, 'Should not get new incidents.'
 
     def test_same_record_returned_in_two_fetches(self, mocker):

--- a/Packs/ArcherRSA/ReleaseNotes/1_1_16.md
+++ b/Packs/ArcherRSA/ReleaseNotes/1_1_16.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### RSA Archer v2
+- Fixed an issue where in some cases the fetch incidents flow would get stuck and not fetch new incidents.
+- Updated the Docker image to: *demisto/python3:3.9.5.20070*.
+

--- a/Packs/ArcherRSA/pack_metadata.json
+++ b/Packs/ArcherRSA/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "RSA Archer",
     "description": "The RSA Archer GRC Platform provides a common foundation for managing policies, controls, risks, assessments and deficiencies across lines of business.",
     "support": "xsoar",
-    "currentVersion": "1.1.15",
+    "currentVersion": "1.1.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress

## Related Issues
fixes: https://github.com/demisto/etc/issues/37013

## Description
if no incidents were fetched we increase the next fetch by 1 second to avoid a case where we might hit the the fetch limit and the next fetch will stuck and the next fetch time wont will not advance

## Does it break backward compatibility?
   - [x] No
