### PR TITLE
Freeze lazy-object-proxy pip package to 1.4.0

### DIFF
--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -12,3 +12,4 @@ pypdf2==1.26.0
 requests-mock==1.8.0
 git+https://github.com/coyo8/parinx.git@6493798ceba8089345d970f71be4a896eb6b081d
 vulture==1.5
+lazy-object-proxy==1.4.0


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: the build

## Description
lazy-object-proxy bumped versions and dropped support for python 2.7 Since Astroid depends on this package, we freeze it at 1.4.0 to meet the minimum required version for Astroid.