### PR TITLE
MPv2: add CoreAlertFields as core pack in mpv2

### DIFF
--- a/Tests/Marketplace/core_packs_mpv2_list.json
+++ b/Tests/Marketplace/core_packs_mpv2_list.json
@@ -15,6 +15,7 @@
   "CommonScripts",
   "CommonPlaybooks",
   "CommonTypes",
+  "CoreAlertFields",
   "HelloWorld",
   "ExportIndicators",
   "Malware",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
add CoreAlertFields as core pack in mpv2

