### PR TITLE
Bug - Azure Sentinel -  Update fetch-incidents to support first fetch after upgrading the integration

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -44,8 +44,6 @@ DEFAULT_SOURCE = 'Azure Sentinel'
 
 THREAT_INDICATORS_HEADERS = ['Name', 'DisplayName', 'Values', 'Types', 'Source', 'Confidence', 'Tags']
 
-MINIMAL_INCIDENT_NUMBER = 0
-
 
 class AzureSentinelClient:
     def __init__(self, server_url: str, tenant_id: str, client_id: str,
@@ -890,13 +888,16 @@ def fetch_incidents(client: AzureSentinelClient, last_run: dict, first_fetch_tim
     # Get the last fetch details, if exist
     last_fetch_time = last_run.get('last_fetch_time')
     last_fetch_ids = last_run.get('last_fetch_ids', [])
-    last_incident_number = last_run.get('last_incident_number', MINIMAL_INCIDENT_NUMBER)
+    last_incident_number = last_run.get('last_incident_number')
     demisto.debug(f"{last_fetch_time=}, {last_fetch_ids=}, {last_incident_number=}")
 
-    if last_fetch_time is None:  # this is the first fetch, or the First fetch timestamp was reset
+    if last_fetch_time is None or last_incident_number is None:
         demisto.debug("handle via timestamp")
-        last_fetch_time_str, _ = parse_date_range(first_fetch_time, DATE_FORMAT)
-        latest_created_time = dateparser.parse(last_fetch_time_str)
+        if last_fetch_time is None:
+            last_fetch_time_str, _ = parse_date_range(first_fetch_time, DATE_FORMAT)
+            latest_created_time = dateparser.parse(last_fetch_time_str)
+        else:
+            latest_created_time = dateparser.parse(last_fetch_time)
         latest_created_time_str = latest_created_time.strftime(DATE_FORMAT)
         command_args = {
             'filter': f'properties/createdTimeUtc ge {latest_created_time_str}',
@@ -932,6 +933,8 @@ def process_incidents(raw_incidents: list, last_fetch_ids: list, min_severity: i
 
     incidents = []
     current_fetch_ids = []
+    if not last_incident_number:
+        last_incident_number = 0
 
     for incident in raw_incidents:
         incident_severity = severity_to_level(incident.get('Severity'))

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -918,7 +918,7 @@ def fetch_incidents(client: AzureSentinelClient, last_run: dict, first_fetch_tim
 
 
 def process_incidents(raw_incidents: list, last_fetch_ids: list, min_severity: int, latest_created_time: datetime,
-                      last_incident_number: int):
+                      last_incident_number):
     """Processing the raw incidents
     Args:
         raw_incidents: The incidents that were fetched from the API.

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -60,8 +60,7 @@ configuration:
   name: proxy
   required: false
   type: 8
-description: Use the Azure Sentinel integration to get and manage incidents and get
-  related entity information for incidents.
+description: Use the Azure Sentinel integration to get and manage incidents and get related entity information for incidents.
 display: Azure Sentinel
 name: Azure Sentinel
 script:
@@ -156,16 +155,13 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Filter results using OData syntax. For example: properties/createdTimeUtc
-        gt 2020-02-02T14:00:00Z`). For more information, see the Azure documentation:
-        https://docs.microsoft.com/bs-latn-ba/azure/search/search-query-odata-filter.'
+      description: 'Filter results using OData syntax. For example: properties/createdTimeUtc gt 2020-02-02T14:00:00Z`). For more information, see the Azure documentation: https://docs.microsoft.com/bs-latn-ba/azure/search/search-query-odata-filter.'
       isArray: false
       name: filter
       required: false
       secret: false
     - default: false
-      description: A link that specifies a starting point to use for subsequent calls.
-        This argument overrides all of the other command arguments.
+      description: A link that specifies a starting point to use for subsequent calls. This argument overrides all of the other command arguments.
       isArray: false
       name: next_link
       required: false
@@ -242,9 +238,7 @@ script:
       description: Description of NextLink.
       type: String
     - contextPath: AzureSentinel.NextLink.URL
-      description: Used if an operation returns partial results. If a response contains
-        a NextLink element, its value specifies a starting point to use for subsequent
-        calls.
+      description: Used if an operation returns partial results. If a response contains a NextLink element, its value specifies a starting point to use for subsequent calls.
       type: String
     - contextPath: AzureSentinel.Incident.Etag
       description: The Etag of the incident.
@@ -295,18 +289,13 @@ script:
       description: Label that will be used to tag and filter on.
       type: unknown
     - contextPath: AzureSentinel.Watchlist.ItemsSearchKey
-      description: The search key is used to optimize query performance when using
-        watchlists for joins with other data. For example, enable a column with IP
-        addresses to be the designated SearchKey field, then use this field as the
-        key field when joining to other event data by IP address.
+      description: The search key is used to optimize query performance when using watchlists for joins with other data. For example, enable a column with IP addresses to be the designated SearchKey field, then use this field as the key field when joining to other event data by IP address.
       type: String
     - contextPath: AzureSentinel.NextLink.Description
       description: Description of NextLink.
       type: String
     - contextPath: AzureSentinel.NextLink.URL
-      description: Used if an operation returns partial results. If a response contains
-        a NextLink element, its value specifies a starting point to use for subsequent
-        calls.
+      description: Used if an operation returns partial results. If a response contains a NextLink element, its value specifies a starting point to use for subsequent calls.
       type: String
   - arguments:
     - default: false
@@ -359,25 +348,20 @@ script:
       required: false
       secret: false
     - default: false
-      description: A file entry with raw content that represents the watchlist items
-        to create.
+      description: A file entry with raw content that represents the watchlist items to create.
       isArray: false
       name: file_entry_id
       required: true
       secret: false
     - default: false
-      description: The search key is used to optimize query performance when using
-        watchlists for joins with other data. For example, enable a column with IP
-        addresses to be the designated SearchKey field, then use this field as the
-        key field when joining to other event data by IP address.
+      description: The search key is used to optimize query performance when using watchlists for joins with other data. For example, enable a column with IP addresses to be the designated SearchKey field, then use this field as the key field when joining to other event data by IP address.
       isArray: false
       name: items_search_key
       required: true
       secret: false
     - default: false
       defaultValue: Text/Csv
-      description: The content type of the raw content. For now, only text/csv is
-        valid.
+      description: The content type of the raw content. For now, only text/csv is valid.
       isArray: false
       name: content_type
       required: false
@@ -421,8 +405,7 @@ script:
       description: List of labels relevant to this watchlist.
       type: Unknown
     - contextPath: AzureSentinel.Watchlist.ItemsSearchKey
-      description: The search key is used to optimize query performance when using
-        watchlists for joins with other data.
+      description: The search key is used to optimize query performance when using watchlists for joins with other data.
       type: String
   - arguments:
     - default: false
@@ -468,8 +451,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: The reason the incident was closed. Required when updating the
-        status to Closed.
+      description: The reason the incident was closed. Required when updating the status to Closed.
       isArray: false
       name: classification
       predefined:
@@ -487,8 +469,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: The classification reason the incident was closed with. Required
-        when updating the status to Closed and the classification is determined.
+      description: The classification reason the incident was closed with. Required when updating the status to Closed and the classification is determined.
       isArray: false
       name: classification_reason
       predefined:
@@ -499,8 +480,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: The email address of the incident assignee. Note that the updated
-        API field is `owner.email`.
+      description: The email address of the incident assignee. Note that the updated API field is `owner.email`.
       isArray: false
       name: assignee_email
       required: false
@@ -602,15 +582,13 @@ script:
       secret: false
     - default: false
       defaultValue: '50'
-      description: The maximum number of incident comments to return. The 
-        maximum value is 50.
+      description: The maximum number of incident comments to return. The maximum value is 50.
       isArray: false
       name: limit
       required: false
       secret: false
     - default: false
-      description: A link that specifies a starting point to use for subsequent calls.
-        Using this argument overrides all of the other command arguments.
+      description: A link that specifies a starting point to use for subsequent calls. Using this argument overrides all of the other command arguments.
       isArray: false
       name: next_link
       required: false
@@ -642,9 +620,7 @@ script:
       description: Description of NextLink.
       type: String
     - contextPath: AzureSentinel.NextLink.URL
-      description: Used if an operation returns a partial result. If a response contains
-        a NextLink element, its value specifies a starting point to use for subsequent
-        calls.
+      description: Used if an operation returns a partial result. If a response contains a NextLink element, its value specifies a starting point to use for subsequent calls.
       type: String
   - arguments:
     - default: false
@@ -714,8 +690,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: A link that specifies a starting point to use for subsequent calls.
-        Using this argument overrides all of the other command arguments.
+      description: A link that specifies a starting point to use for subsequent calls. Using this argument overrides all of the other command arguments.
       isArray: false
       name: next_link
       required: false
@@ -731,9 +706,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Filter results using OData syntax. For example: properties/createdTimeUtc
-        gt 2020-02-02T14:00:00Z`). For more information see the Azure documentation:
-        https://docs.microsoft.com/bs-latn-ba/azure/search/search-query-odata-filter.'
+      description: 'Filter results using OData syntax. For example: properties/createdTimeUtc gt 2020-02-02T14:00:00Z`). For more information see the Azure documentation: https://docs.microsoft.com/bs-latn-ba/azure/search/search-query-odata-filter.'
       isArray: false
       name: filter
       required: false
@@ -753,9 +726,7 @@ script:
       description: The description about NextLink.
       type: String
     - contextPath: AzureSentinel.NextLink.URL
-      description: Used if an operation returns a partial result. If a response contains
-        a NextLink element, its value specifies a starting point to use for subsequent
-        calls.
+      description: Used if an operation returns a partial result. If a response contains a NextLink element, its value specifies a starting point to use for subsequent calls.
       type: String
     - contextPath: AzureSentinel.IncidentRelatedResource.IncidentID
       description: The incident ID.
@@ -827,8 +798,7 @@ script:
       description: The name of the product that published this alert.
       type: String
     - contextPath: AzureSentinel.IncidentAlert.ProductComponentName
-      description: The name of a component inside the product which generated the
-        alert.
+      description: The name of a component inside the product which generated the alert.
       type: String
   - arguments:
     - default: false
@@ -900,8 +870,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: The JSON for the itemsKeyValue of the item (the key value is different
-        from watchlist to watchlist).
+      description: The JSON for the itemsKeyValue of the item (the key value is different from watchlist to watchlist).
       isArray: false
       name: item_key_value
       required: true
@@ -1253,8 +1222,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: The hash type of the new indicator. This argument is mandatory
-        if the indicator type is file.
+      description: The hash type of the new indicator. This argument is mandatory if the indicator type is file.
       isArray: false
       name: hash_type
       predefined:
@@ -1265,8 +1233,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: The confidence of the new threat indicator. Should be a number
-        between 0-100.
+      description: The confidence of the new threat indicator. Should be a number between 0-100.
       isArray: false
       name: confidence
       required: false
@@ -1471,7 +1438,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description:  A comma-separated list of threat types of the threat indicator.
+      description: A comma-separated list of threat types of the threat indicator.
       isArray: true
       name: threat_types
       predefined:
@@ -1809,7 +1776,7 @@ script:
     - contextPath: AzureSentinel.ThreatIndicator.Types
       description: The threat types of the indicator.
       type: Unknown
-  dockerimage: demisto/crypto:1.0.0.27243
+  dockerimage: demisto/crypto:1.0.0.27590
   feed: false
   isfetch: true
   longRunning: false
@@ -1820,6 +1787,5 @@ script:
   type: python
 tests:
 - TestAzureSentinelPlaybookV2
-- No test - Manual test playbook-TestAzureSentinelPlaybook is available in NonCircleTests
-  folder
+- No test - Manual test playbook-TestAzureSentinelPlaybook is available in NonCircleTests folder
 fromversion: 5.0.0

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1257,24 +1257,32 @@ class TestHappyPath:
 
     def test_last_run_in_fetch_incidents(self, mocker):
         """
-        Given: - AzureSentinel client, last_fetched_ids array, last_run, first_fetch_time, and a minimum severity.
+        Scenario: First time fetching incidents after updating the integration.
+        Given: - AzureSentinel client,last_fetched_ids array, last_run dictionary, first_fetch_time,
+        and a minimum severity.
+
+        The last_run dictionary mimics a last_run dict from a previous version of the integration, containing an
+        empty 'last_fetch_ids' array and a valid 'last_fetch_time' string, but does not contain
+        'last_incident_number' that was added in the new version.
 
         When:
             - Calling the fetch_incidents command.
 
-        Then:
-            - Validate the call_args had the correct filter and orderby.
+        Then: - Validate the call_args had the correct filter and orderby, to check that the fetch was handled by
+        created time and not by incident number.
         """
         # prepare
         client = mock_client()
         last_run = {'last_fetch_time': '2022-03-16T13:01:08Z',
                     'last_fetch_ids': []}
         first_fetch_time = '3 days'
+        minimum_severity = 0
+
         mocker.patch('AzureSentinel.process_incidents', return_value=({}, []))
         mocker.patch.object(client, 'http_request', return_value=MOCKED_INCIDENTS_OUTPUT)
 
         # run
-        fetch_incidents(client, last_run, first_fetch_time, 0)
+        fetch_incidents(client, last_run, first_fetch_time, minimum_severity)
         call_args = client.http_request.call_args[1]
 
         # validate

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1263,7 +1263,7 @@ class TestHappyPath:
             - Calling the fetch_incidents command.
 
         Then:
-            - Validate the call_args had the correct filter.
+            - Validate the call_args had the correct filter and orderby.
         """
         # prepare
         client = mock_client()
@@ -1274,11 +1274,12 @@ class TestHappyPath:
         mocker.patch.object(client, 'http_request', return_value=MOCKED_INCIDENTS_OUTPUT)
 
         # run
-        next_run, _ = fetch_incidents(client, last_run, first_fetch_time, 0)
+        fetch_incidents(client, last_run, first_fetch_time, 0)
         call_args = client.http_request.call_args[1]
 
         # validate
-        assert 'properties/createdTimeUtc ge' in call_args.get("params").get("$filter")
+        assert 'properties/createdTimeUtc ge' in call_args.get('params').get('$filter')
+        assert 'properties/createdTimeUtc asc' == call_args.get('params').get('$orderby')
 
 
 class TestEdgeCases:

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1258,18 +1258,19 @@ class TestHappyPath:
     def test_last_run_in_fetch_incidents(self, mocker):
         """
         Scenario: First time fetching incidents after updating the integration.
-        Given: - AzureSentinel client,last_fetched_ids array, last_run dictionary, first_fetch_time,
-        and a minimum severity.
+        Given:
+            - AzureSentinel client, last_run dictionary, first_fetch_time, and a minimum severity.
 
-        The last_run dictionary mimics a last_run dict from a previous version of the integration, containing an
-        empty 'last_fetch_ids' array and a valid 'last_fetch_time' string, but does not contain
-        'last_incident_number' that was added in the new version.
+            The last_run dictionary mimics a last_run dict from a previous version of the integration, containing an
+            empty 'last_fetch_ids' array and a valid 'last_fetch_time' string, but does not contain
+            'last_incident_number' that was added in the new version.
 
         When:
             - Calling the fetch_incidents command.
 
-        Then: - Validate the call_args had the correct filter and orderby, to check that the fetch was handled by
-        created time and not by incident number.
+        Then:
+            - Validate the call_args had the correct filter and orderby, to check that the fetch was handled by
+            created time and not by incident number.
         """
         # prepare
         client = mock_client()

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Azure Sentinel
+- Fixed an issue where the command ***fetch-incidents*** failed to fetch relevant incidents.

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Azure Sentinel
-- Fixed an issue where the command ***fetch-incidents*** failed to fetch relevant incidents.
+- Fixed an issue where the command ***fetch-incidents*** failed to fetch relevant incidents upon updating the integration.

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_4.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Azure Sentinel
-- Fixed an issue where the command ***fetch-incidents*** failed to fetch relevant incidents upon updating the integration.
+- Fixed an issue where the ***fetch-incidents*** command fetched old incidents after upgrading to the previous pack release.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Azure Sentinel",
     "description": "Azure Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.3.3",
+    "currentVersion": "1.3.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47457

## Description
Update fetch-incidents to support first fetch after upgrading the integration, as I originally did not take into account that the last_run dict will not be empty upon upgrading.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
