### PR TITLE
Update http artifact method to GET request and change naming assumptions

### DIFF
--- a/Packs/ContentManagement/Playbooks/playbook-Configuration_Setup.yml
+++ b/Packs/ContentManagement/Playbooks/playbook-Configuration_Setup.yml
@@ -790,10 +790,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "30":
     id: "30"
-    taskid: 56b086df-0caf-401f-81df-6a00c2f7074e
+    taskid: 6009275f-d453-4f60-85dd-281d89081cc5
     type: regular
     task:
-      id: 56b086df-0caf-401f-81df-6a00c2f7074e
+      id: 6009275f-d453-4f60-85dd-281d89081cc5
       version: -1
       name: Download Custom Packs using an HTTP request
       description: Sends an HTTP request. Returns the response as a JSON file.
@@ -805,8 +805,19 @@ tasks:
       '#none#':
       - "12"
     scriptarguments:
+      filename:
+        complex:
+          root: ${ConfigurationSetup.CustomPacks
+          accessor: packid}
+          transformers:
+          - operator: concat
+            args:
+              prefix: {}
+              suffix:
+                value:
+                  simple: .zip
       method:
-        simple: POST
+        simple: GET
       saveAsFile:
         simple: "yes"
       url:

--- a/Packs/ContentManagement/ReleaseNotes/1_1_0.md
+++ b/Packs/ContentManagement/ReleaseNotes/1_1_0.md
@@ -1,0 +1,5 @@
+
+#### Playbooks
+##### Configuration Setup
+- Make !http artifact download method a GET request
+- Append .zip to pack zip downloaded via !http

--- a/Packs/ContentManagement/pack_metadata.json
+++ b/Packs/ContentManagement/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "XSOAR CI/CD (Beta)",
     "description": "This pack enables you to orchestrate your XSOAR system configuration.",
     "support": "xsoar",
-    "currentVersion": "1.0.10",
+    "currentVersion": "1.1.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This PR updates the ContentManagement packs playbook for users wanting to leverage the simple `!http` command to download custom content packs.

Currently the command uses POST, but this is probably not as common as uses GET for servers hosting un authenticated files. Presumably the end user will host files on an internal webserver which xsoar has access to. I would suspect the client to use a GET method when downloading these files.

Either way the current name pulled back by the `!http` command would be `http-file` by default.  The conditional in the `CustomPackInstaller` automation checks for `File.Name` that matches the pack_id. 

```
 if file_in_context['Name'] == f'{pack_id}.zip':
```

 Therefore the downloaded file name should match this naming convention by default (pack_id.zip).

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
