### PR TITLE
Panorama: improved error handling

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -190,7 +190,6 @@ def http_request(uri: str, method: str, headers: dict = {},
     return json_result
 
 
-@logger
 def add_argument_list(arg: Any, field_name: str, member: Optional[bool], any_: Optional[bool] = False) -> str:
     member_stringify_list = ''
     if arg:
@@ -3016,7 +3015,6 @@ def panorama_edit_rule_command(args: dict):
         params['xpath'] += '/' + element_to_change
 
         result = http_request(URL, 'POST', body=params)
-        demisto.info(f'\n\n\nresponse=\n{result}\n\n\n')
 
         rule_output = {
             'Name': rulename,

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -698,3 +698,60 @@ def test_prettify_rule():
     prettify_rule = prettify_rule(rule)
 
     assert prettify_rule == expected_prettify_rule
+
+
+class TestPanoramaEditRuleCommand:
+    EDIT_SUCCESS_RESPONSE = {'response': {'@status': 'success', '@code': '20', 'msg': 'command succeeded'}}
+
+    @staticmethod
+    def test_sanity(mocker):
+        import Panorama
+        args = {
+            'rulename': 'TestRule',
+            'element_to_change': 'source',
+            'element_value': '1.9.9.1,1.3.3.7',
+            'behaviour': 'add',
+        }
+        commited_rule_item = {
+            'response': {
+                '@status': 'success',
+                '@code': '19',
+                'result': {
+                    '@total-count': '1',
+                    '@count': '1',
+                    'source': {
+                         'member': ['1.9.9.1', '1.3.3.7', '1.9.9.17'],
+        }}}}
+        mocker.patch('Panorama.http_request', return_value=commited_rule_item)
+        Panorama.panorama_edit_rule_command(args)
+
+    @staticmethod
+    def test_add_to_element_on_uncommited_rule(mocker):
+        import Panorama
+        args = {
+            'rulename': 'TestRule',
+            'element_to_change': 'source',
+            'element_value': '1.2.3.4',
+            'behaviour': 'add',
+        }
+        uncommited_rule_item = {
+            'response': {
+                '@status': 'success',
+                '@code': '19',
+                'result': {
+                    '@total-count': '1',
+                    '@count': '1',
+                    'source': {
+                        '@admin': 'admin',
+                        '@dirtyId': '1616',
+                        '@time': '2021/11/27 10:55:18',
+                        'member': {
+                            '@admin': 'admin',
+                            '@dirtyId': '1616',
+                            '@time': '2021/11/27 10:55:18',
+                            '#text': '1.3.3.7'
+                        }}}}}
+        mocker.patch('Panorama.http_request', return_value=uncommited_rule_item)
+
+        with pytest.raises(DemistoException):
+            Panorama.panorama_edit_rule_command(args)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -709,7 +709,7 @@ class TestPanoramaEditRuleCommand:
         args = {
             'rulename': 'TestRule',
             'element_to_change': 'source',
-            'element_value': '1.9.9.1,1.3.3.7',
+            'element_value': '2.3.4.5,3.3.3.3',
             'behaviour': 'add',
         }
         commited_rule_item = {
@@ -720,8 +720,11 @@ class TestPanoramaEditRuleCommand:
                     '@total-count': '1',
                     '@count': '1',
                     'source': {
-                         'member': ['1.9.9.1', '1.3.3.7', '1.9.9.17'],
-        }}}}
+                         'member': ['1.1.1.1', '3.3.3.3', '2.3.4.5'],
+                    }
+                }
+            }
+        }
         mocker.patch('Panorama.http_request', return_value=commited_rule_item)
         Panorama.panorama_edit_rule_command(args)
 
@@ -731,7 +734,7 @@ class TestPanoramaEditRuleCommand:
         args = {
             'rulename': 'TestRule',
             'element_to_change': 'source',
-            'element_value': '1.2.3.4',
+            'element_value': '2.3.4.5',
             'behaviour': 'add',
         }
         uncommited_rule_item = {
@@ -749,8 +752,12 @@ class TestPanoramaEditRuleCommand:
                             '@admin': 'admin',
                             '@dirtyId': '1616',
                             '@time': '2021/11/27 10:55:18',
-                            '#text': '1.3.3.7'
-                        }}}}}
+                            '#text': '3.3.3.3',
+                        }
+                    }
+                }
+            }
+        }
         mocker.patch('Panorama.http_request', return_value=uncommited_rule_item)
 
         with pytest.raises(DemistoException):

--- a/Packs/PAN-OS/ReleaseNotes/1_7_5.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_7_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Improved the error handling of the ***panorama-edit-rule*** command.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.7.4",
+    "currentVersion": "1.7.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/43224

## Description
the command should fail when attempting to edit an uncommitted rule.
improved the error handling.

## Screenshots
before:
![image](https://user-images.githubusercontent.com/30797606/143720720-e56e94c3-8c73-4da9-ad12-e6fe7e6f5ddd.png)

after:
![image](https://user-images.githubusercontent.com/30797606/143720726-c505519c-3da2-4c06-8836-c840dceac590.png)

