### PR TITLE
WildFire v2 - Added support for the *Source Reliability* param

### DIFF
--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
@@ -12,6 +12,20 @@ configuration:
   name: token
   required: true
   type: 4
+- additionalinfo: Reliability of the source providing the intelligence data.
+  defaultvalue: B - Usually reliable
+  display: Source Reliability
+  name: integrationReliability
+  options:
+  - A+ - 3rd party enrichment
+  - A - Completely reliable
+  - B - Usually reliable
+  - C - Fairly reliable
+  - D - Not usually reliable
+  - E - Unreliable
+  - F - Reliability cannot be judged
+  required: true
+  type: 15
 - display: Trust any certificate (not secure)
   name: insecure
   required: false

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
@@ -1,9 +1,9 @@
+from requests import Response
+
+import demistomock as demisto
 from Palo_Alto_Networks_WildFire_v2 import prettify_upload, prettify_report_entry, prettify_verdict, \
     create_dbot_score_from_verdict, prettify_verdicts, create_dbot_score_from_verdicts, hash_args_handler, \
     file_args_handler, wildfire_get_sample_command, wildfire_get_report_command
-
-import demistomock as demisto
-from requests import Response
 
 
 def test_will_return_ok():
@@ -35,9 +35,15 @@ def test_prettify_verdict():
 
 
 def test_create_dbot_score_from_verdict():
-    expected_dbot_score = [{
-        'Indicator': "sha256_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 3},
-        {'Indicator': "sha256_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 3},
+    expected_dbot_score = [
+        {
+            'Indicator': "sha256_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 3,
+            'Reliability': 'B - Usually reliable'
+        },
+        {
+            'Indicator': "sha256_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 3,
+            'Reliability': 'B - Usually reliable'
+        },
     ]
     dbot_score_dict = create_dbot_score_from_verdict({'SHA256': "sha256_hash", 'Verdict': "1"})
     assert expected_dbot_score == dbot_score_dict
@@ -52,12 +58,16 @@ def test_prettify_verdicts():
 
 
 def test_create_dbot_score_from_verdicts():
-    expected_dbot_scores = [{'Indicator': "sha256_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 3},
-                            {'Indicator': "sha256_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 3},
-                            {'Indicator': "md5_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 1},
-                            {'Indicator': "md5_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 1}]
+    expected_dbot_scores = [{'Indicator': "sha256_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 3,
+                             'Reliability': 'B - Usually reliable'},
+                            {'Indicator': "sha256_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 3,
+                             'Reliability': 'B - Usually reliable'},
+                            {'Indicator': "md5_hash", 'Type': "hash", 'Vendor': "WildFire", 'Score': 1,
+                             'Reliability': 'B - Usually reliable'},
+                            {'Indicator': "md5_hash", 'Type': "file", 'Vendor': "WildFire", 'Score': 1,
+                             'Reliability': 'B - Usually reliable'}]
     dbot_score_dict = create_dbot_score_from_verdicts(
-        [{'SHA256': "sha256_hash", 'Verdict': "1"}, {'MD5': "md5_hash", 'Verdict': "0"}])
+        [{'SHA256': "sha256_hash", 'Verdict': '1'}, {'MD5': "md5_hash", 'Verdict': '0'}])
     assert expected_dbot_scores == dbot_score_dict
 
 
@@ -170,9 +180,11 @@ def test_report_chunked_response(mocker):
                   {'WildFire.Report(val.SHA256 === obj.SHA256)': {
                       'Status': 'Success',
                       'SHA256': '8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51'},
-                   'DBotScore': [
-                       {'Indicator': '8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51', 'Type': 'hash',
-                        'Vendor': 'WildFire', 'Score': 1},
-                       {'Indicator': '8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51', 'Type': 'file',
-                        'Vendor': 'WildFire', 'Score': 1}]}}
+                      'DBotScore': [
+                          {'Indicator': '8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51',
+                           'Type': 'hash',
+                           'Vendor': 'WildFire', 'Score': 1, 'Reliability': 'B - Usually reliable'},
+                          {'Indicator': '8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51',
+                           'Type': 'file',
+                           'Vendor': 'WildFire', 'Score': 1, 'Reliability': 'B - Usually reliable'}]}}
     assert demisto.results.call_args[0][0] == result

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
@@ -24,6 +24,7 @@ Use the Palo Alto Networks Wildfire integration to automatically identify unknow
     | --- | --- |
     | Server base URL (e.g. https://192.168.0.1/publicapi) | True |
     | API Key | True |
+    | Source Reliability | Reliability of the source providing the intelligence data. | B - Usually reliable |    
     | Trust any certificate (not secure) | False |
     | Use system proxy settings | False |
     | Return warning entry for unsupported file types | False |

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/1_3_8.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/1_3_8.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Palo Alto Networks WildFire v2
+- Added support for the *Source Reliability* integration parameter.

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks WildFire",
     "description": "Perform malware dynamic analysis",
     "support": "xsoar",
-    "currentVersion": "1.3.7",
+    "currentVersion": "1.3.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/38763

## Description
added the reliability para. added its usage to the cmds: !file, get-verdict, get-verdicts, whenever the dbotscore object is returned.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests - updated all UT
- [x] Documentation - added
