### PR TITLE
Ignore conf json validation if the branch is one of the docker updates

### DIFF
--- a/Tests/scripts/validate.sh
+++ b/Tests/scripts/validate.sh
@@ -7,6 +7,8 @@ if [[ $CI_COMMIT_BRANCH = master ]] || [[ -n "${NIGHTLY}" ]] || [[ -n "${BUCKET_
     demisto-sdk validate -a --post-commit --id-set --id-set-path "$ARTIFACTS_FOLDER/unified_id_set.json"
 elif [[ $CI_COMMIT_BRANCH =~ pull/[0-9]+ ]]; then
     demisto-sdk validate -g --post-commit --id-set --id-set-path "$ARTIFACTS_FOLDER/id_set.json"
+elif [[ $CI_COMMIT_BRANCH = demisto/python ]] || [[ $CI_COMMIT_BRANCH = demisto/python3 ]]; then
+    demisto-sdk validate -g --post-commit --id-set --id-set-path "$ARTIFACTS_FOLDER/unified_id_set.json" --no-conf-json
 else
     demisto-sdk validate -g --post-commit --id-set --id-set-path "$ARTIFACTS_FOLDER/unified_id_set.json"
 fi


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/40489

## Description
added the following validation: if the branch name is `demisto/python` or `demisto/python3` then run `demisto-sdk validate` with `--no-conf-json` flag.
opened 3 different branches to test, changed an integration that doesnt have TPB and UT:
- branch name demisto/python: https://github.com/demisto/content/pull/16877
- branch name demisto/python3: https://github.com/demisto/content/pull/16960
- some common branch name: https://github.com/demisto/content/pull/16969

also changed the sdk to run as master in the above PRs, since the current version is not supporting `--no-conf-json` flag

