### PR TITLE
remove Azure and Google Kubernetes from Prisma's mandatory dependencies

### DIFF
--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -70,9 +70,9 @@
             "mandatory": false,
             "display_name": "Google Kubernetes Engine"
         },
-    "AzureKubernetesServices": {
-        "mandatory": false,
-        "display_name": "Azure Kubernetes Services"
+        "AzureKubernetesServices": {
+            "mandatory": false,
+            "display_name": "Azure Kubernetes Services"
         }
     }
 }


### PR DESCRIPTION
## Status
- [] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/41744

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

