### PR TITLE
Fix Gitlab Branch Deletion Scheduled Pipeline

### DIFF
--- a/.gitlab/ci/miscellaneous.yml
+++ b/.gitlab/ci/miscellaneous.yml
@@ -2,7 +2,8 @@ delete-mismatched-branches:
   tags:
     - gke
   stage: .pre
-  extends: .default-job-settings
+  extends:
+    - .default-job-settings
   rules:
     - if: '$DELETE_MISMATCHED_BRANCHES'
   script:

--- a/.gitlab/ci/miscellaneous.yml
+++ b/.gitlab/ci/miscellaneous.yml
@@ -5,7 +5,8 @@ delete-mismatched-branches:
   extends:
     - .default-job-settings
   rules:
-    - if: '$DELETE_MISMATCHED_BRANCHES'
+    - if: '$DELETE_MISMATCHED_BRANCHES == "true"'
+      when: always
   script:
     - python3 ./Utils/delete_mismatched_branches.py
   retry:

--- a/.gitlab/ci/miscellaneous.yml
+++ b/.gitlab/ci/miscellaneous.yml
@@ -8,6 +8,7 @@ delete-mismatched-branches:
     - if: '$DELETE_MISMATCHED_BRANCHES == "true"'
       when: always
   script:
-    - python3 ./Utils/delete_mismatched_branches.py
+    - cd Utils
+    - python3 delete_mismatched_branches.py
   retry:
     max: 2

--- a/.gitlab/ci/miscellaneous.yml
+++ b/.gitlab/ci/miscellaneous.yml
@@ -1,7 +1,7 @@
 delete-mismatched-branches:
   tags:
     - gke
-  stage: .pre
+  stage: fan-in
   extends:
     - .default-job-settings
   rules:

--- a/Utils/delete_mismatched_branches.py
+++ b/Utils/delete_mismatched_branches.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import gitlab
+from blessings import Terminal
 from github import Github
 from github_workflow_scripts.utils import timestamped_print, get_env_var
 
@@ -20,6 +21,7 @@ def main():
     from the Github repository from which we mirror from. This script deletes from GitLab the branches which no
     longer exist in Github.
     """
+    t = Terminal()
     # get github content repo's branches
     github = Github(get_env_var('CONTENT_GITHUB_TOKEN'), verify=False)
     organization = 'demisto'
@@ -44,8 +46,11 @@ def main():
     # delete gitlab branches
     for gitlab_branch in gitlab_branches:
         if gitlab_branch_name := gitlab_branch.name not in github_branch_names:
-            gitlab_branch.delete()
-            print(f'deleted "{gitlab_branch_name}"')
+            try:
+                gitlab_branch.delete()
+                print(f'deleted "{gitlab_branch_name}"')
+            except gitlab.exceptions.GitlabError as e:
+                print(f'{t.red}Deletion of {gitlab_branch_name} encountered an issue: {str(e)}{t.normal}')
 
 
 if __name__ == "__main__":

--- a/Utils/delete_mismatched_branches.py
+++ b/Utils/delete_mismatched_branches.py
@@ -49,7 +49,7 @@ def main():
 
     # delete gitlab branches
     for gitlab_branch in gitlab_branches:
-        if gitlab_branch_name := gitlab_branch.name not in github_branch_names:
+        if (gitlab_branch_name := gitlab_branch.name) not in github_branch_names:
             try:
                 gitlab_branch.delete()
                 print(f'{GREEN}deleted "{gitlab_branch_name}"{RESET}')

--- a/Utils/delete_mismatched_branches.py
+++ b/Utils/delete_mismatched_branches.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 
 import gitlab
-from blessings import Terminal
 from github import Github
 from github_workflow_scripts.utils import timestamped_print, get_env_var
+
+
+# ANSI Colors
+RED = '\033[0;31m'
+GREEN = '\033[0;32m'
+RESET = '\033[0m'
 
 
 GITLAB_PROJECT_ID = get_env_var('CI_PROJECT_ID', '2596')  # the default is the id of the content project in code.pan.run
@@ -21,7 +26,6 @@ def main():
     from the Github repository from which we mirror from. This script deletes from GitLab the branches which no
     longer exist in Github.
     """
-    t = Terminal()
     # get github content repo's branches
     github = Github(get_env_var('CONTENT_GITHUB_TOKEN'), verify=False)
     organization = 'demisto'
@@ -48,9 +52,9 @@ def main():
         if gitlab_branch_name := gitlab_branch.name not in github_branch_names:
             try:
                 gitlab_branch.delete()
-                print(f'deleted "{gitlab_branch_name}"')
+                print(f'{GREEN}deleted "{gitlab_branch_name}"{RESET}')
             except gitlab.exceptions.GitlabError as e:
-                print(f'{t.red}Deletion of {gitlab_branch_name} encountered an issue: {str(e)}{t.normal}')
+                print(f'{RED}Deletion of {gitlab_branch_name} encountered an issue: {str(e)}{RESET}')
 
 
 if __name__ == "__main__":

--- a/Utils/delete_mismatched_branches.py
+++ b/Utils/delete_mismatched_branches.py
@@ -2,7 +2,7 @@
 
 import gitlab
 from github import Github
-from .github_workflow_scripts.utils import timestamped_print, get_env_var
+from github_workflow_scripts.utils import timestamped_print, get_env_var
 
 
 GITLAB_PROJECT_ID = get_env_var('CI_PROJECT_ID', '2596')  # the default is the id of the content project in code.pan.run


### PR DESCRIPTION
## Status
- [x] Ready

## Description
The scheduled pipeline to delete Gitlab branches that exist in the `content` project in Gitlab but do not exist in the GitHub repository (from which the repo is mirrored) was not executing as expected. Background on the issue is that the mirroring of the Github repo does not extend to branch deletion so once a branch is mirrored into Gitlab it is never subsequently deleted. The scheduled pipeline did not execute because the stage was set to `.pre`. I've updated it to use the `fan-in` stage - no stage was exactly appropriate for this cleanup pipeline so my choice was somewhat arbitrary. 

## Screenshots
The number of branches in the `content` project in Gitlab prior to manually triggering the pipeline
![image](https://user-images.githubusercontent.com/46294017/135247162-edd9a439-086c-48da-910f-07b2c1a3f623.png)

The number of branches in the `content` project in Gitlab subsequent to running the pipeline - note that the number of branches now matches the count which exists in GitHub (at the time of opening this PR)
![image](https://user-images.githubusercontent.com/46294017/135247425-3a98f536-5d8e-4073-8d2b-03f400737683.png)


## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ - N/A
- [x] ~~Documentation~~ - N/A
