### PR TITLE
Generic webhooks curl request headers fix in README.md

### DIFF
--- a/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/README.md
@@ -40,11 +40,11 @@ The Generic Webhook integration accepts POST HTTP queries, with the following op
 
 For example, the following triggers the webhook using cURL:
 
-`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
+`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -H "Content-Type: application/json" -d '{"name":"incident created via generic webhook","raw_json":{"some_field":"some_value"}}'`
 
 The request payload does not have to contain the fields mentioned above, and may include anything:
 
-`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
+`curl -POST https://my.demisto.live/instance/execute/webhook -H "Authorization: token" -H "Content-Type: application/json" -d '{"string_field":"string_field_value","array_field":["item1","item2"]}'`
 
 The payload could then be mapped in the [Cortex XSOAR mapping wizard](https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/incidents/classification-and-mapping/create-a-mapper):
 - Note that the *Store sample events for mapping* parameter needs to be set.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/content-docs/issues/837

## Description
Fixed an issue where the described request in the README.md of the integration had a missing header. The given request results an error response, adding the header fixes that. 
