### PR TITLE
AutoFocusV2 Fixed IPv6 recognized as IPv4

### DIFF
--- a/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
@@ -1386,7 +1386,9 @@ def search_ip_command(ip, reliability, create_relationships):
     relationships = []
 
     for ip_address in ip_list:
-        raw_res = search_indicator('ipv4_address', ip_address)
+        ip_type = 'ipv6_address' if is_ipv6_valid(ip_address) else 'ipv4_address'
+        raw_res = search_indicator(ip_type, ip_address)
+
         if not raw_res.get('indicator'):
             raise ValueError('Invalid response for indicator')
 

--- a/Packs/AutoFocus/ReleaseNotes/1_3_11.md
+++ b/Packs/AutoFocus/ReleaseNotes/1_3_11.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks AutoFocus v2
+- Fixed an issue where indicators *IPv6* was recognized as *IPv4* in Human Readable.

--- a/Packs/AutoFocus/ReleaseNotes/1_3_11.md
+++ b/Packs/AutoFocus/ReleaseNotes/1_3_11.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Palo Alto Networks AutoFocus v2
-- Fixed an issue where indicators *IPv6* was recognized as *IPv4* in Human Readable.
+- Fixed an issue where indicators of type *IPv6* were shown as *IPv4* in the result.

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "1.3.10",
+    "currentVersion": "1.3.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/42286

## Description
Added different handling when IPv6 is provided.

## Screenshots
![image](https://user-images.githubusercontent.com/71636766/137894374-cb6b6171-d5cd-42f0-9846-d30db2885b69.png)

## Minimum version of Cortex XSOAR
- [x] 5.5.0

## Does it break backward compatibility?
   - [x] No

