### PR TITLE
Detonate File - Generic: added VMRay outputs

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -925,7 +925,7 @@ outputs:
   description: The size of the submission
   type: number
 - contextPath: Joe.Analysis
-  description: Thee Analysis object
+  description: The Analysis object
   type: unknown
 - contextPath: Cuckoo.Task.Category
   description: Category of task
@@ -1193,6 +1193,7 @@ outputs:
   description: Task analysis status.
   type: String
 - contextPath: VMRay.Job
+  description: ''
   type: unknown
 - contextPath: VMRay.Job.JobID
   description: The ID of a new job.
@@ -1210,6 +1211,7 @@ outputs:
   description: The ID of virtual machine.
   type: number
 - contextPath: VMRay.Sample
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.SampleID
   description: The sample ID of the task.
@@ -1249,6 +1251,7 @@ outputs:
   description: The classifications of the sample.
   type: string
 - contextPath: VMRay.Submission
+  description: ''
   type: unknown
 - contextPath: VMRay.Submission.SubmissionID
   description: The submission ID.
@@ -1285,86 +1288,124 @@ outputs:
   description: The ID of the sample in submission.
   type: number
 - contextPath: VMRay.Sample.IOC.File
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.File.AnalysisID
   description: The IDs of other analyses that contain the given file.
+  type: number
 - contextPath: VMRay.Sample.IOC.File.Name
   description: The name of the file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.Operation
   description: The operation of the given file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.ID
   description: The ID of the file.
+  type: number
 - contextPath: VMRay.Sample.IOC.File.Type
   description: The type of the file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.Hashes
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.File.Hashes.MD5
   description: The MD5 hash of the given file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.Hashes.SSDeep
   description: The SSDeep hash of the given file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.Hashes.SHA256
   description: The SHA256 hash of the given file.
+  type: string
 - contextPath: VMRay.Sample.IOC.File.Hashes.SHA1
   description: The SHA1 hash of the given file.
+  type: string
 - contextPath: VMRay.Sample.IOC.URL
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.URL.AnalysisID
   description: The IDs of the other analyses that contain the given URL.
   type: number
 - contextPath: VMRay.Sample.IOC.URL.URL
   description: The URL.
+  type: string
 - contextPath: VMRay.Sample.IOC.URL.Operation
   description: The operation of the specified URL.
+  type: string
 - contextPath: VMRay.Sample.IOC.URL.ID
   description: The ID of the URL.
+  type: number
 - contextPath: VMRay.Sample.IOC.URL.Type
   description: The type of the URL.
+  type: string
 - contextPath: VMRay.Sample.IOC.Domain
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.Domain.AnalysisID
   description: The IDs of the other analyses that contain the given domain.
+  type: number
 - contextPath: VMRay.Sample.IOC.Domain.Domain
   description: The domain.
+  type: string
 - contextPath: VMRay.Sample.IOC.Domain.ID
   description: The ID of the domain.
+  type: number
 - contextPath: VMRay.Sample.IOC.Domain.Type
   description: The type of the domain.
+  type: string
 - contextPath: VMRay.Sample.IOC.IP
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.IP.AnalysisID
   description: The IDs of the other analyses that contain the given IP address.
+  type: number
 - contextPath: VMRay.Sample.IOC.IP.IP
   description: The IP address.
+  type: string
 - contextPath: VMRay.Sample.IOC.IP.Operation
   description: The operation of the given IP address.
+  type: string
 - contextPath: VMRay.Sample.IOC.IP.ID
   description: The ID of the IP address.
+  type: number
 - contextPath: VMRay.Sample.IOC.IP.Type
   description: The type of the IP address.
+  type: string
 - contextPath: VMRay.Sample.IOC.Mutex
   type: unknown
 - contextPath: VMRay.Sample.IOC.Mutex.AnalysisID
   description: The IDs of other analyses that contain the given IP address.
