### PR TITLE
Add optional args to qualys-schedule-scan-update command

### DIFF
--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -1,9 +1,8 @@
-from typing import Dict, Tuple, Callable
+from typing import Callable, Dict, Tuple
 
+import demistomock as demisto  # noqa: F401
 import requests
-
-from CommonServerPython import *  # noqa # pylint: disable=unused-wildcard-import
-from CommonServerUserPython import *  # noqa
+from CommonServerPython import *  # noqa: F401
 
 requests.packages.urllib3.disable_warnings()  # pylint: disable=no-member
 ''' CONSTANTS '''
@@ -972,7 +971,7 @@ COMMANDS_ARGS_DATA: Dict[str, Any] = {
         'args': ['id', 'scan_title', 'asset_group_ids', 'asset_groups', 'ip', 'frequency_days', 'weekdays',
                  'frequency_weeks', 'frequency_months', 'day_of_month', 'day_of_week', 'week_of_month', 'start_date',
                  'start_hour', 'start_minute', 'time_zone_code', 'exclude_ip_per_scan', 'default_scanner',
-                 'scanners_in_ag', 'active', 'observe_dst', ],
+                 'scanners_in_ag', 'active', 'observe_dst', 'target_from', 'iscanner_name', ],
         'default_added_depended_args': {'frequency_days': {'occurrence': 'daily', },
                                         'frequency_weeks': {'occurrence': 'weekly', },
                                         'frequency_months': {'occurrence': 'monthly', },

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -1,52 +1,48 @@
-commonfields:
-  id: QualysV2_schedule-scan-update-fix
-  version: -1
-vcShouldKeepItemLegacyProdMachine: false
-name: QualysV2_schedule-scan-update-fix
-display: QualysV2_schedule-scan-update-fix
 category: Utilities
-description: Qualys Vulnerability Management lets you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance.
+commonfields:
+  id: QualysV2
+  version: -1
 configuration:
-- display: Server URL
+- defaultvalue: https://qualysguard.qg2.apps.qualys.com
+  display: Server URL
   name: url
-  defaultvalue: https://qualysguard.qg2.apps.qualys.com
-  type: 0
   required: true
+  type: 0
 - display: Username
   name: credentials
-  type: 9
   required: true
+  type: 9
 - display: Trust any certificate (not secure)
   name: insecure
-  type: 8
   required: false
+  type: 8
 - display: Use system proxy settings
   name: proxy
-  type: 8
   required: false
+  type: 8
+description: Qualys Vulnerability Management lets you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance.
+display: Qualys v2
+name: QualysV2
 script:
-  script: ''
-  type: python
   commands:
-  - name: qualys-ip-list
-    arguments:
-    - name: ips
-      description: Show only certain IP addresses/ranges.
-    - name: network_id
-      description: Restrict the request to a certain custom network ID.
-    - name: tracking_method
-      auto: PREDEFINED
+  - arguments:
+    - description: Show only certain IP addresses/ranges.
+      name: ips
+    - description: Restrict the request to a certain custom network ID.
+      name: network_id
+    - auto: PREDEFINED
+      description: Show only IP addresses/ranges which have a certain tracking method.
+      name: tracking_method
       predefined:
       - IP
       - DNS
       - NETBIOS
-      description: Show only IP addresses/ranges which have a certain tracking method.
-    - name: compliance_enabled
-      auto: PREDEFINED
+    - auto: PREDEFINED
+      description: Specify 1 to list compliance IP addresses in the user’s account. These hosts are assigned to the policy compliance module. Specify 0 to get host that are not assigned to the policy compliance module.
+      name: compliance_enabled
       predefined:
       - "0"
       - "1"
-      description: Specify 1 to list compliance IP addresses in the user’s account. These hosts are assigned to the policy compliance module. Specify 0 to get host that are not assigned to the policy compliance module.
     - name: certview_enabled
       auto: PREDEFINED
       predefined:
@@ -55,28 +51,28 @@ script:
       description: (Optional) Specify 1 to list IP addresses in the user’s account assigned to the Certificate View module. Specify 0 to list IP addresses that are not assigned to the Certificate View module. Note - This option will be supported when Certificate View GA is released and is enabled for your account.
     - name: limit
       description: Specify a positive numeric value to limit the amount of results in the requested list.
+    description: View a list of IP addresses in the user account.
+    name: qualys-ip-list
     outputs:
     - contextPath: Qualys.IP.Address
       description: IP addresses.
     - contextPath: Qualys.IP.Range
       description: IP range.
-    description: View a list of IP addresses in the user account.
-  - name: qualys-report-list
-    arguments:
-    - name: id
-      description: Specify a report ID of a report that is saved in the Report Share storage space.
-    - name: state
-      auto: PREDEFINED
+  - arguments:
+    - description: Specify a report ID of a report that is saved in the Report Share storage space.
+      name: id
+    - auto: PREDEFINED
+      description: Specify reports with a certain state.
+      name: state
       predefined:
       - Running
       - Finished
       - Canceled
       - Errors
-      description: Specify reports with a certain state.
-    - name: user_login
-      description: Specify a user login ID to get reports launched by the specified user login ID
-    - name: expires_before_datetime
-      description: Specify the date and time to get only reports that expire before it. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
+    - description: Specify a user login ID to get reports launched by the specified user login ID
+      name: user_login
+    - description: 'Specify the date and time to get only reports that expire before it. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
+      name: expires_before_datetime
     - name: client_id
       description: (Optional) Id assigned to the client (Consultant type subscriptions).
     - name: client_name
@@ -106,8 +102,8 @@ script:
     - contextPath: Qualys.Report.EXPIRATION_DATETIME
       description: Report expiration datetime.
     description: Get a list of generated reports in the system
-  - name: qualys-vm-scan-list
-    arguments:
+    name: qualys-report-list
+  - arguments:
     - name: scan_ref
       description: Show only a scan with a certain scan referenc ecode.
     - name: state
@@ -172,6 +168,8 @@ script:
       description: (Optional) Specify 1 to hide target information from the scan list. Specify 0 to display the target information.
     - name: limit
       description: Specify a positive numeric value to limit the amount of results in the requested list
+    description: Lists vulnerability scans in the user’s account
+    name: qualys-vm-scan-list
     outputs:
     - contextPath: Qualys.Scan.REF
       description: Scan REF.
@@ -201,7 +199,6 @@ script:
       description: Scan Deafualt Flag.
     - contextPath: Qualys.Scan.USER_LOGIN
       description: The user that created the scan.
-    description: Lists vulnerability scans in the user’s account
   - name: qualys-scap-scan-list
     arguments:
     - name: scan_ref
@@ -501,7 +498,7 @@ script:
     - name: vm_scan_since
       description: 'Show hosts that were last scanned for vulnerabilities since a certain date and time (optional). Hosts that were the target of a vulnerability scan since the date/time will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week. Permissions: An Auditor cannot specify this parameter.'
     - name: no_compliance_scan_since
-      description: (Optional) Show compliance hosts not scanned since a certain date and time (optional). This parameter is invalid for an Express Lite user. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
+      description: '(Optional) Show compliance hosts not scanned since a certain date and time (optional). This parameter is invalid for an Express Lite user. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: use_tags
       auto: PREDEFINED
       predefined:
@@ -537,7 +534,7 @@ script:
       - "1"
       description: (Optional) Specify 1 to display asset tags associated with each host in the XML output.
     - name: host_metadata
-      description: 'Specify the name of the cloud provider to show the assets managed by the cloud provider. Valid values: ec2, google, azure'
+      description: "Specify the name of the cloud provider to show the assets managed by the cloud provider. Valid values: ec2, google, azure"
     - name: host_metadata_fields
       description: (Optional when host_metadata is specified) Specify metadata fields to only return data for certain attributes.
     - name: show_cloud_tags
@@ -633,29 +630,29 @@ script:
     - name: ag_titles
       description: (Optional) Show excluded hosts belonging to asset groups with certain strings in the asset group title. One or more asset group titles may be specified. Multiple entries are comma separated (for example, My+First+Asset+Group,Another+Asset+Group).
     - name: use_tags
+      description: (Optional) Specify 0 (the default) if you want to select hosts based on IP addresses/ranges and/or asset groups. Specify 1 if you want to select hosts based on asset tags.
       auto: PREDEFINED
       predefined:
       - "0"
       - "1"
-      description: (Optional) Specify 0 (the default) if you want to select hosts based on IP addresses/ranges and/or asset groups. Specify 1 if you want to select hosts based on asset tags.
     - name: tag_include_selector
-      auto: PREDEFINED
-      predefined:
-      - any
-      - all
       description: (Optional when use_tags=1) Specify "any" (the default) to include excluded hosts that match at least one of the selected tags. Specify "all" to include excluded hosts that match all of the selected tags.
-    - name: tag_exclude_selector
       auto: PREDEFINED
       predefined:
       - any
       - all
+    - name: tag_exclude_selector
       description: (Optional when use_tags=1) Specify "any" (the default) to ignore excluded hosts that match at least one of the selected tags. Specify "all" to ignore excluded hosts that match all of the selected tags.
+      auto: PREDEFINED
+      predefined:
+      - any
+      - all
     - name: tag_set_by
+      description: (Optional when use_tags=1) Specify "id" (the default) to select a tag set by providing tag IDs. Specify "name" to select a tag set by providing tag names.
       auto: PREDEFINED
       predefined:
       - id
       - name
-      description: (Optional when use_tags=1) Specify "id" (the default) to select a tag set by providing tag IDs. Specify "name" to select a tag set by providing tag names.
     - name: tag_set_include
       description: (Optional when use_tags=1) Specify a tag set to include. Excluded hosts that match these tags will be included. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: tag_set_exclude
@@ -779,7 +776,7 @@ script:
     - name: last_modified_before
       description: Used to filter the XML output to show only vulnerabilities last modified before a certain date and time. When specified vulnerabilities last modified by a user or by the service will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_user_after
-      description: Used to filter the XML output to show only vulnerabilities last modified by a user after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
+      description: 'Used to filter the XML output to show only vulnerabilities last modified by a user after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: last_modified_by_user_before
       description: Used to filter the XML output to show only vulnerabilities last modified by a user before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_service_after
@@ -874,7 +871,7 @@ script:
   - name: qualys-group-list
     arguments:
     - name: ids
-      description: Show only asset groups with certain IDs. Multiple IDs are comma separated.
+      description: 'Show only asset groups with certain IDs. Multiple IDs are comma separated.'
     - name: id_min
       description: Show only asset groups with certain IDs. Multiple IDs are comma separated.
     - name: id_max
@@ -1166,7 +1163,7 @@ script:
       - "1"
       description: Specify “0” (the default) to select from all tags (tags with any tag rule). Specify “1” to scan all IP addresses defined in tags. When this is specified, only tags with the dynamic IP address rule called “IP address in Network Range(s)” can be selected.
     - name: iscanner_id
-      description: 'The IDs of the scanner appliances to be used. Multiple entries are comma separated. For an Express Lite user, Internal Scanning must be enabled in the user''s account. One of these parameters must also be specified in a request: iscanner_name, iscanner_id, default_scanner, scanners_in_ag, scanners_in_tagset. When none of these are specified, External scanners are used. These parameters are mutually exclusive and cannot be specified in the same request: iscanner_id and iscanner_name.'
+      description: "The IDs of the scanner appliances to be used. Multiple entries are comma separated. For an Express Lite user, Internal Scanning must be enabled in the user's account. One of these parameters must also be specified in a request: iscanner_name, iscanner_id, default_scanner, scanners_in_ag, scanners_in_tagset. When none of these are specified, External scanners are used. These parameters are mutually exclusive and cannot be specified in the same request: iscanner_id and iscanner_name."
     - name: iscanner_name
       description: Specifies the name of the Scanner Appliance for the map, when the map target has private use internal IPs. Using Express Lite, Internal Scanning must be enabled in your account.
     - name: default_scanner
@@ -1537,6 +1534,7 @@ script:
     description: Launches a map report.
     execution: true
   - name: qualys-report-launch-host-based-findings
+    description: Run host based findings report
     arguments:
     - name: template_id
       required: true
@@ -1577,7 +1575,6 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the scan based findings.
       type: String
-    description: Run host based findings report
     execution: true
   - name: qualys-report-launch-scan-based-findings
     arguments:
@@ -1616,6 +1613,7 @@ script:
       type: String
     description: launches a scan report including scan based findings
   - name: qualys-report-launch-patch
+    description: Run patch report
     arguments:
     - name: template_id
       required: true
@@ -1653,9 +1651,9 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch patch.
       type: String
-    description: Run patch report
     execution: true
   - name: qualys-report-launch-remediation
+    description: Run remediation report
     arguments:
     - name: template_id
       required: true
@@ -1699,9 +1697,9 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch remediation.
       type: String
-    description: Run remediation report
     execution: true
   - name: qualys-report-launch-compliance
+    description: Run compliance report
     arguments:
     - name: template_id
       required: true
@@ -1740,9 +1738,9 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch compliance.
       type: String
-    description: Run compliance report
     execution: true
   - name: qualys-report-launch-compliance-policy
+    description: Run compliance policy report
     arguments:
     - name: template_id
       required: true
@@ -1788,7 +1786,6 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch compliance policy.
       type: String
-    description: Run compliance policy report
     execution: true
   - name: qualys-ip-restricted-list
     arguments:
@@ -2445,7 +2442,11 @@ script:
       type: String
     description: Gets a list of the supported time zone codes.
     execution: true
-  dockerimage: demisto/python3:3.10.1.25933
+  dockerimage: demisto/python3:3.10.1.26972
   runonce: false
+  script: ''
   subtype: python3
-sourcemoduleid: QualysV2
+  type: python
+tests:
+- QualysVulnerabilityManagement-Test
+fromversion: 5.5.0

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -1,133 +1,88 @@
-category: Utilities
 commonfields:
-  id: QualysV2
+  id: QualysV2_schedule-scan-update-fix
   version: -1
+vcShouldKeepItemLegacyProdMachine: false
+name: QualysV2_schedule-scan-update-fix
+display: QualysV2_schedule-scan-update-fix
+category: Utilities
+description: Qualys Vulnerability Management lets you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance.
 configuration:
-- defaultvalue: https://qualysguard.qg2.apps.qualys.com
-  display: Server URL
+- display: Server URL
   name: url
-  required: true
+  defaultvalue: https://qualysguard.qg2.apps.qualys.com
   type: 0
-- display: Username
-  hidden: false
-  name: credentials
   required: true
+- display: Username
+  name: credentials
   type: 9
+  required: true
 - display: Trust any certificate (not secure)
   name: insecure
-  required: false
   type: 8
+  required: false
 - display: Use system proxy settings
   name: proxy
-  required: false
   type: 8
-description: Qualys Vulnerability Management lets you create, run, fetch and manage
-  reports, launch and manage vulnerability and compliance scans, and manage the host
-  assets you want to scan for vulnerabilities and compliance.
-display: Qualys v2
-name: QualysV2
+  required: false
 script:
+  script: ''
+  type: python
   commands:
-  - arguments:
-    - default: false
+  - name: qualys-ip-list
+    arguments:
+    - name: ips
       description: Show only certain IP addresses/ranges.
-      isArray: false
-      name: ips
-      required: false
-      secret: false
-    - default: false
+    - name: network_id
       description: Restrict the request to a certain custom network ID.
-      isArray: false
-      name: network_id
-      required: false
-      secret: false
-    - auto: PREDEFINED
-      description: Show only IP addresses/ranges which have a certain tracking method.
-      isArray: false
-      name: tracking_method
+    - name: tracking_method
+      auto: PREDEFINED
       predefined:
       - IP
       - DNS
       - NETBIOS
-      required: false
-      secret: false
-    - auto: PREDEFINED
-      default: false
-      description: Specify 1 to list compliance IP addresses in the user’s account.
-        These hosts are assigned to the policy compliance module. Specify 0 to get host
-        that are not assigned to the policy compliance module.
-      isArray: false
-      name: compliance_enabled
+      description: Show only IP addresses/ranges which have a certain tracking method.
+    - name: compliance_enabled
+      auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      required: false
-      secret: false
+      - "0"
+      - "1"
+      description: Specify 1 to list compliance IP addresses in the user’s account. These hosts are assigned to the policy compliance module. Specify 0 to get host that are not assigned to the policy compliance module.
     - name: certview_enabled
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: (Optional) Specify 1 to list IP addresses in the user’s account
-        assigned to the Certificate View module. Specify 0 to list IP addresses that are not
-        assigned to the Certificate View module. Note - This option will be supported
-        when Certificate View GA is released and is enabled for your account.
+      - "0"
+      - "1"
+      description: (Optional) Specify 1 to list IP addresses in the user’s account assigned to the Certificate View module. Specify 0 to list IP addresses that are not assigned to the Certificate View module. Note - This option will be supported when Certificate View GA is released and is enabled for your account.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list.
-    deprecated: false
-    description: View a list of IP addresses in the user account.
-    execution: false
-    name: qualys-ip-list
+      description: Specify a positive numeric value to limit the amount of results in the requested list.
     outputs:
     - contextPath: Qualys.IP.Address
       description: IP addresses.
     - contextPath: Qualys.IP.Range
       description: IP range.
-  - arguments:
-    - default: false
-      description: Specify a report ID of a report that is saved in the Report Share
-        storage space.
-      isArray: false
-      name: id
-      required: false
-      secret: false
-    - auto: PREDEFINED
-      default: false
-      description: Specify reports with a certain state.
-      isArray: false
-      name: state
+    description: View a list of IP addresses in the user account.
+  - name: qualys-report-list
+    arguments:
+    - name: id
+      description: Specify a report ID of a report that is saved in the Report Share storage space.
+    - name: state
+      auto: PREDEFINED
       predefined:
       - Running
       - Finished
       - Canceled
       - Errors
-      required: false
-      secret: false
-    - default: false
-      description: Specify a user login ID to get reports launched by the specified
-        user login ID
-      isArray: false
-      name: user_login
-      required: false
-      secret: false
-    - default: false
-      description: Specify the date and time to get only reports that expire before
-        it. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z”
-        or today, yesterday, 24hr ago, 3 days ago, last week.
-      isArray: false
-      name: expires_before_datetime
-      required: false
-      secret: false
+      description: Specify reports with a certain state.
+    - name: user_login
+      description: Specify a user login ID to get reports launched by the specified user login ID
+    - name: expires_before_datetime
+      description: Specify the date and time to get only reports that expire before it. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: client_id
       description: (Optional) Id assigned to the client (Consultant type subscriptions).
     - name: client_name
-      description: (Optional) Name of the client (Consultant type subscriptions).
-        Note, The client_id and client_name parameters are mutually exclusive and
-        cannot be specified together in the same request.
+      description: (Optional) Name of the client (Consultant type subscriptions). Note, The client_id and client_name parameters are mutually exclusive and cannot be specified together in the same request.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Report.ID
       description: Report ID.
@@ -150,11 +105,9 @@ script:
       description: Report status percent.
     - contextPath: Qualys.Report.EXPIRATION_DATETIME
       description: Report expiration datetime.
-    deprecated: false
-    execution: false
     description: Get a list of generated reports in the system
-    name: qualys-report-list
-  - arguments:
+  - name: qualys-vm-scan-list
+    arguments:
     - name: scan_ref
       description: Show only a scan with a certain scan referenc ecode.
     - name: state
@@ -162,10 +115,9 @@ script:
     - name: processed
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 0 to show only scans that are not processed. Specify 1
-        to show only scans that have been processed.
+      - "0"
+      - "1"
+      description: Specify 0 to show only scans that are not processed. Specify 1 to show only scans that have been processed.
     - name: type
       auto: PREDEFINED
       predefined:
@@ -178,66 +130,48 @@ script:
     - name: user_login
       description: Show only a certain user login.
     - name: launched_after_datetime
-      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: launched_before_datetime
-      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: show_ags
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show asset group information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show asset group information for each scan in the output.
     - name: show_op
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show option profile information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show option profile information for each scan in the output.
     - name: show_status
       auto: PREDEFINED
       predefined:
-      - '0'
+      - "0"
       description: Specify 0 to not show scan status for each scan in the output.
     - name: show_last
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show only the most recent scan (which meets all other
-        search filters in the request) in the output.
+      - "1"
+      description: Specify 1 to show only the most recent scan (which meets all other search filters in the request) in the output.
     - name: scan_id
       description: (Optional) Show only a scan with a certain compliance scan ID.
     - name: client_id
-      description: (Optional) Id assigned to the client (Consultant type subscription
-        only). Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Id assigned to the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: client_name
-      description: (Optional) Name of the client (Consultant type subscription only).
-        Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Name of the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: pci_only
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: (Optional) Specify 1 to show only external PCI scans in the XML
-        output. External PCI scans are vulnerability scans run with the option profile
-        "Payment Card Industry (PCI) Options". When pci_only=1 is specified, the XML
-        output will not include other types of scans run with other option profiles.
+      - "1"
+      description: (Optional) Specify 1 to show only external PCI scans in the XML output. External PCI scans are vulnerability scans run with the option profile "Payment Card Industry (PCI) Options". When pci_only=1 is specified, the XML output will not include other types of scans run with other option profiles.
     - name: ignore_target
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: (Optional) Specify 1 to hide target information from the scan list.
-        Specify 0 to display the target information.
+      - "1"
+      - "0"
+      description: (Optional) Specify 1 to hide target information from the scan list. Specify 0 to display the target information.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
-    deprecated: false
-    execution: false
-    description: Lists vulnerability scans in the user’s account
-    name: qualys-vm-scan-list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Scan.REF
       description: Scan REF.
@@ -267,6 +201,7 @@ script:
       description: Scan Deafualt Flag.
     - contextPath: Qualys.Scan.USER_LOGIN
       description: The user that created the scan.
+    description: Lists vulnerability scans in the user’s account
   - name: qualys-scap-scan-list
     arguments:
     - name: scan_ref
@@ -276,10 +211,9 @@ script:
     - name: processed
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 0 to show only scans that are not processed. Specify 1
-        to show only scans that have been processed.
+      - "0"
+      - "1"
+      description: Specify 0 to show only scans that are not processed. Specify 1 to show only scans that have been processed.
     - name: type
       auto: PREDEFINED
       predefined:
@@ -292,62 +226,48 @@ script:
     - name: user_login
       description: Show only a certain user login.
     - name: launched_after_datetime
-      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: launched_before_datetime
-      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: show_ags
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show asset group information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show asset group information for each scan in the output.
     - name: show_op
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show option profile information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show option profile information for each scan in the output.
     - name: show_status
       auto: PREDEFINED
       predefined:
-      - '0'
+      - "0"
       description: Specify 0 to not show scan status for each scan in the output.
     - name: show_last
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show only the most recent scan (which meets all other
-        search filters in the request) in the output.
+      - "1"
+      description: Specify 1 to show only the most recent scan (which meets all other search filters in the request) in the output.
     - name: scan_id
       description: (Optional) Show only a scan with a certain compliance scan ID.
     - name: client_id
-      description: (Optional) Id assigned to the client (Consultant type subscription
-        only). Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Id assigned to the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: client_name
-      description: (Optional) Name of the client (Consultant type subscription only).
-        Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Name of the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: pci_only
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: (Optional) Specify 1 to show only external PCI scans in the XML
-        output. External PCI scans are vulnerability scans run with the option profile
-        "Payment Card Industry (PCI) Options". When pci_only=1 is specified, the XML
-        output will not include other types of scans run with other option profiles.
+      - "1"
+      description: (Optional) Specify 1 to show only external PCI scans in the XML output. External PCI scans are vulnerability scans run with the option profile "Payment Card Industry (PCI) Options". When pci_only=1 is specified, the XML output will not include other types of scans run with other option profiles.
     - name: ignore_target
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: (Optional) Specify 1 to hide target information from the scan list.
-        Specify 0 to display the target information.
+      - "1"
+      - "0"
+      description: (Optional) Specify 1 to hide target information from the scan list. Specify 0 to display the target information.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.SCAP.Scan.ID
       description: Scan ID.
@@ -393,10 +313,9 @@ script:
     - name: processed
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 0 to show only scans that are not processed. Specify 1
-        to show only scans that have been processed.
+      - "0"
+      - "1"
+      description: Specify 0 to show only scans that are not processed. Specify 1 to show only scans that have been processed.
     - name: type
       description: Show only a certain scan type.
     - name: target
@@ -404,61 +323,47 @@ script:
     - name: user_login
       description: Show only a certain user login.
     - name: launched_after_datetime
-      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: launched_before_datetime
-      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.'
+      description: Show only scans launched before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.'
     - name: show_ags
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show asset group information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show asset group information for each scan in the output.
     - name: show_op
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show option profile information for each scan in the
-        output.
+      - "1"
+      description: Specify 1 to show option profile information for each scan in the output.
     - name: show_status
       auto: PREDEFINED
       predefined:
-      - '0'
+      - "0"
       description: Specify 0 to not show scan status for each scan in the output.
     - name: show_last
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: Specify 1 to show only the most recent scan (which meets all other
-        search filters in the request) in the output.
+      - "1"
+      description: Specify 1 to show only the most recent scan (which meets all other search filters in the request) in the output.
     - name: pci_only
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: Specify 1 to show only external PCI scans in the XML output. External
-        PCI scans are vulnerability scans run with the option profile "Payment Card
-        Industry (PCI) Options". When pci_only=1 is specified, the XML output will
-        not include other types of scans run with other option profiles.
+      - "1"
+      - "0"
+      description: Specify 1 to show only external PCI scans in the XML output. External PCI scans are vulnerability scans run with the option profile "Payment Card Industry (PCI) Options". When pci_only=1 is specified, the XML output will not include other types of scans run with other option profiles.
     - name: ignore_target
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: Specify 1 to hide target information from the scan list. Specify
-        0 to display the target information.
+      - "1"
+      - "0"
+      description: Specify 1 to hide target information from the scan list. Specify 0 to display the target information.
     - name: client_id
       description: (Optional) Id assigned to the client (Consultant type subscriptions).
     - name: client_name
-      description: (Optional) Name of the client (Consultant type subscriptions).
-        Note, The client_id and client_name parameters are mutually exclusive and
-        cannot be specified together in the same request.
+      description: (Optional) Name of the client (Consultant type subscriptions). Note, The client_id and client_name parameters are mutually exclusive and cannot be specified together in the same request.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Scan.REF
       description: Scan REF.
@@ -496,13 +401,11 @@ script:
     - name: active
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 for active schedules only, or 0 for deactivated schedules
-        only.
+      - "0"
+      - "1"
+      description: Specify 1 for active schedules only, or 0 for deactivated schedules only.
     - name: show_notifications
-      description: (Optional) Specify 1 to include the notification settings for each
-        schedule in the XML output.
+      description: (Optional) Specify 1 to include the notification settings for each schedule in the XML output.
     - name: scan_type
       auto: PREDEFINED
       predefined:
@@ -510,23 +413,15 @@ script:
       - perimeter
       description: (Optional) Launch a scan with a certain type
     - name: fqdn
-      description: (Optional) The target FQDN for a vulnerability scan. You must specify
-        at least one target i.e. IPs, asset groups or FQDNs. Multiple values are comma
-        separated.
+      description: (Optional) The target FQDN for a vulnerability scan. You must specify at least one target i.e. IPs, asset groups or FQDNs. Multiple values are comma separated.
     - name: show_cloud_details
-      description: (Optional) Set to 1 to display the cloud details (Provider, Connector,
-        Scan Type and Cloud Target) in the XML output. Otherwise the details are not
-        displayed in the output. The cloud details will show scan type "Cloud Perimeter"
-        for cloud perimeter scans.
+      description: (Optional) Set to 1 to display the cloud details (Provider, Connector, Scan Type and Cloud Target) in the XML output. Otherwise the details are not displayed in the output. The cloud details will show scan type "Cloud Perimeter" for cloud perimeter scans.
     - name: client_id
-      description: (Optional) Id assigned to the client (Consultant type subscription
-        only). Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Id assigned to the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: client_name
-      description: (Optional) Name of the client (Consultant type subscription only).
-        Parameter client_id or client_name may be specified for the same request.
+      description: (Optional) Name of the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Scan.ID
       description: Scan ID.
@@ -590,118 +485,71 @@ script:
   - name: qualys-host-list
     arguments:
     - name: os_pattern
-      description: Show only hosts which have an operating system matching a certain
-        regular expression. An empty value cannot be specified. Use “%5E%24” to match
-        empty string.
+      description: Show only hosts which have an operating system matching a certain regular expression. An empty value cannot be specified. Use “%5E%24” to match empty string.
     - name: truncation_limit
-      description: Specify the maximum number of host records processed per request.
-        When not specified, the truncation limit is set to 1000 host records. You
-        may specify a value less than the default (1-999) or greater than the default
-        (1001-1000000).
+      description: Specify the maximum number of host records processed per request. When not specified, the truncation limit is set to 1000 host records. You may specify a value less than the default (1-999) or greater than the default (1001-1000000).
     - name: ips
-      description: Show only certain IP addresses/ranges. One or more IPs/ranges may
-        be specified. Multiple entries are comma separated. An IP range is specified
-        with a hyphen (for example, 10.10.10.1-10.10.10.100).
+      description: Show only certain IP addresses/ranges. One or more IPs/ranges may be specified. Multiple entries are comma separated. An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
     - name: ag_titles
-      description: Show only hosts belonging to asset groups with certain strings
-        in the asset group title. One or more asset group titles may be specified.
-        Multiple entries are comma separated (for example, My+First+Asset+Group,Another+Asset+Group).
+      description: Show only hosts belonging to asset groups with certain strings in the asset group title. One or more asset group titles may be specified. Multiple entries are comma separated (for example, My+First+Asset+Group,Another+Asset+Group).
     - name: ids
-      description: Show only certain host IDs/ranges. One or more host IDs/ranges
-        may be specified. Multiple entries are comma separated. A host ID range is
-        specified with a hyphen (for example, 190-400).Valid host IDs are required.
+      description: Show only certain host IDs/ranges. One or more host IDs/ranges may be specified. Multiple entries are comma separated. A host ID range is specified with a hyphen (for example, 190-400).Valid host IDs are required.
     - name: network_ids
-      description: (Optional, and valid only when the Network Support feature is enabled
-        for the user’s account) Restrict the request to certain custom network IDs.
-        Multiple network IDs are comma separated.
+      description: (Optional, and valid only when the Network Support feature is enabled for the user’s account) Restrict the request to certain custom network IDs. Multiple network IDs are comma separated.
     - name: no_vm_scan_since
-      description: 'Show hosts not scanned since a certain date and time (optional).
-        use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or
-        today, yesterday, 24hr ago, 3 days ago, last week. Permissions: An Auditor
-        cannot specify this parameter.'
+      description: 'Show hosts not scanned since a certain date and time (optional). use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week. Permissions: An Auditor cannot specify this parameter.'
     - name: vm_scan_since
-      description: 'Show hosts that were last scanned for vulnerabilities since a
-        certain date and time (optional). Hosts that were the target of a vulnerability
-        scan since the date/time will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01”
-        or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last
-        week. Permissions: An Auditor cannot specify this parameter.'
+      description: 'Show hosts that were last scanned for vulnerabilities since a certain date and time (optional). Hosts that were the target of a vulnerability scan since the date/time will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week. Permissions: An Auditor cannot specify this parameter.'
     - name: no_compliance_scan_since
-      description: (Optional) Show compliance hosts not scanned since a certain date
-        and time (optional). This parameter is invalid for an Express Lite user. use
-        YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today,
-        yesterday, 24hr ago, 3 days ago, last week.
+      description: (Optional) Show compliance hosts not scanned since a certain date and time (optional). This parameter is invalid for an Express Lite user. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: use_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 0 (the default) if you want to select hosts based on IP
-        addresses/ranges and/or asset groups. Specify 1 if you want to select hosts
-        based on asset tags.
+      - "0"
+      - "1"
+      description: Specify 0 (the default) if you want to select hosts based on IP addresses/ranges and/or asset groups. Specify 1 if you want to select hosts based on asset tags.
     - name: tag_set_by
       auto: PREDEFINED
       predefined:
       - id
       - name
-      description: (Optional when use_tags=1) Specify “id” (the default) to select
-        a tag set by providing tag IDs. Specify “name” to select a tag set by providing
-        tag names.
+      description: (Optional when use_tags=1) Specify “id” (the default) to select a tag set by providing tag IDs. Specify “name” to select a tag set by providing tag names.
     - name: tag_include_selector
       auto: PREDEFINED
       predefined:
       - any
       - all
-      description: (Optional when use_tags=1) Select “any” (the default) to include
-        hosts that match at least one of the selected tags. Select “all” to include
-        hosts that match all of the selected tags.
+      description: (Optional when use_tags=1) Select “any” (the default) to include hosts that match at least one of the selected tags. Select “all” to include hosts that match all of the selected tags.
     - name: tag_exclude_selector
       auto: PREDEFINED
       predefined:
       - any
       - all
-      description: (Optional when use_tags=1) Select “any” (the default) to exclude
-        hosts that match at least one of the selected tags. Select “all” to exclude
-        hosts that match all of the selected tags.
+      description: (Optional when use_tags=1) Select “any” (the default) to exclude hosts that match at least one of the selected tags. Select “all” to exclude hosts that match all of the selected tags.
     - name: tag_set_include
-      description: (Optional when use_tags=1) Specify a tag set to include. Hosts
-        that match these tags will be included. You identify the tag set by providing
-        tag name or IDs. Multiple entries are comma separated.
+      description: (Optional when use_tags=1) Specify a tag set to include. Hosts that match these tags will be included. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: tag_set_exclude
-      description: (Optional when use_tags=1) Specify a tag set to exclude. Hosts
-        that match these tags will be excluded. You identify the tag set by providing
-        tag name or IDs. Multiple entries are comma separated.
+      description: (Optional when use_tags=1) Specify a tag set to exclude. Hosts that match these tags will be excluded. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: show_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: (Optional) Specify 1 to display asset tags associated with each
-        host in the XML output.
+      - "0"
+      - "1"
+      description: (Optional) Specify 1 to display asset tags associated with each host in the XML output.
     - name: host_metadata
-      description: 'Specify the name of the cloud provider to show the assets managed
-        by the cloud provider. Valid values: ec2, google, azure'
+      description: 'Specify the name of the cloud provider to show the assets managed by the cloud provider. Valid values: ec2, google, azure'
     - name: host_metadata_fields
-      description: (Optional when host_metadata is specified) Specify metadata fields
-        to only return data for certain attributes.
+      description: (Optional when host_metadata is specified) Specify metadata fields to only return data for certain attributes.
     - name: show_cloud_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: (Optional) Specify 1 to display cloud provider tags for each scanned
-        host asset in the output. The default value of the parameter is set to 0.
-        When set to 0, we will not show the cloud provider tags for the scanned assets.
+      - "0"
+      - "1"
+      description: (Optional) Specify 1 to display cloud provider tags for each scanned host asset in the output. The default value of the parameter is set to 0. When set to 0, we will not show the cloud provider tags for the scanned assets.
     - name: cloud_tag_fields
-      description: (Optional when show_cloud_tags is specified) Specify cloud tags
-        or cloud tag and name combinations to only return information for specified
-        cloud tags. A cloud tag name and value combination is specified with a colon
-        (for example:SomeTag6:AY_ec2). For each cloud tag, we show the cloud tag’s
-        name, its value, and last success date (the tag last success date/time, fetched
-        from instance). If this parameter is not specified and "show_cloud_tags" is
-        set to 1, we will show all the cloud provider tags for the assets.
+      description: (Optional when show_cloud_tags is specified) Specify cloud tags or cloud tag and name combinations to only return information for specified cloud tags. A cloud tag name and value combination is specified with a colon (for example:SomeTag6:AY_ec2). For each cloud tag, we show the cloud tag’s name, its value, and last success date (the tag last success date/time, fetched from instance). If this parameter is not specified and "show_cloud_tags" is set to 1, we will show all the cloud provider tags for the assets.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Endpoint.ID
       description: Endpoint ID.
@@ -737,8 +585,7 @@ script:
     - name: port
       description: Show only virtual hosts that have a certain port.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.VirtualEndpoint.IP
       description: IP.
@@ -766,13 +613,9 @@ script:
       required: true
       description: A port number for the virtual host configuration.
     - name: network_id
-      description: Network support must be enabled to specify the network_id. If network
-        support is enabled and you do not provide a network_id, then the Default Global
-        Network is considered. You can specify only one network_id.
+      description: Network support must be enabled to specify the network_id. If network support is enabled and you do not provide a network_id, then the Default Global Network is considered. You can specify only one network_id.
     - name: fqdn
-      description: (Required for all actions except “delete”. Invalid for “delete”.)
-        One or more fully-qualified domain names (FQDNs) for the virtual host configuration.
-        Multiple entries are comma separated.
+      description: (Required for all actions except “delete”. Invalid for “delete”.) One or more fully-qualified domain names (FQDNs) for the virtual host configuration. Multiple entries are comma separated.
     outputs:
     - contextPath: Qualys.VirtualEndpoint.DATETIME
       description: Date and time of the executed manage action.
@@ -784,60 +627,41 @@ script:
     - name: ips
       description: Get list of excluded hosts or addresses range
     - name: network_id
-      description: (Optional, and valid only when the Network Support feature is enabled
-        for the user’s account) Restrict the request to a certain custom network ID.
+      description: (Optional, and valid only when the Network Support feature is enabled for the user’s account) Restrict the request to a certain custom network ID.
     - name: ag_ids
-      description: (Optional) Show excluded hosts belonging to asset groups with certain
-        IDs. One or more asset group IDs and/or ranges may be specified. Multiple
-        entries are comma separated. A range is specified with a dash (for example,
-        386941-386945). Valid asset group IDs are required.
+      description: (Optional) Show excluded hosts belonging to asset groups with certain IDs. One or more asset group IDs and/or ranges may be specified. Multiple entries are comma separated. A range is specified with a dash (for example, 386941-386945). Valid asset group IDs are required.
     - name: ag_titles
-      description: (Optional) Show excluded hosts belonging to asset groups with certain
-        strings in the asset group title. One or more asset group titles may be specified.
-        Multiple entries are comma separated (for example, My+First+Asset+Group,Another+Asset+Group).
+      description: (Optional) Show excluded hosts belonging to asset groups with certain strings in the asset group title. One or more asset group titles may be specified. Multiple entries are comma separated (for example, My+First+Asset+Group,Another+Asset+Group).
     - name: use_tags
-      description: (Optional) Specify 0 (the default) if you want to select hosts
-        based on IP addresses/ranges and/or asset groups. Specify 1 if you want to
-        select hosts based on asset tags.
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
+      - "0"
+      - "1"
+      description: (Optional) Specify 0 (the default) if you want to select hosts based on IP addresses/ranges and/or asset groups. Specify 1 if you want to select hosts based on asset tags.
     - name: tag_include_selector
-      description: (Optional when use_tags=1) Specify "any" (the default) to include
-        excluded hosts that match at least one of the selected tags. Specify "all"
-        to include excluded hosts that match all of the selected tags.
       auto: PREDEFINED
       predefined:
       - any
       - all
+      description: (Optional when use_tags=1) Specify "any" (the default) to include excluded hosts that match at least one of the selected tags. Specify "all" to include excluded hosts that match all of the selected tags.
     - name: tag_exclude_selector
-      description: (Optional when use_tags=1) Specify "any" (the default) to ignore
-        excluded hosts that match at least one of the selected tags. Specify "all"
-        to ignore excluded hosts that match all of the selected tags.
       auto: PREDEFINED
       predefined:
       - any
       - all
+      description: (Optional when use_tags=1) Specify "any" (the default) to ignore excluded hosts that match at least one of the selected tags. Specify "all" to ignore excluded hosts that match all of the selected tags.
     - name: tag_set_by
-      description: (Optional when use_tags=1) Specify "id" (the default) to select
-        a tag set by providing tag IDs. Specify "name" to select a tag set by providing
-        tag names.
       auto: PREDEFINED
       predefined:
       - id
       - name
+      description: (Optional when use_tags=1) Specify "id" (the default) to select a tag set by providing tag IDs. Specify "name" to select a tag set by providing tag names.
     - name: tag_set_include
-      description: (Optional when use_tags=1) Specify a tag set to include. Excluded
-        hosts that match these tags will be included. You identify the tag set by
-        providing tag name or IDs. Multiple entries are comma separated.
+      description: (Optional when use_tags=1) Specify a tag set to include. Excluded hosts that match these tags will be included. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: tag_set_exclude
-      description: (Optional when use_tags=1) Specify a tag set to exclude. Excluded
-        hosts that match these tags will be ignored. You identify the tag set by providing
-        tag name or IDs. Multiple entries are comma separated.
+      description: (Optional when use_tags=1) Specify a tag set to exclude. Excluded hosts that match these tags will be ignored. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Excluded.Host.Address
       description: IP Address.
@@ -851,8 +675,7 @@ script:
       description: Expiration date of excluded hosts ranges.
     - contextPath: Qualys.Excluded.Host.Range
       description: Range of IP addresses.
-    description: Show the excluded host list for the user's account. Hosts in your
-      excluded host list will not be scanned.
+    description: Show the excluded host list for the user's account. Hosts in your excluded host list will not be scanned.
   - name: qualys-scheduled-report-list
     arguments:
     - name: id
@@ -860,13 +683,11 @@ script:
     - name: is_active
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: Select is_active=1 for active or is_active=0 for inactive scheduled
-        reports to view
+      - "1"
+      - "0"
+      description: Select is_active=1 for active or is_active=0 for inactive scheduled reports to view
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Report.ID
       description: Report ID.
@@ -909,8 +730,7 @@ script:
   - name: qualys-report-template-list
     arguments:
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.ReportTemplate.ID
       description: Report template ID.
@@ -941,72 +761,35 @@ script:
       - Basic
       - All
       - None
-      description: 'Show the requested amount of information for each vulnerability
-        in the XML output. A valid value is: Basic (default), All, or None. Basic
-        includes basic elements plus CVSS Base and Temporal scores. All includes all
-        vulnerability details, including the Basic details.'
+      description: 'Show the requested amount of information for each vulnerability in the XML output. A valid value is: Basic (default), All, or None. Basic includes basic elements plus CVSS Base and Temporal scores. All includes all vulnerability details, including the Basic details.'
     - name: ids
-      description: Used to filter the XML output to include only vulnerabilities that
-        have QID numbers matching the QID numbers you specify.
+      description: Used to filter the XML output to include only vulnerabilities that have QID numbers matching the QID numbers you specify.
     - name: id_min
-      description: Used to filter the XML output to show only vulnerabilities that
-        have a QID number greater than or equal to a QID number you specify.
+      description: Used to filter the XML output to show only vulnerabilities that have a QID number greater than or equal to a QID number you specify.
     - name: id_max
-      description: Used to filter the XML output to show only vulnerabilities that
-        have a QID number less than or equal to a QID number you specify.
+      description: Used to filter the XML output to show only vulnerabilities that have a QID number less than or equal to a QID number you specify.
     - name: is_patchable
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Used to filter the XML output to show only vulnerabilities that
-        are patchable or not patchable. A vulnerability is considered patchable when
-        a patch exists for it. When 1 is specified, only vulnerabilities that are
-        patchable will be included in the output. When 0 is specified, only vulnerabilities
-        that are not patchable will be included in the output. When unspecified, patchable
-        and unpatchable vulnerabilities will be included in the output.
+      - "0"
+      - "1"
+      description: Used to filter the XML output to show only vulnerabilities that are patchable or not patchable. A vulnerability is considered patchable when a patch exists for it. When 1 is specified, only vulnerabilities that are patchable will be included in the output. When 0 is specified, only vulnerabilities that are not patchable will be included in the output. When unspecified, patchable and unpatchable vulnerabilities will be included in the output.
     - name: last_modified_after
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified after a certain date and time. When specified vulnerabilities last
-        modified by a user or by the service will be shown. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified after a certain date and time. When specified vulnerabilities last modified by a user or by the service will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_before
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified before a certain date and time. When specified vulnerabilities last
-        modified by a user or by the service will be shown. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified before a certain date and time. When specified vulnerabilities last modified by a user or by the service will be shown. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_user_after
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified by a user after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified by a user after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_user_before
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified by a user before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified by a user before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_service_after
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified by the service after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified by the service after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: last_modified_by_service_before
-      description: Used to filter the XML output to show only vulnerabilities last
-        modified by the service before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ]
-        like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago,
-        3 days ago, last week.
+      description: Used to filter the XML output to show only vulnerabilities last modified by the service before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: published_after
-      description: Used to filter the XML output to show only vulnerabilities published
-        after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01”
-        or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last
-        week.
+      description: Used to filter the XML output to show only vulnerabilities published after a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: published_before
-      description: Used to filter the XML output to show only vulnerabilities published
-        before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01”
-        or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last
-        week.
+      description: Used to filter the XML output to show only vulnerabilities published before a certain date and time. use YYYY-MM-DD[THH:MM:SSZ] like “2007-07-01” or “2007-01-25T23:12:00Z” or today, yesterday, 24hr ago, 3 days ago, last week.
     - name: discovery_method
       auto: PREDEFINED
       predefined:
