### PR TITLE
Add input to create service now ticket playbook

### DIFF
--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
@@ -1,12 +1,15 @@
 id: Create ServiceNow Ticket
 version: -1
+contentitemexportablefields:
+  contentitemfields: {}
 name: Create ServiceNow Ticket
 description: "Create ServiceNow Ticket allows you to open new tickets as a task from\
-  \ a parent playbook.\nWhen creating the ticket, you can decide to update based on on the ticket's state, which\
-  \ will wait for the ticket to resolve or close with StatePolling. \nAlternatively, you can\
-  \ select to mirror the ServiceNow ticket and incident fields.
-  \ To apply either of these options, set the SyncTicket value in the playbook inputs to one of the following options:\
-  \ \n1. StatePolling\n2. Mirror\n3. Leave Blank to use none."
+  \ a parent playbook.\nWhen creating the ticket, you can decide to update based on\
+  \ on the ticket's state, which will wait for the ticket to resolve or close with\
+  \ StatePolling. \nAlternatively, you can select to mirror the ServiceNow ticket\
+  \ and incident fields.  To apply either of these options, set the SyncTicket value\
+  \ in the playbook inputs to one of the following options: \n1. StatePolling\n2.\
+  \ Mirror\n3. Leave Blank to use none."
 starttaskid: "0"
 tasks:
   "0":
@@ -22,136 +25,13 @@ tasks:
       description: ''
     nexttasks:
       '#none#':
