### PR TITLE
setGridField: Allow column names to have underscores

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_4_24.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_4_24.md
@@ -1,0 +1,5 @@
+#### Scripts
+
+##### SetGridField
+
+- Grid column names are allowed to include underscores (`_`). Underscores are no longer removed from provided column names. 

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -28,7 +28,8 @@ def normalized_string(phrase: str) -> str:
 
 
 def normalized_column_name(phrase: str) -> str:
-    """ Normalize columns or Grid to connected word in lower-case.
+    """ Normalize columns or Grid to connected word in lowercase, to match the logic of stripToClumnName() from
+        the client's `strings.js` and the server logic.
 
     Args:
         phrase: Phrase to normalize.
@@ -295,7 +296,7 @@ def build_grid_command(grid_id: str, context_path: str, keys: List[str], columns
         raise DemistoException(f'The number of keys: {len(keys)} should match the number of columns: {len(columns)}.')
     # Get old Data
     old_table = get_current_table(grid_id=grid_id)
-    # Change columns to all lower case. Not using `normalize()` as underscores are allowed in columns names.
+    # Change columns to all lower case (underscores allowed).
     columns = [normalized_column_name(phrase) for phrase in columns]
     # Create new Table from the given context path.
     new_table: pd.DataFrame = build_grid(context_path=context_path,

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -122,7 +122,7 @@ def get_current_table(grid_id: str) -> pd.DataFrame:
 
 
 @logger
-def validate_entry_context(context_path, entry_context: Any, keys: List[str], unpack_nested_elements: bool):
+def validate_entry_context(context_path: str, entry_context: Any, keys: List[str], unpack_nested_elements: bool):
     """ Validate entry context structure is valid, should be:
         - For unpack_nested_elements==False:
             1. List[Dict[str, str/bool/int/float]]
@@ -277,8 +277,8 @@ def build_grid_command(grid_id: str, context_path: str, keys: List[str], columns
         raise DemistoException(f'The number of keys: {len(keys)} should match the number of columns: {len(columns)}.')
     # Get old Data
     old_table = get_current_table(grid_id=grid_id)
-    # Normalize columns to match connected words.
-    columns = [normalized_string(phrase) for phrase in columns]
+    # Change columns to all lower case. Not using `normalize()` as underscores are allowed in columns names.
+    columns = [phrase.lower() for phrase in columns]
     # Create new Table from the given context path.
     new_table: pd.DataFrame = build_grid(context_path=context_path,
                                          keys=keys,

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -21,7 +21,7 @@ def normalized_string(phrase: str) -> str:
     Examples:
         >>> normalized_string("TestWord")
         "testword"
-        >>> normalized_string("helloworld")
+        >>> normalized_string("hello_world")
         "helloworld"
     """
     return phrases_case.camel(phrase).replace("'", "").lower()
@@ -39,7 +39,7 @@ def normalized_column_name(phrase: str) -> str:
     Examples:
         >>> normalized_string("Test Word!@#$%^&*()-=+")
         "testword"
-        >>> normalized_string("hello_world@")
+        >>> normalized_string("hello🦦_world@")
         "hello_world"
     """
     return re.sub(r'[^a-zA-Z\d_]', '', phrase[:255]).lower()

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -10,7 +10,7 @@ from CommonServerUserPython import *
 
 
 def normalized_string(phrase: str) -> str:
-    """ Normalize columns or Grid to connected word in lower-case.
+    """ Normalize a string to flatcase (to match `cli name`).
 
     Args:
         phrase: Phrase to normalize.
@@ -21,10 +21,28 @@ def normalized_string(phrase: str) -> str:
     Examples:
         >>> normalized_string("TestWord")
         "testword"
-        >>> normalized_string("hello_world")
-        "hello_world"
+        >>> normalized_string("helloworld")
+        "helloworld"
     """
     return phrases_case.camel(phrase).replace("'", "").lower()
+
+
+def normalized_column_name(phrase: str) -> str:
+    """ Normalize columns or Grid to connected word in lower-case.
+
+    Args:
+        phrase: Phrase to normalize.
+
+    Returns:
+        str: Normalized phrase.
+
+    Examples:
+        >>> normalized_string("Test Word!@#$%^&*()-=+")
+        "testword"
+        >>> normalized_string("hello_world@")
+        "hello_world"
+    """
+    return re.sub(r'[^a-zA-Z\d_]', '', phrase[:255]).lower()
 
 
 def filter_dict(dict_obj: Dict[Any, Any], keys: List[str], max_keys: Optional[int] = None) -> Dict[Any, Any]:
@@ -278,7 +296,7 @@ def build_grid_command(grid_id: str, context_path: str, keys: List[str], columns
     # Get old Data
     old_table = get_current_table(grid_id=grid_id)
     # Change columns to all lower case. Not using `normalize()` as underscores are allowed in columns names.
-    columns = [phrase.lower() for phrase in columns]
+    columns = [normalized_column_name(phrase) for phrase in columns]
     # Create new Table from the given context path.
     new_table: pd.DataFrame = build_grid(context_path=context_path,
                                          keys=keys,

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
@@ -65,3 +65,5 @@ timeout: '0'
 type: python
 dockerimage: demisto/pandas:1.0.0.23402
 fromversion: 5.0.0
+tests:
+  - No tests

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -89,12 +89,12 @@ def test_build_grid(datadir, mocker, keys: list, columns: list, dt_response_json
     ).to_dict()
 
 
-should_be_removed_by_normalize_col = ' \n &$#%?!*;׳()🦦ץ'
+should_be_removed_by_normalize_col = ' \n &$#%?!*;׳()🦦ץ' * 20 + "this should be truncated, more than 255 chars"
 
 
 @pytest.mark.parametrize(argnames="keys, columns, unpack_nested_elements, dt_response_path, expected_results_path",
                          argvalues=[
-                             (["name", "value"], [f"col_{should_be_removed_by_normalize_col}1", "COL2"], False,
+                             (["name", "value"], [f"col_1{should_be_removed_by_normalize_col}", "COL2"], False,
                               'context_entry_list_missing_key.json',
                               'expected_list_grid_none_value.json')
                          ])

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -91,7 +91,7 @@ def test_build_grid(datadir, mocker, keys: list, columns: list, dt_response_json
 
 @pytest.mark.parametrize(argnames="keys, columns, unpack_nested_elements, dt_response_path, expected_results_path",
                          argvalues=[
-                             (["name", "value"], ["col1", "col2"], False, 'context_entry_list_missing_key.json',
+                             (["name", "value"], ["col_1", "Col2"], False, 'context_entry_list_missing_key.json',
                               'expected_list_grid_none_value.json')
                          ])
 def test_build_grid_command(datadir, mocker, keys: List[str], columns: List[str], unpack_nested_elements: bool,

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -89,9 +89,13 @@ def test_build_grid(datadir, mocker, keys: list, columns: list, dt_response_json
     ).to_dict()
 
 
+should_be_removed_by_normalize_col = ' \n &$#%?!*;׳()🦦ץ'
+
+
 @pytest.mark.parametrize(argnames="keys, columns, unpack_nested_elements, dt_response_path, expected_results_path",
                          argvalues=[
-                             (["name", "value"], ["col_1", "Col2"], False, 'context_entry_list_missing_key.json',
+                             (["name", "value"], [f"col_{should_be_removed_by_normalize_col}1", "COL2"], False,
+                              'context_entry_list_missing_key.json',
                               'expected_list_grid_none_value.json')
                          ])
 def test_build_grid_command(datadir, mocker, keys: List[str], columns: List[str], unpack_nested_elements: bool,

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test/expected_list_grid_none_value.json
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test/expected_list_grid_none_value.json
@@ -1,14 +1,14 @@
 [
   {
-    "col1": "name1",
+    "col_1": "name1",
     "col2": "value1"
   },
   {
-    "col1": "name2",
+    "col_1": "name2",
     "col2": "value2"
   },
   {
-    "col1": "name3",
+    "col_1": "name3",
     "col2": "value3"
   },
   {

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.4.23",
+    "currentVersion": "1.4.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/39641

## Description
Column names were transformed to `flatcase` (CLI name), although the server allows (see `utils/strings.js/stripToColumnName`). This caused data of columns whose name include underscores to not be shown on the grid. Changing them to lower case (rather than converting to camelCase, which would remove underscores) allows using column names that include underscores.
 
## Minimum version of Cortex XSOAR
- [x] 5.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [x] Tests
- [ ] Documentation 
