### PR TITLE
changed Cisco Firepower's pack display name

### DIFF
--- a/Packs/CiscoFirepower/pack_metadata.json
+++ b/Packs/CiscoFirepower/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "CiscoFirepower",
+    "name": "Cisco Firepower",
     "description": "Use the CiscoFirepower integration for unified management of firewalls, application control",
     "support": "xsoar",
     "currentVersion": "1.0.9",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/42311

## Description
changed Cisco Firepower's pack display name


## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 5.5.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
