### PR TITLE
Updates to the Devo_v2 plugin

### DIFF
--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2.py
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2.py
@@ -148,9 +148,9 @@ def build_link(query, start_ts_milli, end_ts_milli, mode='queryApp', linq_base=N
     }).encode('ascii'))).decode()
 
     if linq_base:
-        url = linq_base + f"#/vapps/app.custom.queryApp_dev&targetQuery={myb64str}"
+        url = linq_base + f"/#/vapps/app.custom.queryApp_dev?&targetQuery={myb64str}"
     else:
-        url = LINQ_LINK_BASE + f"#/vapps/app.custom.queryApp_dev&targetQuery={myb64str}"
+        url = LINQ_LINK_BASE + f"/#/vapps/app.custom.queryApp_dev?&targetQuery={myb64str}"
 
     return url
 

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2.py
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2.py
@@ -13,6 +13,8 @@ import os
 from datetime import datetime
 from devo.sender import Lookup, SenderConfigSSL, Sender
 from typing import List, Dict, Set
+from devodsconnector import error_checking
+from functools import partial
 
 ''' GLOBAL VARS '''
 ALLOW_INSECURE = demisto.params().get('insecure', False)
@@ -23,6 +25,7 @@ WRITER_CREDENTIALS = demisto.params().get('writer_credentials', None)
 LINQ_LINK_BASE = demisto.params().get('linq_link_base', "https://us.devo.com/welcome")
 FETCH_INCIDENTS_FILTER = demisto.params().get('fetch_incidents_filters', None)
 FETCH_INCIDENTS_DEDUPE = demisto.params().get('fetch_incidents_deduplication', None)
+TIMEOUT = demisto.params().get('timeout', '60')
 HEALTHCHECK_WRITER_RECORD = [{'hello': 'world', 'from': 'demisto-integration'}]
 HEALTHCHECK_WRITER_TABLE = 'test.keep.free'
 RANGE_PATTERN = re.compile('^[0-9]+ [a-zA-Z]+')
@@ -114,7 +117,27 @@ def alert_to_incident(alert):
     return incident
 
 
-def build_link(query, start_ts_milli, end_ts_milli, mode='queryApp'):
+# Monkey patching for backwards compatibility
+def get_types(self, linq_query, start, ts_format):
+    type_map = self._make_type_map(ts_format)
+    stop = self._to_unix(start)
+    start = stop - 1
+
+    response = self._query(linq_query, start=start, stop=stop, mode='json/compact', limit=1)
+
+    try:
+        data = json.loads(response)
+        error_checking.check_status(data)
+    except ValueError:
+        raise Exception('API V2 response error')
+
+    col_data = data['object']['m']
+    type_dict = {c: type_map[v['type']] for c, v in col_data.items()}
+
+    return type_dict
+
+
+def build_link(query, start_ts_milli, end_ts_milli, mode='queryApp', linq_base=None):
     myb64str = base64.b64encode((json.dumps({
         'query': query,
         'mode': mode,
@@ -123,7 +146,12 @@ def build_link(query, start_ts_milli, end_ts_milli, mode='queryApp'):
             'to': end_ts_milli
         }
     }).encode('ascii'))).decode()
-    url = LINQ_LINK_BASE + f"#/verticalApp?path=apps/custom/queryApp_dev&targetQuery={myb64str}"
+
+    if linq_base:
+        url = linq_base + f"#/vapps/app.custom.queryApp_dev&targetQuery={myb64str}"
+    else:
+        url = LINQ_LINK_BASE + f"#/vapps/app.custom.queryApp_dev&targetQuery={myb64str}"
+
     return url
 
 
@@ -292,7 +320,7 @@ def fetch_incidents():
 
     # execute the query and get the events
     # reverse the list so that the most recent event timestamp event is taken when de-duping if needed.
-    events = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE)
+    events = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE, timeout=TIMEOUT)
                     .query(alert_query, start=float(from_time), stop=float(to_time),
                            output='dict', ts_format='timestamp'))[::-1]
 
