### PR TITLE
Fixed misleading arg description

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeamsManagement/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeamsManagement/README.md
@@ -614,7 +614,7 @@ Add a user to be a team member.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | team_id | ID of the team to add the user to. Can be retrieved by running the microsoft-teams-teams-list command. | Required | 
-| user_id | ID of the user to add to the team. Can be retrieved by running the microsoft-teams-members-list command. | Required | 
+| user_id | Email address or ID of the user to add to the team. ID can be retrieved by running the microsoft-teams-members-list command. | Required | 
 | is_owner | Whether to add the member with the owner role. Possible values are: "false" and "true". Default is "false". Possible values are: false, true. Default is false. | Optional | 
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Fixed misleading arg description for `microsoft-teams-member-add` arg `user_id`. We were initially thrown off because the arg description says the value needs to be an ID that can only be retrieved by running a different command where the user is already a member of a team. However, we tested passing the user's email address as the `user_id` and this worked. Perhaps this option was added later on, and just the arg description was not updated. Not sure if the same thing applies to other commands in this integration.

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
