### PR TITLE
CheckEmailAuthenticity original header

### DIFF
--- a/Packs/Phishing/.pack-ignore
+++ b/Packs/Phishing/.pack-ignore
@@ -138,3 +138,6 @@ ignore=IF115
 
 [file:incidentfield-reported_email_origin.json]
 ignore=IF116
+
+[known_words]
+CheckEmailAuthenticity

--- a/Packs/Phishing/ReleaseNotes/3_1_3.md
+++ b/Packs/Phishing/ReleaseNotes/3_1_3.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### CheckEmailAuthenticity
+- Added the argument *original_authentication_header* for when the authenticator header within the *headers* argument 
+  does not represent the right authenticator header.

--- a/Packs/Phishing/ReleaseNotes/3_1_3.md
+++ b/Packs/Phishing/ReleaseNotes/3_1_3.md
@@ -1,5 +1,5 @@
 
 #### Scripts
 ##### CheckEmailAuthenticity
-- Added the argument *original_authentication_header* for when the authenticator header within the *headers* argument 
+- Added the *original_authentication_header* argument for when the authenticator header within the *headers* argument 
   does not represent the right authenticator header.

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
@@ -123,8 +123,7 @@ def get_authentication_value(headers, original_authentication_header):
         The suitable authenticator header.
 
     """
-    headers = [header for header in headers if isinstance(header, dict)]
-    header_dict = {str(header.get('name')).lower(): header.get('value') for header in headers}
+    header_dict = {str(header.get('name')).lower(): header.get('value') for header in headers if isinstance(header, dict)}
     if original_authentication_header and original_authentication_header in header_dict:
         authentication_value = header_dict[original_authentication_header]
     else:

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
@@ -109,6 +109,31 @@ def auth_check(spf_data, dkim_data, dmarc_data, override_dict):
     return 'Pass'
 
 
+def get_authentication_header(headers, original_authentication_header):
+    """
+    Handel the case where the authentication header is given under a different header.
+    This header is represented by the 'original_authentication_header' argument.  This can happen when there is an
+     intermediate server which changes the email and holds the original value of the header in a different header.
+     For more info, see issue #46364.
+    Args:
+        headers: The headers dict argument given by the user
+        original_authentication_header: The name of a header which holds the original value of the
+        Authentication-Results header.
+
+    Returns:
+        The suitable authenticator header.
+
+    """
+    headers = [header for header in headers if isinstance(header, dict)]
+    header_dict = {str(header.get('name')).lower(): header.get('value') for header in headers}
+    if original_authentication_header and original_authentication_header in header_dict:
+        authentication_header = header_dict[original_authentication_header]
+    else:
+        authentication_header = header_dict.get('authentication-results')
+
+    return authentication_header
+
+
 '''MAIN FUNCTION'''
 
 
@@ -116,8 +141,8 @@ def main():
     try:
         args = demisto.args()
         headers = argToList(demisto.args().get('headers'))
-
-        auth = None
+        original_authentication_header = args.get('original_authentication_header').lower()
+        auth = get_authentication_header(headers, original_authentication_header)
         spf = None
         message_id = ''
 
@@ -162,8 +187,6 @@ def main():
 
         for header in headers:
             if isinstance(header, dict):
-                if str(header.get('name')).lower() == 'authentication-results':
-                    auth = header.get('value')
                 if str(header.get('name')).lower() == 'received-spf':
                     spf = header.get('value')
                 if str(header.get('name')).lower() == 'message-id':
@@ -172,7 +195,7 @@ def main():
         email_key = "Email(val.Headers.filter(function(header) {{ return header && header.name === 'Message-ID' && " \
                     "header.value === '{}';}}))".format(message_id)
 
-        if auth is None and spf is None:
+        if not auth and not spf:
             context = {
                 '{}.AuthenticityCheck'.format(email_key): 'undetermined'
             }

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
@@ -112,7 +112,9 @@ def auth_check(spf_data, dkim_data, dmarc_data, override_dict):
 def get_authentication_value(headers, original_authentication_header):
     """
     Handles the case where the authentication header is given under a different header.
