### PR TITLE
Run validation and unit tests and lint even against test bucket

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -154,25 +154,21 @@
     - section_end "Test Infrastructure"
     - section_start "Run Unit Testing and Lint"
     - |
-      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
-        echo "Skipping validations when uploading to a test bucket."
+      echo "demisto-sdk version: $(demisto-sdk --version)"
+      echo "mypy version: $(mypy --version)"
+      echo "flake8 py2 version: $(python2 -m flake8 --version)"
+      echo "flake8 py3 version: $(python3 -m flake8 --version)"
+      echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
+      echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
+      echo "vulture py2 version: $(python2 -m vulture --version 2>&1)"
+      echo "vulture py3 version: $(python3 -m vulture --version 2>&1)"
+      SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
+      mkdir ./unit-tests
+      if [ -n "$SHOULD_LINT_ALL" ]; then
+        echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
+        demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
       else
-        echo "demisto-sdk version: $(demisto-sdk --version)"
-        echo "mypy version: $(mypy --version)"
-        echo "flake8 py2 version: $(python2 -m flake8 --version)"
-        echo "flake8 py3 version: $(python3 -m flake8 --version)"
-        echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
-        echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
-        echo "vulture py2 version: $(python2 -m vulture --version 2>&1)"
-        echo "vulture py3 version: $(python3 -m vulture --version 2>&1)"
-        SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
-        mkdir ./unit-tests
-        if [ -n "$SHOULD_LINT_ALL" ]; then
-          echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
-          demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
-        else
-          demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
-        fi
+        demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
       fi
     - section_end "Run Unit Testing and Lint"
 
@@ -217,19 +213,15 @@
     - section_end "Update Tests"
     - section_start "Validate Files and Yaml"
     - |
-      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
-        echo "Skipping the -Validate Files and Yaml- step when uploading to a test bucket."
-      else
-        echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"
-        ./Tests/scripts/pyflake.sh *.py
-        # do not run pyflake on venv or content-test-conf awsinstancetool
-        find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv -o -path ./Tests \) | xargs ./Tests/scripts/pyflake.sh
-        ./Tests/scripts/pyflake.sh ./Tests/*.py
-        find ./Tests -maxdepth 1 -type d -not \( -path ./Tests -o -path ./Tests/scripts \) | xargs ./Tests/scripts/pyflake.sh
-        ./Tests/scripts/pyflake.sh ./Tests/scripts/*.py
-        find ./Tests/scripts -maxdepth 1 -type d -not \( -path ./Tests/scripts -o -path ./Tests/scripts/awsinstancetool \) | xargs ./Tests/scripts/pyflake.sh
-        ./Tests/scripts/validate.sh
-      fi
+      echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"
+      ./Tests/scripts/pyflake.sh *.py
+      # do not run pyflake on venv or content-test-conf awsinstancetool
+      find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv -o -path ./Tests \) | xargs ./Tests/scripts/pyflake.sh
+      ./Tests/scripts/pyflake.sh ./Tests/*.py
+      find ./Tests -maxdepth 1 -type d -not \( -path ./Tests -o -path ./Tests/scripts \) | xargs ./Tests/scripts/pyflake.sh
+      ./Tests/scripts/pyflake.sh ./Tests/scripts/*.py
+      find ./Tests/scripts -maxdepth 1 -type d -not \( -path ./Tests/scripts -o -path ./Tests/scripts/awsinstancetool \) | xargs ./Tests/scripts/pyflake.sh
+      ./Tests/scripts/validate.sh
     - section_end "Validate Files and Yaml"
     - section_start "Check Spelling"
     - python3 ./Tests/scripts/circleci_spell_checker.py $CI_COMMIT_BRANCH


### PR DESCRIPTION
## Status
- [x] Ready

## Description
So that we see `run-unittests-and-lint-upload-flow` and `run-validations-upload-flow` jobs actually run the relevant `demisto-sdk` commands in the GitLab Upload Flow (even though we are running there against a test bucket) unlike what you see in the attached screenshots and what happens in the bucket upload flow [here](https://code.pan.run/xsoar/content/-/pipelines/1397925). So we can verify that it is working properly.

## Screenshots
![image](https://user-images.githubusercontent.com/46294017/126187834-d0e77b26-2354-4154-96af-6635975aecc3.png)
![image](https://user-images.githubusercontent.com/46294017/126187892-6513fa0c-0c54-4daa-9ac9-a2f1a9d31b45.png)


## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
