### PR TITLE
VirusTotal - Private API - Fixed an issue where the vt-private-get-url-report command would fail on certain urls.

### DIFF
--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.py
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.py
@@ -729,7 +729,7 @@ def create_url_report_output(url, response, threshold, max_len, short_format):
         resolution = additional_info.get('resolution', None)
         if resolution:
             md += 'IP address resolution for this domain is: ' + resolution + '\n'
-        update_entry_context_url(ec_url, url, field_name='Resolutions', field_value=resolution[:max_len])
+            update_entry_context_url(ec_url, url, field_name='Resolutions', field_value=resolution[:max_len])
 
         response_sha256 = additional_info.get('Response content SHA-256', None)
         if response_sha256:

--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.yml
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.yml
@@ -622,7 +622,7 @@ script:
   script: '-'
   subtype: python2
   type: python
-  dockerimage: demisto/python:2.7.18.20958
+  dockerimage: demisto/python:2.7.18.22912
 tests:
 - virusTotalPrivateAPI-test-playbook
 - File Enrichment - Virus Total Private API Test

--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API_test.py
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API_test.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+
 import demistomock as demisto
 
 queued_response = {u'response_code': -2,
@@ -39,72 +40,265 @@ def test_get_url_multiple_results(mocker, requests_mock):
     assert isinstance(output[1]['EntryContext']['DBotScore'], dict)
 
 
-def test_create_url_report_output():
+def test_create_url_report_output_no_resolution():
+    """
+    Given
+    - command args with allInfo=true(implied, raw response is bigger)
+    - command raw response
+    When
+    - mock the get_url_report response.
+    Then
+    - run the create_url_report_output command
+    - validate the markdown, context and the DBotScore of the report generated.
+    """
     vt = importlib.import_module("VirusTotal-Private_API")
-    url = 'demisto.com'
-    response = load_test_data('./test_data/get_url_report_demisto.json')
+    url = 'https://github.com/topics/spacevim'
+    response = load_test_data('./test_data/get_url_report_no_resultion.json')
     threshold = 10
     max_len = 50
     short_format = False
 
-    expected_md = "## VirusTotal URL report for: demisto.com\nScan ID: **someId**\nScan date: **2020-09-24 " \
-                  "13:35:46**\nDetections / Total: **0/79**\nResource: demisto.com\nVT Link: [" \
-                  "https://www.someurl.com/](https://www.someurl.com/)\nIP address resolution for this domain is: " \
-                  "1.2.3.4\nResponse content SHA-256: someSHA\n### " \
-                  "Scans\n|Details|Detected|Result|Source|Update|\n|---|---|---|---|---|\n|  | false | clean site | " \
-                  "CLEAN MX |  |\n| http://www.someurl.com/?search=demisto.com | false | clean site | " \
-                  "MalwareDomainList |  |\n|  | false | clean site | Trustwave |  |\n"
+    expected_md = """## VirusTotal URL report for: https://github.com/topics/spacevim
+Scan ID: **856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923**
+Scan date: **2021-07-27 14:58:43**
+Detections / Total: **0/89**
+Resource: https://github.com/topics/spacevim
+VT Link: [https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923](https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923)
+Response content SHA-256: 0e1a3027e45f3971d9611b88be2b556a166b8e7dcbdbfd4b2de257fc22a86079
+### Scans
+|Details|Detected|Result|Source|Update|
+|---|---|---|---|---|
+|  | false | unrated site | 0xSI_f33d |  |
+|  | false | clean site | ADMINUSLabs |  |
+|  | false | clean site | AICC (MONITORAPP) |  |
+|  | false | clean site | Abusix |  |
+|  | false | clean site | AlienVault |  |
+|  | false | clean site | Antiy-AVL |  |
+|  | false | clean site | Armis |  |
+|  | false | clean site | Artists Against 419 |  |
+|  | false | unrated site | AutoShun |  |
+|  | false | clean site | Avira |  |
+|  | false | clean site | BADWARE.INFO |  |
+|  | false | clean site | Baidu-International |  |
+|  | false | clean site | Bfore.Ai PreCrime |  |
+|  | false | clean site | BitDefender |  |
+|  | false | clean site | BlockList |  |
+|  | false | clean site | Blueliv |  |
+|  | false | clean site | CINS Army |  |
+|  | false | clean site | CMC Threat Intelligence |  |
+|  | false | clean site | CRDF |  |
+|  | false | clean site | Certego |  |
+|  | false | clean site | Comodo Valkyrie Verdict |  |
+|  | false | clean site | CyRadar |  |
+|  | false | unrated site | Cyan |  |
+|  | false | clean site | CyberCrime |  |
+|  | false | clean site | Cyren |  |
+|  | false | clean site | DNS8 |  |
+|  | false | clean site | Dr.Web |  |
+|  | false | clean site | ESET |  |
+|  | false | clean site | EmergingThreats |  |
+|  | false | clean site | Emsisoft |  |
+|  | false | clean site | EonScope |  |
+|  | false | clean site | Feodo Tracker |  |
+|  | false | clean site | Forcepoint ThreatSeeker |  |
+|  | false | clean site | Fortinet |  |
+|  | false | clean site | FraudScore |  |
+|  | false | clean site | G-Data |  |
+|  | false | clean site | Google Safebrowsing |  |
+|  | false | clean site | GreenSnow |  |
+|  | false | clean site | Hoplite Industries |  |
+|  | false | clean site | IPsum |  |
+|  | false | clean site | K7AntiVirus |  |
+|  | false | clean site | Kaspersky |  |
+|  | false | clean site | Lionic |  |
+|  | false | unrated site | Lumu |  |
+|  | false | clean site | MalBeacon |  |
+|  | false | clean site | MalSilo |  |
+| http://www.malwaredomainlist.com/mdl.php?search=github.com | false | clean site | MalwareDomainList |  |
+|  | false | clean site | MalwarePatrol |  |
+|  | false | clean site | Malwared |  |
+|  | false | unrated site | Netcraft |  |
+|  | false | unrated site | NotMining |  |
+|  | false | clean site | Nucleon |  |
+|  | false | clean site | OpenPhish |  |
+|  | false | clean site | PREBYTES |  |
+|  | false | unrated site | PhishLabs |  |
+|  | false | clean site | Phishing Database |  |
+|  | false | clean site | Phishtank |  |
+|  | false | clean site | Quick Heal |  |
+|  | false | clean site | Quttera |  |
+|  | false | clean site | Rising |  |
+|  | false | clean site | SCUMWARE.org |  |
+|  | false | unrated site | SafeToOpen |  |
+|  | false | clean site | Sangfor |  |
+|  | false | clean site | Scantitan |  |
+|  | false | clean site | SecureBrain |  |
+|  | false | clean site | Snort IP sample list |  |
+|  | false | clean site | Sophos |  |
+|  | false | clean site | Spam404 |  |
+|  | false | clean site | Spamhaus |  |
+|  | false | unrated site | StopBadware |  |
+|  | false | clean site | StopForumSpam |  |
+|  | false | clean site | Sucuri SiteCheck |  |
+|  | false | clean site | Tencent |  |
+|  | false | clean site | ThreatHive |  |
+|  | false | clean site | Threatsourcing |  |
+|  | false | clean site | Trustwave |  |
+|  | false | clean site | URLhaus |  |
+|  | false | clean site | VX Vault |  |
+|  | false | clean site | Virusdie External Site Scan |  |
+|  | false | clean site | Web Security Guard |  |
+|  | false | clean site | Webroot |  |
+| http://yandex.com/infected?l10n=en&url=https://github.com/topics/spacevim | false | clean site | Yandex Safebrowsing |  |
+|  | false | clean site | ZeroCERT |  |
+|  | false | clean site | alphaMountain.ai |  |
+|  | false | clean site | benkow.cc |  |
+|  | false | clean site | desenmascara.me |  |
+|  | false | clean site | malwares.com URL checker |  |
+|  | false | clean site | securolytics |  |
+|  | false | clean site | zvelo |  |
+"""
 
     expected_ec_url = {
-        'Data': 'demisto.com',
+        'Data': 'https://github.com/topics/spacevim',
         'VirusTotal': {
-            'ResponseContentSHA256': 'someSHA',
-            'Resolutions': '1.2.3.4',
+            'ResponseContentSHA256': '0e1a3027e45f3971d9611b88be2b556a166b8e7dcbdbfd4b2de257fc22a86079',
             'ResponseHeaders': {
-                'expires': 'Thu, 24 Sep 2020 13:50:50 GMT',
-                'x-content-type-options': 'nosniff',
+                'accept-ranges': 'bytes',
+                'cache-control': 'max-age=0, private, must-revalidate',
+                'content-type': 'text/html; charset=utf-8',
+                'date': 'Tue, 27 Jul 2021 14:58:50 GMT',
+                'etag': 'W/"cc5749d30e85e6e4bbb2a0c8f8b85bb7"',
+                'expect-ct': 'max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"',
+                'permissions-policy': 'interest-cohort=()',
+                'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
+                'server': 'GitHub.com',
+                'set-cookie': '_gh_sess=sD',
+                'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
                 'transfer-encoding': 'chunked',
-                'set-cookie': 'AKA_A2=A; expires=Thu, '
-                              '24-Sep-2020 14:35:50 GMT; path=/; domain=paloaltonetworks.com; secure; HttpOnly',
-                'strict-transport-security': 'max-age=300',
-                'vary': 'Accept-Encoding',
-                'server': 'Apache',
-                'cache-control': 'public, max-age=900',
-                'server-timing': 'cdn-cache; desc=HIT, edge; dur=16',
-                'connection': 'keep-alive, Transfer-Encoding',
-                'link': 'somelink',
-                'access-control-allow-credentials': 'true',
-                'date': 'Thu, 24 Sep 2020 13:35:50 GMT',
-                'x-frame-options': 'SAMEORIGIN',
-                'content-type': 'text/html;charset=utf-8',
-                'x-akamai-transformed': '9 81423 0 pmb=mRUM,2'
-            }, 'Scans': [
-                {
-                    'Details': None,
-                    'Source': 'CLEAN MX',
-                    'Detected': False,
-                    'Result': 'clean site',
-                    'Update': None
-                }, {
-                    'Details': 'http://www.someurl.com/?search=demisto.com',
-                    'Source': 'MalwareDomainList',
-                    'Detected': False,
-                    'Result': 'clean site',
-                    'Update': None
-                }, {
-                    'Details': None,
-                    'Source': 'Trustwave',
-                    'Detected': False,
-                    'Result': 'clean site',
-                    'Update': None
-                }
+                'vary': 'X-PJAX, Accept-Encoding, Accept, X-Requested-With',
+                'x-content-type-options': 'nosniff', 'x-frame-options': 'deny',
+                'x-github-request-id': '897E:5827:6536B6:93B410:61001F29',
+                'x-xss-protection': '0'}, 'Scans': [
+                {'Source': '0xSI_f33d', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'ADMINUSLabs', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'AICC (MONITORAPP)', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Abusix', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'AlienVault', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Antiy-AVL', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Armis', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Artists Against 419', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'AutoShun', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'Avira', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'BADWARE.INFO', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Baidu-International', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Bfore.Ai PreCrime', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'BitDefender', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'BlockList', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Blueliv', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'CINS Army', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'CMC Threat Intelligence', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'CRDF', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Certego', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Comodo Valkyrie Verdict', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'CyRadar', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Cyan', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'CyberCrime', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Cyren', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'DNS8', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Dr.Web', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'ESET', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'EmergingThreats', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Emsisoft', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'EonScope', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Feodo Tracker', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Forcepoint ThreatSeeker', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Fortinet', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'FraudScore', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'G-Data', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Google Safebrowsing', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'GreenSnow', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Hoplite Industries', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'IPsum', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'K7AntiVirus', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Kaspersky', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Lionic', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Lumu', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'MalBeacon', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'MalSilo', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'MalwareDomainList', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': 'http://www.malwaredomainlist.com/mdl.php?search=github.com'},
+                {'Source': 'MalwarePatrol', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Malwared', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Netcraft', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'NotMining', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'Nucleon', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'OpenPhish', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'PREBYTES', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'PhishLabs', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'Phishing Database', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Phishtank', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Quick Heal', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Quttera', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Rising', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'SCUMWARE.org', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'SafeToOpen', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'Sangfor', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Scantitan', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'SecureBrain', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Snort IP sample list', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Sophos', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Spam404', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Spamhaus', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'StopBadware', 'Detected': False, 'Result': 'unrated site', 'Update': None, 'Details': None},
+                {'Source': 'StopForumSpam', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Sucuri SiteCheck', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Tencent', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'ThreatHive', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Threatsourcing', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Trustwave', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'URLhaus', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'VX Vault', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Virusdie External Site Scan', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Web Security Guard', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'Webroot', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'Yandex Safebrowsing', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': 'http://yandex.com/infected?l10n=en&url=https://github.com/topics/spacevim'},
+                {'Source': 'ZeroCERT', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'alphaMountain.ai', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'benkow.cc', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'desenmascara.me', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'malwares.com URL checker', 'Detected': False, 'Result': 'clean site', 'Update': None,
+                 'Details': None},
+                {'Source': 'securolytics', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None},
+                {'Source': 'zvelo', 'Detected': False, 'Result': 'clean site', 'Update': None, 'Details': None}
             ]
         }
     }
 
-    expected_ec_dbot = {'Vendor': 'VirusTotal - Private API', 'Indicator': u'demisto.com', 'Score': 1, 'Type': 'url'}
+    expected_ec_dbot = {'Vendor': 'VirusTotal - Private API', 'Indicator': u'https://github.com/topics/spacevim',
+                        'Score': 1, 'Type': 'url'}
 
     md, ec_url, ec_dbot = vt.create_url_report_output(url, response, threshold, max_len, short_format)
+
     assert md == expected_md
     assert ec_url == expected_ec_url
     assert ec_dbot == expected_ec_dbot
@@ -170,7 +364,7 @@ def test_get_url_report_invalid_url(mocker, requests_mock):
     mocker.patch.object(demisto, 'args', return_value={'resource': 'hts://invalid_url.nfs.cv'})
     requests_mock.get('https://www.virustotal.com/vtapi/v2/url/report',
                       [{'json': load_test_data('./test_data/get_url_report_invalid_url.json'),
-                       'status_code': 200}])
+                        'status_code': 200}])
 
     vt = importlib.import_module("VirusTotal-Private_API")
     output = vt.get_url_report_command()

