### PR TITLE
Update TPB and remove test from skipped

### DIFF
--- a/Packs/PrismaCloud/TestPlaybooks/playbook-RedLockTest.yml
+++ b/Packs/PrismaCloud/TestPlaybooks/playbook-RedLockTest.yml
@@ -70,7 +70,7 @@ tasks:
     task:
       id: c62d4496-3f83-4efe-847c-0d4d4083d396
       version: -1
-      name: Retrieve All Alerts from Last 1 year
+      name: Retrieve All Alerts from Last 1 week
       description: Search alerts on the RedLock platform
       script: '|||redlock-search-alerts'
       type: regular
@@ -83,7 +83,7 @@ tasks:
       alert-status:
         simple: resolved
       time-range-unit:
-        simple: year
+        simple: week
       time-range-value:
         simple: "1"
     separatecontext: false

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5088,7 +5088,6 @@
         "Cofense Intelligence v2 test": "Issue 44499",
         "Endpoint Malware Investigation - Generic - Test": "Issue 44779",
         "Mimecast test": "Issue 26906",
-        "RedLockTest": "Issue 24600",
         "AutoFocus V2 test": "Issue 26464",
         "SplunkPy_KV_commands_default_handler": "Issue 41419",
         "LogRhythm REST test": "Issue 40654",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
- Unskip Redlock TPB after new credentials were added
- Update the TPB to search for alerts within the last week and not the last year since there are many alerts and it causes the query to timeout.
