### PR TITLE
Disable MITRE ATTACK Indicator Type

### DIFF
--- a/Packs/FeedMitreAttack/IndicatorTypes/reputation-mitreAttck.json
+++ b/Packs/FeedMitreAttack/IndicatorTypes/reputation-mitreAttck.json
@@ -13,7 +13,7 @@
     "enhancementScriptNames": [],
     "system": false,
     "locked": false,
-    "disabled": false,
+    "disabled": true,
     "file": false,
     "updateAfter": 0,
     "mergeContext": false,

--- a/Packs/FeedMitreAttack/ReleaseNotes/1_2_1.md
+++ b/Packs/FeedMitreAttack/ReleaseNotes/1_2_1.md
@@ -1,0 +1,4 @@
+
+#### Indicator Types
+- **MITRE ATT&CK**
+Disabled, Use **Attack Pattern** Indicator Type instead.

--- a/Packs/FeedMitreAttack/pack_metadata.json
+++ b/Packs/FeedMitreAttack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MITRE ATT&CK",
     "description": "Fetches indicators from MITRE ATT&CK.",
     "support": "xsoar",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Disabled MITRE ATTACK Indicator type as it uses the same regex pattern as the new Attack Pattern type,
And we recommended the users use the v2 Pack.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
