### PR TITLE
Fix NTLM hash parse and TGT expired issue

### DIFF
--- a/Packs/Pcysys/Integrations/Pcysys/Pcysys.py
+++ b/Packs/Pcysys/Integrations/Pcysys/Pcysys.py
@@ -2,28 +2,30 @@ import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
 
-''' IMPORTS '''
 import jwt
-from enum import Enum
 import requests
 import csv
 import io
 import json
-from typing import List
 
+from typing import List
+from enum import Enum
+
+# Increase csv field size limit
+csv.field_size_limit(sys.maxsize)
 # Disable insecure warnings
 requests.packages.urllib3.disable_warnings()
 
-''' CONSTANTS '''
 HEADERS = {'Accept': 'application/json'}
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
+HEALTH_URL_SUFFIX = '/health/dbChecks'
 AUTH_URL_SUFFIX = '/auth/token'
 LIST_TEMPLATES_URL_SUFFIX = '/api/v1/templates'
 CANCEL_TASK_URL_SUFFIX = '/api/v1/taskRun/{taskRunId}/cancel'
-GET_TASK_STATS_URL_SUFFIX = '/api/v1/taskRun/{taskRunId}'
+GET_TASK_RUN_STATUS_URL_SUFFIX = '/api/v1/taskRun/{taskRunId}'
 RUN_BULK_URL_SUFFIX = '/api/v1/template/runBulk'
 EXPORT_CSV_URL_SUFFIX = '/api/v1/taskRun/{taskRunId}/fullActionReportCSV'
-RAW_NTLM_HASH_LENGTH = 32
 
 
 class Request(Enum):
@@ -36,15 +38,25 @@ class AuthorizationError(Exception):
 
 
 class Client(BaseClient):
-    def __init__(self, base_url: str, client_id: str, verify: bool, proxy: bool, headers):
+    def __init__(self, base_url: str, tgt: str, client_id: str, verify: bool, proxy: bool, headers):
         super().__init__(base_url=f'{base_url}', headers=headers, verify=verify, proxy=proxy)
-        self.client_id = client_id
         self.session = requests.Session()
         self.session.headers = headers
+        self.client_id = client_id
+        self.tgt = tgt
+        self.access_token = str()
+        self.expiry = 0
+        self.load_session_parameters()
+
+    def load_session_parameters(self):
+        context: dict = get_integration_context()
+        if context:
+            self.tgt = context['tgt']
+            self.access_token = context['accessToken']
+            self.expiry = context['expiry']
 
     def generic_request(self, method: str, url_suffix: str = None, full_url: str = None, headers: dict = None,
                         params: dict = None, data: dict = None, response_type: str = 'json'):
-
         full_url = full_url if full_url else f'{self._base_url}{url_suffix}'
         headers = headers if headers else self._headers
         try:
@@ -89,38 +101,55 @@ class Client(BaseClient):
             raise DemistoException(err_msg, exception)
 
         except requests.exceptions.ConnectionError as exception:
-            # Get originating Exception in Exception chain
-            error_class = str(exception.__class__)
-            err_type = '<' + error_class[error_class.find('\'') + 1: error_class.rfind('\'')] + '>'
-            err_msg = f'\nError Type: {err_type}\nError Number: [{exception.errno}]\nMessage: {exception.strerror}\n ' \
-                      f'Verify that the server URL parameter ' \
-                      f'is correct and that you have access to the server from your host.'
+            err_msg = getattr(exception, 'message', str(exception))
             raise DemistoException(err_msg, exception)
 
-        except Exception as exception:
-            raise Exception(str(exception))
+        except Exception as request_error:
+            message = getattr(request_error, 'message', str(request_error))
+            raise DemistoException(
+                f"Could not send request to Pentera, reason: {message}",
+                exception=request_error
+            )
 
-    def authenticate(self, client_id, tgt):
+    def authenticate(self):
         data = {
-            'client_id': client_id,
-            'tgt': tgt
+            'client_id': self.client_id,
+            'tgt': self.tgt
         }
         res = self.generic_request(method=Request.POST.value, url_suffix=AUTH_URL_SUFFIX, data=data)
