### PR TITLE
No output for "thehive-list-observables"

### DIFF
--- a/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.yml
+++ b/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.yml
@@ -1335,6 +1335,10 @@ script:
     - name: id
       description: Case ID
     description: List observables for a case.
+    outputs:
+    - contextPath: TheHive.Observables
+      description: _observable
+      type: string
   - name: thehive-create-observable
     arguments:
     - name: id


### PR DESCRIPTION
When running playbooks on Xsoar, there is no output for the list of observables. I wrote a change, but I believe it needs to be changed.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When running playbooks on Xsoar, there is no output for the list of observables. 
I wrote a change, but I believe it needs to be changed.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [x] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
