### PR TITLE
Revert 13767 run lint and validation on test bucket

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -154,7 +154,7 @@
     - section_end "Test Infrastructure"
     - section_start "Run Unit Testing and Lint"
     - |
-      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
+      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]] && [[ $CI_COMMIT_BRANCH != "master" ]]; then
         echo "Skipping validations when uploading to a test bucket."
       else
         echo "demisto-sdk version: $(demisto-sdk --version)"
@@ -217,7 +217,7 @@
     - section_end "Update Tests"
     - section_start "Validate Files and Yaml"
     - |
-      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
+      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]] && [[ $CI_COMMIT_BRANCH != "master" ]]; then
         echo "Skipping the -Validate Files and Yaml- step when uploading to a test bucket."
       else
         echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -154,21 +154,25 @@
     - section_end "Test Infrastructure"
     - section_start "Run Unit Testing and Lint"
     - |
-      echo "demisto-sdk version: $(demisto-sdk --version)"
-      echo "mypy version: $(mypy --version)"
-      echo "flake8 py2 version: $(python2 -m flake8 --version)"
-      echo "flake8 py3 version: $(python3 -m flake8 --version)"
-      echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
-      echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
-      echo "vulture py2 version: $(python2 -m vulture --version 2>&1)"
-      echo "vulture py3 version: $(python3 -m vulture --version 2>&1)"
-      SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
-      mkdir ./unit-tests
-      if [ -n "$SHOULD_LINT_ALL" ]; then
-        echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
-        demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
+      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
+        echo "Skipping validations when uploading to a test bucket."
       else
-        demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
+        echo "demisto-sdk version: $(demisto-sdk --version)"
+        echo "mypy version: $(mypy --version)"
+        echo "flake8 py2 version: $(python2 -m flake8 --version)"
+        echo "flake8 py3 version: $(python3 -m flake8 --version)"
+        echo "bandit py2 version: $(python2 -m bandit --version 2>&1)"
+        echo "bandit py3 version: $(python3 -m bandit --version 2>&1)"
+        echo "vulture py2 version: $(python2 -m vulture --version 2>&1)"
+        echo "vulture py3 version: $(python3 -m vulture --version 2>&1)"
+        SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
+        mkdir ./unit-tests
+        if [ -n "$SHOULD_LINT_ALL" ]; then
+          echo -e  "----------\nLinting all because:\n${SHOULD_LINT_ALL}\n----------"
+          demisto-sdk lint -p 8 -a -q --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
+        else
+          demisto-sdk lint -p 8 -g -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report
+        fi
       fi
     - section_end "Run Unit Testing and Lint"
 
@@ -213,15 +217,19 @@
     - section_end "Update Tests"
     - section_start "Validate Files and Yaml"
     - |
-      echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"
-      ./Tests/scripts/pyflake.sh *.py
-      # do not run pyflake on venv or content-test-conf awsinstancetool
-      find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv -o -path ./Tests \) | xargs ./Tests/scripts/pyflake.sh
-      ./Tests/scripts/pyflake.sh ./Tests/*.py
-      find ./Tests -maxdepth 1 -type d -not \( -path ./Tests -o -path ./Tests/scripts \) | xargs ./Tests/scripts/pyflake.sh
-      ./Tests/scripts/pyflake.sh ./Tests/scripts/*.py
-      find ./Tests/scripts -maxdepth 1 -type d -not \( -path ./Tests/scripts -o -path ./Tests/scripts/awsinstancetool \) | xargs ./Tests/scripts/pyflake.sh
-      ./Tests/scripts/validate.sh
+      if [[ -n $FORCE_BUCKET_UPLOAD || -n $BUCKET_UPLOAD ]] && [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
+        echo "Skipping the -Validate Files and Yaml- step when uploading to a test bucket."
+      else
+        echo "Run flake8 on all excluding Packs (Integrations and Scripts) - they will be handled in linting"
+        ./Tests/scripts/pyflake.sh *.py
+        # do not run pyflake on venv or content-test-conf awsinstancetool
+        find . -maxdepth 1 -type d -not \( -path . -o -path ./Packs -o -path ./venv -o -path ./Tests \) | xargs ./Tests/scripts/pyflake.sh
+        ./Tests/scripts/pyflake.sh ./Tests/*.py
+        find ./Tests -maxdepth 1 -type d -not \( -path ./Tests -o -path ./Tests/scripts \) | xargs ./Tests/scripts/pyflake.sh
+        ./Tests/scripts/pyflake.sh ./Tests/scripts/*.py
+        find ./Tests/scripts -maxdepth 1 -type d -not \( -path ./Tests/scripts -o -path ./Tests/scripts/awsinstancetool \) | xargs ./Tests/scripts/pyflake.sh
+        ./Tests/scripts/validate.sh
+      fi
     - section_end "Validate Files and Yaml"
     - section_start "Check Spelling"
     - python3 ./Tests/scripts/circleci_spell_checker.py $CI_COMMIT_BRANCH


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
To allow people to test their upload changes without waiting two hours / editing infra code not related to their work, I've added a check for branch name. For master runs we will perform the UT, Lint & Validate, for other branches not.

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
