### PR TITLE
Added Is Processed indicator field

### DIFF
--- a/Packs/CommonTypes/IndicatorFields/indicatorfield-IsProcessed.json
+++ b/Packs/CommonTypes/IndicatorFields/indicatorfield-IsProcessed.json
@@ -1,0 +1,30 @@
+{
+    "id": "indicator_isprocessed",
+    "version": -1,
+    "modified": "2021-06-09T07:38:56.390162193Z",
+    "name": "Is Processed",
+    "ownerOnly": false,
+    "cliName": "isprocessed",
+    "type": "boolean",
+    "closeForm": false,
+    "editForm": true,
+    "required": false,
+    "neverSetAsRequired": false,
+    "isReadOnly": false,
+    "useAsKpi": true,
+    "locked": false,
+    "system": false,
+    "content": true,
+    "group": 2,
+    "hidden": false,
+    "associatedTypes": [
+        "User Profile"
+    ],
+    "associatedToAll": false,
+    "unmapped": false,
+    "unsearchable": false,
+    "caseInsensitive": true,
+    "sla": 0,
+    "threshold": 72,
+    "fromVersion": "5.5.0"
+}

--- a/Packs/CommonTypes/ReleaseNotes/3_0_7.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_0_7.md
@@ -1,0 +1,3 @@
+#### Indicator Fields
+New indicator fields:
+- **Is Processed**

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "3.0.6",
+    "currentVersion": "3.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related to: https://github.com/demisto/etc/issues/34214
Used in: https://github.com/demisto/content-premium/pull/50

## Description
Added the `Is Processed` indicator field that will be used somewhat like a lock mechanism to prevent further incident creations for a User Profile that is being updated.


## Minimum version of Cortex XSOAR
5.5.0


## Does it break backward compatibility?
No


