### PR TITLE
SDK command argument typo - merge with SDK v1.6.3

### DIFF
--- a/Packs/ContentManagement/docs-files/ci-cd.yml
+++ b/Packs/ContentManagement/docs-files/ci-cd.yml
@@ -89,7 +89,7 @@ jobs:
           cd $GITHUB_WORKSPACE/repository
 
           # Run validate on all changed files
-          demisto-sdk validate --quite-bc-validation --no-conf-json --allow-skipped
+          demisto-sdk validate --quiet-bc-validation --no-conf-json --allow-skipped
       - name: Run Unit Testing and Lint
         if: always()
         run: |


### PR DESCRIPTION
SDK command was fixed on https://github.com/demisto/demisto-sdk/pull/1976

FYI @ChanochShayner this will be merged into content when SDK 1.6.3 is merged. 