### PR TITLE
Copy the updated conf to Tests/conf.json before running tests

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -106,6 +106,7 @@ create-instances:
     - !reference [.open-ssh-tunnel]
     - python3 ./Tests/scripts/wait_until_server_ready.py "$INSTANCE_ROLE"
     - ./Tests/scripts/install_content_and_test_integrations.sh "$INSTANCE_ROLE" || EXIT_CODE=$?
+    - cp -f $ARTIFACTS_FOLDER/conf.json Tests/conf.json
     - ./Tests/scripts/run_tests.sh "$INSTANCE_ROLE" || EXIT_CODE=$?
     - |
       if [ -f ./Tests/failed_tests.txt ]; then


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: the nightlys testing different amount of tests

## Description
For GitLab, because the updated `conf.json` doesn't persist at `Tests/conf.json` between jobs, we need to copy the updated `conf.json` file from the artifacts directory to `Tests/conf.json` path before the `run_tests.sh` step since that script is configured to look there. Otherwise, the ordinary `conf.json` is used from when the repo is cloned at the start of the job. Resulting

## Screenshots

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
