### PR TITLE
Remove MITRE TPB as deprecated.

### DIFF
--- a/Packs/FeedMitreAttack/.pack-ignore
+++ b/Packs/FeedMitreAttack/.pack-ignore
@@ -6,3 +6,6 @@ ignore=RM102
 
 [file:layoutscontainer-MITRE_ATT&CK.json]
 ignore=BA101
+
+[file:playbook-Mitre_Attack_List_2_Indicators_Feed_Test.yml]
+ignore=auto-test

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -236,11 +236,6 @@
             "fromversion": "5.5.0"
         },
         {
-            "integrations": "MITRE ATT&CK",
-            "playbookID": "Mitre Attack List 10 Indicators Feed Test",
-            "fromversion": "5.5.0"
-        },
-        {
             "integrations": "URLhaus",
             "playbookID": "Test_URLhaus",
             "timeout": 1000


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://panw-global.slack.com/archives/G011E63JXPB/p1638782192008900

## Description
Remove MITRE TPB from the test.conf file as deprecated.
