### PR TITLE
Pop3 fix ssl default value

### DIFF
--- a/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.yml
+++ b/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.yml
@@ -51,7 +51,7 @@ script:
   script: '-'
   type: python
   subtype: python2
-  dockerimage: demisto/python:2.7.18.22912
+  dockerimage: demisto/python:2.7.18.24019
 beta: true
 tests:
 - MailListener-POP3 - Test

--- a/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.yml
+++ b/Packs/MailListener_-_POP3/Integrations/MailListener_POP3/MailListener_POP3.yml
@@ -20,7 +20,7 @@ configuration:
   name: password
   required: true
   type: 4
-- defaultvalue: 'True'
+- defaultvalue: true
   display: Use SSL connection
   name: ssl
   required: false

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### MailListener - POP3 Beta
-- SSL Connection default value changed from **'True'** to **true**.
+- SSL connection default value changed from **'True'** to **true**.

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### MailListener - POP3 Beta
-- Update the **Use SSL connection** parameter default value to *true*.
+- Updated the **Use SSL connection** parameter default value to *true*.
+- Updated the Docker image to: *demisto/python:2.7.18.24019*.

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### MailListener - POP3 Beta
-- SSL connection default value changed from **'True'** to **true**.
+-  **Breaking changes:** Update the **Use SSL connection** parameter default value to *true*.

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### MailListener - POP3 Beta
--  **Breaking changes:** Update the **Use SSL connection** parameter default value to *true*.
+- Update the **Use SSL connection** parameter default value to *true*.

--- a/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
+++ b/Packs/MailListener_-_POP3/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MailListener - POP3 Beta
+- SSL Connection default value changed from **'True'** to **true**.

--- a/Packs/MailListener_-_POP3/pack_metadata.json
+++ b/Packs/MailListener_-_POP3/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MailListener - POP3 (Beta)",
     "description": "Listen to a mailbox, enable incident triggering via e-mail",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40992

## Description
Changing the ssl checkbox default value from "'True'" to "true" - this resolves an issue with setting up a new instances.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

