### PR TITLE
Fix lingering misleading arg description

### DIFF
--- a/Packs/AWS-EC2/Integrations/AWS-EC2/README.md
+++ b/Packs/AWS-EC2/Integrations/AWS-EC2/README.md
@@ -2015,8 +2015,8 @@ Adds ingress rule to a security group.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | groupId | The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID. | Required | 
-| fromPort | The start of port range for the TCP and UDP protocols. In case ipProtocol is specified, this argument will be ignored. | Optional | 
-| toPort | The end of port range for the TCP and UDP protocols. In case ipProtocol is specified, this argument will be ignored. | Optional | 
+| fromPort | The start of port range for the TCP and UDP protocols. | Optional | 
+| toPort | The end of port range for the TCP and UDP protocols. | Optional | 
 | cidrIp | The CIDR IPv4 address range. | Optional | 
 | ipProtocol | The IP protocol name (tcp , udp , icmp) or number.  Use -1 to specify all protocols. | Optional | 
 | sourceSecurityGroupName | The name of the source security group. The source security group must be in the same VPC. | Optional | 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
n/a

## Description
Fix misleading arg descriptions for command `aws-ec2-revoke-security-group-ingress-rule` args `fromPort` and `toPort`. 

Follow-up to earlier PR https://github.com/demisto/content/pull/18112/, where I accidentally missed a place the descriptions needed changed.

## Screenshots
My goal is to remove the part of the arg description highlighted here:

![Screen Shot 2022-03-16 at 10 27 59 PM](https://user-images.githubusercontent.com/91506078/158737633-c7c4e87a-bc04-41fe-99a2-b90e2251e6de.png)

Please advise if something different needs to be changed to make that happen.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
