### PR TITLE
Fix xql note bug

### DIFF
--- a/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.py
+++ b/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.py
@@ -340,7 +340,7 @@ def start_xql_query(client: Client, args: Dict[str, Any]) -> str:
         raise ValueError('query is not specified')
 
     if 'limit' not in query:  # if user did not provide a limit in the query, we will use the default one.
-        query = f'{query} | limit {str(DEFAULT_LIMIT)}'
+        query = f'{query} \n| limit {str(DEFAULT_LIMIT)}'
     data: Dict[str, Any] = {
         'request_data': {
             'query': query,

--- a/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.py
+++ b/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.py
@@ -338,8 +338,6 @@ def start_xql_query(client: Client, args: Dict[str, Any]) -> str:
     query = args.get('query', '')
     if not query:
         raise ValueError('query is not specified')
-    if '//' in query:
-        raise DemistoException('Please remove notes (//) from query')
 
     if 'limit' not in query:  # if user did not provide a limit in the query, we will use the default one.
         query = f'{query} | limit {str(DEFAULT_LIMIT)}'

--- a/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine_test.py
+++ b/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine_test.py
@@ -422,27 +422,6 @@ def test_start_xql_query_valid(mocker):
     assert response == 'execution_id'
 
 
-def test_start_xql_query_invalid(mocker):
-    """
-    Given:
-    - An invalid query to search.
-
-    When:
-    - Calling start_xql_query function.
-
-    Then:
-    - Ensure an error is returned.
-    """
-    args = {
-        'query': 'test_query // Some Note',
-        'time_frame': '1 year'
-    }
-    mocker.patch.object(CLIENT, 'start_xql_query', return_value='execution_id')
-    with pytest.raises(Exception) as exc:
-        XQLQueryingEngine.start_xql_query(CLIENT, args=args)
-    assert str(exc.value) == 'Please remove notes (//) from query'
-
-
 def test_get_xql_query_results_success_under_1000(mocker):
     """
     Given:

--- a/Packs/CortexXDR/ReleaseNotes/4_2_11.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_2_11.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cortex XDR - XQL Query Engine
+- Removed the "notes" validation check.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.2.10",
+    "currentVersion": "4.2.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/44876

## Description
Removed the notes validations since the code can run without this validation and cant run regexs in the query without it.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

