### PR TITLE
Remove the instance testing from the commit circle workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1304,40 +1304,12 @@ workflows:
           - << pipeline.parameters.instance_tests >>
     jobs:
       - Setup Environment
-      - Create Instances:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
       - Run Unit Testing And Lint:
           requires:
             - Setup Environment
       - Run Validations:
           requires:
             - Setup Environment
-      - Server 5_0:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - Create Instances
-      - Server 5_5:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - Create Instances
-      - Server 6_0:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - Create Instances
-      - Server Master:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - Create Instances
 
   force_pack_upload:
     when: << pipeline.parameters.force_pack_upload >>

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -116,6 +116,7 @@
     paths:
       - /builds/xsoar/content/unit-tests
       - /builds/xsoar/content/artifacts/*
+    when: always
   extends:
     - .default-job-settings
   script:
@@ -164,6 +165,7 @@
     expire_in: 30 days
     paths:
       - /builds/xsoar/content/artifacts/*
+    when: always
   script:
     - section_start "Look For Secrets"
     - demisto-sdk secrets --post-commit --ignore-entropy


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Removes from the CircleCI commit workflow the testing against live cortex XSOAR instances (because that now runs in GitLab).

## Additional Changes
Fix a problem with the hidden GitLab jobs `.run-unittests-and-lint` and `.run-validations` (which jobs in different pipeline configurations extend) so that artifacts are stored even if the job fails.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
