### PR TITLE
Update Slack App Manifest to add new scopes

### DIFF
--- a/Packs/Slack/doc_files/SlackV3_app_manifest.yml
+++ b/Packs/Slack/doc_files/SlackV3_app_manifest.yml
@@ -23,15 +23,20 @@ oauth_config:
     bot:
       - channels:history
       - channels:read
+      - channels:write
       - chat:write
       - files:write
       - groups:history
       - groups:read
+      - groups:write
       - im:history
       - im:read
+      - im:write
       - mpim:history
       - mpim:read
+      - mpim:write
       - users:read
+      - users:read.email
       - commands
 settings:
   event_subscriptions:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39925

## Description
In the SlackV3 manifest, we are missing the following scopes:

- channels:write
- groups:write
- mpim:write
- im:write
- users:read.email