### PR TITLE
Upload flow rn bugfix

### DIFF
--- a/Packs/Threat_Crowd/ReleaseNotes/2_0_1.md
+++ b/Packs/Threat_Crowd/ReleaseNotes/2_0_1.md
@@ -1,4 +1,12 @@
 
 #### Integrations
-##### Threat Crowd v2
-- Maintenance and stability enhancements.
+##### Threat Crowd (Deprecated)
+- Deprecated. Use the **Threat Crowd v2** integration instead.
+
+##### New: Threat Crowd v2
+- Query Threat Crowd for reports. (Available from Cortex XSOAR 5.0.0).
+- **Breaking Changes:**  Changed the following command names from the deprecated integration:
+    * *threat-crowd-ip* is now *ip*
+    * *threat-crowd-file* is now *file*
+    * *threat-crowd-email* is now *email*
+    * *threat-crowd-domain* is now *domain*

--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -1646,6 +1646,34 @@ class TestReleaseNotes:
         assert latest_rn == '1.0.1'
         assert rn_lines == rn
 
+    def test_get_release_notes_lines_no_rn(self, mocker, dummy_pack):
+        """
+           Given:
+               - 2 release notes files, 1.0.0 and 1.0.1 which is the latest rn and exists in the changelog
+           When:
+               - Creating the release notes for version 1.0.1
+           Then:
+               - Verify that the rn are the same
+       """
+        repo_latest_rn = '''
+#### Integrations
+##### CrowdStrike Falcon Intel v2
+- wow2
+        '''
+
+        changelog_latest_rn = '''
+#### Integrations
+##### CrowdStrike Falcon Intel v2
+- wow1
+- wow2
+        '''
+
+        mocker.patch('builtins.open', mock_open(read_data=repo_latest_rn))
+        mocker.patch('os.listdir', return_value=['1_0_0.md', '1_0_1.md'])
+        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.1'))
+        assert latest_rn == '1.0.1'
+        assert rn_lines == changelog_latest_rn
+
     FAILED_PACKS_DICT = {
         'TestPack': {'status': 'wow1'},
         'TestPack2': {'status': 'wow2'}

--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -558,11 +558,6 @@ class TestChangelogCreation:
            Then:
                - return True
        """
-        dummy_pack.current_version = '2.0.2'
-        mocker.patch("Tests.Marketplace.marketplace_services.logging")
-        mocker.patch("os.path.exists", return_value=True)
-        dir_list = ['1_0_1.md', '2_0_2.md', '2_0_0.md']
-        mocker.patch("os.listdir", return_value=dir_list)
         original_changelog = '''{
             "1.0.0": {
                 "releaseNotes": "First release notes",
@@ -575,8 +570,17 @@ class TestChangelogCreation:
                 "released": "2020-06-05T13:39:33Z"
             }
         }'''
-        mocker.patch('builtins.open', mock_open(read_data=original_changelog))
+
+        dummy_pack.current_version = '2.0.2'
+        open_mocker = MockOpen()
         dummy_path = 'Irrelevant/Test/Path'
+        open_mocker[os.path.join(dummy_path, dummy_pack.name, Pack.CHANGELOG_JSON)].read_data = original_changelog
+        open_mocker[os.path.join(dummy_pack.path, Pack.RELEASE_NOTES, '2_0_2.md')].read_data = 'wow'
+        mocker.patch("Tests.Marketplace.marketplace_services.logging")
+        mocker.patch("os.path.exists", return_value=True)
+        dir_list = ['1_0_1.md', '2_0_2.md', '2_0_0.md']
+        mocker.patch("os.listdir", return_value=dir_list)
+        mocker.patch('builtins.open', open_mocker)
         build_number = random.randint(0, 100000)
         task_status, not_updated_build = \
             Pack.prepare_release_notes(self=dummy_pack, index_folder_path=dummy_path, build_number=build_number)
@@ -1570,9 +1574,10 @@ class TestReleaseNotes:
         }
         mocker.patch('builtins.open', mock_open(read_data=original_changelog))
         mocker.patch('os.path.exists', return_value=True)
-        changelog, changelog_latest_rn_version = dummy_pack.get_changelog_latest_rn('fake_path')
+        changelog, changelog_latest_rn_version, changelog_latest_rn = dummy_pack.get_changelog_latest_rn('fake_path')
         assert changelog == original_changelog_dict
         assert changelog_latest_rn_version == LooseVersion('2.0.0')
+        assert changelog_latest_rn == "Second release notes"
 
     def test_create_local_changelog(self, mocker, dummy_pack):
         """
@@ -1622,7 +1627,7 @@ class TestReleaseNotes:
         open_mocker['rn_dir_fake_path/1_1_0.md'].read_data = rn_one
         open_mocker['rn_dir_fake_path/2_0_0.md'].read_data = rn_two
         mocker.patch('builtins.open', open_mocker)
-        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.0'))
+        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.0'), '')
         assert latest_rn == '2.0.0'
         assert rn_lines == aggregated_rn
 
@@ -1642,7 +1647,7 @@ class TestReleaseNotes:
         '''
         mocker.patch('builtins.open', mock_open(read_data=rn))
         mocker.patch('os.listdir', return_value=['1_0_0.md', '1_0_1.md'])
-        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.1'))
+        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.1'), rn)
         assert latest_rn == '1.0.1'
         assert rn_lines == rn
 
@@ -1655,12 +1660,6 @@ class TestReleaseNotes:
            Then:
                - Verify that the rn are the same
        """
-        repo_latest_rn = '''
-#### Integrations
-##### CrowdStrike Falcon Intel v2
-- wow2
-        '''
-
         changelog_latest_rn = '''
 #### Integrations
 ##### CrowdStrike Falcon Intel v2
@@ -1668,9 +1667,8 @@ class TestReleaseNotes:
 - wow2
         '''
 
-        mocker.patch('builtins.open', mock_open(read_data=repo_latest_rn))
         mocker.patch('os.listdir', return_value=['1_0_0.md', '1_0_1.md'])
-        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('rn_dir_fake_path', LooseVersion('1.0.1'))
+        rn_lines, latest_rn = dummy_pack.get_release_notes_lines('wow', LooseVersion('1.0.1'), changelog_latest_rn)
         assert latest_rn == '1.0.1'
         assert rn_lines == changelog_latest_rn
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37577

## Description
When a change in pack has been made that doesn't requires the addition of an RN file (for example Pack README change) we now get the release notes from the bucket as it might have been aggregated.

## Successful Upload Run
1. https://app.circleci.com/pipelines/github/demisto/content/89423/workflows/ca874b45-c2d6-469c-8adb-c68e6c63d71b
2. (Only the create step) https://app.circleci.com/pipelines/github/demisto/content/89490/workflows/7ca59092-8cb4-4d41-92e6-8ce4f1a5f8a4/jobs/370613

## Screenshots
![image](https://user-images.githubusercontent.com/53565845/120104988-bce35100-c15f-11eb-9a8c-d5b57a4d915e.png)

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
