### PR TITLE
get_current_user

### DIFF
--- a/Packs/Base/ReleaseNotes/1_17_8.md
+++ b/Packs/Base/ReleaseNotes/1_17_8.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Added the *get_current_user* command.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -16,16 +16,14 @@ import sys
 import time
 import traceback
 import urllib
-from random import randint
+import warnings
 import xml.etree.cElementTree as ET
+from abc import abstractmethod
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from abc import abstractmethod
 from distutils.version import LooseVersion
+from random import randint
 from threading import Lock
-
-import demistomock as demisto
-import warnings
 
 OS_LINUX = False
 OS_MAC = False
@@ -8586,3 +8584,10 @@ def register_signal_handler_profiling_dump(signal_type=None, profiling_dump_rows
         signal.signal(requested_signal, signal_handler_profiling_dump)
     else:
         demisto.info('Not a Linux or Mac OS, profiling using a signal is not supported.')
+
+def get_current_user():
+    """
+    :return: name of the current user, as it shows in the integration context.
+    returns None if not available.
+    """
+    return demisto.getIntegrationContext().get("context", {}).get("User", {}).get("username")

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -17,7 +17,7 @@ from CommonServerPython import xml2json, json2xml, entryTypes, formats, tableToM
     argToBoolean, ipv4Regex, ipv4cidrRegex, ipv6cidrRegex, ipv6Regex, batch, FeedIndicatorType, \
     encode_string_results, safe_load_json, remove_empty_elements, aws_table_to_markdown, is_demisto_version_ge, \
     appendContext, auto_detect_indicator_type, handle_proxy, get_demisto_version_as_str, get_x_content_info_headers, \
-    url_to_clickable_markdown, WarningsHandler, DemistoException, SmartGetDict, JsonTransformer
+    url_to_clickable_markdown, WarningsHandler, DemistoException, SmartGetDict, JsonTransformer, get_current_user
 import CommonServerPython
 
 try:
@@ -2704,12 +2704,12 @@ class TestBaseClient:
             resp_json = json.loads(e.res.text)
             assert e.res.status_code == 400
             assert resp_json.get('error') == 'additional text'
-    
+
     def test_http_request_timeout_default(self, requests_mock):
         requests_mock.get('http://example.com/api/v2/event', text=json.dumps(self.text))
         self.client._http_request('get', 'event')
         assert requests_mock.last_request.timeout == self.client.REQUESTS_TIMEOUT
-    
+
     def test_http_request_timeout_given_func(self, requests_mock):
         requests_mock.get('http://example.com/api/v2/event', text=json.dumps(self.text))
         timeout = 120
@@ -5999,3 +5999,11 @@ class TestSetAndGetLastMirrorRun:
         with raises(DemistoException, match='You cannot use setLastMirrorRun as your version is below 6.6.0'):
             set_last_mirror_run({"lastMirrorRun": "2018-10-24T14:13:20+00:00"})
             assert set_last_run.called is False
+
+
+def test_get_current_user(mocker):
+    name = 'John'
+    mocker.patch.object(CommonServerPython.demisto, 'getIntegrationContext',
+                        return_value={'context': {'User': {'username': name}}}
+                        )
+    assert get_current_user() == name

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.17.7",
+    "currentVersion": "1.17.8",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -1172,3 +1172,7 @@ def setLastMirrorRun(obj):
 
     """
     return None
+
+
+def getCurrentUser():
+    return getIntegrationContext().get("context", {}).get("User", {}).get("username")


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/24910

## Description
add get_current_user to CSP 

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