+  type: number
 - contextPath: VMRay.Sample.IOC.Mutex.Name
   description: The name of the mutex.
+  type: string
 - contextPath: VMRay.Sample.IOC.Mutex.Operation
   description: The operation of the given mutex
+  type: string
 - contextPath: VMRay.Sample.IOC.Mutex.ID
   description: The ID of the mutex.
+  type: number
 - contextPath: VMRay.Sample.IOC.Mutex.Type
   description: The type of the mutex.
+  type: string
 - contextPath: VMRay.ThreatIndicator
+  description: ''
   type: unknown
 - contextPath: VMRay.ThreatIndicator.AnalysisID
   description: The list of connected analysis IDs.
+  type: number
 - contextPath: VMRay.ThreatIndicator.Category
   description: The category of threat indicators.
+  type: string
 - contextPath: VMRay.ThreatIndicator.Classification
   description: The classifications of threat indicators.
+  type: string
 - contextPath: VMRay.ThreatIndicator.ID
   description: The ID of the threat indicator.
+  type: number
 - contextPath: VMRay.ThreatIndicator.Operation
   description: The operation that caused the indicators.
+  type: string
 fromversion: 5.0.0
 tests:
 - Detonate File - Generic Test

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -1372,6 +1372,7 @@ outputs:
   description: The type of the IP address.
   type: string
 - contextPath: VMRay.Sample.IOC.Mutex
+  description: ''
   type: unknown
 - contextPath: VMRay.Sample.IOC.Mutex.AnalysisID
   description: The IDs of other analyses that contain the given IP address.

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -1192,6 +1192,179 @@ outputs:
 - contextPath: ANYRUN.Task.Status
   description: Task analysis status.
   type: String
