### PR TITLE
fixed typo in an error message when trying to create an indicator wit…

### DIFF
--- a/Packs/Base/ReleaseNotes/1_13_44.md
+++ b/Packs/Base/ReleaseNotes/1_13_44.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed typo in an error message when trying to create an indicator with an unsupported score value.

--- a/Packs/Base/ReleaseNotes/1_13_44.md
+++ b/Packs/Base/ReleaseNotes/1_13_44.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Fixed typo in an error message when trying to create an indicator with an unsupported score value.
+- Fixed a typo in the error message when trying to create an indicator with an unsupported score value.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2454,7 +2454,7 @@ class Common(object):
                 raise TypeError('indicator_type must be of type DBotScoreType enum')
 
             if not Common.DBotScore.is_valid_score(score):
-                raise TypeError('indicator_type must be of type DBotScore enum')
+                raise TypeError('indicator `score` must be of type DBotScore enum')
 
             if reliability and not DBotScoreReliability.is_valid_type(reliability):
                 raise TypeError('reliability must be of type DBotScoreReliability enum')

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.13.43",
+    "currentVersion": "1.13.44",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description

fixed typo in an error message when trying to create an indicator with an unsupported score value.

## Does it break backward compatibility?
   - [x] No