### PR TITLE
Fix Recorded Feed Description Recommended Interval Fetch Grid 

### DIFF
--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture_description.md
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture_description.md
@@ -2,12 +2,12 @@
 1. It is highly recommended to not create multiple instances of the same indicator type, even when fetching both from fusion and connectApi. Creating multiple instances with same indicator type will lead to duplicate indicators being fetched which can cause performance issues for the server.
 2. Recommended interval for fetching indicators according to Recorded Future documentation:
 
-    | **Indicator Type** | **Recommended Fetch Interval**
-    | --- | --- |
-    | IP | 1 Hour. |
-    | Domain | 2 Hours. |
-    | Hash | 1 Day. |
-    | URL | 2 Hours. |
+| **Indicator Type** | **Recommended Fetch Interval**
+| --- | --- |
+| IP | 1 Hour. |
+| Domain | 2 Hours. |
+| Hash | 1 Day. |
+| URL | 2 Hours. |
 3. Per instance configuration, it is recommended to use either `connectApi` or `fusion` as a service for chosen indicator type, and not both, as most of the data between both services is duplicated.
 ## Recorded Future Feed
 This integration downloads from Recorded Future a list of IP addresses, domains, URLs, or file hashes with known risk associations.

--- a/Packs/FeedRecordedFuture/ReleaseNotes/1_0_15.md
+++ b/Packs/FeedRecordedFuture/ReleaseNotes/1_0_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Recorded Future RiskList Feed
+- Maintenance and stability enhancements.

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Recorded Future Feed",
     "description": "Ingests indicators from Recorded Future feeds into Demisto.",
     "support": "xsoar",
-    "currentVersion": "1.0.14",
+    "currentVersion": "1.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
While checking the description md file in Pycharm, it seemed as expected.

When I tried to configure an instance of RF Feed, it was not places correctly
![Screen Shot 2021-09-14 at 11 43 00](https://user-images.githubusercontent.com/70005542/133226244-8a237872-607d-4409-bc46-d7c9b5b430a1.png)

Fixing by removing the indents
![Screen Shot 2021-09-14 at 11 44 10](https://user-images.githubusercontent.com/70005542/133226287-3b86d71c-678d-4faa-a766-49b197450e3c.png)

Is this the expected behaviour? the diff between what is showed in description md in Pycharm to the server?
@dantavori  @Itay4 