### PR TITLE
Added a feature to convert STIX Cyber Observable Objects to STIX Domain Object of 'indicator' so that the Microsoft Azure Sentinel TAXII Connector can feed indicators.

### DIFF
--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
@@ -671,7 +671,7 @@ def convert_sco_to_indicator_sdo(stix_object: dict, xsoar_indicator: dict) -> di
 
     indicator_value = xsoar_indicator.get('value')
     if isinstance(indicator_value, str):
-        indicator_pattern_value = indicator_value.replace("'", "\\'")
+        indicator_pattern_value: Any = indicator_value.replace("'", "\\'")
     else:
         indicator_pattern_value = indicator_value
 

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
@@ -678,15 +678,14 @@ def convert_sco_to_indicator_sdo(stix_object: dict, xsoar_indicator: dict) -> di
     object_type = stix_object['type']
     stix_type = 'indicator'
 
-    stix_domain_object: Dict[str, Any] = {
-        'type': stix_type,
-        'id': create_sdo_stix_uuid(xsoar_indicator, stix_type),
-        'pattern': f"[{object_type}:value = '{indicator_pattern_value}']",
-        'valid_from': stix_object['created'],
-        'valid_until': expiration_parsed,
-        'description': xsoar_indicator.get('CustomFields', {}).get('description', ''),
-        'labels': []
-    }
+    stix_domain_object: Dict[str, Any] = assign_params(
+        type=stix_type,
+        id=create_sdo_stix_uuid(xsoar_indicator, stix_type),
+        pattern=f"[{object_type}:value = '{indicator_pattern_value}']",
+        valid_from=stix_object['created'],
+        valid_until=expiration_parsed,
+        description=xsoar_indicator.get('CustomFields', {}).get('description', '')
+    )
     return dict({k: v for k, v in stix_object.items()
                 if k in ('spec_version', 'created', 'modified')}, **stix_domain_object)
 

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
@@ -673,7 +673,7 @@ def convert_sco_to_indicator_sdo(stix_object: dict, xsoar_indicator: dict) -> di
     if isinstance(indicator_value, str):
         indicator_pattern_value: Any = indicator_value.replace("'", "\\'")
     else:
-        indicator_pattern_value = indicator_value
+        indicator_pattern_value = json.dumps(indicator_value)
 
     object_type = stix_object['type']
     stix_type = 'indicator'

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
@@ -670,13 +670,18 @@ def convert_sco_to_indicator_sdo(stix_object: dict, xsoar_indicator: dict) -> di
         expiration_parsed = ''
 
     indicator_value = xsoar_indicator.get('value')
