### PR TITLE
Ipinfo v2 base_url is required

### DIFF
--- a/Packs/ipinfo/Integrations/ipinfo_v2/README.md
+++ b/Packs/ipinfo/Integrations/ipinfo_v2/README.md
@@ -10,7 +10,7 @@ Use the IPinfo.io API to get data about an IP address.
        | --- | --- | --- |
    | API Token | The API Key to use for connection | True |
    | Source Reliability | Reliability of the source providing the intelligence data. | True |
-   | Base URL |  | False |
+   | Base URL |  | True |
    | Trust any certificate (not secure) |  | False |
    | Use system proxy settings |  | False |
 

--- a/Packs/ipinfo/Integrations/ipinfo_v2/ipinfo_v2.yml
+++ b/Packs/ipinfo/Integrations/ipinfo_v2/ipinfo_v2.yml
@@ -160,7 +160,7 @@ script:
     - contextPath: DBotScore.Vendor
       description: The vendor used to calculate the score.
       type: String
-  dockerimage: demisto/python3:3.9.4.19537
+  dockerimage: demisto/python3:3.9.5.20070
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/ipinfo/Integrations/ipinfo_v2/ipinfo_v2.yml
+++ b/Packs/ipinfo/Integrations/ipinfo_v2/ipinfo_v2.yml
@@ -27,7 +27,7 @@ configuration:
   defaultvalue: https://ipinfo.io
   display: Base URL
   hidden: false
-  required: false
+  required: true
   type: 0
 - name: insecure
   display: Trust any certificate (not secure)

--- a/Packs/ipinfo/ReleaseNotes/2_0_1.md
+++ b/Packs/ipinfo/ReleaseNotes/2_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### IPinfo v2
+- The `Base URL` parameter is now marked as required.

--- a/Packs/ipinfo/pack_metadata.json
+++ b/Packs/ipinfo/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Ipinfo",
     "description": "Use the ipinfo.io API to get data about an IP address",
     "support": "xsoar",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
the `Base URL` field is now marked as required. 


## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
