### PR TITLE
GetListRaw - added list separator arg

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_4_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_4_11.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### GetListRow
+- Added **list_separator** argument to enable custom list delimiter.
+- Updated the Docker image to: *demisto/python3:3.8.3.9324*.

--- a/Packs/CommonScripts/ReleaseNotes/1_4_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_4_11.md
@@ -1,5 +1,5 @@
 
 #### Scripts
 ##### GetListRow
-- Added **list_separator** argument to enable custom list delimiter.
+- Added the **list_separator** argument to enable custom list delimiter.
 - Updated the Docker image to: *demisto/python3:3.8.3.9324*.

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
@@ -17,7 +17,7 @@ def validate_header_exists(headers, header):
         return_error("Error: The supplied header name was not found.")
 
 
-def list_to_headers_and_lines(list_data, list_separator):
+def list_to_headers_and_lines(list_data, list_separator: str):
     lines_and_headers = [line.split(list_separator) for line in list_data.split('\n')]
     headers = lines_and_headers[0]
     return headers, lines_and_headers[1:]
@@ -54,7 +54,7 @@ def parse_relevant_rows(headers, lines, header, value, context, parse_all=False)
     )
 
 
-def parse_list(parse_all, header, value, list_name, list_separator):
+def parse_list(parse_all, header, value, list_name, list_separator: str):
     validate_args(parse_all, header, value)
     list_data = demisto.executeCommand("getList", {'listName': list_name})[0]['Contents']
     context = {
@@ -79,7 +79,7 @@ def main():
     parse_all = args['parse_all']
     header = args.get('header', '')
     value = args.get('value', '')
-    list_separator = args.get('list_separator', ',')
+    list_separator = args.get('list_separator', ',') or ','
 
     return_results(parse_list(parse_all, header, value, list_name, list_separator))
 

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
@@ -46,7 +46,7 @@ def parse_relevant_rows(headers, lines, header, value, context, parse_all=False)
             readable_output="No results found"
         )
     context["Results"] = lines_context
-    human_readable = tableToMarkdown('List Result', lines_context, headers=headers)
+    human_readable = tableToMarkdown('List Result', lines_context, headers=headers, removeNull=True)
     return CommandResults(
         outputs_prefix=output_condition,
         outputs=context,

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
@@ -17,8 +17,8 @@ def validate_header_exists(headers, header):
         return_error("Error: The supplied header name was not found.")
 
 
-def list_to_headers_and_lines(list_data):
-    lines_and_headers = [line.split(',') for line in list_data.split('\n')]
+def list_to_headers_and_lines(list_data, list_separator):
+    lines_and_headers = [line.split(list_separator) for line in list_data.split('\n')]
     headers = lines_and_headers[0]
     return headers, lines_and_headers[1:]
 
@@ -54,7 +54,7 @@ def parse_relevant_rows(headers, lines, header, value, context, parse_all=False)
     )
 
 
-def parse_list(parse_all, header, value, list_name):
+def parse_list(parse_all, header, value, list_name, list_separator):
     validate_args(parse_all, header, value)
     list_data = demisto.executeCommand("getList", {'listName': list_name})[0]['Contents']
     context = {
@@ -64,7 +64,7 @@ def parse_list(parse_all, header, value, list_name):
         "ParseAll": parse_all
     }
     validate_list_exists(list_data)
-    headers, lines = list_to_headers_and_lines(list_data)
+    headers, lines = list_to_headers_and_lines(list_data, list_separator)
     if parse_all.lower() == 'true':
         command_results = parse_relevant_rows(headers, lines, header, value, context, parse_all=True)
     else:
@@ -79,8 +79,9 @@ def main():
     parse_all = args['parse_all']
     header = args.get('header', '')
     value = args.get('value', '')
+    list_separator = args.get('list_separator', ',')
 
-    return_results(parse_list(parse_all, header, value, list_name))
+    return_results(parse_list(parse_all, header, value, list_name, list_separator))
 
 
 if __name__ in ('__main__', '__builtin__', 'builtins'):

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
@@ -65,7 +65,7 @@ subtype: python3
 system: false
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.8.3.9324
+dockerimage: demisto/python3:3.9.6.22912
 runas: DBotWeakRole
 runonce: false
 tests:

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
@@ -1,12 +1,14 @@
 args:
 - default: false
