### PR TITLE
Add Validation Ignore For The New Validation Of Pack/Integration/Script Name To Be Added

### DIFF
--- a/Packs/GreyNoise/.pack-ignore
+++ b/Packs/GreyNoise/.pack-ignore
@@ -1,5 +1,5 @@
 [file:GreyNoise.yml]
-ignore=IN136
+ignore=IN136,IN142
 
 [file:GreyNoise_Community.yml]
 ignore=BA108,BA109


### PR DESCRIPTION
As a part of this ticket

I have received a validation failure
https://app.circleci.com/pipelines/github/demisto/demisto-sdk/10825/workflows/5a597842-78f0-4535-9710-74f803898981/jobs/52224
After conversation with @Itay4, he told me containing Community name was allowed for this specific failing integration, therefore adding ignore to the newly added validation