### PR TITLE
Fix pan-os-edit-rule command bug

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -57,6 +57,7 @@ SECURITY_RULE_ARGS = {
     'action': 'Action',
     'service': 'Service',
     'disable': 'Disabled',
+    'disabled': 'Disabled',
     'application': 'Application',
     'source_user': 'SourceUser',
     'disable_server_response_inspection': 'DisableServerResponseInspection',

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -262,7 +262,7 @@ def add_argument_open(arg: Optional[str], field_name: str, member: bool) -> str:
 
 
 def add_argument_yes_no(arg: Optional[str], field_name: str, option: bool = False) -> str:
-    if arg and arg == 'No':
+    if arg and arg.lower() == 'no':
         result = '<' + field_name + '>' + 'no' + '</' + field_name + '>'
     else:
         result = '<' + field_name + '>' + ('yes' if arg else 'no') + '</' + field_name + '>'

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -783,16 +783,16 @@ class TestPanoramaEditRuleCommand:
             Panorama.panorama_edit_rule_command(args)
 
     @staticmethod
-    def test_edit_rule_to_disabled(mocker):
+    def test_edit_rule_to_disabled_flow(mocker):
         """
-        Given - connection to snapshot.
-
+        Given -
+            arguments to change a pre-rule to 'disabled'
 
         When -
-            Running create_snapshot function.
+            running panorama_edit_rule_command function.
 
         Then -
-            The Task_id should be returned.
+            make sure the entire command flow succeeds.
         """
         from Panorama import panorama_edit_rule_command
         args = {
@@ -806,6 +806,32 @@ class TestPanoramaEditRuleCommand:
         results_mocker = mocker.patch.object(demisto, "results")
         panorama_edit_rule_command(args)
         assert results_mocker.called
+
+    @staticmethod
+    def test_edit_rule_to_disabled_with_no_element_value(mocker):
+        """
+        Given -
+            arguments to change a pre-rule to 'disabled' when the element value should be set to 'no'
+
+        When -
+            running panorama_edit_rule_command function.
+
+        Then -
+            make sure that the `params['element']` contains the 'no' element value.
+        """
+        from Panorama import panorama_edit_rule_command
+        args = {
+            "rulename": "test",
+            "element_to_change": "disabled",
+            "element_value": "no",
+            "behaviour": "replace",
+            "pre_post": "pre-rulebase"
+        }
+        http_req_mocker = mocker.patch(
+            "Panorama.http_request", return_value=TestPanoramaEditRuleCommand.EDIT_SUCCESS_RESPONSE
+        )
+        panorama_edit_rule_command(args)
+        assert http_req_mocker.call_args.kwargs.get('body').get('element') == '<disabled>no</disabled>'
 
 
 class MockedResponse:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -782,6 +782,31 @@ class TestPanoramaEditRuleCommand:
         with pytest.raises(DemistoException):
             Panorama.panorama_edit_rule_command(args)
 
+    @staticmethod
+    def test_edit_rule_to_disabled(mocker):
+        """
+        Given - connection to snapshot.
+
+
+        When -
+            Running create_snapshot function.
+
+        Then -
+            The Task_id should be returned.
+        """
+        from Panorama import panorama_edit_rule_command
+        args = {
+            "rulename": "test",
+            "element_to_change": "disabled",
+            "element_value": "no",
+            "behaviour": "replace",
+            "pre_post": "pre-rulebase"
+        }
+        mocker.patch("Panorama.http_request", return_value=TestPanoramaEditRuleCommand.EDIT_SUCCESS_RESPONSE)
+        results_mocker = mocker.patch.object(demisto, "results")
+        panorama_edit_rule_command(args)
+        assert results_mocker.called
+
 
 class MockedResponse:
     def __init__(self, text, status_code, reason):

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -798,7 +798,7 @@ class TestPanoramaEditRuleCommand:
         args = {
             "rulename": "test",
             "element_to_change": "disabled",
-            "element_value": "no",
+            "element_value": "yes",
             "behaviour": "replace",
             "pre_post": "pre-rulebase"
         }

--- a/Packs/PAN-OS/ReleaseNotes/1_11_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_11_1.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Palo Alto Networks PAN-OS
 - Fixed an issue where the ***pan-os-edit-rule*** command failed when trying to disable a rule.
-- Fixed an issue where the ***pan-os-edit-rule*** command failed when trying to enable a rule which was in a disabled state.
+- Fixed an issue where the ***pan-os-edit-rule*** command does not enable a rule which is in a disabled state.

--- a/Packs/PAN-OS/ReleaseNotes/1_11_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_11_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue where the ***pan-os-edit-rule*** command failed when trying to disable a rule.
+- Fixed an issue where the ***pan-os-edit-rule*** command along with the *element_value* argument was always set to 'yes' when trying to disable a rule.

--- a/Packs/PAN-OS/ReleaseNotes/1_11_1.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_11_1.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Palo Alto Networks PAN-OS
 - Fixed an issue where the ***pan-os-edit-rule*** command failed when trying to disable a rule.
-- Fixed an issue where the ***pan-os-edit-rule*** command along with the *element_value* argument was always set to 'yes' when trying to disable a rule.
+- Fixed an issue where the ***pan-os-edit-rule*** command failed when trying to enable a rule which was in a disabled state.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.11.0",
+    "currentVersion": "1.11.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47779
fixes: https://github.com/demisto/etc/issues/47780

## Description
1) Fixed an issue in which ```pan-os-edit-rule``` command fails on ```KeyError``` when trying to disable a rule in Panorama.

2) Fixed another issue in which ```pan-os-edit-rule``` command always set ```element_value``` argument to 'yes' which makes it impossible to enable a rule from a disabled state

## Screenshots

<img width="1654" alt="image" src="https://user-images.githubusercontent.com/53861351/161733597-226fe5c3-105d-40d5-bf92-e0539989d642.png">


## Must have
- [x] Tests
- [ ] Documentation 