+- contextPath: VMRay.Job
+  type: unknown
+- contextPath: VMRay.Job.JobID
+  description: The ID of a new job.
+  type: number
+- contextPath: VMRay.Job.SampleID
+  description: The ID of sample.
+  type: number
+- contextPath: VMRay.Job.Created
+  description: The timestamp of the created job.
+  type: date
+- contextPath: VMRay.Job.VMName
+  description: The name of virtual machine.
+  type: string
+- contextPath: VMRay.Job.VMID
+  description: The ID of virtual machine.
+  type: number
+- contextPath: VMRay.Sample
+  type: unknown
+- contextPath: VMRay.Sample.SampleID
+  description: The sample ID of the task.
+  type: number
+- contextPath: VMRay.Sample.Created
+  description: The timestamp of the created sample.
+  type: date
+- contextPath: VMRay.Sample.FileName
+  description: The file name of the sample.
+  type: string
+- contextPath: VMRay.Sample.MD5
+  description: The MD5 hash of the sample.
+  type: string
+- contextPath: VMRay.Sample.SHA1
+  description: The SHA1 hash of the sample.
+  type: string
+- contextPath: VMRay.Sample.SHA256
+  description: The SHA256 hash of the sample.
+  type: string
+- contextPath: VMRay.Sample.SSDeep
+  description: The SSDeep of the sample.
+  type: string
+- contextPath: VMRay.Sample.Verdict
+  description: Verdict for the sample (Malicious, Suspicious, Clean, Not Available).
+  type: String
+- contextPath: VMRay.Sample.VerdictReason
+  description: Description of the Verdict Reason.
+  type: String
+- contextPath: VMRay.Sample.Severity
+  description: Severity of the sample (Malicious, Suspicious, Good, Blacklisted, Whitelisted,
+    Unknown). Deprecated.
+  type: string
+- contextPath: VMRay.Sample.Type
+  description: The file type.
+  type: string
+- contextPath: VMRay.Sample.Classifications
+  description: The classifications of the sample.
+  type: string
+- contextPath: VMRay.Submission
+  type: unknown
+- contextPath: VMRay.Submission.SubmissionID
+  description: The submission ID.
+  type: number
+- contextPath: VMRay.Submission.HadErrors
+  description: Whether there are any errors in the submission.
+  type: boolean
+- contextPath: VMRay.Submission.IsFinished
+  description: The status of submission. Can be, "true" or "false".
+  type: boolean
+- contextPath: VMRay.Submission.MD5
+  description: The MD5 hash of the sample in submission.
+  type: string
+- contextPath: VMRay.Submission.SHA1
+  description: The SHA1 hash of the sample in submission.
+  type: string
+- contextPath: VMRay.Submission.SHA256
+  description: The SHA256 hash of the sample in submission.
+  type: string
+- contextPath: VMRay.Submission.Verdict
+  description: Verdict for the sample (Malicious, Suspicious, Clean, Not Available).
+  type: String
+- contextPath: VMRay.Submission.VerdictReason
+  description: Description of the Verdict Reason.
+  type: String
+- contextPath: VMRay.Submission.Severity
+  description: Severity of the sample (Malicious, Suspicious, Good, Blacklisted, Whitelisted,
+    Unknown). Deprecated.
+  type: string
+- contextPath: VMRay.Submission.SSDeep
+  description: The SSDeep hash of the sample in submission.
+  type: string
+- contextPath: VMRay.Submission.SampleID
+  description: The ID of the sample in submission.
+  type: number
+- contextPath: VMRay.Sample.IOC.File
+  type: unknown
+- contextPath: VMRay.Sample.IOC.File.AnalysisID
+  description: The IDs of other analyses that contain the given file.
+- contextPath: VMRay.Sample.IOC.File.Name
+  description: The name of the file.
+- contextPath: VMRay.Sample.IOC.File.Operation
+  description: The operation of the given file.
+- contextPath: VMRay.Sample.IOC.File.ID
+  description: The ID of the file.
+- contextPath: VMRay.Sample.IOC.File.Type
+  description: The type of the file.
+- contextPath: VMRay.Sample.IOC.File.Hashes
+  type: unknown
+- contextPath: VMRay.Sample.IOC.File.Hashes.MD5
+  description: The MD5 hash of the given file.
+- contextPath: VMRay.Sample.IOC.File.Hashes.SSDeep
+  description: The SSDeep hash of the given file.
+- contextPath: VMRay.Sample.IOC.File.Hashes.SHA256
+  description: The SHA256 hash of the given file.
+- contextPath: VMRay.Sample.IOC.File.Hashes.SHA1
+  description: The SHA1 hash of the given file.
+- contextPath: VMRay.Sample.IOC.URL
+  type: unknown
+- contextPath: VMRay.Sample.IOC.URL.AnalysisID
+  description: The IDs of the other analyses that contain the given URL.
+  type: number
+- contextPath: VMRay.Sample.IOC.URL.URL
+  description: The URL.
+- contextPath: VMRay.Sample.IOC.URL.Operation
+  description: The operation of the specified URL.
+- contextPath: VMRay.Sample.IOC.URL.ID
+  description: The ID of the URL.
+- contextPath: VMRay.Sample.IOC.URL.Type
+  description: The type of the URL.
+- contextPath: VMRay.Sample.IOC.Domain
+  type: unknown
+- contextPath: VMRay.Sample.IOC.Domain.AnalysisID
+  description: The IDs of the other analyses that contain the given domain.
+- contextPath: VMRay.Sample.IOC.Domain.Domain
+  description: The domain.
+- contextPath: VMRay.Sample.IOC.Domain.ID
+  description: The ID of the domain.
+- contextPath: VMRay.Sample.IOC.Domain.Type
+  description: The type of the domain.
+- contextPath: VMRay.Sample.IOC.IP
+  type: unknown
+- contextPath: VMRay.Sample.IOC.IP.AnalysisID
+  description: The IDs of the other analyses that contain the given IP address.
+- contextPath: VMRay.Sample.IOC.IP.IP
+  description: The IP address.
+- contextPath: VMRay.Sample.IOC.IP.Operation
+  description: The operation of the given IP address.
+- contextPath: VMRay.Sample.IOC.IP.ID
+  description: The ID of the IP address.
+- contextPath: VMRay.Sample.IOC.IP.Type
+  description: The type of the IP address.
+- contextPath: VMRay.Sample.IOC.Mutex
+  type: unknown
+- contextPath: VMRay.Sample.IOC.Mutex.AnalysisID
+  description: The IDs of other analyses that contain the given IP address.
+- contextPath: VMRay.Sample.IOC.Mutex.Name
+  description: The name of the mutex.
+- contextPath: VMRay.Sample.IOC.Mutex.Operation
+  description: The operation of the given mutex
+- contextPath: VMRay.Sample.IOC.Mutex.ID
+  description: The ID of the mutex.
+- contextPath: VMRay.Sample.IOC.Mutex.Type
+  description: The type of the mutex.
+- contextPath: VMRay.ThreatIndicator
+  type: unknown
+- contextPath: VMRay.ThreatIndicator.AnalysisID
+  description: The list of connected analysis IDs.
+- contextPath: VMRay.ThreatIndicator.Category
+  description: The category of threat indicators.
+- contextPath: VMRay.ThreatIndicator.Classification
+  description: The classifications of threat indicators.
+- contextPath: VMRay.ThreatIndicator.ID
+  description: The ID of the threat indicator.
+- contextPath: VMRay.ThreatIndicator.Operation
+  description: The operation that caused the indicators.
 fromversion: 5.0.0
 tests:
 - Detonate File - Generic Test

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_README.md
@@ -190,3 +190,64 @@ This playbook does not use any commands.
 | File.Malicious.Vendor | For malicious files, the vendor that made the decision. | String |
 | File.Malicious.Description | For malicious files, the reason that the vendor made the decision. | String |
 | ANYRUN.Task.Status | Task analysis status. | String |
