### PR TITLE
OutOfOfficeListCleanup - cleanup OOO list only when the list changed

### DIFF
--- a/Packs/ShiftManagement/ReleaseNotes/1_2_6.md
+++ b/Packs/ShiftManagement/ReleaseNotes/1_2_6.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### OutOfOfficeListCleanup
+- Fixed an issue where the script update out-of-office list if there was no changes.

--- a/Packs/ShiftManagement/Scripts/OutOfOfficeListCleanup/OutOfOfficeListCleanup.py
+++ b/Packs/ShiftManagement/Scripts/OutOfOfficeListCleanup/OutOfOfficeListCleanup.py
@@ -36,12 +36,15 @@ def main():
         else:
             new_list_data.append(i)
 
-    # set the list, return results
-    set_list_res = demisto.executeCommand("setList", {"listName": list_name, "listData": json.dumps(new_list_data)})
-    if isError(set_list_res):
-        return_error(f'Failed to update the list {list_name}: {str(get_error(set_list_res))}')
-    remove = '\n'.join(remove)
-    return_results(f'The following Users were removed from the Out of Office List {list_name}:\n{remove}')
+    if new_list_data != list_data:
+        # set the list, return results
+        set_list_res = demisto.executeCommand("setList", {"listName": list_name, "listData": json.dumps(new_list_data)})
+        if isError(set_list_res):
+            return_error(f'Failed to update the list {list_name}: {str(get_error(set_list_res))}')
+        remove = '\n'.join(remove)
+        return_results(f'The following Users were removed from the Out of Office List {list_name}:\n{remove}')
+    else:
+        return_results(f'No users removed from the list {list_name}')
 
 
 if __name__ in ('__builtin__', 'builtins', '__main__'):

--- a/Packs/ShiftManagement/pack_metadata.json
+++ b/Packs/ShiftManagement/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Shift Management",
     "description": "This pack's purpose is to provide a single interface for all those essential elements of Shift management and handover in one place.",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41826

## Description
While running the playbook shift handover, it using the script `OutOfOfficeListCleanup` that update the OOO list and sometimes gets the error:
`Failed to update the list OOO List: DB Version '2859' and Insert version '2858' do not match for id: OOO List on bucket [] [dataListsBucket] (15)`

Using the command `setList` only if when there was a change in the list fix the issue.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
