### PR TITLE
change release note in order to trigger release note update in upload…

### DIFF
--- a/Packs/Base/ReleaseNotes/1_14_0.md
+++ b/Packs/Base/ReleaseNotes/1_14_0.md
@@ -1,9 +1,10 @@
 #### Scripts
+##### Multi Scrips Changes:
 ***Breaking Change*** The following breaking change applies for organizations that implement pre-set roles on their incidents:
 DBotRole has been removed from these automations. This change will affect any playbook that is dependent on, or runs, these automations.
 These automations will now run using the default Limited User role, unless you explicitly change the permissions.
 For more information, see the section about permissions here:
 [https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-2/cortex-xsoar-admin/playbooks/automations.html
 ](https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-2/cortex-xsoar-admin/playbooks/automations.html)
-- ##### GetIncidentsByQuery
-- ##### FindSimilarIncidentsByText
+- GetIncidentsByQuery
+- FindSimilarIncidentsByText

--- a/Packs/Base/ReleaseNotes/1_14_0.md
+++ b/Packs/Base/ReleaseNotes/1_14_0.md
@@ -1,4 +1,3 @@
-
 #### Scripts
 ***Breaking Change*** The following breaking change applies for organizations that implement pre-set roles on their incidents:
 DBotRole has been removed from these automations. This change will affect any playbook that is dependent on, or runs, these automations.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related PR
the PR with the correct release note: https://github.com/demisto/content/pull/15446
The PR with the release note that overwritten it in the same marketplace upload: https://github.com/demisto/content/pull/15559
fixes: https://github.com/demisto/etc/issues/43882

## Description
release note of Base pack 1.14.0 was overwritten by the release note in 1.13.44 when they were uploaded together in the same marketplace upload iteration. this happened due to a bug in the upload that is investigated.
this PR is intended to re-write the 1.14.0 release note so it will appear correctly in marketplace, because it is a critical release note.

## Screenshots
![image](https://user-images.githubusercontent.com/19407287/142369616-26094649-0399-4b20-b662-81d4a8bf1033.png)
