### PR TITLE
BaseClient - improve if session exist check in del

### DIFF
--- a/Packs/Base/ReleaseNotes/1_13_31.md
+++ b/Packs/Base/ReleaseNotes/1_13_31.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed an issue where the HTTP session failed to be closed when the *BaseClient* was used as global.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -6951,8 +6951,10 @@ if 'requests' in sys.modules:
 
         def __del__(self):
             try:
-                if '_session' in self.__dict__:
-                    self._session.close()
+                self._session.close()
+            except AttributeError:
+                # we ignore exceptions raised due to session not used by the client and hence do not exist in __del__
+                pass
             except Exception:  # noqa
                 demisto.debug('failed to close BaseClient session with the following error:\n{}'.format(traceback.format_exc()))
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -6951,7 +6951,7 @@ if 'requests' in sys.modules:
 
         def __del__(self):
             try:
-                if hasattr(self, '_session'):
+                if '_session' in self.__dict__:
                     self._session.close()
             except Exception:  # noqa
                 demisto.debug('failed to close BaseClient session with the following error:\n{}'.format(traceback.format_exc()))

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.yml
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.yml
@@ -23,4 +23,4 @@ tests:
 - Test-debug-mode
 - Test-CreateDBotScore-With-Reliability
 fromversion: 5.0.0
-dockerimage: demisto/python:2.7.18.24019
+dockerimage: demisto/python:2.7.18.24066

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.13.30",
+    "currentVersion": "1.13.31",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/DeveloperTools/TestPlaybooks/playbook-TestCommonPython.yml
+++ b/Packs/DeveloperTools/TestPlaybooks/playbook-TestCommonPython.yml
@@ -629,3 +629,4 @@ view: |-
     }
   }
 fromversion: 5.0.0
+description: ''

--- a/Packs/DeveloperTools/TestPlaybooks/script-TestPyCommonServer.yml
+++ b/Packs/DeveloperTools/TestPlaybooks/script-TestPyCommonServer.yml
@@ -581,6 +581,8 @@ script: >-
 
 
   if __name__ == '__builtin__':
+      c = BaseClient(base_url='www.google.com')
+      c.__del__()
       main()
 type: python
 subtype: python2

--- a/Packs/DeveloperTools/TestPlaybooks/script-TestPyCommonServer.yml
+++ b/Packs/DeveloperTools/TestPlaybooks/script-TestPyCommonServer.yml
@@ -615,3 +615,5 @@ scripttarget: 0
 runonce: false
 runas: DBotWeakRole
 fromversion: 5.0.0
+tests:
+- TestCommonPython


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/41215

## Description
`BaseClient` failed in `__del__` when used as global

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