-    This header is represented by the 'original_authentication_header' argument.  This can happen when an intermediate server changes the email and holds the original value of the header in a different header.
+    This header is represented by the 'original_authentication_header' argument.
+    This can happen when an intermediate server changes the email and holds the original value of the header
+    in a different header.
     For more info, see issue #46364.
     Args:
         headers: The headers dict argument given by the user

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
@@ -111,10 +111,9 @@ def auth_check(spf_data, dkim_data, dmarc_data, override_dict):
 
 def get_authentication_value(headers, original_authentication_header):
     """
-    Handel the case where the authentication header is given under a different header.
-    This header is represented by the 'original_authentication_header' argument.  This can happen when there is an
-     intermediate server which changes the email and holds the original value of the header in a different header.
-     For more info, see issue #46364.
+    Handles the case where the authentication header is given under a different header.
+    This header is represented by the 'original_authentication_header' argument.  This can happen when an intermediate server changes the email and holds the original value of the header in a different header.
+    For more info, see issue #46364.
     Args:
         headers: The headers dict argument given by the user
         original_authentication_header: The name of a header which holds the original value of the

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.py
@@ -109,7 +109,7 @@ def auth_check(spf_data, dkim_data, dmarc_data, override_dict):
     return 'Pass'
 
 
-def get_authentication_header(headers, original_authentication_header):
+def get_authentication_value(headers, original_authentication_header):
     """
     Handel the case where the authentication header is given under a different header.
     This header is represented by the 'original_authentication_header' argument.  This can happen when there is an
@@ -127,11 +127,11 @@ def get_authentication_header(headers, original_authentication_header):
     headers = [header for header in headers if isinstance(header, dict)]
     header_dict = {str(header.get('name')).lower(): header.get('value') for header in headers}
     if original_authentication_header and original_authentication_header in header_dict:
-        authentication_header = header_dict[original_authentication_header]
+        authentication_value = header_dict[original_authentication_header]
     else:
-        authentication_header = header_dict.get('authentication-results')
+        authentication_value = header_dict.get('authentication-results')
 
-    return authentication_header
+    return authentication_value
 
 
 '''MAIN FUNCTION'''
@@ -141,8 +141,8 @@ def main():
     try:
         args = demisto.args()
         headers = argToList(demisto.args().get('headers'))
-        original_authentication_header = args.get('original_authentication_header').lower()
-        auth = get_authentication_header(headers, original_authentication_header)
+        original_authentication_header = args.get('original_authentication_header', '').lower()
+        auth = get_authentication_value(headers, original_authentication_header)
         spf = None
         message_id = ''
 

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
@@ -10,6 +10,13 @@ args:
   secret: false
 - auto: PREDEFINED
   default: false
+  description: The name of a header which holds the original value of the Authentication-Results header. This can be used when there is an intermediate server which changes the email and holds the original value of the header in a different header. Please be aware that you should use this only if you are trusting the server which creating this header.
+  isArray: false
+  name: original_authentication_header
+  required: false
+  secret: false
+- auto: PREDEFINED
+  default: false
   description: Override value for SPF=None.
   isArray: false
   name: SPF_override_none

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
@@ -10,7 +10,7 @@ args:
   secret: false
 - auto: PREDEFINED
   default: false
-  description: The header's name holds the original value of the Authentication-Results header. This can be used when an intermediate server changes the email and keeps the original value of the header in a different header. Please be aware that you should use this only if you trust the server creating this header.
+  description: The header that holds the original Authentication-Results header value. This can be used when an intermediate server changes the original email and holds the original header value in a different header. Note - Use this only if you trust the server creating this header.
   isArray: false
   name: original_authentication_header
   required: false

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity.yml
@@ -10,7 +10,7 @@ args:
   secret: false
 - auto: PREDEFINED
   default: false