+| VMRay.Job.JobID | The ID of a new job. | number |
+| VMRay.Job.SampleID | The ID of sample. | number |
+| VMRay.Job.Created | The timestamp of the created job. | date |
+| VMRay.Job.VMName | The name of virtual machine. | string |
+| VMRay.Job.VMID | The ID of virtual machine. | number |
+| VMRay.Sample.SampleID | The sample ID of the task. | number |
+| VMRay.Sample.Created | The timestamp of the created sample. | date |
+| VMRay.Sample.FileName | The file name of the sample. | string |
+| VMRay.Sample.MD5 | The MD5 hash of the sample. | string |
+| VMRay.Sample.SHA1 | The SHA1 hash of the sample. | string |
+| VMRay.Sample.SHA256 | The SHA256 hash of the sample. | string |
+| VMRay.Sample.SSDeep | The SSDeep of the sample. | string |
+| VMRay.Sample.Verdict | Verdict for the sample (Malicious, Suspicious, Clean, Not Available). | String |
+| VMRay.Sample.VerdictReason | Description of the Verdict Reason. | String |
+| VMRay.Sample.Severity | Severity of the sample (Malicious, Suspicious, Good, Blacklisted, Whitelisted, Unknown). Deprecated. | string |
+| VMRay.Sample.Type | The file type. | string |
+| VMRay.Sample.Classifications | The classifications of the sample. | string |
+| VMRay.Submission.SubmissionID | The submission ID. | number |
+| VMRay.Submission.HadErrors | Whether there are any errors in the submission. | boolean |
+| VMRay.Submission.IsFinished | The status of submission. Can be, "true" or "false". | boolean |
+| VMRay.Submission.MD5 | The MD5 hash of the sample in submission. | string |
+| VMRay.Submission.SHA1 | The SHA1 hash of the sample in submission. | string |
+| VMRay.Submission.SHA256 | The SHA256 hash of the sample in submission. | string |
+| VMRay.Submission.Verdict | Verdict for the sample (Malicious, Suspicious, Clean, Not Available). | String |
+| VMRay.Submission.VerdictReason | Description of the Verdict Reason. | String |
+| VMRay.Submission.Severity | Severity of the sample (Malicious, Suspicious, Good, Blacklisted, Whitelisted, Unknown). Deprecated. | string |
+| VMRay.Submission.SSDeep | The SSDeep hash of the sample in submission. | string |
+| VMRay.Submission.SampleID | The ID of the sample in submission. | number |
+| VMRay.Sample.IOC.File.AnalysisID | The IDs of other analyses that contain the given file. | unknown |
+| VMRay.Sample.IOC.File.Name | The name of the file. | unknown |
+| VMRay.Sample.IOC.File.Operation | The operation of the given file. | unknown |
+| VMRay.Sample.IOC.File.ID | The ID of the file. | unknown |
+| VMRay.Sample.IOC.File.Type | The type of the file. | unknown |
+| VMRay.Sample.IOC.File.Hashes.MD5 | The MD5 hash of the given file. | unknown |
+| VMRay.Sample.IOC.File.Hashes.SSDeep | The SSDeep hash of the given file. | unknown |
+| VMRay.Sample.IOC.File.Hashes.SHA256 | The SHA256 hash of the given file. | unknown |
+| VMRay.Sample.IOC.File.Hashes.SHA1 | The SHA1 hash of the given file. | unknown |
+| VMRay.Sample.IOC.URL.AnalysisID | The IDs of the other analyses that contain the given URL. | number |
+| VMRay.Sample.IOC.URL.URL | The URL. | unknown |
+| VMRay.Sample.IOC.URL.Operation | The operation of the specified URL. | unknown |
+| VMRay.Sample.IOC.URL.ID | The ID of the URL. | unknown |
+| VMRay.Sample.IOC.URL.Type | The type of the URL. | unknown |
+| VMRay.Sample.IOC.Domain.AnalysisID | The IDs of the other analyses that contain the given domain. | unknown |
+| VMRay.Sample.IOC.Domain.Domain | The domain. | unknown |
+| VMRay.Sample.IOC.Domain.ID | The ID of the domain. | unknown |
+| VMRay.Sample.IOC.Domain.Type | The type of the domain. | unknown |
+| VMRay.Sample.IOC.IP.AnalysisID | The IDs of the other analyses that contain the given IP address. | unknown |
+| VMRay.Sample.IOC.IP.IP | The IP address. | unknown |
+| VMRay.Sample.IOC.IP.Operation | The operation of the given IP address. | unknown |
+| VMRay.Sample.IOC.IP.ID | The ID of the IP address. | unknown |
+| VMRay.Sample.IOC.IP.Type | The type of the IP address. | unknown |
+| VMRay.Sample.IOC.Mutex.AnalysisID | The IDs of other analyses that contain the given IP address. | unknown |
+| VMRay.Sample.IOC.Mutex.Name | The name of the mutex. | unknown |
+| VMRay.Sample.IOC.Mutex.Operation | The operation of the given mutex | unknown |
+| VMRay.Sample.IOC.Mutex.ID | The ID of the mutex. | unknown |
+| VMRay.Sample.IOC.Mutex.Type | The type of the mutex. | unknown |
+| VMRay.ThreatIndicator.AnalysisID | The list of connected analysis IDs. | unknown |
+| VMRay.ThreatIndicator.Category | The category of threat indicators. | unknown |
+| VMRay.ThreatIndicator.Classification | The classifications of threat indicators. | unknown |
+| VMRay.ThreatIndicator.ID | The ID of the threat indicator. | unknown |
+| VMRay.ThreatIndicator.Operation | The operation that caused the indicators. | unknown |

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic_README.md
@@ -40,29 +40,29 @@ This playbook does not use any commands.
 
 | **Path** | **Description** | **Type** |
 | --- | --- | --- |