@@ -1015,48 +798,35 @@ script:
       - RemoteOnly
       - AuthenticatedOnly
       - RemoteAndAuthenticated
-      description: ' (Optional) Used to filter the XML output to show only vulnerabilities
-        assigned a certain discovery method. A valid value is: Remote, Authenticated,
-        RemoteOnly, AuthenticatedOnly, or RemoteAndAuthenticated.'
+      description: ' (Optional) Used to filter the XML output to show only vulnerabilities assigned a certain discovery method. A valid value is: Remote, Authenticated, RemoteOnly, AuthenticatedOnly, or RemoteAndAuthenticated.'
     - name: discovery_auth_types
-      description: 'Used to filter the XML output to show only vulnerabilities having
-        one or more authentication types. A valid value is: Windows, Oracle, Unix
-        or SNMP. Multiple values are entered as a comma-separated list.'
+      description: 'Used to filter the XML output to show only vulnerabilities having one or more authentication types. A valid value is: Windows, Oracle, Unix or SNMP. Multiple values are entered as a comma-separated list.'
     - name: show_pci_reasons
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Used to filter the XML output to show reasons for passing or failing
-        PCI compliance (when the CVSS Scoring feature is turned on in the user’s subscription).
-        Specify 1 to view the reasons in the XML output. When unspecified, the reasons
-        are not included in the XML output.
+      - "0"
+      - "1"
+      description: Used to filter the XML output to show reasons for passing or failing PCI compliance (when the CVSS Scoring feature is turned on in the user’s subscription). Specify 1 to view the reasons in the XML output. When unspecified, the reasons are not included in the XML output.
     - name: show_supported_modules_info
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Used to filter the XML output to show Qualys modules that can be
-        used to detect each vulnerability. Specify 1 to view supported modules in
-        the XML output. When unspecified, supported modules are not included in the
-        XML output.
+      - "0"
+      - "1"
+      description: Used to filter the XML output to show Qualys modules that can be used to detect each vulnerability. Specify 1 to view supported modules in the XML output. When unspecified, supported modules are not included in the XML output.
     - name: show_disabled_flag
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to include the disabled flag for each vulnerability in
-        the XML output.
+      - "0"
+      - "1"
+      description: Specify 1 to include the disabled flag for each vulnerability in the XML output.
     - name: show_qid_change_log
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to include QID changes for each vulnerability in the
-        XML output.
+      - "0"
+      - "1"
+      description: Specify 1 to include QID changes for each vulnerability in the XML output.
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Vulnerability.List.QID
       description: Vulnerability QID.
