### PR TITLE
Fixed an issue where an incorrect name (inputs.IP addresses) is given…

### DIFF
--- a/Packs/PANWComprehensiveInvestigation/Playbooks/Palo_Alto_Networks_-_Hunting_And_Threat_Detection.yml
+++ b/Packs/PANWComprehensiveInvestigation/Playbooks/Palo_Alto_Networks_-_Hunting_And_Threat_Detection.yml
@@ -2104,7 +2104,7 @@ tasks:
       Hash: {}
       IP:
         complex:
-          root: inputs.IP addresses
+          root: inputs.IPAddresses
           transformers:
           - operator: uniq
           - operator: join

--- a/Packs/PANWComprehensiveInvestigation/ReleaseNotes/1_3_10.md
+++ b/Packs/PANWComprehensiveInvestigation/ReleaseNotes/1_3_10.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Palo Alto Networks - Hunting And Threat Detection
+- Fixed an issue where an incorrect name (inputs.IP addresses) is given in an sub-playbook argument.

--- a/Packs/PANWComprehensiveInvestigation/pack_metadata.json
+++ b/Packs/PANWComprehensiveInvestigation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PANW Comprehensive Investigation",
     "description": "Are you a Palo Alto Networks customer? We have just the content pack to help you orchestrate incident response across Palo Alto Networks products.",
     "support": "xsoar",
-    "currentVersion": "1.3.9",
+    "currentVersion": "1.3.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
… in an sub-playbook argument.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Fixed an issue where an incorrect name (inputs.IP addresses) is given in an sub-playbook argument.

## Screenshots
`IPAddresses` is the name of the inputs of the playbook.
![image](https://user-images.githubusercontent.com/54964121/144186331-953f08be-de47-44e5-a9df-9e03d2fa2564.png)

`inputs.IP addresses` is incorrect. This should be `inputs.IPAddresses`.
![image](https://user-images.githubusercontent.com/54964121/144186421-293a65fa-47cc-4215-928b-2d0a37580d0c.png)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
