### PR TITLE
EDL Listen Port restricted ports

### DIFF
--- a/Packs/EDL/Integrations/EDL/README.md
+++ b/Packs/EDL/Integrations/EDL/README.md
@@ -31,7 +31,8 @@ Unlike `PAN-OS EDL Management`, this integration hosts the EDL on the Cortex XSO
 | EDL Size | Maximum number of entries in the service instance. | True |
 | Update EDL On Demand Only | When set to true, will only update the service indicators via the **edl-update** command. | False |
 | Refresh Rate | How often to refresh the export indicators list (&lt;number&gt; &lt;time unit&gt;, e.g., 12 hours, 7 days, 3 months, 1 year) | False |
-| Listen Port | By default HTTP. Runs the *External Dynamic List* on this port from within Cortex XSOAR | True |
+| Listen Port | By default HTTP. Runs the *External Dynamic List* on this port from within Cortex XSOAR. You can use any available port except for 80, 443, or 9100. 
+When the `instance.execute.external.<instance_name>` key is set to true, Cortex XSOAR redirects the endpoint from HTTPS to the container on the port that you specify here, using port 443 as the secured publicly open port. | True |
 | Certificate (Required for HTTPS) | Configure a certificate for the EDL instance. The certificate is provided by pasting its value into this field. Use only when accesing the EDL instance by port. | False |
 | Private Key (Required for HTTPS) | Configure a private key. The private key is provided by pasting its value into this field. Use only when accesing the EDL instance by port. | False |
 | Credentials | Set user and password for accessing the EDL instance. (Only applicable when https is used and a certificate profile is configured on the pan-os edl object) | False |


### PR DESCRIPTION
Added the following to the Listen Port description in light of https://github.com/demisto/etc/issues/41066:

You can use any available port except for 80, 443, or 9100. 
When the `instance.execute.external.<instance_name>` key is set to true, Cortex XSOAR redirects the endpoint from HTTPS to the container on the port that you specify here, using port 443 as the secured publicly open port.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