@@ -1104,40 +874,25 @@ script:
   - name: qualys-group-list
     arguments:
     - name: ids
-      description: Show only asset groups with certain IDs. Multiple IDs are comma
-        separated.
+      description: Show only asset groups with certain IDs. Multiple IDs are comma separated.
     - name: id_min
-      description: Show only asset groups with certain IDs. Multiple IDs are comma
-        separated.
+      description: Show only asset groups with certain IDs. Multiple IDs are comma separated.
     - name: id_max
-      description: Show only asset groups that have an ID less than or equal to the
-        specified ID.
+      description: Show only asset groups that have an ID less than or equal to the specified ID.
     - name: truncation_limit
-      description: Specify the maximum number of asset group records to output. By
-        default this is set to 1000 records. If you specify truncation_limit=0, the
-        output is not paginated and all records are returned in a single output
+      description: Specify the maximum number of asset group records to output. By default this is set to 1000 records. If you specify truncation_limit=0, the output is not paginated and all records are returned in a single output
     - name: network_ids
-      description: Optional and valid only when the Networks feature is enabled in
-        your account) Restrict the request to certain network IDs. Multiple IDs are
-        comma separated.
+      description: Optional and valid only when the Networks feature is enabled in your account) Restrict the request to certain network IDs. Multiple IDs are comma separated.
     - name: unit_id
-      description: Show only asset groups that have a business unit ID equal to the
-        specified ID.
+      description: Show only asset groups that have a business unit ID equal to the specified ID.
     - name: user_id
-      description: Show only asset groups that have a user ID equal to the specified
-        ID.
+      description: Show only asset groups that have a user ID equal to the specified ID.
     - name: title
-      description: ' Show only the asset group that has a title equal to the specified
-        string - this must be an exact match.'
+      description: ' Show only the asset group that has a title equal to the specified string - this must be an exact match.'
     - name: show_attributes
-      description: 'Show attributes for each asset group along with the ID. Your options
-        are: None, All or a comma-separated list of attribute names: ID, TITLE, OWNER_USER_NAME,
-        OWNER_USER_ID, OWNER_UNIT_ID, NETWORK_IDS, LAST_UPDATE, IP_SET, APPLIANCE_LIST,
-        DOMAIN_LIST, DNS_LIST, NETBIOS_LIST, EC2_ID_LIST, HOST_IDS, ASSIGNED_USER_IDS,
-        ASSIGNED_UNIT_IDS, BUSINESS_IMPACT, CVSS, COMMENTS.'
+      description: 'Show attributes for each asset group along with the ID. Your options are: None, All or a comma-separated list of attribute names: ID, TITLE, OWNER_USER_NAME, OWNER_USER_ID, OWNER_UNIT_ID, NETWORK_IDS, LAST_UPDATE, IP_SET, APPLIANCE_LIST, DOMAIN_LIST, DNS_LIST, NETBIOS_LIST, EC2_ID_LIST, HOST_IDS, ASSIGNED_USER_IDS, ASSIGNED_UNIT_IDS, BUSINESS_IMPACT, CVSS, COMMENTS.'
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.AssetGroup.ID
       description: Asset Group ID.
@@ -1174,8 +929,7 @@ script:
       - csv
       - docx
       - online
-      description: Type of the file of the report. Can be checked by calling the qualys-report-list
-        command
+      description: Type of the file of the report. Can be checked by calling the qualys-report-list command
     outputs:
     - contextPath: InfoFile.Name
       description: The file name.
@@ -1184,8 +938,7 @@ script:
     - contextPath: InfoFile.Size
       description: The size of the file (in bytes).
     - contextPath: InfoFile.Type
-      description: The file type, as determined by libmagic (same as displayed in
-        file entries).
+      description: The file type, as determined by libmagic (same as displayed in file entries).
     - contextPath: InfoFile.Extension
       description: The file extension.
     - contextPath: InfoFile.Info
@@ -1195,30 +948,19 @@ script:
     arguments:
     - name: scan_ref
       required: true
-      description: 'The scan reference for a vulnerability scan. This will have the
-        format: scan/nnnnnnnnnn.nnnnn'
+      description: 'The scan reference for a vulnerability scan. This will have the format: scan/nnnnnnnnnn.nnnnn'
     - name: ips
-      description: 'Show only certain IP addresses/ranges in the scan results. One
-        or more IPs/ranges may be specified. A range entry is specified using a hyphen
-        (for example, 10.10.10.1-10.10.10.20). Multiple entries are comma separated.    '
+      description: 'Show only certain IP addresses/ranges in the scan results. One or more IPs/ranges may be specified. A range entry is specified using a hyphen (for example, 10.10.10.1-10.10.10.20). Multiple entries are comma separated.    '
     - name: mode
       auto: PREDEFINED
       predefined:
       - brief
       - extended
-      description: 'The verbosity of the scan results details. One verbosity mode
-        may be specified: brief (the default) or extended. The brief output includes
-        this information: IP address, DNS hostname, NetBIOS hostname, QID and scan
-        test results if applicable. The extended output includes the brief output
-        plus this extended information: protocol, port, an SSL flag (“yes” is returned
-        when SSL was used for the detection, “no” is returned when SSL was not used),
-        and FQDN if applicable.'
+      description: 'The verbosity of the scan results details. One verbosity mode may be specified: brief (the default) or extended. The brief output includes this information: IP address, DNS hostname, NetBIOS hostname, QID and scan test results if applicable. The extended output includes the brief output plus this extended information: protocol, port, an SSL flag (“yes” is returned when SSL was used for the detection, “no” is returned when SSL was not used), and FQDN if applicable.'
     - name: client_id
-      description: Id assigned to the client (Consultant type subscription only).
-        Parameter client_id or client_name may be specified for the same request.
+      description: Id assigned to the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: client_name
-      description: Name of the client (Consultant type subscription only). Parameter
-        client_id or client_name may be specified for the same request.
+      description: Name of the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     outputs:
     - contextPath: Qualys.VM.Dns
       description: Scanned device DNS.
@@ -1232,14 +974,12 @@ script:
       description: Qualys ID for vulnerabilities.
     - contextPath: Qualys.VM.Result
       description: Scan result.
-    description: Download scan results when scan has status Finished, Canceled, Paused
-      or Error
+    description: Download scan results when scan has status Finished, Canceled, Paused or Error
   - name: qualys-pc-scan-fetch
     arguments:
     - name: scan_ref
       required: true
-      description: 'The scan reference for a compliance scan. This will have the format:
-        compliance/nnnnnnnnnn.nnnnn'
+      description: 'The scan reference for a compliance scan. This will have the format: compliance/nnnnnnnnnn.nnnnn'
     outputs:
     - contextPath: Qualys.PC.USERNAME
       description: The user who executed the scan.
@@ -1326,39 +1066,32 @@ script:
     - name: hide_header
       auto: PREDEFINED
       predefined:
-      - '1'
-      - '0'
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report.
+      - "1"
+      - "0"
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report.
     - name: pdf_password
       description: The password to be used for encryption.
     - name: recipient_group
       description: The report recipients in the form of one or more distribution groups
     - name: recipient_group_id
-      description: Specify users who will receive the email notification when the
-        report is complete
+      description: Specify users who will receive the email notification when the report is complete
     - name: asset_groups
-      description: The titles of asset groups to be used as source asset groups for
-        the scorecard report.
+      description: The titles of asset groups to be used as source asset groups for the scorecard report.
     - name: all_asset_groups
       auto: PREDEFINED
       predefined:
-      - '1'
-      description: et to 1 to select all asset groups available in your account as
-        the source asset groups for the scorecard report.
+      - "1"
+      description: et to 1 to select all asset groups available in your account as the source asset groups for the scorecard report.
     - name: business_unit
       description: The title of a business unit containing the source asset groups.
     - name: division
