### PR TITLE
[BugFix] StixParser Custom Fields

### DIFF
--- a/Packs/Base/Scripts/StixParser/StixParser.py
+++ b/Packs/Base/Scripts/StixParser/StixParser.py
@@ -115,7 +115,7 @@ def create_indicator_entry(
     entry = dict()
     entry["indicator_type"] = indicator_type
     entry["value"] = value
-    entry["CustomFields"] = {"indicatorId": ind_id, "stixPackageId": pkg_id}
+    entry["CustomFields"] = {"indicatorid": ind_id, "stixpackageid": pkg_id}
     entry["source"] = source if source else ind_id.split("-")[0]
     entry["score"] = score
     # Times

--- a/Packs/Base/Scripts/StixParser/StixParser.py
+++ b/Packs/Base/Scripts/StixParser/StixParser.py
@@ -336,7 +336,7 @@ def stix2_to_demisto(stx_obj):
 
 def create_new_ioc(data, i, timestamp, pkg_id, ind_id):
     data.append({})
-    data[i]["CustomFields"] = {"indicatorId": ind_id, "stixPackageId": pkg_id}
+    data[i]["CustomFields"] = {"indicatorid": ind_id, "stixpackageid": pkg_id}
     data[i]["source"] = ind_id.split(":")[0]
     if timestamp:
         data[i]["timestamp"] = timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/Packs/CommonScripts/Scripts/CreateIndicatorsFromSTIX/CreateIndicatorsFromSTIX.py
+++ b/Packs/CommonScripts/Scripts/CreateIndicatorsFromSTIX/CreateIndicatorsFromSTIX.py
@@ -46,7 +46,7 @@ def main():
             "type": stix_struct_to_indicator.get(indicator.get("indicator_type")),
             "value": indicator.get("value"),
             "reputation": score_to_reputation(indicator.get("score")),
-            "source": indicator.get("CustomFields", {}).get("stixPackageId", "STIX Bundle"),
+            "source": indicator.get("CustomFields", {}).get("stixpackageid", "STIX Bundle"),
             "rawJSON": indicator,
         }
         for indicator in data


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)


## Description
We would like to be able to search on the “Stix Package Id” and “Indicator ID” and populate the details to the layout, which are created when a STIX file is uploaded via the UI or API. I see in the !StixParser we extract this data from the Stix file and add it to the indicator custom fields 
```
entry["CustomFields"] = {"indicatorId": ind_id, "stixPackageId": pkg_id}
```
these are not OOTB indicator fields as far as I can tell.  If I create indicator fields with the same name the Threat Intel page shows them automatically populated, but they are not searchable and do not appear populated on the indicator layout.  Is this a bug? I don’t see how anyone would necessarily use these custom fields as it stands today at least for this use case.  As custom fields are referenced using all lowercase should the code be changed to the following and we add these as OOTB indicator fields? This would solve their particular issue but not sure if backwards compatibility is an issue here that would block consideration.

```
entry["CustomFields"] = {"indicatorid": ind_id, "stixpackageid": pkg_id}
```

## Screenshots
<img width="788" alt="Screen Shot 2021-09-16 at 10 41 47 AM" src="https://user-images.githubusercontent.com/59053722/133640230-64017e5c-febd-4606-8f55-332a044c4cf9.png">
<img width="914" alt="Screen Shot 2021-09-16 at 10 41 02 AM" src="https://user-images.githubusercontent.com/59053722/133640236-95e8c62a-43c6-4b82-b192-0d5c44e96a5a.png">
<img width="978" alt="Screen Shot 2021-09-16 at 10 39 39 AM" src="https://user-images.githubusercontent.com/59053722/133640239-152618a6-e419-4ee1-aef7-6dcfcba3a87d.png">


## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility? 
Not sure this may potentially break it if someone has created a custom scripts which reference the custom fields as they are formatted today.

## Must have
- [ ] Tests
- [ ] Documentation 
