### PR TITLE
Cisco Umbrella Investigate - fix isarray for domain arg

### DIFF
--- a/Packs/Cisco-umbrella/Integrations/Cisco-umbrella-investigate/Cisco-umbrella-investigate.yml
+++ b/Packs/Cisco-umbrella/Integrations/Cisco-umbrella-investigate/Cisco-umbrella-investigate.yml
@@ -47,7 +47,7 @@ script:
   - arguments:
     - default: true
       description: Enter the domain you would like to categorize (e.g. amazon.com)
-      isArray: true
+      isArray: false
       name: domain
       required: true
       secret: false
@@ -710,7 +710,7 @@ script:
   - arguments:
     - default: true
       description: 'The domain name you would like to categorize. (e.g. : www.amazon.com) Comma separated list allowed. (e.g. : www.amazon.com,www.facebook.com,www.yahoo.com)'
-      isArray: false
+      isArray: true
       name: domain
       required: true
       secret: false
@@ -1371,7 +1371,7 @@ script:
   script: '-'
   type: python
   subtype: python2
-  dockerimage: demisto/python:2.7.18.22912
+  dockerimage: demisto/python:2.7.18.24066
 tests:
 - Cisco Umbrella Test
 fromversion: 5.0.0

--- a/Packs/Cisco-umbrella/ReleaseNotes/1_0_7.md
+++ b/Packs/Cisco-umbrella/ReleaseNotes/1_0_7.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Cisco Umbrella Investigate
+- Fixed an issue where the ***umbrella-domain-categorization*** command failed when given a list of domains.
+- Updated the Docker image to: *demisto/python:2.7.18.24066*.

--- a/Packs/Cisco-umbrella/pack_metadata.json
+++ b/Packs/Cisco-umbrella/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Umbrella Investigate",
     "description": "Cisco Umbrella Investigate",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4611,7 +4611,6 @@
         "Microsoft Teams Management - Test": "Issue 33410",
         "RedLockTest": "Issue 24600",
         "MicrosoftGraphMail-Test_prod": "Issue 40125",
-        "Cisco Umbrella Test": "Issue 24338",
         "Detonate URL - WildFire v2.1 - Test": "Issue 40834",
         "Domain Enrichment - Generic v2 - Test": "Issue 40862",
         "palo_alto_panorama_test_pb": "Issue 34371",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/41151
fixes: https://github.com/demisto/etc/issues/24338

## Description
in https://github.com/demisto/content/pull/14541 i've set the `isArray` flag to the wrong arg

## Does it break backward compatibility?
   - [x] No
