### PR TITLE
Update tld docker

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_4_12.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_4_12.md
@@ -1,0 +1,7 @@
+#### Scripts
+##### ExtractFQDNFromUrlAndEmail
+- Updated the Docker image to: *demisto/tld:1.0.0.23423*.
+##### ExtractDomainFromUrlAndEmail
+- Updated the Docker image to: *demisto/tld:1.0.0.23423*.
+##### ExtractDomainAndFQDNFromUrlAndEmail
+- Updated the Docker image to: *demisto/tld:1.0.0.23423*.

--- a/Packs/CommonScripts/Scripts/ExtractDomainAndFQDNFromUrlAndEmail/ExtractDomainAndFQDNFromUrlAndEmail.yml
+++ b/Packs/CommonScripts/Scripts/ExtractDomainAndFQDNFromUrlAndEmail/ExtractDomainAndFQDNFromUrlAndEmail.yml
@@ -18,7 +18,7 @@ tags:
 - indicator-format
 timeout: '0'
 type: python
-dockerimage: demisto/tld:1.0.0.12410
+dockerimage: demisto/tld:1.0.0.23423
 runas: DBotWeakRole
 runonce: false
 tests:

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
@@ -1,6 +1,6 @@
 import demistomock as demisto
 from CommonServerPython import *
-from tld import get_tld
+from tld import get_fld
 from validate_email import validate_email
 from urllib.parse import urlparse, parse_qs, unquote
 import re
@@ -71,14 +71,14 @@ def extract_domain(the_input):
         # Not ATP Link or Proofpoint URL so just unescape
         else:
             the_input = unescape_url(the_input)
-        is_url = domain = get_tld(the_input, fail_silently=True)
+        is_url = domain = get_fld(the_input, fail_silently=True)
 
     # Extract domain itself from a potential subdomain
     if domain_from_mail or not is_url:
         full_domain = 'https://'
         full_domain += domain_from_mail if domain_from_mail else the_input
         # get_tld fails to parse subdomain since it is not URL, over-ride error by injecting protocol.
-        domain = get_tld(full_domain, fail_silently=True)
+        domain = get_fld(full_domain, fail_silently=True)
 
     # convert None to empty string if needed
     domain = '' if not domain else domain

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
@@ -82,8 +82,6 @@ def extract_domain(the_input):
 
     # convert None to empty string if needed
     domain = '' if not domain else domain
-    if type(domain) == unicode:
-        domain = domain.encode('utf-8', errors='ignore')
     return domain
 
 

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.py
@@ -2,8 +2,7 @@ import demistomock as demisto
 from CommonServerPython import *
 from tld import get_tld
 from validate_email import validate_email
-from urlparse import urlparse, parse_qs
-from urllib import unquote
+from urllib.parse import urlparse, parse_qs, unquote
 import re
 
 # ============================================================================================================== #

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.yml
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.yml
@@ -14,7 +14,7 @@ args:
   isArray: true
 scripttarget: 0
 runonce: false
-dockerimage: demisto/tld
+dockerimage: demisto/tld:1.0.0.23423
 runas: DBotWeakRole
 subtype: python3
 tests:

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat_test.py
@@ -9,8 +9,7 @@ import pytest
     ('http:example.com', 'example.com'),
     ('http:\\\\example.com', 'example.com'),
     ('https://caseapi.phishlabs.com', 'phishlabs.com'),
-    # output needs to be bytes string utf-8 encoded (otherwise python loop demisto.results fails)
-    (u'www.bücher.de', u'bücher.de'.encode('utf-8')),
+    (u'www.bücher.de', u'bücher.de'),
     ('https://urldefense.proofpoint.com/v2/url?u=http-3A__go.getpostman.com_y4wULsdG0h0DDMY0Dv00100&d=DwMFaQ&c=ywDJJevdGcjv4rm9P3FcNg&r=s5kA2oIAQRXsacJiBKmTORIWyRN39ZKhobje2GyRgNs&m=vN1dVSiZvEoM9oExtQqEptm9Dbvq9tnjACDZzrBLaWI&s=zroN7KQdBCPBOfhOmv5SP1DDzZKZ1y9I3x4STS5PbHA&e=', 'getpostman.com'),  # noqa: E501
     ('hxxps://www[.]demisto[.]com', 'demisto.com'),
     ('https://emea01.safelinks.protection.outlook.com/?url=https%3A%2F%2Ftwitter.com%2FPhilipsBeLux&data=02|01||cb2462dc8640484baf7608d638d2a698|1a407a2d76754d178692b3ac285306e4|0|0|636758874714819880&sdata=dnJiphWFhnAKsk5Ps0bj0p%2FvXVo8TpidtGZcW6t8lDQ%3D&reserved=0%3E%5bcid:image003.gif@01CF4D7F.1DF62650%5d%3C', 'twitter.com'),  # noqa: E501 disable-secrets-detection

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
@@ -96,8 +96,6 @@ def extract_fqdn(the_input):
 
     # convert None to empty string if needed
     fqdn = '' if not fqdn else fqdn
-    if type(fqdn) == unicode:
-        fqdn = fqdn.encode('utf-8', errors='ignore')
     return fqdn
 
 

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
@@ -2,8 +2,7 @@ import demistomock as demisto
 from CommonServerPython import *
 from tld import get_tld
 from validate_email import validate_email
-from urlparse import urlparse, parse_qs
-from urllib import unquote
+from urllib.parse import urlparse, parse_qs, unquote
 import re
 
 # ============================================================================================================== #

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.py
@@ -61,7 +61,7 @@ def get_fqdn(the_input):
         # get the subdomain using tld.subdomain
         subdomain = domain.subdomain
         if (subdomain):
-            fqdn = "{}.{}".format(subdomain, str(domain))
+            fqdn = "{}.{}".format(subdomain, domain.fld)
 
     return fqdn
 

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.yml
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.yml
@@ -17,7 +17,7 @@ tags:
 - indicator-format
 timeout: '0'
 type: python
-dockerimage: demisto/tld
+dockerimage: demisto/tld:1.0.0.23423
 runas: DBotWeakRole
 runonce: false
 subtype: python3

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail_test.py
@@ -8,8 +8,7 @@ import pytest
     [  # noqa: E501 disable-secrets-detection
         ("http://this.is.test.com", "this.is.test.com"),
         ("https://caseapi.phishlabs.com", "caseapi.phishlabs.com"),
-        # output needs to be bytes string utf-8 encoded (otherwise python loop demisto.results fails)
-        (u"www.bücher.de", u"www.bücher.de".encode("utf-8")),
+        (u"www.bücher.de", u"www.bücher.de"),
         (
             "https://urldefense.proofpoint.com/v2/url?u=http-3A__go.getpostman.com_y4wULsdG0h0DDMY0Dv00100&d=DwMFaQ&c=yw"
             "DJJevdGcjv4rm9P3FcNg&r=s5kA2oIAQRXsacJiBKmTORIWyRN39ZKhobje2GyRgNs&m=vN1dVSiZvEoM9oExtQqEptm9Dbvq9tnjACDZzr"

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.4.11",
+    "currentVersion": "1.4.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39676

## Description
updating scripts to use the latest demisto/tld docker image
note that `ExtractFQDNFromUrlAndEmail` and `ExtractDomainFromUrlAndEmail` are upgraded in this PR from python2 to python3.
I found that they were marked falsely in the yml as python3 scripts, but the original docker image actually run python2.

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
