### PR TITLE
Add mailto to phish up readme

### DIFF
--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
@@ -75,8 +75,8 @@ class Client(BaseClient):
         self.api_token = self.headers['X-RFToken'] = api_token
         self.services = services
         self.indicator_type = indicator_type
-        self.threshold = int(threshold)
-        self.risk_score_threshold = int(risk_score_threshold)
+        self.threshold = int(threshold) if threshold else threshold
+        self.risk_score_threshold = int(risk_score_threshold) if risk_score_threshold else risk_score_threshold
         self.tags = tags
         self.tlp_color = tlp_color
         super().__init__(self.BASE_URL, proxy=proxy, verify=not insecure)

--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.yml
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.yml
@@ -216,7 +216,7 @@ script:
     - contextPath: RecordedFutureFeed.RiskRule.Criticality
       description: The risk rule criticality.
       type: String
-  dockerimage: demisto/python3:3.10.1.26972
+  dockerimage: demisto/python3:3.10.4.27798
   feed: true
   isfetch: false
   longRunning: false

--- a/Packs/FeedRecordedFuture/ReleaseNotes/1_0_24.md
+++ b/Packs/FeedRecordedFuture/ReleaseNotes/1_0_24.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Recorded Future RiskList Feed
+- Fixed an issue where the **test-module** failed when *Malicious Threshold* or *IOC Risk Score Threshold* were empty.
+- Updated the Docker image to: *demisto/python3:3.10.4.27798*.

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Recorded Future Feed",
     "description": "Ingests indicators from Recorded Future feeds into Demisto.",
     "support": "xsoar",
-    "currentVersion": "1.0.23",
+    "currentVersion": "1.0.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/PhishUp/.pack-ignore
+++ b/Packs/PhishUp/.pack-ignore
@@ -1,0 +1,2 @@
+[known_words]
+PhishUp

--- a/Packs/PhishUp/Integrations/PhishUp/PhishUp.yml
+++ b/Packs/PhishUp/Integrations/PhishUp/PhishUp.yml
@@ -82,7 +82,7 @@ script:
     - contextPath: PhishUp.Evaluation
       description: returns "Phish" if any response has "Phish" result
       type: String
-  dockerimage: demisto/python3:3.10.1.25933
+  dockerimage: demisto/python3:3.10.4.27798
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/PhishUp/Integrations/PhishUp/README.md
+++ b/Packs/PhishUp/Integrations/PhishUp/README.md
@@ -3,7 +3,7 @@
 If you don't have [PhishUp](https://phishup.co) Api Key please create an account on PhishUp and get a free Api Key. 
 Also you can visit and test [PhishUp Web Demo](https://phishup.co).
 
-If you have any question feel free to concat us: [info@phishup.com](info@phishup.co)
+If you have any question feel free to concat us: [info@phishup.com](mailto:info@phishup.co)
 
 ## Configure PhishUp on Cortex XSOAR
 

--- a/Packs/PhishUp/ReleaseNotes/1_0_1.md
+++ b/Packs/PhishUp/ReleaseNotes/1_0_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### PhishUp
+- Documentation and metadata improvements.
+- Updated the Docker image to: *demisto/python3:3.10.4.27798*.

--- a/Packs/PhishUp/pack_metadata.json
+++ b/Packs/PhishUp/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PhishUp",
     "description": "PhishUp prevents phishing attacks, protects your staff and your brand with AI",
     "support": "partner",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "PhishUp",
     "url": "https://phishup.co",
     "email": "info@phishup.co",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Added `mailto:` to the email address to not get an 404 error
[With the solution](https://xsoar-pan-dev--pull-request-1046-bjdlywhh.web.app/docs/reference/integrations/6437c006-1d86-4cdc-89d5-23305f207e3a)
[Without](https://xsoar.pan.dev/docs/reference/integrations/6437c006-1d86-4cdc-89d5-23305f207e3a)

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
