### PR TITLE
Deprecate Largest Inputs And Outputs In Incidents and Largest Incidents by Storage Size

### DIFF
--- a/Packs/CommonWidgets/ReleaseNotes/1_1_6.md
+++ b/Packs/CommonWidgets/ReleaseNotes/1_1_6.md
@@ -1,0 +1,12 @@
+
+#### Scripts
+##### GetLargestInputsAndOuputsInIncidents
+- The script has been deprecated for XSOAR 6.2.0 and later versions. Please checkout the System Diagnostic page for an alternative.
+##### GetLargestInvestigations
+- The script has been deprecated for XSOAR 6.2.0 and later versions. Please checkout the System Diagnostic page for an alternative.
+
+#### Widgets
+##### Largest Incidents by Storage Size
+- The widget has been deprecated for XSOAR 6.2.0 and later versions. Please checkout the System Diagnostic page for an alternative.
+##### Largest Inputs And Outputs In Incidents
+- The widget has been deprecated for XSOAR 6.2.0 and later versions. Please checkout the System Diagnostic page for an alternative.

--- a/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInputsAndOuputsInIncidents/GetLargestInputsAndOuputsInIncidents.py
@@ -72,9 +72,11 @@ def get_extra_data_from_investigations(investigations: list) -> list:
 
 def main():
     try:
+        if not is_demisto_version_ge("6.2.0"):
+            raise DemistoException("This script has been deprecated. Please checkout the System Diagnostic page for an "
+                                   "alternative.")
         args = demisto.args()
         is_table_result = argToBoolean(args.get('table_result', False))
-
         raw_output = demisto.executeCommand('GetLargestInvestigations',
                                             args={
                                                 'from': args.get('from'),

--- a/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
+++ b/Packs/CommonWidgets/Scripts/GetLargestInvestigations/GetLargestInvestigations.py
@@ -86,6 +86,9 @@ def get_month_database_names():
 
 def main():
     try:
+        if not is_demisto_version_ge("6.2.0"):
+            raise DemistoException("This script has been deprecated. Please checkout the System Diagnostic page for an "
+                                   "alternative.")
         investigations: Dict = {}
         args: Dict = demisto.args()
         from_date = args.get('from')

--- a/Packs/CommonWidgets/Widgets/widget-LargestInputsAndOuputsInIncidentsWidget.json
+++ b/Packs/CommonWidgets/Widgets/widget-LargestInputsAndOuputsInIncidentsWidget.json
@@ -20,6 +20,7 @@
   "fromDateLicense": "0001-01-01T00:00:00Z"
  },
  "fromVersion": "6.0.0",
+ "toVersion": "6.1.9",
  "description": "",
  "isPredefined": true
 }

--- a/Packs/CommonWidgets/Widgets/widget-LargestInvestigationsWidget.json
+++ b/Packs/CommonWidgets/Widgets/widget-LargestInvestigationsWidget.json
@@ -20,6 +20,7 @@
   "fromDateLicense": "0001-01-01T00:00:00Z"
  },
  "fromVersion": "6.0.0",
+ "toVersion": "6.1.9",
  "description": "",
  "isPredefined": true
 }

--- a/Packs/CommonWidgets/pack_metadata.json
+++ b/Packs/CommonWidgets/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Widgets",
     "description": "Frequently used widgets pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/41723

## Description
The scripts + widget are being deprecated since in 6.2.0 the system diagnostic page was added, which offers the same functionality with a better experience.