-  description: The name of a header which holds the original value of the Authentication-Results header. This can be used when there is an intermediate server which changes the email and holds the original value of the header in a different header. Please be aware that you should use this only if you are trusting the server which creating this header.
+  description: The header's name holds the original value of the Authentication-Results header. This can be used when an intermediate server changes the email and keeps the original value of the header in a different header. Please be aware that you should use this only if you trust the server creating this header.
   isArray: false
   name: original_authentication_header
   required: false

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity_test.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity_test.py
@@ -1,4 +1,4 @@
-from CheckEmailAuthenticity import main
+from CheckEmailAuthenticity import main, get_authentication_value
 import demistomock as demisto
 
 MOCK_HEADERS = [
@@ -15,6 +15,22 @@ MOCK_HEADERS = [
         'name': 'Authentication-Results',
         'value': 'spf=pass (sender IP is 8.8.8.8) smtp.mailfrom=test.com; dkim=fail (body hash did not verify) '
                  'header.d=test.com; dmarc=pass action=none header.from=test.com;compauth=pass reason=100'
+    }
+]
+
+MOCK_HEADERS_DIFFERENT_AUTH_HEADER = [
+    {
+        'name': 'Message-ID',
+        'value': 'test_message_id'
+    },
+    {
+        'name': 'received-spf',
+        'value': 'Pass (test.com: domain of test.com designates 8.8.8.8 as permitted sender)'
+                 'receiver=test.com; client-ip=8.8.8.8; helo=test.com;'
+    },
+    {
+        'name': 'Authentication-Results',
+        'value': 'mock_different_value'
     }
 ]
 
@@ -46,3 +62,26 @@ def test_check_email_auth(mocker):
 
     # AuthenticityCheck fails because DKIM failed
     assert results[0]['EntryContext']['{}.AuthenticityCheck'.format(EMAIL_KEY)] == 'Fail'
+
+
+def test_get_authentication_value():
+    """
+    Given:
+        an authenticator header that is not a part of the given headers array.
+    When:
+        there is an intermediate server which changes the email and holds the original value of the header in a
+        different header.
+    Then:
+        override the given authenticator headers in the headers array and use the original one.
+    """
+
+    original_authentication_header_included_in_headers = 'Authentication-Results'
+    original_authentication_header_not_included_in_headers = 'Authentication-Results-Not-Included'
+
+    assert get_authentication_value(MOCK_HEADERS_DIFFERENT_AUTH_HEADER,
+                                    original_authentication_header_not_included_in_headers) == 'mock_different_value'
+    assert get_authentication_value(MOCK_HEADERS, original_authentication_header_included_in_headers) \
+           == 'spf=pass (sender IP is 8.8.8.8) smtp.mailfrom=test.com; dkim=fail (body hash did not verify) ' \
+              'header.d=test.com; dmarc=pass action=none header.from=test.com;compauth=pass reason=100'
+
+

--- a/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity_test.py
+++ b/Packs/Phishing/Scripts/CheckEmailAuthenticity/CheckEmailAuthenticity_test.py
@@ -83,5 +83,3 @@ def test_get_authentication_value():
     assert get_authentication_value(MOCK_HEADERS, original_authentication_header_included_in_headers) \
            == 'spf=pass (sender IP is 8.8.8.8) smtp.mailfrom=test.com; dkim=fail (body hash did not verify) ' \
               'header.d=test.com; dmarc=pass action=none header.from=test.com;compauth=pass reason=100'
-
-

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.1.2",
+    "currentVersion": "3.1.3",
     "serverMinVersion": "6.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/46364

## Description
Added the argument original_authentication_header: The name of a header which holds the original value of the Authentication-Results header. This can be used when there is an intermediate server which changes the email and holds the original value of the header in a different header. 

