### PR TITLE
PB name change in the Block IP Generic V3 playbook

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Block_IP_-_Generic_v3.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Block_IP_-_Generic_v3.yml
@@ -3450,8 +3450,8 @@ inputs:
   value: {}
   required: false
   description: Insert a tag name with which indicators will get tagged. This tag can
-    be used later in the External Dynamic Lists integration by using the tag for
-    filtering IPs in the indicator query.
+    be used later in the External Dynamic Lists integration by using the tag for filtering
+    IPs in the indicator query.
   playbookInputQuery:
 - key: DAG
   value: {}

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Block_IP_-_Generic_v3.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Block_IP_-_Generic_v3.yml
@@ -2656,10 +2656,10 @@ tasks:
     task:
       id: 9c275081-8770-40c6-8c5d-9041e5da00bb
       version: -1
-      name: f110702f-70b8-4c74-8438-829d4ec553c1
+      name: Cisco FirePower- Append network group object
       description: This playbook will append a network group object with new elements
         (IPs or network objects).
-      playbookId: f110702f-70b8-4c74-8438-829d4ec553c1
+      playbookName: Cisco FirePower- Append network group object
       type: playbook
       iscommand: false
       brand: ""

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_1_4.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_1_4.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Block IP - Generic v3
+- Fixed sub-playbook issue (Cisco Firepower related)

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.1.3",
+    "currentVersion": "2.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [#44505](https://github.com/demisto/etc/issues/44505)

## Description
Changed a strange bug caused probably during the format action. 
Seems like the SDK changed the playbook to be with its ID instead with `playbookName` and `Name` variables.


## Screenshots
Wrong 🔴 :
![image](https://user-images.githubusercontent.com/88268646/144854959-8cdb602a-16b8-4327-966b-8e6e8bf2ee6d.png)


Right ✅ :
![image](https://user-images.githubusercontent.com/88268646/144854979-da0f1845-56cf-4b33-90bf-f6535691610c.png)


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