--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API_test.py
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API_test.py
@@ -63,7 +63,7 @@ Scan ID: **856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627
 Scan date: **2021-07-27 14:58:43**
 Detections / Total: **0/89**
 Resource: https://github.com/topics/spacevim
-VT Link: [https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923](https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923)
+VT Link: [https://www.virustotal.com/gui/url/truncated](https://www.virustotal.com/gui/url/truncated)
 Response content SHA-256: 0e1a3027e45f3971d9611b88be2b556a166b8e7dcbdbfd4b2de257fc22a86079
 ### Scans
 |Details|Detected|Result|Source|Update|

--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/test_data/get_url_report_no_resultion.json
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/test_data/get_url_report_no_resultion.json
@@ -1,0 +1,403 @@
+{
+    "additional_info": {
+        "BitDefender category": "computersandsoftware",
+        "Comodo Valkyrie Verdict category": "web applications",
+        "Dr.Web category": "social networks",
+        "Forcepoint ThreatSeeker category": "information technology",
+        "Response code": 200,
+        "Response content SHA-256": "0e1a3027e45f3971d9611b88be2b556a166b8e7dcbdbfd4b2de257fc22a86079",
+        "Response headers": {
+            "accept-ranges": "bytes",
+            "cache-control": "max-age=0, private, must-revalidate",
+            "content-type": "text/html; charset=utf-8",
+            "date": "Tue, 27 Jul 2021 14:58:50 GMT",
+            "etag": "W/\"cc5749d30e85e6e4bbb2a0c8f8b85bb7\"",
+            "expect-ct": "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"",
+            "permissions-policy": "interest-cohort=()",
+            "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+            "server": "GitHub.com",
+            "set-cookie": "_gh_sess=sD",
+            "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
+            "transfer-encoding": "chunked",
+            "vary": "X-PJAX, Accept-Encoding, Accept, X-Requested-With",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "deny",
+            "x-github-request-id": "897E:5827:6536B6:93B410:61001F29",
+            "x-xss-protection": "0"
+        },
+        "rlength": 488875,
+        "sophos category": "information technology, storage and backup"
+    },
+    "filescan_id": null,
+    "first_seen": "2021-07-27 14:58:43",
+    "last_seen": "2021-07-27 14:58:43",
+    "permalink": "https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923",
+    "positives": 0,
+    "resource": "https://github.com/topics/spacevim",
+    "response_code": 1,
+    "scan_date": "2021-07-27 14:58:43",
+    "scan_id": "856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923",
+    "scans": {
+        "0xSI_f33d": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "ADMINUSLabs": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "AICC (MONITORAPP)": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Abusix": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "AlienVault": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Antiy-AVL": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Armis": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Artists Against 419": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "AutoShun": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "Avira": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "BADWARE.INFO": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Baidu-International": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Bfore.Ai PreCrime": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "BitDefender": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "BlockList": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Blueliv": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "CINS Army": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "CMC Threat Intelligence": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "CRDF": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Certego": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Comodo Valkyrie Verdict": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "CyRadar": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Cyan": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "CyberCrime": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Cyren": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "DNS8": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Dr.Web": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "ESET": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "EmergingThreats": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Emsisoft": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "EonScope": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Feodo Tracker": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Forcepoint ThreatSeeker": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Fortinet": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "FraudScore": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "G-Data": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Google Safebrowsing": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "GreenSnow": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Hoplite Industries": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "IPsum": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "K7AntiVirus": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Kaspersky": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Lionic": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Lumu": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "MalBeacon": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "MalSilo": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "MalwareDomainList": {
+            "detail": "http://www.malwaredomainlist.com/mdl.php?search=github.com",
+            "detected": false,
+            "result": "clean site"
+        },
+        "MalwarePatrol": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Malwared": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Netcraft": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "NotMining": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "Nucleon": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "OpenPhish": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "PREBYTES": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "PhishLabs": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "Phishing Database": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Phishtank": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Quick Heal": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Quttera": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Rising": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "SCUMWARE.org": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "SafeToOpen": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "Sangfor": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Scantitan": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "SecureBrain": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Snort IP sample list": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Sophos": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Spam404": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Spamhaus": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "StopBadware": {
+            "detected": false,
+            "result": "unrated site"
+        },
+        "StopForumSpam": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Sucuri SiteCheck": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Tencent": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "ThreatHive": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Threatsourcing": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Trustwave": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "URLhaus": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "VX Vault": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Virusdie External Site Scan": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Web Security Guard": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Webroot": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "Yandex Safebrowsing": {
+            "detail": "http://yandex.com/infected?l10n=en\u0026url=https://github.com/topics/spacevim",
+            "detected": false,
+            "result": "clean site"
+        },
+        "ZeroCERT": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "alphaMountain.ai": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "benkow.cc": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "desenmascara.me": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "malwares.com URL checker": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "securolytics": {
+            "detected": false,
+            "result": "clean site"
+        },
+        "zvelo": {
+            "detected": false,
+            "result": "clean site"
+        }
+    },
+    "total": 89,
+    "url": "https://github.com/topics/spacevim",
+    "verbose_msg": "Scan finished, scan information embedded in this object"
+}

