### PR TITLE
Changed file extraction scripts to use DBot role

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_5_5.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_5_5.md
@@ -1,0 +1,8 @@
+
+#### Scripts
+##### ExtractIndicatorsFromWordFile
+- The automation poses no security concern and was changed to execute with DBot role.
+##### ExtractIndicatorsFromTextFile
+- The automation poses no security concern and was changed to execute with DBot role.
+##### ReadPDFFileV2
+- The automation poses no security concern and was changed to execute with DBot role.

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
@@ -57,4 +57,4 @@ tests:
 - Extract Indicators From File - Generic v2 - Test
 fromversion: 5.0.0
 tags: []
-dockerimage: demisto/python:2.7.18.24066
+dockerimage: demisto/python:2.7.18.24398

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
@@ -51,6 +51,7 @@ system: false
 timeout: '0'
 type: python
 subtype: python2
+runas: DBotRole
 runonce: false
 tests:
 - Extract Indicators From File - Generic v2 - Test

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.yml
@@ -1,6 +1,6 @@
 args:
 - default: false
-  description: War Room entryID of the file to read.
+  description: The War-Room entryID of the file to read.
   isArray: false
   name: entryID
   required: true

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
@@ -24,6 +24,7 @@ tags:
 timeout: '0'
 type: python
 subtype: python2
+runas: DBotRole
 dockerimage: demisto/office-utils:2.0.0.23094
 runonce: false
 fromversion: 5.0.0

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
@@ -28,3 +28,5 @@ runas: DBotRole
 dockerimage: demisto/office-utils:2.0.0.23094
 runonce: false
 fromversion: 5.0.0
+tests:
+- Extract Indicators From File - Generic v2 - Test

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
@@ -120,6 +120,7 @@ outputs:
   type: String
 script: '-'
 subtype: python3
+runas: DBotRole
 system: false
 tags:
 - Utility

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.5.4",
+    "currentVersion": "1.5.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/43736

## Description
Changed the following 3 scripts to run with DBot role as they don't pose a security concern, and also don't work otherwise:
- **ExtractIndicatorsFromTextFile**
- **ExtractIndicatorsFromWordFile**
- **ReadPDFFileV2**

## Does it break backward compatibility?
No