+    if isinstance(indicator_value, str):
+        indicator_pattern_value = indicator_value.replace("'", "\\'")
+    else:
+        indicator_pattern_value = indicator_value
+
     object_type = stix_object['type']
     stix_type = 'indicator'
 
     stix_domain_object: Dict[str, Any] = {
         'type': stix_type,
         'id': create_sdo_stix_uuid(xsoar_indicator, stix_type),
-        'pattern': f"[{object_type}:value = '{indicator_value}']",
+        'pattern': f"[{object_type}:value = '{indicator_pattern_value}']",
         'valid_from': stix_object['created'],
         'valid_until': expiration_parsed,
         'description': xsoar_indicator.get('CustomFields', {}).get('description', ''),

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.yml
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.yml
@@ -85,6 +85,21 @@ configuration:
   name: nginx_server_conf
   required: false
   type: 12
+- display: STIX types for STIX indicator Domain Object
+  name: provide_as_indicator
+  type: 16
+  required: false
+  options:
+  - ipv4-addr
+  - domain-name
+  - ipv6-addr
+  - user-account
+  - email-addr
+  - windows-registry-key
+  - file
+  - url
+  additionalinfo: Choose which STIX Cyber Observable Object provides as STIX Domain
+    Object of 'indicator'
 description: This integration provides TAXII2 Services for system indicators (Outbound feed).
 display: TAXII2 Server
 name: TAXII2 Server

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/test_files/objects20-indicators.json
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/test_files/objects20-indicators.json
@@ -1,0 +1,52 @@
+{
+    "id": "bundle--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+    "objects": [{
+            "created": "2021-12-08T09:32:24.104143Z",
+            "description": "",
+            "id": "indicator--5858b9e9-063f-573b-bb34-42cab292eaeb",
+            "labels": [],
+            "modified": "2021-12-08T12:05:28.617414Z",
+            "pattern": "[ipv4-addr:value = '8.8.8.8']",
+            "spec_version": "2.0",
+            "type": "indicator",
+            "valid_from": "2021-12-08T09:32:24.104143Z",
+            "valid_until": "2021-12-15T12:05:31.570698Z"
+        }, {
+            "created": "2021-12-08T09:32:24.104143Z",
+            "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
+            "description": "This schema adds TIM data to the object",
+            "extension_types": ["property-extension"],
+            "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+            "modified": "2021-12-08T12:05:28.617414Z",
+            "name": "Cortex XSOAR TIM IP",
+            "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
+            "spec_version": "2.0",
+            "type": "extension-definition",
+            "version": "1.0"
+        }, {
+            "created": "2021-12-08T09:32:24.102219Z",
+            "description": "",
+            "id": "indicator--40037b66-eb32-562f-8ed0-60f8db598e40",
+            "labels": [],
+            "modified": "2021-12-08T12:05:28.615431Z",
+            "pattern": "[ipv4-addr:value = '1.1.1.1']",
+            "spec_version": "2.0",
+            "type": "indicator",
+            "valid_from": "2021-12-08T09:32:24.102219Z",
+            "valid_until": "2021-12-15T12:05:31.570698Z"
+        }, {
+            "created": "2021-12-08T09:32:24.102219Z",
+            "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
+            "description": "This schema adds TIM data to the object",
+            "extension_types": ["property-extension"],
+            "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+            "modified": "2021-12-08T12:05:28.615431Z",
+            "name": "Cortex XSOAR TIM IP",
+            "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
+            "spec_version": "2.0",
+            "type": "extension-definition",
+            "version": "1.0"
+        }
+    ],
+    "type": "bundle"
+}

