### PR TITLE
Alienvault_OTX_v2 bug fixed- support for multiple ips

### DIFF
--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
@@ -37,7 +37,7 @@ class Client(BaseClient):
         """Performs basic GET request to check if the API is reachable and authentication is successful.
 
         Returns:
-            Response json
+            Response json.
         """
         return self.query(section='IPv4', argument='8.8.8.8')
 
@@ -212,7 +212,7 @@ def ip_command(client: Client, ip_address: str, ip_version: str) -> List[Command
     for ip_ in ips_list:
         raw_response = client.query(section=ip_version,
                                     argument=ip_)
-        if raw_response:
+        if raw_response and raw_response != 404:
             ip_version = FeedIndicatorType.IP if ip_version == 'IPv4' else FeedIndicatorType.IPv6
             relationships = create_attack_pattern_relationships(client, raw_response=raw_response,
                                                                 entity_a=ip_, entity_a_type=ip_version)
@@ -245,6 +245,9 @@ def ip_command(client: Client, ip_address: str, ip_version: str) -> List[Command
                 raw_response=raw_response,
                 relationships=relationships
             ))
+        else:
+            command_results.append(CommandResults(
+                readable_output=f'IP {ip_} could not be found.'))
 
     if not command_results:
         return [CommandResults(f'{INTEGRATION_NAME} - Could not find any results for given query.')]

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
@@ -37,7 +37,7 @@ class Client(BaseClient):
         """Performs basic GET request to check if the API is reachable and authentication is successful.
 
         Returns:
-            Response json.
+            Response json
         """
         return self.query(section='IPv4', argument='8.8.8.8')
 

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
@@ -54,7 +54,7 @@ script:
   - arguments:
     - default: true
       description: The IP address to query.
-      isArray: false
+      isArray: true
       name: ip
       required: true
       secret: false

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
@@ -612,7 +612,7 @@ def test_domain_command(mocker, raw_response, expected):
 
 @pytest.mark.parametrize('ip_,raw_response,expected_ec,expected_relationships', [
     ('8.8.88.8', IP_RAW_RESPONSE, IP_EC, []),
-    ('98.136.103.23', IP_RAW_RESPONSE_WITH_RELATIONSHIPS, IP_EC_WITH_RELATIONSHIPS, IP_RELATIONSHIPS),
+    ('98.136.103.23', IP_RAW_RESPONSE_WITH_RELATIONSHIPS, IP_EC_WITH_RELATIONSHIPS, IP_RELATIONSHIPS)
 ])
 def test_ip_command(mocker, ip_, raw_response, expected_ec, expected_relationships):
     """

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
@@ -197,7 +197,7 @@ DOMAIN_EC = {
         'Name': 'otx.alienvault.com', 'Alexa': 'http://www.alexa.com/siteinfo/otx.alienvault.com',
         'Whois': 'http://whois.domaintools.com/otx.alienvault.com'}
 }
-IP_404_RAW_RESPONSE=404
+IP_404_RAW_RESPONSE = 404
 
 IP_RAW_RESPONSE = {
     "accuracy_radius": 1000,
@@ -637,10 +637,11 @@ def test_ip_command(mocker, ip_, raw_response, expected_ec, expected_relationshi
     relations = all_context['Relationships']
     assert expected_relationships == relations
 
+
 @pytest.mark.parametrize('ip_,raw_response,expected', [
     ('8.8.88.8', IP_404_RAW_RESPONSE, 'IP 8.8.88.8 could not be found.'),
 ])
-def test_ip_command(mocker, ip_, raw_response, expected):
+def test_ip_command_on_404(mocker, ip_, raw_response, expected):
     """
         Given
         - An IPv4 address.

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2_test.py
@@ -197,6 +197,7 @@ DOMAIN_EC = {
         'Name': 'otx.alienvault.com', 'Alexa': 'http://www.alexa.com/siteinfo/otx.alienvault.com',
         'Whois': 'http://whois.domaintools.com/otx.alienvault.com'}
 }
+IP_404_RAW_RESPONSE=404
 
 IP_RAW_RESPONSE = {
     "accuracy_radius": 1000,
@@ -611,7 +612,7 @@ def test_domain_command(mocker, raw_response, expected):
 
 @pytest.mark.parametrize('ip_,raw_response,expected_ec,expected_relationships', [
     ('8.8.88.8', IP_RAW_RESPONSE, IP_EC, []),
-    ('98.136.103.23', IP_RAW_RESPONSE_WITH_RELATIONSHIPS, IP_EC_WITH_RELATIONSHIPS, IP_RELATIONSHIPS)
+    ('98.136.103.23', IP_RAW_RESPONSE_WITH_RELATIONSHIPS, IP_EC_WITH_RELATIONSHIPS, IP_RELATIONSHIPS),
 ])
 def test_ip_command(mocker, ip_, raw_response, expected_ec, expected_relationships):
     """
@@ -635,3 +636,21 @@ def test_ip_command(mocker, ip_, raw_response, expected_ec, expected_relationshi
 
     relations = all_context['Relationships']
     assert expected_relationships == relations
+
+@pytest.mark.parametrize('ip_,raw_response,expected', [
+    ('8.8.88.8', IP_404_RAW_RESPONSE, 'IP 8.8.88.8 could not be found.'),
+])
+def test_ip_command(mocker, ip_, raw_response, expected):
+    """
+        Given
+        - An IPv4 address.
+
+        When
+        - Running ip_command with the IP.
+
+        Then
+        - Validate that the CommandResult created correctly when the api returns 404
+        """
+    mocker.patch.object(client, 'query', side_effect=[raw_response])
+    command_results = ip_command(client, ip_, 'IPv4')
+    assert command_results[0].readable_output == expected

--- a/Packs/AlienVault_OTX/ReleaseNotes/1_1_4.md
+++ b/Packs/AlienVault_OTX/ReleaseNotes/1_1_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### AlienVault OTX v2
-- Fixed an issue where the ***ip*** command failed when ip was not found in api.
+- Fixed an issue where the ***ip*** command failed when the provided IP address was not found in Alienvault.

--- a/Packs/AlienVault_OTX/ReleaseNotes/1_1_4.md
+++ b/Packs/AlienVault_OTX/ReleaseNotes/1_1_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlienVault OTX v2
+- Fixed an issue where the ***ip*** command failed when ip was not found in api.

--- a/Packs/AlienVault_OTX/pack_metadata.json
+++ b/Packs/AlienVault_OTX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AlienVault OTX",
     "description": "Query Indicators of Compromise in AlienVault OTX.",
     "support": "xsoar",
-    "currentVersion": "1.1.3",
+    "currentVersion": "1.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/39006
fixes: https://github.com/demisto/etc/issues/38868

## Description
Added a support for multiple IPs in the ip command + Fixed an issue where if an ip was not found (got 404 from server) then it would crush.

## Screenshots
![image](https://user-images.githubusercontent.com/71636766/124883209-c4590e00-dfd9-11eb-93b0-804cc4c3d985.png)

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
