### PR TITLE
CTIX - fix create intel command context output

### DIFF
--- a/Packs/CTIX/Integrations/CTIX/CTIX.py
+++ b/Packs/CTIX/Integrations/CTIX/CTIX.py
@@ -544,7 +544,7 @@ def create_intel_command(client: Client, args: Dict[str, Any]) -> Dict:
         "CTIX": {
             "Intel": {
                 "response": create_intel_response.get("data"),
-                "code": create_intel_response.get("status")
+                "status": create_intel_response.get("status")
             }
         }
     }

--- a/Packs/CTIX/Integrations/CTIX/CTIX_test.py
+++ b/Packs/CTIX/Integrations/CTIX/CTIX_test.py
@@ -277,4 +277,5 @@ def test_create_intel(requests_mock):
     response = create_intel_command(client, post_data)
 
     assert 'data', 'status' in response['CTIX']['Intel']['response']
+    assert 'status' in response['CTIX']['Intel']
     assert response['CTIX']['Intel']['response']['status'] == 201

--- a/Packs/CTIX/ReleaseNotes/1_1_1.md
+++ b/Packs/CTIX/ReleaseNotes/1_1_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cyware Threat Intelligence eXchange
+- Fixed an issue where to context output of the **ctix-create-intel** command was not correct. 

--- a/Packs/CTIX/pack_metadata.json
+++ b/Packs/CTIX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CTIX",
     "description": "Cyware Threat Intelligence eXchange",
     "support": "partner",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cyware Labs",
     "url": "https://cyware.com/",
     "email": "connector-dev@cyware.com",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixes an issue where the context output of the ```ctix-create-intel``` command isn't correct.

