### PR TITLE
Threat Intel Report - fix widgets sizes

### DIFF
--- a/Packs/ThreatIntel/GenericModules/genericmodule-ThreatIntel.json
+++ b/Packs/ThreatIntel/GenericModules/genericmodule-ThreatIntel.json
@@ -38,8 +38,8 @@
                                 "x": 0,
                                 "y": 0,
                                 "i": "2f7354b0-065f-11ec-ba99-5f74d3ffb017",
-                                "w": 8,
-                                "h": 3,
+                                "w": 6,
+                                "h": 2,
                                 "widget": {
                                     "id": "221c23c9-beff-4ccb-8ccc-dc920876c6fa",
                                     "version": 1,
@@ -94,11 +94,11 @@
                             {
                                 "id": "9cb8f6b0-065f-11ec-ba99-5f74d3ffb017",
                                 "forceRange": false,
-                                "x": 8,
+                                "x": 6,
                                 "y": 0,
                                 "i": "9cb8f6b0-065f-11ec-ba99-5f74d3ffb017",
-                                "w": 2,
-                                "h": 3,
+                                "w": 3,
+                                "h": 2,
                                 "widget": {
                                     "id": "773ad9fb-064c-41e3-855e-fff8f97164e4",
                                     "version": 1,
@@ -150,11 +150,11 @@
                             {
                                 "id": "c370c490-065f-11ec-ba99-5f74d3ffb017",
                                 "forceRange": false,
-                                "x": 10,
+                                "x": 9,
                                 "y": 0,
                                 "i": "c370c490-065f-11ec-ba99-5f74d3ffb017",
-                                "w": 2,
-                                "h": 3,
+                                "w": 3,
+                                "h": 2,
                                 "widget": {
                                     "id": "5f6fa3bd-ddde-404a-875e-46d137b5b0b1",
                                     "version": 1,
@@ -207,10 +207,10 @@
                                 "id": "5490f900-14a1-11ec-8115-a339b813ec6b",
                                 "forceRange": false,
                                 "x": 0,
-                                "y": 3,
+                                "y": 2,
                                 "i": "5490f900-14a1-11ec-8115-a339b813ec6b",
                                 "w": 12,
-                                "h": 4,
+                                "h": 7,
                                 "widget": {
                                     "id": "4ba41bed-cd8a-4562-8daf-5bee6ce5cff6",
                                     "version": 1,

--- a/Packs/ThreatIntel/ReleaseNotes/1_0_8.md
+++ b/Packs/ThreatIntel/ReleaseNotes/1_0_8.md
@@ -1,0 +1,4 @@
+
+#### Modules
+##### Threat Intel
+- Improved the view widgets layout.

--- a/Packs/ThreatIntel/pack_metadata.json
+++ b/Packs/ThreatIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Threat Intel Report",
     "description": "Threat Intel Report Test Pack",
     "support": "xsoar",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "serverMinVersion": "6.5.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/42001


## Minimum version of Cortex XSOAR
- [x] 6.5.0

## Does it break backward compatibility?
   - [x] No
