### PR TITLE
AWS Security Hub - increase fetch time by 1 ms in case findings were fetched

### DIFF
--- a/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.py
+++ b/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.py
@@ -724,7 +724,13 @@ def fetch_incidents(client, aws_sh_severity, archive_findings, additional_filter
         'rawJSON': json.dumps(finding)
     }
         for finding in findings]
-    demisto.setLastRun({'lastRun': max(findings, key=lambda finding: finding.get('CreatedAt')).get('CreatedAt'),
+    if findings:
+        # in case we got finding, we should get the latest created one and increase it by 1 ms so the next fetch
+        # wont include it in the query and fetch duplicates
+        last_created_finding = max(findings, key=lambda finding: finding.get('CreatedAt')).get('CreatedAt')
+        last_created_finding_dt = parse(last_created_finding) + timedelta(milliseconds=1)  # type: ignore[operator]
+        last_run = last_created_finding_dt.isoformat()  # type: ignore[union-attr]
+    demisto.setLastRun({'lastRun': last_run,
                         'next_token': next_token})
     demisto.incidents(incidents)
 

--- a/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.yml
+++ b/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.yml
@@ -3575,7 +3575,7 @@ script:
     description: Deprecated, use aws-securityhub-batch-update-findings instead.
     execution: false
     name: aws-securityhub-update-findings
-  dockerimage: demisto/boto3py3:1.0.0.20516
+  dockerimage: demisto/boto3py3:1.0.0.20894
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.yml
+++ b/Packs/AWS-SecurityHub/Integrations/AWS_SecurityHub/AWS_SecurityHub.yml
@@ -3575,7 +3575,7 @@ script:
     description: Deprecated, use aws-securityhub-batch-update-findings instead.
     execution: false
     name: aws-securityhub-update-findings
-  dockerimage: demisto/boto3py3:1.0.0.20894
+  dockerimage: demisto/boto3py3:1.0.0.20921
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### AWS - Security Hub
-- Fixed an issue where the duplicate findings were fetched.
+- Fixed an issue where duplicate findings were fetched.
 - Updated the Docker image to: *demisto/boto3py3:1.0.0.20894*.

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### AWS - Security Hub
 - Fixed an issue where the duplicate findings were fetched.
+- Updated the Docker image to: *demisto/boto3py3:1.0.0.20894*.

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### AWS - Security Hub
 - Fixed an issue where duplicate findings were fetched.
-- Updated the Docker image to: *demisto/boto3py3:1.0.0.20894*.
+- Updated the Docker image to: *demisto/boto3py3:1.0.0.20921*.

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AWS - Security Hub
+- Fixed an issue where the duplicate findings were fetched.

--- a/Packs/AWS-SecurityHub/pack_metadata.json
+++ b/Packs/AWS-SecurityHub/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - Security Hub",
     "description": "Amazon Web Services Security Hub Service .",
     "support": "xsoar",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
in case findings were fetched, we took the latest one and stored it in the last run
on the next fetch, we used it in the filter, and then the latest one was fetched again as the filter is inclusive 
added 1ms to the date stored in the last run in case finding was fetched

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
