### PR TITLE
Added flag to specify branch for SDK nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1194,7 +1194,9 @@ jobs:
             echo "Server URL: $DEMISTO_BASE_URL"
       - run:
           name: Install SDK
-          command: pip3 install git+https://github.com/demisto/demisto-sdk.git@"$SDK_REF"
+          command: |
+          echo "Installing SDK from $SDK_REF"
+          pip3 install git+https://github.com/demisto/demisto-sdk.git@"$SDK_REF"
       - *wait_until_server_ready
       - run:
           name: Unlock HelloWorld integration and playbook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1195,8 +1195,8 @@ jobs:
       - run:
           name: Install SDK
           command: |
-          echo "Installing SDK from $SDK_REF"
-          pip3 install git+https://github.com/demisto/demisto-sdk.git@"$SDK_REF"
+            echo "Installing SDK from $SDK_REF"
+            pip3 install git+https://github.com/demisto/demisto-sdk.git@"$SDK_REF"
       - *wait_until_server_ready
       - run:
           name: Unlock HelloWorld integration and playbook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,9 @@ parameters:
   slack_channel:
     type: string
     default: "dmst-content-team"
+  sdk_ref:
+    type: string
+    default: "master"
 
 references:
   environment: &environment
@@ -113,6 +116,7 @@ references:
       CONTRIB_PACK_NAME: << pipeline.parameters.contrib_pack_name >>
       GCS_MARKET_BUCKET: << pipeline.parameters.gcs_market_bucket >>
       SLACK_CHANNEL: << pipeline.parameters.slack_channel >>
+      SDK_REF: << pipeline.parameters.sdk_ref >>
       # Giving different names to the following pipeline parameters to avoid collision, handling such collision case
       # is done in 'Setup Environment' step.
       TIME_TO_LIVE_PARAMETER: << pipeline.parameters.time_to_live >>
@@ -221,7 +225,7 @@ references:
         fi
 
         echo "========== Build Parameters =========="
-        set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^NON_AMI_RUN=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^GCS_MARKET_BUCKET=|^SLACK_CHANNEL="
+        set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^NON_AMI_RUN=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^GCS_MARKET_BUCKET=|^SLACK_CHANNEL=|^SDK_REF"
         python --version
         python3 --version
         node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1190,7 +1190,7 @@ jobs:
             echo "Server URL: $DEMISTO_BASE_URL"
       - run:
           name: Install SDK
-          command: pip3 install git+https://github.com/demisto/demisto-sdk.git@"${SDK_REF}"
+          command: pip3 install git+https://github.com/demisto/demisto-sdk.git@"$SDK_REF"
       - *wait_until_server_ready
       - run:
           name: Unlock HelloWorld integration and playbook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1189,8 +1189,8 @@ jobs:
             echo "export DEMISTO_BASE_URL=\"https://localhost:$(cat $ENV_RESULTS_PATH | jq -r '.[0].TunnelPort')\"" >> $BASH_ENV
             echo "Server URL: $DEMISTO_BASE_URL"
       - run:
-          name: Install SDK Master
-          command: pip3 install git+https://github.com/demisto/demisto-sdk.git
+          name: Install SDK
+          command: pip3 install git+https://github.com/demisto/demisto-sdk.git@"${SDK_REF}"
       - *wait_until_server_ready
       - run:
           name: Unlock HelloWorld integration and playbook

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -34,6 +34,7 @@ variables:
   ENV_RESULTS_PATH: "/builds/xsoar/content/artifacts/env_results.json"
   GCS_PRODUCTION_BUCKET: "marketplace-dist" # change to marketplace-dist this after testing period
   DEMISTO_CONNECTION_POOL_MAXSIZE: "180" # see this issue for more info https://github.com/demisto/etc/issues/36886
+  SDK_REF: "master"  # Add comment here
 
 
 include:

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -34,7 +34,7 @@ variables:
   ENV_RESULTS_PATH: "/builds/xsoar/content/artifacts/env_results.json"
   GCS_PRODUCTION_BUCKET: "marketplace-dist" # change to marketplace-dist this after testing period
   DEMISTO_CONNECTION_POOL_MAXSIZE: "180" # see this issue for more info https://github.com/demisto/etc/issues/36886
