### PR TITLE
Fixing overlooked packs

### DIFF
--- a/Packs/Arduino/.pack-ignore
+++ b/Packs/Arduino/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:Arduino]
+ignore=PA129

--- a/Packs/Attlasian/.pack-ignore
+++ b/Packs/Attlasian/.pack-ignore
@@ -4,5 +4,5 @@ ignore=BA108,BA109,IN145
 [file:README.md]
 ignore=RM106
 
-[file:Attlasian]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/BreachNotification-US/.pack-ignore
+++ b/Packs/BreachNotification-US/.pack-ignore
@@ -1,4 +1,4 @@
 [file:layoutscontainer-US_Breach_Notification.json]
 ignore=BA101
-[file:BreachNotification-US]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/CVE_2021_40444/.pack-ignore
+++ b/Packs/CVE_2021_40444/.pack-ignore
@@ -1,5 +1,5 @@
 [file:playbook-CVE-2021-40444_-_MSHTML_RCE_README.md]
 ignore=RM106
 
-[file:CVE_2021_40444]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/CaseManagement-Generic/.pack-ignore
+++ b/Packs/CaseManagement-Generic/.pack-ignore
@@ -39,3 +39,6 @@ ignore=IF100,BA101
 
 [file:playbook-Case_Management_-_Generic.yml]
 ignore=IF100
+
+[file:CaseManagement-Generic]
+ignore=PA129

--- a/Packs/CiscoESAIronPortEmailAPI/.pack-ignore
+++ b/Packs/CiscoESAIronPortEmailAPI/.pack-ignore
@@ -1,4 +1,4 @@
 [file:CiscoIronPortEMailAPI.yml]
 ignore=IN145
-[file:CiscoESAIronPortEmailAPI]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/CommonPlaybooks/.pack-ignore
+++ b/Packs/CommonPlaybooks/.pack-ignore
@@ -60,3 +60,5 @@ ignore=RM106
 
 [file:playbook-Block_Domain_-_Generic.yml]
 ignore=PB110
+[file:CommonPlaybooks]
+ignore=PA129

--- a/Packs/CommonScripts/.pack-ignore
+++ b/Packs/CommonScripts/.pack-ignore
@@ -45,3 +45,5 @@ ignore=BA110
 
 [file:script-PCAPMiner_README.md]
 ignore=RM106
+[file:CommonScripts]
+ignore=PA129

--- a/Packs/CommonTypes/.pack-ignore
+++ b/Packs/CommonTypes/.pack-ignore
@@ -281,3 +281,6 @@ ignore=BA111
 
 [file:incidentfield-Detected_Endpoints.json]
 ignore=IF115
+
+[file:CommonTypes]
+ignore=PA129

--- a/Packs/CommonTypes/.pack-ignore
+++ b/Packs/CommonTypes/.pack-ignore
@@ -149,7 +149,7 @@ ignore=RP102
 ignore=IF107
 
 [file:CommonTypes]
-ignore=PA116
+ignore=PA116,PA129
 
 [file:layoutscontainer-Account.json]
 ignore=BA101
@@ -281,6 +281,3 @@ ignore=BA111
 
 [file:incidentfield-Detected_Endpoints.json]
 ignore=IF115
-
-[file:CommonTypes]
-ignore=PA129

--- a/Packs/Compliance/.pack-ignore
+++ b/Packs/Compliance/.pack-ignore
@@ -88,6 +88,5 @@ ignore=IF107
 [file:incidentfield-affectedindividualscontactinformation.json]
 ignore=IF107
 
-
-[file:Compliance]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/ContentManagement/.pack-ignore
+++ b/Packs/ContentManagement/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ContentManagement]
+ignore=PA129

--- a/Packs/ConvertTimezoneFromUTC/.pack-ignore
+++ b/Packs/ConvertTimezoneFromUTC/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ConvertTimezoneFromUTC]
+ignore=PA129

--- a/Packs/Cortex911/.pack-ignore
+++ b/Packs/Cortex911/.pack-ignore
@@ -1,4 +1,4 @@
 [file:Author_image.png]
 ignore=IM101
