### PR TITLE
phishing layout fix

### DIFF
--- a/Packs/Phishing/IncidentTypes/New_6_1/incidenttype-Phishing_6.1.json
+++ b/Packs/Phishing/IncidentTypes/New_6_1/incidenttype-Phishing_6.1.json
@@ -21,7 +21,7 @@
  "reputationCalc": 2,
  "onChangeRepAlg": 2,
  "fromVersion": "6.1.0",
- "layout": "Phishing_v3",
+ "layout": "Phishing Incident v3",
  "extractSettings": {
  "mode": "Specific",
   "fieldCliNameToExtractSettings": {

--- a/Packs/Phishing/IncidentTypes/New_6_1/incidenttype-Phishing_6.1.json
+++ b/Packs/Phishing/IncidentTypes/New_6_1/incidenttype-Phishing_6.1.json
@@ -21,7 +21,7 @@
  "reputationCalc": 2,
  "onChangeRepAlg": 2,
  "fromVersion": "6.1.0",
- "layout": "Phishing",
+ "layout": "Phishing_v3",
  "extractSettings": {
  "mode": "Specific",
   "fieldCliNameToExtractSettings": {

--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing.json
@@ -1498,6 +1498,5 @@
     "system": true,
     "version": -1,
     "fromVersion": "6.0.0",
-    "toVersion": "6.0.9",
     "description": ""
 }

--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
@@ -76,9 +76,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Case Details",
                         "static": false,
@@ -93,9 +93,9 @@
                         "i": "1vduzkpmlh-61263cc0-98b1-11e9-97d7-ed26ef9e46c8",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Notes",
                         "readOnly": true,
@@ -112,9 +112,9 @@
                         "i": "1vduzkpmlh-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Work Plan",
                         "readOnly": true,
@@ -169,9 +169,9 @@
                         "i": "1vduzkpmlh-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Linked Incidents",
                         "readOnly": true,
@@ -188,9 +188,9 @@
                         "i": "1vduzkpmlh-842632c0-98b1-11e9-97d7-ed26ef9e46c8",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Child Incidents",
                         "readOnly": true,
@@ -207,9 +207,9 @@
                         "i": "1vduzkpmlh-4a31afa0-98ba-11e9-a519-93a53c759fe0",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Evidence",
                         "readOnly": true,
@@ -226,9 +226,9 @@
                         "i": "1vduzkpmlh-7717e580-9bed-11e9-9a3f-8b4b2158e260",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Team Members",
                         "readOnly": true,
@@ -310,9 +310,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Timeline Information",
                         "static": false,
@@ -362,9 +362,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Closing Information",
                         "static": false,
@@ -385,7 +385,7 @@
                         "h": 3,
                         "hideItemTitleOnlyOne": true,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-57f33cc0-97ee-11e9-b8bd-0b00be54d2d3",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-57f33cc0-97ee-11e9-b8bd-0b00be54d2d3",
                         "isVisible": true,
                         "items": [
                             {
@@ -397,9 +397,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Raw Email HTML",
                         "static": false,
@@ -412,7 +412,7 @@
                         "h": 3,
                         "hideItemTitleOnlyOne": true,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-5a552190-97ee-11e9-b8bd-0b00be54d2d3",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-5a552190-97ee-11e9-b8bd-0b00be54d2d3",
                         "isVisible": true,
                         "items": [
                             {
@@ -424,9 +424,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email Text",
                         "static": false,
@@ -438,61 +438,51 @@
                         "displayType": "ROW",
                         "h": 3,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                         "isVisible": true,
                         "items": [
                             {
-                                "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailfrom",
+                                "fieldId": "reportedemailorigin",
                                 "height": 22,
-                                "id": "58283a00-97ef-11e9-b8bd-0b00be54d2d3",
+                                "id": "b8f3e800-6279-11ec-8fa2-217b8b611613",
                                 "index": 0,
-                                "listId": "d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
-                                "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailto",
+                                "fieldId": "reportedemailfrom",
                                 "height": 22,
-                                "id": "6136a5a0-97ef-11e9-b8bd-0b00be54d2d3",
+                                "id": "be942ef0-6279-11ec-8fa2-217b8b611613",
                                 "index": 1,
-                                "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
-                                "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailsubject",
+                                "fieldId": "reportedemailto",
                                 "height": 22,
-                                "id": "53c5a330-97ef-11e9-b8bd-0b00be54d2d3",
+                                "id": "c2ce0810-6279-11ec-8fa2-217b8b611613",
                                 "index": 2,
-                                "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "emailcc",
-                                "height": 22,
-                                "id": "66500950-97ef-11e9-b8bd-0b00be54d2d3",
-                                "index": 3,
-                                "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
+								"endCol": 2,
+								"fieldId": "reportedemailsubject",
+								"height": 22,
+								"id": "c69a5250-6279-11ec-8fa2-217b8b611613",
+								"index": 3,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
                             {
-                                "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailbcc",
+                                "fieldId": "reportedemailcc",
                                 "height": 22,
-                                "id": "69b68ce0-97ef-11e9-b8bd-0b00be54d2d3",
+                                "id": "cabab000-6279-11ec-8fa2-217b8b611613",
                                 "index": 4,
-                                "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -519,21 +509,10 @@
                             {
                                 "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailmessageid",
-                                "height": 22,
-                                "id": "b8a85bd0-97ef-11e9-b8bd-0b00be54d2d3",
-                                "index": 7,
-                                "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
                                 "fieldId": "reporteremailaddress",
                                 "height": 22,
                                 "id": "93c5bbb0-df83-11e9-9d3d-b355b2831118",
-                                "index": 8,
+                                "index": 7,
                                 "listId": "swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
@@ -543,25 +522,34 @@
                                 "fieldId": "emailsenderip",
                                 "height": 22,
                                 "id": "97d4e2c0-97ef-11e9-b8bd-0b00be54d2d3",
-                                "index": 9,
+                                "index": 8,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
+								"endCol": 2,
+								"fieldId": "emailrecipientscount",
+								"height": 22,
+								"id": "77a63970-6279-11ec-8fa2-217b8b611613",
+								"index": 9,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+                            {
                                 "dropEffect": "move",
                                 "endCol": 2,
-                                "fieldId": "emailtocount",
+                                "fieldId": "emailmessageid",
                                 "height": 22,
-                                "id": "8d6c3e50-97ef-11e9-b8bd-0b00be54d2d3",
+                                "id": "b8a85bd0-97ef-11e9-b8bd-0b00be54d2d3",
                                 "index": 10,
-                                "listId": "d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
+                                "listId": "1vduzkpmlh-swtuqptgvs-d431b9b0-97ee-11e9-b8bd-0b00be54d2d3",
                                 "sectionItemType": "field",
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email Basic Information",
                         "static": false,
@@ -573,63 +561,69 @@
                         "displayType": "ROW",
                         "h": 2,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-49052550-97f0-11e9-b8bd-0b00be54d2d3",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-49052550-97f0-11e9-b8bd-0b00be54d2d3",
                         "isVisible": true,
                         "items": [
                             {
                                 "dropEffect": "move",
                                 "endCol": 2,
                                 "fieldId": "attachment",
-                                "height": 55,
+                                "height": 53,
                                 "id": "9cd0f990-ac6b-11e9-bb03-dd1b065c10a8",
                                 "index": 0,
                                 "listId": "swtuqptgvs-49052550-97f0-11e9-b8bd-0b00be54d2d3",
+                                "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
                                 "endCol": 2,
                                 "fieldId": "attachmenthash",
-                                "height": 24,
+                                "height": 22,
                                 "id": "bc56ef70-97f0-11e9-b8bd-0b00be54d2d3",
                                 "index": 1,
+                                "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
                                 "endCol": 2,
                                 "fieldId": "attachmentname",
-                                "height": 24,
+                                "height": 22,
                                 "id": "609ba8b0-97f0-11e9-b8bd-0b00be54d2d3",
                                 "index": 2,
+                                "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
                                 "endCol": 2,
                                 "fieldId": "attachmentsize",
-                                "height": 24,
+                                "height": 22,
                                 "id": "c2b35a70-97f0-11e9-b8bd-0b00be54d2d3",
                                 "index": 3,
+                                "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
                                 "endCol": 2,
                                 "fieldId": "attachmentextension",
-                                "height": 24,
+                                "height": 22,
                                 "id": "bf294950-97f0-11e9-b8bd-0b00be54d2d3",
                                 "index": 4,
+                                "sectionItemType": "field",
                                 "startCol": 0
                             },
                             {
                                 "endCol": 2,
                                 "fieldId": "attachmenttype",
-                                "height": 24,
+                                "height": 22,
                                 "id": "c47d4500-97f0-11e9-b8bd-0b00be54d2d3",
                                 "index": 5,
+                                "sectionItemType": "field",
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email Attachments",
                         "static": false,
@@ -641,12 +635,12 @@
                         "displayType": "ROW",
                         "h": 4,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-067d4900-98b4-11e9-97d7-ed26ef9e46c8",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-067d4900-98b4-11e9-97d7-ed26ef9e46c8",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Incident Files",
                         "query": {
@@ -672,12 +666,12 @@
                         "displayType": "ROW",
                         "h": 3,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-cc557320-98b7-11e9-b34a-852d068f44fe",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-cc557320-98b7-11e9-b34a-852d068f44fe",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 2,
                         "moved": false,
                         "name": "Indicators",
                         "query": "",
@@ -694,12 +688,12 @@
                         "displayType": "ROW",
                         "h": 1,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-3205ebf0-98cc-11e9-a519-93a53c759fe0",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-3205ebf0-98cc-11e9-a519-93a53c759fe0",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Number of incidents per email address",
                         "query": "NumberOfPhishingAttemptPerUser",
@@ -715,12 +709,12 @@
                         "displayType": "ROW",
                         "h": 4,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-0e149ea0-9d8e-11e9-a715-f7bbe72c84a2",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-0e149ea0-9d8e-11e9-a715-f7bbe72c84a2",
                         "isVisible": true,
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email HTML Image",
                         "query": {
@@ -741,7 +735,7 @@
                         "displayType": "ROW",
                         "h": 2,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-ac6702e0-df84-11e9-9d3d-b355b2831118",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-ac6702e0-df84-11e9-9d3d-b355b2831118",
                         "items": [
                             {
                                 "endCol": 2,
@@ -760,9 +754,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email Type Information",
                         "static": false,
@@ -773,11 +767,11 @@
                     {
                         "h": 3,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-b5924880-df88-11e9-9d3d-b355b2831118",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-b5924880-df88-11e9-9d3d-b355b2831118",
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "URL Screenshots",
                         "query": {
@@ -798,7 +792,7 @@
                         "h": 2,
                         "hideItemTitleOnlyOne": true,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-a12ae3c0-e032-11e9-9c9e-41d82f09b6f1",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-a12ae3c0-e032-11e9-9c9e-41d82f09b6f1",
                         "items": [
                             {
                                 "dropEffect": "move",
@@ -811,9 +805,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Email Authenticity Information",
                         "static": false,
@@ -827,7 +821,7 @@
                         "h": 2,
                         "hideItemTitleOnlyOne": true,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-8fd72e00-e837-11e9-9c9e-41d82f09b6f1",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-8fd72e00-e837-11e9-9c9e-41d82f09b6f1",
                         "items": [
                             {
                                 "endCol": 2,
@@ -838,9 +832,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Critical Assets",
                         "static": false,
@@ -853,7 +847,7 @@
                         "displayType": "ROW",
                         "h": 2,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-7852ea30-2c7f-11ea-a369-15269a1bf356",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-7852ea30-2c7f-11ea-a369-15269a1bf356",
                         "items": [
                             {
                                 "endCol": 2,
@@ -880,9 +874,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Machine-learning Predictions",
                         "static": false,
@@ -893,10 +887,10 @@
                     {
                         "description": "Headers extracted from the original email.",
                         "displayType": "ROW",
-                        "h": 6,
+                        "h": 12,
                         "hideItemTitleOnlyOne": true,
                         "hideName": false,
-                        "i": "1vduzkpmlh-swtuqptgvs-a142dfe0-b078-11ea-b16f-0d66a9047a0e",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-a142dfe0-b078-11ea-b16f-0d66a9047a0e",
                         "items": [
                             {
                                 "endCol": 6,
@@ -908,9 +902,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 3,
                         "moved": false,
                         "name": "Email Headers",
                         "static": false,
@@ -921,11 +915,11 @@
                     {
                         "h": 1,
                         "hideName": true,
-                        "i": "1vduzkpmlh-swtuqptgvs-044bccb0-befa-11eb-b351-7bcfe92e5e24",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-swtuqptgvs-044bccb0-befa-11eb-b351-7bcfe92e5e24",
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Related Phishing Campaign",
                         "query": "LinkToPhishingCampaign",
@@ -937,11 +931,11 @@
                         "y": 3
                     },
                     {
-                        "description": "PCL - Phishing Confidence Level (4-8: The message content is likely to be phishing.)\nBCL - Bulk complaint level (4-7: The message is from a bulk sender that generates a mixed number of complaints. 8-9: The message is from a bulk sender that generates a high number of complaints.)\nSCL - Spam confidence level (5-6: Spam filtering marked the message as Spam. 9: Spam filtering marked the message as High confidence spam)",
+                        "description": "**PCL** - Phishing Confidence Level (4-8: The message content is likely to be phishing.)\n**BCL** - Bulk complaint level (4-7: The message is from a bulk sender that generates a mixed number of complaints. 8-9: The message is from a bulk sender that generates a high number of complaints.)\n**SCL** - Spam confidence level (5-6: Spam filtering marked the message as Spam. 9: Spam filtering marked the message as High confidence spam)\n`Note`: The default value is 0, but it can be changed when the \"Process Microsoft's Email Headers\" playbook runs.",
                         "displayType": "ROW",
                         "h": 4,
                         "hideName": false,
-                        "i": "1vduzkpmlh-ef7fd3b0-fdb2-11eb-8fad-971332201675",
+                        "i": "1vduzkpmlh-swtuqptgvs-1vduzkpmlh-ef7fd3b0-fdb2-11eb-8fad-971332201675",
                         "items": [
                             {
                                 "endCol": 2,
@@ -971,9 +965,9 @@
                                 "startCol": 0
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
-                        "minW": 1,
                         "moved": false,
                         "name": "Microsoft Anti-Spam Headers",
                         "static": false,
@@ -1102,7 +1096,7 @@
                         "isVisible": true
                     },
                     {
-                        "fieldId": "incident_emailtocount",
+                        "fieldId": "incident_emailrecipientscount",
                         "isVisible": true
                     }
                 ],
@@ -1194,7 +1188,7 @@
         ]
     },
     "group": "incident",
-    "id": "Phishing",
+    "id": "Phishing_v3",
     "mobile": {
         "sections": [
             {
@@ -1378,7 +1372,7 @@
             }
         ]
     },
-    "name": "Phishing Incident",
+    "name": "Phishing Incident v3",
     "quickView": {
         "sections": [
             {
@@ -1497,7 +1491,6 @@
     },
     "system": true,
     "version": -1,
-    "fromVersion": "6.0.0",
-    "toVersion": "6.0.9",
+    "fromVersion": "6.1.0",
     "description": ""
 }

--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
@@ -1188,7 +1188,7 @@
         ]
     },
     "group": "incident",
-    "id": "Phishing_v3",
+    "id": "Phishing Incident v3",
     "mobile": {
         "sections": [
             {

--- a/Packs/Phishing/ReleaseNotes/3_0_1.md
+++ b/Packs/Phishing/ReleaseNotes/3_0_1.md
@@ -1,7 +1,10 @@
 
 #### Layouts
 ##### New: Phishing Incident v3
-- The previous update broke the layout for versions that are lower than 6.1 - Some fields were missing. This update will return the old layout for these versions and will update the new layout for versions that are greater or equal to 6.1.
+- This layout removes some fields and display new ones instead.
 
 ##### New: Phishing Incident
-- Set the default layout to `Phishing Incident v3`
+- The previous update broke the layout for versions that are lower than 6.1 - Some fields were missing. This update will return the old layout for these versions and will update the new v3 layout for versions that are greater or equal to 6.1.
+
+#### Incident Types
+- Set the default layout to `Phishing Incident v3`.

--- a/Packs/Phishing/ReleaseNotes/3_0_1.md
+++ b/Packs/Phishing/ReleaseNotes/3_0_1.md
@@ -4,7 +4,7 @@
 - This layout removes some fields and display new ones instead.
 
 ##### New: Phishing Incident
-- The previous update broke the layout for versions that are lower than 6.1 - Some fields were missing. This update will return the old layout for these versions and will update the new v3 layout for versions that are greater or equal to 6.1.
+- The previous update did not support the layout for versions prior to 6.1 as some fields were missing. This update reverts to the old layout for these versions and will update the new v3 layout only for versions that are greater or equal to 6.1.
 
 #### Incident Types
 - Set the default layout to `Phishing Incident v3`.

--- a/Packs/Phishing/ReleaseNotes/3_0_1.md
+++ b/Packs/Phishing/ReleaseNotes/3_0_1.md
@@ -1,0 +1,7 @@
+
+#### Layouts
+##### New: Phishing Incident v3
+- The previous update broke the layout for versions that are lower than 6.1 - Some fields were missing. This update will return the old layout for these versions and will update the new layout for versions that are greater or equal to 6.1.
+
+##### New: Phishing Incident
+- Set the default layout to `Phishing Incident v3`

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.0.0",
+    "currentVersion": "3.0.1",
     "serverMinVersion": "6.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45365

## Description
After phishing v3 update, versions lower than 6.1 will get the new layout which will not show all of the new fields. Instead we should return the older layout for older versions and change the id of the new one for the newer version.



## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
