### PR TITLE
bump up SplunkPy to use demisto/splunksdk:1.0.0.24033

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -763,7 +763,7 @@ script:
   - name: splunk-reset-enriching-fetch-mechanism
     arguments: []
     description: Resets the enrichment mechanism of fetched notables.
-  dockerimage: demisto/splunksdk:1.0.0.23135
+  dockerimage: demisto/splunksdk:1.0.0.24033
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/ReleaseNotes/2_2_1.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_2_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Updated the Docker image to: *demisto/splunksdk:1.0.0.24033*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.2.0",
+    "currentVersion": "2.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40179

## Description
Updating the SplunkPy to use the latest docker image of demisto/splunksdk to use tag  1.0.0.24033 that  mitgate CVE-2021-36159 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
