### PR TITLE
Check failed jobs's names to determine slack msg

### DIFF
--- a/Tests/scripts/gitlab_slack_notifier.py
+++ b/Tests/scripts/gitlab_slack_notifier.py
@@ -39,7 +39,7 @@ def options_handler():
     parser.add_argument(
         '-ch', '--slack_channel', help='The slack channel in which to send the notification', default=CONTENT_CHANNEL
     )
-    parser.add_argument('-gp', '--gitlab_project_id', help='The gitlab project_id.', default=GITLAB_PROJECT_ID)
+    parser.add_argument('-gp', '--gitlab_project_id', help='The gitlab project id', default=GITLAB_PROJECT_ID)
     parser.add_argument(
         '-tw', '--triggering-workflow', help='The type of ci pipeline workflow the notifier is reporting on',
         choices=WORKFLOW_TYPES)
@@ -113,8 +113,12 @@ def construct_slack_msg(triggering_workflow, pipeline_url, pipeline_failed_jobs)
 
     triggering_workflow_lower = triggering_workflow.lower()
     check_unittests_substrings = {'lint', 'unit', 'demisto sdk nightly'}
-    if any({substr in triggering_workflow_lower for substr in check_unittests_substrings}):
-        content_fields += unit_tests_results()
+    failed_jobs_or_workflow_title = {job_name.lower() for job_name in failed_jobs_names}
+    failed_jobs_or_workflow_title.add(triggering_workflow_lower)
+    for means_include_unittests_results in failed_jobs_or_workflow_title:
+        if any({substr in means_include_unittests_results for substr in check_unittests_substrings}):
+            content_fields += unit_tests_results()
+            break
     if 'upload' in triggering_workflow_lower:
         content_fields += bucket_upload_results()
     if 'content nightly' in triggering_workflow_lower:


### PR DESCRIPTION
## Status
- [x] Ready

## Description
If certain words are in the workflow name _or_ in the failed jobs' names, then include the failed unit tests in the slack message output. This is so that if a failed content nightly included failed unit tests (and not just failed test playbooks) the failed unit tests will be listed in the slack message to the `dmst-content-team` channel.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