-  description: Value to search for. If you supply a value, you need to supply the "header" argument also.
+  description: Value to search for. If you supply a value, you need to supply the
+    "header" argument also.
   isArray: false
   name: value
   required: false
   secret: false
 - default: false
-  description: Header to filter lines by. If you supply a header, you need to supply the "value" argument.
+  description: Header to filter lines by. If you supply a header, you need to supply
+    the "value" argument.
   isArray: false
   name: header
   required: false
@@ -20,12 +22,20 @@ args:
 - auto: PREDEFINED
   default: false
   defaultValue: 'False'
-  description: If "True", parses the entire list into the context. Can be "True" or "False". Default is "False".
+  description: If "True", parses the entire list into the context. Can be "True" or
+    "False". Default is "False".
   isArray: false
   name: parse_all
   predefined:
   - 'True'
   - 'False'
+  required: false
+  secret: false
+- default: false
+  defaultValue: ','
+  description: Seperator for splitting the list by
+  isArray: false
+  name: list_separator
   required: false
   secret: false
 comment: Parses a list by header and value.

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
@@ -33,7 +33,7 @@ args:
   secret: false
 - default: false
   defaultValue: ','
-  description: Seperator for splitting the list by
+  description: Separator to split the list by.
   isArray: false
   name: list_separator
   required: false

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
@@ -3,6 +3,7 @@ from CommonServerPython import *
 
 RETURN_ERROR_TARGET = 'GetListRow.return_error'
 DATA_WITH_CUSTOM_SEP = [{"Contents": "name;id\nname1;id1\nname2;id2"}]
+DATA_WITH_NEW_LINE_SEP = [{"Contents": "name\nid\nname1\nid1\nname2\nid2"}]
 
 
 @pytest.mark.parametrize(
@@ -77,11 +78,25 @@ def test_parse_list(mocker, parse_all, header, value, list_name, list_separator,
     [
         (DATA_WITH_CUSTOM_SEP, "True", "name", "id", "getListRow", ';',
          [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}]),
-        (DATA_WITH_CUSTOM_SEP, "False", "name", "id", "getListRow", ';',
-         [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}])
+        (DATA_WITH_CUSTOM_SEP, "False", "name", "name2", "getListRow", ';', [{'name': 'name2', 'id': 'id2'}])
     ]
 )
 def test_custom_list_separator(mocker, data, parse_all, header, value, list_name, list_separator, expected):
+    from GetListRow import parse_list
+    mocker.patch.object(demisto, "executeCommand", return_value=data)
+    res = parse_list(parse_all, header, value, list_name, list_separator)
+    assert res.outputs.get('Results') == expected
+
+
+@pytest.mark.parametrize(
+    "data, parse_all, header, value, list_name, list_separator, expected",
+    [
+        (DATA_WITH_NEW_LINE_SEP, "True", "name", "id", "getListRow", '\n',
+         [{'name': 'id'}, {'name': 'name1'}, {'name': 'id1'}, {'name': 'name2'}, {'name': 'id2'}]),
+        (DATA_WITH_NEW_LINE_SEP, "False", "name", "name2", "getListRow", '\n', [{'name': 'name2'}])
+    ]
+)
+def test_custom_list_new_line_sep(mocker, data, parse_all, header, value, list_name, list_separator, expected):
     from GetListRow import parse_list
     mocker.patch.object(demisto, "executeCommand", return_value=data)
     res = parse_list(parse_all, header, value, list_name, list_separator)

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
@@ -82,6 +82,14 @@ def test_parse_list(mocker, parse_all, header, value, list_name, list_separator,
     ]
 )
 def test_custom_list_separator(mocker, data, parse_all, header, value, list_name, list_separator, expected):
+    """
+    Given:
+        - Data that should be split by the custom separator ';'.
+    When:
+        - Running the script with a custom separator arg
+    Then:
+        - Ensure the parsed sata was split correctly
+    """
     from GetListRow import parse_list
     mocker.patch.object(demisto, "executeCommand", return_value=data)
     res = parse_list(parse_all, header, value, list_name, list_separator)
