### PR TITLE
remove private tests from nightly

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3716,6 +3716,9 @@
         "Cortex Data Lake",
         "Mail Listener v2"
     ],
+    "private_tests": [
+        "HelloWorldPremium_Scan-Test"
+    ],
     "docker_thresholds": {
         
         "_comment": "Add here docker images which are specific to an integration and require a non-default threshold (such as rasterize or ews). That way there is no need to define this multiple times. You can specify full image name with version or without.",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3414,7 +3414,6 @@
         "Carbon Black Enterprise Protection V2 Test": "Issue 32322",
         "Google_Vault-Search_And_Display_Results_test": "Issue 24348",
         "FeedThreatConnect-Test": "Issue 32317",
-        "HelloWorldPremium_Scan-Test": "Issue 32512",
         "Palo_Alto_Networks_Enterprise_DLP - Test": "Issue 32568",
         "JoeSecurityTestDetonation": "Issue 25650",
         "JoeSecurityTestPlaybook": "Issue 25649",

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1052,7 +1052,7 @@ def remove_private_tests(tests_without_private_packs):
             tests_without_private_packs.remove(private_test)
 
 
-def filter_tests(tests: set, id_set: json, is_nightly = False) -> set:
+def filter_tests(tests: set, id_set: json, is_nightly=False) -> set:
     """
     Filter tests out from the test set if they are:
     a.Ignored

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1055,8 +1055,8 @@ def remove_private_tests(tests_without_private_packs):
 def filter_tests(tests: set, id_set: json, is_nightly=False) -> set:
     """
     Filter tests out from the test set if they are:
-    a.Ignored
-    b.Non XSOAR or non-supported packs
+    a. Ignored
+    b. Non-XSOAR or non-supported packs
     c. tests of deprecated packs.
     d. tests of private packs (optional)
     Args:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/37860
fixes: https://github.com/demisto/etc/issues/32512

## Description
Added an option of specifying private tests, that will not be run on nightly.
This possibility will allow us to specify timeout values for private tests.
