### PR TITLE
GitLab Flows Tweaks and Fixes

### DIFF
--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -8,6 +8,7 @@
   variables:
     GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period
 
+
 .check_user_permissions_to_upload_packs: &check_user_permissions_to_upload_packs
   - section_start "Check User Permissions to Upload Packs" # if bucket upload and uploading to marketplace-dist
   - |
@@ -25,6 +26,20 @@
     fi
   - section_end "Check User Permissions to Upload Packs"
 
+
+run-validations-upload-flow:
+  extends:
+    - .run-validations
+    - .bucket-upload-rule
+
+
+# Uncomment when docker in docker will work
+# run-unittests-and-lint-upload-flow:
+#   extends:
+#     - .run-unittests-and-lint
+#     - .bucket-upload-rule
+
+
 create-instances-upload-flow:
   extends:
     - create-instances
@@ -38,6 +53,7 @@ create-instances-upload-flow:
       when: never
     - if: '$BUCKET_UPLOAD == "true"'
     - if: '$FORCE_BUCKET_UPLOAD == "true"'
+
 
 .install_packs_in_server:
   needs: ["create-instances-upload-flow"]
@@ -75,15 +91,18 @@ create-instances-upload-flow:
     - section_end "Destroy instances"
     - exit "$EXIT_CODE"
 
+
 install-packs-in-server6_0:
   extends: .install_packs_in_server
   variables:
     INSTANCE_ROLE: "Server 6.0"
 
+
 install-packs-in-server-master:
   extends: .install_packs_in_server
   variables:
     INSTANCE_ROLE: "Server Master"
+
 
 upload-packs-to-marketplace:
   needs: ["run-validations-upload-flow", "install-packs-in-server6_0", "install-packs-in-server-master"] # add "run-unittests-and-lint-upload-flow" after docker in docker is resolved.
@@ -127,6 +146,7 @@ upload-packs-to-marketplace:
       fi
     - section_end "Validate Premium Packs"
 
+
 force-pack-upload:
   stage: upload-to-marketplace
   needs: ["create-instances-upload-flow"]
@@ -152,18 +172,6 @@ force-pack-upload:
     - python3 ./Tests/Marketplace/copy_and_upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -pb "$GCS_MARKET_BUCKET" -bb "$GCS_BUILD_BUCKET" -s $GCS_MARKET_KEY -n $CI_PIPELINE_ID -c $CI_COMMIT_BRANCH -p "${PACKS_TO_UPLOAD}" -pbp "${STORAGE_BASE_PATH}"
 
 
-run-validations-upload-flow:
-  extends:
-    - .run-validations
-    - .bucket-upload-rule
-
-# Uncomment when docker in docker will work
-# run-unittests-and-lint-upload-flow:
-#   extends:
-#     - .run-unittests-and-lint
-#     - .bucket-upload-rule
-
-
 slack-notify-bucket-upload:
   extends:
     - .trigger-slack-notification
@@ -178,3 +186,7 @@ slack-notify-bucket-upload:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Upload Packs to Marketplace Storage'
     JOB_NAME: 'upload-packs-to-marketplace'
+    # Passes the environment variable from the parent pipeline to the child which can be useful for cases
+    # when triggering pipeline with alternate env variable value passed in the API call
+    SLACK_CHANNEL: '$SLACK_CHANNEL'
+    GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -21,19 +21,6 @@ trigger-private-build:
     - python3 Utils/get_private_build_status.py --github-token $GITHUB_TOKEN
 
 
-run-validations:
-  extends:
-    - .run-validations
-    - .push-rule
-
-
-# Uncomment when docker in docker will work
-# run-unittests-and-lint:
-#   extends:
-#     - .run-unittests-and-lint
-#     - .push-rule
-
-
 create-instances:
   extends:
     - .default-job-settings
@@ -160,6 +147,7 @@ server_master:
   rules:
     - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
     - if: '$NIGHTLY'
+      when: always
   variables:
     INSTANCE_ROLE: "Server Master"
 
@@ -174,3 +162,6 @@ slack-notify-nightly-build:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Content Nightly'
     JOB_NAME: 'server_master'
+    # Passes the environment variable from the parent pipeline to the child which can be useful for cases
+    # when triggering pipeline with alternate env variable value passed in the API call
+    SLACK_CHANNEL: '$SLACK_CHANNEL'

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -1,6 +1,12 @@
 .sdk-nightly-schedule-rule:
   rules:
