### PR TITLE
AutoExtract Test - Fixed tasks related to URLs and Domains extractions according to the updated behavior

### DIFF
--- a/Packs/Base/TestPlaybooks/playbook-Autoextract_-_Test.yml
+++ b/Packs/Base/TestPlaybooks/playbook-Autoextract_-_Test.yml
@@ -248,24 +248,6 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: http://www.thisoneshouldnotexisteither4444.com
-                    ignorecase: true
-                accessor: Data
-            iscontext: true
-          ignorecase: true
-      - - operator: isExists
-          left:
-            value:
-              complex:
-                root: URL
-                filters:
-                - - operator: isEqualString
-                    left:
-                      value:
-                        simple: URL.Data
-                      iscontext: true
-                    right:
-                      value:
                         simple: http://www.letsseeifyoucanfindthisone4444.co.il
                 accessor: Data
             iscontext: true
@@ -510,7 +492,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: thisurlwillneverexist4444.co.il
+                        simple: www.thisurlwillneverexist4444.co.il
                     ignorecase: true
                 accessor: Name
             iscontext: true
@@ -527,7 +509,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: thisoneshouldnotexisteither4444.com
+                        simple: www.thisoneshouldnotexisteither4444.com
                     ignorecase: true
                 accessor: Name
             iscontext: true
@@ -545,7 +527,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: letsseeifyoucanfindthisone4444.co.il
+                        simple: www.letsseeifyoucanfindthisone4444.co.il
                 accessor: Name
             iscontext: true
       - - operator: isExists


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [45293](https://github.com/demisto/etc/issues/45293)

## Description
Fixed tasks related to URLs and Domains extractions according to the updated behavior that was defined by the security team: 

According to @melamedbn:
1. A URL that doesn't start with a schema (such as 'https://', 'hxxps://') is not a URL but a Domain. Therefore the condition that was used to check whether the domain: 'www.thisoneshouldnotexisteither4444.com' was extracted to context as a URL by auto-extract was removed. 

2. Domains will be extracted exactly as they are (including the 'www' prefix). For example the domain that should be extracted from this URL: 'http://www.thisurlwillneverexist4444.co.il' is: 'www.thisurlwillneverexist4444.co.il'. 
Therefore 3 conditions were changed in the task that is in charge of verifying domains extraction. 

## Screenshots
A successful run of the playbook after the fix: 
![Autoextract_-_Test_Thu_Feb_17_2022](https://user-images.githubusercontent.com/82749224/154433901-2e242717-6f37-499f-b931-77bb4302f24c.png)


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
