### PR TITLE
Update Base Pack pdf sane reports script with new docker image

### DIFF
--- a/Packs/Base/ReleaseNotes/1_15_9.md
+++ b/Packs/Base/ReleaseNotes/1_15_9.md
@@ -1,0 +1,7 @@
+#### Scripts
+##### SanePdfReports
+- Update the Docker image to: *demisto/sane-pdf-reports:1.0.0.24891*
+- 6.5 includes the following updates:
+    - Fix overflow of text content at markdown sections
+    - Section Date update of date format
+    - Bug fixes of https://github.com/demisto/etc/issues/42120

--- a/Packs/Base/ReleaseNotes/1_15_9.md
+++ b/Packs/Base/ReleaseNotes/1_15_9.md
@@ -1,6 +1,3 @@
 #### Scripts
 ##### SanePdfReports
 - Update the Docker image to: *demisto/sane-pdf-reports:1.0.0.24891*
-- 6.5 includes the following updates:
-    - Fix overflow of text content at markdown sections
-    - Section Date update of date format

--- a/Packs/Base/ReleaseNotes/1_15_9.md
+++ b/Packs/Base/ReleaseNotes/1_15_9.md
@@ -4,4 +4,3 @@
 - 6.5 includes the following updates:
     - Fix overflow of text content at markdown sections
     - Section Date update of date format
-    - Bug fixes of https://github.com/demisto/etc/issues/42120

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
@@ -67,7 +67,7 @@ tags:
 - pdf
 timeout: '0'
 type: python
-dockerimage: demisto/sane-pdf-reports:1.0.0.24346
+dockerimage: demisto/sane-pdf-reports:1.0.0.24891
 runas: DBotWeakRole
 runonce: false
 tests:

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.15.8",
+    "currentVersion": "1.15.9",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Release for: https://github.com/demisto/dockerfiles/pull/6552

## Description
Release `sane pdf reports` build: `demisto/sane-pdf-reports:1.0.0.24891`. So that will bump *Base Pack* to `1.15.9`

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