@@ -333,14 +361,18 @@ def run_query_command():
     timestamp_from = demisto.args()['from']
     timestamp_to = demisto.args().get('to', None)
     write_context = demisto.args()['writeToContext'].lower()
+    query_timeout = int(demisto.args().get('queryTimeout', TIMEOUT))
+    linq_base = demisto.args().get('linqLinkBase', None)
 
     time_range = get_time_range(timestamp_from, timestamp_to)
 
-    results = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE)
+    results = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE,
+                   timeout=query_timeout)
                    .query(to_query, start=float(time_range[0]), stop=float(time_range[1]),
                    output='dict', ts_format='iso'))
 
-    querylink = {'DevoTableLink': build_link(to_query, int(1000 * float(time_range[0])), int(1000 * float(time_range[1])))}
+    querylink = {'DevoTableLink': build_link(to_query, int(1000 * float(time_range[0])),
+                 int(1000 * float(time_range[1])), linq_base=linq_base)}
 
     entry = {
         'Type': entryTypes['note'],
@@ -383,6 +415,8 @@ def get_alerts_command():
     timestamp_to = demisto.args().get('to', None)
     alert_filters = demisto.args().get('filters', None)
     write_context = demisto.args()['writeToContext'].lower()
+    query_timeout = int(demisto.args().get('queryTimeout', TIMEOUT))
+    linq_base = demisto.args().get('linqLinkBase', None)
     alert_query = ALERTS_QUERY
 
     time_range = get_time_range(timestamp_from, timestamp_to)
@@ -399,11 +433,13 @@ def get_alerts_command():
                       for filt in alert_filters['filters']])
         alert_query = f'{alert_query} where {filter_string}'
 
-    results = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE)
+    results = list(ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT,
+                   verify=not ALLOW_INSECURE, timeout=query_timeout)
                    .query(alert_query, start=float(time_range[0]), stop=float(time_range[1]),
                    output='dict', ts_format='iso'))
 
-    querylink = {'DevoTableLink': build_link(alert_query, int(1000 * float(time_range[0])), int(1000 * float(time_range[1])))}
+    querylink = {'DevoTableLink': build_link(alert_query, int(1000 * float(time_range[0])),
+                 int(1000 * float(time_range[1])), linq_base=linq_base)}
 
     for res in results:
         res['extraData'] = json.loads(res['extraData'])
@@ -454,6 +490,7 @@ def multi_table_query_command():
     timestamp_from = demisto.args()['from']
     timestamp_to = demisto.args().get('to', None)
     write_context = demisto.args()['writeToContext'].lower()
+    query_timeout = int(demisto.args().get('queryTimeout', TIMEOUT))
 
     time_range = get_time_range(timestamp_from, timestamp_to)
 
@@ -461,9 +498,12 @@ def multi_table_query_command():
     all_results: List[Dict] = []
     sub_queries = []
 
+    ds_read = ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT,
+                        verify=not ALLOW_INSECURE, timeout=query_timeout)
+    ds_read.get_types = partial(get_types, ds_read)
+
     for table in tables_to_query:
-        fields = ds.Reader(oauth_token=READER_OAUTH_TOKEN, end_point=READER_ENDPOINT, verify=not ALLOW_INSECURE)\
-            ._get_types(f'from {table} select *', 'now', 'iso').keys()
+        fields = ds_read.get_types(f'from {table} select *', 'now', 'iso').keys()
         clauses = [f"( isnotnull({field}) and str({field})->\"" + search_token + "\")" for field in fields]
         sub_queries.append("from " + table + " where" + " or ".join(clauses) + " select *")
 
@@ -500,13 +540,15 @@ def multi_table_query_command():
 def write_to_table_command():
     table_name = demisto.args()['tableName']
     records = check_type(demisto.args()['records'], list)
+    linq_base = demisto.args().get('linqLinkBase', None)
 
     creds = get_writer_creds()
 
     linq = ds.Writer(key=creds['key'].name, crt=creds['crt'].name, chain=creds['chain'].name, relay=WRITER_RELAY)\
         .load(records, table_name, historical=False, linq_func=(lambda x: x))
 
