### PR TITLE
improved "checkout_contribution.sh" script to handle existing branches

### DIFF
--- a/Utils/checkout_contribution.sh
+++ b/Utils/checkout_contribution.sh
@@ -21,14 +21,15 @@ git remote add $USER git@github.com:$USER/content.git
 LOCAL_BRANCH_EXISTS=$(git show-branch --list "${USER}/${BRANCH}")
 if [[ -z ${LOCAL_BRANCH_EXISTS} ]]; then
     # If branch does not exists - fetch and checkout to it with a trace to the origin.
-      git fetch "${USER}"
-      git checkout -t "${USER}/${BRANCH}"
-      git pull
+    git fetch "${USER}"
+    git checkout -t "${USER}/${BRANCH}"
+    git pull
 else
     # If branch already exists - checkout to it(will checkout to head) and switch to wanted branch.
-      git checkout "${USER}/${BRANCH}"
-      git switch "${BRANCH}"
-      git pull
+    git checkout "${USER}/${BRANCH}"
+    git switch -c "${USER}_${BRANCH}"
+    git branch --set-upstream-to="${USER}/${BRANCH}" "${USER}_${BRANCH}"
+    git pull
 fi
 
 if [[ $2 == "true" ]]; then


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
in case the contributor used the `master` branch (or any other branch that already exists locally, the script fails to switch to the contributed branch.

## Screenshots
running `./Utils/checkout_contribution.sh yaakovi:master`
before:
![image](https://user-images.githubusercontent.com/30797606/123519000-55aeb300-d6b1-11eb-8a86-13c1c4bfc70b.png)

after:
![image](https://user-images.githubusercontent.com/30797606/123519035-95759a80-d6b1-11eb-8b1e-2befa52b1808.png)
