### PR TITLE
Fixed an issue where proxy settings haven't been given in BasicClient.

### DIFF
--- a/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
+++ b/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
@@ -62,7 +62,8 @@ class Client(BaseClient):
             api_key: unit42 API Key.
             verify: boolean, if *false* feed HTTPS server certificate is verified. Default: *false*
         """
-        super().__init__(base_url='https://stix2.unit42.org/taxii', verify=verify)
+        super().__init__(base_url='https://stix2.unit42.org/taxii', verify=verify,
+                         proxy=argToBoolean(demisto.params().get('proxy') or 'false'))
         self._api_key = api_key
         self._proxies = handle_proxy()
         self.objects_data = {}

--- a/Packs/FeedUnit42v2/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedUnit42v2/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Unit42 ATOMs Feed
+- Fixed an issue where proxy settings haven't been given in BasicClient.

--- a/Packs/FeedUnit42v2/pack_metadata.json
+++ b/Packs/FeedUnit42v2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Unit42 v2 Feed",
     "description": "Unit42 feed of published IOCs which contains malicious indicators.",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/content/pull/14778

## Description
Unable to connect Unit42 server via a web proxy.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
