### PR TITLE
SlackV3: Add Channel ID when Creating Channel

### DIFF
--- a/Packs/Slack/Integrations/Slack/Slack.py
+++ b/Packs/Slack/Integrations/Slack/Slack.py
@@ -1942,7 +1942,18 @@ def create_channel():
         send_slack_request_sync(CHANNEL_CLIENT, 'conversations.setTopic', body=body)
 
     created_channel_name = conversation.get('name')
+    created_channel_id = conversation.get('id')
     demisto.results(f'Successfully created the channel {created_channel_name}')
+
+    # Save the newly created channel to the context for fast future lookups
+    integration_context = get_integration_context(SYNC_CONTEXT)
+    context_conversations = integration_context.get('conversations', '[]')
+    conversations = json.loads(context_conversations)
+    conversations.append({
+        'name': created_channel_name,
+        'id': created_channel_id
+    })
+    set_to_integration_context_with_retries({'conversations': conversations}, OBJECTS_TO_KEYS, SYNC_CONTEXT)
 
 
 def invite_to_channel():

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1880,7 +1880,18 @@ def create_channel():
         }
         send_slack_request_sync(CLIENT, 'conversations.setTopic', body=body)
     created_channel_name = conversation.get('name')
+    created_channel_id = conversation.get('id')
     demisto.results(f'Successfully created the channel {created_channel_name}')
+
+    # Save the newly created channel to the context for fast future lookups
+    integration_context = get_integration_context(SYNC_CONTEXT)
+    context_conversations = integration_context.get('conversations', '[]')
+    conversations = json.loads(context_conversations)
+    conversations.append({
+        'name': created_channel_name,
+        'id': created_channel_id
+    })
+    set_to_integration_context_with_retries({'conversations': conversations}, OBJECTS_TO_KEYS, SYNC_CONTEXT)
 
 
 def invite_to_channel():

--- a/Packs/Slack/ReleaseNotes/2_3_2.md
+++ b/Packs/Slack/ReleaseNotes/2_3_2.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Slack v3
+- Modification of "create_channel" to add channel ID to the context, so future commands don't query all channels to find it.

--- a/Packs/Slack/ReleaseNotes/2_3_2.md
+++ b/Packs/Slack/ReleaseNotes/2_3_2.md
@@ -1,3 +1,6 @@
 #### Integrations
 ##### Slack v3
-- Modification of "create_channel" to add channel ID to the context, so future commands don't query all channels to find it.
+- Modified the ***slack-create-channel*** command to add the created channel's ID to the context to improve performance.
+
+##### Slack v2
+- Modified the ***slack-create-channel*** command to add the created channel's ID to the context to improve performance.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "2.3.1",
+    "currentVersion": "2.3.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Didn't create the issue in github, but Slack often times out when querying Channel ID. This should alleviate that problem if actions are coming right after a create.

## Description
Add channel ID to context after creating channel to speed up further actions (such as a welcome message, or inviting a large number of additional users)

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
