### PR TITLE
fix widget duplicate id in Elasticsearch Monitoring

### DIFF
--- a/Packs/ElasticsearchMonitoring/Dashboards/elasticsearch_monitoring.json
+++ b/Packs/ElasticsearchMonitoring/Dashboards/elasticsearch_monitoring.json
@@ -22,7 +22,7 @@
             "w": 2,
             "h": 1,
             "widget": {
-                "id": "es-cpu-current-usage",
+                "id": "es-cpu-current",
                 "version": -1,
                 "modified": "2021-01-10T13:24:20.812878Z",
                 "name": "Elasticsearch CPU Current Usage",
@@ -61,7 +61,7 @@
             "w": 2,
             "h": 1,
             "widget": {
-                "id": "es-disk-current-usage",
+                "id": "es-disk-current",
                 "version": -1,
                 "modified": "2021-01-10T13:24:20.812147Z",
                 "name": "Elasticsearch Disk Current Usage",
@@ -102,7 +102,7 @@
             "w": 2,
             "h": 1,
             "widget": {
-                "id": "es-jvm-memory-current-usage",
+                "id": "es-jvm-memory-current",
                 "version": -1,
                 "modified": "2021-01-10T13:24:20.812147Z",
                 "name": "Elasticsearch JVM Memory Current Usage",

--- a/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchCPUCurrentUsage.json
+++ b/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchCPUCurrentUsage.json
@@ -1,5 +1,5 @@
 {
-    "id": "es-cpu-current-usage",
+    "id": "es-cpu-current",
     "version": -1,
     "fromVersion": "6.1.0",
     "modified": "2021-01-10T13:24:20.812878Z",

--- a/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchDiskCurrentUsage.json
+++ b/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchDiskCurrentUsage.json
@@ -1,5 +1,5 @@
 {
-    "id": "es-disk-current-usage",
+    "id": "es-disk-current",
     "version": -1,
     "fromVersion": "6.1.0",
     "modified": "2021-01-10T13:24:20.812147Z",

--- a/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchJVMCurrentUsage.json
+++ b/Packs/ElasticsearchMonitoring/Widgets/widget-ElasticSearchJVMCurrentUsage.json
@@ -1,5 +1,5 @@
 {
-    "id": "es-jvm-memory-current-usage",
+    "id": "es-jvm-memory-current",
     "version": -1,
     "fromVersion": "6.1.0",
     "modified": "2021-01-10T13:24:20.812147Z",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fix Elasticsearch monitoring pack's widget duplicate id with Common Widgets pack

