### PR TITLE
Threat Intel Report - fixed tab name to be in plural

### DIFF
--- a/Packs/ThreatIntel/GenericModules/genericmodule-ThreatIntel.json
+++ b/Packs/ThreatIntel/GenericModules/genericmodule-ThreatIntel.json
@@ -14,7 +14,7 @@
             "title": "Threat Intel View",
             "tabs": [
                 {
-                    "name": "Threat Intel Report",
+                    "name": "Threat Intel Reports",
                     "newButtonDefinitionId": "ThreatIntelReport",
                     "dashboard": {
                         "id": "Threat Intel Dashboard",

--- a/Packs/ThreatIntel/ReleaseNotes/1_0_7.md
+++ b/Packs/ThreatIntel/ReleaseNotes/1_0_7.md
@@ -1,0 +1,4 @@
+
+#### Modules
+##### Threat Intel
+- Fixed the tab name to be in plural.

--- a/Packs/ThreatIntel/pack_metadata.json
+++ b/Packs/ThreatIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Threat Intel Report",
     "description": "Threat Intel Report Test Pack",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "serverMinVersion": "6.5.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/42157

## Minimum version of Cortex XSOAR
- [x] 6.5.0

## Does it break backward compatibility?
   - [x] No
