### PR TITLE
clone content-test-conf repo from Gitlab instead of Github

### DIFF
--- a/Tests/scripts/.secrets-ignore
+++ b/Tests/scripts/.secrets-ignore
@@ -1,0 +1,1 @@
+https://gitlab-ci-token

--- a/Tests/scripts/.secrets-ignore
+++ b/Tests/scripts/.secrets-ignore
@@ -1,1 +1,0 @@
-https://gitlab-ci-token

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -17,7 +17,7 @@ DEMISTO_PACK_SIGNATURE_UTIL_PATH="./signDirectory"
 echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
 # download configuration files from Gitlab repo
-echo "Trying to clone from branch: $UNDERSCORE_BRANCH in content-test-conf"
+echo "clone content-test-conf from branch: $UNDERSCORE_BRANCH in content-test-conf"
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -18,6 +18,7 @@ echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
 # download configuration files from Gitlab repo
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
+git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
     git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -16,8 +16,7 @@ echo ${DEMISTO_LIC_PATH} > demisto_lic_path
 DEMISTO_PACK_SIGNATURE_UTIL_PATH="./signDirectory"
 echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
-# download configuration files from github repo
-echo "CLONING GITLAB"
+# download configuration files from Gitlab repo
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -17,10 +17,11 @@ DEMISTO_PACK_SIGNATURE_UTIL_PATH="./signDirectory"
 echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
 # download configuration files from github repo
-wget --header "Accept: application/vnd.github.v3.raw" --header "Authorization: token $GITHUB_TOKEN" -O ./test_configuration.zip "https://github.com/demisto/content-test-conf/archive/$UNDERSCORE_BRANCH.zip" --no-check-certificate -q
+echo "CLONING GITLAB"
+git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
-    wget --header "Accept: application/vnd.github.v3.raw" --header "Authorization: token $GITHUB_TOKEN" -O ./test_configuration.zip "https://github.com/demisto/content-test-conf/archive/master.zip" --no-check-certificate -q
+    git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git
     unzip ./test_configuration.zip
     cp -r ./content-test-conf-master/awsinstancetool ./Tests/scripts/awsinstancetool
     cp -r ./content-test-conf-master/demisto.lic $DEMISTO_LIC_PATH

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -19,7 +19,6 @@ echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 # download configuration files from github repo
 echo "CLONING GITLAB"
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
-echo "$(ls)"
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
     git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -18,7 +18,6 @@ echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
 # download configuration files from Gitlab repo
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
-git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
     git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -19,10 +19,10 @@ echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 # download configuration files from github repo
 echo "CLONING GITLAB"
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
+echo "$(ls)"
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
     git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git
-    unzip ./test_configuration.zip
     cp -r ./content-test-conf-master/awsinstancetool ./Tests/scripts/awsinstancetool
     cp -r ./content-test-conf-master/demisto.lic $DEMISTO_LIC_PATH
     cp -r ./content-test-conf-master/conf.json $SECRET_CONF_PATH
@@ -30,7 +30,6 @@ if [ "$?" != "0" ]; then
     rm -rf ./content-test-conf-master
     rm -rf ./test_configuration.zip
   else
-    unzip ./test_configuration.zip
     cp -r ./content-test-conf-$UNDERSCORE_BRANCH/awsinstancetool ./Tests/scripts/awsinstancetool
     cp -r ./content-test-conf-$UNDERSCORE_BRANCH/demisto.lic $DEMISTO_LIC_PATH
     cp -r ./content-test-conf-$UNDERSCORE_BRANCH/conf.json $SECRET_CONF_PATH

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -22,20 +22,12 @@ git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/c
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"
     git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git
-    cp -r ./content-test-conf-master/awsinstancetool ./Tests/scripts/awsinstancetool
-    cp -r ./content-test-conf-master/demisto.lic $DEMISTO_LIC_PATH
-    cp -r ./content-test-conf-master/conf.json $SECRET_CONF_PATH
-    cp -r ./content-test-conf-master/signDirectory $DEMISTO_PACK_SIGNATURE_UTIL_PATH
-    rm -rf ./content-test-conf-master
-    rm -rf ./test_configuration.zip
-  else
-    cp -r ./content-test-conf-$UNDERSCORE_BRANCH/awsinstancetool ./Tests/scripts/awsinstancetool
-    cp -r ./content-test-conf-$UNDERSCORE_BRANCH/demisto.lic $DEMISTO_LIC_PATH
-    cp -r ./content-test-conf-$UNDERSCORE_BRANCH/conf.json $SECRET_CONF_PATH
-    cp -r ./content-test-conf-$UNDERSCORE_BRANCH/signDirectory $DEMISTO_PACK_SIGNATURE_UTIL_PATH
-    rm -rf ./content-test-conf-$UNDERSCORE_BRANCH
-    rm -rf ./test_configuration.zip
 fi
+cp -r ./content-test-conf/awsinstancetool ./Tests/scripts/awsinstancetool
+cp -r ./content-test-conf/demisto.lic $DEMISTO_LIC_PATH
+cp -r ./content-test-conf/conf.json $SECRET_CONF_PATH
+cp -r ./content-test-conf/signDirectory $DEMISTO_PACK_SIGNATURE_UTIL_PATH
+rm -rf ./content-test-conf
 
 set -e
 echo "Successfully downloaded configuration files"

--- a/Tests/scripts/download_demisto_conf.sh
+++ b/Tests/scripts/download_demisto_conf.sh
@@ -17,6 +17,7 @@ DEMISTO_PACK_SIGNATURE_UTIL_PATH="./signDirectory"
 echo ${DEMISTO_PACK_SIGNATURE_UTIL_PATH} > demisto_pack_sig_util_path
 
 # download configuration files from Gitlab repo
+echo "Trying to clone from branch: $UNDERSCORE_BRANCH in content-test-conf"
 git clone --depth=1 https://gitlab-ci-token:${CI_JOB_TOKEN}@code.pan.run/xsoar/content-test-conf.git --branch $UNDERSCORE_BRANCH
 if [ "$?" != "0" ]; then
     echo "No such branch in content-test-conf: $UNDERSCORE_BRANCH , falling back to master"

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -2682,7 +2682,8 @@
     "TestGetSuccessfulAndFailedPacks",
     "user_pack_metadata.json",
     "IP.Relationships.EntityAType",
-    "IP.Relationships.EntityBType"
+    "IP.Relationships.EntityBType",
+    "https://gitlab-ci-token"
   ],
   "TrendMicroDDA": [
     "x-dtas"

--- a/Tests/secrets_white_list.json
+++ b/Tests/secrets_white_list.json
@@ -1837,7 +1837,8 @@
       "https://mytenant.blueliv.com",
       "https://api.dehashed.com",
       "https://www.dehashed.com.",
-      "https://www.atlassian.com"
+      "https://www.atlassian.com",
+      "https://gitlab-ci-token"
     ],
     "md5": [
       "c8092abd8d581750c0530fa1fc8d8318",
@@ -2682,8 +2683,7 @@
     "TestGetSuccessfulAndFailedPacks",
     "user_pack_metadata.json",
     "IP.Relationships.EntityAType",
-    "IP.Relationships.EntityBType",
-    "https://gitlab-ci-token"
+    "IP.Relationships.EntityBType"
   ],
   "TrendMicroDDA": [
     "x-dtas"


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/40262

## Description
As part of the Gitlab migration, we want Content repository to download the updated content-test-conf content from Gitlab instead of Github.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
