### PR TITLE
Changed misleading arg descriptions

### DIFF
--- a/Packs/AWS-EC2/Integrations/AWS-EC2/README.md
+++ b/Packs/AWS-EC2/Integrations/AWS-EC2/README.md
@@ -2060,8 +2060,8 @@ Removes egress rule from a security group. To remove a rule, the values that you
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | groupId | The ID of the security group. | Required | 
-| fromPort | The start of port range for the TCP and UDP protocols. In case ipProtocol is specified, this argument will be ignored. | Optional | 
-| toPort | The end of port range for the TCP and UDP protocols. In case ipProtocol is specified, this argument will be ignored. | Optional | 
+| fromPort | The start of port range for the TCP and UDP protocols. | Optional | 
+| toPort | The end of port range for the TCP and UDP protocols. | Optional | 
 | cidrIp | The CIDR IPv4 address range. | Optional | 
 | ipProtocol | The IP protocol name (tcp , udp , icmp) or number. Use -1 to specify all protocols. | Optional | 
 | sourceSecurityGroupName | The name of the source security group. The source security group must be in the same VPC. | Optional | 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Changed misleading arg descriptions for `aws-ec2-revoke-security-group-ingress-rule` args `fromPort` and `toPort`. From testing, we found that even if `ipProtocol` is specified, `fromPort` and `toPort` must also be specified if they are set for the rule being revoked.

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [X] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
