### PR TITLE
MS Teams Video - replace blob with raw in video link

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -85,9 +85,9 @@ All HTTPS traffic that will hit the selected messaging endpoint will be directed
 
 ## Setup Video
 <video controls>
-    <source src="https://github.com/demisto/content-assets/blob/845c0d790ceb4fbac08c5c7852b2a3bed0829778/Assets/MicrosoftTeams/config.mp4"
+    <source src="https://github.com/demisto/content-assets/raw/845c0d790ceb4fbac08c5c7852b2a3bed0829778/Assets/MicrosoftTeams/config.mp4"
             type="video/mp4"/>
-    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/blob/845c0d790ceb4fbac08c5c7852b2a3bed0829778/Assets/MicrosoftTeams/config.mp4
+    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/raw/845c0d790ceb4fbac08c5c7852b2a3bed0829778/Assets/MicrosoftTeams/config.mp4
 </video>
 
 ## Prerequisites


### PR DESCRIPTION
## Status
- [x] Ready

## Description
need to use the `raw` ref instead of `blob`