-| Joe.Analysis.Status | Analysis Status | string |
-| Joe.Analysis.WebID | Web ID | string |
-| File.Name | Filename \(only in case of report type=json\) | string |
+| File | The File's object | unknown |
+| File.Name | The name of the file submitted for analysis. | String |
+| File.Extension | File Extension | string |
+| File.MD5 | MD5 of the file | string |
 | File.SHA1 | SHA1 of the file | string |
 | File.SHA256 | SHA256 of the file | string |
 | File.Size | File size \(only in case of report type=json\) | number |
 | File.Type | File type e.g. "PE" \(only in case of report type=json\) | string |
 | File.Malicious | The File malicious description | unknown |
-| File.Malicious.Description | For malicious files, the reason for the vendor to make the decision | string |
+| File.Malicious.Description | For malicious files, the reason that the vendor made the decision. | String |
 | File.Malicious.Vendor | For malicious files, the vendor that made the decision | string |
+| IP.Address | IP's relevant to the sample | string |
 | DBotScore | The Indicator's object | unknown |
 | DBotScore.Indicator | The indicator that was tested | string |
 | DBotScore.Score | The actual score | number |
 | DBotScore.Type | The type of the indicator | string |
 | DBotScore.Vendor | Vendor used to calculate the score | string |
-| IP.Address | IP's relevant to the sample | string |
 | DBotScore.Malicious.Vendor | Vendor used to calculate the score | string |
 | DBotScore.Malicious.Detections | The sub analysis detection statuses | string |
 | DBotScore.Malicious.SHA1 | The SHA1 of the file | string |
 | Sample.State | The sample state | unknown |
 | Sample.ID | The sample ID | unknown |
