### PR TITLE
Dashboard widgets to use selected time range

### DIFF
--- a/Packs/CommonDashboards/Dashboards/dashboard-Home.json
+++ b/Packs/CommonDashboards/Dashboards/dashboard-Home.json
@@ -90,7 +90,7 @@
   },
   {
    "id": "173ed090-1c89-11e8-a678-fdff55233dc8",
-   "forceRange": false,
+   "forceRange": true,
    "x": 4,
    "y": 0,
    "i": "173ed090-1c89-11e8-a678-fdff55233dc8",
@@ -141,7 +141,7 @@
   },
   {
    "id": "51fa5e20-1c89-11e8-a678-fdff55233dc8",
-   "forceRange": false,
+   "forceRange": true,
    "x": 6,
    "y": 0,
    "i": "51fa5e20-1c89-11e8-a678-fdff55233dc8",
@@ -192,7 +192,7 @@
   },
   {
    "id": "f12d1f00-1c8e-11e8-b5cb-47979f799c06",
-   "forceRange": false,
+   "forceRange": true,
    "x": 0,
    "y": 2,
    "i": "f12d1f00-1c8e-11e8-b5cb-47979f799c06",

--- a/Packs/CommonDashboards/Dashboards/dashboard-Home.json
+++ b/Packs/CommonDashboards/Dashboards/dashboard-Home.json
@@ -15,7 +15,7 @@
  "layout": [
   {
    "id": "a0e381e0-1c86-11e8-8581-45a91cd24d8e",
-   "forceRange": true,
+   "forceRange": false,
    "x": 8,
    "y": 0,
    "i": "a0e381e0-1c86-11e8-8581-45a91cd24d8e",
@@ -55,7 +55,7 @@
   },
   {
    "id": "d9955cc0-1c86-11e8-8581-45a91cd24d8e",
-   "forceRange": true,
+   "forceRange": false,
    "x": 0,
    "y": 0,
    "i": "d9955cc0-1c86-11e8-8581-45a91cd24d8e",
@@ -90,7 +90,7 @@
   },
   {
    "id": "173ed090-1c89-11e8-a678-fdff55233dc8",
-   "forceRange": true,
+   "forceRange": false,
    "x": 4,
    "y": 0,
    "i": "173ed090-1c89-11e8-a678-fdff55233dc8",
@@ -141,7 +141,7 @@
   },
   {
    "id": "51fa5e20-1c89-11e8-a678-fdff55233dc8",
-   "forceRange": true,
+   "forceRange": false,
    "x": 6,
    "y": 0,
    "i": "51fa5e20-1c89-11e8-a678-fdff55233dc8",
@@ -192,7 +192,7 @@
   },
   {
    "id": "f12d1f00-1c8e-11e8-b5cb-47979f799c06",
-   "forceRange": true,
+   "forceRange": false,
    "x": 0,
    "y": 2,
    "i": "f12d1f00-1c8e-11e8-b5cb-47979f799c06",
@@ -232,7 +232,7 @@
   },
   {
    "id": "0cce7c40-1c8f-11e8-b5cb-47979f799c06",
-   "forceRange": true,
+   "forceRange": false,
    "x": 4,
    "y": 1,
    "i": "0cce7c40-1c8f-11e8-b5cb-47979f799c06",

--- a/Packs/CommonDashboards/ReleaseNotes/1_1_2.md
+++ b/Packs/CommonDashboards/ReleaseNotes/1_1_2.md
@@ -1,0 +1,4 @@
+
+#### Dashboards
+##### My Dashboard
+- All dashboard widgets now query information within the selected time range, rather than all available data.

--- a/Packs/CommonDashboards/ReleaseNotes/1_1_2.md
+++ b/Packs/CommonDashboards/ReleaseNotes/1_1_2.md
@@ -1,4 +1,4 @@
 
 #### Dashboards
 ##### My Dashboard
-- All dashboard widgets now query information within the selected time range, rather than all available data.
+- *Breaking Change:* All dashboard widgets now query information within the selected time range, rather than all times.

--- a/Packs/CommonDashboards/pack_metadata.json
+++ b/Packs/CommonDashboards/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Dashboards",
     "description": "Frequently used dashboards pack.",
     "support": "xsoar",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41535

## Description
The `my-tasks`, `my-mean-time-to-resolution`, `my-mentions` tasks now use the selected time range, rather than show all data. 

## Screenshots
Before
![image](https://user-images.githubusercontent.com/81086590/137126191-49ca63fd-9c51-4629-b0e4-c7e449662f5d.png)

After
![image](https://user-images.githubusercontent.com/81086590/137126216-95790eb4-a7c4-474d-9c1d-3b9d76e188f9.png)

## Minimum version of Cortex XSOAR
5.0.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details: widgets now only show data from the selected time range, and not all data, as default. This can be changed by customising the dashboard. 

## Must have
- [ ] Documentation 

