### PR TITLE
Replace Demisto to Cortex XSOAR

### DIFF
--- a/Packs/AWS-EC2/.pack-ignore
+++ b/Packs/AWS-EC2/.pack-ignore
@@ -1,2 +1,5 @@
 [file:AWS-EC2.yml]
 ignore=BA108,BA109
+
+[file:READNE.md]
+ignore=RM106

--- a/Packs/AWS-EC2/.pack-ignore
+++ b/Packs/AWS-EC2/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AWS-EC2.yml]
 ignore=BA108,BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/AWS_DynamoDB/.pack-ignore
+++ b/Packs/AWS_DynamoDB/.pack-ignore
@@ -1,2 +1,5 @@
 [file:AWS_DynamoDB.yml]
 ignore=BA108,BA109
+
+[file:README.md]
+ignore=RM106

--- a/Packs/Active_Directory_Query/.pack-ignore
+++ b/Packs/Active_Directory_Query/.pack-ignore
@@ -1,5 +1,5 @@
 [file:README.md]
-ignore=RM104
+ignore=RM104,RM106
 
 [file:Active_Directory_Query.yml]
 ignore=BA108,BA109

--- a/Packs/ApiModules/.pack-ignore
+++ b/Packs/ApiModules/.pack-ignore
@@ -1,0 +1,2 @@
+[file:READNE.md]
+ignore=RM106

--- a/Packs/ApiModules/.pack-ignore
+++ b/Packs/ApiModules/.pack-ignore
@@ -1,2 +1,2 @@
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/Attlasian/.pack-ignore
+++ b/Packs/Attlasian/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Attlasian_IAM.yml]
 ignore=BA108,BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/Attlasian/.pack-ignore
+++ b/Packs/Attlasian/.pack-ignore
@@ -1,2 +1,5 @@
 [file:Attlasian_IAM.yml]
 ignore=BA108,BA109
+
+[file:READNE.md]
+ignore=RM106

--- a/Packs/AzureCompute/.pack-ignore
+++ b/Packs/AzureCompute/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AzureCompute_v2.yml]
-ignore=BA108,BA109
+ignore=BA108,BA109,DS107
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/AzureSecurityCenter/.pack-ignore
+++ b/Packs/AzureSecurityCenter/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AzureSecurityCenter_v2.yml]
-ignore=BA108,BA109
+ignore=BA108,BA109,DS107
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/Base/.pack-ignore
+++ b/Packs/Base/.pack-ignore
@@ -37,4 +37,5 @@ ignore=BA109
 [file:WordTokenizerV2.yml]
 ignore=BA109
 
-
+[file:READNE.md]
+ignore=RM106

--- a/Packs/Base/.pack-ignore
+++ b/Packs/Base/.pack-ignore
@@ -37,5 +37,5 @@ ignore=BA109
 [file:WordTokenizerV2.yml]
 ignore=BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/BluecatAddressManager/.pack-ignore
+++ b/Packs/BluecatAddressManager/.pack-ignore
@@ -1,2 +1,2 @@
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/BruteForce/.pack-ignore
+++ b/Packs/BruteForce/.pack-ignore
@@ -1,2 +1,5 @@
 [file:layoutscontainer-Brute_Force.json]
 ignore=BA101
+
+[file:Brute_Force_Investigation_-_Generic_README.md]
+ignore=RM106

--- a/Packs/Code42/.pack-ignore
+++ b/Packs/Code42/.pack-ignore
@@ -5,4 +5,4 @@ ignore=IN126
 ignore=RM102
 
 [file:playbook-Code42_Exfiltration_Playbook.yml]
-ignore=BA110
+ignore=BA110,RM106

--- a/Packs/Code42/.pack-ignore
+++ b/Packs/Code42/.pack-ignore
@@ -5,4 +5,7 @@ ignore=IN126
 ignore=RM102
 
 [file:playbook-Code42_Exfiltration_Playbook.yml]
