### PR TITLE
Proofpoint Threat Response - handle expand_events arg in get-incident cmd

### DIFF
--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
@@ -321,6 +321,7 @@ def get_incident_command():
     """
     args = demisto.args()
     incident_id = args.pop('incident_id')
+    expand_events = args.get('expand_events')
     fullurl = BASE_URL + 'api/incidents/{}.json'.format(incident_id)
     incident_data = requests.get(
         fullurl,
@@ -328,7 +329,10 @@ def get_incident_command():
             'Content-Type': 'application/json',
             'Authorization': API_KEY
         },
-        verify=VERIFY_CERTIFICATE
+        params={
+            'expand_events': expand_events,
+        },
+        verify=VERIFY_CERTIFICATE,
     )
 
     if incident_data.status_code < 200 or incident_data.status_code >= 300:

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
@@ -245,7 +245,10 @@ def get_emails_context(event):
                 'body': email.get('body'),
                 'body_type': email.get('bodyType'),
                 'headers': email.get('headers'),
-                'urls': email.get('urls')
+                'urls': email.get('urls'),
+                'sender_vap': email.get('sender', {}).get('vap'),
+                'recipient_vap': email.get('recipient', {}).get('vap'),
+                'attachments': email.get('attachments'),
             }))
 
     return emails_context

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.yml
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.yml
@@ -284,7 +284,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: ' If false, will return an array of event IDs instead of full event objects. This will significantly speed up the response time of the API for incidents with large numbers of alerts.'
+      description: If false, will return an array of event IDs instead of full event objects. This will significantly speed up the response time of the API for incidents with large numbers of alerts.
       isArray: false
       name: expand_events
       predefined:

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/test_data/incident_expand_events_false.json
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/test_data/incident_expand_events_false.json
@@ -1,0 +1,51 @@
+{
+    "id": 3064,
+    "summary": "",
+    "description": "",
+    "score": 200,
+    "state": "4000",
+    "created_at": "2021-03-30T11:44:24Z",
+    "updated_at": "2021-03-30T11:44:24Z",
+    "event_count": 3,
+    "false_positive_count": null,
+    "event_sources": [
+        "Proofpoint TAP"
+    ],
+    "users": [],
+    "assignee": "Unassigned",
+    "team": "TEST-TEST",
+    "hosts": {
+        "url": [
+            "http://test.com/"
+        ]
+    },
+    "incident_field_values": [
+        {
+            "name": "Classification",
+            "value": "Phishing"
+        },
+        {
+            "name": "Attack Vector",
+            "value": "Email"
+        },
+        {
+            "name": "Abuse Disposition",
+            "value": null
+        },
+        {
+            "name": "Severity",
+            "value": "High"
+        }
+    ],
+    "events": null,
+    "event_ids": [
+        44249,
+        44248,
+        44247
+    ],
+    "comments": [],
+    "quarantine_results": [],
+    "successful_quarantines": 0,
+    "failed_quarantines": 0,
+    "pending_quarantines": 0
+}

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/test_data/raw_response.json
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/test_data/raw_response.json
@@ -82,7 +82,23 @@
                                 "vap": false,
                                 "email": "sabrina.test@test.com"
                             },
-                            "subject": "[EXTERNAL] FW: Message from test Reception 01:28 PM, March 30, 2021"
+                            "subject": "[EXTERNAL] FW: Message from test Reception 01:28 PM, March 30, 2021",
+                            "attachments": [
+                                {
+                                    "timestamp": {
+                                        "epochSecond": 1629455474,
+                                        "nano": 0
+                                    },
+                                    "safename": "9e7d56ad15ebe0705686ffbae32827ag.JPG",
+                                    "realnamePII": {
+                                        "secret": "test.JPG"
+                                    },
+                                    "size": 26091,
+                                    "contentType": "image/jpeg",
+                                    "md5": "12ddf622c090be352f4cb7c1df0e7f1k",
+                                    "sha256": "g82a86a8dd3ce77c203177de514a4d6851bba0a13caa7f273567a096df816f1c"
+                                }
+                            ]
                         }
                     ],
                     "source": "Proofpoint TAP",

--- a/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_6.md
+++ b/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_6.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Proofpoint Threat Response (Beta)
 - Fixed an issue where the *expand_events* argument of the ***proofpoint-tr-get-incident*** did not affect the response.
+- Enhanced the incident commands outputs.

--- a/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_6.md
+++ b/Packs/ProofpointThreatResponse/ReleaseNotes/1_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Proofpoint Threat Response (Beta)
+- Fixed an issue where the *expand_events* argument of the ***proofpoint-tr-get-incident*** did not affect the response.

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Threat Response (Beta)",
     "description": "Use the Proofpoint Threat Response integration to orchestrate and automate incident response.",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

fixes https://github.com/demisto/etc/issues/40564

## Description
 - the `expand_events` arg was not implemented for the `proofpoint-tr-get-incident` command in the code
 - added `vap` and `attachments` to incident commands outputs

## Does it break backward compatibility?
   - [x] No