-      description: A business info tag identifying a division that asset group(s)
-        belong to.
+      description: A business info tag identifying a division that asset group(s) belong to.
     - name: function
       description: A business info tag identifying a business function for asset group(s).
     - name: location
-      description: A business info tag identifying a location where asset group(s)
-        are located.
+      description: A business info tag identifying a location where asset group(s) are located.
     - name: patch_qids
-      description: Up to 10 QIDs for vulnerabilities or potential vulnerabilities
-        with available patches. Multiple QIDs are comma separated.
+      description: Up to 10 QIDs for vulnerabilities or potential vulnerabilities with available patches. Multiple QIDs are comma separated.
     - name: missing_qids
       description: One or two QIDs for missing software. Two QIDs are comma separated.
     outputs:
@@ -1382,200 +1115,125 @@ script:
       predefined:
       - assets
       - tags
-      description: Specify “assets” (the default) when your scan target will include
-        IP addresses/ranges and/or asset groups. Specify “tags” when your scan target
-        will include asset tags.
+      description: Specify “assets” (the default) when your scan target will include IP addresses/ranges and/or asset groups. Specify “tags” when your scan target will include asset tags.
+      defaultValue: assets
     - name: ip
-      description: 'The IP addresses to be scanned. You may enter individual IP addresses
-        and/or ranges. Multiple entries are comma separated. One of these parameters
-        is required: ip, asset_groups or asset_group_ids.'
+      description: 'The IP addresses to be scanned. You may enter individual IP addresses and/or ranges. Multiple entries are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: asset_groups
-      description: 'The titles of asset groups containing the hosts to be scanned.
-        Multiple titles are comma separated. One of these parameters is required:
-        ip, asset_groups or asset_group_ids.'
+      description: 'The titles of asset groups containing the hosts to be scanned. Multiple titles are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: asset_group_ids
-      description: 'The IDs of asset groups containing the hosts to be scanned. Multiple
-        IDs are comma separated. One of these parameters is required: ip, asset_groups
-        or asset_group_ids.'
+      description: 'The IDs of asset groups containing the hosts to be scanned. Multiple IDs are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: exclude_ip_per_scan
-      description: The IP addresses to be excluded from the scan when the scan target
-        is specified as IP addresses (not asset tags). You may enter individual IP
-        addresses and/or ranges. Multiple entries are comma separated.
+      description: The IP addresses to be excluded from the scan when the scan target is specified as IP addresses (not asset tags). You may enter individual IP addresses and/or ranges. Multiple entries are comma separated.
     - name: tag_include_selector
       auto: PREDEFINED
       predefined:
       - all
       - any
-      description: ' Select “any” (the default) to include hosts that match at least
-        one of the selected tags. Select “all” to include hosts that match all of
-        the selected tags.'
+      description: ' Select “any” (the default) to include hosts that match at least one of the selected tags. Select “all” to include hosts that match all of the selected tags.'
     - name: tag_exclude_selector
       auto: PREDEFINED
       predefined:
       - all
       - any
-      description: Select “any” (the default) to exclude hosts that match at least
-        one of the selected tags. Select “all” to exclude hosts that match all of
-        the selected tags.
+      description: Select “any” (the default) to exclude hosts that match at least one of the selected tags. Select “all” to exclude hosts that match all of the selected tags.
     - name: tag_set_by
       auto: PREDEFINED
       predefined:
       - id
       - name
-      description: Specify “id” (the default) to select a tag set by providing tag
-        IDs. Specify “name” to select a tag set by providing tag names.
+      description: Specify “id” (the default) to select a tag set by providing tag IDs. Specify “name” to select a tag set by providing tag names.
     - name: tag_set_include
-      description: Specify a tag set to include. Hosts that match these tags will
-        be included. You identify the tag set by providing tag name or IDs. Multiple
-        entries are comma separated.
+      description: Specify a tag set to include. Hosts that match these tags will be included. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: tag_set_exclude
-      description: Specify a tag set to exclude. Hosts that match these tags will
-        be excluded. You identify the tag set by providing tag name or IDs. Multiple
-        entries are comma separated.
+      description: Specify a tag set to exclude. Hosts that match these tags will be excluded. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: use_ip_nt_range_tags_include
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify “0” (the default) to select from all tags (tags with any
-        tag rule). Specify “1” to scan all IP addresses defined in tag selection.
-        When this is specified, only tags with the dynamic IP address rule called
-        “IP address in Network Range(s)” can be selected. valid only when target_from=tags
-        is specified.
+      - "0"
+      - "1"
+      description: Specify “0” (the default) to select from all tags (tags with any tag rule). Specify “1” to scan all IP addresses defined in tag selection. When this is specified, only tags with the dynamic IP address rule called “IP address in Network Range(s)” can be selected. valid only when target_from=tags is specified.
     - name: use_ip_nt_range_tags_exclude
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify “0” (the default) to select from all tags (tags with any
-        tag rule). Specify “1” to exclude all IP addresses defined in tag selection.
-        When this is specified, only tags with the dynamic IP address rule called
-        “IP address in Network Range(s)” can be selected.  valid only when target_from=tags
-        is specified.
+      - "0"
+      - "1"
+      description: Specify “0” (the default) to select from all tags (tags with any tag rule). Specify “1” to exclude all IP addresses defined in tag selection. When this is specified, only tags with the dynamic IP address rule called “IP address in Network Range(s)” can be selected.  valid only when target_from=tags is specified.
     - name: use_ip_nt_range_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify “0” (the default) to select from all tags (tags with any
-        tag rule). Specify “1” to scan all IP addresses defined in tags. When this
-        is specified, only tags with the dynamic IP address rule called “IP address
-        in Network Range(s)” can be selected.
+      - "0"
+      - "1"
+      description: Specify “0” (the default) to select from all tags (tags with any tag rule). Specify “1” to scan all IP addresses defined in tags. When this is specified, only tags with the dynamic IP address rule called “IP address in Network Range(s)” can be selected.
     - name: iscanner_id
-      description: "The IDs of the scanner appliances to be used. Multiple entries\
-        \ are comma separated. For an Express Lite user, Internal Scanning must be\
-        \ enabled in the user's account. One of these parameters must also be specified\
-        \ in a request: iscanner_name, iscanner_id, default_scanner, scanners_in_ag,\
-        \ scanners_in_tagset. When none of these are specified, External scanners\
-        \ are used. These parameters are mutually exclusive and cannot be specified\
-        \ in the same request: iscanner_id and iscanner_name."
+      description: 'The IDs of the scanner appliances to be used. Multiple entries are comma separated. For an Express Lite user, Internal Scanning must be enabled in the user''s account. One of these parameters must also be specified in a request: iscanner_name, iscanner_id, default_scanner, scanners_in_ag, scanners_in_tagset. When none of these are specified, External scanners are used. These parameters are mutually exclusive and cannot be specified in the same request: iscanner_id and iscanner_name.'
     - name: iscanner_name
-      description: Specifies the name of the Scanner Appliance for the map, when the
-        map target has private use internal IPs. Using Express Lite, Internal Scanning
-        must be enabled in your account.
+      description: Specifies the name of the Scanner Appliance for the map, when the map target has private use internal IPs. Using Express Lite, Internal Scanning must be enabled in your account.
     - name: default_scanner
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to use the default scanner in each target asset group.
-        For an Express Lite user, Internal Scanning must be enabled in the user’s
-        account.
+      - "0"
+      - "1"
+      description: Specify 1 to use the default scanner in each target asset group. For an Express Lite user, Internal Scanning must be enabled in the user’s account.
     - name: scanners_in_ag
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to distribute the scan to the target asset groups’ scanner
-        appliances. Appliances in each asset group are tasked with scanning the IPs
-        in the group. By default up to 5 appliances per group will be used and this
-        can be configured for your account (please contact your Account Manager or
-        Support). For an Express Lite user, Internal Scanning must be enabled in the
-        user’s account.
+      - "0"
+      - "1"
+      description: Specify 1 to distribute the scan to the target asset groups’ scanner appliances. Appliances in each asset group are tasked with scanning the IPs in the group. By default up to 5 appliances per group will be used and this can be configured for your account (please contact your Account Manager or Support). For an Express Lite user, Internal Scanning must be enabled in the user’s account.
     - name: scanners_in_tagset
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: 'Specify 1 to distribute the scan to scanner appliances that match
-        the asset tags specified for the scan target. One of these parameters must
-        be specified in a request for an internal scan: iscanner_name, iscanner_id,
-        default_scanner, scanners_in_ag, scanners_in_tagset. When none of these are
-        specified, external scanners are used. Only valid when the target_from=tags is
-        specified.'
+      - "0"
+      - "1"
+      description: 'Specify 1 to distribute the scan to scanner appliances that match the asset tags specified for the scan target. One of these parameters must be specified in a request for an internal scan: iscanner_name, iscanner_id, default_scanner, scanners_in_ag, scanners_in_tagset. When none of these are specified, external scanners are used. Only valid when the target_from=tags is specified.'
     - name: scanners_in_network
-      description: Specify 1 to distribute the scan to all scanner appliances in the
-        network.
+      description: Specify 1 to distribute the scan to all scanner appliances in the network.
     - name: option_title
-      description: 'The title of the compliance option profile to be used. One of
-        these parameters must be specified in a request: option_title or option_id.
-        These are mutually exclusive and cannot be specified in the same request.'
+      description: 'The title of the compliance option profile to be used. One of these parameters must be specified in a request: option_title or option_id. These are mutually exclusive and cannot be specified in the same request.'
     - name: option_id
-      description: 'The ID of the compliance option profile to be used. One of these
-        parameters must be specified in a request: option_title or option_id. These
-        are mutually exclusive and cannot be specified in the same request.'
+      description: 'The ID of the compliance option profile to be used. One of these parameters must be specified in a request: option_title or option_id. These are mutually exclusive and cannot be specified in the same request.'
     - name: priority
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-      - '5'
-      - '6'
-      - '7'
-      - '8'
-      - '9'
-      description: Specify a value of 0 - 9 to set a processing priority level for
-        the scan. When not specified, a value of 0 (no priority) is used. 0 = No Priority
-        (the default), 1 = Emergency, 2 = Ultimate, 3 = Critical, 4 = Major, 5 = High,
-        6 = Standard, 7 = Medium, 8 = Minor, 9 = Low
+      - "0"
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+      - "5"
+      - "6"
+      - "7"
+      - "8"
+      - "9"
+      description: Specify a value of 0 - 9 to set a processing priority level for the scan. When not specified, a value of 0 (no priority) is used. 0 = No Priority (the default), 1 = Emergency, 2 = Ultimate, 3 = Critical, 4 = Major, 5 = High, 6 = Standard, 7 = Medium, 8 = Minor, 9 = Low
     - name: connector_name
-      description: (Required for EC2 scan) The name of the EC2 connector for the AWS
-        integration you want to run the scan on.
+      description: (Required for EC2 scan) The name of the EC2 connector for the AWS integration you want to run the scan on.
     - name: ec2_endpoint
-      description: (Required for EC2 scan) The EC2 region code or the ID of the Virtual
-        Private Cloud (VPC) zone.
+      description: (Required for EC2 scan) The EC2 region code or the ID of the Virtual Private Cloud (VPC) zone.
     - name: ec2_instance_ids
-      description: The ID of the EC2 instance on which you want to launch the VM or
-        compliance scan. Multiple ec2 instance ids are comma separated. You can add
-        up to maximum 10 instance Ids.
+      description: The ID of the EC2 instance on which you want to launch the VM or compliance scan. Multiple ec2 instance ids are comma separated. You can add up to maximum 10 instance Ids.
     - name: ip_network_id
-      description: The ID of a network used to filter the IPs/ranges specified in
-        the“ip” parameter. Set to a custom network ID (note this does not filter IPs/ranges
-        specified in “asset_groups” or “asset_group_ids”). Or set to “0” (the default)
-        for the Global Default Network - this is used to scan hosts outside of your
-        custom networks.
+      description: The ID of a network used to filter the IPs/ranges specified in the“ip” parameter. Set to a custom network ID (note this does not filter IPs/ranges specified in “asset_groups” or “asset_group_ids”). Or set to “0” (the default) for the Global Default Network - this is used to scan hosts outside of your custom networks.
     - name: runtime_http_header
-      description: Set a custom value in order to drop defenses (such as logging,
-        IPs, etc) when an authorized scan is being run. The value you enter will be
-        used in the “Qualys-Scan:” header that will be set for many CGI and web application
-        fingerprinting checks. Some discovery and web server fingerprinting checks
-        will not use this header.
+      description: Set a custom value in order to drop defenses (such as logging, IPs, etc) when an authorized scan is being run. The value you enter will be used in the “Qualys-Scan:” header that will be set for many CGI and web application fingerprinting checks. Some discovery and web server fingerprinting checks will not use this header.
     - name: scan_type
       auto: PREDEFINED
       predefined:
       - certview
-      description: Launch a CertView type scan. This option will be supported when
-        CertView GA is released and enabled for your account.
+      description: Launch a CertView type scan. This option will be supported when CertView GA is released and enabled for your account.
     - name: fqdn
-      description: The target FQDN for a vulnerability scan. You must specify at least
-        one target i.e. IPs, asset groups or FQDNs. Multiple values are comma separated.
+      description: The target FQDN for a vulnerability scan. You must specify at least one target i.e. IPs, asset groups or FQDNs. Multiple values are comma separated.
     - name: client_id
-      description: Id assigned to the client (Consultant type subscription only).
-        Parameter client_id or client_name may be specified for the same request.
+      description: Id assigned to the client (Consultant type subscription only). Parameter client_id or client_name may be specified for the same request.
     - name: client_name
-      description: Name of the client (Consultant type subscriptions  only). Parameter
-        client_id or client_name may be specified for the same request.
+      description: Name of the client (Consultant type subscriptions  only). Parameter client_id or client_name may be specified for the same request.
     - name: include_agent_targets
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 when your scan target includes agent hosts. This lets
-        you scan private IPs where agents are installed when these IPs are not in
-        your VM/PC license.
+      - "0"
+      - "1"
+      description: Specify 1 when your scan target includes agent hosts. This lets you scan private IPs where agents are installed when these IPs are not in your VM/PC license.
     outputs:
     - contextPath: Qualys.Report.VM.Launched.KEY
       description: Key name of launched VM scan, either ID or a REFERENCE.
@@ -1595,10 +1253,8 @@ script:
       description: One action required for the request
     - name: scan_ref
       required: true
-      description: 'The scan reference for a vulnerability scan. This will have the
-        format: scan/nnnnnnnnnn.nnnnn'
-    description: allows users to take actions on vulnerability scans in their account,
-      like cancel, pause, resume, delete and fetch completed scan results
+      description: 'The scan reference for a vulnerability scan. This will have the format: scan/nnnnnnnnnn.nnnnn'
+    description: allows users to take actions on vulnerability scans in their account, like cancel, pause, resume, delete and fetch completed scan results
     execution: true
   - name: qualys-pc-scan-manage
     arguments:
@@ -1613,126 +1269,82 @@ script:
       description: One action required for the request
     - name: scan_ref
       required: true
-      description: ' The scan reference for a compliance scan. This will have the
-        format: compliance/nnnnnnnnnn.nnnnn'
+      description: ' The scan reference for a compliance scan. This will have the format: compliance/nnnnnnnnnn.nnnnn'
     outputs:
     - contextPath: Qualys.Scan.KEY
       description: Key name, either ID or REFERENCE.
     - contextPath: Qualys.Scan.VALUE
       description: Value of either ID or REFERENCE.
-    description: Allows users to take actions on compliance scans in their account,
-      like cancel, pause, resume, delete and fetch completed scan results.
+    description: Allows users to take actions on compliance scans in their account, like cancel, pause, resume, delete and fetch completed scan results.
   - name: qualys-pc-scan-launch
     arguments:
     - name: scan_title
       description: The scan title. This can be a maximum of 2000 characters (ascii).
     - name: option_id
-      description: ' The ID of the compliance option profile to be used. One of these
-        parameters must be specified in a request: option_title or option_id. These
-        are mutually exclusive and cannot be specified in the same request.'
+      description: ' The ID of the compliance option profile to be used. One of these parameters must be specified in a request: option_title or option_id. These are mutually exclusive and cannot be specified in the same request.'
     - name: option_title
-      description: 'The title of the compliance option profile to be used. One of
-        these parameters must be specified in a request: option_title or option_id.
-        These are mutually exclusive and cannot be specified in the same request.'
+      description: 'The title of the compliance option profile to be used. One of these parameters must be specified in a request: option_title or option_id. These are mutually exclusive and cannot be specified in the same request.'
     - name: ip
-      description: ' The IP addresses to be scanned. You may enter individual IP addresses
-        and/or ranges. Multiple entries are comma separated. One of these parameters
-        is required: ip, asset_groups or asset_group_ids.'
+      description: ' The IP addresses to be scanned. You may enter individual IP addresses and/or ranges. Multiple entries are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: asset_group_ids
-      description: 'The IDs of asset groups containing the hosts to be scanned. Multiple
-        IDs are comma separated. One of these parameters is required: ip, asset_groups
-        or asset_group_ids.'
+      description: 'The IDs of asset groups containing the hosts to be scanned. Multiple IDs are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: asset_groups
-      description: 'The titles of asset groups containing the hosts to be scanned.
-        Multiple titles are comma separated. One of these parameters is required:
-        ip, asset_groups or asset_group_ids.'
+      description: 'The titles of asset groups containing the hosts to be scanned. Multiple titles are comma separated. One of these parameters is required: ip, asset_groups or asset_group_ids.'
     - name: exclude_ip_per_scan
-      description: The IP addresses to be excluded from the scan when the scan target
-        is specified as IP addresses (not asset tags). You may enter individual IP
-        addresses and/or ranges. Multiple entries are comma separated.
+      description: The IP addresses to be excluded from the scan when the scan target is specified as IP addresses (not asset tags). You may enter individual IP addresses and/or ranges. Multiple entries are comma separated.
     - name: default_scanner
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to use the default scanner in each target asset group.
-        For an Express Lite user, Internal Scanning must be enabled in the user’s
-        account.
+      - "0"
+      - "1"
+      description: Specify 1 to use the default scanner in each target asset group. For an Express Lite user, Internal Scanning must be enabled in the user’s account.
     - name: scanners_in_ag
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 1 to distribute the scan to the target asset groups’ scanner
-        appliances. Appliances in each asset group are tasked with scanning the IPs
-        in the group. By default up to 5 appliances per group will be used and this
-        can be configured for your account (please contact your Account Manager or
-        Support). For an Express Lite user, Internal Scanning must be enabled in the
-        user’s account.
+      - "0"
+      - "1"
+      description: Specify 1 to distribute the scan to the target asset groups’ scanner appliances. Appliances in each asset group are tasked with scanning the IPs in the group. By default up to 5 appliances per group will be used and this can be configured for your account (please contact your Account Manager or Support). For an Express Lite user, Internal Scanning must be enabled in the user’s account.
     - name: target_from
       auto: PREDEFINED
       predefined:
       - assets
       - tags