--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/test_data/get_url_report_no_resultion.json
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/test_data/get_url_report_no_resultion.json
@@ -31,7 +31,7 @@
     "filescan_id": null,
     "first_seen": "2021-07-27 14:58:43",
     "last_seen": "2021-07-27 14:58:43",
-    "permalink": "https://www.virustotal.com/gui/url/856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c/detection/u-856ec9887a4ffccbb8f5f4b559e6cb10751c9c411bd96464a47b50bc9c387b9c-1627397923",
+    "permalink": "https://www.virustotal.com/gui/url/truncated",
     "positives": 0,
     "resource": "https://github.com/topics/spacevim",
     "response_code": 1,

--- a/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_10.md
+++ b/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VirusTotal - Private API
+- Fixed an issue where the ***vt-private-get-url-report*** command would fail on certain urls.

--- a/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_10.md
+++ b/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_10.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### VirusTotal - Private API
 - Fixed an issue where the ***vt-private-get-url-report*** command would fail on certain urls.
+- Updated the Docker image to: *demisto/python:2.7.18.22912*.

--- a/Packs/VirusTotal-Private_API/pack_metadata.json
+++ b/Packs/VirusTotal-Private_API/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VirusTotal - Private API",
     "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/39587

## Description
wrong indent, would try to access non existent list in some cases.

## Screenshots
Successful now
![Screen Shot 2021-07-28 at 9 49 32](https://user-images.githubusercontent.com/37335599/127277122-9c76cf7c-e59c-4b7a-a274-779e7633f58e.png)


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
