### PR TITLE
Make some fields available to all incident types

### DIFF
--- a/Packs/Phishing/IncidentFields/incidentfield-Attachment_Count.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Attachment_Count.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Attachment_Extension.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Attachment_Extension.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Attachment_Hash.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Attachment_Hash.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Attachment_Name.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Attachment_Name.json
@@ -23,16 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Trend Micro CAS Event",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Attachment_size.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Attachment_size.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Body.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Body.json
@@ -23,15 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": true,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Body_Format.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Body_Format.json
@@ -23,15 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Body_HTML.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Body_HTML.json
@@ -23,15 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": true,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_From.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_From.json
@@ -23,19 +23,7 @@
   "content": true,
   "group": 0,
   "hidden": false,
-  "associatedTypes": [
-    "Phishing",
-    "Trend Micro CAS Event",
-    "Email Communication",
-    "FireEye NX IPS Event",
-    "FireEye NX Alert",
-    "FireEye EX Alert"
-  ],
-  "systemAssociatedTypes": [
-    "Phishing",
-    "Email Communication"
-  ],
-  "associatedToAll": false,
+  "associatedToAll": true,
   "unmapped": false,
   "unsearchable": false,
   "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Message_ID.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Message_ID.json
@@ -23,15 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Return_Path.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Return_Path.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_Subject.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_Subject.json
@@ -23,19 +23,7 @@
   "content": true,
   "group": 0,
   "hidden": false,
-  "associatedTypes": [
-    "Phishing",
-    "Trend Micro CAS Event",
-    "Email Communication",
-    "FireEye NX IPS Event",
-    "FireEye NX Alert",
-    "FireEye EX Alert"
-  ],
-  "systemAssociatedTypes": [
-    "Phishing",
-    "Email Communication"
-  ],
-  "associatedToAll": false,
+  "associatedToAll": true,
   "unmapped": false,
   "unsearchable": false,
   "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_To.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_To.json
@@ -23,19 +23,7 @@
   "content": true,
   "group": 0,
   "hidden": false,
-  "associatedTypes": [
-    "Phishing",
-    "Trend Micro CAS Event",
-    "Email Communication",
-    "FireEye NX IPS Event",
-    "FireEye NX Alert",
-    "FireEye EX Alert"
-  ],
-  "systemAssociatedTypes": [
-    "Phishing",
-    "Email Communication"
-  ],
-  "associatedToAll": false,
+  "associatedToAll": true,
   "unmapped": false,
   "unsearchable": false,
   "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-Email_To_Count.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-Email_To_Count.json
@@ -23,13 +23,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing"
- ],
- "systemAssociatedTypes": [
-  "Phishing"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "fromVersion": "5.0.0"

--- a/Packs/Phishing/IncidentFields/incidentfield-emailheaders.json
+++ b/Packs/Phishing/IncidentFields/incidentfield-emailheaders.json
@@ -25,14 +25,7 @@
  "content": true,
  "group": 0,
  "hidden": false,
- "associatedTypes": [
-  "Phishing",
-  "Email Communication"
- ],
- "systemAssociatedTypes": [
-  "Email Communication"
- ],
- "associatedToAll": false,
+ "associatedToAll": true,
  "unmapped": false,
  "unsearchable": false,
  "caseInsensitive": true,

--- a/Packs/Phishing/ReleaseNotes/2_4_1.md
+++ b/Packs/Phishing/ReleaseNotes/2_4_1.md
@@ -1,0 +1,18 @@
+
+#### Incident Fields
+- Modify some incident fields in order to make them associate to all incident types. Modified fields:
+- **Attachment Count**
+- **Attachment Hash**
+- **Email Return Path**
+- **Email Body**
+- **Email Message ID**
+- **Attachment size**
+- **Attachment Extension**
+- **Email To Count**
+- **Email Subject**
+- **Email To**
+- **Email Body Format**
+- **Attachment Name**
+- **Email From**
+- **Email Body HTML**
+- **Email Headers**

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "2.4.0",
+    "currentVersion": "2.4.1",
     "serverMinVersion": "6.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)


## Description
Some fields are only associated with certain incident types, while I feel they are a little too general to be used only for those. This change makes them available to every type.
For Example, the "email", "email to" and "email from" fields. These might be used in an extremly wide range of cases (either manual ones or fetched by an integration) and its impossible to expect every XSOAR customer/user to: 

- add the incident type to the main repository
- add that incident type to the associatedTypes list
- wait for a review

Even if they did, the list will grow very large and some incident types might not even be useful for other customers, so it would be pointless to have them in the main repository.

Of course, these fields can be modified inside the XSOAR UI, and add the incident type in there. The problem with this is that the  field would get rewritten at the next pack update/reinstall and all the changes would be lost. In addition to this, even if the custom incident type is associated to the field, it is still shown as a system field and not exported as a custom content, making it difficult to version control internally.

One workaround would be the ability to have multiple fields inside xsoar with the same "displayname". So you would have, for example, "incidentfield_email" and "incidentfield_email_custom" as ids, but both of them would have the "name" equal to "email". This is a little harder to do, since it will require a pretty big platform change (for example, you should be able to tell the difference between which field is which in the field mapping section of a playbook task).

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
