### PR TITLE
Updated Pack rasterize to use the latest release for demisto/chromium docker image 1.0.0.24317

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.yml
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.yml
@@ -217,7 +217,7 @@ script:
     description: Converts a PDF file to an image file.
     execution: false
     name: rasterize-pdf
-  dockerimage: demisto/chromium:1.0.0.24144
+  dockerimage: demisto/chromium:1.0.0.24317
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/rasterize/ReleaseNotes/1_0_14.md
+++ b/Packs/rasterize/ReleaseNotes/1_0_14.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Rasterize
+- Updated the Docker image to: *demisto/chromium:1.0.0.24317*.

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "1.0.13",
+    "currentVersion": "1.0.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Updated Pack rasterize to use the latest release for demisto/chromium docker image 1.0.0.24144

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/42713

## Description
bumping up the chromium docker image in rasterize pack

## Minimum version of Cortex XSOAR
- [X] 6.0.0
- [X] 6.1.0
- [X] 6.2.0
- [X] 6.5.0

## Does it break backward compatibility?
   - [X] No

## Must have
- [X] Tests
- [X] Documentation 