-        tgt = res.get('tgt')
-        access_token = res.get('token')
-        return tgt, access_token
+        self.tgt = res.get('tgt')
+        self.access_token = res.get('token')
+        jwt_decode_dict = jwt.get_unverified_header(self.access_token)
+        self.expiry = jwt_decode_dict.get('exp', 0) if jwt_decode_dict else 0
+        self.save_session_parameters()
 
-    @staticmethod
-    def create_basic_authentication_header(token: str):
+    def save_session_parameters(self):
+        context = {
+            'tgt': self.tgt,
+            'accessToken': self.access_token,
+            'expiry': self.expiry
+        }
+        set_integration_context(context)
+
+    def is_access_token_valid(self):
+        if not self.access_token or not self.expiry or self.expiry < int(datetime.utcnow().timestamp()):
+            return False
+        return True
+
+    def create_basic_authentication_header(self):
         authentication_headers = HEADERS.copy()
-        token = token + ':'
+        token = self.access_token + ':'
         encoded_bytes = base64.b64encode(token.encode("utf-8"))
         encoded_str = str(encoded_bytes, "utf-8")
         authentication_headers['Authorization'] = 'Basic ' + encoded_str
         return authentication_headers
 
-    def run_template_by_name(self, template_name, access_token):
-        headers = self.create_basic_authentication_header(access_token)
+    def run_db_health_checks(self):
+        res = self.generic_request(method=Request.GET.value, url_suffix=HEALTH_URL_SUFFIX)
+        return res
+
+    def run_template_by_name(self, template_name):
+        headers = self.create_basic_authentication_header()
         data = {
             'templateNames': [template_name]
         }
@@ -128,73 +157,77 @@ class Client(BaseClient):
                                    data=data)
         return res
 
-    def get_task_stats_by_task_run_id(self, task_run_id: str, access_token: str):
-        headers = self.create_basic_authentication_header(access_token)
-        url_suffix = GET_TASK_STATS_URL_SUFFIX.format(taskRunId=task_run_id)
+    def get_task_run_status_by_task_run_id(self, task_run_id: str):
+        headers = self.create_basic_authentication_header()
+        url_suffix = GET_TASK_RUN_STATUS_URL_SUFFIX.format(taskRunId=task_run_id)
         res = self.generic_request(method=Request.GET.value, url_suffix=url_suffix, headers=headers, data={})
-        task_stats = res['taskRuns'][0]
-        return task_stats
+        task_status = res.get('taskRuns')[0]
+        return task_status
 
-    def get_task_run_full_action_report_by_task_run_id(self, task_run_id: str, access_token: str):
-        headers = self.create_basic_authentication_header(access_token)
+    def get_task_run_full_action_report_by_task_run_id(self, task_run_id: str):
+        headers = self.create_basic_authentication_header()
         url_suffix = EXPORT_CSV_URL_SUFFIX.format(taskRunId=task_run_id)
         res = self.generic_request(method=Request.GET.value, url_suffix=url_suffix, headers=headers,
                                    response_type='csv')
         return res
 
-    @staticmethod
-    def is_access_token_valid(access_token: str, expiry: int):
-        if not access_token or not expiry or expiry < int(datetime.utcnow().timestamp()):
-            return False
-        return True
 
-
-def pentera_authentication(client: Client):
+def pentera_test_module_command(client: Client):
     try:
