### PR TITLE
removed the gke tag from run-validations job

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -179,8 +179,6 @@
     - section_end "Run Unit Testing and Lint"
 
 .run-validations:
-  tags:
-    - gke
   stage: unittests-and-validations
   extends:
     - .default-job-settings


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
reverts part of: https://github.com/demisto/content/pull/14075

## Description
Removed the tag gke from the run-validations job, looks like it is related to the `upload packs to market place` build failures, such as https://code.pan.run/xsoar/content/-/jobs/7012694.

@avidan-H FYI