### PR TITLE
Add note on required input for RTR `put` command

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
@@ -447,7 +447,7 @@ Sends commands to hosts.
 | host_ids | A comma-separated list of host agent IDs for which to run commands. (Can be retrieved by running the 'cs-falcon-search-device' command.) | Required | 
 | command_type | The type of command to run. | Required | 
 | full_command | The full command to run. | Required | 
-| scope | The scope for which to run the command. Possible values are: "read", "write", and "admin". Default is "read". (NOTE: To run the CrowdStrike RTR `put` command, it is nessary to pass `scope=admin`.) | Optional | 
+| scope | The scope for which to run the command. Possible values are: "read", "write", and "admin". Default is "read". (NOTE: In order to run the CrowdStrike RTR `put` command, it is necessary to pass `scope=admin`.) | Optional | 
 | target | The target for which to run the command. Possible values are: "single" and "batch". Default is "batch". | Optional | 
 
 

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
@@ -436,6 +436,7 @@ There is no context output for this command.
 ### 7. cs-falcon-run-command
 ---
 Sends commands to hosts.
+
 #### Base Command
 
 `cs-falcon-run-command`
@@ -446,7 +447,7 @@ Sends commands to hosts.
 | host_ids | A comma-separated list of host agent IDs for which to run commands. (Can be retrieved by running the 'cs-falcon-search-device' command.) | Required | 
 | command_type | The type of command to run. | Required | 
 | full_command | The full command to run. | Required | 
-| scope | The scope for which to run the command. Possible values are: "read", "write", and "admin". Default is "read". | Optional | 
+| scope | The scope for which to run the command. Possible values are: "read", "write", and "admin". Default is "read". (NOTE: To run the CrowdStrike RTR `put` command, it is nessary to pass `scope=admin`.) | Optional | 
 | target | The target for which to run the command. Possible values are: "single" and "batch". Default is "batch". | Optional | 
 
 


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Added note that `cs-falcon-run-command` `scope=admin` is required for an RTR `put` command. This seems to be a common use case and I have seen this question from clients a few times. Not sure the best place to put this note; feel free to move it to a different part of the page. Maybe start a FAQ or Troubleshooting section?

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
