### PR TITLE
[Elasticsearch Feed] Fix lastTime timestamp in wrong format

### DIFF
--- a/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.py
+++ b/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.py
@@ -225,7 +225,7 @@ def fetch_indicators_command(client, feed_type, src_val, src_type, default_type,
             # ensure batch sizes don't exceed 2000
             for b in batch(enrch_batch, batch_size=2000):
                 demisto.createIndicators(b)
-    demisto.setLastRun({'time': now.timestamp() * 1000})
+    demisto.setLastRun({'time': int(now.timestamp() * 1000)})
 
 
 def get_last_fetch_timestamp(last_fetch, time_method, fetch_time):

--- a/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
+++ b/Packs/FeedElasticsearch/Integrations/FeedElasticsearch/FeedElasticsearch.yml
@@ -175,7 +175,7 @@ script:
     description: Gets indicators available in the configured Elasticsearch database.
     execution: false
     name: es-get-indicators
-  dockerimage: demisto/elasticsearch:1.0.0.14274
+  dockerimage: demisto/elasticsearch:1.0.0.23275
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedElasticsearch/ReleaseNotes/1_0_9.md
+++ b/Packs/FeedElasticsearch/ReleaseNotes/1_0_9.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Elasticsearch Feed
-- Fixed an issue where fetches failed to parse the lastRun date field
+- Fixed an issue where fetching indicators failed to parse the lastRun date field.
 - Updated the Docker image to: *demisto/elasticsearch:1.0.0.23275*.

--- a/Packs/FeedElasticsearch/ReleaseNotes/1_0_9.md
+++ b/Packs/FeedElasticsearch/ReleaseNotes/1_0_9.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Elasticsearch Feed
+- Fixed an issue where fetches failed to parse the lastRun date field
+- Updated the Docker image to: *demisto/elasticsearch:1.0.0.23275*.

--- a/Packs/FeedElasticsearch/pack_metadata.json
+++ b/Packs/FeedElasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch Feed",
     "description": "Indicators feed from Elasticsearch database",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/39361

## Description
Changed the timestamp to a `13 digit` timestamp (mili seconds) rather than `16 digits` (microseconds).
## Does it break backward compatibility?
   - [x] No