### PR TITLE
Fix bug in TenableSC context

### DIFF
--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
@@ -1168,7 +1168,7 @@ def get_vulnerability_command():
 
     context = {}
 
-    context['TenableSC.ScanResults.Vulnerability(val.ID=={})'.format(vuln_id)] = createContext(scan_result['Vulnerability'], removeNull=True)
+    context['TenableSC.ScanResults.Vulnerability(val.ID===obj.ID)'] = createContext(scan_result['Vulnerability'], removeNull=True)
 
     if len(cves_output) > 0:
         context['CVE(val.ID===obj.ID)'] = createContext(cves_output)

--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
@@ -1168,7 +1168,8 @@ def get_vulnerability_command():
 
     context = {}
 
-    context['TenableSC.ScanResults(val.ID===obj.ID)'] = createContext(scan_result, removeNull=True)
+    context['TenableSC.ScanResults.Vulnerability(val.ID=={})'.format(vuln_id)] = createContext(scan_result['Vulnerability'], removeNull=True)
+
     if len(cves_output) > 0:
         context['CVE(val.ID===obj.ID)'] = createContext(cves_output)
 

--- a/Packs/Tenable_sc/ReleaseNotes/1_0_5.md
+++ b/Packs/Tenable_sc/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Tenable.sc
+- Fix bug in tenable-sc-get-vulnerability which caused context to be overwritten

--- a/Packs/Tenable_sc/pack_metadata.json
+++ b/Packs/Tenable_sc/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tenable.sc",
     "description": "With Tenable.sc (formerly SecurityCenter) you get a real-time, continuous assessment of your security posture so you can find and fix vulnerabilities faster.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Today if you run tenable-sc-get-scan-report or another command followed by tenable-sc-get-vulnerability to get the details for each vulnerability the complete scan context is overwritten.  This fix allows the additional vuln data to be appended to the entries returned from the original scan report.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
