### PR TITLE
Fix a git diff cmd

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -36,9 +36,11 @@
 
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
+  - section_start "Git - Job Start Actions" --collapsed
   - git fetch --unshallow origin
   - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
+  - section_end "Git - Job Start Actions"
   - mkdir -p -m 777 $ARTIFACTS_FOLDER/
   - |
     if [[ -f "$BASH_ENV" ]]; then

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -37,7 +37,7 @@
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
   - section_start "Git - Job Start Actions" --collapsed
-  - git fetch --unshallow origin
+  - git fetch origin
   - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - section_end "Git - Job Start Actions"

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -36,7 +36,7 @@
 
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
-  - git fetch --all
+  - git fetch --unshallow origin
   - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - mkdir -p -m 777 $ARTIFACTS_FOLDER/

--- a/Tests/scripts/collect_tests_and_content_packs.py
+++ b/Tests/scripts/collect_tests_and_content_packs.py
@@ -1389,10 +1389,7 @@ def create_test_file(is_nightly, skip_save=False, path_to_pack=''):
                 packs_diff = tools.run_command("git diff --name-status HEAD -- Packs")
                 files_string += f"\n{packs_diff}"
         else:
-            commit_string = tools.run_command("git log -n 2 --pretty='%H'")
-            commit_string = commit_string.replace("'", "")
-            last_commit, second_last_commit = commit_string.split()
-            files_string = tools.run_command("git diff --name-status {}...{}".format(second_last_commit, last_commit))
+            files_string = tools.run_command("git diff --name-status HEAD~...HEAD")
         logging.debug(f'Files string: {files_string}')
 #         files_string = """M	Tests/Marketplace/Tests/marketplace_services_test.py
 # M	Tests/Marketplace/Tests/test_data/user_pack_metadata.json


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/jobs/6865777 (hopefully)

## Description
Implements a couple of modifications.
- Simplifies the `git` commands run in `collect_tests_and_content_packs.py` to retrieve the `git diff` between the previous and current commits.
- Improves the GitLab nightly trigger script's usability.
- Set the `fetch` command to explicitly fetch from the `origin` remote.

Linked [here](https://code.pan.run/xsoar/content/-/pipelines/1468557) is the bucket upload flow triggered against this branch.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
