### PR TITLE
Fixed timeout in isIncidentPartOfCampaign script

### DIFF
--- a/Packs/Campaign/ReleaseNotes/3_2_8.md
+++ b/Packs/Campaign/ReleaseNotes/3_2_8.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### IsIncidentPartOfCampaign
+- Fixed an issue where the script fails on timeout.

--- a/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign.py
+++ b/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign.py
@@ -26,9 +26,6 @@ def get_incidents_ids_by_type(incident_type: str) -> Iterable[str]:
     incidents = execute_command("GetIncidentsByQuery", search_args)
     demisto.debug(f"Incidents getting from response: {incidents}")
 
-    if is_error(incidents):
-        return_error(incidents)
-
     incidents = json.loads(incidents)
     campaign_ids = [incident.get('id') for incident in incidents]
     demisto.debug(f"Found campaing incident ids: {campaign_ids}")

--- a/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign.yml
+++ b/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign.yml
@@ -25,7 +25,7 @@ outputs:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.1.25933
+dockerimage: demisto/python3:3.10.1.26972
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign_test.py
+++ b/Packs/Campaign/Scripts/IsIncidentPartOfCampaign/IsIncidentPartOfCampaign_test.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 import demistomock as demisto
 from IsIncidentPartOfCampaign import check_incidents_ids_in_campaign, get_incidents_ids_by_type, main
@@ -24,8 +25,8 @@ def _wrap_mocked_get_context(raw_incident):
     return [{'Type': 'note', 'Contents': {'context': raw_incident}}]
 
 
-def _wrap_mocked_get_incident(raw_incidents):
-    return [{'Type': 'note', 'Contents': {'data': raw_incidents}}]
+def _wrap_mocked_get_incident_by_query(raw_incidents):
+    return [{'Type': 'note', 'Contents': json.dumps(raw_incidents)}]
 
 
 @pytest.mark.parametrize('incidents_ids_set, result',
@@ -53,8 +54,8 @@ class TestGetIncidentsIDsByType:
         """
         mocker.patch.object(demisto, 'executeCommand',
                             side_effect=[
-                                _wrap_mocked_get_incident(PHISHING_CAMPAIGN_INCIDENTS + OTHER_INCIDENTS),
-                                _wrap_mocked_get_incident([])])
+                                _wrap_mocked_get_incident_by_query(PHISHING_CAMPAIGN_INCIDENTS),
+                                _wrap_mocked_get_context([])])
         assert list(get_incidents_ids_by_type('Phishing Campaign')) == ['1', '2']
 
     @staticmethod
@@ -68,7 +69,7 @@ class TestGetIncidentsIDsByType:
             Only incident with the given type are returned.
         """
         mocker.patch.object(demisto, 'executeCommand',
-                            return_value=_wrap_mocked_get_incident(None))
+                            return_value=_wrap_mocked_get_incident_by_query([]))
         assert list(get_incidents_ids_by_type('Phishing Campaign')) == []
 
 
@@ -78,13 +79,13 @@ class TestMain:
         mocker.patch.object(demisto, 'args',
                             return_value={'CampaignIncidentType': 'Phishing Campaign', 'IncidentIDs': '11,21'})
         mocker.patch.object(demisto, 'executeCommand',
-                            side_effect=[_wrap_mocked_get_incident(PHISHING_CAMPAIGN_INCIDENTS + OTHER_INCIDENTS)] + [
+                            side_effect=[_wrap_mocked_get_incident_by_query(PHISHING_CAMPAIGN_INCIDENTS)] + [
                                 _wrap_mocked_get_context(incident) for incident in PHISHING_CAMPAIGN_INCIDENTS])
         results = main()
         assert results.readable_output == "Found campaign with ID - 1"
         assert results.outputs['ExistingCampaignID'] == '1'
         mocker.patch.object(demisto, 'executeCommand',
-                            side_effect=[_wrap_mocked_get_incident(None)])
+                            side_effect=[_wrap_mocked_get_incident_by_query([])])
         results = main()
         assert results.readable_output == "No campaign has found"
         assert results.outputs['ExistingCampaignID'] is None
@@ -105,8 +106,7 @@ class TestMain:
             'IncidentIDs': '123'
         })
         mocker.patch.object(demisto, 'executeCommand', side_effect=[
-            _wrap_mocked_get_incident(OTHER_INCIDENTS * 2),
-            _wrap_mocked_get_incident(PHISHING_CAMPAIGN_INCIDENTS),
+            _wrap_mocked_get_incident_by_query(PHISHING_CAMPAIGN_INCIDENTS),
             _wrap_mocked_get_context({'EmailCampaign': {'incidents': [{'id': '11'}, {'id': '12'}]}}),
             _wrap_mocked_get_context({'EmailCampaign': {'incidents': [{'id': '11'}, {'id': '123'}]}}),
         ])

--- a/Packs/Campaign/pack_metadata.json
+++ b/Packs/Campaign/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing Campaign",
     "description": "This pack can help you find related phishing, spam or other types of email incidents and characterize campaigns.",
     "support": "xsoar",
-    "currentVersion": "3.2.7",
+    "currentVersion": "3.2.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46483

## Description
Fixed an issue where the script isIncidentPartOfCampaign fails on timeout.
Changed the incidents search to be by query and not by type.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
