### PR TITLE
ExtractEmailV2: fixed local-part detection

### DIFF
--- a/Packs/CommonScripts/.secrets-ignore
+++ b/Packs/CommonScripts/.secrets-ignore
@@ -30,3 +30,4 @@ Xsoar@xsoar.co.il
 Xsoar@test.uk
 Xsoar@Xsoar.png
 Xsoar@Xsoar.BMP
+https://datatracker.ietf.org

--- a/Packs/CommonScripts/ReleaseNotes/1_3_56.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_3_56.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### ExtractEmailV2
+- Fixed an issue where some special characters didn't exist in the email regex.
+- Updated the Docker image to: *demisto/python3:3.9.5.20958*.

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.py
@@ -7,8 +7,8 @@ import re
 VALID_EXTENSION = r'(?!\S*\.(?:zip|jpg|jpeg|csv|png|gif|bmp|txt|pdf|ppt|pptx|xls|xlsx|doc|docx|eml|msg)(?:\s*$))'
 
 """
-First Group - [a-z0-9._%+-]+ :
-    any character of: 'A-Z', '0-9','.', '_', '%', '+', '-' 1 or more times
+First Group - [a-z0-9.!#$%&'*+-/=?^_`{|}~]+ :
+    any valid character in the valid local part (see in: https://datatracker.ietf.org/doc/html/rfc3696#section-3) 1 or more times
 Second Group - [a-z0-9.-]+ :
     any character of: 'A-Z', '0-9','.', '-' 1 or more times
 Third Group - [a-z]{2,} :
@@ -16,7 +16,7 @@ Third Group - [a-z]{2,} :
 
 The pattern will be: <First Group>@<Second Group>.<Third Group>
 """
-VALID_ADDRESS_FORMAT = r'[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}'
+VALID_ADDRESS_FORMAT = r"[a-z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-z0-9.-]+\.[a-z]{2,}"
 VALID_ADDRESS_REGEX = VALID_EXTENSION + VALID_ADDRESS_FORMAT
 
 

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.yml
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.yml
@@ -6,7 +6,8 @@ script: '-'
 type: python
 tags:
 - indicator-format
-comment: Verifies that an email address is valid and only returns the address if it is valid.
+comment: Verifies that an email address is valid and only returns the address if it
+  is valid.
 enabled: true
 args:
 - name: input
@@ -16,7 +17,7 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.9.5.20070
+dockerimage: demisto/python3:3.9.5.20958
 fromversion: 5.5.0
 tests:
-  - ExtractEmailV2-Test
+- ExtractEmailV2-Test

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting_test.py
@@ -12,6 +12,7 @@ testdata = [
     ('randomName@randomDomain.com', True),
     ('Xsoar@xsoar.xlsx', False),
     ('Xsoa r@ test.BmP', False),
+    ('bt53h6htyj8j57k9k=organization.org@ozzy.qwer.de', True),
 ]
 
 

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.3.55",
+    "currentVersion": "1.3.56",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CommonTypes/IndicatorTypes/reputation-email.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-email.json
@@ -7,7 +7,7 @@
   "commitMessage": "",
   "shouldPublish": false,
   "shouldCommit": false,
-  "regex": "\\b[A-Za-z0-9._%=+\\p{L}-]+@[A-Za-z0-9\\p{L}.-]+\\.[A-Za-z]{2,}\\b",
+  "regex": "\\b[A-Za-z0-9.!#$%&'*+/=?^_`{|}~\\p{L}-]+@[A-Za-z0-9\\p{L}.-]+\\.[A-Za-z]{2,}\\b",
   "details": "Email",
   "prevDetails": "Email",
   "reputationScriptName": "",

--- a/Packs/CommonTypes/ReleaseNotes/3_0_6.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_0_6.md
@@ -1,0 +1,3 @@
+
+#### Indicator Types
+- Fixed an issue where some special characters didn't exist in the **emailRep** regex.

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "3.0.5",
+    "currentVersion": "3.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/26601

## Description
fixed the regex to include all the allowed characters according to the [IETF standard](https://datatracker.ietf.org/doc/html/rfc3696#section-3)

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

## Must have
- [x] Tests