### PR TITLE
Remove Problematic Echoing of Shell Version

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -104,12 +104,12 @@
     - mkdir -p $ARTIFACTS_FOLDER/logs
     - section_end "Creating new clean logs folder"
     - *install_node_modules
+    - $(echo $0) --version
     - *install_venv
     - *get_contribution_pack
     - *install_ssh_keys
     - section_start "Build Parameters"
     - set | grep -E "^NIGHTLY=|^INSTANCE_TESTS=|^SERVER_BRANCH_NAME=|^ARTIFACT_BUILD_NUM=|^DEMISTO_SDK_NIGHTLY=|^TIME_TO_LIVE=|^CONTRIB_BRANCH=|^FORCE_PACK_UPLOAD=|^PACKS_TO_UPLOAD=|^BUCKET_UPLOAD=|^STORAGE_BASE_PATH=|^GCS_MARKET_BUCKET=|^SLACK_CHANNEL=|^NVM_DIR=|^NODE_VERSION=|^PATH="
-    - $(echo $0) --version
     - python --version
     - python2 --version
     - python3 --version

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -104,7 +104,6 @@
     - mkdir -p $ARTIFACTS_FOLDER/logs
     - section_end "Creating new clean logs folder"
     - *install_node_modules
-    - $(echo $0) --version
     - *install_venv
     - *get_contribution_pack
     - *install_ssh_keys


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
[Update of the GKE runners](https://panw-global.slack.com/archives/CRKK3S2QY/p1633573509411000?thread_ts=1633551603.378100&cid=CRKK3S2QY) to Gitlab version 14.0 caused the line,
`$(echo $0) --version` in the `.default-before-script` hidden job configuration to reinvoke the shell with the configuration as the shell command argument - this is presumably due to the shell type changing. Caused what looked like looping in the `create-instances` job - see an example [here](https://code.pan.run/xsoar/content/-/jobs/7983956). Removed this line as it was only used for debugging anyways.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 5.5.0
- [x] 6.0.0
- [x] 6.1.0
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] ~~Tests~~ N/A
- [x] ~~Documentation~~ N/A
