### PR TITLE
cyberArk fix test

### DIFF
--- a/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
+++ b/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
@@ -122,7 +122,17 @@ def test_module(client: Client) -> str:
     :param client: the client object with the given params
     :return: ok if the request succeeded
     """
-    client.list_credentials()
+    if client._credentials_list:
+        client.list_credentials()
+    else:
+        try:
+            # Running a dummy credential just to check connection.
+            client.get_credentials("test_cred")
+        except DemistoException as e:
+            if 'Error in API call [500]' in e.message:
+                return 'ok'
+            else:
+                raise e
     return "ok"
 
 

--- a/Packs/cyberark_AIM/ReleaseNotes/1_0_9.md
+++ b/Packs/cyberark_AIM/ReleaseNotes/1_0_9.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### CyberArk AIM v2
-- Fixed an issue in **test** module when empty credential_names parameter caused success without an actual test. 
+- Fixed an issue where the **test** module returned "success" for incorrect integration configuration.

--- a/Packs/cyberark_AIM/ReleaseNotes/1_0_9.md
+++ b/Packs/cyberark_AIM/ReleaseNotes/1_0_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CyberArk AIM v2
+- Fixed an issue in **test** module when empty credential_names parameter caused success without an actual test. 

--- a/Packs/cyberark_AIM/pack_metadata.json
+++ b/Packs/cyberark_AIM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CyberArk AIM",
     "description": "Query CyberArk Application Identity Manager for accounts and credentials",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/43000

## Description
The test module does fetch on each credential in the credential_names. When this was not provided, it caused the fetch to end successfully, even if the instance configuration was incorrect.
Added a check- if the credential_names provided, will continue the test, otherwise will try with a dummy credential.

## Does it break backward compatibility?
   - [x] No

