### PR TITLE
FireEye HX - fix api version check for host-containment

### DIFF
--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.py
@@ -1068,7 +1068,7 @@ def containment_request(agent_id):
         api_version = int(VERSION[-1])
     except Exception as exc:
         raise ValueError('Invalid version was set: {} - {}'.format(VERSION, str(exc)))
-    if api_version > 3:
+    if api_version >= 3:
         http_request(
             'POST',
             url,

--- a/Packs/FireEyeHX/ReleaseNotes/1_0_15.md
+++ b/Packs/FireEyeHX/ReleaseNotes/1_0_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### FireEye HX
+- Fixed an issue where the ***fireeye-hx-host-containment*** command failed using API v3.

--- a/Packs/FireEyeHX/pack_metadata.json
+++ b/Packs/FireEyeHX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye HX",
     "description": "FireEye Endpoint Security is an integrated solution that detects what others miss and protects endpoint against known and unknown threats. The FireEye HX Demisto integration provides access to information about endpoints, acquisitions, alerts, indicators, and containment. Customers can extract critical data and effectively operate security operations automated playbooks.",
     "support": "xsoar",
-    "currentVersion": "1.0.14",
+    "currentVersion": "1.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

fixes https://github.com/demisto/etc/issues/28360

## Description
fixed an issue where the check if api v3 is used was wrong as it was missing checking if api is v3


## Does it break backward compatibility?
   - [x] No
