### PR TITLE
MS Graph Mail Single User - set the contentId attribute in the attachment object

### DIFF
--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.py
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.py
@@ -508,7 +508,8 @@ class MsGraphClient:
                 'contentBytes': b64_encoded_data.decode('utf-8'),
                 'isInline': is_inline,
                 'name': attach_name if provided_names else uploaded_file_name,
-                'size': file_size
+                'size': file_size,
+                'contentId': attach_id,
             }
             file_attachments_result.append(attachment)
 

--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
@@ -378,7 +378,7 @@ script:
     description: Tests connectivity of the email.
     execution: false
     name: msgraph-mail-test
-  dockerimage: demisto/crypto:1.0.0.18288
+  dockerimage: demisto/crypto:1.0.0.19032
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/README.md
+++ b/Packs/MicrosoftGraphListener/Integrations/MicrosoftGraphListener/README.md
@@ -593,6 +593,14 @@ The following permissions are required for all commands:
  alt="image" width="749" height="412"></a>
  -->
 </p>
+<p>
+  <h5>Sending mails with embedded images</h5>
+  In order to send a mail with embedded image, the image content ID should be passed the <b>attach_cids</b> argument and referenced in the HTML mark-up.
+  Note: You will have to specify this CID reference when you add the attachment to the mail message.
+  For example:
+
+  <code>!send-mail subject="Mail with an embedded image" attach_cids=1@2 body_type=HTML body="&lt;h1&gt;A mail with an embedded image &lt;img src='cid:1@2' /&gt;&lt;/h1&gt;"</code>
+</p>
 
 <h3 id="msgraph-mail-reply-to">3. msgraph-mail-reply-to</h3>
 <hr>

--- a/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_16.md
+++ b/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_16.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Graph Mail Single User
+- Fixed an issue where embedded images could not be referenced from the mail body.

--- a/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_16.md
+++ b/Packs/MicrosoftGraphListener/ReleaseNotes/1_0_16.md
@@ -2,3 +2,5 @@
 #### Integrations
 ##### Microsoft Graph Mail Single User
 - Fixed an issue where embedded images could not be referenced from the mail body.
+- Updated the Docker image to: *demisto/crypto:1.0.0.19032*.
+

--- a/Packs/MicrosoftGraphListener/pack_metadata.json
+++ b/Packs/MicrosoftGraphListener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail Single User",
     "description": "Microsoft Graph grants Demisto authorized access to a user's Microsoft Outlook mail data in a personal account or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.0.15",
+    "currentVersion": "1.0.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/37983

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
