### PR TITLE
Some Improvements to GitLab Flows

### DIFF
--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -12,6 +12,7 @@ stages:
   - create-instances
   - run-instances
   - upload-to-marketplace
+  - fan-in  # concentrate pipeline artifacts to single job before triggering child slack pipeline
 
 
 variables:

--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -129,7 +129,7 @@ upload-packs-to-marketplace:
     SSH_TUNNEL_TIMEOUT: 10
     TIME_TO_LIVE: ""
   extends:
-    - .bucket-upload-rule-always
+    - .bucket-upload-rule
     - .default-job-settings
   script:
     - !reference [.open-ssh-tunnel]
@@ -183,11 +183,19 @@ force-pack-upload:
     - python3 ./Tests/Marketplace/copy_and_upload_packs.py -a $PACK_ARTIFACTS -e $EXTRACT_FOLDER -pb "$GCS_MARKET_BUCKET" -bb "$GCS_BUILD_BUCKET" -s $GCS_MARKET_KEY -n $CI_PIPELINE_ID -c $CI_COMMIT_BRANCH -p "${PACKS_TO_UPLOAD}" -pbp "${STORAGE_BASE_PATH}"
 
 
+fan-in-bucket-upload:
+  stage: fan-in
+  extends:
+    - .bucket-upload-rule-always
+  script:
+    - echo "fan in"
+
+
 slack-notify-bucket-upload:
   variables:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Upload Packs to Marketplace Storage'
-    JOB_NAME: 'upload-packs-to-marketplace'
+    JOB_NAME: 'fan-in-bucket-upload'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
     SLACK_CHANNEL: $SLACK_CHANNEL

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -104,6 +104,7 @@
 .trigger-slack-notification:
   stage: .post
   trigger:
+    strategy: depend
     include:
       - local: .gitlab/ci/slack-notify.yml
 

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -153,6 +153,15 @@ server_master:
     INSTANCE_ROLE: "Server Master"
 
 
+fan-in-nightly:
+  stage: fan-in
+  rules:
+    - if: '$NIGHTLY'
+      when: always
+  script:
+    - echo "fan in"
+
+
 slack-notify-nightly-build:
   extends:
     - .trigger-slack-notification
@@ -162,7 +171,7 @@ slack-notify-nightly-build:
   variables:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Content Nightly'
-    JOB_NAME: 'server_master'
+    JOB_NAME: 'fan-in-nightly'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
     SLACK_CHANNEL: $SLACK_CHANNEL

--- a/.gitlab/ci/sdk-nightly.yml
+++ b/.gitlab/ci/sdk-nightly.yml
@@ -141,6 +141,14 @@ demisto-sdk-nightly:run-commands-against-instance:
     - section_end "Destroy instances"
 
 
+demisto-sdk-nightly:fan-in:
+  stage: fan-in
+  extends:
+    - .sdk-nightly-schedule-rule-always
+  script:
+    - echo "fan in"
+
+
 demisto-sdk-nightly:trigger-slack-notify:
   extends:
     - .trigger-slack-notification
@@ -148,7 +156,7 @@ demisto-sdk-nightly:trigger-slack-notify:
   variables:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: 'Demisto SDK Nightly'
-    JOB_NAME: 'demisto-sdk-nightly:run-commands-against-instance'
+    JOB_NAME: 'demisto-sdk-nightly:fan-in'
     # Passes the environment variable from the parent pipeline to the child which can be useful for cases
     # when triggering pipeline with alternate env variable value passed in the API call
     SLACK_CHANNEL: $SLACK_CHANNEL

--- a/.gitlab/ci/slack-notify.yml
+++ b/.gitlab/ci/slack-notify.yml
@@ -20,6 +20,8 @@ slack-notify:
   extends: .default-job-settings
   script:
     - python3 ./Tests/scripts/gitlab_slack_notifier.py -p "$PIPELINE_TO_QUERY" -s "$SLACK_TOKEN" -c "$GITLAB_STATUS_TOKEN" -ca "$ARTIFACTS_FOLDER" -ch "$SLACK_CHANNEL" -tw "$WORKFLOW"
+  retry:
+    max: 2
   needs:
     - pipeline: $PIPELINE_TO_QUERY
       job: $JOB_NAME


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
- Adds a `fan-in` stage
- Adds a `fan-in` job to the following flows
	- nightly
	- bucket-upload
	- sdk-nightly
- Changes the bucket-upload flow so that the `upload-packs-to-marketplace` job will not be run if previous jobs failed
- Adds retry to the slack-notify job
- Makes the slack notification trigger job's status dependent on the child pipeline's status, i.e. it will fail if the slack-notify job fails

## Screenshots
Should prevent such cases as in the attached screenshot where the packs were uploaded despite installation of those packs on a server instance failing
![image](https://user-images.githubusercontent.com/46294017/123543941-95c97080-d759-11eb-857a-a23e41b0066e.png)


## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x ] No

## Must have
- [ ] Tests
- [ ] Documentation 
