### PR TITLE
Increase fetch depth

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -37,7 +37,7 @@
 .clone_and_export_variables: &clone_and_export_variables
   - source .gitlab/helper_functions.sh
   - section_start "Git - Job Start Actions" --collapsed
-  - git fetch origin
+  - git fetch origin --depth=100 -t
   - git checkout -B $CI_COMMIT_BRANCH $CI_COMMIT_SHA
   - git config diff.renameLimit 6000
   - section_end "Git - Job Start Actions"


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://code.pan.run/xsoar/content/-/jobs/6887465 (hopefully)
fixes: https://code.pan.run/xsoar/content/-/jobs/6890070 (hopefully)

## Description
Set the `git fetch` depth argument to a large number (arbitrarily chose 100). Also fetches tags.

The bucket upload flow [pipeline](https://code.pan.run/xsoar/content/-/pipelines/1474192) from triggering the flow against this branch.
The nightly flow [pipeline](https://code.pan.run/xsoar/content/-/pipelines/1474409) from triggering the flow against my branch.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
