### PR TITLE
Checkpoint FWv2: test connection on SID restore

### DIFF
--- a/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2.py
+++ b/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2.py
@@ -64,9 +64,9 @@ class Client(BaseClient):
                                           domain_arg: str = None):
 
         if sid_from_context := demisto.getIntegrationContext().get('cp_sid'):
-            demisto.debug(f"restore sid: found some session id ({sid_from_context}) in context ")
+            demisto.debug(f"restore sid: found some session id ({sid_from_context}) in context")
             if self.test_connection() == 'ok':
-                demisto.debug(f"restore sid: success, setting restored session id ({sid_from_context}) on Client ")
+                demisto.debug(f"restore sid: success, setting restored session id ({sid_from_context}) on Client")
                 self.sid = sid_from_context
                 return
             else:

--- a/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2.py
+++ b/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2.py
@@ -62,12 +62,18 @@ class Client(BaseClient):
 
     def restore_sid_from_context_or_login(self, username: str, password: str, session_timeout: int,
                                           domain_arg: str = None):
+
         if sid_from_context := demisto.getIntegrationContext().get('cp_sid'):
-            demisto.debug(f"restore sid: success, setting restored sid on Client (sid={sid_from_context})")
-            self.sid = sid_from_context
-        else:
-            demisto.debug("restore sid: failed to restore, logging in")
-            self.login(username, password, session_timeout, domain_arg)
+            demisto.debug(f"restore sid: found some session id ({sid_from_context}) in context ")
+            if self.test_connection() == 'ok':
+                demisto.debug(f"restore sid: success, setting restored session id ({sid_from_context}) on Client ")
+                self.sid = sid_from_context
+                return
+            else:
+                demisto.debug(f"restore sid: test-connection with session id ({sid_from_context}) failed")
+
+        demisto.debug("restore sid: failure, attempting login instead")
+        self.login(username, password, session_timeout, domain_arg)
 
     def test_connection(self):
         """

--- a/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2_test.py
+++ b/Packs/CheckpointFirewall/Integrations/CheckPointFirewallV2/CheckPointFirewallV2_test.py
@@ -57,15 +57,13 @@ INTEGRATION_CONTEXT_EMPTY = dict()
 INTEGRATION_CONTEXT_WITH_SID = {'cp_sid': DUMMY_SID}
 
 
-@pytest.mark.parametrize('session_id,integration_context,should_log_in',
-                         (
-                                 (None, INTEGRATION_CONTEXT_EMPTY, True),
-                                 ('None', INTEGRATION_CONTEXT_EMPTY, True),
-                                 (DUMMY_SID, INTEGRATION_CONTEXT_EMPTY, False),
-                                 (None, INTEGRATION_CONTEXT_WITH_SID, False),
-                                 ('None', INTEGRATION_CONTEXT_WITH_SID, False),
-                                 (DUMMY_SID, INTEGRATION_CONTEXT_WITH_SID, False))
-                         )
+@pytest.mark.parametrize('session_id,integration_context,should_log_in', ((None, INTEGRATION_CONTEXT_EMPTY, True),
+                                                                          ('None', INTEGRATION_CONTEXT_EMPTY, True),
+                                                                          (DUMMY_SID, INTEGRATION_CONTEXT_EMPTY, False),
+                                                                          (None, INTEGRATION_CONTEXT_WITH_SID, False),
+                                                                          ('None', INTEGRATION_CONTEXT_WITH_SID, False),
+                                                                          (DUMMY_SID, INTEGRATION_CONTEXT_WITH_SID,
+                                                                           False)))
 def test_checkpoint_login_mechanism(mocker, session_id, integration_context, should_log_in):
     """
     Given

--- a/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CheckPoint Firewall v2
-- Improved login mechanism: restoration of session id is followed by a connection test, and failure to connect triggers a login.
+- Improved login mechanism: When reusing a session id saved in context the connection is tested, and a failure automatically triggers a login and fetching of a new session id.

--- a/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CheckPoint Firewall v2
+- Improved login mechanism: restoration of session id is followed by a connection test, and failure to connect triggers a login.

--- a/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
+++ b/Packs/CheckpointFirewall/ReleaseNotes/2_1_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CheckPoint Firewall v2
-- Improved login mechanism: When reusing a session id saved in context the connection is tested, and a failure automatically triggers a login and fetching of a new session id.
+- Improved login mechanism: When reusing a session id from context, a connection test is performed. Failure of this test automatically triggers a login and fetching of a new session id.

--- a/Packs/CheckpointFirewall/pack_metadata.json
+++ b/Packs/CheckpointFirewall/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Check Point Firewall",
     "description": "Manage Check Point firewall via API",
     "support": "xsoar",
-    "currentVersion": "2.1.4",
+    "currentVersion": "2.1.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

fixes: https://github.com/demisto/etc/issues/39704

## Description
When restoring SID, test it to make sure it's valid. If it isn't valid, attempt to login.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