-[file:Cortex911]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/CreatePlbkDoc/.pack-ignore
+++ b/Packs/CreatePlbkDoc/.pack-ignore
@@ -1,2 +1,5 @@
 [file:README.md]
 ignore=RM106
+
+[file:CreatePlbkDoc]
+ignore=PA129

--- a/Packs/CrowdStrikeIntel/.pack-ignore
+++ b/Packs/CrowdStrikeIntel/.pack-ignore
@@ -1,4 +1,4 @@
 [file:CrowdStrikeFalconIntel_v2.yml]
 ignore=BA108,BA109
-[file:CrowdStrikeIntel]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/Dig/.pack-ignore
+++ b/Packs/Dig/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:Dig]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/ElasticsearchMonitoring/.pack-ignore
+++ b/Packs/ElasticsearchMonitoring/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:ElasticsearchMonitoring]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/EmailCommunication/.pack-ignore
+++ b/Packs/EmailCommunication/.pack-ignore
@@ -6,3 +6,5 @@ ignore=BA101
 
 [file:classifier-MSGraphMail_-_Incoming_Mapper_-_Email_Communication.json]
 ignore=BA101
+[file:EmailCommunication]
+ignore=PA129

--- a/Packs/ExportToXLSX/.pack-ignore
+++ b/Packs/ExportToXLSX/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ExportToXLSX]
+ignore=PA129

--- a/Packs/ExtFilter/.pack-ignore
+++ b/Packs/ExtFilter/.pack-ignore
@@ -1,2 +1,4 @@
 [file:README.md]
 ignore=RM106
+[file:ExtFilter]
+ignore=PA129

--- a/Packs/FeedDHS/.pack-ignore
+++ b/Packs/FeedDHS/.pack-ignore
@@ -1,5 +1,5 @@
 [file:DHS_Feed.yml]
 ignore=IN122,BA108,BA109,IN145
 
-[file:FeedDHS]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/FeedMajesticMillion/.pack-ignore
+++ b/Packs/FeedMajesticMillion/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:FeedMajesticMillion]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/FetchIndicatorsFromFile/.pack-ignore
+++ b/Packs/FetchIndicatorsFromFile/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:FetchIndicatorsFromFile]
+ignore=PA129

--- a/Packs/FireEyeCommonFields/.pack-ignore
+++ b/Packs/FireEyeCommonFields/.pack-ignore
@@ -8,5 +8,5 @@ ignore=IF100
 [file:incidentfield-FireEye_Alert_Vlan.json]
 ignore=IF100
 
-[file:FireEyeCommonFields]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/ForwardXSOARAuditLogsToSplunkHEC/.pack-ignore
+++ b/Packs/ForwardXSOARAuditLogsToSplunkHEC/.pack-ignore
@@ -1,5 +1,5 @@
 [file:README.md]
 ignore=RM106
 
-[file:ForwardXSOARAuditLogsToSplunkHEC]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/GetLicenseID/.pack-ignore
+++ b/Packs/GetLicenseID/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:GetLicenseID]
+ignore=PA129

--- a/Packs/HIPAA-BreachNotification/.pack-ignore
+++ b/Packs/HIPAA-BreachNotification/.pack-ignore
@@ -1,4 +1,4 @@
 [file:layoutscontainer-HIPAA_Breach_Notification.json]
 ignore=BA101
-[file:HIPAA-BreachNotification]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/Hunting/.pack-ignore
+++ b/Packs/Hunting/.pack-ignore
@@ -1,5 +1,8 @@
 [file:Hunting]
 ignore=PA116,PA129
 
+[file:pack_metadata.json]
+ignore=PA129
+
 [file:README.md]
 ignore=RM104

--- a/Packs/IP-API/.pack-ignore
+++ b/Packs/IP-API/.pack-ignore
@@ -1,4 +1,4 @@
 [file:IPAPI.yml]
 ignore=IN145
-[file:IP-API]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/IntegrationsAndIncidentsHealthCheck/.pack-ignore
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/.pack-ignore
@@ -94,3 +94,5 @@ ignore=RM106
 
 [file:RestartFailedTasks.py]
 ignore=E9003
+[file:IntegrationsAndIncidentsHealthCheck]
+ignore=PA129

