### PR TITLE
Fix GitLab Job Failures

### DIFF
--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -26,9 +26,9 @@ variables:
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
   FEATURE_BRANCH_NAME: "v4.5.0"
   IFRA_ENV_TYPE: "Content-Env"
-# Remove this when https://github.com/demisto/etc/issues/36775 is done.
+  SKIP_PRIVATE_BUILD: "true"  # Remove this when https://github.com/demisto/etc/issues/36775 is done.
   GIT_DEPTH: 1
-  SKIP_PRIVATE_BUILD: "true"
+  GET_SOURCES_ATTEMPTS: 3  # see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts
   ENV_RESULTS_PATH: "/builds/xsoar/content/artifacts/env_results.json"
   GCS_PRODUCTION_BUCKET: "marketplace-dist" # change to marketplace-dist this after testing period
   DEMISTO_CONNECTION_POOL_MAXSIZE: "180" # see this issue for more info https://github.com/demisto/etc/issues/36886

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -27,6 +27,7 @@ variables:
   FEATURE_BRANCH_NAME: "v4.5.0"
   IFRA_ENV_TYPE: "Content-Env"
 # Remove this when https://github.com/demisto/etc/issues/36775 is done.
+  GIT_DEPTH: 10
   SKIP_PRIVATE_BUILD: "true"
   ENV_RESULTS_PATH: "/builds/xsoar/content/artifacts/env_results.json"
   GCS_PRODUCTION_BUCKET: "marketplace-dist" # change to marketplace-dist this after testing period

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -28,7 +28,6 @@ variables:
 # Gitlab CI/CD uses shallow fetch with default depth of 50, these arguments are used to override it
 # See here for more about that https://docs.gitlab.com/ee/ci/pipelines/settings.html#git-shallow-clone  # disable-secrets-detection
   GIT_STRATEGY: clone
-  GIT_DEPTH: 0
   IFRA_ENV_TYPE: "Content-Env"
 # Remove this when https://github.com/demisto/etc/issues/36775 is done.
   SKIP_PRIVATE_BUILD: "true"

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -25,9 +25,6 @@ variables:
   PYTHONPATH: "/builds/xsoar/content"
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
   FEATURE_BRANCH_NAME: "v4.5.0"
-# Gitlab CI/CD uses shallow fetch with default depth of 50, these arguments are used to override it
-# See here for more about that https://docs.gitlab.com/ee/ci/pipelines/settings.html#git-shallow-clone  # disable-secrets-detection
-  GIT_STRATEGY: clone
   IFRA_ENV_TYPE: "Content-Env"
 # Remove this when https://github.com/demisto/etc/issues/36775 is done.
   SKIP_PRIVATE_BUILD: "true"

--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -27,7 +27,7 @@ variables:
   FEATURE_BRANCH_NAME: "v4.5.0"
   IFRA_ENV_TYPE: "Content-Env"
 # Remove this when https://github.com/demisto/etc/issues/36775 is done.
-  GIT_DEPTH: 10
+  GIT_DEPTH: 1
   SKIP_PRIVATE_BUILD: "true"
   ENV_RESULTS_PATH: "/builds/xsoar/content/artifacts/env_results.json"
   GCS_PRODUCTION_BUCKET: "marketplace-dist" # change to marketplace-dist this after testing period

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -36,6 +36,7 @@
 
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
+  - git fetch --all
   - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - mkdir -p -m 777 $ARTIFACTS_FOLDER/

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -657,6 +657,7 @@
     ],
     "_comment": "ENTER URLS WITHOUT http/s, www and path",
     "urls": [
+      "https://docs.gitlab.com",
       "https://my.eula.com",
       "https://open.vscode.dev",
       "https://forms.gle",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/EP-1336

## Description
Changes the git strategy to the default method of `fetch` instead of `clone`. Also changes the depth to 1 so that the git request made by GitLab will be as minimal as possible. Moves full "fetching" from the remote to the `before_script` wherein the git fetch request seems to complete without any problems.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
