### PR TITLE
Allow attaching files that do not have an explicit file name in XSOAR

### DIFF
--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
@@ -381,7 +381,7 @@ class MsGraphClient:
                 '@odata.type': cls.FILE_ATTACHMENT,
                 'contentBytes': b64_encoded_data.decode('utf-8'),
                 'isInline': is_inline,
-                'name': attach_name if provided_names else uploaded_file_name,
+                'name': attach_name if provided_names or not uploaded_file_name else uploaded_file_name,
                 'size': file_size
             }
             file_attachments_result.append(attachment)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Allow embedded attachments without file name with MicrosoftGraphMail

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
When providing embedded attachments to the `send-mail` command useing the `attachCIDs` parameter, sending the email fails when the attachment does not have a `uploaded_file_name`. 
See screenshot 1.
With this change, the file EntryID is used when no file name provided. This fixes the issue for embedded attachments.
For regular (not embedded) attachments everything works like before.

There are many situation when `uploaded_file_name` is empty (''), e.g., when the file entry is created by `!Base64ListToFile`.
See screenshot 2.

Looking at the `zip` function and comment a few lines above this change, it seems like you also stumbled over that problem at some point. However, you did not use the pre-filled `attach_name` here.
Using the `attach_name` pre-filled with the file EntryID if `uploaded_file_name` is empty fixes the issue.

## Screenshots
Screenshot 1: Before the change, when `provided_names` is false the attachment's name attribute is set to an empty string when `uploaded_file_name` is empty. This will cause error 400 in graph API. 
![grafik](https://user-images.githubusercontent.com/1359917/133619757-c46929ed-b75e-4fe1-85ff-6c0979ce6047.png)

Screenshot 2: output of `demisto.getFilePath()` for a file created using `!Base64ListToFile`. name attribute is empty.
![grafik](https://user-images.githubusercontent.com/1359917/133619008-afe8deaf-6a21-4dad-9ca9-427e8745d4de.png)


## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