-      description: Specify “assets” (the default) when your scan target will include
-        IP addresses/ranges and/or asset groups. Specify “tags” when your scan target
-        will include asset tags.
+      description: Specify “assets” (the default) when your scan target will include IP addresses/ranges and/or asset groups. Specify “tags” when your scan target will include asset tags.
+      defaultValue: assets
     - name: tag_include_selector
       auto: PREDEFINED
       predefined:
       - all
       - any
-      description: ' Select “any” (the default) to include hosts that match at least
-        one of the selected tags. Select “all” to include hosts that match all of
-        the selected tags.'
+      description: ' Select “any” (the default) to include hosts that match at least one of the selected tags. Select “all” to include hosts that match all of the selected tags.'
     - name: tag_exclude_selector
       auto: PREDEFINED
       predefined:
       - all
       - any
-      description: Select “any” (the default) to exclude hosts that match at least
-        one of the selected tags. Select “all” to exclude hosts that match all of
-        the selected tags.
+      description: Select “any” (the default) to exclude hosts that match at least one of the selected tags. Select “all” to exclude hosts that match all of the selected tags.
     - name: tag_set_by
       auto: PREDEFINED
       predefined:
       - id
       - name
-      description: Specify “id” (the default) to select a tag set by providing tag
-        IDs. Specify “name” to select a tag set by providing tag names.
+      description: Specify “id” (the default) to select a tag set by providing tag IDs. Specify “name” to select a tag set by providing tag names.
     - name: tag_set_include
-      description: Specify a tag set to include. Hosts that match these tags will
-        be included. You identify the tag set by providing tag name or IDs. Multiple
-        entries are comma separated.
+      description: Specify a tag set to include. Hosts that match these tags will be included. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: tag_set_exclude
-      description: Specify a tag set to exclude. Hosts that match these tags will
-        be excluded. You identify the tag set by providing tag name or IDs. Multiple
-        entries are comma separated.
+      description: Specify a tag set to exclude. Hosts that match these tags will be excluded. You identify the tag set by providing tag name or IDs. Multiple entries are comma separated.
     - name: use_ip_nt_range_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify “0” (the default) to select from all tags (tags with any
-        tag rule). Specify “1” to scan all IP addresses defined in tags. When this
-        is specified, only tags with the dynamic IP address rule called “IP address
-        in Network Range(s)” can be selected.
+      - "0"
+      - "1"
+      description: Specify “0” (the default) to select from all tags (tags with any tag rule). Specify “1” to scan all IP addresses defined in tags. When this is specified, only tags with the dynamic IP address rule called “IP address in Network Range(s)” can be selected.
     - name: ip_network_id
-      description: The ID of a network used to filter the IPs/ranges specified in
-        the“ip” parameter. Set to a custom network ID (note this does not filter IPs/ranges
-        specified in “asset_groups” or “asset_group_ids”). Or set to “0” (the default)
-        for the Global Default Network - this is used to scan hosts outside of your
-        custom networks.
+      description: The ID of a network used to filter the IPs/ranges specified in the“ip” parameter. Set to a custom network ID (note this does not filter IPs/ranges specified in “asset_groups” or “asset_group_ids”). Or set to “0” (the default) for the Global Default Network - this is used to scan hosts outside of your custom networks.
     - name: runtime_http_header
-      description: Set a custom value in order to drop defenses (such as logging,
-        IPs, etc) when an authorized scan is being run. The value you enter will be
-        used in the “Qualys-Scan:” header that will be set for many CGI and web application
-        fingerprinting checks. Some discovery and web server fingerprinting checks
-        will not use this header.
+      description: Set a custom value in order to drop defenses (such as logging, IPs, etc) when an authorized scan is being run. The value you enter will be used in the “Qualys-Scan:” header that will be set for many CGI and web application fingerprinting checks. Some discovery and web server fingerprinting checks will not use this header.
     - name: iscanner_name
-      description: Specifies the name of the Scanner Appliance for the map, when the
-        map target has private use internal IPs. Using Express Lite, Internal Scanning
-        must be enabled in your account.
+      description: Specifies the name of the Scanner Appliance for the map, when the map target has private use internal IPs. Using Express Lite, Internal Scanning must be enabled in your account.
     outputs:
     - contextPath: Qualys.Scan.KEY
       description: Scan key, either ID or Reference
@@ -1751,52 +1363,41 @@ script:
       - IP
       - DNS
       - NETBIOS
-      description: The tracking method is set to IP for IP address by default. To
-        use another tracking method specify DNS or NETBIOS.
+      description: The tracking method is set to IP for IP address by default. To use another tracking method specify DNS or NETBIOS.
     - name: enable_vm
       required: true
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: You must enable the hosts for the VM application (enable_vm=1)
-        or the PC application (enable_pc=1) or both VM and PC.
-      defaultValue: '0'
+      - "0"
+      - "1"
+      description: You must enable the hosts for the VM application (enable_vm=1) or the PC application (enable_pc=1) or both VM and PC.
+      defaultValue: "0"
     - name: enable_pc
       required: true
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: You must enable the hosts for the VM application (enable_vm=1)
-        or the PC application (enable_pc=1) or both VM and PC.
-      defaultValue: '0'
+      - "0"
+      - "1"
+      description: You must enable the hosts for the VM application (enable_vm=1) or the PC application (enable_pc=1) or both VM and PC.
+      defaultValue: "0"
     - name: owner
-      description: The owner of the host asset(s). The owner must be a Manager or
-        a Unit Manager.
+      description: The owner of the host asset(s). The owner must be a Manager or a Unit Manager.
     - name: ud1
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: ud2
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: ud3
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: comment
       description: User-defined comments.
     - name: ag_title
-      description: (Required if the request is being made by a Unit Manager; otherwise
-        invalid) The title of an asset group in the Unit Manager’s business unit that
-        the host(s) will be added to.
+      description: (Required if the request is being made by a Unit Manager; otherwise invalid) The title of an asset group in the Unit Manager’s business unit that the host(s) will be added to.
     - name: enable_certview
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Set to 1 to add IPs to your CertView license. By default IPs are
-        not added to your CertView license. This option will be supported when CertView
-        GA is released and is enabled for your account.
+      - "0"
+      - "1"
+      description: Set to 1 to add IPs to your CertView license. By default IPs are not added to your CertView license. This option will be supported when CertView GA is released and is enabled for your account.
     outputs:
     - contextPath: Qualys.IP.Add.TEXT
       description: Action result message.
@@ -1812,37 +1413,26 @@ script:
       required: true
       description: ' The hosts within the subscription that you want to update.'
     - name: network_id
-      description: (valid only when the Network Support feature is enabled for the
-        user's account) Restrict the request to a certain custom network by specifying
-        the network ID. When unspecified, we default to "0" for Global Default Network.
+      description: (valid only when the Network Support feature is enabled for the user's account) Restrict the request to a certain custom network by specifying the network ID. When unspecified, we default to "0" for Global Default Network.
     - name: host_dns
-      description: (Optional) The DNS hostname for the IP you want to update. A single
-        IP must be specified in the same request and the IP will only be updated if
-        it matches the hostname specified.
+      description: (Optional) The DNS hostname for the IP you want to update. A single IP must be specified in the same request and the IP will only be updated if it matches the hostname specified.
     - name: host_netbios
-      description: (Optional) The NetBIOS hostname for the IP you want to update.
-        A single IP must be specified in the same request and the IP will only be
-        updated if it matches the hostname specified.
+      description: (Optional) The NetBIOS hostname for the IP you want to update. A single IP must be specified in the same request and the IP will only be updated if it matches the hostname specified.
     - name: tracking_method
       auto: PREDEFINED
       predefined:
       - IP
       - DNS
       - NETBIOS
-      description: The tracking method is set to IP for IP address by default. To
-        use another tracking method specify DNS or NETBIOS.
+      description: The tracking method is set to IP for IP address by default. To use another tracking method specify DNS or NETBIOS.
     - name: owner
-      description: The owner of the host asset(s). The owner must be a Manager or
-        a Unit Manager.
+      description: The owner of the host asset(s). The owner must be a Manager or a Unit Manager.
     - name: ud1
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: ud2
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: ud3
-      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum
-        of 128 characters
+      description: Values for user-defined fields 1, 2 and 3. You can specify a maximum of 128 characters
     - name: comment
       description: User-defined comments.
     outputs:
@@ -1866,28 +1456,19 @@ script:
       required: true
       description: User-defined notes (up to 1024 characters).
     - name: ips
-      description: 'The IP addresses to be added to the excluded IPs list. Enter a
-        comma separated list of IPv4 singletons or ranges. For example: 10.10.10.13,10.10.10.25-10.10.10.29'
+      description: 'The IP addresses to be added to the excluded IPs list. Enter a comma separated list of IPv4 singletons or ranges. For example: 10.10.10.13,10.10.10.25-10.10.10.29'
     - name: expiry_days
-      description: (Optional when action=add) The number of days the IPs being added
-        to the excluded IPs list will be considered valid for exclusion. When the
-        expiration is reached, the IPs are removed from the list and made available
-        again for scanning. When unspecified, the IPs being added have no expiration
-        and will remain on the list until removed by a user.
+      description: (Optional when action=add) The number of days the IPs being added to the excluded IPs list will be considered valid for exclusion. When the expiration is reached, the IPs are removed from the list and made available again for scanning. When unspecified, the IPs being added have no expiration and will remain on the list until removed by a user.
     - name: dg_names
-      description: (Optional when action=add) Specify users who will be notified 7
-        days before hosts are removed from the excluded hosts list (i.e. supply distribution
-        group names as defined in the Qualys UI).
+      description: (Optional when action=add) Specify users who will be notified 7 days before hosts are removed from the excluded hosts list (i.e. supply distribution group names as defined in the Qualys UI).
     - name: network_id
-      description: Assign a network ID to the IPs being added to the excluded IPs
-        list. By default, the user’s default network ID is assigned.
+      description: Assign a network ID to the IPs being added to the excluded IPs list. By default, the user’s default network ID is assigned.
     outputs:
     - contextPath: Qualys.Endpoint.KEY
       description: Result of action requested.
     - contextPath: Qualys.Endpoint
       description: IPs action was made on.
-    description: Manage your excluded IPs list using the Excluded IP. The IPs in your
-      excluded IPs list will not be scanned.
+    description: Manage your excluded IPs list using the Excluded IP. The IPs in your excluded IPs list will not be scanned.
     execution: true
   - name: qualys-scheduled-report-launch
     arguments:
@@ -1910,14 +1491,10 @@ script:
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running the command qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running the command qualys-report-template-list.
     - name: report_refs
       required: true
-      description: Specifies the map references (1 or 2) to include. A map reference
-        starts with the string "map/" followed by a reference ID number. When two
-        map references are given, the report compares map results. Two map references
-        are comma separated.
+      description: Specifies the map references (1 or 2) to include. A map reference starts with the string "map/" followed by a reference ID number. When two map references are given, the report compares map results. Two map references are comma separated.
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -1930,43 +1507,23 @@ script:
       description: One output format may be specified
     - name: domain
       required: true
-      description: Specifies the target domain for the map report. Include the domain
-        name only; do not enter "www." at the start of the domain name. When the special
-        “none” domain is specified as a parameter value, the ip_restriction parameter
-        is required.
+      description: Specifies the target domain for the map report. Include the domain name only; do not enter "www." at the start of the domain name. When the special “none” domain is specified as a parameter value, the ip_restriction parameter is required.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      - "0"
+      - "1"
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: pdf_password
-      description: (Required for secure PDF distribution, Manager or Unit Manager
-        only) Used for secure PDF report distribution when this feature is enabled
-        in the user's account (under Reports > Setup > Report Share). The password
-        to be used for encryption. - the password must have a minimum of 8 characters
-        (ascii), and a maximum of 32 characters - the password must contain alpha
-        and numeric characters - the password cannot match the password for the user’s
-        Qualys account. - the password must follow the password security guidelines
-        defined for your subscription (under Users > Setup > Security)
+      description: (Required for secure PDF distribution, Manager or Unit Manager only) Used for secure PDF report distribution when this feature is enabled in the user's account (under Reports > Setup > Report Share). The password to be used for encryption. - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (under Users > Setup > Security)
     - name: recipient_group
-      description: Used for secure PDF distribution. The report recipients in the
-        form of one or more distribution group names, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered.
+      description: Used for secure PDF distribution. The report recipients in the form of one or more distribution group names, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered.
     - name: recipient_group_id
-      description: The report recipients in the form of one or more distribution group
-        IDs. Multiple distribution group IDs are comma separated. Where do I find
-        this ID? Log in to your Qualys account, go to Users > Distribution Groups
-        and select Info for a group in the list.
+      description: The report recipients in the form of one or more distribution group IDs. Multiple distribution group IDs are comma separated. Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: ip_restriction
-      description: For a map report, specifies certain IPs/ranges to include in the
-        report. Multiple IPs and/or ranges are comma separated.
+      description: For a map report, specifies certain IPs/ranges to include in the report. Multiple IPs and/or ranges are comma separated.
     outputs:
     - contextPath: Qualys.Report.ID
       description: Launched map report ID.
@@ -1980,12 +1537,10 @@ script:
     description: Launches a map report.
     execution: true
   - name: qualys-report-launch-host-based-findings
-    description: Run host based findings report
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running the command qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running the command qualys-report-template-list.
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -1995,50 +1550,23 @@ script:
       - mht
       - xml
       - csv
-      description: output format may be specified. When output_format=pdf is specified,
-        the Secure PDF Distribution may be used.
+      description: output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: Specify users who will receive the email notification when the
-        report is complete (i.e. supply a distribution group ID). Where do I find
-        this ID? Log in to your Qualys account, go to Users > Distribution Groups
-        and select Info for a group in the list.
+      description: Specify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: ips
-      description: Specify IPs/ranges to change (override) the report target, as defined
-        in the scan report template. Multiple IPs/ranges are comma separated. When
-        specified, hosts defined in the report template are not included in the report.
-        See also “Using Asset Tags.”
+      description: Specify IPs/ranges to change (override) the report target, as defined in the scan report template. Multiple IPs/ranges are comma separated. When specified, hosts defined in the report template are not included in the report. See also “Using Asset Tags.”
     - name: asset_group_ids
-      description: Specify asset group IDs to change (override) the report target,
-        as defined in the scan report template. When specified, hosts defined in the
-        report template are not included in the report. Looking for asset group IDs?
-        Use the asset_group_list.php function (see the API v1 User Guide).
+      description: Specify asset group IDs to change (override) the report target, as defined in the scan report template. When specified, hosts defined in the report template are not included in the report. Looking for asset group IDs? Use the asset_group_list.php function (see the API v1 User Guide).
     - name: ips_network_id
-      description: Optional, and valid only when the Network Support feature is enabled
-        for the user’s account) The ID of a network that is used to restrict the report’s
-        target to the IPs/ranges specified in the“ips” parameter. Set to a custom
-        network ID (note this does not filter IPs/ranges specified in “asset_group_ids”).
-        Or set to “0” (the default) for the Global Default Network - this is used
-        to report on hosts outside of your custom networks.
+      description: Optional, and valid only when the Network Support feature is enabled for the user’s account) The ID of a network that is used to restrict the report’s target to the IPs/ranges specified in the“ips” parameter. Set to a custom network ID (note this does not filter IPs/ranges specified in “asset_group_ids”). Or set to “0” (the default) for the Global Default Network - this is used to report on hosts outside of your custom networks.
     outputs:
     - contextPath: Qualys.Report.ID
       description: Report ID.
@@ -2049,13 +1577,13 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the scan based findings.
       type: String
+    description: Run host based findings report
     execution: true
   - name: qualys-report-launch-scan-based-findings
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running qualys-report-template-list.
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -2066,54 +1594,32 @@ script:
       - xml
       - csv
       - docx
-      description: One output format may be specified. When output_format=pdf is specified,
-        the Secure PDF Distribution may be used.
+      description: One output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used.
     - name: report_refs
       required: true
-      description: (Required) This parameter specifies the scan references to include.
-        A scan reference starts with the string "scan/" followed by a reference ID
-        number. Multiple scan references are comma separated. Reference can be found
-        by running the command qualys-vm-scan-list.
+      description: (Required) This parameter specifies the scan references to include. A scan reference starts with the string "scan/" followed by a reference ID number. Multiple scan references are comma separated. Reference can be found by running the command qualys-vm-scan-list.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: Specify users who will receive the email notification when the
-        report is complete (i.e. supply a distribution group ID). Where do I find
-        this ID? Log in to your Qualys account, go to Users > Distribution Groups
-        and select Info for a group in the list.
+      description: Specify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: ip_restriction
-      description: (Optional)  For a scan report, the report content will be restricted
-        to the specified IPs/ranges. Multiple IPs and/or ranges are comma separated.
+      description: (Optional)  For a scan report, the report content will be restricted to the specified IPs/ranges. Multiple IPs and/or ranges are comma separated.
     outputs:
     - contextPath: Qualys.Report.ID
       description: Report ID.
       type: String
     description: launches a scan report including scan based findings
   - name: qualys-report-launch-patch
-    description: Run patch report
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running the command qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running the command qualys-report-template-list.
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -2122,44 +1628,21 @@ script:
       - online
       - xml
       - csv
-      description: One output format may be specified. When output_format=pdf is specified,
-        the Secure PDF Distribution may be used.
+      description: One output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: pecify users who will receive the email notification when the report
-        is complete (i.e. supply a distribution group ID). Where do I find this ID?
-        Log in to your Qualys account, go to Users > Distribution Groups and select
-        Info for a group in the list.
+      description: pecify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: ips
-      description: Specify IPs/ranges to change (override) the report target, as defined
-        in the patch report template. Multiple IPs/ranges are comma separated. When
-        specified, hosts defined in the report template are not included in the report.
-        See also “Using Asset Tags.”
+      description: Specify IPs/ranges to change (override) the report target, as defined in the patch report template. Multiple IPs/ranges are comma separated. When specified, hosts defined in the report template are not included in the report. See also “Using Asset Tags.”
     - name: asset_group_ids
