### PR TITLE
Splunk raw labels fix

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1391,6 +1391,8 @@ def rawToDict(raw):
             key_val_arr = raw.split(",")
             for key_val in key_val_arr:
                 single_key_val = key_val.split(":", 1)
+                if len(single_key_val) <= 1:
+                    single_key_val = key_val.split("=", 1)
                 if len(single_key_val) > 1:
                     val = single_key_val[1]
                     key = single_key_val[0].strip()

--- a/Packs/SplunkPy/ReleaseNotes/2_1_2.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Fixing the way labels are parsed from notable events' raw data.
+- Fixed the way labels are parsed from the raw data of a notable event.

--- a/Packs/SplunkPy/ReleaseNotes/2_1_2.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixing the way labels are parsed from notable events' raw data.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.1.1",
+    "currentVersion": "2.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/35176

## Description
Incident labels were not properly processed when the word message was in the raw data.
Introduced a fix for it.
