### PR TITLE
add keywords to generic export indicators

### DIFF
--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Generic Export Indicators Service",
-    "description": "Ongoing distribution of indicators from XSOAR to other products in the network, using an endpoint with a list of indicators that can be pulled by external vendors.\n",
+    "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to ANY other product in your network, such as your firewall, agent or SIEM. This pack is built for ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
     "currentVersion": "3.0.3",
     "author": "Cortex XSOAR",
@@ -14,7 +14,14 @@
     ],
     "created": "2020-04-14T00:00:00Z",
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "EDL",
+        "pan-os EDL",
+        "panos EDL",
+        "panos",
+        "export-indicators",
+        "export"
+    ],
     "dependencies": {},
     "marketplaces": [
         "xsoar",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46712

## Description
Add edl, pan-os keywords to generic export indicators pack

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
