### PR TITLE
GitLab Job to Delete Branches Already Deleted from Github

### DIFF
--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -41,3 +41,4 @@ include:
   - local: .gitlab/ci/bucket-upload.yml
   - local: .gitlab/ci/instance-test.yml
   - local: .gitlab/ci/sdk-nightly.yml
+  - local: .gitlab/ci/miscellaneous.yml

--- a/.gitlab/ci/miscellaneous.yml
+++ b/.gitlab/ci/miscellaneous.yml
@@ -1,0 +1,11 @@
+delete-mismatched-branches:
+  tags:
+    - gke
+  stage: .pre
+  extends: .default-job-settings
+  rules:
+    - if: '$DELETE_MISMATCHED_BRANCHES'
+  script:
+    - python3 ./Utils/delete_mismatched_branches.py
+  retry:
+    max: 2

--- a/Utils/delete_mismatched_branches.py
+++ b/Utils/delete_mismatched_branches.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import gitlab
+from github import Github
+from .github_workflow_scripts.utils import timestamped_print, get_env_var
+
+
+GITLAB_PROJECT_ID = get_env_var('CI_PROJECT_ID', '2596')  # the default is the id of the content project in code.pan.run
+GITLAB_SERVER_URL = get_env_var('CI_SERVER_URL', 'https://code.pan.run')  # disable-secrets-detection
+GITLAB_WRITE_TOKEN = get_env_var('GITLAB_WRITE_TOKEN')
+
+print = timestamped_print
+
+
+def main():
+    """
+    Remove branches from GitLab content repository that do not exist in the Github repository it is mirrored from
+
+    Head branches in Github that are deleted upon a PR merge event, persist in GitLab despite having been deleted
+    from the Github repository from which we mirror from. This script deletes from GitLab the branches which no
+    longer exist in Github.
+    """
+    # get github content repo's branches
+    github = Github(get_env_var('CONTENT_GITHUB_TOKEN'), verify=False)
+    organization = 'demisto'
+    repo = 'content'
+    content_repo = github.get_repo(f'{organization}/{repo}')
+
+    github_branches = content_repo.get_branches()
+    print(f'{github_branches.totalCount=}')
+    github_branch_names = set()
+    for github_branch in github_branches:
+        github_branch_names.add(github_branch.name)
+
+    # get gitlab content repo's branches
+    gitlab_client = gitlab.Gitlab(GITLAB_SERVER_URL, private_token=GITLAB_WRITE_TOKEN, ssl_verify=False)
+    gl_project = gitlab_client.projects.get(int(GITLAB_PROJECT_ID))
+    gitlab_branches = gl_project.branches.list(as_list=False)
+    print(f'{gitlab_branches.total=}')
+
+    diff_count = gitlab_branches.total - github_branches.totalCount
+    print(f'{diff_count} branches require deletion')
+
+    # delete gitlab branches
+    for gitlab_branch in gitlab_branches:
+        if gitlab_branch_name := gitlab_branch.name not in github_branch_names:
+            gitlab_branch.delete()
+            print(f'deleted "{gitlab_branch_name}"')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Our GitLab `content` repository doesn't reflect when branches are deleted in the Github `content` repository from which it is mirrored. This leads to the branches in the GitLab repo ever-increasing and eventually in turn, causing repo cloning failures at the start of GitLab jobs because the repo's size is so great and the request takes so much time that almost always results in connectivity interruptions and failures. Adds a GitLab job that executes a script to delete "excess" branches in GitLab - AKA branches that have already been deleted from the Github `content` repo but still exist in GitLab. I will add a scheduled pipeline that will run once a day to trigger this job once this is merged.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