-    - if: '$CI_PIPELINE_SOURCE =~ /^(schedule)$/ && $DEMISTO_SDK_NIGHTLY == "true"'
+    - if: '$CI_PIPELINE_SOURCE =~ /^(schedule|trigger)$/ && $DEMISTO_SDK_NIGHTLY == "true"'
+
+# used for jobs which we want to run in a pipeline even when previous jobs in the pipeline fail e.g. slack notification
+.sdk-nightly-schedule-rule-always:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE =~ /^(schedule|trigger)$/ && $DEMISTO_SDK_NIGHTLY == "true"'
+      when: always
 
 
 .upload-entities-to-cortex-xsoar: &upload-entities-to-cortex-xsoar
@@ -32,6 +38,7 @@ demisto_sdk_nightly:check_idset_dependent_commands:
     - .default-job-settings
     - .sdk-nightly-schedule-rule
   stage: unittests-and-validations
+  needs: []
   inherit:
     variables: true
   variables:
@@ -93,13 +100,9 @@ demisto-sdk-nightly:create-instance:
 demisto-sdk-nightly:run-commands-against-instance:
   extends:
     - .default-job-settings
-    - .sdk-nightly-schedule-rule
+    - .sdk-nightly-schedule-rule-always
   variables:
-    DESTROY_INSTANCES: "true"
     INSTANCE_ROLE: "Server Master"
-  needs: ["demisto-sdk-nightly:create-instance"]
-  dependencies:
-    - demisto-sdk-nightly:create-instance
   stage: run-instances
   script:
     - !reference [.open-ssh-tunnel]
@@ -141,10 +144,11 @@ demisto-sdk-nightly:run-commands-against-instance:
 demisto-sdk-nightly:trigger-slack-notify:
   extends:
     - .trigger-slack-notification
-  rules:
-    - if: '$CI_PIPELINE_SOURCE =~ /^(schedule)$/ && $DEMISTO_SDK_NIGHTLY == "true"'
-      when: always
+    - .sdk-nightly-schedule-rule-always
   variables:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Demisto SDK Nightly'
     JOB_NAME: 'demisto-sdk-nightly:run-commands-against-instance'
+    # Passes the environment variable from the parent pipeline to the child which can be useful for cases
+    # when triggering pipeline with alternate env variable value passed in the API call
+    SLACK_CHANNEL: '$SLACK_CHANNEL'

--- a/.gitlab/ci/slack-notify.yml
+++ b/.gitlab/ci/slack-notify.yml
@@ -18,8 +18,6 @@ include:
 slack-notify:
   stage: notify
   extends: .default-job-settings
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master" || $SLACK_CHANNEL != "dmst-content-team"
   script:
     - python3 ./Tests/scripts/gitlab_slack_notifier.py -p "$PIPELINE_TO_QUERY" -s "$SLACK_TOKEN" -c "$GITLAB_STATUS_TOKEN" -ca "$ARTIFACTS_FOLDER" -ch "$SLACK_CHANNEL" -tw "$WORKFLOW"
   needs:


### PR DESCRIPTION
## Status
- [x] Ready


## Fixes
- https://github.com/demisto/etc/issues/37789


## Description
Implements the following fixes and tweaks:
- Removes the job rules condition from the slack-notification child pipeline workflow. This is because any job in the parent pipeline that triggers the slack notification child pipeline should have the proper rule conditions for running. Therefore we can remove the rule conditions from the child.
- Adds a `when: always` field to rules of jobs that should run even when previous jobs failed. Used in the various `<trigger-slack-notification>` jobs and the jobs whose artifacts the trigger jobs depend upon. This way, these jobs won't be skipped if previous jobs in the pipeline fail (which should prevent the slack notification to the `dmst-content-team` channel from not occurring).
- Explicitly pass the `$SLACK_CHANNEL` environment variable to the `slack-notification` child pipeline from the parent pipeline's trigger job. This is useful when passing an alternate value for the environment variable when triggering a pipeline manually (either via the UI or API) - this way the value in the child pipeline is not the default but rather the value that was passed to the parent from the trigger.
- Removes the `run-validations` job from the `on-push` flow.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation