### PR TITLE
Fix Path to failed_tests.txt File

### DIFF
--- a/Tests/scripts/slack_notifier.py
+++ b/Tests/scripts/slack_notifier.py
@@ -263,9 +263,11 @@ def get_attachments_for_test_playbooks(build_url, env_results_file_name):
 
 def get_fields():
     failed_tests = []
-    if os.path.isfile('./Tests/failed_tests.txt'):
+    # failed_tests.txt is copied into the artifacts directory
+    failed_tests_file_path = os.path.join(ARTIFACTS_FOLDER, 'failed_tests.txt')
+    if os.path.isfile(failed_tests_file_path):
         logging.info('Extracting failed_tests')
-        with open('./Tests/failed_tests.txt', 'r') as failed_tests_file:
+        with open(failed_tests_file_path, 'r') as failed_tests_file:
             failed_tests = failed_tests_file.readlines()
             failed_tests = [line.strip('\n') for line in failed_tests]
 


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixes the failed tests not being detailed in the slack notification about the `Content Nightly` run from GitLab as shown in the attached screenshot below.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/123644692-46a13f80-d82e-11eb-9ec1-30892cd09ff6.png)

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
