### PR TITLE
Fix passing SLACK_CHANNEL env var value

### DIFF
--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -188,5 +188,5 @@ slack-notify-bucket-upload:
     JOB_NAME: 'upload-packs-to-marketplace'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
-    SLACK_CHANNEL: '$SLACK_CHANNEL'
+    SLACK_CHANNEL: $SLACK_CHANNEL
     GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period

--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -8,6 +8,17 @@
   variables:
     GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period
 
+.bucket-upload-rule-always:
+  rules:
+    - if: '$GCS_MARKET_BUCKET == "marketplace-dist"' # remove this after testing period
+      when: never # remove this after testing period
+    - if: '$CI_COMMIT_BRANCH =~ /pull\/[0-9]+/'
+      when: never
+    - if: '$BUCKET_UPLOAD == "true"'
+      when: always
+  variables:
+    GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period
+
 
 .check_user_permissions_to_upload_packs: &check_user_permissions_to_upload_packs
   - section_start "Check User Permissions to Upload Packs" # if bucket upload and uploading to marketplace-dist
@@ -118,7 +129,7 @@ upload-packs-to-marketplace:
     SSH_TUNNEL_TIMEOUT: 10
     TIME_TO_LIVE: ""
   extends:
-    - .bucket-upload-rule
+    - .bucket-upload-rule-always
     - .default-job-settings
   script:
     - !reference [.open-ssh-tunnel]
@@ -173,15 +184,6 @@ force-pack-upload:
 
 
 slack-notify-bucket-upload:
-  extends:
-    - .trigger-slack-notification
-  rules:
-    - if: '$GCS_MARKET_BUCKET == "marketplace-dist"' # remove this after testing period
-      when: never # remove this after testing period
-    - if: '$CI_COMMIT_BRANCH =~ /pull\/[0-9]+/'
-      when: never
-    - if: '$BUCKET_UPLOAD == "true"'
-      when: always
   variables:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Upload Packs to Marketplace Storage'
@@ -189,4 +191,6 @@ slack-notify-bucket-upload:
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
     SLACK_CHANNEL: $SLACK_CHANNEL
-    GCS_PRODUCTION_BUCKET: "marketplace-dist-dev" # remove this after testing period
+  extends:
+    - .trigger-slack-notification
+    - .bucket-upload-rule-always

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -164,4 +164,4 @@ slack-notify-nightly-build:
     JOB_NAME: 'server_master'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
-    SLACK_CHANNEL: '$SLACK_CHANNEL'
+    SLACK_CHANNEL: $SLACK_CHANNEL

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -151,4 +151,4 @@ demisto-sdk-nightly:trigger-slack-notify:
     JOB_NAME: 'demisto-sdk-nightly:run-commands-against-instance'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
-    SLACK_CHANNEL: '$SLACK_CHANNEL'
+    SLACK_CHANNEL: $SLACK_CHANNEL


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Our scheduled pipelines passed the string literal `$SLACK_CHANNEL` instead of the environment variable's value. See this [pipeline](https://code.pan.run/xsoar/content/-/pipelines/1250578) for an example.

## Additional Changes
Change the `upload-packs-to-marketplace` job to always run during the bucket-upload flow even if previous jobs failed.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
