### PR TITLE
Make type b in Create Indicator Relationship required

### DIFF
--- a/Packs/Base/ReleaseNotes/1_18_16.md
+++ b/Packs/Base/ReleaseNotes/1_18_16.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CreateIndicatorRelationship
+- Updated the *entity_b_type* to be required

--- a/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
+++ b/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
@@ -291,7 +291,7 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.9.8.24399
+dockerimage: demisto/python3:3.10.1.26972
 fromversion: 6.2.0
 tests:
 - Relationships scripts - Test

--- a/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
+++ b/Packs/Base/Scripts/CreateIndicatorRelationship/CreateIndicatorRelationship.yml
@@ -73,7 +73,7 @@ args:
   - Course of Action
   - Infrastructure
   - Intrusion Set
-  required: false
+  required: true
   secret: false
 - default: false
   description: 'The indicator query for all the entity_b results. The indicators that are the results of the query will be used as the destination of the relationship. For example type:ip AND tags:mytag. For more query examples, see https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/manage-indicators/understand-indicators/indicators-page.html. This argument cannot be used in conjunction with the entity_b argument or the entity_b_type argument.'

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.18.15",
+    "currentVersion": "1.18.16",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47092

## Description
Chnaged `entity_b_type` argument to be required.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