@@ -97,6 +105,14 @@ def test_custom_list_separator(mocker, data, parse_all, header, value, list_name
     ]
 )
 def test_custom_list_new_line_sep(mocker, data, parse_all, header, value, list_name, list_separator, expected):
+    """
+    Given:
+        - Data that should be split by the custom separator '\n'.
+    When:
+        - Running the script with a custom separator arg
+    Then:
+        - Ensure the parsed sata was split correctly
+    """
     from GetListRow import parse_list
     mocker.patch.object(demisto, "executeCommand", return_value=data)
     res = parse_list(parse_all, header, value, list_name, list_separator)

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow_test.py
@@ -1,8 +1,8 @@
 import pytest
 from CommonServerPython import *
 
-
 RETURN_ERROR_TARGET = 'GetListRow.return_error'
+DATA_WITH_CUSTOM_SEP = [{"Contents": "name;id\nname1;id1\nname2;id2"}]
 
 
 @pytest.mark.parametrize(
@@ -55,18 +55,34 @@ def test_does_header_exist(mocker, headers, header, expected):
 
 
 @pytest.mark.parametrize(
-    "parse_all, header, value, list_name, expected",
+    "parse_all, header, value, list_name, list_separator, expected",
     [
-        ("True", "", "on", "getListRow", "List Result"),
-        ("False", "status", "on", "getListRow", "List Result"),
-        ("False", "status", "n", "getListRow", "No results found")
+        ("True", "", "on", "getListRow", ',', "List Result"),
+        ("False", "status", "on", "getListRow", ',', "List Result"),
+        ("False", "status", "n", "getListRow", ',', "No results found")
     ]
 )
-def test_parse_list(mocker, parse_all, header, value, list_name, expected):
+def test_parse_list(mocker, parse_all, header, value, list_name, list_separator, expected):
     from GetListRow import parse_list
     mocker.patch.object(demisto, "executeCommand", return_value=[{"Contents": '''id,name,title,status
                                                                   1,Chanoch,junior,on
                                                                   2,Or,manager,off
                                                                   3,Chen,developer,on'''}])
-    res = parse_list(parse_all, header, value, list_name)
+    res = parse_list(parse_all, header, value, list_name, list_separator)
     assert expected in res.readable_output
+
+
+@pytest.mark.parametrize(
+    "data, parse_all, header, value, list_name, list_separator, expected",
+    [
+        (DATA_WITH_CUSTOM_SEP, "True", "name", "id", "getListRow", ';',
+         [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}]),
+        (DATA_WITH_CUSTOM_SEP, "False", "name", "id", "getListRow", ';',
+         [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}])
+    ]
+)
+def test_custom_list_separator(mocker, data, parse_all, header, value, list_name, list_separator, expected):
+    from GetListRow import parse_list
+    mocker.patch.object(demisto, "executeCommand", return_value=data)
+    res = parse_list(parse_all, header, value, list_name, list_separator)
+    assert res.outputs.get('Results') == expected

--- a/Packs/CommonScripts/Scripts/GetlistRow/README.md
+++ b/Packs/CommonScripts/Scripts/GetlistRow/README.md
@@ -1,4 +1,5 @@
 Parses a list by header and value.
+
 ## Script Data
 ---
 
@@ -17,6 +18,7 @@ Parses a list by header and value.
 | header | Header to filter lines by. If you supply a header, you need to supply the "value" argument. |
 | list_name | The list name in which to search. |
 | parse_all | If "True", parses the entire list into the context. Can be "True" or "False". Default is "False". |
+| list_separator | Separator to split the list by. |
 
 ## Outputs
 ---

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.4.10",
+    "currentVersion": "1.4.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39652

## Description
Add a separator argument (the default is `,` )

## Screenshots
with default sep:
![image](https://user-images.githubusercontent.com/71635916/127479370-fd9ecf73-5117-4731-9be9-0321e572a007.png)
on the list:
![image](https://user-images.githubusercontent.com/71635916/127479411-dc4d7525-98c0-48f8-a70d-b4a8aa71b302.png)

with custom sep:
![image](https://user-images.githubusercontent.com/71635916/127479567-8a4dc9d4-d416-4204-8754-c087a94a7860.png)
on the list:
![image](https://user-images.githubusercontent.com/71635916/127479581-1347b601-08ab-45e7-bb07-77bc3f8eb2f4.png)

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
