### PR TITLE
Splunk - remove earliest and latest fetch params

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -33,8 +33,6 @@ This integration was integrated and tested with Splunk v7.2.
 | extractFields | The CSV fields that will be parsed out of _raw notable events. | False |
 | useSplunkTime | Uses the Splunk clock time for the fetch. | False |
 | unsecure | When selected, certificates are not checked (not secure). | False |
-| earliest_fetch_time_fieldname | The earliest time to fetch (the name of the Splunk field whose value defines the query's earliest time to fetch). | False |
-| latest_fetch_time_fieldname | The latest time to fetch (the name of the Splunk field whose value defines the query's latest time to fetch). | False |
 | app | The context of the application's namespace. | False |
 | hec_token | The HEC token (HTTP Event Collector). | False |
 | hec_url | The HEC URL. For example, https://localhost:8088. | False |

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1151,8 +1151,8 @@ def get_mapping_fields_command(service):
 
     kwargs_oneshot = {
         'earliest_time': last_run,
-        'latest_time': now, 
-        'count': FETCH_LIMIT, 
+        'latest_time': now,
+        'count': FETCH_LIMIT,
         'offset': search_offset,
     }
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -114,8 +114,8 @@ def fetch_notables(service, cache_object=None, enrich_notables=False):
 
     kwargs_oneshot = {
         'earliest_time': last_run,
-        'latest_time': now, 
-        'count': FETCH_LIMIT, 
+        'latest_time': now,
+        'count': FETCH_LIMIT,
         'offset': search_offset,
     }
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1149,11 +1149,12 @@ def get_mapping_fields_command(service):
     start_time_for_fetch = current_time_for_fetch - timedelta(minutes=fetch_time_in_minutes)
     last_run = start_time_for_fetch.strftime(SPLUNK_TIME_FORMAT)
 
-    earliest_fetch_time_fieldname = dem_params.get("earliest_fetch_time_fieldname", "earliest_time")
-    latest_fetch_time_fieldname = dem_params.get("latest_fetch_time_fieldname", "latest_time")
-
-    kwargs_oneshot = {earliest_fetch_time_fieldname: last_run,
-                      latest_fetch_time_fieldname: now, "count": FETCH_LIMIT, 'offset': search_offset}
+    kwargs_oneshot = {
+        'earliest_time': last_run,
+        'latest_time': now, 
+        'count': FETCH_LIMIT, 
+        'offset': search_offset,
+    }
 
     searchquery_oneshot = dem_params['fetchQuery']
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -112,11 +112,12 @@ def fetch_notables(service, cache_object=None, enrich_notables=False):
         start_time_for_fetch = current_time_for_fetch - timedelta(minutes=fetch_time_in_minutes)
         last_run = start_time_for_fetch.strftime(SPLUNK_TIME_FORMAT)
 
-    earliest_fetch_time_fieldname = dem_params.get("earliest_fetch_time_fieldname", "earliest_time")
-    latest_fetch_time_fieldname = dem_params.get("latest_fetch_time_fieldname", "latest_time")
-
-    kwargs_oneshot = {earliest_fetch_time_fieldname: last_run,
-                      latest_fetch_time_fieldname: now, "count": FETCH_LIMIT, 'offset': search_offset}
+    kwargs_oneshot = {
+        'earliest_time': last_run,
+        'latest_time': now, 
+        'count': FETCH_LIMIT, 
+        'offset': search_offset,
+    }
 
     searchquery_oneshot = dem_params['fetchQuery']
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -72,18 +72,6 @@ configuration:
   name: fetch_time
   required: false
   type: 0
-- defaultvalue: earliest_time
-  display: Earliest time to fetch (The name of the Splunk field whose value defines
-    the query's earliest time to fetch.)
-  name: earliest_fetch_time_fieldname
-  required: false
-  type: 0
-- defaultvalue: latest_time
-  display: Latest time to fetch (The name of the Splunk field whose value defines
-    the query's latest time to fetch.)
-  name: latest_fetch_time_fieldname
-  required: false
-  type: 0
 - display: Extract Fields - CSV fields that will be parsed out of _raw notable events
   name: extractFields
   required: false

--- a/Packs/SplunkPy/ReleaseNotes/2_1_10.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Removed the *Earliest time to fetch* and the *Latest time to fetch* integration parameters as they are redundant.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.1.9",
+    "currentVersion": "2.1.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/40473

## Description
see detailed description in the issue

## Does it break backward compatibility?
   - [x] No
