### PR TITLE
Blacklist fix

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -20,8 +20,8 @@ except ImportError:
 requests.packages.urllib3.disable_warnings()
 
 '''GLOBAL VARS'''
-BLACKLISTED_URL_ERROR_MESSAGE = 'The submitted domain is on our blacklist. ' \
-                                'For your own safety we did not perform this scan...'
+BLACKLISTED_URL_ERROR_MESSAGE = 'The submitted domain is on our blacklist, ' \
+                                'we will not scan it.'
 BRAND = 'urlscan.io'
 
 """ RELATIONSHIP TYPE"""

--- a/Packs/UrlScan/ReleaseNotes/1_1_15.md
+++ b/Packs/UrlScan/ReleaseNotes/1_1_15.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### urlscan.io
-- Fixed continue\_on\_blacklisted\_urls setting
+- Fixed operation of `continue\_on\_blacklisted\_urls` argument to `url` command. This setting had been rendered ineffectual by a change in the urlscan API, but nowfunctions again as expected.

--- a/Packs/UrlScan/ReleaseNotes/1_1_15.md
+++ b/Packs/UrlScan/ReleaseNotes/1_1_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Fixed continue\_on\_blacklisted\_urls setting

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.1.14",
+    "currentVersion": "1.1.15",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The integration recognizes urlscan rejecting a scan submission due to the target being on the service's blacklist by comparing against the HTTP Error message. The message returned by urlscan indicating a blacklisted URL has changed in its wording, so this patch simply reflects that change.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [X] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
