### PR TITLE
fix upload-flow bug in collect_content_items

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -1659,7 +1659,7 @@ class Pack(object):
             logging.exception(f"Failed collecting content items in {self._pack_name} pack")
         finally:
             self._content_items = content_items_result
-            return task_status, content_items_result
+            return task_status
 
     def load_user_metadata(self):
         """ Loads user defined metadata and stores part of it's data in defined properties fields.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/content/pull/14578

## Description
As can be seen in the following [upload](https://code.pan.run/xsoar/content/-/jobs/7335091), packs are not failing but the pack processing is continued (`Screenshot 1`). This should not happen and we should see failure in that Pack method, as can be seen in the same build, packs are not listed as failed to upload. Bug reproduce is showed in `Screenshot 2`.

## Screenshot 1
![image](https://user-images.githubusercontent.com/53565845/131265523-7aa6224a-743e-4e57-85b0-70747828c3a9.png)

## Screenshot 2
<img src=https://user-images.githubusercontent.com/53565845/131290699-2c81988d-c307-4bf5-bbf1-d0039a9b3805.png width=300>

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