-        tgt = demisto.getIntegrationContext().get('tgt')
-        client_id = demisto.params().get('clientId')
-        new_tgt, access_token = client.authenticate(client_id, tgt)
-        jwt_decode_dict = jwt.get_unverified_header(access_token)
-        expiry = jwt_decode_dict.get('exp', 0) if jwt_decode_dict else 0
-        demisto.setIntegrationContext({
-            'accessToken': access_token,
-            'tgt': new_tgt,
-            'expiry': expiry
-        })
-        return 'ok'
-
-    except Exception as e:
-        demisto.error(f'An error occurred during the authentication: {str(e)}')
-        raise e
+        response = client.run_db_health_checks()
+    except Exception as test_error:
+        message = getattr(test_error, 'message', str(test_error))
+        raise DemistoException(message)
+    exceptions: list = response.get('exceptions')
+    if exceptions:
+        raise DemistoException(", ".join(exceptions))
+    return 'ok'
 
 
-def pentera_get_task_run_full_action_report_command(client: Client, args, access_token: str):
+def pentera_run_template_command(client: Client, args):
+    template_name = args.get('template_name')
+    try:
+        response = client.run_template_by_name(template_name)
+        task_run_json = response.get('taskRuns')[0]
+        parsed_response = parse_task_run_status(task_run_json)
+        readable_output = tableToMarkdown(template_name, parse_task_run_status(task_run_json),
+                                          removeNull=True)
+        return (
+            readable_output,
+            {'Pentera.TaskRun(val.ID == obj.ID)': parsed_response},
+            response  # raw response - the original response
+        )
+
+    except Exception as run_template_error:
+        message = getattr(run_template_error, 'message', str(run_template_error))
+        raise DemistoException(
+            f"Could not run template with template_name: '{template_name}', reason: {message}",
+            exception=run_template_error
+        )
+
+
+def pentera_get_task_run_status_command(client: Client, args):
+    task_run_id = args.get('task_run_id')
+    try:
+        task_run_status = client.get_task_run_status_by_task_run_id(task_run_id)
+        parsed_response = parse_task_run_status(task_run_status)
+        title = parsed_response['TemplateName'] + ': ' + parsed_response['Status']
+        readable_output = tableToMarkdown(title, parsed_response, removeNull=True)
+        return (
+            readable_output,
+            {'Pentera.TaskRun(val.ID == obj.ID)': parsed_response},
+            task_run_status  # raw response - the original response
+        )
+    except Exception as status_error:
+        message = getattr(status_error, 'message', str(status_error))
+        raise DemistoException(
+            f"Could not get task run status for task_run_id: '{task_run_id}', reason: {message}",
+            exception=status_error
+        )
+
+
+def pentera_get_task_run_full_action_report_command(client: Client, args):
     def _convert_csv_file_to_dict(csv_file):
-        def _handle_hash_parameter(hash_param: str):
-            def _is_raw_ntlm_hash(hash_str: str):
-                return len(hash_str) == RAW_NTLM_HASH_LENGTH
-
-            def _extract_user_name_and_host_name_from_ntlm_v1_2(hash_str: str):
-                try:
-                    hash_list_split_by_two_colons = hash_str.split('::')
-                    hash_list_split_by_one_colon = hash_list_split_by_two_colons[1].split(':')
-                    user_name = hash_list_split_by_two_colons[0]
-                    domain_or_host_name = hash_list_split_by_one_colon[0]
-                    return user_name, domain_or_host_name
-                except IndexError:
-                    return None
-
-            if not isinstance(hash_param, str):
-                return None
-
-            if _is_raw_ntlm_hash(hash_param):
-                return {'hash': f'Raw NTLM Hash: {hash_param[0]}{hash_param[1]}****'}
-
-            username, domain_or_hostname = _extract_user_name_and_host_name_from_ntlm_v1_2(hash_param)
-            return {'username': username,
-                    'domainOrHostname': domain_or_hostname,
-                    'hash': f'{hash_param[0]}{hash_param[1]}****'}
-
         def _map_parameters_string_to_object(str_parameters: str = None):
             if str_parameters:
                 return json.loads(str_parameters)
