### PR TITLE
Crowdstrike datetime bug

### DIFF
--- a/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed.py
+++ b/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed.py
@@ -290,7 +290,8 @@ def main() -> None:
     credentials = params.get('credentials')
     proxy = params.get('proxy', False)
     insecure = params.get('insecure', False)
-    first_fetch_datetime = arg_to_datetime(params.get('first_fetch'))
+    first_fetch_param = params.get('first_fetch')
+    first_fetch_datetime = arg_to_datetime(first_fetch_param) if first_fetch_param else None
     first_fetch = first_fetch_datetime.timestamp() if first_fetch_datetime else None
 
     base_url = params.get('base_url')

--- a/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed_test.py
+++ b/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed_test.py
@@ -1,6 +1,6 @@
 import json
 import io
-
+import demistomock as demisto
 import pytest
 
 
@@ -81,3 +81,12 @@ def test_create_indicators_from_response():
     expected_result = util_load_json('test_data/create_indicators_from_response.json')
     res = Client.create_indicators_from_response(raw_response)
     assert res == expected_result
+
+
+def test_empty_first_fetch(mocker, requests_mock):
+    mocker.patch.object(demisto, 'params', return_value={'first_fetch': None})
+    mocker.patch.object(demisto, 'command', return_value='')
+    requests_mock.post('https://api.crowdstrike.com/oauth2/token', json={'access_token': '12345'})
+    from CrowdStrikeIndicatorFeed import main
+    main()
+    assert True

--- a/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed_test.py
+++ b/Packs/FeedCrowdstrikeFalconIntel/Integrations/CrowdStrikeIndicatorFeed/CrowdStrikeIndicatorFeed_test.py
@@ -84,7 +84,7 @@ def test_create_indicators_from_response():
 
 
 def test_empty_first_fetch(mocker, requests_mock):
-    mocker.patch.object(demisto, 'params', return_value={'first_fetch': None})
+    mocker.patch.object(demisto, 'params', return_value={'first_fetch': ''})
     mocker.patch.object(demisto, 'command', return_value='')
     requests_mock.post('https://api.crowdstrike.com/oauth2/token', json={'access_token': '12345'})
     from CrowdStrikeIndicatorFeed import main

--- a/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/2_0_4.md
+++ b/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/2_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike Indicator Feed
+- Fixed a bug in **fetch-indicators** when no first_fetch was entered.

--- a/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/2_0_4.md
+++ b/Packs/FeedCrowdstrikeFalconIntel/ReleaseNotes/2_0_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CrowdStrike Indicator Feed
-- Fixed a bug in **fetch-indicators** when no first_fetch was entered.
+- Fixed an issue where ***fetch-indicators*** failed when the *First fetch time* integration parameter was not entered.

--- a/Packs/FeedCrowdstrikeFalconIntel/pack_metadata.json
+++ b/Packs/FeedCrowdstrikeFalconIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Crowdstrike Falcon Intel Feed",
     "description": "Tracks the activities of threat actor groups and advanced persistent threats (APTs) to understand as much as possible about their known aliases, targets, methods, and more.",
     "support": "xsoar",
-    "currentVersion": "2.0.3",
+    "currentVersion": "2.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Test module and Fetch indicators fails with error when no first_fetch param entered: 
"Script failed to run: Error:[Traceback (most recent call last): File "<string>", line 473, in <module. File "<string>", line 414 in main File "<string>", line 5469, in arg_to_datetime ValueError: "" is not a valid date] (2604) (2603)

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
