### PR TITLE
add packs to core packs 6.2

### DIFF
--- a/Tests/Marketplace/core_packs_list.json
+++ b/Tests/Marketplace/core_packs_list.json
@@ -24,5 +24,9 @@
   "ExportIndicators",
   "Malware",
   "DefaultPlaybook",
-  "AccessInvestigation"
+  "AccessInvestigation",
+  "ThreatIntelligenceManagement",
+  "ipinfo",
+  "FeedMitreAttackv2",
+  "FeedUnit42v2"
 ]


### PR DESCRIPTION



## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37776

## Description
add packs to core packs: 
- ThreatIntelligenceManagement
- ipinfo
- FeedMitreAttackv2
- FeedUnit42v2

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
