### PR TITLE
Enhance test_module Resiliency

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -1310,16 +1310,18 @@ def test_module_command(client: Client, params: Dict) -> str:
         if is_long_running:
             validate_long_running_params(params)
             ip_enrich, asset_enrich = get_offense_enrichment(params.get('enrichment', 'IPs And Assets'))
+            # Try to retrieve the last successfully retrieved offense
+            last_highest_id = max(ctx.get(LAST_FETCH_KEY, 0) - 1, 0)
             get_incidents_long_running_execution(
                 client=client,
                 offenses_per_fetch=1,
                 user_query=params.get('query', ''),
                 fetch_mode=params.get('fetch_mode', ''),
                 events_columns=params.get('events_columns', ''),
-                events_limit=1,
+                events_limit=0,
                 ip_enrich=ip_enrich,
                 asset_enrich=asset_enrich,
-                last_highest_id=ctx.get(LAST_FETCH_KEY, 0),
+                last_highest_id=last_highest_id,
                 incident_type=params.get('incident_type'),
                 mirror_direction=MIRROR_DIRECTION.get(params.get('mirror_options', DEFAULT_MIRRORING_DIRECTION))
             )

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -2955,7 +2955,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.9.8.24399
+  dockerimage: demisto/python3:3.10.1.25933
   feed: false
   isfetch: false
   isremotesyncin: true

--- a/Packs/QRadar/ReleaseNotes/2_1_26.md
+++ b/Packs/QRadar/ReleaseNotes/2_1_26.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### IBM QRadar v3
 - Improved **test_module** resiliency.
+- Updated the docker image to *demisto/python3:3.10.1.25933*.

--- a/Packs/QRadar/ReleaseNotes/2_1_26.md
+++ b/Packs/QRadar/ReleaseNotes/2_1_26.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### IBM QRadar v3
+- Improved **test_module** resiliency.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.1.25",
+    "currentVersion": "2.1.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/45981

## Description
Enhance the test_module resiliency by:
- Try to retrieve the last successfully retrieved offense
- - Only check the events query, without actually retrieving events

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
