### PR TITLE
Bcl score fix

### DIFF
--- a/Packs/Phishing/Playbooks/Process_Microsoft's_Anti-Spam_Headers.yml
+++ b/Packs/Phishing/Playbooks/Process_Microsoft's_Anti-Spam_Headers.yml
@@ -1189,7 +1189,7 @@ tasks:
               period_matches_newline: {}
               regex:
                 value:
-                  simple: '[5-9]'
+                  simple: '[4-9]'
           - operator: uniq
     separatecontext: false
     view: |-

--- a/Packs/Phishing/ReleaseNotes/3_1_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_1_6.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Process Microsoft's Anti-Spam Headers
+- The task `Set BCL score` was addressed to extract the correct BCL scores (4-9) on the second transformer.

--- a/Packs/Phishing/ReleaseNotes/3_1_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_1_6.md
@@ -1,4 +1,4 @@
 
 #### Playbooks
 ##### Process Microsoft's Anti-Spam Headers
-- The task `Set BCL score` was addressed to extract the correct BCL scores (4-9) on the second transformer.
+- The **Set BCL score** task was updated to extract the correct BCL scores (4-9) on the second transformer.

--- a/Packs/Phishing/ReleaseNotes/3_1_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_1_6.md
@@ -1,4 +1,4 @@
 
 #### Playbooks
 ##### Process Microsoft's Anti-Spam Headers
-- The **Set BCL score** task was updated to extract the correct BCL scores (4-9) on the second transformer.
+- The **Set BCL score** task was updated to extract the correct BCL scores (4-9) from the `X-Microsoft-Antispam` email header.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.1.5",
+    "currentVersion": "3.1.6",
     "serverMinVersion": "6.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/47365)

## Description
- The task `Set BCL score` was addressed to extract the correct BCL scores (4-9) on the second transformer.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

