### PR TITLE
Fix release notes creation in sdk-nightly & on push flows

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -71,9 +71,20 @@ create-instances:
         ./Tests/scripts/prepare_content_packs_for_testing.sh "$GCS_MARKET_BUCKET"
       fi
     - section_end "Prepare Content Packs for Testing"
+    - section_start "Create Content Descriptor"
+    - |
+      if [[ $CI_COMMIT_BRANCH == master ]] || [[ $CI_COMMIT_BRANCH =~ 21\.* ]] || [[ $CI_COMMIT_BRANCH =~ 22\.* ]]; then
+        echo "Creating Release Notes and Content Descriptor"
+        python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
+        cp content-descriptor.json $ARTIFACTS_FOLDER
+      else
+        echo "Skipping creation of content descriptor and release notes because not on master or release branch"
+        echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
+      fi
+    - section_end "Create Content Descriptor"
     - section_start "Zip Marketplace Packs"
     - |
-      if [[ $CI_COMMIT_BRANCH != master ]] && [[ $CI_COMMIT_BRANCH != 20\.* ]] && [[ $CI_COMMIT_BRANCH != 21\.* ]]; then
+      if [[ $CI_COMMIT_BRANCH != master ]] && [[ $CI_COMMIT_BRANCH != 21\.* ]] && [[ $CI_COMMIT_BRANCH != 22\.* ]]; then
         echo "Skipping packs download to artifact on branch that is not master or a release branch"
         echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
       else

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -36,8 +36,15 @@ create-instances:
     - !reference [.download-demisto-conf]
     - !reference [.create-id-set]
     - section_start "Create Release Notes and Common Server Documentation"
-    - python3 Utils/release_notes_generator.py $CONTENT_VERSION $CI_COMMIT_SHA $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
-    - cp content-descriptor.json $ARTIFACTS_FOLDER
+    - |
+      if [[ $CI_COMMIT_BRANCH == master ]] || [[ $CI_COMMIT_BRANCH == 21\.* ]] || [[ $CI_COMMIT_BRANCH == 22\.* ]]; then
+        echo "Creating Release Notes and Saving Content Descriptor"
+        python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
+        cp content-descriptor.json $ARTIFACTS_FOLDER
+      else
+        echo "Skipping creation of content descriptor and release notes because not on master or release branch"
+        echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
+      fi
     - ./Documentation/commonServerDocs.sh
     - section_end "Create Release Notes and Common Server Documentation"
     - section_start "Create Content Artifacts and Update Conf"
@@ -71,17 +78,6 @@ create-instances:
         ./Tests/scripts/prepare_content_packs_for_testing.sh "$GCS_MARKET_BUCKET"
       fi
     - section_end "Prepare Content Packs for Testing"
-    - section_start "Create Content Descriptor"
-    - |
-      if [[ $CI_COMMIT_BRANCH == master ]] || [[ $CI_COMMIT_BRANCH =~ 21\.* ]] || [[ $CI_COMMIT_BRANCH =~ 22\.* ]]; then
-        echo "Creating Release Notes and Content Descriptor"
-        python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
-        cp content-descriptor.json $ARTIFACTS_FOLDER
-      else
-        echo "Skipping creation of content descriptor and release notes because not on master or release branch"
-        echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
-      fi
-    - section_end "Create Content Descriptor"
     - section_start "Zip Marketplace Packs"
     - |
       if [[ $CI_COMMIT_BRANCH != master ]] && [[ $CI_COMMIT_BRANCH != 21\.* ]] && [[ $CI_COMMIT_BRANCH != 22\.* ]]; then

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -66,7 +66,7 @@ demisto_sdk_nightly:check_idset_dependent_commands:
     - echo "successfully merged public and private ID sets"
     - section_end "Merge public and private ID sets"
     - section_start "Build Content Descriptor" --collapsed
-    - python3 Utils/release_notes_generator.py $CONTENT_VERSION $CI_COMMIT_SHA $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
+    - python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
     - cp content-descriptor.json $ARTIFACTS_FOLDER
     - section_end "Build Content Descriptor"
     - section_start "Common Server Documentation" --collapsed


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/jobs/6074172

## Description
In the job artifacts of the link above, the [packs-release-notes.md file](https://code.pan.run/xsoar/content/-/jobs/6074172/artifacts/file/artifacts/packs-release-notes.md) which was created (and which we use when creating a content release) didn't detect and add the release notes since the last release. This is because we were passing the current branch's ref instead of the `$GIT_SHA1` env variable stored value from `.circleci/content_release_vars.sh` which contains the sha ref of the last release.

## Additional Changes
Added the creation of the release notes file and content descriptor file to the `on-push` flow (to only execute on master or release branches).

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
