### PR TITLE
AF Tags Feed defaultEnabled field 

### DIFF
--- a/Packs/AutoFocus/Integrations/AutoFocusTagsFeed/AutoFocusTagsFeed.yml
+++ b/Packs/AutoFocus/Integrations/AutoFocusTagsFeed/AutoFocusTagsFeed.yml
@@ -2,7 +2,7 @@ category: Data Enrichment & Threat Intelligence
 commonfields:
   id: AutoFocusTagsFeed
   version: -1
-defaultEnabled: true
+defaultEnabled: false
 configuration:
 - display: AutoFocus Endpoint URL
   name: url

--- a/Packs/AutoFocus/ReleaseNotes/2_0_1.md
+++ b/Packs/AutoFocus/ReleaseNotes/2_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AutoFocus Tags Feed
+- Maintenance and stability enhancements.

--- a/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocusTagsFeed_test.yml
+++ b/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocusTagsFeed_test.yml
@@ -3,7 +3,7 @@ version: -1
 contentitemexportablefields:
   contentitemfields: {}
 name: AutoFocusTagsFeed-test
-description: Test playbook for AutoFocus Tags Feed integration
+description: Test playbook for AutoFocus Tags Feed integration.
 starttaskid: "0"
 tasks:
   "0":

--- a/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocusTagsFeed_test.yml
+++ b/Packs/AutoFocus/TestPlaybooks/playbook-AutoFocusTagsFeed_test.yml
@@ -3,7 +3,7 @@ version: -1
 contentitemexportablefields:
   contentitemfields: {}
 name: AutoFocusTagsFeed-test
-description: Test playbook for AutoFocus Tags Feed integration.
+description: Test playbook for AutoFocus Tags Feed integration
 starttaskid: "0"
 tasks:
   "0":

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4588,7 +4588,7 @@
             "playbookID": "TestAzureSentinelPlaybookV2"
         },
         {
-            "integrations": "AutoFocusTagsFeed",
+            "integrations": ["AutoFocusTagsFeed", "Demisto REST API"],
             "playbookID": "AutoFocusTagsFeed-test"
         },
         {


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Changed defaultEnabled field so server build stop fail

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

