### PR TITLE
added McAfee ESM v2 - Test v11.1.3 to skipped integrations.

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4819,6 +4819,7 @@
         "McAfee ESM v2 - Test v10.2.0": "Issue 35670",
         "McAfee ESM Watchlists - Test v10.3.0": "Issue 37130",
         "McAfee ESM Watchlists - Test v10.2.0": "Issue 39389",
+        "McAfee ESM v2 - Test v11.1.3": "Issue 43825",
         "Microsoft Teams Management - Test": "Issue 33410",
         "RedLockTest": "Issue 24600",
         "MicrosoftGraphMail-Test_prod": "Issue 40125",


### PR DESCRIPTION
added McAfee ESM v2 - Test v11.1.3 to skipped integrations.