### PR TITLE
Exclude protected branches

### DIFF
--- a/Utils/github_workflow_scripts/delete_stale_non_contrib_branches.py
+++ b/Utils/github_workflow_scripts/delete_stale_non_contrib_branches.py
@@ -17,7 +17,7 @@ print = timestamped_print
 
 def get_non_contributor_stale_branch_names(repo: Repository) -> List[str]:  # noqa: E999
     """Return the list of branches that do not have the prefix of "contrib/" without open pull requests
-    and that have not been updated for 2 months (stale)
+    and that have not been updated for 2 months (stale). Protected branches are excluded from consideration.
 
     Args:
         repo (Repository): The repository whose branches will be searched and listed

--- a/Utils/github_workflow_scripts/delete_stale_non_contrib_branches.py
+++ b/Utils/github_workflow_scripts/delete_stale_non_contrib_branches.py
@@ -33,6 +33,9 @@ def get_non_contributor_stale_branch_names(repo: Repository) -> List[str]:  # no
     for branch in all_branches:
         # Make sure the branch is not prefixed with contrib
         if not branch.name.startswith('contrib/'):
+            if branch.protected:
+                print(f"Skipping branch {branch.name} because it is a protected branch")
+                continue
             # Make sure HEAD commit is stale
             if (last_modified := branch.commit.commit.last_modified) and (
                     last_commit_datetime := parse(last_modified)):


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Our maintenance script `delete_stale_non_contrib_branches.py` which deletes stale non-contribution branches will try to create time after time a posterity PR for stale branches which are protected (since it doesn't successfully delete the branch after creating the posterity PR and therefore the branch is collected as stale the next time the script is run). I've updated the script so that it does not consider protected branches.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests - N/A
- [x] Documentation
