### PR TITLE
Checkout commit sha instead of branch (whose head could change)

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -36,7 +36,7 @@
 
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
-  - git checkout $CI_COMMIT_BRANCH
+  - git checkout $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - mkdir -p -m 777 $ARTIFACTS_FOLDER/
   - |

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -36,7 +36,7 @@
 
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
-  - git checkout $CI_COMMIT_SHA
+  - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - mkdir -p -m 777 $ARTIFACTS_FOLDER/
   - |


### PR DESCRIPTION
## Status
- [x] In Progress

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/pipelines/1312732

## Description
We clone the repo in every job and `checkout` the `$CI_COMMIT_BRANCH` - if the HEAD has changed between subsequent jobs in a Pipeline (AKA if we are working against the `master` branch, if someone merged to master between the time job1 ran and job2 ran, then you have a situation where job1 and job2 are at two different commits in the branch history) causes a problem where the jobs are at different commits in the branch history.

With the current solution as implemented... the repo will probably be in a `detached HEAD` state which may have implications at various times in the build... might be better to have a job run in the `.pre` stage in which we create a temporary branch that the rest of the jobs will checkout from (and which we clean in a `.post` job). Open to other solutions... since

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No?

## Must have
- [ ] Tests
- [ ] Documentation 
