### PR TITLE
set no output timeout for validate in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ references:
     run:
       name: Validate Files and Yaml
       when: always
+      no_output_timeout: 1h
       command: |
         if [[ "$(echo "$GCS_MARKET_BUCKET" | tr '[:upper:]' '[:lower:]')" != "marketplace-dist" ]]; then
           echo "Skipping the -Validate Files and Yaml- step when uploading to a test bucket."


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://app.circleci.com/pipelines/github/demisto/content/149599/workflows/3fc30491-9443-4d45-939a-3ae47f8742f4/jobs/491089

## Description
increase the time threshold with "no output" in the CircleCI job.