-| File | The File's object | unknown |
-| File.MD5 | MD5 of the file | string |
+| Joe.Analysis | Thee Analysis object | unknown |
 | Joe.Analysis.SampleName | Sample Data, could be a file name or URL | string |
 | Joe.Analysis.Comments | Analysis Comments | string |
 | Joe.Analysis.Time | Submitted Time | date |
@@ -73,20 +73,20 @@ This playbook does not use any commands.
 | Joe.Analysis.MD5 | MD5 of analysis sample | string |
 | Joe.Analysis.SHA1 | SHA1 of analysis sample | string |
 | Joe.Analysis.SHA256 | SHA256 of analysis sample | string |
+| Joe.Analysis.Status | Analysis Status | string |
+| Joe.Analysis.WebID | Web ID | string |
+| InfoFile | The report file's object | unknown |
 | InfoFile.Name | FileName of the report file | string |
 | InfoFile.EntryID | The EntryID of the report file | string |
 | InfoFile.Size | File Size | number |
 | InfoFile.Type | File type e.g. "PE" | string |
 | InfoFile.Info | Basic information of the file | string |
-| File.Extension | File Extension | string |
-| InfoFile | The report file's object | unknown |
 | WildFire.Report | The submission object | unknown |
 | WildFire.Report.Status | The status of the submission | string |
 | WildFire.Report.SHA256 | SHA256 of the submission | string |
 | WildFire.Report.MD5 | MD5 of the submission | string |
 | WildFire.Report.FileType | The type of the submission | string |
 | WildFire.Report.Size | The size of the submission | number |
-| Joe.Analysis | Thee Analysis object | unknown |
 | Cuckoo.Task.Category | Category of task | unknown |
 | Cuckoo.Task.Machine | Machine of task | unknown |
 | Cuckoo.Task.Errors | Errors of task | unknown |
@@ -181,14 +181,6 @@ This playbook does not use any commands.
 | ANYRUN.Task.Process.Version.Company | Company responsible for the program executed. | String |
 | ANYRUN.Task.Process.Version.Description | Description of the type of program. | String |
 | ANYRUN.Task.Process.Version.Version | Version of the program executed. | String |
