### PR TITLE
remove packs from marketplace v2

### DIFF
--- a/Packs/Campaign/pack_metadata.json
+++ b/Packs/Campaign/pack_metadata.json
@@ -49,7 +49,6 @@
         "CommonScripts"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/CommonDashboards/pack_metadata.json
+++ b/Packs/CommonDashboards/pack_metadata.json
@@ -15,7 +15,6 @@
     "keywords": [],
     "dependencies": {},
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/CommonReports/pack_metadata.json
+++ b/Packs/CommonReports/pack_metadata.json
@@ -15,7 +15,6 @@
     "keywords": [],
     "dependencies": {},
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/CommonWidgets/pack_metadata.json
+++ b/Packs/CommonWidgets/pack_metadata.json
@@ -15,7 +15,6 @@
     "keywords": [],
     "dependencies": {},
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -76,7 +76,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
+++ b/Packs/CrowdStrikeFalconStreamingV2/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ElasticsearchMonitoring/pack_metadata.json
+++ b/Packs/ElasticsearchMonitoring/pack_metadata.json
@@ -19,7 +19,6 @@
         "OpenSearch"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/EmployeeOffboarding/pack_metadata.json
+++ b/Packs/EmployeeOffboarding/pack_metadata.json
@@ -74,7 +74,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/Expanse/pack_metadata.json
+++ b/Packs/Expanse/pack_metadata.json
@@ -20,7 +20,6 @@
         "andrew-expanse"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ExpanseV2/pack_metadata.json
+++ b/Packs/ExpanseV2/pack_metadata.json
@@ -78,7 +78,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/IAM-SCIM/pack_metadata.json
+++ b/Packs/IAM-SCIM/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -48,7 +48,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/MultiTenantPerformance/pack_metadata.json
+++ b/Packs/MultiTenantPerformance/pack_metadata.json
@@ -15,7 +15,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ShiftManagement/pack_metadata.json
+++ b/Packs/ShiftManagement/pack_metadata.json
@@ -52,7 +52,6 @@
         "MicrosoftTeams"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/TIM_Processing/pack_metadata.json
+++ b/Packs/TIM_Processing/pack_metadata.json
@@ -240,7 +240,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/TIM_SIEM/pack_metadata.json
+++ b/Packs/TIM_SIEM/pack_metadata.json
@@ -28,7 +28,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ThreatIntelReports/pack_metadata.json
+++ b/Packs/ThreatIntelReports/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/Traps/pack_metadata.json
+++ b/Packs/Traps/pack_metadata.json
@@ -16,7 +16,6 @@
         "Traps"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://github.com/demisto/etc/issues/44221

## Description
removed the following packs from MPv2:

1. Campaign
2. CommonDashboards
3. CommonReports
4. CommonWidgets
5. CortexXDR
6. CrowdStrikeFalconStreamingV2
7. ElasticsearchMonitoring
8. EmployeeOffboarding
9. Expanse
10. ExpanseV2
11. IAM-SCIM (IAM pack is in a different repo)
12. IntegrationsAndIncidentsHealthCheck
13. MultiTenantPerformance
14. ShiftManagement
15. TIM_Processing
16. TIM - SIEM Integration
17. ThreatIntelReports
18. Traps