### PR TITLE
Remove mcafee 10.2, 10.3 since reached end of life

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1513,13 +1513,6 @@
         },
         {
             "integrations": "McAfee ESM v2",
-            "instance_names": "v10.2.0",
-            "playbookID": "McAfee ESM v2 - Test v10.2.0",
-            "fromversion": "5.0.0",
-            "is_mockable": false
-        },
-        {
-            "integrations": "McAfee ESM v2",
             "instance_names": "v11.1.3",
             "playbookID": "McAfee ESM v2 - Test v11.1.3",
             "fromversion": "5.0.0",
@@ -5078,9 +5071,7 @@
         "Majestic Million Test Playbook": "Issue 30931",
         "iDefense_v2_Test": "Issue 40126",
         "EWS Mail Sender Test": "Issue 27944",
-        "McAfee ESM v2 - Test v10.3.0": "Issue 35616",
         "Feed iDefense Test": "Issue 34035",
-        "McAfee ESM v2 - Test v10.2.0": "Issue 35670",
         "McAfee ESM Watchlists - Test v10.3.0": "Issue 37130",
         "McAfee ESM Watchlists - Test v10.2.0": "Issue 39389",
         "McAfee ESM v2 - Test v11.1.3": "Issue 43825",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/35616
https://github.com/demisto/etc/issues/35670

## Description
Removing those instances from conf.json since they reached end of life.
https://github.com/demisto/etc/issues/38269#issuecomment-872303499

