### PR TITLE
BaseClient class - fixed a bug when choosing xml as resp_type

### DIFF
--- a/Packs/Base/ReleaseNotes/1_14_1.md
+++ b/Packs/Base/ReleaseNotes/1_14_1.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### CommonServerPython
+- %%CommonServerPython%%
+    - Fixed a bug in BaseClient class when choosing xml as resp_type which raised a python exception.

--- a/Packs/Base/ReleaseNotes/1_14_1.md
+++ b/Packs/Base/ReleaseNotes/1_14_1.md
@@ -1,5 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- %%CommonServerPython%%
-    - Fixed a bug in BaseClient class when choosing xml as resp_type which raised a python exception.
+- Fixed a bug in BaseClient class when choosing xml as resp_type which raised a python exception.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -7187,7 +7187,7 @@ if 'requests' in sys.modules:
                     if resp_type == 'content':
                         return res.content
                     if resp_type == 'xml':
-                        ET.parse(res.text)
+                        ET.fromstring(res.text)
                     if resp_type == 'response':
                         return res
                     return res

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.14.0",
+    "currentVersion": "1.14.1",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
_http_request function is using ET.parse() (which take a file as parameter and not a string) instead of using ET.fromstring().
