### PR TITLE
Remove DEMISTO_SDK_NIGHTLY env var

### DIFF
--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -4,12 +4,14 @@
 
 
 .upload-entities-to-cortex-xsoar: &upload-entities-to-cortex-xsoar
+  - section_start "Upload Entities to Cortex XSOAR" --collapsed
   - demisto-sdk upload -i Packs/HelloWorld/Integrations/ --insecure
   - demisto-sdk upload -i Packs/HelloWorld/TestPlaybooks/playbook-HelloWorld-Test.yml --insecure
   - demisto-sdk upload -i Packs/HelloWorld/Layouts/layoutscontainer-Hello_World_Test_Layout.json --insecure
   - demisto-sdk upload -i Packs/HelloWorld/IncidentFields/incidentfield-Hello_World_Incident_Test.json --insecure
   - demisto-sdk upload -i Packs/HelloWorld/IncidentTypes/incidenttype-Hello_World_Alert_Test.json --insecure
   - demisto-sdk upload -i Packs/HelloWorld/Classifiers/classifier-mapper-incoming-HelloWorldTest.json --insecure
+  - section_end "Upload Entities to Cortex XSOAR"
 
 
 #### Commented Out Until Resolve Running Docker in Docker #### 
@@ -126,14 +128,14 @@ demisto-sdk-nightly:run-commands-against-instance:
       export DEMISTO_API_KEY=$(cat $SECRET_CONF_PATH | jq -r '.temp_apikey')
       export DEMISTO_BASE_URL="https://localhost:$(cat $ARTIFACTS_FOLDER/env_results.json | jq -r '.[0].TunnelPort')"
       echo "Server URL: $DEMISTO_BASE_URL"
-    - section_start "Unlock HelloWorld Integration and Playbook"
+    - section_start "Unlock HelloWorld Integration and Playbook" --collapsed
     - python3 Tests/sdknightly/unlock_entity.py integration "HelloWorld,HelloWorld Feed"
     - section_end "Unlock HelloWorld Integration and Playbook"
-    - section_start "Create & Upload Entities to XSOAR Instance"
+    - section_start "Create and Upload Entities to XSOAR Instance" --collapsed
     - python3 Tests/sdknightly/create_entities_for_nightly_sdk.py HelloWorld --artifacts-folder $ARTIFACTS_FOLDER
     - *upload-entities-to-cortex-xsoar
-    - section_end "Create & Upload Entities to XSOAR Instance"
-    - section_start "Download Entities from XSOAR Instance"
+    - section_end "Create and Upload Entities to XSOAR Instance"
+    - section_start "Download Entities from XSOAR Instance" --collapsed
     - demisto-sdk download -o Packs/HelloWorld/ -i HelloWorld --insecure -f
     - demisto-sdk download -o Packs/HelloWorld/ -i HelloWorld-Test --insecure -f
     - demisto-sdk download -o Packs/HelloWorld/ -i "Hello World Incident Test" --insecure -f

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -20,7 +20,6 @@
 #     - .run-unittests-and-lint
 #     - .sdk-nightly-schedule-rule
 #   variables:
-#     DEMISTO_SDK_NIGHTLY: "true"
 #     SLACK_TEST_TYPE: "sdk_unittests"
 #     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
 #     SLACK_ONLY_IF: "true"
@@ -31,7 +30,6 @@ demisto-sdk-nightly:run-validations:
     - .run-validations
     - .sdk-nightly-schedule-rule
   variables:
-    DEMISTO_SDK_NIGHTLY: "true"
     SLACK_TEST_TYPE: "sdk_unittests"
     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
     SLACK_ONLY_IF: "true"
@@ -45,7 +43,6 @@ demisto_sdk_nightly:check_idset_dependent_commands:
   inherit:
     variables: true
   variables:
-    DEMISTO_SDK_NIGHTLY: "true"
     IS_NIGHTLY: "false"
     SLACK_TEST_TYPE: "sdk_failed_steps"
     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
@@ -92,7 +89,6 @@ demisto-sdk-nightly:create-instance:
     - .default-job-settings
     - .sdk-nightly-schedule-rule
   variables:
-    DEMISTO_SDK_NIGHTLY: "true"
     IFRA_ENV_TYPE: "Server Master"
   cache:
     policy: pull-push
@@ -110,7 +106,6 @@ demisto-sdk-nightly:run-commands-against-instance:
     - .default-job-settings
     - .sdk-nightly-schedule-rule
   variables:
-    DEMISTO_SDK_NIGHTLY: "true"
     DESTROY_INSTANCES: "true"
     INSTANCE_ROLE: "Server Master"
     SLACK_TEST_TYPE: "sdk_run_against_failed_steps"


### PR DESCRIPTION
## Status
- [x] Ready

## Description
The `dmst-content-team` slack channel received this [message](https://panw-global.slack.com/archives/G011E63JXPB/p1621805925116800) about the `SDK Nightly Unit Tests`. But as you can see in the GitLab [pipeline](https://code.pan.run/xsoar/content/-/pipelines/1170205) it links to, this was actually a scheduled run for the `NIGHTLY` build (check the build parameters section of the [create-instances job](https://code.pan.run/xsoar/content/-/jobs/5705693). I removed the env variable from the `demisto_sdk_nightly` jobs that was causing the `Demisto SDK Nightly`-related jobs to run on every scheduled run (nightly, instance-testing, etc.). Now the `DEMISTO_SDK_NIGHTLY` environment variable isn't set by the `Demisto SDK Nightly`-related job configurations but rather only by it being passed via the scheduled trigger.

## Screenshots
Can see in the attached screenshot that the `Demisto SDK Nightly`-related jobs ran in the pipeline in addition to the `create-instances` and `server_master` jobs that ran for the scheduled nightly (which we don't want to happen).
![image](https://user-images.githubusercontent.com/46294017/119321078-ed6d4b80-bc84-11eb-81f5-b72dd5ff0ca4.png)


## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
