### PR TITLE
download offline packs: remove ":" from file name

### DIFF
--- a/Utils/download_packs_and_docker_images.py
+++ b/Utils/download_packs_and_docker_images.py
@@ -127,7 +127,7 @@ def download_and_save_docker_images(docker_images: set, output_path: str) -> Non
             print(f"\tDownloading docker image: {image}")
             image_pair = image.split(':')
             image_data = cli.images.pull(image_pair[0], image_pair[1])
-            image_file_name = os.path.join(temp_dir.name, os.path.basename(image) + '.tar')
+            image_file_name = os.path.join(temp_dir.name, os.path.basename(f"{image_pair[0]}_{image_pair[1]}.tar"))
             with open(image_file_name, 'wb') as f:
                 for chunk in image_data.save(named=True):
                     f.write(chunk)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Related: https://github.com/demisto/content-docs/pull/1042

When using podman `:` in the file name is problematic. Use `_` instead.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
