### PR TITLE
Fix arg to number python2

### DIFF
--- a/Packs/Base/ReleaseNotes/1_15_7.md
+++ b/Packs/Base/ReleaseNotes/1_15_7.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed an issue where *arg_to_number* did not handle unicode object on python 2.7.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -5280,6 +5280,9 @@ def arg_to_number(arg, arg_name=None, required=False):
                 raise ValueError('Missing required argument')
 
         return None
+
+    arg = encode_string_results(arg)
+
     if isinstance(arg, str):
         if arg.isdigit():
             return int(arg)

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -5281,7 +5281,7 @@ def arg_to_number(arg, arg_name=None, required=False):
 
         return None
 
-    # arg = encode_string_results(arg)
+    arg = encode_string_results(arg)
 
     if isinstance(arg, str):
         if arg.isdigit():

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -5281,7 +5281,7 @@ def arg_to_number(arg, arg_name=None, required=False):
 
         return None
 
-    arg = encode_string_results(arg)
+    # arg = encode_string_results(arg)
 
     if isinstance(arg, str):
         if arg.isdigit():

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -5729,3 +5729,10 @@ def test_indicators_value_to_clickable_invalid(mocker):
     assert not result
 
 
+def test_arg_to_number():
+    """
+    Test if arg_to_number handles unicode object without failing.
+    """
+    from CommonServerPython import arg_to_number
+    result = arg_to_number(u'1')
+    assert result == 1

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.15.6",
+    "currentVersion": "1.15.7",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Running arg_to_number on python 2.7 would fail due to mishandling of unicode object, this fix converts the unicode to str when needed.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