@@ -206,11 +239,6 @@ def pentera_get_task_run_full_action_report_command(client: Client, args, access
             row_copy = row.copy()
             converted_params = _map_parameters_string_to_object(row_copy.get('Parameters'))
             if converted_params:
-                if 'hash' in converted_params:
-                    hash_parameter = converted_params['hash']
-                    parsed_hash_parameters = _handle_hash_parameter(hash_parameter)
-                    if parsed_hash_parameters:
-                        converted_params = parsed_hash_parameters
                 row_copy['Parameters'] = converted_params
             data.append(row_copy)
         return data
@@ -240,7 +268,7 @@ def pentera_get_task_run_full_action_report_command(client: Client, args, access
     entries = []
     task_run_id = args.get('task_run_id')
     try:
-        response_csv = client.get_task_run_full_action_report_by_task_run_id(task_run_id, access_token)
+        response_csv = client.get_task_run_full_action_report_by_task_run_id(task_run_id)
         readable_output = f"# Pentera Report for TaskRun ID {task_run_id}"
         entry = fileResult(f'penterascan-{task_run_id}.csv', response_csv, entryTypes['entryInfoFile'])
         entry["HumanReadable"] = readable_output
@@ -263,29 +291,15 @@ def pentera_get_task_run_full_action_report_command(client: Client, args, access
             "HumanReadable": human_readable
         })
         return entries
-    except Exception as e:
-        demisto.error(f'An error occurred when tried to get task run id: {task_run_id} full action report: {str(e)}')
-        raise e
-
-
-def pentera_get_task_run_stats_command(client: Client, args, access_token: str):
-    task_run_id = args.get('task_run_id')
-    try:
-        task_run_stats = client.get_task_stats_by_task_run_id(task_run_id, access_token)
-        parsed_response = parse_task_run_stats(task_run_stats)
-        title = parsed_response['TemplateName'] + ': ' + parsed_response['Status']
-        readable_output = tableToMarkdown(title, parsed_response, removeNull=True)
-        return (
-            readable_output,
-            {'Pentera.TaskRun(val.ID == obj.ID)': parsed_response},
-            task_run_stats  # raw response - the original response
+    except Exception as report_error:
+        message = getattr(report_error, 'message', str(report_error))
+        raise DemistoException(
+            f"Could not get full action report for task_run_id: '{task_run_id}', reason: {message}",
+            exception=report_error
         )
-    except Exception as e:
-        demisto.error(f'An error occurred when tried to get task run id: {task_run_id} stats: {str(e)}')
-        raise e
 
 
-def parse_task_run_stats(json_response):
+def parse_task_run_status(json_response):
     def _convert_time_in_millis_to_date_format(time_in_millis):
         time_in_date_format = None
         try:
@@ -307,74 +321,49 @@ def parse_task_run_stats(json_response):
         return parsed_json_response
 
 
-def pentera_run_template_command(client, args, access_token):
-    template_name = args.get('template_name')
-    try:
-        response = client.run_template_by_name(template_name, access_token)
-        task_run_json = response['taskRuns'][0]
-        parsed_response = parse_task_run_stats(task_run_json)
-        readable_output = tableToMarkdown(template_name, parse_task_run_stats(task_run_json),
-                                          removeNull=True)
-        return (
-            readable_output,
-            {'Pentera.TaskRun(val.ID == obj.ID)': parsed_response},
-            response  # raw response - the original response
-        )
-
-    except Exception as e:
-        demisto.error(f'An error occurred when tried to run a template by name. Template name: {template_name}. '
-                      f'Error message: {str(e)}')
-        raise e
+def pentera_authentication(client: Client):
+    if not client.is_access_token_valid():
+        try:
+            client.authenticate()
+        except Exception as auth_error:
+            message = getattr(auth_error, 'message', str(auth_error))
+            raise DemistoException(
+                f"Could not authenticate to Pentera, reason: {message}",
+                exception=auth_error
+            )
 
 
 def main():
-    client_id = demisto.params().get('clientId')
-    application_port = demisto.params().get('port')
-    base_url = demisto.params()['url'].rstrip('/') + ':' + application_port
-    verify_certificate = not demisto.params().get('insecure', False)
-    proxy = demisto.params().get('proxy', False)
-    tgt = demisto.getIntegrationContext().get('tgt', None)
-    if not tgt:
-        params_tgt = demisto.params()['tgt']
-        demisto.setIntegrationContext({
-            'tgt': params_tgt
-        })
-    access_token = demisto.getIntegrationContext().get('accessToken', None)
-    expiry = demisto.getIntegrationContext().get('expiry', 0)
-    demisto.debug(f'Got command: {demisto.command()}')
+    params: dict = demisto.params()
+    application_port = params['port']
+    base_url = params['url'].rstrip('/') + ':' + application_port
+    client_id = params['clientId']
+    tgt = params['tgt']
+    verify_certificate = not params.get('insecure', False)
+    proxy = params.get('proxy', False)
+    client = Client(
+        base_url=base_url,
+        tgt=tgt,
+        verify=verify_certificate,
+        client_id=client_id,
+        proxy=proxy,
+        headers=HEADERS
+    )
+    command = demisto.command()
+    demisto.debug(f'Got command: {command}')
     try:
-        client = Client(
-            base_url=base_url,
-            verify=verify_certificate,
-            client_id=client_id,
-            proxy=proxy,
-            headers=HEADERS
-        )
         if demisto.command() == 'test-module':
-            demisto.results('ok')
-
-        elif demisto.command() == 'pentera-run-template-by-name':
-            if not client.is_access_token_valid(access_token, expiry):
-                pentera_authentication(client)
-            return_outputs(*pentera_run_template_command(client, demisto.args(),
-                                                         demisto.getIntegrationContext().get('accessToken')))
-
-        elif demisto.command() == 'pentera-get-task-run-status':
-            if not client.is_access_token_valid(access_token, expiry):
-                pentera_authentication(client)
-            return_outputs(*pentera_get_task_run_stats_command(client, demisto.args(),
-                                                               demisto.getIntegrationContext()
-                                                               .get('accessToken')))
-
-        elif demisto.command() == 'pentera-get-task-run-full-action-report':
-            if not client.is_access_token_valid(access_token, expiry):
-                pentera_authentication(client)
-            demisto.results(pentera_get_task_run_full_action_report_command(client, demisto.args(),
-                                                                            demisto.getIntegrationContext().get(
-                                                                                'accessToken')))
-    # Log exceptions
+            demisto.results(pentera_test_module_command(client))
+        else:
+            pentera_authentication(client)
+            if demisto.command() == 'pentera-run-template-by-name':
+                return_outputs(*pentera_run_template_command(client, demisto.args()))
+            elif demisto.command() == 'pentera-get-task-run-status':
+                return_outputs(*pentera_get_task_run_status_command(client, demisto.args()))
+            elif demisto.command() == 'pentera-get-task-run-full-action-report':
+                demisto.results(pentera_get_task_run_full_action_report_command(client, demisto.args()))
     except Exception as e:
-        return_error(f'Failed to execute {demisto.command()} command. Error: {str(e)}')
+        return_error(f'Failed to execute command: {command}, {getattr(e, "message", str(e))}', error=e)
 
 
 if __name__ in ('__main__', '__builtin__', 'builtins'):

--- a/Packs/Pcysys/Integrations/Pcysys/Pcysys.yml
+++ b/Packs/Pcysys/Integrations/Pcysys/Pcysys.yml
@@ -138,7 +138,7 @@ script:
     - contextPath: Pentera.TaskRun.FullActionReport.Status
       description: 'The status of the action. Can be: success, failed, canceled, no_results'
       type: String
-  dockerimage: demisto/pyjwt3:1.0.0.19327
+  dockerimage: demisto/pyjwt3:1.0.0.23674
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/Pcysys/Integrations/Pcysys/Pcysys_test.py
+++ b/Packs/Pcysys/Integrations/Pcysys/Pcysys_test.py
@@ -42,6 +42,7 @@ def test_pentera_get_task_run_full_action_report(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'base_url': 'https://pentera.com',
         'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP
@@ -80,6 +81,7 @@ def test_pentera_get_task_run_stats(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'base_url': 'https://pentera.com',
         'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP
@@ -113,6 +115,7 @@ def test_pentera_run_template(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'base_url': 'https://pentera.com',
         'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP

--- a/Packs/Pcysys/Integrations/Pcysys/Pcysys_test.py
+++ b/Packs/Pcysys/Integrations/Pcysys/Pcysys_test.py
@@ -1,7 +1,9 @@
-from Pcysys import Client, pentera_authentication, pentera_run_template_command, pentera_get_task_run_stats_command, \
-    pentera_get_task_run_full_action_report_command
 import demistomock as demisto
 import jwt
+
+from Pcysys import Client, pentera_run_template_command, pentera_get_task_run_status_command, \
+    pentera_get_task_run_full_action_report_command, pentera_authentication
+
 
 MOCK_PENTERA_FULL_ACTION_REPORT = 'penterascan-5e4530961deb8eda82b08730.csv'
 MOCK_CSV = open('TestData/mock_csv_file', 'r').read()
@@ -40,6 +42,7 @@ def test_pentera_get_task_run_full_action_report(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP
     })
@@ -49,18 +52,19 @@ def test_pentera_get_task_run_full_action_report(mocker, requests_mock):
     requests_mock.get('https://pentera.com:8181/api/v1/taskRun/5e4530961deb8eda82b08730/fullActionReportCSV',
                       text=MOCK_CSV)
     client_id = demisto.params().get('clientId')
+    tgt = demisto.params().get('tgt')
     base_url = demisto.params()['url'].rstrip('/') + ':' + demisto.params()['port']
     verify_certificate = not demisto.params().get('insecure', False)
     proxy = demisto.params().get('proxy', False)
     args = demisto.args()
-    access_token = demisto.getIntegrationContext().get('accessToken')
     client = Client(
         base_url=base_url,
+        tgt=tgt,
         verify=verify_certificate,
         client_id=client_id,
         proxy=proxy,
         headers={'Accept': 'application/json'})
-    entries = pentera_get_task_run_full_action_report_command(client, args, access_token)
+    entries = pentera_get_task_run_full_action_report_command(client, args)
     raw_csv_file_name = entries[0]['File']
     assert raw_csv_file_name == MOCK_PENTERA_FULL_ACTION_REPORT
     task_run_id = entries[1]['EntryContext']['Pentera.TaskRun(val.ID == obj.ID)']['ID']
@@ -76,6 +80,7 @@ def test_pentera_get_task_run_stats(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP
     })
@@ -85,18 +90,19 @@ def test_pentera_get_task_run_stats(mocker, requests_mock):
     requests_mock.get('https://pentera.com:8181/api/v1/taskRun/5e41923cf24e1f99979b1cb4',
                       json=MOCK_RUN_TEMPLATE)
     client_id = demisto.params().get('clientId')
+    tgt = demisto.params().get('tgt')
     base_url = demisto.params()['url'].rstrip('/') + ':' + demisto.params()['port']
     verify_certificate = not demisto.params().get('insecure', False)
     proxy = demisto.params().get('proxy', False)
     args = demisto.args()
-    access_token = demisto.getIntegrationContext().get('accessToken')
     client = Client(
         base_url=base_url,
+        tgt=tgt,
         verify=verify_certificate,
         client_id=client_id,
         proxy=proxy,
         headers={'Accept': 'application/json'})
-    readable, parsed, raw = pentera_get_task_run_stats_command(client, args, access_token)
+    readable, parsed, raw = pentera_get_task_run_status_command(client, args)
 
     assert parsed['Pentera.TaskRun(val.ID == obj.ID)']['ID'] == MOCK_TASK_RUN_STATS['taskRuns'][0]['taskRunId']
 
@@ -107,6 +113,7 @@ def test_pentera_run_template(mocker, requests_mock):
         'port': '8181'
     })
     mocker.patch.object(demisto, 'getIntegrationContext', return_value={
+        'tgt': 'omgNewTGT',
         'accessToken': 'omgNewSecret',
         'expiry': MOCK_AUTHENTICATION_EXP
     })
@@ -115,19 +122,19 @@ def test_pentera_run_template(mocker, requests_mock):
     })
     requests_mock.post('https://pentera.com:8181/api/v1/template/runBulk', json=MOCK_RUN_TEMPLATE)
     client_id = demisto.params().get('clientId')