--- a/Packs/InvertEveryTwoItems/.pack-ignore
+++ b/Packs/InvertEveryTwoItems/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:InvertEveryTwoItems]
+ignore=PA129

--- a/Packs/JsonUnescape/.pack-ignore
+++ b/Packs/JsonUnescape/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:JsonUnescape]
+ignore=PA129

--- a/Packs/LSASSCredentialDumping/.pack-ignore
+++ b/Packs/LSASSCredentialDumping/.pack-ignore
@@ -1,4 +1,4 @@
 [file:README.md]
 ignore=RM104
-[file:LSASSCredentialDumping]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/MajorBreachesInvestigationandResponse/.pack-ignore
+++ b/Packs/MajorBreachesInvestigationandResponse/.pack-ignore
@@ -12,3 +12,6 @@ ignore=RM106
 
 [file:playbook-CVE-2021-1675_-_PrintNightmare.yml]
 ignore=BA101
+
+[file:MajorBreachesInvestigationandResponse]
+ignore=PA129

--- a/Packs/MapPattern/.pack-ignore
+++ b/Packs/MapPattern/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:MapPattern]
+ignore=PA129

--- a/Packs/MapRegex/.pack-ignore
+++ b/Packs/MapRegex/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:MapRegex]
+ignore=PA129

--- a/Packs/MergeDictArray/.pack-ignore
+++ b/Packs/MergeDictArray/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:MergeDictArray]
+ignore=PA129

--- a/Packs/MicrosoftPolicyAndCompliance/.pack-ignore
+++ b/Packs/MicrosoftPolicyAndCompliance/.pack-ignore
@@ -1,4 +1,4 @@
 [file:playbook-Azure_Hunting_playbook.yml]
 ignore=BA110
-[file:MicrosoftPolicyAndCompliance]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/ModulesManagement/.pack-ignore
+++ b/Packs/ModulesManagement/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ModulesManagement]
+ignore=PA129

--- a/Packs/NCSCCyberAsssessmentFramework/.pack-ignore
+++ b/Packs/NCSCCyberAsssessmentFramework/.pack-ignore
@@ -6,5 +6,5 @@ ignore=BA101
 
 [file:README.md]
 ignore=RM104
-[file:NCSCCyberAsssessmentFramework]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/NonSupported/.pack-ignore
+++ b/Packs/NonSupported/.pack-ignore
@@ -100,7 +100,7 @@ ignore=RP104
 [file:playbook-Detonate_url_-_Generic_4_9_9.yml]
 ignore=BA101
 
-[file:NonSupported]
+[file:pack_metadata.json]
 ignore=PA116,PA129
 
 [file:integration-SecureWorks_V350.yml]

--- a/Packs/Oracle_IAM/.pack-ignore
+++ b/Packs/Oracle_IAM/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:Oracle_IAM]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/PaloAltoNetworksAutomaticSLR_Community/.pack-ignore
+++ b/Packs/PaloAltoNetworksAutomaticSLR_Community/.pack-ignore
@@ -6,3 +6,5 @@ ignore=BA111
 
 [file:PaloAltoNetworksAutomaticSLRCommunity.yml]
 ignore=IN145
+[file:PaloAltoNetworksAutomaticSLR_Community]
+ignore=PA129

--- a/Packs/ParseHTMLTables/.pack-ignore
+++ b/Packs/ParseHTMLTables/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ParseHTMLTables]
+ignore=PA129

--- a/Packs/ParseYAML/.pack-ignore
+++ b/Packs/ParseYAML/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ParseYAML]
+ignore=PA129

--- a/Packs/PopularCybersecurityNews/.pack-ignore
+++ b/Packs/PopularCybersecurityNews/.pack-ignore
@@ -1,4 +1,4 @@
 [file:layoutscontainer-News_Layout.json]
 ignore=BA101
-[file:PopularCybersecurityNews]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/PowershellPayloadResponse/.pack-ignore
+++ b/Packs/PowershellPayloadResponse/.pack-ignore
@@ -1,2 +1,4 @@
 [file:README.md]
 ignore=RM104
+[file:PowershellPayloadResponse]
+ignore=PA129

