### PR TITLE
binded the ip command to ipinfo_v2 brand

### DIFF
--- a/Packs/ipinfo/TestPlaybooks/playbook-IPinfo_v2_Test.yml
+++ b/Packs/ipinfo/TestPlaybooks/playbook-IPinfo_v2_Test.yml
@@ -74,7 +74,7 @@ tasks:
       id: c1e0c60a-755f-4f33-8786-26453ce41437
       version: -1
       name: ip
-      script: '|||ip'
+      script: 'ipinfo_v2|||ip'
       type: regular
       iscommand: true
       brand: ""


### PR DESCRIPTION
The IP command in TPB trigerred this test to be collected when it shouldn't have. @ChanochShayner Correct me if i am wrong. As can be seen in this PR
https://github.com/demisto/content/pull/13838