### PR TITLE
Microsoft Defender For Endpoint - support fileMD5

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -43,6 +43,7 @@ SC_INDICATORS_HEADERS = (
 INDICATOR_TYPE_TO_DBOT_TYPE = {
     'FileSha256': DBotScoreType.FILE,
     'FileSha1': DBotScoreType.FILE,
+    'FileMd5': DBotScoreType.FILE,
     'Url': DBotScoreType.URL,
     'DomainName': DBotScoreType.DOMAIN,
     'IpAddress': DBotScoreType.IP,

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_4_1.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_4_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Defender for Endpoint
+- Fixed an issue where the ***microsoft-atp-sc-indicator-list*** command did not support FileMd5.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.4.0",
+    "currentVersion": "1.4.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes :[ link to the issue](https://github.com/demisto/etc/issues/46808)

## Description
- Fixed an issue where the ***microsoft-atp-sc-indicator-list*** command did not support FileMd5.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
