### PR TITLE
Add badge to open the repo in vs code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Content logo](xsoar_content_logo.png)
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/demisto/content)
 [![CircleCI](https://circleci.com/gh/demisto/content.svg?style=svg)](https://circleci.com/gh/demisto/content)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/demisto/content.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/demisto/content/context:python)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Content logo](xsoar_content_logo.png)
 
-[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/demisto/content)
 [![CircleCI](https://circleci.com/gh/demisto/content.svg?style=svg)](https://circleci.com/gh/demisto/content)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/demisto/content.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/demisto/content/context:python)
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/demisto/content)
 
 # Cortex XSOAR Platform - Content Repository
 #### Demisto is now Cortex XSOAR.

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -657,6 +657,7 @@
     ],
     "_comment": "ENTER URLS WITHOUT http/s, www and path",
     "urls": [
+      "https://open.vscode.dev",
       "https://forms.gle",
       "https://www.office.com",
       "testurl.com",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Adds a badge to the `content` repo README to open the repository in vs code as described [here](https://code.visualstudio.com/updates/v1_58#_open-in-vs-code-badge). Also adds the URL used in the badge to the whitelisted URLs group.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/125269743-ac52f880-e311-11eb-9634-2dc88c0256ee.png)


## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
