### PR TITLE
change channels:write to channels:manage scope SlackV3

### DIFF
--- a/Packs/Slack/doc_files/SlackV3_app_manifest.yml
+++ b/Packs/Slack/doc_files/SlackV3_app_manifest.yml
@@ -23,7 +23,7 @@ oauth_config:
     bot:
       - channels:history
       - channels:read
-      - channels:write
+      - channels:manage
       - chat:write
       - files:write
       - groups:history


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40819

## Description
Apparently it's now `channels:manage` and not `channels:write`.