### PR TITLE
SlackV3 user email retrieval was unsuccessful

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1257,7 +1257,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
             entitlement_reply = json.loads(entitlement_json).get("reply", "Thank you for your reply.")
             action_text = actions[0].get('text').get('text')
             user = await ASYNC_CLIENT.users_info(user=user_id)
-            answer_question(action_text, entitlement_string, user.get('profile', {}).get('email'))
+            answer_question(action_text, entitlement_string, user.get('user', {}).get('profile', {}).get('email'))
 
         else:
             if user_id != '':

--- a/Packs/Slack/ReleaseNotes/2_4_4.md
+++ b/Packs/Slack/ReleaseNotes/2_4_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v3
+- Fixed an issue where an email for a user responding to a question was not successfully retrieved.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "2.4.3",
+    "currentVersion": "2.4.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/44744

## Description
Fixed an issue where a user's email was not retrieved successfully while responding to a question