-      description: Specify IPs/ranges to change (override) the report target, as defined
-        in the patch report template. Multiple asset group IDs are comma separated.
-        When specified, hosts defined in the report template are not included in the
-        report. Looking for asset group IDs? Use the asset_group_list.php function
-        (see the API v1 User Guide).
+      description: Specify IPs/ranges to change (override) the report target, as defined in the patch report template. Multiple asset group IDs are comma separated. When specified, hosts defined in the report template are not included in the report. Looking for asset group IDs? Use the asset_group_list.php function (see the API v1 User Guide).
     outputs:
     - contextPath: Qualys.Report.ID
       description: Report ID.
@@ -2170,14 +1653,13 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch patch.
       type: String
+    description: Run patch report
     execution: true
   - name: qualys-report-launch-remediation
-    description: Run remediation report
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running qualys-report-template-list.
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -2186,48 +1668,27 @@ script:
       - html
       - mht
       - csv
-      description: One output format may be specified. When output_format=pdf is specified,
-        the Secure PDF Distribution may be used.
+      description: One output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: pecify users who will receive the email notification when the report
-        is complete (i.e. supply a distribution group ID). Where do I find this ID?
-        Log in to your Qualys account, go to Users > Distribution Groups and select
-        Info for a group in the list.
+      description: pecify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: ips
-      description: (Optional for remediation report) Specify IPs/ranges you want to
-        include in the report. Multiple IPs and/or ranges are comma separated.
+      description: (Optional for remediation report) Specify IPs/ranges you want to include in the report. Multiple IPs and/or ranges are comma separated.
     - name: asset_group_ids
-      description: Specify asset group IDs that identify hosts you want to include
-        in the report. Multiple asset group IDs are comma separated. Looking for asset
-        group IDs? Use the asset_group_list.php function (in the API v1 User Guide).
+      description: Specify asset group IDs that identify hosts you want to include in the report. Multiple asset group IDs are comma separated. Looking for asset group IDs? Use the asset_group_list.php function (in the API v1 User Guide).
     - name: assignee_type
       auto: PREDEFINED
       predefined:
       - User
       - All
-      description: ' Specifies whether the report will include tickets assigned to
-        the current user, or all tickets in the user account. By default tickets assigned
-        to the current user are included. Valid values are: User (default) or All.'
+      description: ' Specifies whether the report will include tickets assigned to the current user, or all tickets in the user account. By default tickets assigned to the current user are included. Valid values are: User (default) or All.'
     outputs:
     - contextPath: Qualys.Report.ID
       description: Remediation report ID.
@@ -2238,39 +1699,23 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch remediation.
       type: String
+    description: Run remediation report
     execution: true
   - name: qualys-report-launch-compliance
-    description: Run compliance report
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running the command qualys-report-template-list
+      description: The template ID of the report you want to launch. Can be found by running the command qualys-report-template-list
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: Specify users who will receive the email notification when the
-        report is complete (i.e. supply a distribution group ID). Where do I find
-        this ID? Log in to your Qualys account, go to Users > Distribution Groups
-        and select Info for a group in the list.
+      description: Specify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -2278,24 +1723,13 @@ script:
       - pdf
       - html
       - mht
-      description: 'One output format may be specified. When output_format=pdf is
-        specified, the Secure PDF Distribution may be used. '
+      description: 'One output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used. '
     - name: ips
-      description: (Optional for compliance report) For a compliance report (except
-        a PCI report), specify the IPs/ranges you want to include in the report. Multiple
-        IPs and/or ranges are comma separated.
+      description: (Optional for compliance report) For a compliance report (except a PCI report), specify the IPs/ranges you want to include in the report. Multiple IPs and/or ranges are comma separated.
     - name: asset_group_ids
-      description: (Optional for compliance report) For a compliance report (except
-        a PCI report), specify asset groups IDs which identify hosts to include in
-        the report. Multiple asset group IDs are comma separated. Looking for asset
-        group IDs? Use the asset_group_list.php function (in the API v1 User Guide).
+      description: (Optional for compliance report) For a compliance report (except a PCI report), specify asset groups IDs which identify hosts to include in the report. Multiple asset group IDs are comma separated. Looking for asset group IDs? Use the asset_group_list.php function (in the API v1 User Guide).
     - name: report_refs
-      description: For a PCI compliance report, either the technical or executive
-        report, this parameter specifies the scan reference to include. A scan reference
-        starts with the string “scan/” followed by a reference ID number. The scan
-        reference must be for a scan that was run using the PCI Options profile. Only
-        one scan reference may be specified. Reference can be found by running the
-        command qualys-pc-scan-list.
+      description: For a PCI compliance report, either the technical or executive report, this parameter specifies the scan reference to include. A scan reference starts with the string “scan/” followed by a reference ID number. The scan reference must be for a scan that was run using the PCI Options profile. Only one scan reference may be specified. Reference can be found by running the command qualys-pc-scan-list.
     outputs:
     - contextPath: Qualys.Report.ID
       description: Compliance report ID.
@@ -2306,39 +1740,23 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch compliance.
       type: String
+    description: Run compliance report
     execution: true
   - name: qualys-report-launch-compliance-policy
-    description: Run compliance policy report
     arguments:
     - name: template_id
       required: true
-      description: The template ID of the report you want to launch. Can be found
-        by running the command qualys-report-template-list.
+      description: The template ID of the report you want to launch. Can be found by running the command qualys-report-template-list.
     - name: report_title
-      description: A user-defined report title. The title may have a maximum of 128
-        characters. For a PCI compliance report, the report title is provided by Qualys
-        and cannot be changed.
+      description: A user-defined report title. The title may have a maximum of 128 characters. For a PCI compliance report, the report title is provided by Qualys and cannot be changed.
     - name: hide_header
-      description: (Valid for CSV format report only). Specify hide_header=1 to omit
-        the header information from the report. By default this information is included.
+      description: (Valid for CSV format report only). Specify hide_header=1 to omit the header information from the report. By default this information is included.
     - name: recipient_group_id
-      description: Specify users who will receive the email notification when the
-        report is complete (i.e. supply a distribution group ID). Where do I find
-        this ID? Log in to your Qualys account, go to Users > Distribution Groups
-        and select Info for a group in the list.
+      description: Specify users who will receive the email notification when the report is complete (i.e. supply a distribution group ID). Where do I find this ID? Log in to your Qualys account, go to Users > Distribution Groups and select Info for a group in the list.
     - name: pdf_password
-      description: '(Optional; Required for secure PDF distribution) The password
-        to be used for encryption. Requirements: - the password must have a minimum
-        of 8 characters (ascii), and a maximum of 32 characters - the password must
-        contain alpha and numeric characters - the password cannot match the password
-        for the user’s Qualys account. - the password must follow the password security
-        guidelines defined for your subscription (log in and go to Subscription Setup—>Security
-        Options).'
+      description: '(Optional; Required for secure PDF distribution) The password to be used for encryption. Requirements: - the password must have a minimum of 8 characters (ascii), and a maximum of 32 characters - the password must contain alpha and numeric characters - the password cannot match the password for the user’s Qualys account. - the password must follow the password security guidelines defined for your subscription (log in and go to Subscription Setup—>Security Options).'
     - name: recipient_group
-      description: Optional; Optional for secure PDF distribution) The report recipients
-        in the form of one or more distribution groups, as defined using the Qualys
-        UI. Multiple distribution groups are comma separated. A maximum of 50 distribution
-        groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
+      description: Optional; Optional for secure PDF distribution) The report recipients in the form of one or more distribution groups, as defined using the Qualys UI. Multiple distribution groups are comma separated. A maximum of 50 distribution groups may be entered. Chapter 4 — Report API Launch Report  recipient_group={value}
     - name: output_format
       required: true
       auto: PREDEFINED
@@ -2348,29 +1766,18 @@ script:
       - mht
       - xml
       - csv
-      description: 'One output format may be specified. When output_format=pdf is
-        specified, the Secure PDF Distribution may be used. '
+      description: 'One output format may be specified. When output_format=pdf is specified, the Secure PDF Distribution may be used. '
     - name: policy_id
       required: true
-      description: Specifies the policy to run the report on. A valid policy ID must
-        be entered.
+      description: Specifies the policy to run the report on. A valid policy ID must be entered.
     - name: asset_group_ids
-      description: Specify asset group IDS if you want to include only certain asset
-        groups in your report. These asset groups must be assigned to the policy you
-        are reporting on. Multiple asset group IDs are comma separated. Looking for
-        asset group IDs? Use the asset_group_list.php function (in the API v1 User
-        Guide).
+      description: Specify asset group IDS if you want to include only certain asset groups in your report. These asset groups must be assigned to the policy you are reporting on. Multiple asset group IDs are comma separated. Looking for asset group IDs? Use the asset_group_list.php function (in the API v1 User Guide).
     - name: ips
-      description: Specify IPs/ranges if you want to include only certain IP addresses
-        in your report. These IPs must be assigned to the policy you’re reporting
-        on. Multiple entries are comma separated.
+      description: Specify IPs/ranges if you want to include only certain IP addresses in your report. These IPs must be assigned to the policy you’re reporting on. Multiple entries are comma separated.
     - name: host_id
-      description: ' In the policy report output, show only results for a single host
-        instance. Specify the ID for the host to include in the report. A valid host
-        ID must be entered.'
+      description: ' In the policy report output, show only results for a single host instance. Specify the ID for the host to include in the report. A valid host ID must be entered.'
     - name: instance_string
-      description: Specifies a single instance on the selected host. The instance
-        string may be “os” or a string like “oracle10:1:1521:ora10204u”.
+      description: Specifies a single instance on the selected host. The instance string may be “os” or a string like “oracle10:1:1521:ora10204u”.
     outputs:
     - contextPath: Qualys.Report.ID
       description: Policy report ID.
@@ -2381,12 +1788,12 @@ script:
     - contextPath: Qualys.ScheduleScan.TEXT
       description: Qualys response for the launch compliance policy.
       type: String
+    description: Run compliance policy report
     execution: true
   - name: qualys-ip-restricted-list
     arguments:
     - name: limit
-      description: Specify a positive numeric value to limit the amount of results
-        in the requested list
+      description: Specify a positive numeric value to limit the amount of results in the requested list
     outputs:
     - contextPath: Qualys.Restricted.Address
       description: List of the restricted IPs.
@@ -2405,21 +1812,15 @@ script:
       - add
       - delete
       - replace
-      description: activate - enable or disable the restricted IPs feature. clear
-        - clear all restricted IPs and de-active this feature. add - add restricted
-        IPs. delete - delete restricted IPs. replace - replace restricted IPs
+      description: activate - enable or disable the restricted IPs feature. clear - clear all restricted IPs and de-active this feature. add - add restricted IPs. delete - delete restricted IPs. replace - replace restricted IPs
     - name: enable
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Enable or disable the restricted IPs list. set enable=1 to enable
-        the list; set enable=0 to clear any IPs in the list and disable the feature.
+      - "0"
+      - "1"
+      description: Enable or disable the restricted IPs list. set enable=1 to enable the list; set enable=0 to clear any IPs in the list and disable the feature.
     - name: ips
-      description: The hosts you want to add to, remove from or replace in the restricted
-        IPs list. How to specify IP addresses. One or more IPs/ranges may be specified.
-        Multiple IPs/ranges are comma separated. An IP range is specified with a hyphen
-        (for example, 10.10.30.1-10.10.30.50).
+      description: The hosts you want to add to, remove from or replace in the restricted IPs list. How to specify IP addresses. One or more IPs/ranges may be specified. Multiple IPs/ranges are comma separated. An IP range is specified with a hyphen (for example, 10.10.30.1-10.10.30.50).
     outputs:
     - contextPath: Qualys.Restricted.Manage.TEXT
       description: Action result message.
@@ -2431,100 +1832,58 @@ script:
     execution: true
   - name: qualys-host-list-detection
     arguments:
-    - default: false
-      description: A comma-separated list of host IDs/ranges. A host ID range is
-        specified with a hyphen (for example, 190-400). Valid host IDs are required.
+    - name: ids
+      description: A comma-separated list of host IDs/ranges. A host ID range is specified with a hyphen (for example, 190-400). Valid host IDs are required.
       isArray: true
-      name: ids
-      required: false
-      secret: false
-    - default: false
-      description: A comma-separated list of host IP addresses/ranges. 
-        An IP address range is specified with a hyphen (for example, 10.10.30.1-10.10.30.50).
+    - name: ips
+      description: A comma-separated list of host IP addresses/ranges. An IP address range is specified with a hyphen (for example, 10.10.30.1-10.10.30.50).
       isArray: true
-      name: ips
-      required: false
-      secret: false
-    - default: false
-      description: A comma-separated list of valid detection record QIDs. 
-        A range is specified with a dash (for example, 68518-68522).
+    - name: qids
+      description: A comma-separated list of valid detection record QIDs. A range is specified with a dash (for example, 68518-68522).
       isArray: true
-      name: qids
-      required: false
-      secret: false
-    - default: false
-      description: A comma-separated list of severity levels.
-       A range is specified with a dash (for example, 1-3). 
+    - name: severities
+      description: A comma-separated list of severity levels. A range is specified with a dash (for example, 1-3).
       isArray: true
-      name: severities
-      required: false
-      secret: false
     - name: use_tags
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: Specify 0 (the default) to select hosts based on IP
-        addresses/ranges and/or asset groups. 
-        Specify 1 to select hosts based on asset tags.
+      - "0"
+      - "1"
+      description: Specify 0 (the default) to select hosts based on IP addresses/ranges and/or asset groups. Specify 1 to select hosts based on asset tags.
     - name: tag_set_by
       auto: PREDEFINED
       predefined:
       - id
       - name
-      description: (Optional when use_tags=1) Specify “id” (the default) to select
-        a tag set by providing tag IDs. Specify “name” to select a tag set by providing
-        tag names.
+      description: (Optional when use_tags=1) Specify “id” (the default) to select a tag set by providing tag IDs. Specify “name” to select a tag set by providing tag names.
     - name: tag_include_selector
       auto: PREDEFINED
       predefined:
       - any
       - all
-      description: (Optional when use_tags=1) Specify “any” (the default) to include
-        hosts that match at least one of the selected tags. Specify “all” to include
-        hosts that match all of the selected tags.
+      description: (Optional when use_tags=1) Specify “any” (the default) to include hosts that match at least one of the selected tags. Specify “all” to include hosts that match all of the selected tags.
     - name: tag_exclude_selector
       auto: PREDEFINED
       predefined:
       - any
       - all
-      description: (Optional when use_tags=1) Specify “any” (the default) to exclude
-        hosts that match at least one of the selected tags. Specify “all” to exclude
-        hosts that match all of the selected tags.
+      description: (Optional when use_tags=1) Specify “any” (the default) to exclude hosts that match at least one of the selected tags. Specify “all” to exclude hosts that match all of the selected tags.
     - name: tag_set_include
-      description: (Optional when use_tags=1) Specify a comma-separated list of 
-        tag names or IDs to include hosts that match these tags. 
+      description: (Optional when use_tags=1) Specify a comma-separated list of tag names or IDs to include hosts that match these tags.
       isArray: true
     - name: tag_set_exclude
-      description: (Optional when use_tags=1) Specify a comma-separated list of 
-        tag names or IDs for which to exclude hosts that match the tags. 
+      description: (Optional when use_tags=1) Specify a comma-separated list of tag names or IDs for which to exclude hosts that match the tags.
       isArray: true
     - name: detection_processed_before
-      description: Specify the date before which to retrieve detections vulnerability 
-        scan results that were processed. 
-        Specify the date in YYYY-MMDD[THH:MM:SSZ] format
-        (UTC/GMT), for example, “2016-09-12” or “2016-09-12T23:15:00Z”.
+      description: Specify the date before which to retrieve detections vulnerability scan results that were processed. Specify the date in YYYY-MMDD[THH:MM:SSZ] format (UTC/GMT), for example, “2016-09-12” or “2016-09-12T23:15:00Z”.
     - name: detection_processed_after
-      description: Specify the date after which to retrieve detections vulnerability
-        scan results that were processed. 
-        Specify the date in YYYY-MMDD[THH:MM:SSZ] format
-        (UTC/GMT), for example, “2016-09-12” or “2016-09-12T23:15:00Z”.
+      description: Specify the date after which to retrieve detections vulnerability scan results that were processed. Specify the date in YYYY-MMDD[THH:MM:SSZ] format (UTC/GMT), for example, “2016-09-12” or “2016-09-12T23:15:00Z”.
     - name: vm_scan_since
-      description: 'Show hosts that were last scanned for vulnerabilities since the
-        specified date and time (optional). Hosts that were the target of a vulnerability
-        scan since the date/time will be shown. Date/time is specified in the following format:
-        YYYY-MM-DD[THH:MM:SSZ] (UTC/GMT). Permissions: An Auditor cannot specify this
-        parameter.'
+      description: 'Show hosts that were last scanned for vulnerabilities since the specified date and time (optional). Hosts that were the target of a vulnerability scan since the date/time will be shown. Date/time is specified in the following format: YYYY-MM-DD[THH:MM:SSZ] (UTC/GMT). Permissions: An Auditor cannot specify this parameter.'
     - name: no_vm_scan_since
-      description: 'Show hosts not scanned since the specified date and time (optional).
-        The date/time is specified in the following format: YYYY-MMDD[THH:MM:SSZ] format (UTC/GMT), for example,
-        “2007-07-01” or “2007-01-25T23:12:00Z”. Permissions - An Auditor cannot specify
-        this parameter.'
+      description: 'Show hosts not scanned since the specified date and time (optional). The date/time is specified in the following format: YYYY-MMDD[THH:MM:SSZ] format (UTC/GMT), for example, “2007-07-01” or “2007-01-25T23:12:00Z”. Permissions - An Auditor cannot specify this parameter.'
     - name: truncation_limit
-      description: Specify the maximum number of host records processed per request.
-        When not specified, the truncation limit is set to 1000 host records. You
-        may specify a value less than the default (1-999) or greater than the default
-        (1001-1000000).
+      description: Specify the maximum number of host records processed per request. When not specified, the truncation limit is set to 1000 host records. You may specify a value less than the default (1-999) or greater than the default (1001-1000000).
     outputs:
     - contextPath: Qualys.HostDetections.ID
       description: Host detection ID.
@@ -2616,50 +1975,22 @@ script:
     - contextPath: Qualys.HostDetections.DETECTION_LIST.DETECTION.PROTOCOL
       description: Detection protocol.
       type: String
