### PR TITLE
Added ignoring errors BA113,BA112 in packs.

### DIFF
--- a/Packs/Armis/.pack-ignore
+++ b/Packs/Armis/.pack-ignore
@@ -9,7 +9,7 @@ ignore=IF100
 ignore=IF100
 
 [file:incidentfields_Armis_Alert_Status.json]
-ignore=IF100
+ignore=IF100,BA113
 
 [file:incidentfields_Armis_Alert_Type.json]
 ignore=IF100

--- a/Packs/Compliance/.pack-ignore
+++ b/Packs/Compliance/.pack-ignore
@@ -38,7 +38,7 @@ ignore=IF107
 ignore=IF107
 
 [file:incidentfield-isthedatasubjecttodpia.json]
-ignore=IF107
+ignore=IF107,BA113
 
 [file:incidentfield-possiblecauseofthebreach.json]
 ignore=IF107

--- a/Packs/CortexXDR/.pack-ignore
+++ b/Packs/CortexXDR/.pack-ignore
@@ -38,3 +38,6 @@ ignore=IF100
 
 [file:incidentfield-XDR_Similar_Incidents.json]
 ignore=IF100
+
+[file:widget-Cortex_XDR_Disconnected_Endpoints.json]
+ignore=BA113

--- a/Packs/DigitalGuardian/.pack-ignore
+++ b/Packs/DigitalGuardian/.pack-ignore
@@ -6,3 +6,6 @@ ignore=RM104
 
 [file:DigitalGuardian_Demo.yml]
 ignore=BA110
+
+[file:incidentfield-Digital_Guardian_Computer_Name.json]
+ignore=BA113

--- a/Packs/F5Silverline/.pack-ignore
+++ b/Packs/F5Silverline/.pack-ignore
@@ -1,5 +1,5 @@
 [file:incident_f5silverlinealertgeneratedtimestamp.json]
-ignore=IF100
+ignore=IF100,BA113
 
 [file:incident_f5silverlinealerttype.json]
 ignore=IF100
@@ -9,3 +9,9 @@ ignore=IF100
 
 [file:classifier-F5Silverline_mapper.json]
 ignore=BA101
+
+[file:incident_f5silverlineactionreason.json]
+ignore=BA113
+
+[file:incident_f5silverlinemessageoriginatorsourceip.json]
+ignore=BA113

--- a/Packs/MicrosoftAdvancedThreatAnalytics/.pack-ignore
+++ b/Packs/MicrosoftAdvancedThreatAnalytics/.pack-ignore
@@ -2,4 +2,7 @@
 ignore=RM104
 
 [file:classifier-mapper-incoming-MicrosoftAdvancedThreatAnalytics.json]
-ignore=BA101
+ignore=BA101,BA113
+
+[file:classifier-MicrosoftAdvancedThreatAnalytics.json]
+ignore=BA113

--- a/Packs/ShiftManagement/.pack-ignore
+++ b/Packs/ShiftManagement/.pack-ignore
@@ -1,3 +1,9 @@
 
 [file:incidentfield-Shift_open_incidents.json]
 ignore=IF100
+
+[file:dashboard-Shift_Management_.json]
+ignore=BA113,BA112
+
+[file:incidentfield-Shift_manager_briefing.json]
+ignore=BA113


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Ignoring this error at the files that failed here: https://app.circleci.com/pipelines/github/demisto/demisto-sdk/11606/workflows/f4558dc2-eca4-461f-87d6-1d60e7ba7a63/jobs/58567 

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
