### PR TITLE
Only sync contrib base branch with master at night

### DIFF
--- a/.github/workflows/sync-contribution-base-branch.yml
+++ b/.github/workflows/sync-contribution-base-branch.yml
@@ -1,8 +1,8 @@
 name: Sync contributor base branch
 on:
   schedule:
-    # runs at minute 0 of the 0th and 12th hour every day.
-    - cron:  '0 0,12 * * *'
+    # runs at minute 0 of the 0th hour every day.
+    - cron:  '0 0 * * *'
 
 jobs:
   sync_contributor_base_branch:


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Only syncs contribution PRs' base branches with updated `master` at night. This should reduce the runner instance load during the day (when people are working) since we don't want any pipeline bottlenecking. See this [slack discussion](https://panw-global.slack.com/archives/C0117K6N5NW/p1633009822195600) for more details.

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ - N/A
- [x] ~~Documentation~~ - N/A
