### PR TITLE
Upgrade pyspellchecker

### DIFF
--- a/.circleci/build-requirements.txt
+++ b/.circleci/build-requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.18.199
 slackclient==2.9.3
-pyspellchecker==0.5.2
+pyspellchecker==0.6.2
 ansible==2.8.6
 ansible-runner==1.4.2
 rsa==3.4.2


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/jobs/5650895

## Description
GitLab containers are using python 3.9.1 whereas the CircleCI containers are using python 3.8.5. We had set `pyspellchecker==0.5.2` in `.circleci/build-requirements.txt` to maintain compatibility with python2 but we only install these dependencies for python3 in our build so it should be fine to upgrade to the latest version. Running the `spell_checker.py` with python 3.9.1 with `pyspellchecker==0.5.2` results in an error since python 3.9 is not supported by that `pyspellchecker` version. Upgrading to the latest version resolves the issue. Additionally, there are dependency conflicts with using `pyspellchecker==0.5.2` and the `demisto-sdk` which requires a version greater than 0.6.0, as shown in the attached screenshot.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/118955662-922b1880-b967-11eb-8275-56a35a315ceb.png)

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
