### PR TITLE
renamed stix to non stix indicator for the create relationship automa…

### DIFF
--- a/Packs/Base/ReleaseNotes/1_11_6.md
+++ b/Packs/Base/ReleaseNotes/1_11_6.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CreateIndicatorRelationship
+- Maintenance and stability enhancements.

--- a/Packs/Base/ReleaseNotes/1_11_6.md
+++ b/Packs/Base/ReleaseNotes/1_11_6.md
@@ -2,3 +2,5 @@
 #### Scripts
 ##### CreateIndicatorRelationship
 - Maintenance and stability enhancements.
+##### CommonServerPython
+- Maintenance and stability enhancements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -413,8 +413,7 @@ class FeedIndicatorType(object):
         :rtype: ``str``
         :return:: Indicator type .
         """
-        a = is_demisto_version_ge("6.2.0")
-        if a and indicator_type.startswith(STIX_PREFIX):
+        if is_demisto_version_ge("6.2.0") and indicator_type.startswith(STIX_PREFIX):
             return indicator_type[len(STIX_PREFIX):]
         return indicator_type
 

--- a/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
+++ b/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
@@ -287,7 +287,7 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.9.4.19537
+dockerimage: demisto/python3:3.9.5.20070
 fromversion: 6.2.0
 tests:
 - Relationships scripts - Test

--- a/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
+++ b/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
@@ -26,11 +26,15 @@ args:
   - ssdeep
   - accountRep
   - CIDR
-  - STIX Attack Pattern
-  - STIX Malware
-  - STIX Report
-  - STIX Threat Actor
-  - STIX Tool
+  - Attack Pattern
+  - Malware
+  - Report
+  - Threat Actor
+  - Tool
+  - Campaign
+  - Course of Action
+  - Infrastructure
+  - Intrusion Set
   required: true
   secret: false
 - default: false

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.11.5",
+    "currentVersion": "1.11.6",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
Updated the optional indicator types for the creation of an indicator as part of the create relationship.


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/37266

## Description
Updated the optional indicator types for the creation of an indicator as part of the create relationship.


## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
