### PR TITLE
Demisto Class - add note about custom fields returned from the incident method

### DIFF
--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -773,7 +773,8 @@ def incidents(incidents=None):
 
 def incident():
     """Retrieves the current incident and all its fields (e.g. name, type).
-    The incident custom fields will be populated under as an array under the CustomFields attribute.
+    The incident custom fields will be populated as a `dict` under the CustomFields attribute
+    (for example the `filename` custom field can be retrieved using `demisto.incident()['CustomFields'].get('filename')`).
 
     Returns:
       dict: dict representing an incident object

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -772,7 +772,8 @@ def incidents(incidents=None):
 
 
 def incident():
-    """Retrieves the current incident
+    """Retrieves the current incident and all its fields (e.g. name, type).
+    The incident custom fields will be populated under as an array under the CustomFields attribute.
 
     Returns:
       dict: dict representing an incident object


### PR DESCRIPTION
## Status
- [x] Ready

## Description
clarify how custom fields are returned from the `demisto.incident()` func
