### PR TITLE
Splunk Fixes

### DIFF
--- a/Packs/SplunkPy/Classifiers/classifier-Splunk_-_Notable_Generic_Outgoing_Mapper.json
+++ b/Packs/SplunkPy/Classifiers/classifier-Splunk_-_Notable_Generic_Outgoing_Mapper.json
@@ -27,7 +27,7 @@
 										"isContext": false,
 										"value": {
 											"complex": null,
-											"simple": "New, In Progress, Pending, Resolved, Closed"
+											"simple": "New,In Progress,Pending,Resolved,Closed"
 										}
 									},
 									"mapped_values": {

--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -96,10 +96,13 @@ Run the ***splunk-reset-enriching-fetch-mechanism*** command and the mechanism w
 - The drilldown search, does not support Splunk's advanced syntax. For example: Splunk filters (**|s**, **|h**, etc.)  
 
 ### Incident Mirroring
-**NOTE: This feature is available from Cortex XSOAR version 6.0.0**
-**NOTE: This feature is supported by Splunk Enterprise Security only**
-**NOTE: To make sure the mirroring is stable, when fetching the first time one needs to make sure that the mirroring option is enabled**
-
+**Imporatnt Notes*** 
+ - This feature is available from Cortex XSOAR version 6.0.0.
+ - This feature is supported by Splunk Enterprise Security only.
+ - In order for the mirroring to work, the *Incident Mirroring Direction* parameter needs to be set before the incident is fetched.
+ - In order to ensure the mirroring works as expected, mappers are required, both for incoming and outgoing, to map the expected fields in Cortex XSOAR and Splunk. 
+ - For mirroring the *owner* field, the usernames need to be transformed to the corresponding in Cortex XSOAR and Splunk.
+ 
 You can enable incident mirroring between Cortex XSOAR incidents and Splunk notables.
 To setup the mirroring follow these instructions:
 1. Navigate to __Settings__ > __Integrations__ > __Servers & Services__.

--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -98,6 +98,7 @@ Run the ***splunk-reset-enriching-fetch-mechanism*** command and the mechanism w
 ### Incident Mirroring
 **NOTE: This feature is available from Cortex XSOAR version 6.0.0**
 **NOTE: This feature is supported by Splunk Enterprise Security only**
+**NOTE: To make sure the mirroring is stable, when fetching the first time one needs to make sure that the mirroring option is enabled**
 
 You can enable incident mirroring between Cortex XSOAR incidents and Splunk notables.
 To setup the mirroring follow these instructions:

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1084,11 +1084,11 @@ def update_remote_system_command(args, params, service, auth_token):
                     urgency=changed_data['urgency'], owner=changed_data['owner'], eventIDs=[notable_id],
                     auth_token=auth_token, sessionKey=session_key
                 )
-                msg = response_info.get('message')
                 if 'success' not in response_info or not response_info['success']:
-                    demisto.error('Failed updating notable {}: {}'.format(notable_id, msg))
+                    demisto.error('Failed updating notable {}: {}'.format(notable_id, str(response_info)))
                 else:
-                    demisto.debug('update-remote-system for notable {}: {}'.format(notable_id, msg))
+                    demisto.debug('update-remote-system for notable {}: {}'.format(notable_id,
+                                                                                   response_info.get('message')))
 
             except Exception as e:
                 demisto.error('Error in Splunk outgoing mirror for incident corresponding to notable {}. '

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -787,4 +787,5 @@ tests:
 - SplunkPy parse-raw - Test
 defaultclassifier: SplunkPy
 defaultmapperin: SplunkPy-mapper
+defaultmapperout: Splunk - Notable Generic Outgoing Mapper
 fromversion: 5.0.0

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_description.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_description.md
@@ -43,10 +43,13 @@ Run the ***splunk-reset-enriching-fetch-mechanism*** command and the mechanism w
 - The drilldown search, does not support Splunk's advanced syntax. For example: Splunk filters (**|s**, **|h**, etc.)  
 
 ### Incident Mirroring
-**NOTE: This feature is available from Cortex XSOAR version 6.0.0**
-**NOTE: This feature is supported by Splunk Enterprise Security only**
-**NOTE: To make sure the mirroring is stable, when fetching the first time one needs to make sure that the mirroring option is enabled**
-
+**Imporatnt Notes*** 
+ - This feature is available from Cortex XSOAR version 6.0.0.
+ - This feature is supported by Splunk Enterprise Security only.
+ - In order for the mirroring to work, the *Incident Mirroring Direction* parameter needs to be set before the incident is fetched.
+ - In order to ensure the mirroring works as expected, mappers are required, both for incoming and outgoing, to map the expected fields in Cortex XSOAR and Splunk. 
+ - For mirroring the *owner* field, the usernames need to be transformed to the corresponding in Cortex XSOAR and Splunk.
+ 
 You can enable incident mirroring between Cortex XSOAR incidents and Splunk notables.
 To setup the mirroring follow these instructions:
 1. Navigate to __Settings__ > __Integrations__ > __Servers & Services__.

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_description.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_description.md
@@ -45,6 +45,7 @@ Run the ***splunk-reset-enriching-fetch-mechanism*** command and the mechanism w
 ### Incident Mirroring
 **NOTE: This feature is available from Cortex XSOAR version 6.0.0**
 **NOTE: This feature is supported by Splunk Enterprise Security only**
+**NOTE: To make sure the mirroring is stable, when fetching the first time one needs to make sure that the mirroring option is enabled**
 
 You can enable incident mirroring between Cortex XSOAR incidents and Splunk notables.
 To setup the mirroring follow these instructions:

--- a/Packs/SplunkPy/ReleaseNotes/2_1_11.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_11.md
@@ -1,6 +1,10 @@
 
 #### Integrations
 ##### SplunkPy
+- Fixed an issue where the ***update-remote-system*** mirroring command was returning an incorrect error message `AttributeError: 'unicode' object has no attribute 'get'`.
+- Documentation and metadata improvements.
+- Added a default outgoing mapper.
+
+#### Mappers
+##### Splunk - Notable Generic Outgoing Mapper
 - Fixed an issue in the Outgoing Mapper where whitespace in mapped values were causing wrong output.
-- Fixed an issue in the **update-remote-system** command where unicode value was lacking the get method.
-- Improved mirroring documentation with instructions for first fetch.

--- a/Packs/SplunkPy/ReleaseNotes/2_1_11.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_1_11.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue in the Outgoing Mapper where whitespace in mapped values were causing wrong output.
+- Fixed an issue in the **update-remote-system** command where unicode value was lacking the get method.
+- Improved mirroring documentation with instructions for first fetch.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.1.10",
+    "currentVersion": "2.1.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/40851

## Description
- Fixed an issue in the outgoing mapper where whitespace in the list of mapped values has caused a wrong output of the transformer.
- Fixed an issue with unicode not having the `get` arg, similar to what have been done in https://github.com/demisto/content/pull/13747.
- Improved the documentation regarding the mirroring
- Added a default outgoing mapper

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Documentation 
