### PR TITLE
Add value failedFetchIncidents to permitted_notifications in instance params

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.yml
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.yml
@@ -44,6 +44,7 @@ configuration:
   - taskCompleted
   - incidentStatusChanged
   - externalFormSubmit
+  - failedFetchIncidents
 - defaultvalue: Unclassified
   display: Type of incidents created in Slack
   name: incidentType

--- a/Packs/Slack/ReleaseNotes/2_5_4.md
+++ b/Packs/Slack/ReleaseNotes/2_5_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v3
+- Added support for the *failedFetchIncidents* message type in the ***send-notification*** command.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "2.5.3",
+    "currentVersion": "2.5.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/47267

## Description
Add value `failedFetchIncidents` to `permitted_notifications` multi-select in instance parameters so users know it exists. `failedFetchIncidents` can be added to receive system notifications via Slack for integration fetch failures.

## Screenshots
![Screen Shot 2022-03-15 at 7 28 49 PM](https://user-images.githubusercontent.com/91506078/158498711-d4539895-1c65-48db-ab4f-fb001819a147.png)

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0 

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
