### PR TITLE
Manager email address field association

### DIFF
--- a/Packs/CommonTypes/IncidentFields/incidentfield-Manager_Email_Address.json
+++ b/Packs/CommonTypes/IncidentFields/incidentfield-Manager_Email_Address.json
@@ -6,7 +6,8 @@
   "IAM - Update User",
   "IAM - Terminate User",
   "IAM - Sync User",
-  "IAM - Rehire User"
+  "IAM - Rehire User",
+  "IAM - AD User Activation"
  ],
  "caseInsensitive": true,
  "cliName": "manageremailaddress",

--- a/Packs/CommonTypes/ReleaseNotes/3_1_7.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_1_7.md
@@ -1,3 +1,3 @@
 
 #### Incident Fields
-- **Manager Email Address** Associated the field with the IAM - AD User Activation event from the ILM Content Pack.
+- **Manager Email Address** Associated the field with the ***IAM - AD User Activation*** event from the ILM Content Pack.

--- a/Packs/CommonTypes/ReleaseNotes/3_1_7.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_1_7.md
@@ -1,0 +1,3 @@
+
+#### Incident Fields
+- **Manager Email Address** Associated the field with the IAM - AD User Activation event from the ILM Content Pack.

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "3.1.6",
+    "currentVersion": "3.1.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related to: https://github.com/demisto/etc/issues/34214

## Description
Found a bug where the Manager Email Address was not associated to the `IAM - AD User Activation` incident type. This caused the welcome email for newly activated users to not be sent to the manager.
