### PR TITLE
RQL command fix

### DIFF
--- a/Packs/PrismaCloud/Integrations/RedLock/RedLock.py
+++ b/Packs/PrismaCloud/Integrations/RedLock/RedLock.py
@@ -402,9 +402,9 @@ def get_rql_response(args):
     payload = {"query": rql, "filter": {}}
 
     handle_filters(payload['filter'])
-    handle_time_filter(payload['filter'], {'type': 'to_now', 'value': 'epoch'})
+    handle_time_filter(payload, {'type': 'to_now', 'value': 'epoch'})
 
-    response = req('POST', 'search/config', payload, None)
+    response = req('POST', 'search', payload, None)
 
     human_readable = []
 

--- a/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
+++ b/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Prisma Cloud (RedLock)
+- Fix get-rql-response command

--- a/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
+++ b/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Prisma Cloud (RedLock)
-- Fix get-rql-response command
+- Change get-rql-response command to the `/search` endpoint instead of `/search/config` endpoint
+- Change the location of the timeRange model to the correct location.

--- a/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
+++ b/Packs/PrismaCloud/ReleaseNotes/2_0_6.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Prisma Cloud (RedLock)
-- Change get-rql-response command to the `/search` endpoint instead of `/search/config` endpoint
-- Change the location of the timeRange model to the correct location.
+- Changed ***redlock-get-rql-response*** command to use `/search` API instead of `/search/config` API.
+- Fixed an issue in ***redlock-get-rql-response*** command where the **timeRange** wasn't calculated correctly.

--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud",
     "description": "Automate and unify security incident response across your cloud environments, while still giving a degree of control to dedicated cloud teams.",
     "support": "xsoar",
-    "currentVersion": "2.0.5",
+    "currentVersion": "2.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/24600

## Description
- Change get-rql-response command to the `/search` endpoint instead of `/search/config` endpoint
- Change the location of the timeRange model to the correct location.


## Minimum version of Cortex XSOAR
- [x] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [x] Tests
- [x] Documentation 
