### PR TITLE
Azure Sentinel - mark `server url` as required

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -889,7 +889,7 @@ def main():
     LOG(f'Command being called is {demisto.command()}')
     try:
         client = AzureSentinelClient(
-            server_url=params.get('server_url', DEFAULT_AZURE_SERVER_URL),
+            server_url=params.get('server_url') or DEFAULT_AZURE_SERVER_URL,
             tenant_id=params.get('tenant_id', ''),
             client_id=params.get('credentials', {}).get('identifier'),
             client_secret=params.get('credentials', {}).get('password'),

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -7,7 +7,7 @@ configuration:
   defaultvalue: https://management.azure.com
   hidden: false
   name: server_url
-  required: false
+  required: true
   type: 0
 - display: Tenant ID
   name: tenant_id

--- a/Packs/AzureSentinel/ReleaseNotes/1_2_1.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_2_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Azure Sentinel
+- The `Server URL` parameter is now required to set up an integration instance.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Azure Sentinel",
     "description": "Azure Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/43471

## Description
the server url param is now marked as required. 

## Does it break backward compatibility?
Surprisingly, no, keeping in mind that no **functional** instance could have had an empty value. Non-working ones will stay non-working. 