-| File.Extension | Extension of the file submitted for analysis. | String |
-| File.Name | The name of the file submitted for analysis. | String |
-| File.MD5 | MD5 hash of the file submitted for analysis. | String |
-| File.SHA1 | SHA1 hash of the file submitted for analysis. | String |
-| File.SHA256 | SHA256 hash of the file submitted for analysis. | String |
-| File.SSDeep | SSDeep hash of the file submitted for analysis. | String |
-| File.Malicious.Vendor | For malicious files, the vendor that made the decision. | String |
-| File.Malicious.Description | For malicious files, the reason that the vendor made the decision. | String |
 | ANYRUN.Task.Status | Task analysis status. | String |
 | VMRay.Job.JobID | The ID of a new job. | number |
 | VMRay.Job.SampleID | The ID of sample. | number |
@@ -218,36 +210,37 @@ This playbook does not use any commands.
 | VMRay.Submission.Severity | Severity of the sample (Malicious, Suspicious, Good, Blacklisted, Whitelisted, Unknown). Deprecated. | string |
 | VMRay.Submission.SSDeep | The SSDeep hash of the sample in submission. | string |
 | VMRay.Submission.SampleID | The ID of the sample in submission. | number |
-| VMRay.Sample.IOC.File.AnalysisID | The IDs of other analyses that contain the given file. | unknown |
-| VMRay.Sample.IOC.File.Name | The name of the file. | unknown |
-| VMRay.Sample.IOC.File.Operation | The operation of the given file. | unknown |
-| VMRay.Sample.IOC.File.ID | The ID of the file. | unknown |
-| VMRay.Sample.IOC.File.Type | The type of the file. | unknown |
-| VMRay.Sample.IOC.File.Hashes.MD5 | The MD5 hash of the given file. | unknown |
-| VMRay.Sample.IOC.File.Hashes.SSDeep | The SSDeep hash of the given file. | unknown |
-| VMRay.Sample.IOC.File.Hashes.SHA256 | The SHA256 hash of the given file. | unknown |
-| VMRay.Sample.IOC.File.Hashes.SHA1 | The SHA1 hash of the given file. | unknown |
+| VMRay.Sample.IOC.File.AnalysisID | The IDs of other analyses that contain the given file. | number |
+| VMRay.Sample.IOC.File.Name | The name of the file. | string |
+| VMRay.Sample.IOC.File.Operation | The operation of the given file. | string |
+| VMRay.Sample.IOC.File.ID | The ID of the file. | number |
+| VMRay.Sample.IOC.File.Type | The type of the file. | string |
+| VMRay.Sample.IOC.File.Hashes.MD5 | The MD5 hash of the given file. | string |
+| VMRay.Sample.IOC.File.Hashes.SSDeep | The SSDeep hash of the given file. | string |
+| VMRay.Sample.IOC.File.Hashes.SHA256 | The SHA256 hash of the given file. | string |
+| VMRay.Sample.IOC.File.Hashes.SHA1 | The SHA1 hash of the given file. | string |
 | VMRay.Sample.IOC.URL.AnalysisID | The IDs of the other analyses that contain the given URL. | number |