-      - "3"
+      - "13"
     separatecontext: false
     view: |-
       {
         "position": {
           "x": 450,
           "y": 60
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
-  "3":
-    id: "3"
-    taskid: ae4ddf63-1283-46ce-8c36-31173098968b
-    type: regular
-    task:
-      id: ae4ddf63-1283-46ce-8c36-31173098968b
-      version: -1
-      name: Create ServiceNow ticket
-      description: Creates a ServiceNow ticket.
-      script: ServiceNow v2|||servicenow-create-ticket
-      type: regular
-      iscommand: true
-      brand: ServiceNow v2
-    nexttasks:
-      '#none#':
-      - "9"
-    scriptarguments:
-      active: {}
-      activity_due: {}
-      additional_assignee_list: {}
-      additional_fields: {}
-      approval: {}
-      approval_history: {}
-      approval_set: {}
-      assigned_to: {}
-      assignment_group:
-        complex:
-          root: inputs.AssignmentGroup
-      business_duration: {}
-      business_service: {}
-      business_stc: {}
-      calendar_duration: {}
-      caller: {}
-      caller_id:
-        complex:
-          root: ServiceNow.User
-          accessor: ID
-      category:
-        complex:
-          root: inputs.Category
-      caused_by: {}
-      change_type: {}
-      close_code: {}
-      close_notes: {}
-      closed_at: {}
-      closed_by: {}
-      cmdb_ci: {}
-      comments:
-        complex:
-          root: inputs.Comment
-      comments_and_work_notes: {}
-      company: {}
-      contact_type: {}
-      correlation_display: {}
-      correlation_id: {}
-      custom_fields: {}
-      delivery_plan: {}
-      description: {}
-      display: {}
-      due_date: {}
-      escalation: {}
-      expected_start: {}
-      follow_up: {}
-      group_list: {}
-      impact:
-        complex:
-          root: inputs.Impact
-      incident_state: {}
-      input_display_value: {}
-      knowledge: {}
-      location: {}
-      made_sla: {}
-      notify: {}
-      number: {}
-      opened_at: {}
-      order: {}
-      parent: {}
-      parent_incident: {}
-      priority: {}
-      problem_id: {}
-      reassignment_count: {}
-      reopen_count: {}
-      resolved_at: {}
-      resolved_by: {}
-      rfc: {}
-      severity:
-        complex:
-          root: 'inputs.Severity '
-      short_description:
-        complex:
-          root: inputs.ShortDescription
-      sla_due: {}
-      state: {}
-      subcategory: {}
-      sys_updated_by: {}
-      sys_updated_on: {}
-      template: {}
-      ticket_type: {}
-      urgency:
-        complex:
-          root: inputs.Urgency
-      user_input: {}
-      using:
-        complex:
-          root: inputs.InstanceName
-      watch_list: {}
-      work_end: {}
-      work_notes: {}
-      work_notes_list: {}
-      work_start: {}
-    separatecontext: false
-    view: |-
-      {
-        "position": {
-          "x": 450,
-          "y": 220
         }
       }
     note: false
@@ -192,10 +72,10 @@ tasks:
       id: ccbdd637-fa6d-4c61-8c8f-5335843393b4
       version: -1
       name: Mirror or State Polling?
+      description: Check for a playbook input to indicate which sync mode was selected.
       type: condition
       iscommand: false
       brand: ""
-      description: 'Check for a playbook input to indicate which sync mode was selected.'
     nexttasks:
       '#default#':
       - "8"
@@ -355,6 +235,68 @@ tasks:
     ignoreworker: false
     skipunavailable: false
     quietmode: 0
+  "13":
+    id: "13"
+    taskid: c5b89716-e739-462c-817d-29ad856a6034
+    type: regular
+    task:
+      id: c5b89716-e739-462c-817d-29ad856a6034
+      version: -1
+      name: Create ServiceNow ticket
+      description: Creates a ServiceNow ticket.
+      script: ServiceNow v2|||servicenow-create-ticket
+      type: regular
+      iscommand: true
+      brand: ServiceNow v2
+    nexttasks:
+      '#none#':
+      - "9"
+    scriptarguments:
+      assignment_group:
+        complex:
+          root: inputs.AssignmentGroup
+      caller_id:
+        complex:
+          root: ServiceNow.User
+          accessor: ID
+      category:
+        complex:
+          root: inputs.Category
+      comments:
+        complex:
+          root: inputs.Comment
+      impact:
+        complex:
+          root: inputs.Impact
+      severity:
+        complex:
+          root: 'inputs.Severity '
+      short_description:
+        complex:
+          root: inputs.ShortDescription
+      ticket_type:
+        complex:
+          root: inputs.TicketType
+      urgency:
+        complex:
+          root: inputs.Urgency
+      using:
+        complex:
+          root: inputs.InstanceName
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 230
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+system: true
 view: |-
   {
     "linkLabelsPosition": {
@@ -380,7 +322,7 @@ inputs:
 - key: AssignmentGroup
   value: {}
   required: false
-  description: 'The group to which to assign the new ticket.'
+  description: The group to which to assign the new ticket.
   playbookInputQuery:
 - key: ShortDescription
   value: {}
@@ -390,12 +332,14 @@ inputs:
 - key: Impact
   value: {}
   required: false
-  description: Set the impact for the new ticket. Leave empty for ServiceNow default impact.
+  description: Set the impact for the new ticket. Leave empty for ServiceNow default
+    impact.
   playbookInputQuery:
 - key: Urgency
   value: {}
   required: false
-  description: Set the urgency of the new ticket. Leave empty for ServiceNow default urgency.
+  description: Set the urgency of the new ticket. Leave empty for ServiceNow default
+    urgency.
   playbookInputQuery:
 - key: 'Severity '
   value: {}
@@ -413,12 +357,11 @@ inputs:
   required: false
   description: "Set the value of the desired sync method with ServiceNow Ticket. you\
     \ can choose one of three options:\n1. StatePolling\n2. Mirror \n3. Blank for\
-    \ none \n\nGenericPolling polls for the state of the\
-    \ ticket and runs until the ticket state is either resolved or\
-    \ closed. \n\nMirror - You can use the Mirror option to perform a full sync with\
-    \ the ServiceNow Ticket. The ticket data is synced automatically between ServiceNow\
-    \ and Cortex xSOAR with the ServiceNow mirror feature.\nIf this option is selected,\
-    \ FieldPolling is true by default. "
+    \ none \n\nGenericPolling polls for the state of the ticket and runs until the\
+    \ ticket state is either resolved or closed. \n\nMirror - You can use the Mirror\
+    \ option to perform a full sync with the ServiceNow Ticket. The ticket data is\
+    \ synced automatically between ServiceNow and Cortex xSOAR with the ServiceNow\
+    \ mirror feature.\nIf this option is selected, FieldPolling is true by default. "
   playbookInputQuery:
 - key: PollingInterval
   value: {}
@@ -453,8 +396,8 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "Set the mirror direction, should be one of the following: \n1. In\n2. Out\n3.
-    Both"
+  description: "Set the mirror direction, should be one of the following: \n1. In\n\
+    2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorCommentTags
   value:
@@ -471,7 +414,19 @@ inputs:
     It is useful when it is needed to wait for the ServiceNow ticket to be resolved and continue the parent playbook.
     FieldPolling will run until the ticket state is either resolved or closed.
   playbookInputQuery:
+- key: TicketType
+  value: {}
+  required: false
+  description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
+    "sc_task", or "sc_req_item". Default is "incident".
+  playbookInputQuery:
 outputs: []
 tests:
-- No tests (auto formatted)
+- Create ServiceNow Ticket and Mirror Test
+- Create ServiceNow Ticket and State Polling Test
+- ServiceNow_CMDB_OAuth_Test
+- ServiceNow_CMDB_Test
+- ServiceNow_OAuth_Test
+- servicenow_test_v2
+- ServiceNow IAM - Test Playbook
 fromversion: 6.0.0

--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
@@ -396,7 +396,7 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "Set the mirror direction, should be one of the following: \n1. In\n\
+  description: "Set the mirror direction. It should be one of the following: \n1. In\n\
     2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorCommentTags
@@ -410,14 +410,14 @@ inputs:
     simple: "true"
   required: false
   description: |-
-    Set the value to true or false to determine if the paybook will execute the FieldPolling sub playbook.
+    Set the value to true or false to determine if the playbook will execute the FieldPolling sub playbook.
     It is useful when it is needed to wait for the ServiceNow ticket to be resolved and continue the parent playbook.
     FieldPolling will run until the ticket state is either resolved or closed.
   playbookInputQuery:
 - key: TicketType
   value: {}
   required: false
-  description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
+  description: Set the ServiceNow ticket type. Options are "incident", "problem", "change_request", "sc_request",
     "sc_task", or "sc_req_item". Default is "incident".
   playbookInputQuery:
 outputs: []

--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket_README.md
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket_README.md
@@ -38,10 +38,10 @@ This playbook does not use any scripts.
 | PollingTimeout | Set the amount of time to poll the status of the ticket before declaring a timeout and resuming the playbook.<br/>\(In minutes\) |  | Optional |
 | AdditionalPollingCommandName | In this use case, Additional polling commands are relevant when using StatePolling, and there is more than one ServiceNow instance. It will specify the polling command to use a specific instance to run on. <br/>If so, please add "Using" to the value. <br/>The playbook will then take the instance name as the instance to use.  |  | Optional |
 | InstanceName | Set the ServiceNow Instance that will be used for mirroring/running polling commands.<br/> |  | Optional |
-| MirrorDirection | Set the mirror direction, should be one of the following: <br/>1. In<br/>2. Out<br/>3. Both | Both | Optional |
+| MirrorDirection | Set the mirror direction. It should be one of the following: <br/>1. In<br/>2. Out<br/>3. Both | Both | Optional |
 | MirrorCommentTags | Set tags for mirror comments and files to ServiceNow. | comments,work_notes,ForServiceNow | Optional |
-| FieldPolling | Set the value to true or false to determine if the paybook will execute the FieldPolling sub playbook.<br/>It is useful when it is needed to wait for the ServiceNow ticket to be resolved and continue the parent playbook.<br/>FieldPolling will run until the ticket state is either resolved or closed. | true | Optional |
-| TicketType | Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", or "sc_req_item". Default is "incident". |  | Optional |
+| FieldPolling | Set the value to true or false to determine if the playbook will execute the FieldPolling sub playbook.<br/>It is useful when it is needed to wait for the ServiceNow ticket to be resolved and continue the parent playbook.<br/>FieldPolling will run until the ticket state is either resolved or closed. | true | Optional |
+| TicketType | Set the ServiceNow ticket type. Options are "incident", "problem", "change_request", "sc_request", "sc_task", or "sc_req_item". |  | Optional |
 
 ## Playbook Outputs
 ---

--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket_README.md
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket_README.md
@@ -1,7 +1,6 @@
 Create ServiceNow Ticket allows you to open new tickets as a task from a parent playbook.
-It is an option to set sync with the ticket's state, which will wait for the ticket to resolve or close with StatePolling.
-You can alternatively select to mirror the ServiceNow ticket and incident fields. Mirroring includes its equivalent for StatePolling -  FieldPolling.
-To apply either of these options, set the SyncTicket value in the playbook inputs to one of the following options:
+When creating the ticket, you can decide to update based on on the ticket's state, which will wait for the ticket to resolve or close with StatePolling. 
+Alternatively, you can select to mirror the ServiceNow ticket and incident fields.  To apply either of these options, set the SyncTicket value in the playbook inputs to one of the following options: 
 1. StatePolling
 2. Mirror
 3. Leave Blank to use none.
@@ -10,8 +9,8 @@ To apply either of these options, set the SyncTicket value in the playbook input
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
-* Mirror ServiceNow Ticket
 * ServiceNow Ticket State Polling
+* Mirror ServiceNow Ticket
 
 ### Integrations
 * ServiceNow v2
@@ -28,20 +27,21 @@ This playbook does not use any scripts.
 | **Name** | **Description** | **Default Value** | **Required** |
 | --- | --- | --- | --- |
 | Category | Set the category of the ServiceNow Ticket. |  | Optional |
-| AssignmentGroup | The group to assign the new ticket to  |  | Optional |
-| ShortDescription | Set A short description of the ticket. |  | Optional |
-| Impact | Set Impact for the new ticket, leave empty for ServiceNow default impact. |  | Optional |
-| Urgency | Set urgency to the new ticket, leave empty for ServiceNow default urgency. |  | Optional |
-| Severity  | Set severity to the new ticket, leave empty for ServiceNow default severity. |  | Optional |
+| AssignmentGroup | The group to which to assign the new ticket. |  | Optional |
+| ShortDescription | Set a short description of the ticket. |  | Optional |
+| Impact | Set the impact for the new ticket. Leave empty for ServiceNow default impact. |  | Optional |
+| Urgency | Set the urgency of the new ticket. Leave empty for ServiceNow default urgency. |  | Optional |
+| Severity  | Set the severity of the new ticket. Leave empty for ServiceNow default severity. |  | Optional |
 | Comment | Add a comment for the created ticket. |  | Optional |
-| SyncTicket | Set the value of the desired sync method with ServiceNow Ticket. you can choose one of three options:<br/>1. StatePolling<br/>2. Mirror <br/>3. Blank for none <br/><br/>GenericPolling uses as cold sync, which polls for the state of the ticket.<br/>GenericPoliing will run until the ticket state is either resolved or closed. <br/><br/>Mirror - You can use the Mirror option to perform a full sync with ServiceNow Ticket. The ticket data is synced automatically between ServiceNow and Cortex xSOAR with the ServiceNow mirror feature.<br/>If this option is selected, FieldPolling is true by default.  |  | Optional |
+| SyncTicket | Set the value of the desired sync method with ServiceNow Ticket. you can choose one of three options:<br/>1. StatePolling<br/>2. Mirror <br/>3. Blank for none <br/><br/>GenericPolling polls for the state of the ticket and runs until the ticket state is either resolved or closed. <br/><br/>Mirror - You can use the Mirror option to perform a full sync with the ServiceNow Ticket. The ticket data is synced automatically between ServiceNow and Cortex xSOAR with the ServiceNow mirror feature.<br/>If this option is selected, FieldPolling is true by default.  |  | Optional |
 | PollingInterval | Set interval time for the polling to run<br/>\(In minutes\) |  | Optional |
 | PollingTimeout | Set the amount of time to poll the status of the ticket before declaring a timeout and resuming the playbook.<br/>\(In minutes\) |  | Optional |
 | AdditionalPollingCommandName | In this use case, Additional polling commands are relevant when using StatePolling, and there is more than one ServiceNow instance. It will specify the polling command to use a specific instance to run on. <br/>If so, please add "Using" to the value. <br/>The playbook will then take the instance name as the instance to use.  |  | Optional |
 | InstanceName | Set the ServiceNow Instance that will be used for mirroring/running polling commands.<br/> |  | Optional |
-| MirrorDirection | Set the mirror direction, should be one of the following: <br/>1. Out<br/>2. Both | Both | Optional |
+| MirrorDirection | Set the mirror direction, should be one of the following: <br/>1. In<br/>2. Out<br/>3. Both | Both | Optional |
 | MirrorCommentTags | Set tags for mirror comments and files to ServiceNow. | comments,work_notes,ForServiceNow | Optional |
 | FieldPolling | Set the value to true or false to determine if the paybook will execute the FieldPolling sub playbook.<br/>It is useful when it is needed to wait for the ServiceNow ticket to be resolved and continue the parent playbook.<br/>FieldPolling will run until the ticket state is either resolved or closed. | true | Optional |
+| TicketType | Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", or "sc_req_item". Default is "incident". |  | Optional |
 
 ## Playbook Outputs
 ---
@@ -49,4 +49,4 @@ There are no outputs for this playbook.
 
 ## Playbook Image
 ---
-![Create ServiceNow Ticket](https://raw.githubusercontent.com/demisto/content/master/Packs/ServiceNow/doc_files/Create_ServiceNow_Ticket.png)
+![Create ServiceNow Ticket](../doc_files/Create_ServiceNow_Ticket.png)

--- a/Packs/ServiceNow/ReleaseNotes/2_2_7.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_2_7.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Create ServiceNow Ticket
+- Added ticket type input to Create ServiceNow Ticket playbook.  

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.2.6",
+    "currentVersion": "2.2.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41703

## Description
The playbook "Create ServiceNow Ticket" missing the input Ticket type, As a result of that the playbook only creates incidents.
Added ticket type input to Create ServiceNow Ticket playbook


## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
