### PR TITLE
Delete wrong script id from ironscales's incident field to correalte scripts ids new validation

### DIFF
--- a/Packs/Ironscales/IncidentFields/incidentfield-Ironscales-Resolver-email-address.json
+++ b/Packs/Ironscales/IncidentFields/incidentfield-Ironscales-Resolver-email-address.json
@@ -8,7 +8,7 @@
     "closeForm": false,
     "content": true,
     "editForm": true,
-    "fieldCalcScript": "345fe646-a9fe-437b-89c3-fd7d0c02cd68",
+    "fieldCalcScript": "",
     "group": 0,
     "hidden": false,
     "id": "incident_ironscalesresolveremailaddress",

--- a/Packs/Ironscales/ReleaseNotes/1_0_2.md
+++ b/Packs/Ironscales/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Incident Fields
-- **Ironscales-Resolver-email-address**
-- Delete wrong script IDs in **Ironscales-Resolver-email-address**.
+**Ironscales-Resolver-email-address**
+- Maintenance and stability enhancements..

--- a/Packs/Ironscales/ReleaseNotes/1_0_2.md
+++ b/Packs/Ironscales/ReleaseNotes/1_0_2.md
@@ -1,4 +1,4 @@
 
 #### Incident Fields
 **Ironscales-Resolver-email-address**
-- Maintenance and stability enhancements..
+- Maintenance and stability enhancements.

--- a/Packs/Ironscales/ReleaseNotes/1_0_2.md
+++ b/Packs/Ironscales/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Incident Fields
+- **Ironscales-Resolver-email-address**
+- Delete wrong script IDs in **Ironscales-Resolver-email-address**.

--- a/Packs/Ironscales/pack_metadata.json
+++ b/Packs/Ironscales/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Ironscales",
     "description": "IRONSCALES is a self-learning email security platform, automatically responding to malicious emails.",
     "support": "partner",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Ironscales",
     "url": "",
     "email": "support@ironscales.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/39948

## Description
Deleted a wrong script id from Packs/Ironscales/IncidentFields/incidentfield-Ironscales-Resolver-email-address.json.
The deleted ID doesn't exist in content repository. 
In addition there aren't any scripts in the partner's original PR. 
According to @ShahafBenYakir the script ID is there by mistake and should be deleted. 

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
