### PR TITLE
Splunk - handle commas in raw event values

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1406,7 +1406,7 @@ def rawToDict(raw):
             # search for the pattern: `key="value", `
             # (the double quotes are optional)
             # we append `, ` to the end of the string to catch the last value
-            raw_response = re.findall(r'(\S+=("?)[\S\s]+?\2), ', raw + ', ')  
+            raw_response = re.findall(r'(\S+=("?)[\S\s]+?\2), ', raw + ', ')
             for key_val, _ in raw_response:
                 key_value = key_val.replace('"', '').strip()
                 if '=' in key_value:

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1403,8 +1403,11 @@ def rawToDict(raw):
                         result[key] = val
 
         else:
-            raw_response = re.split('(?<=\S),', raw)  # split by any non-whitespace character
-            for key_val in raw_response:
+            # search for the pattern: `key="value", `
+            # (the double quotes are optional)
+            # we append `, ` to the end of the string to catch the last value
+            raw_response = re.findall(r'(\S+=("?)[\S\s]+?\2), ', raw + ', ')  
+            for key_val, _ in raw_response:
                 key_value = key_val.replace('"', '').strip()
                 if '=' in key_value:
                     key_and_val = key_value.split('=', 1)

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -184,6 +184,8 @@ def test_raw_to_dict():
     assert splunk.rawToDict(RAW_JSON) == RAW_JSON_AND_STANDARD_OUTPUT
     assert splunk.rawToDict(RAW_STANDARD) == RAW_JSON_AND_STANDARD_OUTPUT
 
+    assert splunk.rawToDict('drilldown_search="key IN ("test1","test2")') == {'drilldown_search': 'key IN (test1,test2)'}
+
 
 data_test_replace_keys = [
     ({}, {}),

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -629,7 +629,7 @@ def test_get_drilldown_timeframe(notable_data, raw, status, earliest, latest, mo
 @pytest.mark.parametrize('raw_field, notable_data, expected_field, expected_value', [
     ('field|s', {'field': '1'}, 'field', '1'),
     ('field', {'field': '1'}, 'field', '1'),
-    ('field|s', {'_raw': 'field=1,value=2'}, 'field', '1'),
+    ('field|s', {'_raw': 'field=1, value=2'},'field', '1'),
     ('x', {'y': '2'}, '', '')
 ])
 def test_get_notable_field_and_value(raw_field, notable_data, expected_field, expected_value, mocker):
@@ -683,8 +683,8 @@ def test_build_drilldown_search(notable_data, search, raw, expected_search, mock
 
 @pytest.mark.parametrize('notable_data, prefix, fields, query_part', [
     ({'user': ['u1', 'u2']}, 'identity', ['user'], '(identity="u1" OR identity="u2")'),
-    ({'_raw': '1233,user=u1'}, 'user', ['user'], 'user="u1"'),
-    ({'user': ['u1', 'u2'], '_raw': '1321,src_user=u3'}, 'user', ['user', 'src_user'],
+    ({'_raw': '1233, user=u1'}, 'user', ['user'], 'user="u1"'),
+    ({'user': ['u1', 'u2'], '_raw': '1321, src_user=u3'}, 'user', ['user', 'src_user'],
      '(user="u1" OR user="u2" OR user="u3")'),
     ({}, 'prefix', ['field'], '')
 ])

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -629,7 +629,7 @@ def test_get_drilldown_timeframe(notable_data, raw, status, earliest, latest, mo
 @pytest.mark.parametrize('raw_field, notable_data, expected_field, expected_value', [
     ('field|s', {'field': '1'}, 'field', '1'),
     ('field', {'field': '1'}, 'field', '1'),
-    ('field|s', {'_raw': 'field=1, value=2'},'field', '1'),
+    ('field|s', {'_raw': 'field=1, value=2'}, 'field', '1'),
     ('x', {'y': '2'}, '', '')
 ])
 def test_get_notable_field_and_value(raw_field, notable_data, expected_field, expected_value, mocker):

--- a/Packs/SplunkPy/ReleaseNotes/2_1_9.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where the ***splunk-parse-raw*** command failed to parse field with commas in its value.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.1.8",
+    "currentVersion": "2.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/40268

## Description
improved regex to catch the proper pattern of the `raw` event to handle possible comma chars in the values


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
