### PR TITLE
ignore template-name validation in xsoar linter

### DIFF
--- a/Packs/HelloWorld/Scripts/HelloWorldScript/HelloWorldScript.py
+++ b/Packs/HelloWorld/Scripts/HelloWorldScript/HelloWorldScript.py
@@ -89,7 +89,7 @@ def main():
         return_results(say_hello_command(demisto.args()))
     except Exception as ex:
         demisto.error(traceback.format_exc())  # print the traceback
-        return_error(f'Failed to execute HelloWorldScript. Error: {str(ex)}')
+        return_error(f'Failed to execute HelloWorldScript. Error: {str(ex)}')     # pylint: disable=E9008
 
 
 ''' ENTRY POINT '''

--- a/Packs/StarterPack/Scripts/BaseScript/BaseScript.py
+++ b/Packs/StarterPack/Scripts/BaseScript/BaseScript.py
@@ -68,7 +68,7 @@ def main():
         return_results(basescript_dummy_command(demisto.args()))
     except Exception as ex:
         demisto.error(traceback.format_exc())  # print the traceback
-        return_error(f'Failed to execute BaseScript. Error: {str(ex)}')
+        return_error(f'Failed to execute BaseScript. Error: {str(ex)}')     # pylint: disable=E9008
 
 
 ''' ENTRY POINT '''


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
related: https://github.com/demisto/etc/issues/36706

## Description
Ignore xsoar-linter validation for template names in code - https://github.com/demisto/demisto-sdk/pull/1440
