### PR TITLE
Changed the Demisto Lock instance in the Phishing Campaign test

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4313,7 +4313,7 @@
                 "Rasterize",
                 "Demisto Lock"
             ],
-            "instance_names": "no_sync"
+            "instance_names": "no_sync_long_timeout"
         },
         {
             "playbookID": "PCAP Search test",


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related to this merge request on GitLab: https://code.pan.run/xsoar/content-test-conf/-/merge_requests/1346

## Description
I added a new Demisto Lock instance in the conf.json in test-conf which has a very long timeout (9000).
Now I'm updating the Phishing Campaign test to use the instance with the longer timeout to avoid failures when phishing incidents take long.

## Minimum version of Cortex XSOAR
6.0.0

## Does it break backward compatibility?
No

