### PR TITLE
Office-utils - Upgraded the Docker image

### DIFF
--- a/Packs/CommonScripts/.pack-ignore
+++ b/Packs/CommonScripts/.pack-ignore
@@ -69,3 +69,5 @@ ignore=SC106
 
 [known_words]
 UnzipFile
+ConvertFile
+ExtractIndicatorsFromWordFile

--- a/Packs/CommonScripts/ReleaseNotes/1_6_43.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_6_43.md
@@ -1,6 +1,6 @@
 
 #### Scripts
 ##### ConvertFile
-- Upgraded the Docker image to: *demisto/office-utils:2.0.0.27298*.
+- Updated the Docker image to: *demisto/office-utils:2.0.0.27298*.
 ##### ExtractIndicatorsFromWordFile
-- Upgraded the Docker image to: *demisto/office-utils:2.0.0.27298*.
+- Updated the Docker image to: *demisto/office-utils:2.0.0.27298*.

--- a/Packs/CommonScripts/ReleaseNotes/1_6_43.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_6_43.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+##### ConvertFile
+- Upgraded the Docker image to: *demisto/office-utils:2.0.0.27298*.
+##### ExtractIndicatorsFromWordFile
+- Upgraded the Docker image to: *demisto/office-utils:2.0.0.27298*.

--- a/Packs/CommonScripts/Scripts/ConvertFile/ConvertFile.yml
+++ b/Packs/CommonScripts/Scripts/ConvertFile/ConvertFile.yml
@@ -43,5 +43,5 @@ outputs:
   type: String
 scripttarget: 0
 runonce: false
-dockerimage: demisto/office-utils:2.0.0.23094
+dockerimage: demisto/office-utils:2.0.0.27298
 runas: DBotWeakRole

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromWordFile/ExtractIndicatorsFromWordFile.yml
@@ -29,7 +29,7 @@ timeout: '0'
 type: python
 subtype: python2
 runas: DBotRole
-dockerimage: demisto/office-utils:2.0.0.23094
+dockerimage: demisto/office-utils:2.0.0.27298
 runonce: false
 fromversion: 5.0.0
 tests:

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.6.42",
+    "currentVersion": "1.6.43",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/47197

## Description
Upgrade the docker image for the scripts `ConvertFile` and `ExtractIndicatorsFromWordFile` to **demisto/office-utils:2.0.0.27298**

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
