### PR TITLE
fixed the file_name parameter in upload file

### DIFF
--- a/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/CrowdStrikeFalconX.py
+++ b/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/CrowdStrikeFalconX.py
@@ -203,7 +203,7 @@ class Client:
     def upload_file(
             self,
             file: str,
-            file_name: str,
+            file_name: str = None,
             is_confidential: str = "true",
             comment: str = ""
     ) -> dict:
@@ -216,7 +216,8 @@ class Client:
         """
         get_file_path_res = demisto.getFilePath(file)
         file_path = get_file_path_res["path"]
-        file_name = get_file_path_res["name"]
+        file_name_by_path = get_file_path_res["name"]
+        file_name = file_name if file_name else file_name_by_path
 
         url_suffix = f"/samples/entities/samples/v2?file_name={file_name}&is_confidential={is_confidential}" \
                      f"&comment={comment}"
@@ -545,7 +546,7 @@ def test_module(
 def upload_file_command(
         client: Client,
         file: str,
-        file_name: str,
+        file_name: str = None,
         is_confidential: str = "true",
         comment: str = "",
         submit_file: str = "no",
@@ -1017,8 +1018,6 @@ def validate_command_args(command, args):
     if command == 'cs-fx-upload-file':
         if 'file' not in args:
             raise Exception("file argument is a mandatory for cs-fx-upload-file command")
-        if 'file_name' not in args:
-            raise Exception("file_name argument is a mandatory for cs-fx-upload-file command")
         if 'polling' in args and args.get('submit_file') != 'yes':
             raise Exception("The command cs-fx-upload-file support the polling option "
                             "just when the submit_file argument is yes.")

--- a/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/CrowdStrikeFalconX.yml
+++ b/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/CrowdStrikeFalconX.yml
@@ -67,8 +67,8 @@ script:
       isArray: false
       name: polling
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - auto: PREDEFINED
@@ -77,8 +77,8 @@ script:
       isArray: false
       name: extended_data
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - default: false
@@ -308,8 +308,7 @@ script:
       type: String
   - arguments:
     - default: false
-      description: SHA256 ID of the sample, which is a SHA256 hash value. Find the sample
-        ID from the response when uploading a malware sample or search with the cs-fx-upload-file command.
+      description: SHA256 ID of the sample, which is a SHA256 hash value. Find the sample ID from the response when uploading a malware sample or search with the cs-fx-upload-file command.
       isArray: false
       name: sha256
       required: false
@@ -345,15 +344,13 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Command line script passed to the submitted file at runtime. Max
-        length: 2048 characters.'
+      description: 'Command line script passed to the submitted file at runtime. Max length: 2048 characters.'
       isArray: false
       name: command_line
       required: false
       secret: false
     - default: false
-      description: 'Auto-filled for Adobe or Office files that prompt for a password.
-        Max length: 32 characters.'
+      description: 'Auto-filled for Adobe or Office files that prompt for a password. Max length: 32 characters.'
       isArray: false
       name: document_password
       required: false
@@ -369,8 +366,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Name of the malware sample that’s used for file type detection.
-        and analysis.
+      description: Name of the malware sample that’s used for file type detection. and analysis.
       isArray: false
       name: submit_name
       required: false
@@ -387,8 +383,8 @@ script:
       isArray: false
       name: polling
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - auto: PREDEFINED
@@ -397,8 +393,8 @@ script:
       isArray: false
       name: extended_data
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - default: false
@@ -641,8 +637,7 @@ script:
       type: Unknown
   - arguments:
     - default: false
-      description: ID of a submitted malware sample. Find a submission ID from the
-        response when submitting a malware sample or search with the cs-fx-submit-uploaded-file command.
+      description: ID of a submitted malware sample. Find a submission ID from the response when submitting a malware sample or search with the cs-fx-submit-uploaded-file command.
       isArray: true
       name: ids
       required: true
@@ -653,8 +648,8 @@ script:
       isArray: false
       name: extended_data
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     deprecated: false
@@ -919,8 +914,7 @@ script:
       type: String
   - arguments:
     - default: false
-      description: ID of a submitted malware sample. Find a submission ID from the
-        response when submitting a malware sample or search with the cs-fx-submit-uploaded-file command.
+      description: ID of a submitted malware sample. Find a submission ID from the response when submitting a malware sample or search with the cs-fx-submit-uploaded-file command.
       isArray: true
       name: ids
       required: true
@@ -995,8 +989,7 @@ script:
       type: String
   - arguments:
     - default: false
-      description: ID of a submitted malware sample. Find a submission ID from the
-        response when submitting a malware sample or search with the cs-fx-submit-uploaded-file/url command.
+      description: ID of a submitted malware sample. Find a submission ID from the response when submitting a malware sample or search with the cs-fx-submit-uploaded-file/url command.
       isArray: true
       name: ids
       required: true
@@ -1144,8 +1137,7 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: Finds submission IDs for uploaded files by providing an FQL filter
-      and paging details. Returns a set of submission IDs that match the search criteria.
+    description: Finds submission IDs for uploaded files by providing an FQL filter and paging details. Returns a set of submission IDs that match the search criteria.
     execution: false
     name: cs-fx-find-submission-id
     outputs:
@@ -1191,15 +1183,13 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Command line script passed to the submitted file at runtime. Max
-        length: 2048 characters'
+      description: 'Command line script passed to the submitted file at runtime. Max length: 2048 characters'
       isArray: false
       name: command_line
       required: false
       secret: false
     - default: false
-      description: 'Auto-filled for Adobe or Office files that prompt for a password.
-        Max length: 32 characters.'
+      description: 'Auto-filled for Adobe or Office files that prompt for a password. Max length: 32 characters.'
       isArray: false
       name: document_password
       required: false
@@ -1216,8 +1206,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Name of the malware sample that’s used for file type detection
-        and analysis.
+      description: Name of the malware sample that’s used for file type detection and analysis.
       isArray: false
       name: submit_name
       required: false
@@ -1234,8 +1223,8 @@ script:
       isArray: false
       name: polling
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - default: false
@@ -1251,8 +1240,8 @@ script:
       isArray: false
       name: extended_data
       predefined:
-        - 'true'
-        - 'false'
+      - 'true'
+      - 'false'
       required: false
       secret: false
     - default: false
@@ -1488,8 +1477,7 @@ script:
       type: Unknown
   - arguments:
     - default: false
-      description: ID of an artifact, such as an IOC pack, PCAP file, or actor image.
-        Find an artifact ID in a report or summary.
+      description: ID of an artifact, such as an IOC pack, PCAP file, or actor image. Find an artifact ID in a report or summary.
       isArray: false
       name: id
       required: true
@@ -1502,8 +1490,7 @@ script:
       secret: false
     - default: false
       defaultValue: gzip
-      description: Format used to compress the downloaded file. Currently, you must
-        provide the value of the GZIP file.
+      description: Format used to compress the downloaded file. Currently, you must provide the value of the GZIP file.
       isArray: false
       name: accept_encoding
       required: false
@@ -1512,7 +1499,7 @@ script:
     description: Downloads IOC packs, PCAP files, and other analysis artifacts.
     execution: false
     name: cs-fx-download-ioc
-  dockerimage: demisto/python3:3.10.1.25933
+  dockerimage: demisto/python3:3.10.1.26972
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/CrowdStrikeFalconX/ReleaseNotes/1_1_8.md
+++ b/Packs/CrowdStrikeFalconX/ReleaseNotes/1_1_8.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### CrowdStrike Falcon X
-- fix an issue with ***cs-fx-upload-file*** command, *file_name* was not passed to the api call.
+- Fixed an issue where the *file_name* argument was not used in the ***cs-fx-upload-file*** command.
 - Updated the Docker image to: *demisto/python3:3.10.1.26972*

--- a/Packs/CrowdStrikeFalconX/ReleaseNotes/1_1_8.md
+++ b/Packs/CrowdStrikeFalconX/ReleaseNotes/1_1_8.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### CrowdStrike Falcon X
+- fix an issue with ***cs-fx-upload-file*** command, *file_name* was not passed to the api call.
+- Updated the Docker image to: *demisto/python3:3.10.1.26972*

--- a/Packs/CrowdStrikeFalconX/pack_metadata.json
+++ b/Packs/CrowdStrikeFalconX/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Fully automated malware analysis",
     "support": "xsoar",
     "serverMinVersion": "5.0.0",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47217

## Description
fixed the file_name argument in cs-fx-upload-file command if file name is added it will reflect in the human readable and context.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
