### PR TITLE
Fix for SlackV3 Operand Error on missing Bot ID

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1239,7 +1239,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
             if event.get('subtype') == 'bot_message':
                 demisto.debug("Received bot_message event type. Ignoring.")
                 return
-            if event.get('bot_id', None) in bot_id:
+            if event.get('bot_id', '') == bot_id:
                 demisto.debug("Received bot message from the current bot. Ignoring.")
                 return
         if event.get('subtype') == 'message_changed':

--- a/Packs/Slack/ReleaseNotes/2_4_1.md
+++ b/Packs/Slack/ReleaseNotes/2_4_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v3
+- Fixed an issue where a missing bot ID in some Slack events would cause an error.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "2.4.0",
+    "currentVersion": "2.4.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: issue identified via slack

## Description
I botched a merge while releasing that last version and accidentally reverted this minor change.
