### PR TITLE
Qradar V3 adding clarification for the needed version for mirroring 

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -85,7 +85,7 @@ configuration:
   - Mirror Offense
   required: false
   type: 15
-  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done, available from QRadar 7.3.3 Fix Pack 3. For further explanation on how to check your QRadar version, see README.
+  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done, available from QRadar 7.3.3 Fix Pack 3. For further explanation on how to check your QRadar version, see the integration documentation at https://xsoar.pan.dev.
 - additionalinfo: When selected, closing the QRadar offense is mirrored in Cortex
     XSOAR.
   defaultvalue: 'false'

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -85,7 +85,7 @@ configuration:
   - Mirror Offense
   required: false
   type: 15
-  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done, available from QRadar 7.3.3 Fix Pack 3.
+  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done, available from QRadar 7.3.3 Fix Pack 3. For further explanation on how to check your QRadar version, see README.
 - additionalinfo: When selected, closing the QRadar offense is mirrored in Cortex
     XSOAR.
   defaultvalue: 'false'

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -2810,7 +2810,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.9.4.18682
+  dockerimage: demisto/python3:3.9.5.20070
   feed: false
   isfetch: false
   isremotesyncin: true

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -85,7 +85,7 @@ configuration:
   - Mirror Offense
   required: false
   type: 15
-  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done.
+  additionalinfo: How mirroring from QRadar to Cortex XSOAR should be done, available from QRadar 7.3.3 Fix Pack 3.
 - additionalinfo: When selected, closing the QRadar offense is mirrored in Cortex
     XSOAR.
   defaultvalue: 'false'

--- a/Packs/QRadar/ReleaseNotes/2_0_6.md
+++ b/Packs/QRadar/ReleaseNotes/2_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### IBM QRadar v3
+- Added clarification for the needed Qradar version for mirroring.

--- a/Packs/QRadar/ReleaseNotes/2_0_6.md
+++ b/Packs/QRadar/ReleaseNotes/2_0_6.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### IBM QRadar v3
 - Added clarification for the needed Qradar version for mirroring.
+- Updated the Docker image to: *demisto/python3:3.9.5.20070*.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.0.5",
+    "currentVersion": "2.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/37360

## Description
The mirroring depends on a specific param that was added from a specific qradar server version:
https://www.ibm.com/support/pages/release-qradar-v733-fix-pack-3-sfs-733-qradar-qrsiem-20200409085709 

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
