### PR TITLE
Update playbook api path

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -103,7 +103,7 @@ def http_post(url_suffix, params=None, data=None):
 
 
 def playbook_name_to_id(name):
-    playbooks = http_get('/exec/playbooks')['data']
+    playbooks = http_get('/automate/playbooks')['data']
     ids = [p['id'] for p in playbooks if p['name'] == name]
     if len(ids) != 1:
         raise ValueError('Could not find specific id for name "{}"'.format(name))
@@ -534,7 +534,7 @@ def execute_playbook_command():
 
 
 def execute_playbook(playbook_id, detection_id):
-    res = http_post('/exec/playbooks/{}/execute'.format(playbook_id), params={
+    res = http_post('/automate/playbooks/{}/execute'.format(playbook_id), params={
         'resource_type': 'Detection',
         'resource_id': detection_id,
     })

--- a/Packs/RedCanary/ReleaseNotes/1_1_5.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Red Canary
-- Fixed the api path used by the **redcanary-execute-playbook** command
+- Fixed the api path used by the **redcanary-execute-playbook** command.

--- a/Packs/RedCanary/ReleaseNotes/1_1_5.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Red Canary
+- Fixed the api path used by the **redcanary-execute-playbook** command

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Red Canary",
     "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
     "support": "xsoar",
-    "currentVersion": "1.1.4",
+    "currentVersion": "1.1.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Description
The API path for the execute playbook functionality of the integration is out of date.

## Screenshots
Current API doc from Red Canary:
![image](https://user-images.githubusercontent.com/32440065/148948099-30b00ad8-c1d0-4caa-80c1-ab9b5ea559b6.png)

Error when using the function:
![image](https://user-images.githubusercontent.com/32440065/148948714-519b2184-ae84-4e2d-ab76-b3dbe729010c.png)

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
       - Further details: Fixes already broken external dependency.

## Must have
- [ ] Tests
- [ ] Documentation 
