### PR TITLE
[greynoise-266] Fix bug that broke compatibility with pre-6.1 versions

### DIFF
--- a/Packs/GreyNoise/Integrations/GreyNoise/GreyNoise.py
+++ b/Packs/GreyNoise/Integrations/GreyNoise/GreyNoise.py
@@ -7,7 +7,6 @@ import traceback
 import requests
 import re
 import copy
-from distutils.version import StrictVersion
 from typing import Tuple, Dict, Any
 from greynoise import GreyNoise, exceptions, util  # type: ignore
 from greynoise.exceptions import RequestFailure, RateLimitError  # type: ignore
@@ -910,7 +909,7 @@ def main() -> None:
     :rtype:
     """
     # get pack version
-    if StrictVersion(demisto.demistoVersion()['version']) >= StrictVersion("6.1.0"):
+    if is_demisto_version_ge("6.1.0"):
         response = demisto.internalHttpRequest("GET", "/contentpacks/metadata/installed")
         packs = json.loads(response["body"])
     else:

--- a/Packs/GreyNoise/Integrations/GreyNoise/GreyNoise.py
+++ b/Packs/GreyNoise/Integrations/GreyNoise/GreyNoise.py
@@ -7,6 +7,7 @@ import traceback
 import requests
 import re
 import copy
+from distutils.version import StrictVersion
 from typing import Tuple, Dict, Any
 from greynoise import GreyNoise, exceptions, util  # type: ignore
 from greynoise.exceptions import RequestFailure, RateLimitError  # type: ignore
@@ -909,10 +910,13 @@ def main() -> None:
     :rtype:
     """
     # get pack version
-    response = demisto.internalHttpRequest("GET", "/contentpacks/metadata/installed")
-    packs = json.loads(response["body"])
+    if StrictVersion(demisto.demistoVersion()['version']) >= StrictVersion("6.1.0"):
+        response = demisto.internalHttpRequest("GET", "/contentpacks/metadata/installed")
+        packs = json.loads(response["body"])
+    else:
+        packs = []
 
-    pack_version = "1.1.0"
+    pack_version = "1.1.1"
     for pack in packs:
         if pack["name"] == "GreyNoise":
             pack_version = pack["currentVersion"]

--- a/Packs/GreyNoise/Integrations/GreyNoise_Community/GreyNoise_Community.py
+++ b/Packs/GreyNoise/Integrations/GreyNoise_Community/GreyNoise_Community.py
@@ -8,7 +8,6 @@ import urllib3  # type: ignore
 import traceback
 import requests
 import copy
-from distutils.version import StrictVersion
 from typing import Tuple
 from greynoise import GreyNoise, util  # type: ignore
 from greynoise.exceptions import RequestFailure, RateLimitError  # type: ignore
@@ -289,7 +288,7 @@ def main() -> None:
     """
 
     # get pack version
-    if StrictVersion(demisto.demistoVersion()['version']) >= StrictVersion("6.1.0"):
+    if is_demisto_version_ge("6.1.0"):
         response = demisto.internalHttpRequest("GET", "/contentpacks/metadata/installed")
         packs = json.loads(response["body"])
     else:

--- a/Packs/GreyNoise/Integrations/GreyNoise_Community/GreyNoise_Community.py
+++ b/Packs/GreyNoise/Integrations/GreyNoise_Community/GreyNoise_Community.py
@@ -8,6 +8,7 @@ import urllib3  # type: ignore
 import traceback
 import requests
 import copy
+from distutils.version import StrictVersion
 from typing import Tuple
 from greynoise import GreyNoise, util  # type: ignore
 from greynoise.exceptions import RequestFailure, RateLimitError  # type: ignore
@@ -288,10 +289,13 @@ def main() -> None:
     """
 
     # get pack version
-    response = demisto.internalHttpRequest('GET', '/contentpacks/metadata/installed')
-    packs = json.loads(response['body'])
+    if StrictVersion(demisto.demistoVersion()['version']) >= StrictVersion("6.1.0"):
+        response = demisto.internalHttpRequest("GET", "/contentpacks/metadata/installed")
+        packs = json.loads(response["body"])
+    else:
+        packs = []
 
-    pack_version = "1.1.0"
+    pack_version = "1.1.1"
     for pack in packs:
         if pack["name"] == "GreyNoise":
             pack_version = pack["currentVersion"]

--- a/Packs/GreyNoise/ReleaseNotes/1_1_1.md
+++ b/Packs/GreyNoise/ReleaseNotes/1_1_1.md
@@ -1,0 +1,5 @@
+#### Integrations
+##### GreyNoise
+- Fixed bug to allow backward compatibility
+##### GreyNoise Community
+- Fixed bug to allow backward compatibility

--- a/Packs/GreyNoise/pack_metadata.json
+++ b/Packs/GreyNoise/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GreyNoise",
     "description": "GreyNoise is a threat intelligence service that collects and analyzes Internet-wide scan and attack traffic. With this integration, users can contextualize existing alerts, filter false-positives, identify compromised devices, and track emerging threats. The full integration code can be found here: https://github.com/demisto/content/tree/master/Packs/GreyNoise",
     "support": "partner",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "GreyNoise",
     "url": "https://greynoise.io",
     "email": "support@greynoise.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

- The 1.1.0 version introduced a bug where the pack would no longer work with 6.1 and previous.  I've added a fix to allow it to work as expected on previous versions.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