--- a/Packs/PrismaCloudCompute/.pack-ignore
+++ b/Packs/PrismaCloudCompute/.pack-ignore
@@ -18,5 +18,5 @@ ignore=BA101
 [file:incidentfield-Prisma_Cloud_Compute_Raw_Alert_JSON.json]
 ignore=IF100
 
-[file:PrismaCloudCompute]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/PublishList/.pack-ignore
+++ b/Packs/PublishList/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:PublishList]
+ignore=PA129

--- a/Packs/QRCodeReader/.pack-ignore
+++ b/Packs/QRCodeReader/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:QRCodeReader]
+ignore=PA129

--- a/Packs/RandomImages_VideosAndAudio/.pack-ignore
+++ b/Packs/RandomImages_VideosAndAudio/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:RandomImages_VideosAndAudio]
+ignore=PA129

--- a/Packs/Redact_DefangIndicators_URLs_IPs_Email/.pack-ignore
+++ b/Packs/Redact_DefangIndicators_URLs_IPs_Email/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:Redact_DefangIndicators_URLs_IPs_Email]
+ignore=PA129

--- a/Packs/RegexReplace/.pack-ignore
+++ b/Packs/RegexReplace/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:RegexReplace]
+ignore=PA129

--- a/Packs/RemoveEmpty/.pack-ignore
+++ b/Packs/RemoveEmpty/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:RemoveEmpty]
+ignore=PA129

--- a/Packs/SAP_IAM/.pack-ignore
+++ b/Packs/SAP_IAM/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:SAP_IAM]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/ServerLogs/.pack-ignore
+++ b/Packs/ServerLogs/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:ServerLogs]
+ignore=PA129

--- a/Packs/ShiftManagement-AssignToNextShift/.pack-ignore
+++ b/Packs/ShiftManagement-AssignToNextShift/.pack-ignore
@@ -1,2 +1,4 @@
 [file:README.md]
 ignore=RM104
+[file:ShiftManagement-AssignToNextShift]
+ignore=PA129

--- a/Packs/SplunkCIMFields/.pack-ignore
+++ b/Packs/SplunkCIMFields/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:SplunkCIMFields]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/StringifyArray/.pack-ignore
+++ b/Packs/StringifyArray/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:StringifyArray]
+ignore=PA129

--- a/Packs/StripAccentMarksFromString/.pack-ignore
+++ b/Packs/StripAccentMarksFromString/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:StripAccentMarksFromString]
+ignore=PA129

--- a/Packs/TIMCampaignTracking/.pack-ignore
+++ b/Packs/TIMCampaignTracking/.pack-ignore
@@ -1,4 +1,4 @@
 [file:README.md]
 ignore=RM104
-[file:TIMCampaignTracking]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/TeamManagement/.pack-ignore
+++ b/Packs/TeamManagement/.pack-ignore
@@ -1,2 +1,5 @@
 [file:README.md]
 ignore=RM104
+
+[file:TeamManagement]
+ignore=PA129

--- a/Packs/TwitterIOCHunter-FullDailyFeed/.pack-ignore
+++ b/Packs/TwitterIOCHunter-FullDailyFeed/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:TwitterIOCHunter-FullDailyFeed]
+[file:pack_metadata.json]
 ignore=PA129

--- a/Packs/UnifiVideoNVR/.pack-ignore
+++ b/Packs/UnifiVideoNVR/.pack-ignore
@@ -6,3 +6,5 @@ ignore=BA101
 
 [file:UnifiVideo.yml]
 ignore=IN145
+[file:UnifiVideoNVR]
+ignore=PA129

--- a/Packs/UpdateEntriesBySearch/.pack-ignore
+++ b/Packs/UpdateEntriesBySearch/.pack-ignore
@@ -1,0 +1,3 @@
+
+[file:UpdateEntriesBySearch]
+ignore=PA129

--- a/Packs/UpdateEntriesBySearch/.pack-ignore
+++ b/Packs/UpdateEntriesBySearch/.pack-ignore
@@ -1,3 +1,3 @@
 
-[file:UpdateEntriesBySearch]
+[file:pack_metadata.json]
 ignore=PA129


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: continue of #[42578](https://github.com/demisto/etc/issues/42578)

## Description
Fixing missed packs that don't ignore PA129 code, adding it to `.pack-ignore` file.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
