### PR TITLE
Secrets Detection - ignore fork PRs

### DIFF
--- a/.github/workflows/run-secrets-detection.yml
+++ b/.github/workflows/run-secrets-detection.yml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
   secrets_detection:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content'
+    if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
We would like to ignore this workflow on Content forks as they don't have the right permissions to Gold. 
In addition, the run will be executed once an internal PR to Content will be opened. 

I have opened a PR from a fork to verify my change:
https://github.com/demisto/content/pull/15310
The step is really skipped:
![image](https://user-images.githubusercontent.com/71635916/137104788-7bf3b06c-bf26-4794-a836-4a569d2db46f.png)

