### PR TITLE
Deprecate LogRhythm SOAP pack and remove from MPv2

### DIFF
--- a/Packs/ExportIndicators/pack_metadata.json
+++ b/Packs/ExportIndicators/pack_metadata.json
@@ -16,7 +16,6 @@
         "Export Indicators"
     ],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/FeedProofpoint/pack_metadata.json
+++ b/Packs/FeedProofpoint/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/LogRhythm/pack_metadata.json
+++ b/Packs/LogRhythm/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "LogRhythm",
-    "description": "LogRhythm security intelligence",
+    "description": "Deprecated. Use LogRhythmRest pack instead.",
     "support": "xsoar",
     "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ProofpointServerProtection/pack_metadata.json
+++ b/Packs/ProofpointServerProtection/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ProofpointTAP/pack_metadata.json
+++ b/Packs/ProofpointTAP/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -14,7 +14,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
-        "marketplacev2"
+        "xsoar"
     ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46963
fixes: https://github.com/demisto/etc/issues/46962

## Description
* deprecate LogRhythm SOAP pack
* remove Proofpoint packs from MPv2
* remove deprecated packs from MPv2