+    tgt = demisto.params().get('tgt')
     base_url = demisto.params()['url'].rstrip('/') + ':' + demisto.params()['port']
     verify_certificate = not demisto.params().get('insecure', False)
     proxy = demisto.params().get('proxy', False)
     args = demisto.args()
-    access_token = demisto.getIntegrationContext().get('accessToken')
     client = Client(
         base_url=base_url,
+        tgt=tgt,
         verify=verify_certificate,
         client_id=client_id,
         proxy=proxy,
         headers={'Accept': 'application/json'})
-    readable, parsed, raw = pentera_run_template_command(client, args, access_token)
-
+    readable, parsed, raw = pentera_run_template_command(client, args)
     assert parsed['Pentera.TaskRun(val.ID == obj.ID)']['Status'] == MOCK_RUN_TEMPLATE['taskRuns'][0]['status']
 
 
@@ -138,9 +145,6 @@ def test_pentera_authentication(mocker, requests_mock):
         'url': 'https://pentera.com',
         'port': '8181'
     })
-    mocker.patch.object(demisto, 'getIntegrationContext', return_value={
-        'tgt': 'omgNewSecret'
-    })
     mocker.patch.object(jwt, 'get_unverified_header',
                         return_value={'alg': 'HS256', 'exp': 1579763364, 'iat': 1579762464})
 
