### PR TITLE
insight get-alerts fix

### DIFF
--- a/Packs/IntSight/Integrations/IntSight/IntSight.py
+++ b/Packs/IntSight/Integrations/IntSight/IntSight.py
@@ -209,10 +209,20 @@ def hash_identifier(hash_val):
 
 def extract_tags(tags):
     pretty_tags = []
-    string_format = "ID: {0} - Name: {1}"
+    string_format = u"ID: {0} - Name: {1}"
     for tag in tags:
         pretty_tags.append(string_format.format(tag.get('_id'), tag.get('Name')))
     return pretty_tags
+
+
+def unicode_to_str_recur(obj):
+    if isinstance(obj, dict):
+        obj = {unicode_to_str_recur(k): unicode_to_str_recur(v) for k, v in obj.iteritems()}
+    elif isinstance(obj, list):
+        obj = map(unicode_to_str_recur, obj)
+    elif isinstance(obj, unicode):
+        obj = obj.encode('utf-8')
+    return obj
 
 
 def get_alerts():
@@ -227,7 +237,8 @@ def get_alerts():
         'Type': entryTypes['note'],
         'EntryContext': {'IntSights.Alerts(val.ID === obj.ID)': alerts_context},
         'Contents': alerts_context,
-        'HumanReadable': tableToMarkdown('IntSights Alerts', alerts_human_readable, headers=headers, removeNull=False),
+        'HumanReadable': tableToMarkdown('IntSights Alerts', unicode_to_str_recur(alerts_human_readable),
+                                         headers=headers, removeNull=False),
         'ContentsFormat': formats['json']
     })
 

--- a/Packs/IntSight/Integrations/IntSight/IntSight.yml
+++ b/Packs/IntSight/Integrations/IntSight/IntSight.yml
@@ -935,7 +935,7 @@ script:
   isfetch: true
   runonce: false
   subtype: python2
-  dockerimage: demisto/python:2.7.18.20958
+  dockerimage: demisto/python:2.7.18.22912
 fromversion: 5.0.0
 tests:
 - No tests (auto formatted)

--- a/Packs/IntSight/Integrations/IntSight/IntSight_test.py
+++ b/Packs/IntSight/Integrations/IntSight/IntSight_test.py
@@ -678,3 +678,16 @@ def test_assign_alert(mocker_results, mocker):
         ]
         IntSight.assign_alert()
         assert(assignee_id == mocker_results.call_args[0][0]['Contents']['Assignees.AssigneeID'])
+
+
+def test_unicode_to_str_recur(mocker):
+    mocker.patch.object(demisto, 'command', return_value='intsights-test-action')
+    mocker.patch.object(demisto, 'params', return_value=INTSIGHTS_PARAMS)
+    mocker.patch.object(demisto, 'args', return_value={
+        'alert-id': '5e7b0b5620d02a00085ab21e',
+        'assignee-email': 'email@domain.com',
+        'is-mssp-optional': 'false'
+    })
+    from IntSight import unicode_to_str_recur
+    non_ascii_str = '\u05d5\u05d5\u05d0\u05d5'
+    assert unicode_to_str_recur(non_ascii_str) == b'\xd7\x95\xd7\x95\xd7\x90\xd7\x95'

--- a/Packs/IntSight/Integrations/IntSight/IntSight_test.py
+++ b/Packs/IntSight/Integrations/IntSight/IntSight_test.py
@@ -689,5 +689,5 @@ def test_unicode_to_str_recur(mocker):
         'is-mssp-optional': 'false'
     })
     from IntSight import unicode_to_str_recur
-    non_ascii_str = '\u05d5\u05d5\u05d0\u05d5'
-    assert unicode_to_str_recur(non_ascii_str) == b'\xd7\x95\xd7\x95\xd7\x90\xd7\x95'
+    non_ascii_str = u'\u05d5\u05d5\u05d0\u05d5'
+    assert unicode_to_str_recur(non_ascii_str) == '\xd7\x95\xd7\x95\xd7\x90\xd7\x95'

--- a/Packs/IntSight/ReleaseNotes/1_0_7.md
+++ b/Packs/IntSight/ReleaseNotes/1_0_7.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### IntSights
-- Fixed an issue where non-ascii characters were causing the `fetch-incidents` and `intsights-get-alerts` commands to fail.
+- Fixed an issue where non-ascii characters were causing the ***fetch-incidents*** and ***intsights-get-alerts*** commands to fail.
 - Updated the Docker image to: *demisto/python:2.7.18.20958*.

--- a/Packs/IntSight/ReleaseNotes/1_0_7.md
+++ b/Packs/IntSight/ReleaseNotes/1_0_7.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### IntSights
+- Fixed an issue where non-ascii characters were causing the `fetch-incidents` and `intsights-get-alerts` commands to fail.
+- Updated the Docker image to: *demisto/python:2.7.18.20958*.

--- a/Packs/IntSight/pack_metadata.json
+++ b/Packs/IntSight/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IntSights",
     "description": "Use IntSights to manage and mitigate threats.",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/39229

## Description
Fixed an issue where non-ascii characters were causing the `fetch-incidents` and `intsights-get-alerts` commands to fail.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