-    description: Get a list of hosts with the hosts latest vulnerability data. The list is based
-      on the host based scan data available in the user’s account.
+    description: Get a list of hosts with the hosts latest vulnerability data. The list is based on the host based scan data available in the user’s account.
     execution: true
   - name: qualys-host-update
     arguments:
-    - default: false
-      description: A comma-separated list of host IDs/ranges to update. A host ID range is
-        specified with a hyphen (for example, 190-400). Valid host IDs are required.
-        Either the `ips` or `ids` parameter must be supplied. IDs or IPs can be retrieved
-        via running the `qualys-host-list-detection` command, using the ID field or
-        IPs field.
+    - name: ids
+      description: A comma-separated list of host IDs/ranges to update. A host ID range is specified with a hyphen (for example, 190-400). Valid host IDs are required. Either the `ips` or `ids` parameter must be supplied. IDs or IPs can be retrieved via running the `qualys-host-list-detection` command, using the ID field or IPs field.
       isArray: true
-      name: ids
-      required: false
-      secret: false
-    - default: false
-      description: A comma-separated list of host IP addresses/ranges to add to, 
-        remove from or replace in the restricted
-        IPs list. An IP range is specified with a hyphen
-        (for example, 10.10.30.1-10.10.30.50). Either the `ips` or `ids` parameter must be supplied.
+    - name: ips
+      description: A comma-separated list of host IP addresses/ranges to add to, remove from or replace in the restricted IPs list. An IP range is specified with a hyphen (for example, 10.10.30.1-10.10.30.50). Either the `ips` or `ids` parameter must be supplied.
       isArray: true
-      name: ips
-      required: false
-      secret: false
-    - default: false
-      description: (Valid only when the Network Support feature is enabled for the
-        user’s account.) The network ID of the custom network for which to restrict the request. When unspecified, defaults to Global Default Network.
-      name: network_id
-      required: false
-      secret: false
-    - default: false
-      description: The DNS hostname for the IP you want to update. A single IP must
-        be specified in the same request and the IP will only be updated if it matches
-        the hostname specified.
-      name: host_dns
-      required: false
-      secret: false
-    - default: false
-      description: The NetBIOS hostname for the IP you want to update. A single IP
-        must be specified in the same request and the IP will only be updated if it
-        matches the hostname specified.
-      name: host_netbios
-      required: false
-      secret: false
+    - name: network_id
+      description: (Valid only when the Network Support feature is enabled for the user’s account.) The network ID of the custom network for which to restrict the request. When unspecified, defaults to Global Default Network.
+    - name: host_dns
+      description: The DNS hostname for the IP you want to update. A single IP must be specified in the same request and the IP will only be updated if it matches the hostname specified.
+    - name: host_netbios
+      description: The NetBIOS hostname for the IP you want to update. A single IP must be specified in the same request and the IP will only be updated if it matches the hostname specified.
     - name: tracking_method
       auto: PREDEFINED
       predefined:
@@ -2673,42 +2004,18 @@ script:
       - IP
       - DNS
       - NETBIOS
-      description: The new tracking method. 
-        Note - You cannot change the tracking method to EC2 or AGENT. If an IP is
-        already tracked by EC2 or AGENT, you cannot change the tracking method to
-        something else.
-    - default: false
-      description: The new owner of the host asset(s). The owner must be a Manager.
-        Another user (Unit Manager, Scanner, Reader) can be the owner if the IP address
-        is in the user’s account.
+      description: The new tracking method. Note - You cannot change the tracking method to EC2 or AGENT. If an IP is already tracked by EC2 or AGENT, you cannot change the tracking method to something else.
+    - name: new_owner
+      description: The new owner of the host asset(s). The owner must be a Manager. Another user (Unit Manager, Scanner, Reader) can be the owner if the IP address is in the user’s account.
       isArray: true
-      name: new_owner
-      required: false
-      secret: false
-    - default: false
-      description: The user-defined comments. Specify new comments for the
-        host asset(s).
-      name: new_comment
-      required: false
-      secret: false
-    - default: false
-      description: Change value for user-defined field 1. You can specify a maximum
-        of 128 characters (ASCII) for each field value.
-      name: new_ud1
-      required: false
-      secret: false
-    - default: false
-      description: Change value for user-defined field 2. You can specify a maximum
-        of 128 characters (ASCII) for each field value.
-      name: new_ud2
-      required: false
-      secret: false
-    - default: false
-      description: Change value for user-defined field 3. You can specify a maximum
-        of 128 characters (ASCII) for each field value.
-      name: new_ud3
-      required: false
-      secret: false
+    - name: new_comment
+      description: The user-defined comments. Specify new comments for the host asset(s).
+    - name: new_ud1
+      description: Change value for user-defined field 1. You can specify a maximum of 128 characters (ASCII) for each field value.
+    - name: new_ud2
+      description: Change value for user-defined field 2. You can specify a maximum of 128 characters (ASCII) for each field value.
+    - name: new_ud3
+      description: Change value for user-defined field 3. You can specify a maximum of 128 characters (ASCII) for each field value.
     outputs:
     - contextPath: Qualys.Endpoint.Update.DATETIME
       description: Date the command was executed.
@@ -2720,58 +2027,27 @@ script:
     execution: true
   - name: qualys-schedule-scan-create
     arguments:
-    - default: false
+    - name: scan_title
+      required: true
       description: The scan title.
-      isArray: false
-      name: scan_title
-      required: true
-      secret: false
     - name: ip
+      description: 'A comma-separated list of IP addresses/ranges to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of IP addresses/ranges to be scanned. 
-        At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
     - name: asset_group_ids
+      description: 'A comma-separated list of IDs of asset groups containing the hosts to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of IDs of asset groups containing the hosts to be scanned. 
-        At most, one of these parameters can be supplied: ip, asset_groups
-        or asset_group_ids.'
     - name: asset_groups
+      description: 'A comma-separated list of titles of asset groups containing the hosts to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of titles of asset groups containing the hosts to be scanned.
-        At most, one of these parameters can be supplied:
-        ip, asset_groups or asset_group_ids.'
     - name: option_title
-      description: The title of the compliance option profile to be used.
       required: true
-    - default: false
-      description: "The frequency (days) in which the scan occurs. The value is between 1-365. For example:\
-        \ '1' indicates that the schedule will occur every day. '2' indicates that the schedule will\
-        \ occur every 2 days. At most, one of these parameters can be supplied: 'frequency_days',\
-        \ 'frequency_weeks', 'frequency_months'."
-      name: frequency_days
-      required: false
-      secret: false
-    - default: false
-      description: "The frequency (weeks) in which the scan occurs. The value is between 1-52. For example:\
-        \ '1' indicates that the schedule will occur every week. '2' indicates that the schedule\
-        \ will occur every 2 weeks. The argument 'weekdays' is required when frequency_weeks\
-        \ is given. Scan will occur only on specified days given in the 'weekdays'\
-        \ argument. At most, one of these parameters can be supplied: 'frequency_days', 'frequency_weeks',\
-        \ 'frequency_months'."
-      name: frequency_weeks
-      required: false
-      secret: false
-    - default: false
-      description: "The frequency (months) in which the scan occurs. The value is between 1-12. For example:\
-        \ '1' indicates that the schedule will occur every month. '2' indicates that the schedule\
-        \ will occur every 2 months. Either the argument 'day_of_month' or the arguments\
-        \ 'day_of_week' and 'week_of_month' are required when frequency_months is\
-        \ given. The scan will occur only on specified days given in those arguments\
-        \ At most, one of these parameters can be supplied: 'frequency_days', 'frequency_weeks',\
-        \ 'frequency_months'."
-      name: frequency_months
-      required: false
-      secret: false
+      description: The title of the compliance option profile to be used.
+    - name: frequency_days
+      description: 'The frequency (days) in which the scan occurs. The value is between 1-365. For example: ''1'' indicates that the schedule will occur every day. ''2'' indicates that the schedule will occur every 2 days. At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
+    - name: frequency_weeks
+      description: 'The frequency (weeks) in which the scan occurs. The value is between 1-52. For example: ''1'' indicates that the schedule will occur every week. ''2'' indicates that the schedule will occur every 2 weeks. The argument ''weekdays'' is required when frequency_weeks is given. Scan will occur only on specified days given in the ''weekdays'' argument. At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
+    - name: frequency_months
+      description: 'The frequency (months) in which the scan occurs. The value is between 1-12. For example: ''1'' indicates that the schedule will occur every month. ''2'' indicates that the schedule will occur every 2 months. Either the argument ''day_of_month'' or the arguments ''day_of_week'' and ''week_of_month'' are required when frequency_months is given. The scan will occur only on specified days given in those arguments At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
     - name: weekdays
       auto: PREDEFINED
       predefined:
@@ -2782,52 +2058,22 @@ script:
       - thursday
       - friday
       - saturday
-      description: "A comma-separated list of the days when the scan will occur each week. 
-        Required when 'frequency_weeks' is given. For example: 
-        weekdays='sunday,tuesday' along with 'frequency_weeks=2'
-        means the scan will occur on Sunday and Tuesday every two weeks."
+      description: 'A comma-separated list of the days when the scan will occur each week. Required when ''frequency_weeks'' is given. For example: weekdays=''sunday,tuesday'' along with ''frequency_weeks=2'' means the scan will occur on Sunday and Tuesday every two weeks.'
       isArray: true
-    - default: false
-      description: "Day of the month the monthly schedule will run on. 
-        The value is between 1-31 depending on the month. 
-        Only relevant when 'frequency_months' value was given.        
-        For example: day_of_month=15 along with frequency_months=2 will result in
-        the scan running every 2 months on the 15th of the month."
-      name: day_of_month
-      required: false
-      secret: false
-    - default: false
-      description: "Day of week that the schedule will run on.
-        The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month.
-        Only relevant when 'frequency_months' value was given. Must be
-        used with 'week_of_month' as well. 
-        For example: day_of_week=2, week_of_month=second along with frequency_months=2
-        will result in the scan running every 2 months on Tuesday in the second week
-        of the month."
-      name: day_of_week
-      required: false
-      secret: false
+    - name: day_of_month
+      description: 'Day of the month the monthly schedule will run on. The value is between 1-31 depending on the month. Only relevant when ''frequency_months'' value was given. For example: day_of_month=15 along with frequency_months=2 will result in the scan running every 2 months on the 15th of the month.'
+    - name: day_of_week
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-      - '5'
-      - '6'
-    - default: false
-      description: "Comma-separated list of the days of the week that the
-        schedule will run on. 
-        The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending
-        on the month. Only relevant when 'frequency_months' value
-        was given. Must be used with 'week_of_month' as well. For example: day_of_week=2, week_of_month=second along with
-        frequency_months=2 will result in the scan running every 2 months on Tuesday
-        in the second week of the month."
-      name: week_of_month
-      required: false
-      isArray: true
-      secret: false
+      - "0"
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+      - "5"
+      - "6"
+      description: 'Day of week that the schedule will run on. The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month. Only relevant when ''frequency_months'' value was given. Must be used with ''week_of_month'' as well. For example: day_of_week=2, week_of_month=second along with frequency_months=2 will result in the scan running every 2 months on Tuesday in the second week of the month.'
+    - name: week_of_month
       auto: PREDEFINED
       predefined:
       - first
@@ -2835,66 +2081,41 @@ script:
       - third
       - fourth
       - last
-    - default: false
-      description: "The start date of the schedule in the format of mm/dd/yyyy. 
-        For example: 12/15/2020."
-      name: start_date
+      description: 'Comma-separated list of the days of the week that the schedule will run on. The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month. Only relevant when ''frequency_months'' value was given. Must be used with ''week_of_month'' as well. For example: day_of_week=2, week_of_month=second along with frequency_months=2 will result in the scan running every 2 months on Tuesday in the second week of the month.'
+      isArray: true
+    - name: start_date
       required: true
-      secret: false
-    - default: false
-      description: The start hour of the scheduled scan. 
-        Required when 'start_date' is given. The value is between 0-23.
-      name: start_hour
+      description: 'The start date of the schedule in the format of mm/dd/yyyy. For example: 12/15/2020.'
+    - name: start_hour
       required: true
-      secret: false
-    - default: false
-      description: The start minute of the scheduled scan. 
-        Required when 'start_date' is given. The value is between 0-59.
-      name: start_minute
+      description: The start hour of the scheduled scan. Required when 'start_date' is given. The value is between 0-23.
+    - name: start_minute
       required: true
-      secret: false
-    - default: false
-      description: "Time zone code of the given scheduled scan. For example: US-CA for
-        California time zone in the US. Required when 'start_date' is given."
-      name: time_zone_code
+      description: The start minute of the scheduled scan. Required when 'start_date' is given. The value is between 0-59.
+    - name: time_zone_code
       required: true
-      secret: false
-    - default: false
+      description: 'Time zone code of the given scheduled scan. For example: US-CA for California time zone in the US. Required when ''start_date'' is given.'
+    - name: observe_dst
       auto: PREDEFINED
       predefined:
-        - 'yes'
-        - 'no'
-      description: Whether to observe Daylight Saving Time (DST).
-        Required when start_date is given. This parameter is valid when the time zone code specified in
-        time_zone_code supports DST. To get the list of time zones and their DST support, use the `qualys-time-zone-code` command.
-      name: observe_dst
-      required: false
-      secret: false
+      - "yes"
+      - "no"
+      description: Whether to observe Daylight Saving Time (DST). Required when start_date is given. This parameter is valid when the time zone code specified in time_zone_code supports DST. To get the list of time zones and their DST support, use the `qualys-time-zone-code` command.
     - name: exclude_ip_per_scan
-      description: "A comma-separated list of IP addresses/ranges to be excluded from the scan when the scan target\
-        \ is specified as IP addresses (not asset tags). One of\
-        \ the following parameters must be set: 'scanners_in_ag', 'default_scanner'."
+      description: 'A comma-separated list of IP addresses/ranges to be excluded from the scan when the scan target is specified as IP addresses (not asset tags). One of the following parameters must be set: ''scanners_in_ag'', ''default_scanner''.'
       isArray: true
     - name: default_scanner
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: "Specify 1 to use the default scanner in each target asset group.\
-        \ For an Express Lite user, Internal Scanning must be enabled in the user’s\
-        \ account. At most, one of these parameters can be supplied: 'scanners_in_ag', 'default_scanner'."
+      - "0"
+      - "1"
+      description: 'Specify 1 to use the default scanner in each target asset group. For an Express Lite user, Internal Scanning must be enabled in the user’s account. At most, one of these parameters can be supplied: ''scanners_in_ag'', ''default_scanner''.'
     - name: scanners_in_ag
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: "Specify 1 to distribute the scan to the target asset groups’ scanner\
-        \ appliances. Appliances in each asset group are tasked with scanning the\
-        \ IPs in the group. By default, up to 5 appliances per group will be used and\
-        \ this can be configured for your account (contact your Account Manager\
-        \ or Support). For an Express Lite user, Internal Scanning must be enabled\
-        \ in the user’s account. At most, one of these parameters can be supplied:\
-        \ 'scanners_in_ag', 'default_scanner'."
+      - "0"
+      - "1"
+      description: 'Specify 1 to distribute the scan to the target asset groups’ scanner appliances. Appliances in each asset group are tasked with scanning the IPs in the group. By default, up to 5 appliances per group will be used and this can be configured for your account (contact your Account Manager or Support). For an Express Lite user, Internal Scanning must be enabled in the user’s account. At most, one of these parameters can be supplied: ''scanners_in_ag'', ''default_scanner''.'
     outputs:
     - contextPath: Qualys.ScheduleScan.ID
       description: ID of the new scheduled scan.
@@ -2909,62 +2130,26 @@ script:
     execution: true
   - name: qualys-schedule-scan-update
     arguments:
-    - default: false
-      description: The scan ID to update. The ID can be retrieved by running the
-        'qualys-schedule-scan-list' command, and using the ID field.
-      isArray: false
-      name: id
+    - name: id
       required: true
-      secret: false
-    - default: false
+      description: The scan ID to update. The ID can be retrieved by running the 'qualys-schedule-scan-list' command, and using the ID field.
+    - name: scan_title
       description: The scan title.
-      isArray: false
-      name: scan_title
-      required: false
-      secret: false
     - name: ip
+      description: 'A comma-separated list of IP addresses/ranges to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of IP addresses/ranges to be scanned. 
-        At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
     - name: asset_group_ids
+      description: 'A comma-separated list of IDs of asset groups containing the hosts to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of IDs of asset groups containing the hosts to be scanned. 
-        At most, one of these parameters can be supplied:
-        ip, asset_groups or asset_group_ids.'
     - name: asset_groups
+      description: 'A comma-separated list of titles of asset groups containing the hosts to be scanned. At most, one of these parameters can be supplied: ip, asset_groups or asset_group_ids.'
       isArray: true
-      description: 'A comma-separated list of titles of asset groups containing the hosts to be scanned.
-       At most, one of these parameters can be supplied: 
-       ip, asset_groups or asset_group_ids.'
-    - default: false
-      description: "The frequency (days) in which the scan occurs. The value is between 1-365. For example:\
-        \ '1' indicates that the schedule will occur every day. '2' indicates that the schedule will\
-        \ occur every 2 days. At most, one of these parameters can be supplied: 'frequency_days',\
-        \ 'frequency_weeks', 'frequency_months'."
-      name: frequency_days
-      required: false
-      secret: false
-    - default: false
-      description: "The frequency (weeks) in which the scan occurs. The value is between 1-52. For example:\
-        \ '1' indicates that the schedule will occur every week. '2' indicates that the schedule\
-        \ will occur every 2 weeks. The argument 'weekdays' is required when frequency_weeks\
-        \ is given. Scan will occur only on specified days given in the 'weekdays'\
-        \ argument. At most, one of these parameters can be supplied: 'frequency_days', 'frequency_weeks',\
-        \ 'frequency_months'."
-      name: frequency_weeks
-      required: false
-      secret: false
-    - default: false
-      description: "The frequency (months) in which the scan occurs. The value is between 1-12. For example:\
-        \ '1' indicates that the schedule will occur every month. '2' indicates that the schedule\
-        \ will occur every 2 months. Either the argument 'day_of_month' or the arguments\
-        \ 'day_of_week' and 'week_of_month' are required when frequency_months is\
-        \ given. The scan will occur only on specified days given in those arguments\
-        \ At most, one of these parameters can be supplied: 'frequency_days', 'frequency_weeks',\
-        \ 'frequency_months'."
-      name: frequency_months
-      required: false
-      secret: false
+    - name: frequency_days
+      description: 'The frequency (days) in which the scan occurs. The value is between 1-365. For example: ''1'' indicates that the schedule will occur every day. ''2'' indicates that the schedule will occur every 2 days. At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
+    - name: frequency_weeks
+      description: 'The frequency (weeks) in which the scan occurs. The value is between 1-52. For example: ''1'' indicates that the schedule will occur every week. ''2'' indicates that the schedule will occur every 2 weeks. The argument ''weekdays'' is required when frequency_weeks is given. Scan will occur only on specified days given in the ''weekdays'' argument. At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
+    - name: frequency_months
+      description: 'The frequency (months) in which the scan occurs. The value is between 1-12. For example: ''1'' indicates that the schedule will occur every month. ''2'' indicates that the schedule will occur every 2 months. Either the argument ''day_of_month'' or the arguments ''day_of_week'' and ''week_of_month'' are required when frequency_months is given. The scan will occur only on specified days given in those arguments At most, one of these parameters can be supplied: ''frequency_days'', ''frequency_weeks'', ''frequency_months''.'
     - name: weekdays
       auto: PREDEFINED
       predefined:
