### PR TITLE
bug - azure sentinel - create threat intelligence indicator command small fixes

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -1073,7 +1073,6 @@ def build_threat_indicator_data(args):
     value = args.get('value')
 
     data = {
-        'patternType': value,
         'displayName': args.get('display_name'),
         'description': args.get('description'),
         'revoked': args.get('revoked', ''),
@@ -1089,20 +1088,20 @@ def build_threat_indicator_data(args):
 
     indicator_type = args.get('indicator_type')
     if indicator_type == 'ipv4':
-        indicator_type = 'ipv4-address'
+        indicator_type = 'ipv4-addr'
     elif indicator_type == 'ipv6':
-        indicator_type = 'ipv6-address'
+        indicator_type = 'ipv6-addr'
     elif indicator_type == 'domain':
         indicator_type = 'domain-name'
 
-    data['patternTypes'] = indicator_type
+    data['patternType'] = indicator_type
 
     if indicator_type == 'file':
         hash_type = args.get('hash_type')
         data['hashType'] = hash_type
-        data['pattern'] = f"[file:hashes.'{hash_type}' = {value}]"
+        data['pattern'] = f"[file:hashes.'{hash_type}' = '{value}']"
     else:
-        data['pattern'] = f'[{indicator_type}:value = {value}]'
+        data['pattern'] = f"[{indicator_type}:value = '{value}']"
 
     data['killChainPhases'] = []
 

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1341,10 +1341,11 @@ class TestHappyPath:
                 - Ensure the results holds the expected outcomes.
         """
         # prepare
-        args = {'value': '1.1.1.1',
-                'display_name': 'displaytest',
-                'indicator_types': 'ipv4',
-                'threat_types': ["malicious-activity"]
+        args = {'display_name': 'displayname',
+                'indicator_type': 'ipv4',
+                'revoked': 'false',
+                'threat_types': 'compromised',
+                'value': '1.1.1.1',
                 }
 
         # run

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1352,7 +1352,7 @@ class TestHappyPath:
 
         # validate
 
-        assert "'https://test.com'" in output.get('pattern')
+        assert " '1.1.1.1'" in output.get('pattern')
         assert output.get('patternType') == 'ipv4-addr'
 
 

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -13,7 +13,7 @@ from AzureSentinel import AzureSentinelClient, list_incidents_command, list_inci
     delete_incident_command, XSOAR_USER_AGENT, incident_delete_comment_command, \
     query_threat_indicators_command, create_threat_indicator_command, delete_threat_indicator_command, \
     append_tags_threat_indicator_command, replace_tags_threat_indicator_command, update_threat_indicator_command, \
-    list_threat_indicator_command, NEXTLINK_DESCRIPTION, process_incidents, fetch_incidents
+    list_threat_indicator_command, NEXTLINK_DESCRIPTION, process_incidents, fetch_incidents, build_threat_indicator_data
 
 TEST_ITEM_ID = 'test_watchlist_item_id_1'
 
@@ -1330,6 +1330,30 @@ class TestHappyPath:
         assert next_run.get('last_fetch_ids') == ['inc_ID', 'inc_ID_3']
         assert next_run.get('last_incident_number') == 3
         assert len(incidents) == expected_incident_num
+
+    def test_build_threat_indicator_data(self):
+        """
+            Given:
+                - Args with values.
+            When:
+                - Calling function build_threat_indicator_data.
+            Then:
+                - Ensure the results holds the expected outcomes.
+        """
+        # prepare
+        args = {'value': '1.1.1.1',
+                'display_name': 'displaytest',
+                'indicator_types': 'ipv4',
+                'threat_types': ["malicious-activity"]
+                }
+
+        # run
+        output = build_threat_indicator_data(args)
+
+        # validate
+
+        assert "'https://test.com'" in output.get('pattern')
+        assert output.get('patternType') == 'ipv4-addr'
 
 
 class TestEdgeCases:

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Azure Sentinel
-- Fixed an issue where the command ***azure-sentinel-threat-indicator-create*** did not work properly.
+- Fixed an issue where the ***azure-sentinel-threat-indicator-create*** command created new indicators with a malformed pattern and indicator type.

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Azure Sentinel
+- Fixed an issue where the command ***azure-sentinel-threat-indicator-create*** did not work properly.

--- a/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_3_9.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Azure Sentinel
-- Fixed an issue where the ***azure-sentinel-threat-indicator-create*** command created new indicators with a malformed pattern and indicator type.
+- Fixed an issue where the ***azure-sentinel-threat-indicator-create*** command created new indicators with malformed pattern and type.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Azure Sentinel",
     "description": "Azure Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.3.8",
+    "currentVersion": "1.3.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47751

## Description
There was a problem in sending correctly the information of the threat indicator, resulting in a problem in the data that was printed in the war room:
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/93524335/161416872-dbc8379f-b0aa-48f0-8966-cd1b102b220a.png">

3 changes:
1. The pattern entry misses a quotation marks:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/93524335/161416521-5883e640-a9d7-4282-a302-ab7c6e19cff7.png">  This fixes the original issue

2. Indicator type of type ipv4/ipv6 needs to be sent as "ipv4-addr"/"ipv6-addr" instead of "ipv4-address"/"ipv6-address"
<img width="285" alt="image" src="https://user-images.githubusercontent.com/93524335/161416626-2067dbeb-3019-4cc6-81a8-a7f9b572a221.png">

3. The entry "patternType" needs to be the indicator type, and not the value of the indicator.
<img width="196" alt="image" src="https://user-images.githubusercontent.com/93524335/161416718-ea5370b2-a835-42e2-bc6c-ee4682039b97.png">
Also, There is no entry called "patternTypes" as seen here in the API documentation: https://docs.microsoft.com/en-us/rest/api/securityinsights/stable/threat-intelligence-indicator/create-indicator

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
