### PR TITLE
Panorama grt-url-catagory: return CommandResult instead of raise exception

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -2324,6 +2324,7 @@ def panorama_get_url_category_command(url_cmd: str, url: str, additional_suspici
     categories_dict_hr: Dict[str, list] = {}
     command_results: List[CommandResults] = []
     for url in urls:
+        err_readable_output = None
         try:
             category = panorama_get_url_category(url_cmd, url)
             if category in categories_dict:
@@ -2336,31 +2337,24 @@ def panorama_get_url_category_command(url_cmd: str, url: str, additional_suspici
             categories_dict[category] = list((set(categories_dict[category])).union(set(context_urls)))
 
             score = calculate_dbot_score(category.lower(), additional_suspicious, additional_malicious)
-            dbot_score = Common.DBotScore(
-                indicator=url,
-                indicator_type=DBotScoreType.URL,
-                integration_name='PAN-OS',
-                score=score
-            )
-            url_obj = Common.URL(
-                url=url,
-                dbot_score=dbot_score,
-                category=category
-            )
-            readable_output = tableToMarkdown('URL', url_obj.to_context())
-        except Exception as e:
-            dbot_score = Common.DBotScore(
-                indicator=url,
-                indicator_type=DBotScoreType.URL,
-                integration_name='PAN-OS',
-                score=0
-            )
-            url_obj = Common.URL(
-                url=url,
-                dbot_score=dbot_score
-            )
-            readable_output = str(e)
 
+        except Exception as e:
+            score = 0
+            category = None
+            err_readable_output = str(e)
+
+        dbot_score = Common.DBotScore(
+            indicator=url,
+            indicator_type=DBotScoreType.URL,
+            integration_name='PAN-OS',
+            score=score
+        )
+        url_obj = Common.URL(
+            url=url,
+            dbot_score=dbot_score,
+            category=category
+        )
+        readable_output = err_readable_output or tableToMarkdown('URL', url_obj.to_context())
         command_results.append(CommandResults(
             indicator=url_obj,
             readable_output=readable_output

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -86,6 +86,10 @@ class PAN_OS_Not_Found(Exception):
         pass
 
 
+class InvalidUrlLengthException(Exception):
+    pass
+
+
 def http_request(uri: str, method: str, headers: dict = {},
                  body: dict = {}, params: dict = {}, files: dict = None, is_pcap: bool = False) -> Any:
     """
@@ -130,7 +134,7 @@ def http_request(uri: str, method: str, headers: dict = {},
                 if DEVICE_GROUP:
                     raise Exception('URL filtering commands are only available on Firewall devices.')
                 if 'Node can be at most 1278 characters' in response_msg:
-                    raise Exception('URL Node can be at most 1278 characters.')
+                    raise InvalidUrlLengthException('URL Node can be at most 1278 characters.')
                 raise Exception('The URL filtering license is either expired or not active.'
                                 ' Please contact your PAN-OS representative.')
 
@@ -2338,7 +2342,7 @@ def panorama_get_url_category_command(url_cmd: str, url: str, additional_suspici
 
             score = calculate_dbot_score(category.lower(), additional_suspicious, additional_malicious)
 
-        except Exception as e:
+        except InvalidUrlLengthException as e:
             score = 0
             category = None
             err_readable_output = str(e)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -942,3 +942,40 @@ def test_panorama_push_to_device_group_command(mocker, args, expected_request_pa
 
     demisto_result_got = return_results_mock.call_args.args[0]['EntryContext']
     assert demisto_result_got == expected_demisto_result
+
+
+def test_get_url_category__url_length_gt_1278(mocker):
+    """
+    Given:
+        - Error in response indicating the url to get category for is over the allowed length (1278 chars)
+
+    When:
+        - Run get_url_category command
+
+    Then:
+        - Validate a commandResult is returned with detailed readable output
+    """
+
+    # prepare
+    import Panorama
+    import requests
+    from Panorama import panorama_get_url_category_command
+    Panorama.DEVICE_GROUP = ''
+    mocked_res_dict = {
+        'response': {
+            '@status': 'error',
+            '@code': '20',
+            'msg': {'line': 'test -> url Node can be at most 1278 characters, but current length: 1288'}
+        }}
+    mocked_res_obj = requests.Response()
+    mocked_res_obj.status_code = 200
+    mocked_res_obj._content = json.dumps(mocked_res_dict).encode('utf-8')
+    mocker.patch.object(requests, 'request', return_value=mocked_res_obj)
+    mocker.patch.object(Panorama, 'xml2json', return_value=mocked_res_obj._content)
+    return_results_mock = mocker.patch.object(Panorama, 'return_results')
+
+    # run
+    panorama_get_url_category_command(url_cmd='url', url='test_url', additional_suspicious=[], additional_malicious=[])
+
+    # validate
+    assert 'URL Node can be at most 1278 characters.' == return_results_mock.call_args[0][0][1].readable_output

--- a/Packs/PAN-OS/ReleaseNotes/1_8_2.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_8_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue where the **panorama-get-url-category** would fail in case the length of the url is longer than 1278 characters.

--- a/Packs/PAN-OS/ReleaseNotes/1_8_2.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_8_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Palo Alto Networks PAN-OS
-- Fixed an issue where the **panorama-get-url-category** would fail in case the length of the url is longer than 1278 characters.
+- Fixed an issue where the ***panorama-get-url-category*** would fail in case the length of the URL is longer than 1278 characters.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.8.1",
+    "currentVersion": "1.8.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->


## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45101

## Description
In case there is error in getting the url category - return CommandResult with detailed info instead of throwing an exception