### PR TITLE
ParseEmailFiles - handle mime encoded word header with underscore

### DIFF
--- a/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles_test.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles_test.py
@@ -419,7 +419,11 @@ def test_email_with_special_character(mocker):
         '=?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= '
         '=?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?=',
         'メール�と�日本語文字が表示されない文字のテスト'
-    )
+    ),
+    (
+        '=?UTF-8?Q?TEST_UNDERSCORE?=',
+        'TEST UNDERSCORE'
+    ),
     # (
     #   'This is test =?iso-2022-jp?B?GyRCJWEhPCVrLSEkSHxxGyhC?= '
     #   '=?iso-2022-jp?B?GyRCRnxLXDhsSjg7eiQsST08KCQ1JGwkSiQkSjg7eiROJUYlOSVIGyhC?=',


### PR DESCRIPTION
## Status
- [x] In Progress

## Description
handling underscores as spaces as defined in https://datatracker.ietf.org/doc/html/rfc1522.html#section-4.2

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests

