### PR TITLE
fix: remove testsuite usage

### DIFF
--- a/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
+++ b/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
@@ -6,24 +6,24 @@ import os
 import tempfile
 from pathlib import Path
 
+import demisto_sdk.commands.common.tools as demisto_sdk_tools
 import pytest
+from demisto_sdk.commands.common.constants import (PACK_METADATA_SUPPORT,
+                                                   PACKS_DIR,
+                                                   PACKS_PACK_META_FILE_NAME)
 from ruamel.yaml import YAML
 
-import demisto_sdk.commands.common.tools as demisto_sdk_tools
 import Tests
-from Tests.scripts.utils import logging_wrapper as logging
-from demisto_sdk.commands.common.constants import (PACK_METADATA_SUPPORT,
-                                                   PACKS_PACK_META_FILE_NAME,
-                                                   PACKS_DIR)
 from Tests.scripts.collect_tests_and_content_packs import (
-    SANITY_TESTS, TestConf, collect_content_packs_to_install,
-    create_filter_envs_file, get_from_version_and_to_version_bounderies,
+    SANITY_TESTS, TestConf, check_if_test_should_not_be_missed,
+    collect_content_packs_to_install, create_filter_envs_file,
+    get_from_version_and_to_version_bounderies,
     get_test_list_and_content_packs_to_install, is_documentation_changes_only,
-    remove_ignored_tests, remove_tests_for_non_supported_packs, check_if_test_should_not_be_missed)
-from Tests.scripts.utils.get_modified_files_for_testing import get_modified_files_for_testing, ModifiedFiles
+    remove_ignored_tests, remove_tests_for_non_supported_packs)
 from Tests.scripts.utils import content_packs_util
-
-from TestSuite import repo, test_tools
+from Tests.scripts.utils import logging_wrapper as logging
+from Tests.scripts.utils.get_modified_files_for_testing import (
+    ModifiedFiles, get_modified_files_for_testing)
 
 with open('Tests/scripts/infrastructure_tests/tests_data/mock_id_set.json', 'r') as mock_id_set_f:
     MOCK_ID_SET = json.load(mock_id_set_f)
@@ -1222,7 +1222,7 @@ def test_is_documentation_only(files_string, expected_result):
     assert documentation_only == expected_result
 
 
-def test_get_from_version_and_to_version_bounderies_modified_metadata():
+def test_get_from_version_and_to_version_bounderies_modified_metadata(monkeypatch):
     """
     Given:
         - metadata file with serverMinVersion 6.1.0.
@@ -1233,20 +1233,22 @@ def test_get_from_version_and_to_version_bounderies_modified_metadata():
         - Check that the minimum version is 6.1.0
 
     """
-    all_modified_files_paths: set = set([])
+    all_modified_files_paths: set = set()
     pack_list = {'Pack1'}
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        with test_tools.ChangeCWD(temp_dir):
-            content = repo.Repo(Path(temp_dir))
-            pack1 = content.create_pack('Pack1')
-            pack1.pack_metadata.write_json({'serverMinVersion': '6.1.0', 'name': 'Pack1'})
+        monkeypatch.chdir(temp_dir)
+        pack = Path(temp_dir) / 'Packs' / 'Pack1' 
+        pack.mkdir(parents=True)
+        metadata = pack / 'pack_metadata.json'
+        with metadata.open('w+') as stream:
+            json.dump({'serverMinVersion': '6.1.0', 'name': 'Pack1'}, stream)
 
-            from_version, to_version = get_from_version_and_to_version_bounderies(
-                all_modified_files_paths,
-                {},
-                modified_packs=pack_list,
-            )
+        from_version, to_version = get_from_version_and_to_version_bounderies(
+            all_modified_files_paths,
+            {},
+            modified_packs=pack_list,
+        )
 
     assert '6.1.0' in from_version
     assert '99.99.99' in to_version

--- a/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
+++ b/Tests/scripts/infrastructure_tests/test_collect_tests_and_content_packs.py
@@ -1238,7 +1238,7 @@ def test_get_from_version_and_to_version_bounderies_modified_metadata(monkeypatc
 
     with tempfile.TemporaryDirectory() as temp_dir:
         monkeypatch.chdir(temp_dir)
-        pack = Path(temp_dir) / 'Packs' / 'Pack1' 
+        pack = Path(temp_dir) / 'Packs' / 'Pack1'
         pack.mkdir(parents=True)
         metadata = pack / 'pack_metadata.json'
         with metadata.open('w+') as stream:


### PR DESCRIPTION
replaced a use of a `demisto-sdk.TestSuite` with an equivalent function, as TestSuite will soon no longer be part of the SDK pack.