### PR TITLE
ParseEmailFiles -  roll back to multiple encoding part

### DIFF
--- a/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles_test.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles_test.py
@@ -416,9 +416,8 @@ def test_email_with_special_character(mocker):
         '\xe3\x80\x90\xe2\x91\xa0'  # 【①
     ),
     (
-        'This is test =?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= '
-        '=?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?=',
-        'This is test メール�と�日本語文字が表示されない文字のテスト'
+        '=?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= =?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?=',
+        'メール�と�日本語文字が表示されない文字のテスト'
     )
 ])
 def test_utf_subject_convert(encoded_subject, decoded_subject):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [40877](https://github.com/demisto/etc/issues/40877)

## Description
We have some issues with decode headers  like this: `This =?UTF-8?B?VGVzdMKu?= passes` so we added a function for checking mime encoding words and we expanded it to handle multiple encoding: ```
 =?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= '
        '=?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?=
```. 
Since every header that contains multiple encoding words and previously could handle with `decode_header(s)`  will now  goes to the new code.
We will prefer to have a mistakes once a time in case like this: 
'This is test =?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= '
        '=?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?='

I assume we should check it and handle it with the new repository. @moishce 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [x] Tests
- [ ] Documentation 
