### PR TITLE
Change Microsoft Graph User Terminate Command Description

### DIFF
--- a/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/MicrosoftGraphUser.yml
+++ b/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/MicrosoftGraphUser.yml
@@ -59,8 +59,9 @@ script:
       secret: false
     deprecated: false
     description: |-
-      Terminates a user's session from all Office 365 applications, and prevents sign in.
-      Supported only in a self deployed app flow with the Permission: Directory.AccessAsUser.All(Delegated)
+      Disables a user from all Office 365 applications, and prevents sign in. Note: This command disables user,
+      but does not terminate an existing session. Supported only in a self deployed app flow with the
+      Permission: Directory.AccessAsUser.All(Delegated)
     execution: false
     name: msgraph-user-terminate-session
   - arguments:

--- a/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/README.md
+++ b/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/README.md
@@ -61,7 +61,7 @@ For more details about the authentication used in this integration, see <a href=
 </div>
 <div class="cl-preview-section"><hr></div>
 <div class="cl-preview-section">
-<p>Terminates a user’s session from all Office 365 applications, and prevents sign in. Can only work with a self-deployed application and the permission: Directory.AccessAsUser.All(Delegated)</p>
+<p>Disables a user from all Office 365 applications, and prevents sign in. Note: This command disables user, but does not terminate an existing session. Supported only in a self deployed app flow with the Permission: Directory.AccessAsUser.All(Delegated)</p>
 </div>
 <div class="cl-preview-section">
 <h5 id="base-command">Base Command</h5>

--- a/Packs/MicrosoftGraphUser/ReleaseNotes/1_3_13.md
+++ b/Packs/MicrosoftGraphUser/ReleaseNotes/1_3_13.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Azure Active Directory Users
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftGraphUser/pack_metadata.json
+++ b/Packs/MicrosoftGraphUser/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph User",
     "description": "Use the Microsoft Graph integration to connect to and interact with user objects on Microsoft Platforms.",
     "support": "xsoar",
-    "currentVersion": "1.3.12",
+    "currentVersion": "1.3.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Changing the Microsoft Graph User Description For Command Because It Was Misleading. As Can Be Seen Here
https://github.com/demisto/etc/issues/41571