-ignore=BA110,RM106
+ignore=BA110
+
+[file:playbook-Code42_Exfiltration_Playbook_README.md]
+ignore=RM106

--- a/Packs/CommonPlaybooks/.pack-ignore
+++ b/Packs/CommonPlaybooks/.pack-ignore
@@ -48,3 +48,6 @@ ignore=RM106
 
 [file:playbook-Threat_Hunting_-_Generic_README.md]
 ignore=RM106
+
+[file:playbook-Block_Indicators_-_Generic_v2_README.md]
+ignore=RM106

--- a/Packs/CommonPlaybooks/.pack-ignore
+++ b/Packs/CommonPlaybooks/.pack-ignore
@@ -42,3 +42,9 @@ ignore=RM104
 
 [file:playbook-Get_File_Sample_From_Path_-_Generic_README.md]
 ignore=RM106
+
+[file:playbook-Block_Email_-_Generic_README.md]
+ignore=RM106
+
+[file:playbook-Threat_Hunting_-_Generic_README.md]
+ignore=RM106

--- a/Packs/CommonScripts/.pack-ignore
+++ b/Packs/CommonScripts/.pack-ignore
@@ -42,3 +42,6 @@ ignore=RM106
 
 [file:script-ExampleJSScript.yml]
 ignore=BA110
+
+[file:script-PCAPMiner_README.md]
+ignore=RM106

--- a/Packs/CommonScripts/Scripts/AddDBotScoreToContext/README.md
+++ b/Packs/CommonScripts/Scripts/AddDBotScoreToContext/README.md
@@ -7,7 +7,7 @@ Add DBot score to context for indicators with custom vendor, score, reliability,
 | --- | --- |
 | Script Type | python3 |
 | Tags |  |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ## Inputs
 ---

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/README.md
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/README.md
@@ -7,7 +7,7 @@ Verifies that an email address is valid and only returns the address if it is va
 | --- | --- |
 | Script Type | python3 |
 | Tags | indicator-format |
-| Demisto Version | 5.5.0 |
+| Cortex XSOAR Version | 5.5.0 |
 
 ## Inputs
 ---

--- a/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/README.md
+++ b/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/README.md
@@ -7,7 +7,7 @@ Get the overall score for the indicator as calculated by DBot.
 | --- | --- |
 | Script Type | python3 |
 | Tags |  |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ## Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraDetectionsCount/README.md
+++ b/Packs/Confluera/Scripts/ConflueraDetectionsCount/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraDetectionsData/README.md
+++ b/Packs/Confluera/Scripts/ConflueraDetectionsData/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraDetectionsDataWarroom/README.md
+++ b/Packs/Confluera/Scripts/ConflueraDetectionsDataWarroom/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraDetectionsSummary/README.md
+++ b/Packs/Confluera/Scripts/ConflueraDetectionsSummary/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraDetectionsSummaryWarroom/README.md
+++ b/Packs/Confluera/Scripts/ConflueraDetectionsSummaryWarroom/README.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Script Example
 ---

--- a/Packs/Confluera/Scripts/ConflueraProgressionsCount/README.md
+++ b/Packs/Confluera/Scripts/ConflueraProgressionsCount/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraProgressionsData/README.md
+++ b/Packs/Confluera/Scripts/ConflueraProgressionsData/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/ConflueraProgressionsDataWarroom/README.md
+++ b/Packs/Confluera/Scripts/ConflueraProgressionsDataWarroom/README.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Confluera/Scripts/IqHubLog/README.md
+++ b/Packs/Confluera/Scripts/IqHubLog/README.md
@@ -7,7 +7,7 @@
 | --- | --- |
 | Script Type | python3 |
 | Tags | Confluera |
-| Demisto Version | 6.0.0 |
+| Cortex XSOAR Version | 6.0.0 |
 
 ### Inputs
 ---

--- a/Packs/Coralogix/.pack-ignore
+++ b/Packs/Coralogix/.pack-ignore
@@ -2,4 +2,4 @@
 ignore=IN126
 
 [file:README.md]
