### PR TITLE
Add Default Value for IndicatorsSearcher iocs

### DIFF
--- a/Packs/Base/ReleaseNotes/1_13_11.md
+++ b/Packs/Base/ReleaseNotes/1_13_11.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Maintenance and stability enhancements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -7858,7 +7858,7 @@ class IndicatorsSearcher:
                                                 size=size,
                                                 to_date=self._to_date,
                                                 value=self._value)
-        fetched_len = len(res.get('iocs', []) or [])
+        fetched_len = len(res.get('iocs') or [])
         if fetched_len == 0:
             raise StopIteration
         if self.limit:
@@ -7940,7 +7940,7 @@ class IndicatorsSearcher:
             page=self.page if use_paging else None
         )
         res = demisto.searchIndicators(**search_iocs_params)
-        if len(res.get('iocs', [])) > 0:
+        if len(res.get('iocs') or []) > 0:
             self._page += 1  # advance pages for search_after, as fallback
         else:
             self._search_is_done = True

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.13.10",
+    "currentVersion": "1.13.11",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/39311

## Description
Add default value for the `iocs` value when using `IndicatorsSearcher`.