-    querylink = {'DevoTableLink': build_link(linq, int(1000 * time.time()) - 3600000, int(1000 * time.time()))}
+    querylink = {'DevoTableLink': build_link(linq, int(1000 * time.time()) - 3600000,
+                 int(1000 * time.time()), linq_base=linq_base)}
 
     entry = {
         'Type': entryTypes['note'],

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
@@ -28,7 +28,7 @@ configuration:
   required: false
 - display: Devo base domain
   name: linq_link_base
-  defaultvalue: https://us.devo.com/welcome
+  defaultvalue: https://us.devo.com
   type: 0
   required: false
 - display: Fetch incidents

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
@@ -49,6 +49,11 @@ configuration:
   defaultvalue: ""
   type: 12
   required: false
+- display: Global query default timeout
+  name: timeout
+  defaultvalue: "60"
+  type: 0
+  required: false
 - display: Trust any certificate (not secure)
   name: insecure
   defaultvalue: ""
@@ -73,9 +78,13 @@ script:
       description: Start datetime for the specified query. This argument supports natural language (e.g., 2 day, 3 week), Unix timestamps, Python datetime objects, and string datetimes.
     - name: to
       description: End datetime for specified query. If provided must be in same format as "from" argument. This argument is ignored in a date range.
+    - name: queryTimeout
+      description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"
+    - name: linqLinkBase
+      description: Overrides the global Devo base domain for linq linking.
     outputs:
     - contextPath: Devo.QueryResults
       description: List of dictionary alerts from the specified time range.
@@ -93,9 +102,13 @@ script:
     - name: filters
       description: Key value filter to apply to retrieve the specified alerts. For more information, see the Devo documentation.
       isArray: true
+    - name: queryTimeout
+      description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"
+    - name: linqLinkBase
+      description: Overrides the global Devo base domain for linq linking.
     outputs:
     - contextPath: Devo.AlertsResults
       description: List of dictionary alerts from the specified time range.
@@ -116,6 +129,8 @@ script:
       description: Start datetime for the specified query. This argument supports natural language (e.g., 2 day, 3 week), Unix timestamps, Python datetime objects, and string datetimes
     - name: to
       description: End datetime for specified query. If provided must be in same format as "from" argument. This argument is ignored in a date range.
+    - name: queryTimeout
+      description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"
@@ -132,6 +147,8 @@ script:
       required: true
       description: Records to write to the specified table.
       isArray: true
+    - name: linqLinkBase
+      description: Overrides the global Devo base domain for linq linking.
     outputs:
     - contextPath: Devo.RecordsWritten
       description: Records written to specified Devo table.
@@ -161,7 +178,7 @@ script:
       type: unknown
     description: Writes lookup table entry records to a specified Devo table.
     execution: true
-  dockerimage: demisto/devo:1.0.0.13898
+  dockerimage: demisto/devo:1.0.0.21408
   isfetch: true
   runonce: false
   subtype: python3

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2.yml
@@ -49,7 +49,7 @@ configuration:
   defaultvalue: ""
   type: 12
   required: false
-- display: Global query default timeout
+- display: Global query default timeout in seconds
   name: timeout
   defaultvalue: "60"
   type: 0
@@ -80,6 +80,7 @@ script:
       description: End datetime for specified query. If provided must be in same format as "from" argument. This argument is ignored in a date range.
     - name: queryTimeout
       description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
+      defaultValue: "60"
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"
@@ -104,6 +105,7 @@ script:
       isArray: true
     - name: queryTimeout
       description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
+      defaultValue: "60"
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"
@@ -129,8 +131,12 @@ script:
       description: Start datetime for the specified query. This argument supports natural language (e.g., 2 day, 3 week), Unix timestamps, Python datetime objects, and string datetimes
     - name: to
       description: End datetime for specified query. If provided must be in same format as "from" argument. This argument is ignored in a date range.
+    - name: limit
+      description: Limit of results to return to context. 0 for no limit.
+      defaultValue: "50"
     - name: queryTimeout
       description: Timeout in seconds for this query to run against Devo to override the minute default in the platform.
+      defaultValue: "60"
     - name: writeToContext
       description: Whether to write results to context. Can be "true" or "false". The default value is "true".
       defaultValue: "true"

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2_description.md
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2_description.md
@@ -72,5 +72,9 @@ If writing back to Devo make sure to also create a set of TLS credentials.
   ```
   - Uses the `context` column to group all alerts so all alerts that get processed by this will share the same cooldown.
   - This is a Beta feature so please use with caution as we will make usability enhancements.
-11. Use system proxy settings
+11. Global query default timeout
+  - Global read timeout for all requests hitting Devo API for reading data out of Devo. By default if unset will be 60 seconds.
+12. Trust any certificate (not secure)
+  - If your Devo instance you are making requests to does not have a valid SSL certificate attached to the domain check this box.
+13. Use system proxy settings
   - Uses the proxy on the system.

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2_description.md
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2_description.md
@@ -42,7 +42,7 @@ If writing back to Devo make sure to also create a set of TLS credentials.
   }
   ```
 6. Devo base domain
-  - This is the base web UI URL that you use to interact with Devo. If you login to `us.devo.com` -> `https://us.devo.com/welcome`
+  - This is the base web UI URL that you use to interact with Devo. If you login to `us.devo.com` -> `https://us.devo.com`
 7. Fetches incidents
   - Check this box if you would like for the plugin to pull in Devo alerts as incidents. Please refer to `Fetch incident alert filter` and
     `Deduplication parameters JSON` for advanced configuration

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2_test.py
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2_test.py
@@ -155,6 +155,10 @@ class MOCK_SENDER(object):
         pass
 
 
+class MOCK_READER(object):
+    pass
+
+
 def test_time_range():
     time_from = time.time() - 60
     time_to = time.time()
@@ -240,9 +244,12 @@ def test_run_query(mock_query_results, mock_args_results):
 @patch('Devo_v2.concurrent.futures.ThreadPoolExecutor.submit')
 @patch('Devo_v2.demisto.args')
 @patch('Devo_v2.ds.Reader.query')
-@patch('Devo_v2.ds.Reader._get_types')
-def test_multi_query(mock_query_types, mock_query_results, mock_args_results, mock_submit_results, mock_wait_results):
+@patch('Devo_v2.ds.Reader')
+@patch('Devo_v2.get_types')
+def test_multi_query(mock_query_types, mock_query_reader, mock_query_results, mock_args_results,
+                     mock_submit_results, mock_wait_results):
     mock_query_types.return_value = MOCK_KEYS
+    mock_query_reader.return_value = MOCK_READER
     mock_query_results.return_value = copy.deepcopy(MOCK_QUERY_RESULTS)
     mock_args_results.return_value = MOCK_MULTI_ARGS
     mock_submit_results.return_value = None

--- a/Packs/Devo/Integrations/Devo_v2/Devo_v2_test.py
+++ b/Packs/Devo/Integrations/Devo_v2/Devo_v2_test.py
@@ -117,7 +117,7 @@ MOCK_MULTI_ARGS = {
     'writeToContext': 'true'
 }
 MOCK_WRITER_ARGS = {
-    'tableName': 'hello.world',
+    'tableName': 'whatever.table',
     'records': [{'foo': 'hello'}, {'foo': 'world'}, {'foo': 'demisto'}]
 }
 MOCK_LOOKUP_WRITER_ARGS = {
@@ -183,7 +183,7 @@ def test_time_range():
 @patch('Devo_v2.FETCH_INCIDENTS_FILTER', MOCK_FETCH_INCIDENTS_FILTER, create=True)
 @patch('Devo_v2.FETCH_INCIDENTS_DEDUPE', MOCK_FETCH_INCIDENTS_DEDUPE, create=True)
 @patch('Devo_v2.ds.Reader.query')
-@patch('Devo_v2.ds.Writer')
+@patch('Devo_v2.Sender')
 def test_command(mock_query_results, mock_write_args):
     mock_query_results.return_value = copy.deepcopy(MOCK_QUERY_RESULTS)
     mock_write_args.return_value = MOCK_WRITER_ARGS
@@ -261,7 +261,7 @@ def test_multi_query(mock_query_types, mock_query_reader, mock_query_results, mo
 @patch('Devo_v2.WRITER_RELAY', MOCK_WRITER_RELAY, create=True)
 @patch('Devo_v2.WRITER_CREDENTIALS', MOCK_WRITER_CREDENTIALS, create=True)
 @patch('Devo_v2.demisto.args')
-@patch('Devo_v2.ds.Writer')
+@patch('Devo_v2.Sender')
 def test_write_devo(mock_load_results, mock_write_args):
     mock_load_results.return_value.load.return_value = MOCK_LINQ_RETURN
     mock_write_args.return_value = MOCK_WRITER_ARGS

--- a/Packs/Devo/Integrations/Devo_v2/README.md
+++ b/Packs/Devo/Integrations/Devo_v2/README.md
@@ -134,12 +134,14 @@ Please refer to to the Devo documentation for building a query with LINQ
 `devo-run-query`
 ##### Input
 
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| query | A LINQ Query to run | Required |
-| from | Start datetime for specified query. Unix timestamp in seconds expected (Decimal milliseconds okay) | Required |
-| to | End datetime for specified query. Unix timestamp in seconds expected (Decimal milliseconds okay) | Optional |
-| writeToContext | Whether to write results to context or not | Optional |
+| **Argument Name** | **Description**                                                                                    | **Required** |
+|-------------------|----------------------------------------------------------------------------------------------------|--------------|
+| query             | A LINQ Query to run                                                                                | Required     |
+| from              | Start datetime for specified query. Unix timestamp in seconds expected (Decimal milliseconds okay) | Required     |
+| to                | End datetime for specified query. Unix timestamp in seconds expected (Decimal milliseconds okay)   | Optional     |
+| queryTimeout      | Query timeout in seconds. Defaults to global which defaults to 60 seconds                          | Optional     |
+| writeToContext    | Whether to write results to context or not                                                         | Optional     |
+| linqLinkBase      | Overrides the global link base so is able to be set at run time                                    | Optional     |
 
 #####__from__ and __to__ time note:
 This integration allows for the following formats. Note that when __from__ and __to__ times
@@ -192,12 +194,14 @@ that are allowed.
 `devo-get-alerts`
 ##### Input
 
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| from | Start datetime for alerts to fetch | Required |
-| to | End datetime for alerts to fetch | Optional |
-| filters | key value filter to apply to retrieve specified alerts. refer to docs | Optional |
-| writeToContext | write results to context or not | Optional |
+| **Argument Name** | **Description**                                                           | **Required** |
+|-------------------|---------------------------------------------------------------------------|--------------|
+| from              | Start datetime for alerts to fetch                                        | Required     |
+| to                | End datetime for alerts to fetch                                          | Optional     |
+| filters           | key value filter to apply to retrieve specified alerts. refer to docs     | Optional     |
+| queryTimeout      | Query timeout in seconds. Defaults to global which defaults to 60 seconds | Optional     |
+| writeToContext    | write results to context or not                                           | Optional     |
+| linqLinkBase      | Overrides the global link base so is able to be set at run time           | Optional     |
 
 #####__from__ and __to__ time note:
 This integration allows for the following formats. Note that when __from__ and __to__ times
@@ -245,13 +249,14 @@ Thus querying all columns for the search token and returning a union of the give
 `devo-multi-table-query`
 ##### Input
 
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| tables | List of table names to check for searchToken | Required |
-| searchToken | String that you wish to search for in given tables in any column | Required |
-| from | Start time in seconds unix timestamp | Required |
-| to | End time in seconds unix timestamp | Optional |
-| writeToContext | write results to context or not | Optional |
+| **Argument Name** | **Description**                                                           | **Required** |
+|-------------------|---------------------------------------------------------------------------|--------------|
+| tables            | List of table names to check for searchToken                              | Required     |
+| searchToken       | String that you wish to search for in given tables in any column          | Required     |
+| from              | Start time in seconds unix timestamp                                      | Required     |
+| to                | End time in seconds unix timestamp                                        | Optional     |
+| queryTimeout      | Query timeout in seconds. Defaults to global which defaults to 60 seconds | Optional     |
+| writeToContext    | write results to context or not                                           | Optional     |
 
 #####__from__ and __to__ time note:
 This integration allows for the following formats. Note that when __from__ and __to__ times
@@ -304,10 +309,11 @@ For more information on the way we write to a table please refer to this documen
 `devo-write-to-table`
 ##### Input
 
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| tableName | Table name to write to | Required |
-| records | Records to write to given tableName | Required |
+| **Argument Name** | **Description**                                                 | **Required** |
+|-------------------|-----------------------------------------------------------------|--------------|
+| tableName         | Table name to write to                                          | Required     |
+| records           | Records to write to given tableName                             | Required     |
+| linqLinkBase      | Overrides the global link base so is able to be set at run time | Optional     |
 
 
 ##### Context Output

--- a/Packs/Devo/Integrations/Devo_v2/README.md
+++ b/Packs/Devo/Integrations/Devo_v2/README.md
@@ -255,6 +255,7 @@ Thus querying all columns for the search token and returning a union of the give
 | searchToken       | String that you wish to search for in given tables in any column          | Required     |
 | from              | Start time in seconds unix timestamp                                      | Required     |
 | to                | End time in seconds unix timestamp                                        | Optional     |
+| limit             | Number of entries to return to context. Default is 50. 0 sets to no limit | Optional     |
 | queryTimeout      | Query timeout in seconds. Defaults to global which defaults to 60 seconds | Optional     |
 | writeToContext    | write results to context or not                                           | Optional     |
 

--- a/Packs/Devo/README.md
+++ b/Packs/Devo/README.md
@@ -1,0 +1,1 @@
+Note: Support for this pack will be moving to the partner around October 1st, 2021

--- a/Packs/Devo/ReleaseNotes/1_1_0.md
+++ b/Packs/Devo/ReleaseNotes/1_1_0.md
@@ -1,0 +1,13 @@
+#### Integrations
+##### Devo v2
+- Updated to use newer version of Devo Python SDK with better stability issues
+- Added Global timeout variable for all Devo requests to be 60 seconds
+- In the following commands added queryTimeout argument which overrides the global default timeout variable
+  - devo-run-query
+  - devo-get-alerts
+  - devo-multi-table-query
+- In the following commands added linqLinkBase argument which overrides the global linq linking base
+  - devo-run-query
+  - devo-get-alerts
+  - devo-write-to-table
+- Maintenance and stability enhancements.

--- a/Packs/Devo/ReleaseNotes/1_1_0.md
+++ b/Packs/Devo/ReleaseNotes/1_1_0.md
@@ -10,4 +10,7 @@
   - devo-run-query
   - devo-get-alerts
   - devo-write-to-table
+- Devo write to table no longer writes in format. Will send raw message within list of messages.
+- Fixed fetches incidents as alerts table has changed epoch format.
+- Fixed linq linking directly back to Devo.
 - Maintenance and stability enhancements.

--- a/Packs/Devo/pack_metadata.json
+++ b/Packs/Devo/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Devo",
     "description": "Use the Devo integration to query Devo for alerts, lookup tables, and to write to lookup tables.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.1.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)



## Description
This is an update to the Devo_v2 Integration in the Devo packs.

More detailed breakdown of changes can be found in the changelog documented here:
Packs/Devo/ReleaseNotes/1_1_0.md

Main key takeaways are using updated devo-sdk underlying package with updated docker.
Added 2 new arguments to a few commands which are linkLinqBase and queryTimeout which will override default global values in the plugin.

Bumped version to 1.1.0

## Minimum version of Cortex XSOAR
- [X] 5.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [X] Tests
- [X] Documentation 
