### PR TITLE
Symantec_ATP: search for incidents in time period of a week when fetching incidents

### DIFF
--- a/Packs/Symantec_Advanced_Threat_Protection/Integrations/SymantecAdvancedThreatProtection/SymantecAdvancedThreatProtection.js
+++ b/Packs/Symantec_Advanced_Threat_Protection/Integrations/SymantecAdvancedThreatProtection/SymantecAdvancedThreatProtection.js
@@ -308,8 +308,8 @@ var fetchIncidents = function(type, query, limit, first_fetch_time) {
     }
 
     // set the time period to the max allowed - a week
-    startTimeWeekAhed = new Date(Date.parse(startTime) + 7*DAY_IN_MILLIS)
-    endTimeDate = new Date(endTime)
+    var startTimeWeekAhed = new Date(Date.parse(startTime) + 7*DAY_IN_MILLIS)
+    var endTimeDate = new Date(endTime)
     endTime = new Date(Math.min(now, endTimeDate, startTimeWeekAhed)).toISOString();
 
     var p = {verb: 'query'};

--- a/Packs/Symantec_Advanced_Threat_Protection/Integrations/SymantecAdvancedThreatProtection/SymantecAdvancedThreatProtection.js
+++ b/Packs/Symantec_Advanced_Threat_Protection/Integrations/SymantecAdvancedThreatProtection/SymantecAdvancedThreatProtection.js
@@ -306,6 +306,12 @@ var fetchIncidents = function(type, query, limit, first_fetch_time) {
         n.setTime(now.getTime() - 1 * DAY_IN_MILLIS);
         startTime = n.toISOString();
     }
+
+    // set the time period to the max allowed - a week
+    startTimeWeekAhed = new Date(Date.parse(startTime) + 7*DAY_IN_MILLIS)
+    endTimeDate = new Date(endTime)
+    endTime = new Date(Math.min(now, endTimeDate, startTimeWeekAhed)).toISOString();
+
     var p = {verb: 'query'};
     add(p, 'where', query);
     addTime(p, 'start_time', startTime);
@@ -333,7 +339,7 @@ var fetchIncidents = function(type, query, limit, first_fetch_time) {
     if (next) {
         setLastRun({ time: startTime, next: next, end_time: endTime });
     } else {
-        setLastRun({ time: currentFetch ? currentFetch : startTime});
+        setLastRun({ time: currentFetch ? currentFetch : endTime});
     }
     return JSON.stringify(incidents);
 };

--- a/Packs/Symantec_Advanced_Threat_Protection/ReleaseNotes/1_1_5.md
+++ b/Packs/Symantec_Advanced_Threat_Protection/ReleaseNotes/1_1_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Symantec Advanced Threat Protection
+- Fixed an issue in fetch incidents, where process failed if no incident was fetched in more then a week.

--- a/Packs/Symantec_Advanced_Threat_Protection/pack_metadata.json
+++ b/Packs/Symantec_Advanced_Threat_Protection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Symantec Advanced Threat Protection",
     "description": "Advanced protection capabilities from Symantec",
     "support": "xsoar",
-    "currentVersion": "1.1.4",
+    "currentVersion": "1.1.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46009

## Description
When fetching incident there is an error occurred in Symantec server if the time period (start_time till end_time) is more than a week

the fix will run the search in a time period of a week

