### PR TITLE
adding core alert fields as a dependency

### DIFF
--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -64,6 +64,10 @@
         "EWSMailSender": {
             "mandatory": false,
             "display_name": "EWS Mail Sender"
+        },
+        "CoreAlertFields": {
+            "mandatory": false,
+            "display_name": "Core Alert Fields"
         }
     },
     "marketplaces": [


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Adding the Core Alert Fields pack as a dependency to the Phishing pack.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [x] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
