### PR TITLE
Added docker tag to UT and lint job

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -136,6 +136,8 @@
 
 
 .run-unittests-and-lint:
+  tags:
+    - docker
   needs: []
   stage: unittests-and-validations
   artifacts:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Added the `docker` executor tag to the `run-unittests-and-lint` job as the `kubernetes` executor seems to be related to mypy failing the linter, causing our builds to fail.

