### PR TITLE
Proofpoint Threat Response - set first fetch param default value by or operator

### DIFF
--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
@@ -16,7 +16,7 @@ if BASE_URL and BASE_URL[-1] != '/':
 API_KEY = demisto.params().get('apikey')
 VERIFY_CERTIFICATE = not demisto.params().get('insecure')
 # How many time before the first fetch to retrieve incidents
-FIRST_FETCH, _ = parse_date_range(demisto.params().get('first_fetch', '3 days'), date_format=TIME_FORMAT)
+FIRST_FETCH, _ = parse_date_range(demisto.params().get('first_fetch', '12 hours') or '12 hours', date_format=TIME_FORMAT)
 
 ''' COMMAND FUNCTIONS '''
 

--- a/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_4.md
+++ b/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Proofpoint Threat Response (Beta)
+- Added default value of 12 hours to the *First fetch timestamp* integration parameter.

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Threat Response (Beta)",
     "description": "Use the Proofpoint Threat Response integration to orchestrate and automate incident response.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

fixes: https://github.com/demisto/etc/issues/37757

## Description
in https://github.com/demisto/content/pull/12042 we added the first fetch param
integration instances that were configured before that change now fail with:
```
   File "<string>", line 19, in <module>
   File "<string>", line 6314, in parse_date_range
 AttributeError: 'NoneType' object has no attribute 'strip'
```
thats because the param exist in the params dict, but with value of `None` 
setting the default by using the `or` operator

setting default to `12 hours` according to the default in the yml file

## Does it break backward compatibility?
   - [x] No