### PR TITLE
Fix Slack DM To Get Msgs From Bot Only

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1055,6 +1055,10 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
     try:
         data: dict = req.payload
         event: dict = data.get('event', {})
+        if authorizations := data.get('authorizations', []):
+            is_bot = authorizations[0].get('is_bot', False)
+        else:
+            is_bot = False
         subtype = data.get('subtype', '')
         text = event.get('text', '')
         user_id = event.get('user', '')
@@ -1117,7 +1121,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
                                                'text': entitlement_reply
                                            })
 
-        elif channel and channel[0] == 'D' and ENABLE_DM:
+        elif channel and is_bot and ENABLE_DM:
             # DM
             await handle_dm(user, text, ASYNC_CLIENT)  # type: ignore
         else:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.yml
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.yml
@@ -1,7 +1,7 @@
 beta: false
 category: Messaging
 commonfields:
-  id: SlackV3
+  id: SlackV3_Test
   version: -1
 configuration:
 - display: ""
@@ -102,8 +102,8 @@ configuration:
   required: false
   type: 8
 description: Send messages and notifications to your Slack team.
-display: Slack v3
-name: SlackV3
+display: Slack v3_Test
+name: SlackV3_Test
 script:
   commands:
   - arguments:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45234

## Description
Messages were sent from XSOAR app to people when they were sending message to the creator if the app. Reason was the filter of whether message was sent to the bot or not was not accurate. Using the is_bot parameter from payload should solve this issue

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests - Cannot add UT
- [ ] Documentation - After customer approval
