### PR TITLE
adding better error handling

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1,22 +1,21 @@
+import hashlib
+import io
+import json
+import re
+import ssl
+from datetime import timedelta, datetime
+
+import dateparser
+import pytz
+import requests
+import splunklib.client as client
+import splunklib.results as results
+import urllib2
+import urllib3
+from StringIO import StringIO
 from splunklib.binding import HTTPError, namespace
 
-import demistomock as demisto
 from CommonServerPython import *
-import splunklib.client as client
-
-import splunklib.results as results
-import json
-from datetime import timedelta, datetime
-import pytz
-import dateparser
-import urllib2
-import hashlib
-import ssl
-from StringIO import StringIO
-import requests
-import urllib3
-import io
-import re
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -1879,7 +1878,7 @@ def splunk_edit_notable_event_command(service, auth_token):
                                         urgency=demisto.get(demisto.args(), 'urgency'),
                                         owner=demisto.get(demisto.args(), 'owner'), eventIDs=eventIDs,
                                         auth_token=auth_token, sessionKey=sessionKey)
-    if 'success' not in response_info or not response_info['success']:
+    if 'success' not in response_info or not response_info['success'] or type(response_info) is str:
         demisto.results({'ContentsFormat': formats['text'], 'Type': entryTypes['error'],
                          'Contents': "Could not update notable "
                                      "events: " + demisto.args()['eventIDs'] + ' : ' + str(response_info)})


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39263

## Description
Apparently, when an error occurs while updating a notable, the `response_info` might be a string.
Handling that case now.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
