### PR TITLE
Update CrowdStrikeFalcon.yml to fix capitalisation error

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -83,12 +83,12 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: 'The status of the device. Possible values are: "Normal", "containment_pending",
+      description: 'The status of the device. Possible values are: "normal", "containment_pending",
         "contained", and "lift_containment_pending".'
       isArray: false
       name: status
       predefined:
-      - Normal
+      - normal
       - containment_pending
       - contained
       - lift_containment_pending


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- Ready

## Related Issues
fixes: I couldn't find Issues section in Github, below is a full description.

## Description
It seems your command arguments text box at the xsoar playbook integration settings has auto-capitalisation and so for Crowdstrike you have this listed as the available options that become available:

Normal,containment_pending,contained,lift_containment_pending

However, the integration, like all others, uses lower-case only and so the python script will fail when you submit 'Normal' as it is only expecting 'normal'.

I expect this error is probably prevalent across many more integrations and properties.

## Screenshots
![image](https://user-images.githubusercontent.com/32641242/134950662-17c32c15-f930-4608-b600-7e928e773121.png)

## Minimum version of Cortex XSOAR
- 6.2.0

## Does it break backward compatibility?
   - No