--- a/Packs/TAXIIServer/Integrations/TAXII2Server/test_files/objects20-indicators.json
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/test_files/objects20-indicators.json
@@ -1,52 +1,48 @@
 {
-    "id": "bundle--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
-    "objects": [{
-            "created": "2021-12-08T09:32:24.104143Z",
-            "description": "",
-            "id": "indicator--5858b9e9-063f-573b-bb34-42cab292eaeb",
-            "labels": [],
-            "modified": "2021-12-08T12:05:28.617414Z",
-            "pattern": "[ipv4-addr:value = '8.8.8.8']",
-            "spec_version": "2.0",
-            "type": "indicator",
-            "valid_from": "2021-12-08T09:32:24.104143Z",
-            "valid_until": "2021-12-15T12:05:31.570698Z"
-        }, {
-            "created": "2021-12-08T09:32:24.104143Z",
-            "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
-            "description": "This schema adds TIM data to the object",
-            "extension_types": ["property-extension"],
-            "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
-            "modified": "2021-12-08T12:05:28.617414Z",
-            "name": "Cortex XSOAR TIM IP",
-            "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
-            "spec_version": "2.0",
-            "type": "extension-definition",
-            "version": "1.0"
-        }, {
-            "created": "2021-12-08T09:32:24.102219Z",
-            "description": "",
-            "id": "indicator--40037b66-eb32-562f-8ed0-60f8db598e40",
-            "labels": [],
-            "modified": "2021-12-08T12:05:28.615431Z",
-            "pattern": "[ipv4-addr:value = '1.1.1.1']",
-            "spec_version": "2.0",
-            "type": "indicator",
-            "valid_from": "2021-12-08T09:32:24.102219Z",
-            "valid_until": "2021-12-15T12:05:31.570698Z"
-        }, {
-            "created": "2021-12-08T09:32:24.102219Z",
-            "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
-            "description": "This schema adds TIM data to the object",
-            "extension_types": ["property-extension"],
-            "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
-            "modified": "2021-12-08T12:05:28.615431Z",
-            "name": "Cortex XSOAR TIM IP",
-            "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
-            "spec_version": "2.0",
-            "type": "extension-definition",
-            "version": "1.0"
-        }
-    ],
-    "type": "bundle"
+  "id": "bundle--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+  "objects": [{
+      "created": "2021-12-08T09:32:24.104143Z",
+      "id": "indicator--5858b9e9-063f-573b-bb34-42cab292eaeb",
+      "modified": "2021-12-08T12:05:28.617414Z",
+      "pattern": "[ipv4-addr:value = '8.8.8.8']",
+      "spec_version": "2.0",
+      "type": "indicator",
+      "valid_from": "2021-12-08T09:32:24.104143Z",
+      "valid_until": "2021-12-15T12:05:31.570698Z"
+    }, {
+      "created": "2021-12-08T09:32:24.104143Z",
+      "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
+      "description": "This schema adds TIM data to the object",
+      "extension_types": ["property-extension"],
+      "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+      "modified": "2021-12-08T12:05:28.617414Z",
+      "name": "Cortex XSOAR TIM IP",
+      "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
+      "spec_version": "2.0",
+      "type": "extension-definition",
+      "version": "1.0"
+    }, {
+      "created": "2021-12-08T09:32:24.102219Z",
+      "id": "indicator--40037b66-eb32-562f-8ed0-60f8db598e40",
+      "modified": "2021-12-08T12:05:28.615431Z",
+      "pattern": "[ipv4-addr:value = '1.1.1.1']",
+      "spec_version": "2.0",
+      "type": "indicator",
+      "valid_from": "2021-12-08T09:32:24.102219Z",
+      "valid_until": "2021-12-15T12:05:31.570698Z"
+    }, {
+      "created": "2021-12-08T09:32:24.102219Z",
+      "created_by_ref": "identity--749249c0-f7c7-5428-a4ad-ea5e1627a221",
+      "description": "This schema adds TIM data to the object",
+      "extension_types": ["property-extension"],
+      "id": "extension-definition--1ffe4bee-95e7-4e36-9a17-f56dbab3c777",
+      "modified": "2021-12-08T12:05:28.615431Z",
+      "name": "Cortex XSOAR TIM IP",
+      "schema": "https://github.com/demisto/content/blob/4265bd5c71913cd9d9ed47d9c37d0d4d3141c3eb/Packs/TAXIIServer/doc_files/XSOAR_indicator_schema.json",
+      "spec_version": "2.0",
+      "type": "extension-definition",
+      "version": "1.0"
+    }
+  ],
+  "type": "bundle"
 }

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_2.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### TAXII2 Server
+- Added a feature to convert STIX Cyber Observable Objects tos STIX Domain Object of 'indicator' so that the Microsoft Azure Sentinel TAXII Connector can feed indicators.

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_2.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_2.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### TAXII2 Server
-- Added a feature to convert STIX Cyber Observable Objects tos STIX Domain Object of 'indicator' so that the Microsoft Azure Sentinel TAXII Connector can feed indicators.
+- Added a feature to convert STIX Cyber Observable Objects to 'indicator' STIX Domain Objects so that the Microsoft Azure Sentinel TAXII Connector can feed indicators.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "2.0.1",
+    "currentVersion": "2.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Added a feature to convert STIX Cyber Observable Objects tos STIX Domain Object of 'indicator' so that the Microsoft Azure Sentinel TAXII Connector can feed indicators.
The current version only works with STIX 2.0.

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
