### PR TITLE
CortexXDR: fixed the XDR unassigned incidents widget for 6.5

### DIFF
--- a/Packs/CortexXDR/Dashboards/dashboard-Cortex_XDR.json
+++ b/Packs/CortexXDR/Dashboards/dashboard-Cortex_XDR.json
@@ -148,7 +148,7 @@
                 "prevName": "Cortex XDR Unassigned Incidents",
                 "dataType": "incidents",
                 "widgetType": "number",
-                "query": "type:\"Cortex XDR Incident\" and status:Active and owner:",
+                "query": "type:\"Cortex XDR Incident\" and status:Active and owner:\"\"",
                 "sort": null,
                 "isPredefined": false,
                 "dateRange": {

--- a/Packs/CortexXDR/ReleaseNotes/4_2_4.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_2_4.md
@@ -2,3 +2,8 @@
 #### Widgets
 ##### Cortex XDR Unassigned Incidents
 - Maintenance and stability enhancements.
+
+#### Dashboards
+##### Cortex XDR
+- Maintenance and stability enhancements.
+

--- a/Packs/CortexXDR/ReleaseNotes/4_2_4.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_2_4.md
@@ -1,0 +1,4 @@
+
+#### Widgets
+##### Cortex XDR Unassigned Incidents
+- Maintenance and stability enhancements.

--- a/Packs/CortexXDR/Widgets/widget-Cortex_XDR_Unassigned_Incidents.json
+++ b/Packs/CortexXDR/Widgets/widget-Cortex_XDR_Unassigned_Incidents.json
@@ -80,7 +80,7 @@
             }
         ]
     },
-    "query": "type:\"Cortex XDR Incident\" and status:Active and owner:",
+    "query": "type:\"Cortex XDR Incident\" and status:Active and owner:\"\"",
     "size": 0,
     "version": -1,
     "widgetType": "number",

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.2.3",
+    "currentVersion": "4.2.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/43050

## Description
fixed the widget query.
this is only relevant for 6.5 so not specifying it in the RN.

## Screenshots
before (shows incident 102):
![image](https://user-images.githubusercontent.com/30797606/143554041-8afb3aaa-5023-4734-b74f-aadc83c939cf.png)

after (incident 102 is filtered):
![image](https://user-images.githubusercontent.com/30797606/143555574-737194b0-3b82-4a08-8efb-2f0b7cba7fc0.png)
