### PR TITLE
bump up demisto/netutils:24101 over Integration and Automations

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_4_38.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_4_38.md
@@ -1,0 +1,11 @@
+#### Scripts
+##### IsRFC1918Address
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.
+##### IsInCidrRanges
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.
+##### IPv4Whitelist
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.
+##### IsNotInCidrRanges
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.
+##### IPv4Blacklist
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.

--- a/Packs/CommonScripts/Scripts/IPv4Blacklist/IPv4Blacklist.yml
+++ b/Packs/CommonScripts/Scripts/IPv4Blacklist/IPv4Blacklist.yml
@@ -22,7 +22,7 @@ args:
   isArray: true
 scripttarget: 0
 runonce: false
-dockerimage: demisto/netutils:1.0.0.23344
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - No test - unit test

--- a/Packs/CommonScripts/Scripts/IPv4Whitelist/IPv4Whitelist.yml
+++ b/Packs/CommonScripts/Scripts/IPv4Whitelist/IPv4Whitelist.yml
@@ -22,7 +22,7 @@ args:
   isArray: true
 scripttarget: 0
 runonce: false
-dockerimage: demisto/netutils:1.0.0.23344
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - No test - unit test

--- a/Packs/CommonScripts/Scripts/IsInCidrRanges/IsInCidrRanges.yml
+++ b/Packs/CommonScripts/Scripts/IsInCidrRanges/IsInCidrRanges.yml
@@ -18,7 +18,7 @@ args:
   description: Comma-separated list of IPv4 ranges in CIDR notation against which to match.
 scripttarget: 0
 runonce: false
-dockerimage: demisto/netutils:1.0.0.23344
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - No test - unit test

--- a/Packs/CommonScripts/Scripts/IsNotInCidrRanges/IsNotInCidrRanges.yml
+++ b/Packs/CommonScripts/Scripts/IsNotInCidrRanges/IsNotInCidrRanges.yml
@@ -18,7 +18,7 @@ args:
   description: Comma-separated list of IPv4 ranges in CIDR notation against which to match.
 scripttarget: 0
 runonce: false
-dockerimage: demisto/netutils:1.0.0.23344
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - No test - unit test

--- a/Packs/CommonScripts/Scripts/IsRFC1918Address/IsRFC1918Address.yml
+++ b/Packs/CommonScripts/Scripts/IsRFC1918Address/IsRFC1918Address.yml
@@ -19,7 +19,7 @@ args:
   description: The IPv4 address to check (can be used instead of the value argument).
 scripttarget: 0
 runonce: false
-dockerimage: demisto/netutils:1.0.0.14492
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - IsRFC1918-Test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.4.36",
+    "currentVersion": "1.4.38",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/DeveloperTools/ReleaseNotes/1_2_3.md
+++ b/Packs/DeveloperTools/ReleaseNotes/1_2_3.md
@@ -1,0 +1,3 @@
+#### Scripts
+##### CompareIndicators
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.

--- a/Packs/DeveloperTools/Scripts/CompareIndicators/CompareIndicators.yml
+++ b/Packs/DeveloperTools/Scripts/CompareIndicators/CompareIndicators.yml
@@ -27,7 +27,7 @@ outputs:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/netutils:1.0.0.23344
+dockerimage: demisto/netutils:1.0.0.24101
 runas: DBotWeakRole
 tests:
 - No test

--- a/Packs/DeveloperTools/pack_metadata.json
+++ b/Packs/DeveloperTools/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Developer Tools",
     "description": "Basic tools for content development.",
     "support": "xsoar",
-    "currentVersion": "1.2.2",
+    "currentVersion": "1.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Dig/Scripts/Dig/Dig.yml
+++ b/Packs/Dig/Scripts/Dig/Dig.yml
@@ -18,7 +18,7 @@ comment: 'DNS lookup utility to provide ''A'' and ''PTR'' record '
 commonfields:
   id: Dig
   version: -1
-dockerimage: demisto/netutils:1.0.0.22589
+dockerimage: demisto/netutils:1.0.0.24101
 enabled: true
 name: Dig
 runas: DBotRole

--- a/Packs/Dig/pack_metadata.json
+++ b/Packs/Dig/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Dig",
     "description": "Run Dig automation to get 'A' and 'PTR' records.",
     "support": "community",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Anil Agrawal",
     "url": "",
     "email": "",

--- a/Packs/FeedPublicDNS/Integrations/FeedPublicDNS/FeedPublicDNS.yml
+++ b/Packs/FeedPublicDNS/Integrations/FeedPublicDNS/FeedPublicDNS.yml
@@ -106,7 +106,7 @@ script:
     description: Gets indicators from the feed.
     execution: false
     name: public-dns-get-indicators
-  dockerimage: demisto/netutils:1.0.0.23344
+  dockerimage: demisto/netutils:1.0.0.24101
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedPublicDNS/ReleaseNotes/1_0_4.md
+++ b/Packs/FeedPublicDNS/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Public DNS Feed
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.
+

--- a/Packs/FeedPublicDNS/pack_metadata.json
+++ b/Packs/FeedPublicDNS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Public DNS Feed",
     "description": "The Public DNS Feed fetches known IPs associated with public DNS servers from https://public-dns.info/",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Tufin/Integrations/Tufin/Tufin.yml
+++ b/Packs/Tufin/Integrations/Tufin/Tufin.yml
@@ -281,7 +281,7 @@ script:
       description: Connection comment
       type: string
     description: Get SecureApp application connections
-  dockerimage: demisto/netutils:1.0.0.10767
+  dockerimage: demisto/netutils:1.0.0.24101
   runonce: false
   subtype: python3
 fromversion: 5.0.0

--- a/Packs/Tufin/ReleaseNotes/1_2_1.md
+++ b/Packs/Tufin/ReleaseNotes/1_2_1.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Tufin
+- Updated the Docker image to: *demisto/netutils:1.0.0.24101*.

--- a/Packs/Tufin/pack_metadata.json
+++ b/Packs/Tufin/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tufin",
     "description": "Gather network intelligence from SecureTrack and SecureApp, perform topology queries in SecureTrack, and submit change tickets from SecureChange.",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Tufin",
     "url": "https://www.tufin.com",
     "email": "support@tufin.com",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40179

## Description
update integration and script to use new tag of demisto/netutils:24101 which mitigate the APK vulnerability that was inherited from the base docker image python3

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
