### PR TITLE
Unit42 ATOMs fix get-indicators command

### DIFF
--- a/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
+++ b/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
@@ -72,12 +72,12 @@ class Client(BaseClient):
         for type_ in items_types:
             self.fetch_stix_objects_from_api(test, type=type_)
 
-    def fetch_stix_objects_from_api(self, test: bool = False, **kwargs):
+    def fetch_stix_objects_from_api(self, test: bool = False, limit: int = -1, **kwargs):
         """Retrieves all entries from the feed.
 
         Args:
             test: Whether it was called during clicking the test button or not - designed to save time.
-
+            limit: number of indicators for get command
         """
         data = []
 
@@ -88,7 +88,7 @@ class Client(BaseClient):
             for collection in api_root.collections:
                 for bundle in as_pages(collection.get_objects, per_request=100, **kwargs):
                     data.extend(bundle.get('objects'))
-                    if test:
+                    if test and limit < len(data):
                         return data
 
         self.objects_data[kwargs.get('type')] = data
@@ -646,7 +646,7 @@ def get_indicators_command(client: Client, args: Dict[str, str], feed_tags: list
     """
     limit = int(args.get('limit', '10'))
 
-    indicators = client.fetch_stix_objects_from_api(test=True, type='indicator')
+    indicators = client.fetch_stix_objects_from_api(test=True, type='indicator', limit=limit)
 
     indicators = parse_indicators(indicators, feed_tags, tlp_color)
     limited_indicators = indicators[:limit]

--- a/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
+++ b/Packs/FeedUnit42v2/Integrations/FeedUnit42v2/FeedUnit42v2.py
@@ -91,6 +91,8 @@ class Client(BaseClient):
                     if test and limit < len(data):
                         return data
 
+        if test:
+            return data
         self.objects_data[kwargs.get('type')] = data
 
 

--- a/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Unit42 ATOMs Feed
-- Fixed an issue where **unit42-get-indicators** command were not handle **limit** argument properly.
+- Fixed an issue where **unit42-get-indicators** command was not handled **limit** argument properly.

--- a/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Unit42 ATOMs Feed
+- Fixed an issue where **unit42-get-indicators** command were not handle **limit** argument properly.

--- a/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
+++ b/Packs/FeedUnit42v2/ReleaseNotes/1_0_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Unit42 ATOMs Feed
-- Fixed an issue where **unit42-get-indicators** command was not handled **limit** argument properly.
+- Fixed an issue where the ***unit42-get-indicators*** command was not handling the **limit** argument properly.

--- a/Packs/FeedUnit42v2/pack_metadata.json
+++ b/Packs/FeedUnit42v2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Unit42 v2 Feed",
     "description": "Unit42 feed of published IOCs which contains malicious indicators.",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://panw-global.slack.com/archives/C011E5T5K17/p1638866887083000

## Description
Fixed an issue where **unit42-get-indicators** command was not handled **limit** argument properly.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No