### PR TITLE
Added associateIndicatorsToIncident ecxecution to GetCampaignIndicatorsByIncidentId script

### DIFF
--- a/Packs/Campaign/ReleaseNotes/3_1_6.md
+++ b/Packs/Campaign/ReleaseNotes/3_1_6.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### GetCampaignIndicatorsByIncidentId
+Fixed issues that prevented the campaign indicators from updating and displaying properly in the Phishing Campaign incident layout.

--- a/Packs/Campaign/Scripts/GetCampaignIndicatorsByIncidentId/GetCampaignIndicatorsByIncidentId.yml
+++ b/Packs/Campaign/Scripts/GetCampaignIndicatorsByIncidentId/GetCampaignIndicatorsByIncidentId.yml
@@ -7,6 +7,7 @@ type: python
 comment: Gets the campaign indicators by the campaign incident ids as a MD table.
 tags:
 - field-display
+- dynamic-section
 enabled: true
 scripttarget: 0
 subtype: python3

--- a/Packs/Campaign/Scripts/GetCampaignIndicatorsByIncidentId/GetCampaignIndicatorsByIncidentId_test.py
+++ b/Packs/Campaign/Scripts/GetCampaignIndicatorsByIncidentId/GetCampaignIndicatorsByIncidentId_test.py
@@ -76,3 +76,22 @@ def test_get_indicators_by_incident_id(mocker, incident_ids, indicators, expecte
     result = format_results(indicators_res, incident_ids)
 
     assert result == expected_result
+
+
+def test_set_path(mocker):
+    execute_command_mocker = mocker.patch.object(demisto, 'executeCommand')
+    mocker.patch('GetCampaignIndicatorsByIncidentId.get_incidents_ids_from_context', return_value={})
+    mocker.patch('GetCampaignIndicatorsByIncidentId.get_indicatos_from_incidents', return_value={})
+    mocker.patch('GetCampaignIndicatorsByIncidentId.format_results', return_value='test')
+    main()
+    execute_command_mocker.assert_called_once_with('setIncident', {'campaignmutualindicators': 'test'})
+
+
+def test_associate_to_current_incident(mocker):
+    execute_command_mocker = mocker.patch.object(demisto, 'executeCommand')
+    mocker.patch.object(demisto, 'incident', return_value={'id': 'id'})
+    associate_to_current_incident([{'value': 'indicators'}])
+    execute_command_mocker.assert_called_once_with(
+        'associateIndicatorsToIncident',
+        {'incidentId': 'id', 'indicatorsValues': ['indicators']}
+    )

--- a/Packs/Campaign/pack_metadata.json
+++ b/Packs/Campaign/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing Campaign",
     "description": "This pack can help you find related phishing, spam or other types of email incidents and characterize campaigns.",
     "support": "xsoar",
-    "currentVersion": "3.1.5",
+    "currentVersion": "3.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->


## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/43586

## Description
Added associateIndicatorsToIncident so the indicators will be extracted and clickable.

## Minimum version of Cortex XSOAR
- [x] 6.0.0

## Does it break backward compatibility?
- [x] No

## Must have
- [x] Tests