-ignore=RM104
+ignore=RM104,RM106

--- a/Packs/CortexDataLake/.pack-ignore
+++ b/Packs/CortexDataLake/.pack-ignore
@@ -2,4 +2,4 @@
 ignore=IN126,IN136
 
 [file:README.md]
-ignore=RM102
+ignore=RM102,RM106

--- a/Packs/DemistoLocking/.pack-ignore
+++ b/Packs/DemistoLocking/.pack-ignore
@@ -1,5 +1,5 @@
 [file:integration-DemistoLocking.yml]
 ignore=DS107
 
-[file:README.md]
+[file:integration-DemistoLocking_README.md]
 ignore=RM106

--- a/Packs/DeprecatedContent/.pack-ignore
+++ b/Packs/DeprecatedContent/.pack-ignore
@@ -261,3 +261,7 @@ ignore=RM106
 
 [file:playbook-Demisto_Self-Defense_-_Account_policy_monitoring_playbook_README.md]
 ignore=RM106
+
+[file:playbook-ExtraHop_-_Ticket_Tracking_README.md]
+ignore=RM106
+

--- a/Packs/DevSecOps/Integrations/GitLab/README.md
+++ b/Packs/DevSecOps/Integrations/GitLab/README.md
@@ -15,7 +15,7 @@ This integration was integrated and tested with version v4.0 of GitLab API
 
 4. Click **Test** to validate the URLs, token, and connection.
 ## Commands
-You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
+You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
 ### gitlab-get-projects
 ***

--- a/Packs/Devo/.pack-ignore
+++ b/Packs/Devo/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Devo_v2.yml]
 ignore=IN126,BA108,BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/EDL/.pack-ignore
+++ b/Packs/EDL/.pack-ignore
@@ -1,2 +1,5 @@
 [file:README.md]
 ignore=RM104
+
+[file:playbook-PAN-OS_EDL_Service_Configuration_README.md]
+ignore=RM106

--- a/Packs/ExtFilter/.pack-ignore
+++ b/Packs/ExtFilter/.pack-ignore
@@ -1,0 +1,2 @@
+[file:READNE.md]
+ignore=RM106

--- a/Packs/ExtFilter/.pack-ignore
+++ b/Packs/ExtFilter/.pack-ignore
@@ -1,2 +1,2 @@
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/README.md
+++ b/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/README.md
@@ -5,7 +5,7 @@ This is a widget script returning MITRE indicators information for top indicator
 | --- | --- |
 | Script Type | python3 |
 | Tags | widget |
-| Demisto Version | 5.5.0 |
+| Cortex XSOAR Version | 5.5.0 |
 ## Inputs
 ---
 There are no inputs for this script.

--- a/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/README.md
+++ b/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/README.md
@@ -25,7 +25,7 @@ Note: Install the MITRE ATT&CK pack if you want the feed to create MITRE ATT&CK 
 
 4. Click **Test** to validate the URLs, token, and connection.
 ## Commands
-You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
+You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
 ### unit42-get-indicators
 ***

--- a/Packs/Gmail/.pack-ignore
+++ b/Packs/Gmail/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Gmail.yml]
 ignore=IN126
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/Gmail/.pack-ignore
+++ b/Packs/Gmail/.pack-ignore
@@ -1,2 +1,5 @@
 [file:Gmail.yml]
 ignore=IN126
+
+[file:READNE.md]
+ignore=RM106

--- a/Packs/GmailSingleUser/.pack-ignore
+++ b/Packs/GmailSingleUser/.pack-ignore
@@ -1,5 +1,5 @@
 [file:GmailSingleUser.yml]
 ignore=BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/Lokpath_Keylight/.pack-ignore
