### PR TITLE
Typo fix constnats upload

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1745,7 +1745,7 @@ class Pack(object):
             self._categories = input_to_list(input_data=self.user_metadata.get(Metadata.CATEGORIES), capitalize_input=True)
             self._keywords = input_to_list(self.user_metadata.get(Metadata.KEY_WORDS))
         self._dependencies = self._parse_pack_dependencies(
-            self.user_metadata.get(Metadata.DEPENDENCIES, {}), dependencies_data)
+            self.user_metadata.get(Metadata.DEPENDENCIES, {}), dependencies_data) # ADDWDW
 
         # ===== Pack Private Attributes =====
         if not format_dependencies_only:

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1745,7 +1745,7 @@ class Pack(object):
             self._categories = input_to_list(input_data=self.user_metadata.get(Metadata.CATEGORIES), capitalize_input=True)
             self._keywords = input_to_list(self.user_metadata.get(Metadata.KEY_WORDS))
         self._dependencies = self._parse_pack_dependencies(
-            self.user_metadata.get(Metadata.DEPENDENCIES, {}), dependencies_data) # ADDWDW
+            self.user_metadata.get(Metadata.DEPENDENCIES, {}), dependencies_data)
 
         # ===== Pack Private Attributes =====
         if not format_dependencies_only:

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1754,7 +1754,7 @@ class Pack(object):
             self._preview_only = get_valid_bool(self.user_metadata.get(Metadata.PREVIEW_ONLY, False))
             self._price = convert_price(pack_id=self._pack_name, price_value_input=self.user_metadata.get('price'))
             if self._is_private_pack:
-                self._vendor_id = self.user_metadata.get(Metadata.VERNDOR_ID, "")
+                self._vendor_id = self.user_metadata.get(Metadata.VENDOR_ID, "")
                 self._partner_id = self.user_metadata.get(Metadata.PARTNER_ID, "")
                 self._partner_name = self.user_metadata.get(Metadata.PARTNER_NAME, "")
                 self._content_commit_hash = self.user_metadata.get(Metadata.CONTENT_COMMIT_HASH, "")


### PR DESCRIPTION
Fixing a typo in an attribute under the marketplace_constants python file .