### PR TITLE
VerifyIPv6Indicator - return empty string instead of empty list

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_3_59.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_3_59.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### VerifyIPv6Indicator
+- Fixed an issue where the script did not drop indicators as expected.

--- a/Packs/CommonScripts/ReleaseNotes/1_3_59.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_3_59.md
@@ -2,3 +2,4 @@
 #### Scripts
 ##### VerifyIPv6Indicator
 - Fixed an issue where the script did not drop indicators as expected.
+- Updated the Docker image to: *demisto/python3:3.9.5.21272*.

--- a/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator.py
+++ b/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator.py
@@ -24,9 +24,9 @@ def main():
             continue
 
     if entries_list:
-        demisto.results(entries_list)
+        return_results(entries_list)
     else:
-        demisto.results([])
+        return_results('')
 
 
 # python2 uses __builtin__ python3 uses builtins

--- a/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator.yml
+++ b/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator.yml
@@ -18,7 +18,7 @@ tags:
 - indicator-format
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.8.6.12176
+dockerimage: demisto/python3:3.9.5.21272
 runas: DBotWeakRole
 runonce: false
 tests:

--- a/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator_test.py
+++ b/Packs/CommonScripts/Scripts/VerifyIPv6Indicator/VerifyIPv6Indicator_test.py
@@ -1,5 +1,7 @@
-from VerifyIPv6Indicator import is_valid_ipv6_address
 import pytest
+
+import demistomock as demisto
+from VerifyIPv6Indicator import is_valid_ipv6_address, main
 
 
 @pytest.mark.parametrize(
@@ -18,3 +20,18 @@ import pytest
 def test_set_limit(address, expected):
     ipv6_address = is_valid_ipv6_address(address)
     assert ipv6_address == expected
+
+
+def test_main(mocker):
+    """
+    Given:
+        - MAC Address as input
+    When:
+        - Running the script
+    Then:
+        - Ensure the MAC address is caught as invalid IPv6 and returns empty string
+    """
+    mocker.patch.object(demisto, 'args', return_value={'input': '00:16:45:00:46:91'})
+    mocker.patch.object(demisto, 'results')
+    main()
+    demisto.results.assert_called_with('')

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.3.58",
+    "currentVersion": "1.3.59",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
should return empty string in case we want to drop the indicator and not an empty array


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

