### PR TITLE
All search tickets in Contents

### DIFF
--- a/Packs/OTRS/Integrations/OTRS/OTRS.py
+++ b/Packs/OTRS/Integrations/OTRS/OTRS.py
@@ -260,6 +260,7 @@ def search_ticket_command():
 
     if tickets:
         output = []
+        raw_output = []
         for ticket_id in tickets:
             raw_ticket = get_ticket(ticket_id)
             ticket = {
@@ -274,6 +275,7 @@ def search_ticket_command():
                 'Type': raw_ticket['Type']
             }
             output.append(ticket)
+            raw_output.append(raw_ticket)
         ec = {
             'OTRS.Ticket(val.ID===obj.ID)': output
         }
@@ -282,7 +284,7 @@ def search_ticket_command():
 
         demisto.results({
             'Type': entryTypes['note'],
-            'Contents': raw_ticket,
+            'Contents': raw_output,
             'ContentsFormat': formats['json'],
             'ReadableContentsFormat': formats['markdown'],
             'HumanReadable': tableToMarkdown(title, output, headers),


### PR DESCRIPTION
OTRS Integrations search command only contained the last raw ticket in "Contents". Fixed to store all of them in list like EntryContext.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
The search command of OTRS Integration only returns the last raw ticket which is missleading when using in an automation.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
