### PR TITLE
DevSecOps: pack readme: images to absolute links

### DIFF
--- a/Packs/DevSecOps/Integrations/GitLab/README.md
+++ b/Packs/DevSecOps/Integrations/GitLab/README.md
@@ -8,7 +8,7 @@ This integration was integrated and tested with version v4.0 of GitLab API
 
 | **Parameter** | **Description** | **Required** |
 | --- | --- | --- |
-| url | Server URL \(e.g. https://gitlab.com/api/v4\) | True |
+| url | Server URL (e.g. `https://gitlab.com/api/v4`) | True |
 | api_key | API Key | True |
 | insecure | Trust any certificate \(not secure\) | False |
 | proxy | Use system proxy settings | False |

--- a/Packs/DevSecOps/README.md
+++ b/Packs/DevSecOps/README.md
@@ -1,11 +1,11 @@
 DevSecOps content pack contains multiple integrations and playbooks to help shifting security as left as the planning stage of a continues integration pipeline and make DevSecOps orchestration to be within reach.
 
-![](doc_files/Inspiration.png)
+![](https://github.com/demisto/content/raw/ede7f0dc6211dd5aeaec77fa9912d9a57d5976b0/Packs/DevSecOps/doc_files/Inspiration.png)
 
 While CI/CD orchestration tools such as Jenkins, CircleCI and others were primarily built by and to developers, SOAR is better positioned to bridge this orchestration gap between DevOps and SecOps for the following reasons:
-![](doc_files/Playbooks.png)
+![](https://github.com/demisto/content/raw/ede7f0dc6211dd5aeaec77fa9912d9a57d5976b0/Packs/DevSecOps/doc_files/Playbooks.png)
 * CI/CD orchestration pipelines are arguably easy to read and troubleshoot by developers , SOAR provides the same orchestration workflow in two different formats that are readable by both Developers and Security Analysts.
-![](doc_files/SOAR%20Features.png)
+![](https://github.com/demisto/content/raw/ede7f0dc6211dd5aeaec77fa9912d9a57d5976b0/Packs/DevSecOps/doc_files/SOAR%20Features.png)
 * SOAR provides way more to a DevSecOps Eco-System than CI/CD Orchestrator does:
     * Collaboration between teams members in the Eco-System.
     * Cases management.
@@ -13,11 +13,11 @@ While CI/CD orchestration tools such as Jenkins, CircleCI and others were primar
 
 With SOAR integrations, playbooks, fields, XSOAR can be turned into a DevSecOps Orchestrator that taps in a DevSecOps Eco-System and solve for a spectrum of use cases in different stages of CI/CD piplines.
 
-![](doc_files/DevOps%20Services.png)
+![](https://github.com/demisto/content/raw/ede7f0dc6211dd5aeaec77fa9912d9a57d5976b0/Packs/DevSecOps/doc_files/DevOps%20Services.png)
 
 From threat-modeling in the **Planning** stage to IaC security in **Dev**, static code analysis in **Build**, post deployment scans in **Deploy** and **Monitoring**/Responding to incidents once the code is running in production.
 
-![](doc_files/Architecture.png)
+![](https://github.com/demisto/content/raw/ede7f0dc6211dd5aeaec77fa9912d9a57d5976b0/Packs/DevSecOps/doc_files/Architecture.png)
 
 This content pack will be updated with more integrations with different software factory tools:
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Changed to use absolute urls as documented here: https://xsoar.pan.dev/docs/documentation/pack-docs#images . The images are not displaying in the marketplace.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
