### PR TITLE
Elasticsearch v2 - update Server URL description

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -7,6 +7,7 @@ configuration:
   name: url
   required: true
   type: 0
+  additionalInfo: The Elasticsearch server to which the integration connects. Ensure that the URL includes the correct Elasticsearch port. By default this is 9200.
 - additionalinfo: Provide Username + Passoword instead of API key + API ID
   display: Username for server login
   name: credentials

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -7,7 +7,7 @@ configuration:
   name: url
   required: true
   type: 0
-  additionalInfo: The Elasticsearch server to which the integration connects. Ensure that the URL includes the correct Elasticsearch port. By default this is 9200.
+  additionalinfo: The Elasticsearch server to which the integration connects. Ensure that the URL includes the correct Elasticsearch port. By default this is 9200.
 - additionalinfo: Provide Username + Passoword instead of API key + API ID
   display: Username for server login
   name: credentials

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/README.md
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/README.md
@@ -20,7 +20,7 @@
 <li>
 <strong>Name</strong>: a textual name for the integration instance.</li>
 <li>
-<strong>Server URL</strong>: the Elasticsearch server to which the integration connects.</li>
+<strong>Server URL</strong>: the Elasticsearch server to which the integration connects. Ensure that the URL includes the correct Elasticsearch port. By default this is 9200.</li>
 <li>
 <strong>Username and password</strong>: to log in to the server.</li>
 </ul>

--- a/Packs/Elasticsearch/ReleaseNotes/1_1_8.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_1_8.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Elasticsearch v2
+- Updated the **URL** parameter description with the suggested default parameter.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Added the following description to the Server URL field in light of feedback on dmst-usecases channel:
"Ensure that the URL includes the correct Elasticsearch port. By default this is 9200."

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
