### PR TITLE
Add to ServerLogs dependency of RemoteAccess

### DIFF
--- a/Packs/ServerLogs/ReleaseNotes/1_0_1.md
+++ b/Packs/ServerLogs/ReleaseNotes/1_0_1.md
@@ -1,3 +1,4 @@
 #### Scripts
 ##### ServerLogs
 - Added required dependency of **Remote Access** integration (**ssh** command).
+- Upgraded the Docker image to: *demisto/python3:3.9.5.21272*

--- a/Packs/ServerLogs/ReleaseNotes/1_0_1.md
+++ b/Packs/ServerLogs/ReleaseNotes/1_0_1.md
@@ -1,0 +1,3 @@
+#### Scripts
+##### ServerLogs
+- Added required dependency of **Remote Access** integration (**ssh** command).

--- a/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.py
+++ b/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.py
@@ -5,7 +5,12 @@ from CommonServerPython import *
 
 file = '/var/log/demisto/server.log'
 
-res = demisto.executeCommand('ssh', {'cmd': f'tail {file}', 'using': 'localhost'})
+try:
+    res = demisto.executeCommand('ssh', {'cmd': f'tail {file}', 'using': 'localhost'})
+except ValueError as e:
+    demisto.error(str(e))
+    return_error('The script could not execute command `ssh`. Please create an instance of '
+                 '`RemoteAccess` integration and try to run the script again.')
 output = f'File: {file}\n'
 output += res[0].get('Contents').get('output')
 output = re.sub(r' \(source: .*\)', '', output)

--- a/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.yml
+++ b/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.yml
@@ -10,6 +10,9 @@ runonce: false
 script: ''
 scripttarget: 0
 subtype: python3
+dependson:
+  must:
+  - remoteaccess|||ssh
 tags:
 - widget
 type: python

--- a/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.yml
+++ b/Packs/ServerLogs/Scripts/ServerLogs/ServerLogs.yml
@@ -2,7 +2,7 @@ comment: Uses the ssh integration to grab the host server logs
 commonfields:
   id: ServerLogs
   version: -1
-dockerimage: demisto/python3:3.8.5.10845
+dockerimage: demisto/python3:3.9.5.21272
 enabled: true
 name: ServerLogs
 runas: DBotWeakRole

--- a/Packs/ServerLogs/pack_metadata.json
+++ b/Packs/ServerLogs/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServerLogs",
     "description": "Dashboard widget to display server logs. Makes troubleshooting more convenient by reducing the need to download the zipped server logs or remoting into the server itself.",
     "support": "community",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Matt Houston",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/38812

## Description
Added required dependency of `RemoteAccess` for CLI usage, and improved error message for `widget` usage.