### PR TITLE
HashiCorp Vault - add concat username to cred param

### DIFF
--- a/Packs/HashiCorp-Vault/Integrations/HashiCorpVault/HashiCorpVault.yml
+++ b/Packs/HashiCorp-Vault/Integrations/HashiCorpVault/HashiCorpVault.yml
@@ -46,6 +46,12 @@ configuration:
   defaultvalue: KV,Cubbyhole
   type: 0
   required: false
+- display: Concat username to credential object name
+  name: concat_username_to_cred_name
+  type: 8
+  required: false
+  additionalinfo: Should be used in case there are several secrets 
+    under the same folder in order to make the credential object unique.
 script:
   script: ''
   type: python

--- a/Packs/HashiCorp-Vault/Integrations/HashiCorpVault/README.md
+++ b/Packs/HashiCorp-Vault/Integrations/HashiCorpVault/README.md
@@ -30,6 +30,7 @@ For more details, see the <a href="https://www.vaultproject.io/docs/auth/approle
 <li>
 <strong>Fetches credentials</strong> - If set, the integration will fetch credentials from Vault to Cortex XSOAR.</li>
 <li><strong>CSV list of secrets engine types to fetch secrets from</strong></li>
+<li><strong>Concat username to credential object name</strong></li>
 </ul>
 </li>
 <li>Click <strong>Test</strong> to validate the URLs, token, and connection.</li>

--- a/Packs/HashiCorp-Vault/ReleaseNotes/1_0_4.md
+++ b/Packs/HashiCorp-Vault/ReleaseNotes/1_0_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### HashiCorp Vault
+- Added the *Concat username to credential object name* integration parameter to be used in case there are several secrets under the same folder in order to make the credential object unique.

--- a/Packs/HashiCorp-Vault/pack_metadata.json
+++ b/Packs/HashiCorp-Vault/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HashiCorp Vault",
     "description": "Manage Secrets and Protect Sensitive Data through HashiCorp Vault",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
added the `Concat username to credential object name` to handle the case there is more than one secret in the folder, which causes to fetch credentials under the same name and then integrations are unable to use them


## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Documentation 
