### PR TITLE
AWS API Module get timeout fix

### DIFF
--- a/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
+++ b/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-ACM
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
+++ b/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
@@ -1,0 +1,2 @@
+##### AWS-ACM
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
+++ b/Packs/AWS-ACM/ReleaseNotes/1_1_5.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-ACM
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-ACM/pack_metadata.json
+++ b/Packs/AWS-ACM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - ACM",
     "description": "Amazon Web Services Certificate Manager Service (acm)",
     "support": "xsoar",
-    "currentVersion": "1.1.4",
+    "currentVersion": "1.1.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-CloudWatchLogs
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-CloudWatchLogs
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-CloudWatchLogs/ReleaseNotes/1_2_2.md
@@ -1,0 +1,2 @@
+##### AWS-CloudWatchLogs
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-CloudWatchLogs/pack_metadata.json
+++ b/Packs/AWS-CloudWatchLogs/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - CloudWatchLogs",
     "description": "Amazon Web Services CloudWatch Logs (logs).",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-EC2
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-EC2
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_2_7.md
@@ -1,0 +1,2 @@
+##### AWS-EC2
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-EC2/pack_metadata.json
+++ b/Packs/AWS-EC2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - EC2",
     "description": "Amazon Web Services Elastic Compute Cloud (EC2)",
     "support": "xsoar",
-    "currentVersion": "1.2.6",
+    "currentVersion": "1.2.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
@@ -1,0 +1,2 @@
+##### AWS-GuardDuty
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-GuardDuty
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_2.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-GuardDuty
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-GuardDuty/pack_metadata.json
+++ b/Packs/AWS-GuardDuty/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - GuardDuty",
     "description": "Amazon Web Services Guard Duty Service (gd)",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
+++ b/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-IAM
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
+++ b/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-IAM
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
+++ b/Packs/AWS-IAM/ReleaseNotes/1_1_8.md
@@ -1,0 +1,2 @@
+##### AWS-IAM
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-IAM/pack_metadata.json
+++ b/Packs/AWS-IAM/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Amazon Web Services Identity and Access Management (IAM)",
     "support": "xsoar",
     "author": "Cortex XSOAR",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
     "created": "2020-04-14T00:00:00Z",

--- a/Packs/AWS-Lambda/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-Lambda/ReleaseNotes/1_2_6.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-Lambda
 - Fixed an issue where the timeout parameter couldn’t be of type *int*.

--- a/Packs/AWS-Lambda/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-Lambda/ReleaseNotes/1_2_6.md
@@ -1,0 +1,2 @@
+##### AWS-Lambda
+- Fixed an issue where the timeout parameter couldn’t be of type *int*.

--- a/Packs/AWS-Lambda/pack_metadata.json
+++ b/Packs/AWS-Lambda/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - Lambda",
     "description": "Amazon Web Services Serverless Compute service (lambda)",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-S3/ReleaseNotes/1_1_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_1_3.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-S3
 - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-S3/ReleaseNotes/1_1_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_1_3.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-S3
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-S3/ReleaseNotes/1_1_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_1_3.md
@@ -1,0 +1,2 @@
+##### AWS-S3
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-S3/pack_metadata.json
+++ b/Packs/AWS-S3/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - S3",
     "description": "Amazon Web Services Simple Storage Service (S3)",
     "support": "xsoar",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
@@ -1,0 +1,2 @@
+##### AWS-SQS
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
@@ -1,2 +1,4 @@
+#### Integrations
 ##### AWS-SQS
 - Fixed an issue where the timeout parameter couldn't be of type *int*.
+

--- a/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_2.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### AWS-SQS
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.
 

--- a/Packs/AWS-SQS/pack_metadata.json
+++ b/Packs/AWS-SQS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - SQS",
     "description": "Amazon Web Services Simple Queuing Service (SQS)",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
@@ -1,0 +1,2 @@
+##### AWS-SecurityHub
+- - Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS-SecurityHub
-- Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter would not support an integer.

--- a/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
+++ b/Packs/AWS-SecurityHub/ReleaseNotes/1_1_6.md
@@ -1,2 +1,3 @@
+#### Integrations
 ##### AWS-SecurityHub
-- - Fixed an issue where the timeout parameter couldn't be of type *int*.
+- Fixed an issue where the timeout parameter couldn't be of type *int*.

--- a/Packs/AWS-SecurityHub/pack_metadata.json
+++ b/Packs/AWS-SecurityHub/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - Security Hub",
     "description": "Amazon Web Services Security Hub Service .",
     "support": "xsoar",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ApiModules/Scripts/AWSApiModule/AWSApiModule.py
+++ b/Packs/ApiModules/Scripts/AWSApiModule/AWSApiModule.py
@@ -142,11 +142,19 @@ class AWSClient:
         if not timeout:
             timeout = "60,10"  # default values
         try:
-            timeout_vals = timeout.split(',')
-            read_timeout = int(timeout_vals[0])
+            if isinstance(timeout, str):
+                timeout_vals = timeout.split(',')
+                read_timeout = int(timeout_vals[0])
+                connect_timeout = 10 if len(timeout_vals) == 1 else int(timeout_vals[1])
+
+            elif isinstance(timeout, int):
+                read_timeout = timeout
+                connect_timeout = 10
+            else:
+                raise ValueError
+
         except ValueError:
             raise DemistoException("You can specify just the read timeout (for example 60) or also the connect "
                                    "timeout followed after a comma (for example 60,10). If a connect timeout is not "
                                    "specified, a default of 10 second will be used.")
-        connect_timeout = 10 if len(timeout_vals) == 1 else int(timeout_vals[1])
         return read_timeout, connect_timeout

--- a/Packs/ApiModules/Scripts/AWSApiModule/AWSApiModule_test.py
+++ b/Packs/ApiModules/Scripts/AWSApiModule/AWSApiModule_test.py
@@ -98,3 +98,5 @@ def test_get_timeout():
     assert read == 100 and connect == 10
     (read, connect) = AWSClient.get_timeout("200,2")
     assert read == 200 and connect == 2
+    (read, connect) = AWSClient.get_timeout(60)
+    assert read == 60 and connect == 10


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45557

To prevent similar issues in the future I have decided to fix the AWSApiModule.get_timeout method.

Kept the original code that parse strings to avoid regression issues.