@@ -149,20 +153,21 @@ def test_pentera_authentication(mocker, requests_mock):
     mocker.patch.object(demisto, 'setIntegrationContext')
 
     client_id = demisto.params().get('clientId')
+    tgt = demisto.params().get('tgt')
     base_url = demisto.params()['url'].rstrip('/') + ':' + demisto.params()['port']
     verify_certificate = not demisto.params().get('insecure', False)
     proxy = demisto.params().get('proxy', False)
     client = Client(
         base_url=base_url,
+        tgt=tgt,
         verify=verify_certificate,
         client_id=client_id,
         proxy=proxy,
         headers={'Accept': 'application/json'})
-    output = pentera_authentication(client)
-    assert output == 'ok'
+    pentera_authentication(client)
 
     assert demisto.setIntegrationContext.call_count == 1
-    integrationContext = demisto.setIntegrationContext.call_args[0][0]
-    assert isinstance(integrationContext, dict)
-    assert integrationContext['expiry'] == MOCK_AUTHENTICATION_EXP
-    assert integrationContext['accessToken'] == MOCK_AUTHENTICATION['token']
+    integration_context = demisto.setIntegrationContext.call_args[0][0]
+    assert isinstance(integration_context, dict)
+    assert integration_context['expiry'] == MOCK_AUTHENTICATION_EXP
+    assert integration_context['accessToken'] == MOCK_AUTHENTICATION['token']

