### PR TITLE
Servicenow v2 - added support for nested 'additional fields' argument

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -204,8 +204,11 @@ def create_ticket_context(data: dict, additional_fields: list = None) -> Any:
     }
     if additional_fields:
         for additional_field in additional_fields:
-            if additional_field in data.keys() and camelize_string(additional_field) not in context.keys():
-                context[additional_field] = data.get(additional_field)
+            if camelize_string(additional_field) not in context.keys():
+                # in case of a nested additional field (in the form of field1.field2)
+                nested_additional_field_list = additional_field.split('.')
+                if value := dict_safe_get(data, nested_additional_field_list):
+                    context[additional_field] = value
 
     # These fields refer to records in the database, the value is their system ID.
     closed_by = data.get('closed_by')
@@ -331,7 +334,9 @@ def get_ticket_human_readable(tickets, ticket_type: str, additional_fields: list
 
         if additional_fields:
             for additional_field in additional_fields:
-                hr[additional_field] = ticket.get(additional_field)
+                # in case of a nested additional field (in the form of field1.field2)
+                nested_additional_field_list = additional_field.split('.')
+                hr[additional_field] = dict_safe_get(ticket, nested_additional_field_list)
         result.append(hr)
 
     return result

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -2407,7 +2407,7 @@ script:
       is used as part of a Mirroring feature, which is available from version 6.1.
     execution: false
     name: get-modified-remote-data
-  dockerimage: demisto/python3:3.9.7.24076
+  dockerimage: demisto/python3:3.9.8.24399
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1415,7 +1415,7 @@ script:
       secret: false
     - default: false
       description: Additional fields to present in the War Room entry and incident
-        context.
+        context. Can be nested (in the form of field1.field2).
       isArray: true
       name: additional_fields
       required: false

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
@@ -27,7 +27,8 @@ from test_data.result_constants import EXPECTED_TICKET_CONTEXT, EXPECTED_MULTIPL
     EXPECTED_QUERY_COMPUTERS, EXPECTED_GET_TABLE_NAME, EXPECTED_UPDATE_TICKET_ADDITIONAL, \
     EXPECTED_QUERY_TABLE_SYS_PARAMS, EXPECTED_ADD_TAG, EXPECTED_QUERY_ITEMS, EXPECTED_ITEM_DETAILS, \
     EXPECTED_CREATE_ITEM_ORDER, EXPECTED_DOCUMENT_ROUTE, EXPECTED_MAPPING, \
-    EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS, EXPECTED_QUERY_TICKETS_EXCLUDE_REFERENCE_LINK
+    EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS, EXPECTED_QUERY_TICKETS_EXCLUDE_REFERENCE_LINK, \
+    EXPECTED_TICKET_CONTEXT_WITH_NESTED_ADDITIONAL_FIELDS
 
 import demistomock as demisto
 from urllib.parse import urlencode
@@ -56,6 +57,20 @@ def test_get_ticket_context_additional_fields():
     """
     assert EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS == get_ticket_context(RESPONSE_TICKET,
                                                                                 ['Summary', 'sys_created_by'])
+
+
+def test_get_ticket_context_nested_additional_fields():
+    """Unit test
+    Given
+        - nested additional keys of a ticket (in the form of a.b), alongside regular keys.
+    When
+        - getting a ticket context
+    Then
+        - validate that all the details of the ticket were updated, and all the updated keys are shown in
+        the context with do duplicates.
+    """
+    assert EXPECTED_TICKET_CONTEXT_WITH_NESTED_ADDITIONAL_FIELDS == get_ticket_context(RESPONSE_TICKET,
+                                                                                       ['Summary', 'opened_by.link'])
 
 
 def test_get_ticket_human_readable():

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/test_data/result_constants.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/test_data/result_constants.py
@@ -25,6 +25,20 @@ EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS = {
     'sys_created_by': 'admin'
 }
 
+EXPECTED_TICKET_CONTEXT_WITH_NESTED_ADDITIONAL_FIELDS = {
+    'Active': 'true',
+    'CreatedOn': '2019-09-05 00:42:29',
+    'Creator': 'test',
+    'ID': 'sys_id',
+    'Number': 'INC0000039',
+    'OpenedAt': '2019-09-05 00:41:01',
+    'OpenedBy': 'test',
+    'Priority': '4 - Low',
+    'State': '1',
+    'Summary': 'Trouble getting to Oregon mail server',
+    'opened_by': {'link': 'demisto.com'}
+}
+
 EXPECTED_MULTIPLE_TICKET_CONTEXT = [
     {
         'Active': 'true',

--- a/Packs/ServiceNow/ReleaseNotes/2_2_14.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_2_14.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ServiceNow v2
+- Fixed an issue in the **servicenow-query-tickets** command where the *additional_fields* argument did not support nested values.

--- a/Packs/ServiceNow/ReleaseNotes/2_2_14.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_2_14.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### ServiceNow v2
 - Fixed an issue in the **servicenow-query-tickets** command where the *additional_fields* argument did not support nested values.
+- Updated the Docker image to: *demisto/python3:3.9.8.24399*.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.2.13",
+    "currentVersion": "2.2.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/43868 

## Description
In servicenow-query-tickets, the 'additional_fields' argument was not supporting nested values.
