### PR TITLE
Update Circle Nightly to only Run Validations and Lint & Unit Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,8 @@ references:
       # is done in 'Setup Environment' step.
       TIME_TO_LIVE_PARAMETER: << pipeline.parameters.time_to_live >>
       PULL_REQUEST_NUMBER: << pipeline.parameters.pr_number >>
-      NIGHTLY_PARAMETER: << pipeline.parameters.nightly >> || << pipeline.parameters.legacy_nightly >>
+      NIGHTLY_PARAMETER: << pipeline.parameters.nightly >>
+      LEGACY_NIGHTLY_PARAMETER: << pipeline.parameters.legacy_nightly >>
       INSTANCE_TESTS_PARAMETER: << pipeline.parameters.instance_tests >>
       DEMISTO_SDK_NIGHTLY_PARAMETER: << pipeline.parameters.demisto_sdk_nightly >>
       FORCE_PACK_UPLOAD_PARAMETER: << pipeline.parameters.force_pack_upload >>
@@ -171,7 +172,7 @@ references:
         echo 'source /home/circleci/project/.circleci/content_release_vars.sh' >> $BASH_ENV
         chmod +x .circleci/gitlab-ci-env-variables.sh
         ./.circleci/gitlab-ci-env-variables.sh
-        if [ -n "${NIGHTLY_PARAMETER}" ];
+        if [ -n "${NIGHTLY_PARAMETER}" ] || [ -n "{LEGACY_NIGHTLY_PARAMETER}" ];
         then
             echo 'export NIGHTLY=true' >> $BASH_ENV
         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ parameters:
   nightly:
     type: string
     default: ""
+  legacy_nightly:
+    type: string
+    default: ""
   instance_tests:
     type: string
     default: ""
@@ -121,7 +124,7 @@ references:
       # is done in 'Setup Environment' step.
       TIME_TO_LIVE_PARAMETER: << pipeline.parameters.time_to_live >>
       PULL_REQUEST_NUMBER: << pipeline.parameters.pr_number >>
-      NIGHTLY_PARAMETER: << pipeline.parameters.nightly >>
+      NIGHTLY_PARAMETER: << pipeline.parameters.nightly >> || << pipeline.parameters.legacy_nightly >>
       INSTANCE_TESTS_PARAMETER: << pipeline.parameters.instance_tests >>
       DEMISTO_SDK_NIGHTLY_PARAMETER: << pipeline.parameters.demisto_sdk_nightly >>
       FORCE_PACK_UPLOAD_PARAMETER: << pipeline.parameters.force_pack_upload >>
@@ -549,6 +552,17 @@ references:
           - Create Instances
 
   nightly_jobs: &nightly_jobs
+    - Setup Environment:
+        context: nightly_env
+    - Run Unit Testing And Lint:
+        context: nightly_env
+        requires:
+          - Setup Environment
+    - Run Validations:
+        requires:
+          - Setup Environment
+
+  legacy_nightly_jobs: &legacy_nightly_jobs
     - Setup Environment:
         context: nightly_env
     - Create Instances:
@@ -1301,6 +1315,7 @@ workflows:
           - << pipeline.parameters.force_pack_upload >>
           - << pipeline.parameters.bucket_upload >>
           - << pipeline.parameters.demisto_sdk_nightly >>
+          - << pipeline.parameters.legacy_nightly >>
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.instance_tests >>
     jobs:
@@ -1361,6 +1376,14 @@ workflows:
     when: << pipeline.parameters.nightly >>
     jobs:
       *nightly_jobs
+
+  legacy_nightly_trigger:
+    # considered legacy since we now run the nightly (test playbooks against live xsoar instances) in gitlab
+    # use to trigger a fullblown nightly in circle including the jobs to test against xsoar instances
+    # will initiate when using the trigger script with the appropriate option.
+    when: << pipeline.parameters.legacy_nightly >>
+    jobs:
+      *legacy_nightly_jobs
 
   sdk_nightly:
     triggers:

--- a/Utils/trigger_content_nightly_build.sh
+++ b/Utils/trigger_content_nightly_build.sh
@@ -1,7 +1,42 @@
 #!/usr/bin/env bash
 
-_circle_token=$1
-[ -n "$2" ] && _branch="$2" || _branch="$(git branch  --show-current)"
+if [ "$#" -lt "1" ]; then
+  echo "Usage:
+  $0 -ct <token> -b <branch>
+  [-ct, --ci-token]           The ci token.
+  [-b, --branch]              The content repo branch name. Default is the current branch.
+  [-l, --legacy]              Flag to pass if triggering a legacy nightly build (aka running all test playbooks)
+  "
+  exit 1
+fi
+
+_branch="$(git branch  --show-current)"
+_nightly_type="nightly"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+
+  -ct|--ci-token) _ci_token="$2"
+    shift
+    shift;;
+
+  -b|--branch) _branch="$2"
+    shift
+    shift;;
+
+  -l|--legacy) _nightly_type="legacy_nightly"
+    shift
+    shift;;
+
+  *)    # unknown option.
+    shift;;
+  esac
+done
+
+if [ -z "$_ci_token" ]; then
+    echo "You must provide a ci token."
+    exit 1
+fi
 
 trigger_build_url="https://circleci.com/api/v2/project/github/demisto/content/pipeline"
 
@@ -9,7 +44,7 @@ post_data=$(cat <<-EOF
 {
   "branch": "${_branch}",
   "parameters": {
-    "nightly": "true",
+    "${_nightly_type}": "true",
     "time_to_live": "900"
   }
 }
@@ -23,4 +58,4 @@ curl \
 -k \
 --data "${post_data}" \
 --request POST ${trigger_build_url} \
---user "$_circle_token:"
+--user "$_ci_token:"

--- a/Utils/trigger_nightly_sdk_build.sh
+++ b/Utils/trigger_nightly_sdk_build.sh
@@ -73,8 +73,8 @@ else
       "sdk_ref": "${_sdk_ref}"
     }
   }
-  EOF
-  )
+EOF
+)
 
   curl \
   --header "Accept: application/json" \


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
- Removes the `Create Instances` and `Server Master` jobs from the CircleCI nightly workflow jobs - AKA removes running the test playbooks against XSOAR instances (since this runs in GitLab).
- Adds a `legacy_nightly` pipeline parameter which will trigger a nightly build in CircleCI *as it used to be - aka how it ran before these changes*.
- Updates the CircleCI nightly trigger script
	- to use option flag inputs
	- an option to trigger a legacy nightly build

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [x] Yes

## Must have
- [ ] Tests
- [ ] Documentation

## Additional Changes
Tweaked the syntax in `Utils/trigger_nightly_sdk_build.sh` (removed spaces) so that VS Code linter doesn't complain.
