### PR TITLE
Fix copy of content-descriptor.json to artifacts

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -38,13 +38,13 @@ create-instances:
     - section_start "Create Release Notes and Common Server Documentation"
     - |
       if [[ $CI_COMMIT_BRANCH == master ]] || [[ $CI_COMMIT_BRANCH == 21\.* ]] || [[ $CI_COMMIT_BRANCH == 22\.* ]]; then
-        echo "Creating Release Notes and Saving Content Descriptor"
+        echo "Creating Release Notes"
         python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
-        cp content-descriptor.json $ARTIFACTS_FOLDER
       else
-        echo "Skipping creation of content descriptor and release notes because not on master or release branch"
+        echo "Skipping creation release notes because not on master or release branch"
         echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
       fi
+    - cp content-descriptor.json $ARTIFACTS_FOLDER
     - ./Documentation/commonServerDocs.sh
     - section_end "Create Release Notes and Common Server Documentation"
     - section_start "Create Content Artifacts and Update Conf"

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -41,7 +41,7 @@ create-instances:
         echo "Creating Release Notes"
         python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
       else
-        echo "Skipping creation release notes because not on master or release branch"
+        echo "Skipping creation of release notes because we are not on master or a release branch"
         echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
       fi
     - cp content-descriptor.json $ARTIFACTS_FOLDER

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -36,14 +36,8 @@ create-instances:
     - !reference [.download-demisto-conf]
     - !reference [.create-id-set]
     - section_start "Create Release Notes and Common Server Documentation"
-    - |
-      if [[ $CI_COMMIT_BRANCH == master ]] || [[ $CI_COMMIT_BRANCH == 21\.* ]] || [[ $CI_COMMIT_BRANCH == 22\.* ]]; then
-        echo "Creating Release Notes"
-        python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
-      else
-        echo "Skipping creation of release notes because we are not on master or a release branch"
-        echo "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH"
-      fi
+    - echo "Creating Release Notes and Content Descriptor"
+    - python3 Utils/release_notes_generator.py $CONTENT_VERSION $GIT_SHA1 $CI_BUILD_ID --output $ARTIFACTS_FOLDER/packs-release-notes.md --github-token $GITHUB_TOKEN
     - cp content-descriptor.json $ARTIFACTS_FOLDER
     - ./Documentation/commonServerDocs.sh
     - section_end "Create Release Notes and Common Server Documentation"


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/jobs/6159487

## Description
Reverting putting the execution of `Utils/release_notes_generator.py` under a condition checking whether we were on the `master` or a release branch. That script also generates the `content-descriptor.json` file which is used in updating the content on an xsoar instance.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/122733515-ed616b00-d285-11eb-8e0f-42257db0ead2.png)

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No - it fixes the bc that I broke 🙍🏼‍♂️ in this [PR](https://github.com/demisto/content/pull/13265)

## Must have
- [ ] Tests
- [ ] Documentation 
