### PR TITLE
add egg to demisto-sdk requirement

### DIFF
--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,7 +1,7 @@
 flake8==3.9.2
 bandit==1.7.0
 demisto-py>=3.0.2
-git+https://github.com/demisto/demisto-sdk.git@5b220445c7e84ed5e80afe83bba21b39ffd9fef7
+git+https://github.com/demisto/demisto-sdk.git@5b220445c7e84ed5e80afe83bba21b39ffd9fef7#egg=demisto-sdk
 pytest==6.2.1
 pytest-mock==3.4.0
 requests-mock==1.8.0


### PR DESCRIPTION
[x] - Ready

Egg is critical to venvs like pipenv to determine the dependency name.