### PR TITLE
FireEye - Increasing the validity of the API Key

### DIFF
--- a/Packs/ApiModules/Scripts/FireEyeApiModule/FireEyeApiModule.py
+++ b/Packs/ApiModules/Scripts/FireEyeApiModule/FireEyeApiModule.py
@@ -125,7 +125,7 @@ class FireEyeClient(BaseClient):
 
         integration_context = get_integration_context()
         integration_context.update({'token': token})
-        time_buffer = 10  # minutes by which to lengthen the validity period
+        time_buffer = 600  # 600 seconds (10 minutes) by which to lengthen the validity period
         integration_context.update({'valid_until': datetime.timestamp(datetime.now() + timedelta(seconds=time_buffer))})
         set_integration_context(integration_context)
 

--- a/Packs/FireEyeCM/Integrations/FireEyeCM/FireEyeCM_description.md
+++ b/Packs/FireEyeCM/Integrations/FireEyeCM/FireEyeCM_description.md
@@ -1,3 +1,7 @@
 To configure the integration, enter your credentials in the following fields:
 - Username
 - Password
+
+## Known Limitations
+Clicking the **Test** button of the **Integration instance settings** window verifies that the instance configuration is correct.
+Due to a known limitation, clicking the **Test** button several times in quick succession may result in an "Unauthorized" error, even after a successful result was initially returned. It is enough to receive one success message to verify that the configuration is correct. "Unauthorized" error messages received from repeated clicking of the instance configuration **Test** button do not affect the validity of the instance if the initial response was successful.

--- a/Packs/FireEyeCM/Integrations/FireEyeCM/README.md
+++ b/Packs/FireEyeCM/Integrations/FireEyeCM/README.md
@@ -677,3 +677,5 @@ Returns reports on selected alerts.
 #### Human Readable Output
 
 
+## Known Limitations
+Clicking the **Test** button verifies that the instance configuration is correct. Clicking the **Test** button several times in a row may result in a known Unauthorized error. Please ignore that error. 

--- a/Packs/FireEyeCM/Integrations/FireEyeCM/README.md
+++ b/Packs/FireEyeCM/Integrations/FireEyeCM/README.md
@@ -678,4 +678,5 @@ Returns reports on selected alerts.
 
 
 ## Known Limitations
-Clicking the **Test** button verifies that the instance configuration is correct. Clicking the **Test** button several times in a row may result in a known Unauthorized error. Please ignore that error. 
+Clicking the **Test** button of the **Integration instance settings** window verifies that the instance configuration is correct.
+Due to a known limitation, clicking the **Test** button several times in quick succession may result in an "Unauthorized" error, even after a successful result was initially returned. It is enough to receive one success message to verify that the configuration is correct. "Unauthorized" error messages received from repeated clicking of the instance configuration **Test** button do not affect the validity of the instance if the initial response was successful.

--- a/Packs/FireEyeCM/ReleaseNotes/1_1_8.md
+++ b/Packs/FireEyeCM/ReleaseNotes/1_1_8.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### FireEye Central Management
-- Fixed an issue where the validity of the API Key was set to 10 seconds instead of 10 minutes. 
+- Fixed an issue where the authorization token was not cached properly.

--- a/Packs/FireEyeCM/ReleaseNotes/1_1_8.md
+++ b/Packs/FireEyeCM/ReleaseNotes/1_1_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### FireEye Central Management
+- Fixed an issue where the validity of the API Key was set to 10 seconds instead of 10 minutes. 

--- a/Packs/FireEyeCM/pack_metadata.json
+++ b/Packs/FireEyeCM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye Central Management",
     "description": "FireEye Central Management (CM Series) is the FireEye threat intelligence hub. It services the FireEye ecosystem, ensuring that FireEye products share the latest intelligence and correlate across attack vectors to detect and prevent cyber attacks",
     "support": "xsoar",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FireEyeEX/Integrations/FireEyeEX/FireEyeEX_description.md
+++ b/Packs/FireEyeEX/Integrations/FireEyeEX/FireEyeEX_description.md
@@ -1,3 +1,7 @@
 To configure the integration, enter your credentials in the following fields:
 - Username
 - Password
+
+## Known Limitations
+Clicking the **Test** button of the **Integration instance settings** window verifies that the instance configuration is correct.
+Due to a known limitation, clicking the **Test** button several times in quick succession may result in an "Unauthorized" error, even after a successful result was initially returned. It is enough to receive one success message to verify that the configuration is correct. "Unauthorized" error messages received from repeated clicking of the instance configuration **Test** button do not affect the validity of the instance if the initial response was successful.

--- a/Packs/FireEyeEX/Integrations/FireEyeEX/README.md
+++ b/Packs/FireEyeEX/Integrations/FireEyeEX/README.md
@@ -960,3 +960,6 @@ Deletes blocked sender domain.
 #### Human Readable Output
 
 
+## Known Limitations
+Clicking the **Test** button of the **Integration instance settings** window verifies that the instance configuration is correct.
+Due to a known limitation, clicking the **Test** button several times in quick succession may result in an "Unauthorized" error, even after a successful result was initially returned. It is enough to receive one success message to verify that the configuration is correct. "Unauthorized" error messages received from repeated clicking of the instance configuration **Test** button do not affect the validity of the instance if the initial response was successful.

--- a/Packs/FireEyeEX/ReleaseNotes/2_0_5.md
+++ b/Packs/FireEyeEX/ReleaseNotes/2_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### FireEye Email Security
+- Fixed an issue where the validity of the API Key was set to 10 seconds instead of 10 minutes.

--- a/Packs/FireEyeEX/ReleaseNotes/2_0_5.md
+++ b/Packs/FireEyeEX/ReleaseNotes/2_0_5.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### FireEye Email Security
-- Fixed an issue where the validity of the API Key was set to 10 seconds instead of 10 minutes.
+- Fixed an issue where the authorization token was not cached properly.

--- a/Packs/FireEyeEX/pack_metadata.json
+++ b/Packs/FireEyeEX/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "FireEye Email Security series protects against breaches caused by advanced email attacks.",
     "support": "xsoar",
     "serverMinVersion": "6.0.0",
-    "currentVersion": "2.0.4",
+    "currentVersion": "2.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [46273](https://github.com/demisto/etc/issues/46273).

## Description
Increased the time buffer of API Key's validity to 10 minutes (it was set to 10 seconds by mistake). 

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