+++ b/Packs/Lokpath_Keylight/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Lockpath_KeyLight_v2.yml]
 ignore=IN126,BA108,BA109
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/MajorBreachesInvestigationandResponse/Scripts/RapidBreachResponseParseBlog/README.md
+++ b/Packs/MajorBreachesInvestigationandResponse/Scripts/RapidBreachResponseParseBlog/README.md
@@ -7,7 +7,7 @@ Parse Volexity request blog
 | --- | --- |
 | Script Type | python3 |
 | Tags |  |
-| Demisto Version | 5.5.0 |
+| Cortex XSOAR Version | 5.5.0 |
 
 ## Inputs
 ---

--- a/Packs/Malware/.pack-ignore
+++ b/Packs/Malware/.pack-ignore
@@ -15,3 +15,7 @@ ignore=PA116
 
 [file:layoutscontainer-Malware.json]
 ignore=BA101
+
+[file:playbook-Endpoint_Malware_Investigation_-_Generic_V2_README.md]
+ignore=RM106
+

--- a/Packs/MicrosoftAdvancedThreatAnalytics/Integrations/MicrosoftAdvancedThreatAnalytics/README.md
+++ b/Packs/MicrosoftAdvancedThreatAnalytics/Integrations/MicrosoftAdvancedThreatAnalytics/README.md
@@ -23,7 +23,7 @@ This integration was integrated and tested with version 1.9.7478.57683 of Micros
 
 4. Click **Test** to validate the URLs, token, and connection.
 ## Commands
-You can execute these commands from the Demisto CLI, as part of an automation, or in a playbook.
+You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
 ### ms-ata-suspicious-activities-list
 ***

--- a/Packs/NetscoutArborSightline/.pack-ignore
+++ b/Packs/NetscoutArborSightline/.pack-ignore
@@ -1,2 +1,2 @@
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/OpenCTI/.pack-ignore
+++ b/Packs/OpenCTI/.pack-ignore
@@ -1,2 +1,2 @@
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/PagerDuty/.pack-ignore
+++ b/Packs/PagerDuty/.pack-ignore
@@ -1,5 +1,5 @@
 [file:PagerDuty.yml]
 ignore=IN126
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106

--- a/Packs/SplunkPy/.pack-ignore
+++ b/Packs/SplunkPy/.pack-ignore
@@ -1,7 +1,7 @@
 [file:SplunkPy.yml]
 ignore=IN126,IN135
 
-[file:READNE.md]
+[file:README.md]
 ignore=RM106
 
 [file:playbook-Splunk_Indicator_Hunting_README.md]

--- a/Packs/ThreatGrid/.pack-ignore
+++ b/Packs/ThreatGrid/.pack-ignore
@@ -1,5 +1,11 @@
 [file:playbook-Detonate_File_-_ThreatGrid.yml]
-ignore=BA101,RM106
+ignore=BA101
 
 [file:playbook-Detonate_URL_-_ThreatGrid.yml]
-ignore=BA101,RM106
+ignore=BA101
+
+[file:playbook-Detonate_File_-_ThreatGrid_README.md]
+ignore=RM106
+
+[file:playbook-Detonate_URL_-_ThreatGrid_README.md]
+ignore=RM106

--- a/Packs/XSOAR-SimpleDevToProd/.pack-ignore
+++ b/Packs/XSOAR-SimpleDevToProd/.pack-ignore
@@ -1,8 +1,14 @@
 [file:playbook-JOB_-_XSOAR_-_Simple_Dev_to_Prod.yml]
-ignore=PB106,RM106
+ignore=PB106
 
 [file:playbook-JOB_-_XSOAR_-_Export_Selected_Custom_Content.yml]
-ignore=PB106,RM106
+ignore=PB106
+
+[file:playbook-JOB_-_XSOAR_-_Simple_Dev_to_Prod_README.md]
+ignore=RM106
+
+[file:playbook-JOB_-_XSOAR_-_Export_Selected_Custom_Content_README.md]
+ignore=RM106
 
 [file:README.md]
 ignore=RM106


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Updating content with changing the word Demisto to Cortex XSOAR

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