-  SDK_REF: "master"  # Add comment here
+  SDK_REF: "master" # The default sdk branch to use
 
 
 include:

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -64,7 +64,7 @@
   - |
     if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
       echo "Installing SDK from master branch" | tee --append $ARTIFACTS_FOLDER/logs/installations.log
-      pip3 install git+https://github.com/demisto/demisto-sdk@master >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
+      pip3 install "git+https://github.com/demisto/demisto-sdk@${SDK_REF}" >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
     fi
   - section_end "Installing Virtualenv"
 

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -63,7 +63,7 @@
   - source ./venv/bin/activate
   - |
     if [ -n "${DEMISTO_SDK_NIGHTLY}" ]; then
-      echo "Installing SDK from master branch" | tee --append $ARTIFACTS_FOLDER/logs/installations.log
+      echo "Installing SDK from $SDK_REF" | tee --append $ARTIFACTS_FOLDER/logs/installations.log
       pip3 install "git+https://github.com/demisto/demisto-sdk@${SDK_REF}" >> $ARTIFACTS_FOLDER/logs/installations.log 2>&1
     fi
   - section_end "Installing Virtualenv"

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -70,7 +70,7 @@ else
     "branch": "${_branch}",
     "parameters": {
       "demisto_sdk_nightly": "true",
-      "sdk_ref": ${_sdk_ref}
+      "sdk_ref": "${_sdk_ref}"
     }
   }
   EOF

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -69,7 +69,8 @@ else
   {
     "branch": "${_branch}",
     "parameters": {
-      "demisto_sdk_nightly": "true"
+      "demisto_sdk_nightly": "true",
+      "sdk_ref": ${_sdk_ref}"
     }
   }
   EOF

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -8,10 +8,12 @@ if [ "$#" -lt "1" ]; then
   [-b, --branch]              The branch name. Default is the current branch.
   [-g, --gitlab]              Flag to pass if triggering a build in GitLab
   [-ch, --slack-channel]      A slack channel to send notifications to. Default is dmst-bucket-upload.
+  [-sr, --sdk-ref]            Branch in the demisto-sdk repo to checkout. Useful for testing large changes
   "
   exit 1
 fi
 _branch="$(git branch  --show-current)"
+_sdk_ref="master"
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -25,6 +27,10 @@ while [[ "$#" -gt 0 ]]; do
     shift;;
 
   -ch|--slack-channel) _slack_channel="$2"
+    shift
+    shift;;
+
+  -sr|--sdk-ref) _sdk_ref="$2"
     shift
     shift;;
 
@@ -53,6 +59,7 @@ if [ -n "$_gitlab" ]; then
     --form ref="${_branch}" \
     --form "${_variables}" \
     --form "variables[SLACK_CHANNEL]=${_slack_channel}" \
+    --form "variables[SDK_REF]=${_sdk_ref}" \
     "$BUILD_TRIGGER_URL"
 
 else

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -5,10 +5,10 @@ if [ "$#" -lt "1" ]; then
   echo "Usage:
   $0 -ct <token>
   -ct, --ci-token             The ci token.
-  [-b, --branch]              The branch name. Default is the current branch.
+  [-b, --branch]              The content repo branch name. Default is the current branch.
   [-g, --gitlab]              Flag to pass if triggering a build in GitLab
   [-ch, --slack-channel]      A slack channel to send notifications to. Default is dmst-bucket-upload.
-  [-sr, --sdk-ref]            Branch in the demisto-sdk repo to checkout. Useful for testing large changes
+  [-sr, --sdk-ref]            The demisto-sdk repo branch to run this build with.
   "
   exit 1
 fi

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -70,7 +70,7 @@ else
     "branch": "${_branch}",
     "parameters": {
       "demisto_sdk_nightly": "true",
-      "sdk_ref": ${_sdk_ref}"
+      "sdk_ref": ${_sdk_ref}
     }
   }
   EOF


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/32647

## Description
Added the option to give a specific demisto-sdk branch that will be used by trigger_nightly_sdk_build

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
