### PR TITLE
Fix `misp-add-url-object` command

### DIFF
--- a/Packs/MISP/Integrations/MISPV3/MISPV3.py
+++ b/Packs/MISP/Integrations/MISPV3/MISPV3.py
@@ -1329,7 +1329,7 @@ def add_url_object(demisto_args: dict):
     url = demisto_args.get('url')
     url_parse = urlparse(url)
     url_obj = [{'url': url}]
-    url_obj.extend({'scheme': url_parse.scheme}) if url_parse.scheme else None
+    url_obj.append({'scheme': url_parse.scheme}) if url_parse.scheme else None
     url_obj.append({'resource_path': url_parse.path}) if url_parse.path else None
     url_obj.append({'query_string': url_parse.query}) if url_parse.query else None
     url_obj.append({'domain': url_parse.netloc}) if url_parse.netloc else None

--- a/Packs/MISP/ReleaseNotes/2_1_4.md
+++ b/Packs/MISP/ReleaseNotes/2_1_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MISP v3
+- Fixed issue in which ***misp-add-url-object*** command failed to run when url with schema was provided.

--- a/Packs/MISP/pack_metadata.json
+++ b/Packs/MISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP",
     "description": "Malware information and threat sharing platform.",
     "support": "xsoar",
-    "currentVersion": "2.1.3",
+    "currentVersion": "2.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Because `extend` method expects "iterable" as parameter then, when `url_parse.scheme` was provided, string `"scheme"` was added to `url_obj` list ( should be dict `{"scheme": url_parse.scheme}`).

Because string `"scheme"` is not a `dict`, `build_generic_object` function throw error in such case.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fix ***misp-add-url-object** command

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