-| VMRay.Sample.IOC.URL.URL | The URL. | unknown |
-| VMRay.Sample.IOC.URL.Operation | The operation of the specified URL. | unknown |
-| VMRay.Sample.IOC.URL.ID | The ID of the URL. | unknown |
-| VMRay.Sample.IOC.URL.Type | The type of the URL. | unknown |
-| VMRay.Sample.IOC.Domain.AnalysisID | The IDs of the other analyses that contain the given domain. | unknown |
-| VMRay.Sample.IOC.Domain.Domain | The domain. | unknown |
-| VMRay.Sample.IOC.Domain.ID | The ID of the domain. | unknown |
-| VMRay.Sample.IOC.Domain.Type | The type of the domain. | unknown |
-| VMRay.Sample.IOC.IP.AnalysisID | The IDs of the other analyses that contain the given IP address. | unknown |
-| VMRay.Sample.IOC.IP.IP | The IP address. | unknown |
-| VMRay.Sample.IOC.IP.Operation | The operation of the given IP address. | unknown |
-| VMRay.Sample.IOC.IP.ID | The ID of the IP address. | unknown |
-| VMRay.Sample.IOC.IP.Type | The type of the IP address. | unknown |
-| VMRay.Sample.IOC.Mutex.AnalysisID | The IDs of other analyses that contain the given IP address. | unknown |
-| VMRay.Sample.IOC.Mutex.Name | The name of the mutex. | unknown |
-| VMRay.Sample.IOC.Mutex.Operation | The operation of the given mutex | unknown |
-| VMRay.Sample.IOC.Mutex.ID | The ID of the mutex. | unknown |
-| VMRay.Sample.IOC.Mutex.Type | The type of the mutex. | unknown |
-| VMRay.ThreatIndicator.AnalysisID | The list of connected analysis IDs. | unknown |
-| VMRay.ThreatIndicator.Category | The category of threat indicators. | unknown |
-| VMRay.ThreatIndicator.Classification | The classifications of threat indicators. | unknown |
-| VMRay.ThreatIndicator.ID | The ID of the threat indicator. | unknown |
-| VMRay.ThreatIndicator.Operation | The operation that caused the indicators. | unknown |
+| VMRay.Sample.IOC.URL.URL | The URL. | string |
+| VMRay.Sample.IOC.URL.Operation | The operation of the specified URL. | string |
+| VMRay.Sample.IOC.URL.ID | The ID of the URL. | number |
+| VMRay.Sample.IOC.URL.Type | The type of the URL. | string |
+| VMRay.Sample.IOC.Domain |  | unknown |
+| VMRay.Sample.IOC.Domain.AnalysisID | The IDs of the other analyses that contain the given domain. | number |
+| VMRay.Sample.IOC.Domain.Domain | The domain. | string |
+| VMRay.Sample.IOC.Domain.ID | The ID of the domain. | number |
+| VMRay.Sample.IOC.Domain.Type | The type of the domain. | string |
+| VMRay.Sample.IOC.IP.AnalysisID | The IDs of the other analyses that contain the given IP address. | number |
+| VMRay.Sample.IOC.IP.IP | The IP address. | string |
+| VMRay.Sample.IOC.IP.Operation | The operation of the given IP address. | string |
+| VMRay.Sample.IOC.IP.ID | The ID of the IP address. | number |
+| VMRay.Sample.IOC.IP.Type | The type of the IP address. | string |
+| VMRay.Sample.IOC.Mutex.AnalysisID | The IDs of other analyses that contain the given IP address. | number |
+| VMRay.Sample.IOC.Mutex.Name | The name of the mutex. | string |
+| VMRay.Sample.IOC.Mutex.Operation | The operation of the given mutex | string |
+| VMRay.Sample.IOC.Mutex.ID | The ID of the mutex. | number |
+| VMRay.Sample.IOC.Mutex.Type | The type of the mutex. | string |
+| VMRay.ThreatIndicator.AnalysisID | The list of connected analysis IDs. | number |
+| VMRay.ThreatIndicator.Category | The category of threat indicators. | string |
+| VMRay.ThreatIndicator.Classification | The classifications of threat indicators. | string |
+| VMRay.ThreatIndicator.ID | The ID of the threat indicator. | number |
+| VMRay.ThreatIndicator.Operation | The operation that caused the indicators. | string |

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_1_1.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_1_1.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Detonate File - Generic
+- Fixed an issue where the context outputs of the **Detonate File - VMRay** playbook were missing.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.1.0",
+    "currentVersion": "2.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/43679

## Description
added the VMRay context outputs to the `Detonate File - Generic` playbook.