@@ -2975,52 +2160,22 @@ script:
       - thursday
       - friday
       - saturday
-      description: "A comma-separated list of the days when the scan will occur each week. 
-        Required when 'frequency_weeks' is given. For example: 
-        weekdays='sunday,tuesday' along with 'frequency_weeks=2'
-        means the scan will occur on Sunday and Tuesday every two weeks."
+      description: 'A comma-separated list of the days when the scan will occur each week. Required when ''frequency_weeks'' is given. For example: weekdays=''sunday,tuesday'' along with ''frequency_weeks=2'' means the scan will occur on Sunday and Tuesday every two weeks.'
       isArray: true
-    - default: false
-      description: "Day of the month the monthly schedule will run on. 
-        The value is between 1-31 depending on the month. 
-        Only relevant when 'frequency_months' value was given.        
-        For example: day_of_month=15 along with frequency_months=2 will result in
-        the scan running every 2 months on the 15th of the month."
-      name: day_of_month
-      required: false
-      secret: false
-    - default: false
-      description: "Day of week that the schedule will run on.
-        The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month.
-        Only relevant when 'frequency_months' value was given. Must be
-        used with 'week_of_month' as well. 
-        For example: day_of_week=2, week_of_month=second along with frequency_months=2
-        will result in the scan running every 2 months on Tuesday in the second week
-        of the month."
-      name: day_of_week
-      required: false
-      secret: false
+    - name: day_of_month
+      description: 'Day of the month the monthly schedule will run on. The value is between 1-31 depending on the month. Only relevant when ''frequency_months'' value was given. For example: day_of_month=15 along with frequency_months=2 will result in the scan running every 2 months on the 15th of the month.'
+    - name: day_of_week
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-      - '5'
-      - '6'
-    - default: false
-      description: "Comma-separated list of the days of the week that the
-        schedule will run on. 
-        The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending
-        on the month. Only relevant when 'frequency_months' value
-        was given. Must be used with 'week_of_month' as well. For example: day_of_week=2, week_of_month=second along with
-        frequency_months=2 will result in the scan running every 2 months on Tuesday
-        in the second week of the month."
-      name: week_of_month
-      required: false
-      isArray: true
-      secret: false
+      - "0"
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+      - "5"
+      - "6"
+      description: 'Day of week that the schedule will run on. The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month. Only relevant when ''frequency_months'' value was given. Must be used with ''week_of_month'' as well. For example: day_of_week=2, week_of_month=second along with frequency_months=2 will result in the scan running every 2 months on Tuesday in the second week of the month.'
+    - name: week_of_month
       auto: PREDEFINED
       predefined:
       - first
@@ -3028,73 +2183,52 @@ script:
       - third
       - fourth
       - last
-    - default: false
-      description: "The start date of the schedule in the format of mm/dd/yyyy. 
-        For example: 12/15/2020."
-      name: start_date
-      required: false
-      secret: false
-    - default: false
-      description: The start hour of the scheduled scan. 
-        Required when 'start_date' is given. The value is between 0-23.
-      name: start_hour
-      required: false
-      secret: false
-    - default: false
-      description: The start minute of the scheduled scan. 
-        Required when 'start_date' is given. The value is between 0-59.
-      name: start_minute
-      required: false
-      secret: false
-    - default: false
-      description: "Time zone code of the given scheduled scan. For example: US-CA for
-        California time zone in the US. Required when 'start_date' is given."
-      name: time_zone_code
-      required: false
-      secret: false
-    - default: false
+      description: 'Comma-separated list of the days of the week that the schedule will run on. The value is between 0-6, where 0 is Sunday, and 6 is Saturday depending on the month. Only relevant when ''frequency_months'' value was given. Must be used with ''week_of_month'' as well. For example: day_of_week=2, week_of_month=second along with frequency_months=2 will result in the scan running every 2 months on Tuesday in the second week of the month.'
+      isArray: true
+    - name: start_date
+      description: 'The start date of the schedule in the format of mm/dd/yyyy. For example: 12/15/2020.'
+    - name: start_hour
+      description: The start hour of the scheduled scan. Required when 'start_date' is given. The value is between 0-23.
+    - name: start_minute
+      description: The start minute of the scheduled scan. Required when 'start_date' is given. The value is between 0-59.
+    - name: time_zone_code
+      description: 'Time zone code of the given scheduled scan. For example: US-CA for California time zone in the US. Required when ''start_date'' is given.'
+    - name: observe_dst
       auto: PREDEFINED
       predefined:
-        - 'yes'
-        - 'no'
-      description: Whether to observe Daylight Saving Time (DST).
-        Required when start_date is given. This parameter is valid when the time zone code specified in
-        time_zone_code supports DST. To get the list of time zones and their DST support, use the `qualys-time-zone-code` command.
-      name: observe_dst
-      required: false
-      secret: false
+      - "yes"
+      - "no"
+      description: Whether to observe Daylight Saving Time (DST). Required when start_date is given. This parameter is valid when the time zone code specified in time_zone_code supports DST. To get the list of time zones and their DST support, use the `qualys-time-zone-code` command.
     - name: exclude_ip_per_scan
-      description: "A comma-separated list of IP addresses/ranges to be excluded from the scan when the scan target\
-        \ is specified as IP addresses (not asset tags). One of\
-        \ the following parameters must be set: 'scanners_in_ag', 'default_scanner'."
+      description: 'A comma-separated list of IP addresses/ranges to be excluded from the scan when the scan target is specified as IP addresses (not asset tags). One of the following parameters must be set: ''scanners_in_ag'', ''default_scanner''.'
       isArray: true
     - name: default_scanner
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: "Specify 1 to use the default scanner in each target asset group.\
-        \ For an Express Lite user, Internal Scanning must be enabled in the user’s\
-        \ account. At most, one of these parameters can be supplied: 'scanners_in_ag',\
-        \ 'default_scanner'."
+      - "0"
+      - "1"
+      description: 'Specify 1 to use the default scanner in each target asset group. For an Express Lite user, Internal Scanning must be enabled in the user’s account. At most, one of these parameters can be supplied: ''scanners_in_ag'', ''default_scanner''.'
     - name: scanners_in_ag
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
-      description: "Specify 1 to distribute the scan to the target asset groups’ scanner\
-        \ appliances. Appliances in each asset group are tasked with scanning the\
-        \ IPs in the group. By default, up to 5 appliances per group will be used and\
-        \ this can be configured for your account (contact your Account Manager\
-        \ or Support). For an Express Lite user, Internal Scanning must be enabled\
-        \ in the user’s account. At most, one of these parameters can be supplied:\
-        \ 'scanners_in_ag', 'default_scanner'."
+      - "0"
+      - "1"
+      description: 'Specify 1 to distribute the scan to the target asset groups’ scanner appliances. Appliances in each asset group are tasked with scanning the IPs in the group. By default, up to 5 appliances per group will be used and this can be configured for your account (contact your Account Manager or Support). For an Express Lite user, Internal Scanning must be enabled in the user’s account. At most, one of these parameters can be supplied: ''scanners_in_ag'', ''default_scanner''.'
     - name: active
       auto: PREDEFINED
       predefined:
-      - '0'
-      - '1'
+      - "0"
+      - "1"
       description: Whether the scheduled scan is activated.
+    - name: target_from
+      auto: PREDEFINED
+      predefined:
+      - assets
+      - tags
+      description: Specify “assets” (the default) when your scan target will include IP addresses/ranges and/or asset groups. Specify “tags” when your scan target will include asset tags.
+      defaultValue: assets
+    - name: iscanner_name
+      description: Specifies the name of the Scanner Appliance for the map, when the map target has private use internal IPs. Using Express Lite, Internal Scanning must be enabled in your account.
     outputs:
     - contextPath: Qualys.ScheduleScan.ID
       description: ID of the scheduled scan to be updated.
@@ -3109,34 +2243,21 @@ script:
     execution: true
   - name: qualys-asset-group-add
     arguments:
-    - default: false
-      description: The asset group title to add.
-      isArray: false
-      name: title
+    - name: title
       required: true
-      secret: false
-    - default: false
+      description: The asset group title to add.
+    - name: network_id
       description: Restrict the request to a certain custom network ID.
-      isArray: false
-      name: network_id
-      required: false
-      secret: false
     - name: ips
-      description: A comma-separated list of IP address/ranges to add to an asset group. 
-        An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
+      description: A comma-separated list of IP address/ranges to add to an asset group. An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
       isArray: true
     - name: domains
-      required: false
-      description: A comma-separated list of domains to add to an asset group. 
-        Do not enter "www." at the start of
-        the domain name. 
+      description: A comma-separated list of domains to add to an asset group. Do not enter "www." at the start of the domain name.
       isArray: true
     - name: dns_names
-      required: false
       description: A comma-separated list of DNS names to add to an asset group.
       isArray: true
     - name: netbios_names
-      required: false
       description: A comma-separated list of NETBIOS names to add to an asset group.
       isArray: true
     - name: cvss_enviro_td
@@ -3147,7 +2268,6 @@ script:
       - low
       - none
       description: The CVSS environment target distribution to add.
-      isArray: false
     - name: cvss_enviro_cr
       auto: PREDEFINED
       predefined:
@@ -3155,7 +2275,6 @@ script:
       - medium
       - low
       description: The CVSS environment confidentiality requirement to add.
-      isArray: false
     - name: cvss_enviro_ir
       auto: PREDEFINED
       predefined:
@@ -3163,7 +2282,6 @@ script:
       - medium
       - low
       description: The CVSS environment integrity requirement to add.
-      isArray: false
     - name: cvss_enviro_ar
       auto: PREDEFINED
       predefined:
@@ -3171,10 +2289,8 @@ script:
       - medium
       - low
       description: The CVSS environment availability requirement to add.
-      isArray: false
     - name: appliance_ids
-      required: false
-      description: A comma-separated list of appliance IDs to add to an asset group. 
+      description: A comma-separated list of appliance IDs to add to an asset group.
       isArray: true
     outputs:
     - contextPath: Qualys.AssetGroup.ID
@@ -3190,73 +2306,46 @@ script:
     execution: true
   - name: qualys-asset-group-edit
     arguments:
-    - default: false
+    - name: set_title
       description: The new asset group title.
-      isArray: false
-      name: set_title
-      required: false
-      secret: false
-    - default: false
-      description: The ID of the asset group to edit. The ID of asset groups can be retrieved
-        via running the `qualys-group-list` command and using its ID field.
-      isArray: false
-      name: id
+    - name: id
       required: true
-      secret: false
+      description: The ID of the asset group to edit. The ID of asset groups can be retrieved via running the `qualys-group-list` command and using its ID field.
     - name: add_ips
-      description: A comma-separated list of IP address/ranges to add to an asset group. 
-        An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
+      description: A comma-separated list of IP address/ranges to add to an asset group. An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
       isArray: true
     - name: set_ips
-      description: A comma-separated list of IP address/ranges of an asset group to set.
-        An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
+      description: A comma-separated list of IP address/ranges of an asset group to set. An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
       isArray: true
     - name: remove_ips
-      description: A comma-separated list of IP addresses/ranges to remove 
-        from an asset group. 
-        An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
+      description: A comma-separated list of IP addresses/ranges to remove from an asset group. An IP range is specified with a hyphen (for example, 10.10.10.1-10.10.10.100).
       isArray: true
     - name: add_domains
-      required: false
-      description: A comma-separated list of domains to add to an asset group. 
-        Do not enter "www." at the start of
-        the domain name. 
+      description: A comma-separated list of domains to add to an asset group. Do not enter "www." at the start of the domain name.
       isArray: true
     - name: set_domains
-      required: false
-      description: A comma-separated list of domains of an asset group to set. 
-        Do not enter "www." at the start of
-        the domain name. 
+      description: A comma-separated list of domains of an asset group to set. Do not enter "www." at the start of the domain name.
       isArray: true
     - name: remove_domains
-      required: false
-      description: A comma-separated list of domains to remove from an asset group.
-        Do not enter "www." at the start
-        of the domain name. 
+      description: A comma-separated list of domains to remove from an asset group. Do not enter "www." at the start of the domain name.
       isArray: true
     - name: add_dns_names
-      required: false
-      description: A comma-separated list of DNS names to add to an asset group. 
+      description: A comma-separated list of DNS names to add to an asset group.
       isArray: true
     - name: set_dns_names
-      required: false
-      description: A comma-separated list of DNS names of asset group to set. 
+      description: A comma-separated list of DNS names of asset group to set.
       isArray: true
     - name: remove_dns_names
-      required: false
-      description: A comma-separated list of DNS names to remove from an asset group. 
+      description: A comma-separated list of DNS names to remove from an asset group.
       isArray: true
     - name: add_netbios_names
-      required: false
-      description: A comma-separated list of NETBIOS names to add to an asset group. 
+      description: A comma-separated list of NETBIOS names to add to an asset group.
       isArray: true
     - name: set_netbios_names
-      required: false
       description: A comma-separated list of NETBIOS names of an asset group to set.
       isArray: true
     - name: remove_netbios_names
-      required: false
-      description: A comma-separated list of NETBIOS names to delete from an asset group. 
+      description: A comma-separated list of NETBIOS names to delete from an asset group.
       isArray: true
     - name: set_cvss_enviro_td
       auto: PREDEFINED
@@ -3266,7 +2355,6 @@ script:
       - low
       - none
       description: The CVSS environment target distribution to set.
-      isArray: false
     - name: set_cvss_enviro_cr
       auto: PREDEFINED
       predefined:
@@ -3274,7 +2362,6 @@ script:
       - medium
       - low
       description: The CVSS environment confidentiality requirement to set.
-      isArray: false
     - name: set_cvss_enviro_ir
       auto: PREDEFINED
       predefined:
@@ -3282,7 +2369,6 @@ script:
       - medium
       - low
       description: The CVSS environment integrity requirement to set.
-      isArray: false
     - name: set_cvss_enviro_ar
       auto: PREDEFINED
       predefined:
@@ -3290,18 +2376,14 @@ script:
       - medium
       - low
       description: The CVSS environment availability requirement to set.
-      isArray: false
     - name: add_appliance_ids
-      required: false
       description: A comma-separated list of appliance IDs to add to an asset group.
       isArray: true
     - name: set_appliance_ids
-      required: false
       description: A comma-separated list of appliance IDs of an asset group to set.
       isArray: true
     - name: remove_appliance_ids
-      required: false
-      description: A comma-separated list of appliance IDs to remove from an asset group. 
+      description: A comma-separated list of appliance IDs to remove from an asset group.
       isArray: true
     outputs:
     - contextPath: Qualys.AssetGroup.ID
@@ -3317,13 +2399,9 @@ script:
     execution: true
   - name: qualys-asset-group-delete
     arguments:
-    - default: false
-      description: Asset group ID to delete. ID of asset groups can be retrieved via
-        running the `qualys-group-list` command and using its ID field.
-      isArray: false
-      name: id
+    - name: id
       required: true
-      secret: false
+      description: Asset group ID to delete. ID of asset groups can be retrieved via running the `qualys-group-list` command and using its ID field.
     outputs:
     - contextPath: Qualys.AssetGroup.ID
       description: Asset group ID.
@@ -3338,13 +2416,9 @@ script:
     execution: true
   - name: qualys-schedule-scan-delete
     arguments:
-    - default: false
-      description: Scheduled Scan ID to delete. The ID can be retrieved via running
-        the `qualys-schedule-scan-list` command, and using the ID field.
-      isArray: false
-      name: id
+    - name: id
       required: true
-      secret: false
+      description: Scheduled Scan ID to delete. The ID can be retrieved via running the `qualys-schedule-scan-list` command, and using the ID field.
     outputs:
     - contextPath: Qualys.ScheduleScan.ID
       description: ID of the scheduled scan to be deleted.
@@ -3372,14 +2446,6 @@ script:
     description: Gets a list of the supported time zone codes.
     execution: true
   dockerimage: demisto/python3:3.10.1.25933
-  feed: false
-  isfetch: false
-  longRunning: false
-  longRunningPort: false
   runonce: false
-  script: '-'
   subtype: python3
-  type: python
-tests:
-- QualysVulnerabilityManagement-Test
-fromversion: 5.5.0
+sourcemoduleid: QualysV2

--- a/Packs/qualys/ReleaseNotes/1_0_17.md
+++ b/Packs/qualys/ReleaseNotes/1_0_17.md
@@ -1,3 +1,4 @@
 #### Integrations
 ##### Qualys v2
 - Command ***qualys-schedule-scan-update***: Added optional arguments ***target_from*** and ***iscanner_name***
+- Updated docker image to demisto/python3:3.10.1.26972

--- a/Packs/qualys/ReleaseNotes/1_0_17.md
+++ b/Packs/qualys/ReleaseNotes/1_0_17.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Qualys v2
+- Command ***qualys-schedule-scan-update***: Added optional arguments ***target_from*** and ***iscanner_name***

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Qualys",
     "description": "Qualys Vulnerability Management let's you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance",
     "support": "xsoar",
-    "currentVersion": "1.0.16",
+    "currentVersion": "1.0.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
n/a

## Description
Add optional arguments to command `qualys-schedule-scan-update` to fix limitation where the command could not be used to update asset groups to include in scheduled scan. Args required for this use case:
- `id`
- `asset_groups`
- `target_from` (newly added in this PR)
- `iscanner_name` (newly added in this PR)

## Screenshots
Contact developer for more info/screenshots if needed. (Cannot include in public repo.)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
