### PR TITLE
remove NetscoutAED-test playbook from skipped

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4880,8 +4880,7 @@
         "GuardiCoreV2-Test": "Issue 43822",
         "LogRhythm REST test": "Issue 40654",
         "Tanium Threat Response V2 Test": "Issue 44201",
-        "ExtractAttackPattern-Test": "Issue 44095",
-        "NetscoutAED-Test": "Issue 44455"
+        "ExtractAttackPattern-Test": "Issue 44095"
     },
     "skipped_integrations": {
         "AutoFocus V2": "Issue 26464",


### PR DESCRIPTION
NetscoutAED testPlaybook was fixed here: https://github.com/demisto/content/pull/16183
Removed it from skipped tests.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)
