### PR TITLE
Fixed docs for GenericWebhook

### DIFF
--- a/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
@@ -22,9 +22,9 @@ The Generic Webhook integration is used to create incidents on event triggers. T
 
 You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>/instance/execute/<INTEGRATION-INSTANCE-NAME>`. For example, `https://my.demisto.live/instance/execute/webhook`. Please note that the string `instance` does not refer to the name of your XSOAR instance, but rather is part of the URL.
 
-If you're not invoking the integration via the server's HTTPS endpoint, then you should trigger the webhook URL as follows: `<CORTEX-XSOAR-URL>:<LISTEN_PORT>/`. For example, `https://my.demisto.live:8000/`.
+If you're not invoking the integration via the server HTTPS endpoint, then you should trigger the webhook URL as follows: `<CORTEX-XSOAR-URL>:<LISTEN_PORT>/`. For example, `https://my.demisto.live:8000/`.
 
-The examples below assume you use invoke the integration via the server's HTTPS endpoint. In case you don't, replace the URL in the examples as suggested above.
+The examples below assume you invoke the integration via the server HTTPS endpoint. In case you don't, replace the URL in the examples as suggested above.
 
 **Note**: The ***Listen Port*** needs to be available, which means it has to be unique for each integration instance. It cannot be used by other long-running integrations.
 

--- a/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
@@ -20,7 +20,7 @@ The Generic Webhook integration is used to create incidents on event triggers. T
 5. Navigate to  **Settings > About > Troubleshooting**.
 6. In the **Server Configuration** section, verify that the value for the ***instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>*** key is set to *true*. If this key does not exist, click **+ Add Server Configuration** and add *instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>* and set the value to *true*. See the following [reference article](https://xsoar.pan.dev/docs/reference/articles/long-running-invoke) for further information.
 
-You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>/instance/execute/<INTEGRATION-INSTANCE-NAME>`. For example, `https://my.demisto.live/instance/execute/webhook`. Please note that the string `instance` does not refer to the name of your XSOAR instance, but rather is part of the URL.
+You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>:<LISTEN_PORT/`. For example, `https://my.demisto.live:8000/`.
 
 **Note**: The ***Listen Port*** needs to be available, which means it has to be unique for each integration instance. It cannot be used by other long-running integrations.
 
@@ -36,11 +36,11 @@ The Generic Webhook integration accepts POST HTTP queries, with the following op
 
 For example, the following triggers the webhook using cURL:
 
-`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
+`curl -POST https://my.demisto.live:8000/ -H "Authorization: token" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
 
 The request payload does not have to contain the fields mentioned above, and may include anything:
 
-`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
+`curl -POST https://my.demisto.live:8000/ -H "Authorization: token" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
 
 The payload could then be mapped in the [Cortex XSOAR mapping wizard](https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/incidents/classification-and-mapping/create-a-mapper):
 - Note that the *Store sample events for mapping* parameter needs to be set.

--- a/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
@@ -20,7 +20,11 @@ The Generic Webhook integration is used to create incidents on event triggers. T
 5. Navigate to  **Settings > About > Troubleshooting**.
 6. In the **Server Configuration** section, verify that the value for the ***instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>*** key is set to *true*. If this key does not exist, click **+ Add Server Configuration** and add *instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>* and set the value to *true*. See the following [reference article](https://xsoar.pan.dev/docs/reference/articles/long-running-invoke) for further information.
 
-You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>:<LISTEN_PORT>/`. For example, `https://my.demisto.live:8000/`.
+You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>/instance/execute/<INTEGRATION-INSTANCE-NAME>`. For example, `https://my.demisto.live/instance/execute/webhook`. Please note that the string `instance` does not refer to the name of your XSOAR instance, but rather is part of the URL.
+
+If you're not invoking the integration via the server's HTTPS endpoint, then you should trigger the webhook URL as follows: `<CORTEX-XSOAR-URL>:<LISTEN_PORT>/`. For example, `https://my.demisto.live:8000/`.
+
+The examples below assume you use invoke the integration via the server's HTTPS endpoint. In case you don't, replace the URL in the examples as suggested above.
 
 **Note**: The ***Listen Port*** needs to be available, which means it has to be unique for each integration instance. It cannot be used by other long-running integrations.
 
@@ -36,11 +40,11 @@ The Generic Webhook integration accepts POST HTTP queries, with the following op
 
 For example, the following triggers the webhook using cURL:
 
-`curl -POST https://my.demisto.live:8000/ -H "Authorization: token" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
+`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
 
 The request payload does not have to contain the fields mentioned above, and may include anything:
 
-`curl -POST https://my.demisto.live:8000/ -H "Authorization: token" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
+`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
 
 The payload could then be mapped in the [Cortex XSOAR mapping wizard](https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/incidents/classification-and-mapping/create-a-mapper):
 - Note that the *Store sample events for mapping* parameter needs to be set.

--- a/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
@@ -20,7 +20,7 @@ The Generic Webhook integration is used to create incidents on event triggers. T
 5. Navigate to  **Settings > About > Troubleshooting**.
 6. In the **Server Configuration** section, verify that the value for the ***instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>*** key is set to *true*. If this key does not exist, click **+ Add Server Configuration** and add *instance.execute.external.\<INTEGRATION-INSTANCE-NAME\>* and set the value to *true*. See the following [reference article](https://xsoar.pan.dev/docs/reference/articles/long-running-invoke) for further information.
 
-You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>:<LISTEN_PORT/`. For example, `https://my.demisto.live:8000/`.
+You can now trigger the webhook URL: `<CORTEX-XSOAR-URL>:<LISTEN_PORT>/`. For example, `https://my.demisto.live:8000/`.
 
 **Note**: The ***Listen Port*** needs to be available, which means it has to be unique for each integration instance. It cannot be used by other long-running integrations.
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

## Description
The current Generic Webhook documentation shows the URI path to reach the webhook to be `<CORTEX-XSOAR-URL>/instance/execute/<INTEGRATION-INSTANCE-NAME>`. This did not work for me in production, and after looking into the integration code, it actually listens at the root (`<CORTEX-XSOAR-URL>/`). This fixes the documentation to address the discrepancy.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
