### PR TITLE
Fix condition to only apply during bucket upload flow

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -208,7 +208,7 @@
     - section_end "Update Tests"
     - section_start "Validate Files and Yaml"
     - |
-      if [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
+      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
         echo "Skipping the -Validate Files and Yaml- step when uploading to a test bucket."
       else
         echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
Can see an example of the validations not running in this `demisto-sdk` nightly GitLab run (where they should have) - https://code.pan.run/xsoar/content/-/jobs/5807340#queue-placeholder/containers/0

## Description
The `.run-validation` configuration which job configurations in various workflows inherit from contains an incorrect condition causing validations to not run. The condition prevented the validations from running during the current overlap period where we have the bucket upload flow in GitLab uploading to a test bucket.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/120151478-f7e39400-c1f4-11eb-8fa5-366942cde0db.png)
> example of the validations not running in the `Demisto SDK Nightly` flow in GitLab (where they should have run).

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [x] ~~Documentation~~ N/A
