### PR TITLE
fix typo

### DIFF
--- a/Tests/Marketplace/marketplace_constants.py
+++ b/Tests/Marketplace/marketplace_constants.py
@@ -109,7 +109,7 @@ class Metadata(object):
     KEY_WORDS = 'keywords'
     DEPENDENCIES = 'dependencies'
     PREMIUM = 'premium'
-    VERNDOR_ID = 'vendorId'
+    VENDOR_ID = 'vendorId'
     PARTNER_ID = 'partnerId'
     PARTNER_NAME = 'partnerName'
     CONTENT_COMMIT_HASH = 'contentCommitHash'


### PR DESCRIPTION
Fixing a typo in an attribute under the marketplace_constants python file .
