### PR TITLE
Change Slack Notification Scripts for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,6 @@ stages:
 
 
 variables:
-  FORCE_COLOR: 1
-  TERM: "xterm-256color"
   DONT_CACHE_LAST_RESPONSE: "true"
   GCS_MARKET_BUCKET: "marketplace-dist-dev"
   SLACK_CHANNEL: "dmst-content-team"

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -20,7 +20,7 @@
 #     - .run-unittests-and-lint
 #     - .sdk-nightly-schedule-rule
 #   variables:
-#     SLACK_TEST_TYPE: "sdk_unittests"
+#     SLACK_TEST_TYPE: ${CI_JOB_NAME}
 #     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
 #     SLACK_ONLY_IF: "true"
 
@@ -30,7 +30,7 @@ demisto-sdk-nightly:run-validations:
     - .run-validations
     - .sdk-nightly-schedule-rule
   variables:
-    SLACK_TEST_TYPE: "sdk_unittests"
+    SLACK_TEST_TYPE: ${CI_JOB_NAME}
     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
     SLACK_ONLY_IF: "true"
 
@@ -44,7 +44,7 @@ demisto_sdk_nightly:check_idset_dependent_commands:
     variables: true
   variables:
     IS_NIGHTLY: "false"
-    SLACK_TEST_TYPE: "sdk_failed_steps"
+    SLACK_TEST_TYPE: ${CI_JOB_NAME}
     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
     SLACK_ONLY_IF: "true"
   script:
@@ -108,7 +108,7 @@ demisto-sdk-nightly:run-commands-against-instance:
   variables:
     DESTROY_INSTANCES: "true"
     INSTANCE_ROLE: "Server Master"
-    SLACK_TEST_TYPE: "sdk_run_against_failed_steps"
+    SLACK_TEST_TYPE: ${CI_JOB_NAME}
     SLACK_ENV_RESULTS: ${ARTIFACTS_FOLDER}/env_results.json
     SLACK_ONLY_IF: "true"
   needs: ["demisto-sdk-nightly:create-instance"]

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -17,6 +17,7 @@ from demisto_sdk.commands.common.tools import str2bool, run_command
 
 DEMISTO_GREY_ICON = 'https://3xqz5p387rui1hjtdv1up7lw-wpengine.netdna-ssl.com/wp-content/' \
                     'uploads/2018/07/Demisto-Icon-Dark.png'
+ARTIFACTS_FOLDER = os.getenv('ARTIFACTS_FOLDER', './artifacts')
 UNITTESTS_TYPE = 'unittests'
 TEST_PLAYBOOK_TYPE = 'test_playbooks'
 SDK_UNITTESTS_TYPE = 'sdk_unittests'
@@ -25,6 +26,10 @@ SDK_RUN_AGAINST_FAILED_STEPS_TYPE = 'sdk_run_against_failed_steps'
 SDK_BUILD_TITLE = 'SDK Nightly Build'
 SDK_XSOAR_BUILD_TITLE = 'Demisto SDK Nightly - Run Against Cortex XSOAR'
 CONTENT_CHANNEL = 'dmst-content-team'
+DMST_SDK_NIGHTLY_GITLAB_JOBS_PREFIX = 'demisto-sdk-nightly'
+SDK_NIGHTLY_CIRCLE_OPTS = {
+    SDK_UNITTESTS_TYPE, SDK_FAILED_STEPS_TYPE, SDK_RUN_AGAINST_FAILED_STEPS_TYPE
+}
 
 
 def get_failed_steps_list():
@@ -60,13 +65,12 @@ def get_gitlab_failed_steps(ci_token, build_number, server_url, project_id):
     failed_steps_list = []
     gitlab_client = gitlab.Gitlab(server_url, private_token=ci_token)
     project = gitlab_client.projects.get(int(project_id))
-    pipeline = project.pipelines.get(int(build_number))
-    jobs = pipeline.jobs.list()
-
-    for job in jobs:
-        if job.status == 'failed':
-            logging.info(f'collecting failed job {job.name}')
-            failed_steps_list.append(f'{job.name}')
+    job = project.jobs.get(int(build_number))
+    logging.info(f'status of gitlab job with id {job.id} and name {job.name} is {job.status}')
+    if job.status == 'failed':
+        logging.info(f'collecting failed job {job.name}')
+        logging.info(f'pipeline associated with failed job is {job.pipeline.get("web_url")}')
+        failed_steps_list.append(f'{job.name}')
 
     return failed_steps_list
 
@@ -108,9 +112,9 @@ def options_handler():
 
 
 def get_failing_unit_tests_file_data():
+    failing_ut_list = None
     try:
-        failing_ut_list = None
-        file_name = './artifacts/failed_lint_report.txt'
+        file_name = f'{ARTIFACTS_FOLDER}/failed_lint_report.txt'
         if os.path.isfile(file_name):
             logging.info('Extracting lint_report')
             with open(file_name, 'r') as failed_unittests_file:
@@ -335,7 +339,21 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
                 build_url=build_url, job_name=job_name, packs_results_file_path=packs_results_file
             )
         elif test_type == SDK_RUN_AGAINST_FAILED_STEPS_TYPE:
+            logging.info("Starting Slack notifications about SDK nightly build - run against an xsoar instance")
             content_team_attachments = get_attachments_for_all_steps(build_url, build_title=SDK_XSOAR_BUILD_TITLE)
