### PR TITLE
fix test-playbook command

### DIFF
--- a/Packs/NetscoutAED/TestPlaybooks/NetscoutAED-Test.yml
+++ b/Packs/NetscoutAED/TestPlaybooks/NetscoutAED-Test.yml
@@ -591,7 +591,7 @@ tasks:
       version: -1
       name: Add host to the inbound block listed list
       description: Adds one or more hosts to the inbound block listed list.
-      script: '|||na-ed-inbound-block listed-hosts-add'
+      script: '|||na-ed-inbound-blacklisted-hosts-add'
       type: regular
       iscommand: true
       brand: ""


### PR DESCRIPTION
The command name was mistakenly renamed as part of https://github.com/demisto/content/pull/15858 causing the test-playbook to fail.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)
