### PR TITLE
panorama - increase timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -940,14 +940,14 @@
             "instance_names": "palo_alto_panorama",
             "playbookID": "palo_alto_panorama_test_pb",
             "fromversion": "6.1.0",
-            "timeout": 2000
+            "timeout": 3600
         },
         {
             "integrations": "Panorama",
             "instance_names": "palo_alto_panorama_9.0",
             "playbookID": "palo_alto_panorama_test_pb",
             "fromversion": "6.1.0",
-            "timeout": 2000
+            "timeout": 3600
         },
         {
             "integrations": "Panorama",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/34371

https://code.pan.run/xsoar/content/-/jobs/6956374
```
[2021-08-09 03:18:21] - [Thread-5] - [ERROR] - "palo_alto_panorama_test_pb" failed on timeout
[2021-08-09 03:18:22] - [Thread-5] - [ERROR] - Test failed: playbook: "palo_alto_panorama_test_pb" with integration(s): ["Panorama"]
[2021-08-09 03:18:22] - [Thread-5] - [INFO] - ------ Test playbook: "palo_alto_panorama_test_pb" with integration(s): ["Panorama"] end ------
```