+        elif job_name and test_type == job_name:
+            if job_name.startswith(DMST_SDK_NIGHTLY_GITLAB_JOBS_PREFIX):
+                # We run the various circleci sdk nightly builds in a single pipeline in GitLab
+                # as different jobs so it requires different handling
+                logging.info(f"Starting Slack notifications for {job_name}")
+                if 'unittest' in job_name:
+                    content_team_attachments = get_attachments_for_unit_test(build_url, is_sdk_build=True)
+                    # override the 'title' from the attachment to be the job name 
+                    content_team_attachments[0]['title'] = content_team_attachments[0]['title'].replace('SDK Nightly Unit Tests', job_name)
+                else:
+                    content_team_attachments = get_attachments_for_all_steps(build_url, build_title=job_name)
+                    # override the 'fields' from the attachment since any failure will be the same as the job name
+                    content_team_attachments[0]['fields'] = []
         else:
             raise NotImplementedError('The test_type parameter must be only \'test_playbooks\' or \'unittests\'')
         logging.info(f'Content team attachments:\n{content_team_attachments}')
@@ -363,15 +381,19 @@ def main():
     ci_artifacts_path = options.ci_artifacts
     job_name = options.job_name
     slack_channel = options.slack_channel or CONTENT_CHANNEL
+    gitlab_server = options.gitlab_server
     if nightly:
         slack_notifier(url, slack, test_type, env_results_file_name)
     elif bucket_upload:
         slack_notifier(url, slack, test_type,
                        packs_results_file=os.path.join(
                            ci_artifacts_path, BucketUploadFlow.PACKS_RESULTS_FILE), job_name=job_name,
-                       slack_channel=slack_channel, gitlab_server=options.gitlab_server)
-    elif test_type in (SDK_UNITTESTS_TYPE, SDK_FAILED_STEPS_TYPE, SDK_RUN_AGAINST_FAILED_STEPS_TYPE):
-        slack_notifier(url, slack, test_type)
+                       slack_channel=slack_channel, gitlab_server=gitlab_server)
+    elif test_type in SDK_NIGHTLY_CIRCLE_OPTS or test_type == job_name:
+        slack_notifier(
+            url, slack, test_type, job_name=job_name,
+            slack_channel=slack_channel, gitlab_server=gitlab_server
+        )
     else:
         logging.error("Not nightly build, stopping Slack Notifications about Content build")
 

--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -348,8 +348,10 @@ def slack_notifier(build_url, slack_token, test_type, env_results_file_name=None
                 logging.info(f"Starting Slack notifications for {job_name}")
                 if 'unittest' in job_name:
                     content_team_attachments = get_attachments_for_unit_test(build_url, is_sdk_build=True)
-                    # override the 'title' from the attachment to be the job name 
-                    content_team_attachments[0]['title'] = content_team_attachments[0]['title'].replace('SDK Nightly Unit Tests', job_name)
+                    # override the 'title' from the attachment to be the job name
+                    content_team_attachments[0]['title'] = content_team_attachments[0]['title'].replace(
+                        'SDK Nightly Unit Tests', job_name
+                    )
                 else:
                     content_team_attachments = get_attachments_for_all_steps(build_url, build_title=job_name)
                     # override the 'fields' from the attachment since any failure will be the same as the job name

--- a/Tests/scripts/slack_notifier.sh
+++ b/Tests/scripts/slack_notifier.sh
@@ -10,7 +10,7 @@ echo "start slack notifier"
 # $3 = Slack channel
 
 if [ "$CIRCLECI" != "true" ]; then
-  python3 ./Tests/scripts/slack_notifier.py -n $IS_NIGHTLY -u "$CI_PIPELINE_URL" -b "$CI_PIPELINE_ID" -s "$SLACK_TOKEN" -c "$GITLAB_STATUS_TOKEN" -t "$1" -f "$2" -bu $IS_BUCKET_UPLOAD -j "$CI_JOB_NAME" -ca "$ARTIFACTS_FOLDER" -ch "$3" -g "$CI_SERVER_URL" -gp "$CI_PROJECT_ID"
+  python3 ./Tests/scripts/slack_notifier.py -n $IS_NIGHTLY -u "$CI_JOB_URL" -b "$CI_JOB_ID" -s "$SLACK_TOKEN" -c "$GITLAB_STATUS_TOKEN" -t "$1" -f "$2" -bu $IS_BUCKET_UPLOAD -j "$CI_JOB_NAME" -ca "$ARTIFACTS_FOLDER" -ch "$3" -g "$CI_SERVER_URL" -gp "$CI_PROJECT_ID"
 else
   python3 ./Tests/scripts/slack_notifier.py -n $IS_NIGHTLY -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -s "$SLACK_TOKEN" -c "$CIRCLECI_TOKEN" -t "$1" -f "$2" -bu $IS_BUCKET_UPLOAD -j "$CIRCLE_JOB" -ca $CIRCLE_ARTIFACTS -ch "$3"
 fi

--- a/Tests/scripts/utils/log_util.py
+++ b/Tests/scripts/utils/log_util.py
@@ -86,8 +86,7 @@ def install_logging(log_file_name: str, include_process_name=False) -> str:
         os.path.join(ARTIFACTS_PATH, 'logs')) else os.path.join(ARTIFACTS_PATH, log_file_name)
     fh = logging.FileHandler(log_file_path)
     fh.setFormatter(formatter)
-    ch_log_level = logging.INFO if os.getenv('CIRCLECI') else logging.WARNING
-    ch.setLevel(ch_log_level)
+    ch.setLevel(logging.INFO)
     fh.setLevel(logging.DEBUG)
     configure_root_logger(ch, fh)
     return log_file_path


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Slack notification was incorrect when triggered from GitLab *Demisto SDK Nightly*-related jobs. Updated the slack notifications scripts to accommodate the GitLab architecture.

## Additional Changes
- Revert the change that was made to the logging utility that disincluded info-level logs from being output to the GitLab CI console.
- Remove environment variables from the GitLab configuration file that had been added to test enabling color outputs in the GitLab CI console.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
