### PR TITLE
bootstrap: added force install + python 3.10 support

### DIFF
--- a/.hooks/bootstrap
+++ b/.hooks/bootstrap
@@ -43,11 +43,15 @@ if [ "$1" == "-u" -o "$1" == "--update" ]; then
     exit 0
 fi
 
-if [ ! "$PWD" == "$(git rev-parse --show-toplevel)" ]; then
-    cat >&2 <<__EOF__
-ERROR: this script must be run at the root of the source tree
+if [ ! "$FORCE_SETUP" ]; then
+
+    if [ ! "$PWD" == "$(git rev-parse --show-toplevel)" ]; then
+        cat >&2 <<__EOF__
+    ERROR: this script must be run at the root of the source tree
 __EOF__
-    exit 1
+        exit 1
+    fi
+
 fi
 
 HOOKS_DIR="${PWD}/.hooks"
@@ -96,7 +100,9 @@ else
         fi
 
         PY3CMD="python3"
-        if command -v python3.9 >/dev/null 2>&1; then
+        if command -v python3.10 >/dev/null 2>&1; then
+            PY3CMD="python3.10"
+        elif command -v python3.9 >/dev/null 2>&1; then
             PY3CMD="python3.9"
         elif command -v python3.8 >/dev/null 2>&1; then
             PY3CMD="python3.8"


### PR DESCRIPTION
bootstrap: added force install + python 3.10 support

Needed to install where we want a content environment without the repository itself.