### PR TITLE
urljoin enhancments

### DIFF
--- a/Packs/Base/ReleaseNotes/1_10_28.md
+++ b/Packs/Base/ReleaseNotes/1_10_28.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+Updated the **urljoin** function to support multiple arguments.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -14,6 +14,7 @@ import socket
 import sys
 import time
 import traceback
+from functools import reduce
 from random import randint
 import xml.etree.cElementTree as ET
 from collections import OrderedDict
@@ -544,10 +545,8 @@ def skip_cert_verification():
         if k in os.environ:
             del os.environ[k]
 
-
-def urljoin(url, suffix=""):
-    """
-        Will join url and its suffix
+def urljoin(*args, **kwargs):
+    """Gets arguments to join as url
 
         Example:
         "https://google.com/", "/"   => "https://google.com/"
@@ -556,24 +555,18 @@ def urljoin(url, suffix=""):
         "https://google.com", "/api"  => "https://google.com/api"
         "https://google.com/", "api"  => "https://google.com/api"
         "https://google.com/", "/api" => "https://google.com/api"
+        "https://google.com/", "/api", "v1" => "https://google.com/api/v1"
 
-        :type url: ``string``
-        :param url: URL string (required)
-
-        :type suffix: ``string``
-        :param suffix: the second part of the url
+        :type args: ``string``
+        :param args: URL string (required)
 
         :rtype: ``string``
         :return: Full joined url
     """
-    if url[-1:] != "/":
-        url = url + "/"
-
-    if suffix.startswith("/"):
-        suffix = suffix[1:]
-        return url + suffix
-
-    return url + suffix
+    if kwargs.get('suffix'):  # Preserves BC with old urljoin function signature urljoin(url, suffix)
+        args = list(args)
+        args.append(kwargs['suffix'])
+    return reduce(lambda a, b: str(a).rstrip('/') + '/' + str(b).lstrip('/'), args).rstrip("/")
 
 
 def positiveUrl(entry):

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -17,7 +17,7 @@ from CommonServerPython import xml2json, json2xml, entryTypes, formats, tableToM
     argToBoolean, ipv4Regex, ipv4cidrRegex, ipv6cidrRegex, ipv6Regex, batch, FeedIndicatorType, \
     encode_string_results, safe_load_json, remove_empty_elements, aws_table_to_markdown, is_demisto_version_ge, \
     appendContext, auto_detect_indicator_type, handle_proxy, get_demisto_version_as_str, get_x_content_info_headers, \
-    url_to_clickable_markdown, WarningsHandler, DemistoException
+    url_to_clickable_markdown, WarningsHandler, DemistoException, urljoin
 
 try:
     from StringIO import StringIO
@@ -2476,6 +2476,18 @@ def test_encode_string_results():
     assert encode_string_results(s2) == res
     not_string = [1, 2, 3]
     assert not_string == encode_string_results(not_string)
+
+
+@pytest.mark.parametrize('args, result', [
+    (['https://google.com/', '/'], 'https://google.com'),
+    (['https://google.com', '/'], 'https://google.com'),
+    (['https://google.com', 'api'], 'https://google.com/api'),
+    (['https://google.com', '/api'], 'https://google.com/api'),
+    (['https://google.com', 'api/'], 'https://google.com/api'),
+    (['https://google.com', '/api', 'v1/', 'a'], 'https://google.com/api/v1/a')
+])
+def test_urljoin(args, result):
+    assert urljoin(*args) == result
 
 
 class TestReturnOutputs:

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.10.27",
+    "currentVersion": "1.10.28",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
urljoin will accept unlimited args.
it's the same function used in the demisto-sdk

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
