### PR TITLE
Upload-Flow installation bug fix

### DIFF
--- a/Tests/Marketplace/configure_and_install_packs.py
+++ b/Tests/Marketplace/configure_and_install_packs.py
@@ -5,11 +5,13 @@ import sys
 from Tests.configure_and_test_integration_instances import set_marketplace_url, MARKET_PLACE_CONFIGURATION, \
     Build, Server
 from Tests.test_content import get_json_file
-from Tests.Marketplace.search_and_install_packs import install_all_content_packs
+from Tests.Marketplace.search_and_install_packs import install_all_content_packs_from_build_bucket
 from Tests.scripts.utils.log_util import install_logging
+from Tests.Marketplace.marketplace_constants import GCPConfig
 
 
 def options_handler():
+    # disable-secrets-detection-start
     parser = argparse.ArgumentParser(description='Utility for instantiating integration instances')
     parser.add_argument('--ami_env', help='The AMI environment for the current run. Options are '
                                           '"Server 6.0", "Server Master". The server url is determined by the'
@@ -17,8 +19,17 @@ def options_handler():
     parser.add_argument('-s', '--secret', help='Path to secret conf file')
     parser.add_argument('--branch', help='GitHub branch name', required=True)
     parser.add_argument('--build_number', help='CI job number where the instances were created', required=True)
+    parser.add_argument('--service_account', help="Path to gcloud service account, is for circleCI usage. For local "
+                                                  "development use your personal account and authenticate using Google "
+                                                  "Cloud SDK by running: `gcloud auth application-default login` and "
+                                                  "leave this parameter blank. For more information go to: "
+                                                  "https://googleapis.dev/python/google-api-core/latest/auth.html",
+                        required=True)
+    parser.add_argument('-e', '--extract_path', help=f'Full path of folder to extract the {GCPConfig.INDEX_NAME}.zip '
+                                                     f'to', required=True)
 
     options = parser.parse_args()
+    # disable-secrets-detection-end
 
     return options
 
@@ -34,6 +45,8 @@ def main():
     secret_conf_file = get_json_file(path=options.secret)
     username: str = secret_conf_file.get('username')
     password: str = secret_conf_file.get('userPassword')
+    branch_name: str = options.branch
+    build_number: str = options.build_number
 
     # Configure the Servers
     for server_url, port in server_to_port_mapping.items():
@@ -41,12 +54,16 @@ def main():
         logging.info(f'Adding Marketplace configuration to {server_url}')
         error_msg: str = 'Failed to set marketplace configuration.'
         server.add_server_configuration(config_dict=MARKET_PLACE_CONFIGURATION, error_msg=error_msg)
-        set_marketplace_url(servers=[server], branch_name=options.branch, ci_build_number=options.build_number)
+        set_marketplace_url(servers=[server], branch_name=branch_name, ci_build_number=build_number)
 
         # Acquire the server's host and install all content packs (one threaded execution)
         logging.info(f'Starting to install all content packs in {server_url}')
         server_host: str = server.client.api_client.configuration.host
-        success_flag = install_all_content_packs(client=server.client, host=server_host, server_version=server_version)
+        success_flag = install_all_content_packs_from_build_bucket(
+            client=server.client, host=server_host, server_version=server_version,
+            bucket_packs_root_path=GCPConfig.BUILD_BUCKET_PACKS_ROOT_PATH.format(branch_name, build_number),
+            service_account=options.service_account, extract_destination_path=options.extract_path
+        )
 
         if success_flag:
             logging.success(f'Finished installing all content packs in {server_url}')

--- a/Tests/Marketplace/configure_and_install_packs.py
+++ b/Tests/Marketplace/configure_and_install_packs.py
@@ -19,12 +19,7 @@ def options_handler():
     parser.add_argument('-s', '--secret', help='Path to secret conf file')
     parser.add_argument('--branch', help='GitHub branch name', required=True)
     parser.add_argument('--build_number', help='CI job number where the instances were created', required=True)
-    parser.add_argument('--service_account', help="Path to gcloud service account, is for circleCI usage. For local "
-                                                  "development use your personal account and authenticate using Google "
-                                                  "Cloud SDK by running: `gcloud auth application-default login` and "
-                                                  "leave this parameter blank. For more information go to: "
-                                                  "https://googleapis.dev/python/google-api-core/latest/auth.html",
-                        required=True)
+    parser.add_argument('--service_account', help="Path to gcloud service account", required=True)
     parser.add_argument('-e', '--extract_path', help=f'Full path of folder to extract the {GCPConfig.INDEX_NAME}.zip '
                                                      f'to', required=True)
 
@@ -61,7 +56,8 @@ def main():
         server_host: str = server.client.api_client.configuration.host
         success_flag = install_all_content_packs_from_build_bucket(
             client=server.client, host=server_host, server_version=server_version,
-            bucket_packs_root_path=GCPConfig.BUILD_BUCKET_PACKS_ROOT_PATH.format(branch_name, build_number),
+            bucket_packs_root_path=GCPConfig.BUILD_BUCKET_PACKS_ROOT_PATH.format(branch=branch_name,
+                                                                                 build=build_number),
             service_account=options.service_account, extract_destination_path=options.extract_path
         )
 

--- a/Tests/Marketplace/install_packs.sh
+++ b/Tests/Marketplace/install_packs.sh
@@ -4,8 +4,18 @@ echo "starting to install packs ..."
 
 SECRET_CONF_PATH=$(cat secret_conf_path)
 
+EXTRACT_FOLDER=$(mktemp -d)
+
+if [[ ! -f "$GCS_MARKET_KEY" ]]; then
+    echo "GCS_MARKET_KEY not set aborting pack installation!"
+    exit 1
+fi
+
+gcloud auth activate-service-account --key-file="$GCS_MARKET_KEY" > auth.out 2>&1
+echo "Auth loaded successfully."
+
 echo "starting configure_and_install_packs ..."
 
-python3 ./Tests/Marketplace/configure_and_install_packs.py -s "$SECRET_CONF_PATH" --ami_env "$1" --branch "$CI_COMMIT_BRANCH" --build_number "$CI_PIPELINE_ID"
+python3 ./Tests/Marketplace/configure_and_install_packs.py -s "$SECRET_CONF_PATH" --ami_env "$1" --branch "$CI_COMMIT_BRANCH" --build_number "$CI_PIPELINE_ID" --service_account $GCS_MARKET_KEY -e "$EXTRACT_FOLDER"
 
 exit $RETVAL

--- a/Tests/Marketplace/marketplace_constants.py
+++ b/Tests/Marketplace/marketplace_constants.py
@@ -54,6 +54,7 @@ class GCPConfig(object):
     BASE_PACK = "Base"  # base pack name
     INDEX_NAME = "index"  # main index folder name
     CORE_PACK_FILE_NAME = "corepacks.json"  # core packs file name
+    BUILD_BUCKET_PACKS_ROOT_PATH = 'content/builds/{}/{}/content/packs'
 
     with open(os.path.join(os.path.dirname(__file__), 'core_packs_list.json'), 'r') as core_packs_list_file:
         CORE_PACKS_LIST = json.load(core_packs_list_file)
@@ -80,6 +81,9 @@ class Metadata(object):
     SERVER_DEFAULT_MIN_VERSION = "6.0.0"
     CERTIFIED = "certified"
     EULA_URL = "https://github.com/demisto/content/blob/master/LICENSE"  # disable-secrets-detection
+    CURRENT_VERSION = 'currentVersion'
+    SERVER_MIN_VERSION = 'serverMinVersion'
+    HIDDEN = 'hidden'
 
 
 class PackFolders(enum.Enum):

--- a/Tests/Marketplace/marketplace_constants.py
+++ b/Tests/Marketplace/marketplace_constants.py
@@ -54,7 +54,7 @@ class GCPConfig(object):
     BASE_PACK = "Base"  # base pack name
     INDEX_NAME = "index"  # main index folder name
     CORE_PACK_FILE_NAME = "corepacks.json"  # core packs file name
-    BUILD_BUCKET_PACKS_ROOT_PATH = 'content/builds/{}/{}/content/packs'
+    BUILD_BUCKET_PACKS_ROOT_PATH = 'content/builds/{branch}/{build}/content/packs'
 
     with open(os.path.join(os.path.dirname(__file__), 'core_packs_list.json'), 'r') as core_packs_list_file:
         CORE_PACKS_LIST = json.load(core_packs_list_file)

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -447,7 +447,7 @@ class Pack(object):
         for dependency_id, dependency_data in dependencies_data.items():
             parsed_result[dependency_id] = {
                 "mandatory": first_level_dependencies.get(dependency_id, {}).get('mandatory', True),
-                "minVersion": dependency_data.get('currentVersion', Pack.PACK_INITIAL_VERSION),
+                "minVersion": dependency_data.get(Metadata.CURRENT_VERSION, Pack.PACK_INITIAL_VERSION),
                 "author": dependency_data.get('author', ''),
                 "name": dependency_data.get('name') if dependency_data.get('name') else dependency_id,
                 "certification": dependency_data.get('certification', 'certified')
@@ -570,8 +570,8 @@ class Pack(object):
             'authorImage': self._author_image,
             'certification': self._certification,
             'price': self._price,
-            'serverMinVersion': user_metadata.get('serverMinVersion') or self.server_min_version,
-            'currentVersion': user_metadata.get('currentVersion', ''),
+            Metadata.SERVER_MIN_VERSION: user_metadata.get(Metadata.SERVER_MIN_VERSION) or self.server_min_version,
+            Metadata.CURRENT_VERSION: user_metadata.get(Metadata.CURRENT_VERSION, ''),
             'versionInfo': build_number,
             'commit': commit_hash,
             'downloads': self._downloads_count,
@@ -1590,8 +1590,8 @@ class Pack(object):
                 user_metadata = {} if isinstance(user_metadata, list) else user_metadata
             # store important user metadata fields
             self.support_type = user_metadata.get('support', Metadata.XSOAR_SUPPORT)
-            self.current_version = user_metadata.get('currentVersion', '')
-            self.hidden = user_metadata.get('hidden', False)
+            self.current_version = user_metadata.get(Metadata.CURRENT_VERSION, '')
+            self.hidden = user_metadata.get(Metadata.HIDDEN, False)
             self.description = user_metadata.get('description', False)
             self.display_name = user_metadata.get('name', '')
 

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -14,8 +14,9 @@ from google.cloud.storage import Bucket
 from distutils.version import LooseVersion
 from typing import List
 
-from Tests.Marketplace.marketplace_services import init_storage_client
-from Tests.Marketplace.marketplace_constants import GCPConfig, PACKS_FULL_PATH, IGNORED_FILES, PACKS_FOLDER
+from Tests.Marketplace.marketplace_services import init_storage_client, Pack, load_json
+from Tests.Marketplace.upload_packs import download_and_extract_index
+from Tests.Marketplace.marketplace_constants import GCPConfig, PACKS_FULL_PATH, IGNORED_FILES, PACKS_FOLDER, Metadata
 from Tests.scripts.utils.content_packs_util import is_pack_deprecated
 
 PACK_METADATA_FILE = 'pack_metadata.json'
@@ -480,32 +481,46 @@ def install_all_content_packs_for_nightly(client: demisto_client, host: str, ser
     install_packs(client, host, all_packs, is_nightly=True)
 
 
-def install_all_content_packs(client: demisto_client, host: str, server_version: str):
-    """ Iterates over the packs currently located in the Packs directory. Wrapper for install_packs.
-    Retrieving the latest version of each pack from the metadata file in content repo.
+def install_all_content_packs_from_build_bucket(client: demisto_client, host: str, server_version: str,
+                                                bucket_packs_root_path: str, service_account: str,
+                                                extract_destination_path: str):
+    """ Iterates over the packs currently located in the Build bucket. Wrapper for install_packs.
+    Retrieving the metadata of the latest version of each pack from the index.zip of the build bucket.
 
     :param client: Demisto-py client to connect to the server.
     :param host: FQDN of the server.
     :param server_version: The version of the server the packs are installed on.
+    :param bucket_packs_root_path: The prefix to the root of packs in the bucket
+    :param service_account: Google Service Account
+    :param extract_destination_path: the full path of extract folder for the index.
     :return: None. Prints the response from the server in the build.
     """
     all_packs = []
-    logging.debug(f"Installing all content packs in server {host}")
+    logging.debug(f"Installing all content packs in server {host} from packs path {bucket_packs_root_path}")
 
-    for pack_id in os.listdir(PACKS_FULL_PATH):
-        if pack_id not in IGNORED_FILES:
-            metadata_path = os.path.join(PACKS_FULL_PATH, pack_id, PACK_METADATA_FILE)
-            with open(metadata_path, 'r') as json_file:
-                pack_metadata = json.load(json_file)
-                pack_version = pack_metadata.get('currentVersion')
-                server_min_version = pack_metadata.get('serverMinVersion', '6.0.0')
-                hidden = pack_metadata.get('hidden', False)
+    storage_client = init_storage_client(service_account)
+    build_bucket = storage_client.bucket(GCPConfig.CI_BUILD_BUCKET)
+    GCPConfig.STORAGE_BASE_PATH = bucket_packs_root_path  # Setting Storage base path
+    index_folder_path, _, _ = download_and_extract_index(build_bucket, extract_destination_path)
+
+    for pack_id in os.listdir(index_folder_path):
+        if os.path.isdir(os.path.join(index_folder_path, pack_id)):
+            metadata_path = os.path.join(index_folder_path, pack_id, Pack.METADATA)
+            pack_metadata = load_json(metadata_path)
+            if 'partnerId' in pack_metadata:  # not installing private packs
+                continue
+            pack_version = pack_metadata.get(Metadata.CURRENT_VERSION, Metadata.SERVER_DEFAULT_MIN_VERSION)
+            server_min_version = pack_metadata.get(Metadata.SERVER_MIN_VERSION, Metadata.SERVER_DEFAULT_MIN_VERSION)
+            hidden = pack_metadata.get(Metadata.HIDDEN, False)
             # Check if the server version is greater than the minimum server version required for this pack or if the
             # pack is hidden (deprecated):
             if ('Master' in server_version or LooseVersion(server_version) >= LooseVersion(server_min_version)) and \
                     not hidden:
                 logging.debug(f"Appending pack id {pack_id}")
                 all_packs.append(get_pack_installation_request_data(pack_id, pack_version))
+            else:
+                logging.debug(f'{pack_id} pack in version {pack_version} will not be installed on {host}. Pack is '
+                              f'{"not" if not hidden else ""} hidden. Pack min server version is {server_min_version}')
     return install_packs(client, host, all_packs)
 
 

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -519,8 +519,9 @@ def install_all_content_packs_from_build_bucket(client: demisto_client, host: st
                 logging.debug(f"Appending pack id {pack_id}")
                 all_packs.append(get_pack_installation_request_data(pack_id, pack_version))
             else:
-                logging.debug(f'{pack_id} pack in version {pack_version} will not be installed on {host}. Pack is '
-                              f'{"not" if not hidden else ""} hidden. Pack min server version is {server_min_version}')
+                reason = 'Is hidden' if hidden else f'min server version is {server_min_version}'
+                logging.debug(f'Pack: {pack_id} with version: {pack_version} will not be installed on {host}. '
+                              f'Pack {reason}.')
     return install_packs(client, host, all_packs)
 
 

--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -22,7 +22,7 @@ from demisto_sdk.commands.test_content.constants import SSH_USER
 from ruamel import yaml
 
 from Tests.Marketplace.search_and_install_packs import search_and_install_packs_and_their_dependencies, \
-    install_all_content_packs, upload_zipped_packs, install_all_content_packs_for_nightly
+    upload_zipped_packs, install_all_content_packs_for_nightly
 from Tests.scripts.utils.log_util import install_logging
 from Tests.test_content import extract_filtered_tests, get_server_numeric_version
 from Tests.test_integration import __get_integration_config, __test_integration_instance, disable_all_integrations
@@ -983,8 +983,11 @@ def get_pack_ids_to_install():
         #  END CHANGE ON LOCAL RUN  #
 
 
-def nightly_install_packs(build, install_method=install_all_content_packs, pack_path=None, service_account=None):
+def nightly_install_packs(build, install_method=None, pack_path=None, service_account=None):
     threads_list = []
+
+    if not install_method:
+        raise Exception('Install method was not provided.')
 
     # For each server url we install pack/ packs
     for thread_index, server in enumerate(build.servers):

--- a/Utils/gitlab_triggers/trigger_upload_flow_build.sh
+++ b/Utils/gitlab_triggers/trigger_upload_flow_build.sh
@@ -14,7 +14,7 @@ if [ "$#" -lt "1" ]; then
   exit 1
 fi
 
-branch="$(git branch  --show-current)"
+_branch="$(git branch  --show-current)"
 _bucket="marketplace-dist-dev"
 _bucket_upload="true"
 _slack_channel="dmst-bucket-upload"
@@ -78,7 +78,7 @@ fi
 
 source Utils/gitlab_triggers/trigger_build_url.sh
 
-curl --request POST \
+curl -k -v --request POST \
   --form token="${_ci_token}" \
   --form ref="${_branch}" \
   --form "${_variables}" \


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
When trying to install **all packs** the current script is iterating over the content repo and checking the `serverMinVersion` for each pack. This field is usually populated in the upload-flow (and minorly exists in the repo) we end up installing packs with fromversion > 6.0 on a 6.0 server. This is causing the installation to fail.

## Description
Now iterating over the build bucket that was configured in a pre-job to the installation job.

## Circle Successful Run
https://app.circleci.com/pipelines/github/demisto/content/99975/workflows/b6f99c3b-3f36-4027-a3b1-bfa6e8a6f447

## GitLab Successful Run
https://code.pan.run/xsoar/content/-/pipelines/1371791