--- a/Packs/Pcysys/ReleaseNotes/1_3_0.md
+++ b/Packs/Pcysys/ReleaseNotes/1_3_0.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+##### Pentera
+- Added pentera_test_module_command function for test-module command.
+- Fixed an issue where the user had to renew the TGT token every 15 minutes.
+- Fixed an issue where pentera-get-task-run-full-action-report command would fail on "field larger than field limit (131072)".
+- Fixed an issue where pentera-get-task-run-full-action-report command would fail on "cannot unpack non-iterable NoneType object".
+- Updated the Docker image to: *demisto/pyjwt3:1.0.0.19327*.

--- a/Packs/Pcysys/pack_metadata.json
+++ b/Packs/Pcysys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Pentera",
     "description": "Automate remediation actions based on Pentera, the Automated Security Validation Platform, proactively exposing high-risk vulnerabilities.",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.3.0",
     "author": "Pentera",
     "url": "https://pentera.io",
     "email": "support@pentera.io",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues


## Description
Added pentera_test_module_command function for test-module command.
Fixed an issue where the user had to renew the TGT token every 15 minutes.
Fixed an issue where pentera-get-task-run-full-action-report command would fail on "field larger than field limit (131072)".
Fixed an issue where pentera-get-task-run-full-action-report command would fail on "cannot unpack non-iterable NoneType object".

## Screenshots

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
