### PR TITLE
FireEye HX - handle parsing alert with unicode in event type

### DIFF
--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.yml
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX.yml
@@ -1313,8 +1313,9 @@ script:
   longRunningPort: false
   runonce: false
   script: '-'
-  subtype: python3
+  subtype: python2
   type: python
+  dockerimage: demisto/python:2.7.18.20958
 tests:
 - FireEye HX Test
 fromversion: 5.0.0

--- a/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX_test.py
+++ b/Packs/FireEyeHX/Integrations/FireEyeHX/FireEyeHX_test.py
@@ -1,7 +1,12 @@
 import demistomock as demisto
+import pytest
 
 
-def test_parse_alert_to_incident(mocker):
+@pytest.mark.parametrize('alert, expected', [
+    ({'event_values': []}, {'name': 'New Event: ', 'rawJSON': '{"event_values": []}'}),
+    ({'event_type': u'\u37cb'}, {}),
+])
+def test_parse_alert_to_incident(mocker, alert, expected):
     """
     Given:
         - Alert with event_values as list
@@ -27,4 +32,4 @@ def test_parse_alert_to_incident(mocker):
         }
     )
     from FireEyeHX import parse_alert_to_incident
-    assert parse_alert_to_incident({'event_values': []}) == {'name': 'New Event: ', 'rawJSON': '{"event_values": []}'}
+    assert parse_alert_to_incident(alert) == expected


### PR DESCRIPTION

## Status
- [x] In Progress

## Description

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
