### PR TITLE
Reorg and Tweaks for on-push GitLab Config File

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -48,9 +48,12 @@ create-instances:
   script:
     - !reference [.download-demisto-conf]
     - !reference [.create-id-set]
+    - section_start "Create Release Notes and Common Server Documentation"
     - python3 Utils/release_notes_generator.py $CONTENT_VERSION $CI_COMMIT_SHA $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
     - cp content-descriptor.json $ARTIFACTS_FOLDER
     - ./Documentation/commonServerDocs.sh
+    - section_end "Create Release Notes and Common Server Documentation"
+    - section_start "Create Content Artifacts and Update Conf"
     - demisto-sdk create-content-artifacts -a $ARTIFACTS_FOLDER --cpus 8 --content_version $CONTENT_VERSION >> $ARTIFACTS_FOLDER/logs/create_content_artifacts.log
     - gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY"
     - successful_feature_branch_build=$(gsutil ls "gs://xsoar-ci-artifacts/content/$FEATURE_BRANCH_NAME/*" | tail -n 1 | grep -o -E "content/$FEATURE_BRANCH_NAME/[0-9]*")
@@ -60,37 +63,46 @@ create-instances:
     - rm -rf $ARTIFACTS_FOLDER/uploadable_packs
     - python3 ./Tests/scripts/update_conf_json.py
     - cp "./Tests/conf.json" "$ARTIFACTS_FOLDER/conf.json"
+    - section_end "Create Content Artifacts and Update Conf"
+    - section_start "Collect Tests and Content Packs"
     - |
       if [ -n "${INSTANCE_TESTS}" ]; then
         echo "Skipping - not running in INSTANCE_TESTS build"
       else
-        echo "====== Collecting tests and content packs ======"
         [ -n "${NIGHTLY}" ] && IS_NIGHTLY=true || IS_NIGHTLY=false
         python3 ./Tests/scripts/collect_tests_and_content_packs.py -n $IS_NIGHTLY
       fi
+    - section_end "Collect Tests and Content Packs"
+    - section_start "Calculate Packs Dependencies"
     - python3 ./Tests/Marketplace/packs_dependencies.py -i ./Tests/id_set.json -o $ARTIFACTS_FOLDER/packs_dependencies.json
+    - section_end "Calculate Packs Dependencies"
+    - section_start "Prepare Content Packs for Testing"
     - |
       if [[ -n "${CONTRIB_BRANCH}" ]]; then
-        echo "Skipping Preparing Content Packs For Testing since nightly instances uses production bucket"
+        echo "Skipping Preparing Content Packs For Testing since CONTRIB_BRANCH was $CONTRIB_BRANCH"
       else
-        echo "====== Preparing Content Packs For Testing ======"
         ./Tests/scripts/prepare_content_packs_for_testing.sh "$GCS_MARKET_BUCKET"
       fi
+    - section_end "Prepare Content Packs for Testing"
+    - section_start "Zip Marketplace Packs"
     - |
       if [[ $CI_COMMIT_BRANCH != master ]] && [[ $CI_COMMIT_BRANCH != 20\.* ]] && [[ $CI_COMMIT_BRANCH != 21\.* ]]; then
-        echo "Skipping packs download to artifact on non master or release branch"
+        echo "Skipping packs download to artifact on branch that is not master or a release branch"
+        echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
       else
         ZIP_FOLDER=$(mktemp -d)
         python3 ./Tests/Marketplace/zip_packs.py -b 'marketplace-dist' -z $ZIP_FOLDER -a $ARTIFACTS_FOLDER -s $GCS_MARKET_KEY
       fi
+    - section_end "Zip Marketplace Packs"
+    - section_start "Create Instances"
     - |
-      echo "====== Creating instances ======"
       [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=300
       python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile "$ARTIFACTS_FOLDER/env_results.json"
+    - section_end "Create Instances"
   after_script:
-    - |
-      echo "====== Uploading artifacts to GCP ======"
-      ./Tests/scripts/upload_artifacts.sh
+    - section_start "Upload Artifacts to GCP"
+    - ./Tests/scripts/upload_artifacts.sh
+    - section_end "Upload Artifacts to GCP"
 
 
 .test_content_on_server_instances_base:

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -99,7 +99,6 @@ create-instances:
       [ -n "${TIME_TO_LIVE}" ] && TTL=${TIME_TO_LIVE} || TTL=300
       python3 ./Tests/scripts/awsinstancetool/aws_instance_tool.py -envType "$IFRA_ENV_TYPE" -timetolive $TTL -outfile "$ARTIFACTS_FOLDER/env_results.json"
     - section_end "Create Instances"
-  after_script:
     - section_start "Upload Artifacts to GCP"
     - ./Tests/scripts/upload_artifacts.sh
     - section_end "Upload Artifacts to GCP"

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -20,6 +20,20 @@ trigger-private-build:
     - python3 Utils/trigger_private_build.py --github-token $GITHUB_TOKEN
     - python3 Utils/get_private_build_status.py --github-token $GITHUB_TOKEN
 
+
+run-validations:
+  extends:
+    - .run-validations
+    - .push-rule
+
+
+# Uncomment when docker in docker will work
+# run-unittests-and-lint:
+#   extends:
+#     - .run-unittests-and-lint
+#     - .push-rule
+
+
 create-instances:
   extends:
     - .default-job-settings
@@ -78,6 +92,7 @@ create-instances:
       echo "====== Uploading artifacts to GCP ======"
       ./Tests/scripts/upload_artifacts.sh
 
+
 .test_content_on_server_instances_base:
   extends:
     - .default-job-settings
@@ -105,15 +120,18 @@ create-instances:
     - python3 ./Tests/scripts/destroy_instances.py $ARTIFACTS_FOLDER $ARTIFACTS_FOLDER/env_results.json "$INSTANCE_ROLE" "$TIME_TO_LIVE" || EXIT_CODE=$?
     - exit $EXIT_CODE
 
+
 server_5_0:
   extends: .test_content_on_server_instances_base
   variables:
     INSTANCE_ROLE: "Server 5.0"
 
+
 server_5_5:
   extends: .test_content_on_server_instances_base
   variables:
     INSTANCE_ROLE: "Server 5.5"
+
 
 server_6_0:
   extends: .test_content_on_server_instances_base
@@ -122,6 +140,7 @@ server_6_0:
     - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
   variables:
     INSTANCE_ROLE: "Server 6.0"
+
 
 server_master:
   extends:
@@ -133,16 +152,6 @@ server_master:
   variables:
     INSTANCE_ROLE: "Server Master"
 
-run-validations:
-  extends:
-    - .run-validations
-    - .push-rule
-
-# Uncomment when docker in docker will work
-# run-unittests-and-lint:
-#   extends:
-#     - .run-unittests-and-lint
-#     - .push-rule
 
 slack-notify-nightly-build:
   extends:


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Reorganizes the `.gitlab/ci/on-push.yml` file.
- Two empty lines between configuration sections
- Use `section_start` and `section_end` helper functions in the `create-instances` job
- Move execution of the upload of artifacts from the `after_script` section of the `create-instances` job to the `script` section

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
