### PR TITLE
fix bug in pan-os-policy-optimizer pan-os-get-dag command

### DIFF
--- a/Packs/PANOSPolicyOptimizer/Integrations/PANOSPolicyOptimizer/PANOSPolicyOptimizer_test.py
+++ b/Packs/PANOSPolicyOptimizer/Integrations/PANOSPolicyOptimizer/PANOSPolicyOptimizer_test.py
@@ -1,8 +1,7 @@
 import pytest
-import json
 import io
 from CommonServerPython import *
-from PANOSPolicyOptimizer import Client, policy_optimizer_get_rules_command
+from PANOSPolicyOptimizer import Client, policy_optimizer_get_rules_command, policy_optimizer_get_dag_command
 
 
 BASE_URL = 'https://test.com'
@@ -111,3 +110,25 @@ def test_querying_rules_is_valid(mocker, client):
     assert isinstance(rules.outputs, list)
     assert len(rules.outputs) > 0
     assert 'PolicyOptimizer Unused-security-rules' in rules.readable_output
+
+
+@pytest.mark.parametrize("client", CLIENTS)
+def test_querying_invalid_dynamic_address_group_response(mocker, client):
+    """
+    Given
+        - a response which indicates no dynamic address group was found.
+
+    When
+        - querying for a specific dynamic group.
+
+    Then
+        - a valid error response is returned.
+    """
+    mocker.patch.object(client, 'token_generator', return_value='123')
+    mocker.patch.object(client.session, 'post')
+    mocker.patch.object(
+        json, 'loads', return_value=read_json_file(path='test_data/invalid_dynamic_group_response.json')
+    )
+
+    with pytest.raises(Exception, match=f'Dynamic Address Group dag_test_ag was not found.'):
+        policy_optimizer_get_dag_command(client=client, args={'dag': 'dag_test_ag'})

--- a/Packs/PANOSPolicyOptimizer/Integrations/PANOSPolicyOptimizer/test_data/invalid_dynamic_group_response.json
+++ b/Packs/PANOSPolicyOptimizer/Integrations/PANOSPolicyOptimizer/test_data/invalid_dynamic_group_response.json
@@ -1,0 +1,19 @@
+{
+   "type":"rpc",
+   "tid":"51",
+   "action":"PanDirect",
+   "method":"execute",
+   "predefinedCacheUpdate":"true",
+   "result":{
+      "@status":"success",
+      "result":{
+         "dyn-addr-grp":{
+            "entry":[
+               {
+                  "member-list":"\n\t"
+               }
+            ]
+         }
+      }
+   }
+}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fixes an issue where in the ```!pan-os-get-dag``` command, when a dynamic group address was cannot be found, then invalid error is returned instead of meaningful error.

```
Raw Response section:
string indices must be integers.
 Trace:Traceback (most recent call last):
  File "<string>", line 9581, in main
  File "<string>", line 9543, in policy_optimizer_get_dag_command
TypeError: string indices must be integers


Traceback (most recent call last):
  File "<CustomScriptIntegration>", line 440, in main
  File "<CustomScriptIntegration>", line 402, in policy_optimizer_get_dag_command
TypeError: string indices must be integers
```
 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
