### PR TITLE
Added since in red canary to params

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -349,7 +349,7 @@ def get_unacknowledged_detections(t: datetime, per_page: int = 50) -> Generator[
             # If 'last_acknowledged_at' or 'last_acknowledged_by' are in attributes,
             # the detection is acknowledged and should not create a new incident.
             if attributes.get('last_acknowledged_at') is None and attributes.get('last_acknowledged_by') is None:
-                demisto.debug('This is the detection: '.format(detection))
+                demisto.debug('This is the detection: {}'.format(detection))
                 yield detection
 
         page += 1
@@ -549,7 +549,7 @@ def execute_playbook(playbook_id, detection_id):
 
 def fetch_incidents(last_run):
     last_incidents_ids = []
-    demisto.debug('This is the last_run (start): '.format(last_run))
+    demisto.debug('This is the last_run (start): {}'.format(last_run))
 
     if last_run:
         last_fetch = last_run.get('time')
@@ -563,13 +563,13 @@ def fetch_incidents(last_run):
     incidents = []
     # new_incidents_ids = []
     for raw_detection in get_unacknowledged_detections(last_fetch, per_page=2):
-        demisto.debug('This is the raw detection: '.format(raw_detection))
+        demisto.debug('This is the raw detection: {}'.format(raw_detection))
         demisto.debug('found a new detection in RedCanary #{}'.format(raw_detection['id']))
         incident = detection_to_incident(raw_detection)
-        demisto.debug('This is the incident: '.format(incident))
+        demisto.debug('This is the incident: {}'.format(incident))
         # the rawJson is a string of dictionary e.g. - ('{"ID":2,"Type":5}')
         incident_id = json.loads(incident.get('rawJSON')).get("ID")
-        demisto.debug('This is the last_incidents_ids: '.format(last_incidents_ids))
+        demisto.debug('This is the last_incidents_ids: {}'.format(last_incidents_ids))
         if incident_id not in last_incidents_ids:
             # makes sure that the incident wasn't fetched before
             incidents.append(incident)
@@ -578,9 +578,9 @@ def fetch_incidents(last_run):
     if incidents:
         last_fetch = max([get_time_obj(incident['occurred']) for incident in incidents])  # noqa:F812
         last_run = {'time': get_time_str(last_fetch), 'last_event_ids': last_incidents_ids}
-        demisto.debug('This is the last_run (middle): '.format(last_run))
+        demisto.debug('This is the last_run (middle): {}'.format(last_run))
 
-    demisto.debug('This is the last_run (end): '.format(last_run))
+    demisto.debug('This is the last_run (end): {}'.format(last_run))
     return last_run, incidents
 
 

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
@@ -45,7 +45,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.1.26972
+  dockerimage: demisto/python3:3.10.4.27798
   commands:
   - name: redcanary-acknowledge-detection
     arguments:

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
@@ -1,8 +1,8 @@
 commonfields:
-  id: RedCanary
+  id: RedCanary -logs
   version: -1
-name: RedCanary
-display: Red Canary
+name: RedCanary -logs
+display: Red Canary -logs
 category: Endpoint
 description: Red Canary collects endpoint data using Carbon Black Response and CrowdStrike
   Falcon.  The collected data is standardized into a common schema which allows teams

--- a/Packs/RedCanary/ReleaseNotes/1_1_7.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_7.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Red Canary
+- Updated the Docker image to: *demisto/python3:3.10.4.27798*.
 - Fixed an issue with the ***fetch-incidents*** command which would cause duplicate incidents.

--- a/Packs/RedCanary/ReleaseNotes/1_1_7.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Red Canary
+- Fixed an issue with the ***fetch-incidents*** command which would cause duplicate incidents.

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Red Canary",
     "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
     "support": "xsoar",
-    "currentVersion": "1.1.6",
+    "currentVersion": "1.1.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47603

## Description
Added since to params (and removed from data since by fetch incidents we use get not post method).
Keep all of the detection id's (not just from the last fetch).

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
