### PR TITLE
Return the whole object in mirror in

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -44,7 +44,7 @@ MIRROR_DIRECTION = {
     'Incoming And Outgoing': 'Both'
 }
 OUTGOING_MIRRORED_FIELDS = ['comment', 'status', 'owner', 'urgency']
-INCOMING_MIRRORED_FIELDS = ['comment', 'status', 'owner', 'urgency', 'status_label']
+# INCOMING_MIRRORED_FIELDS = ['comment', 'status', 'owner', 'urgency', 'status_label']
 
 # =========== Enrichment Mechanism Globals ===========
 ENABLED_ENRICHMENTS = params.get('enabled_enrichments', [])
@@ -1179,11 +1179,9 @@ def get_remote_data_command(service, args, close_incident):
 
     for item in results.ResultsReader(service.jobs.oneshot(search)):
         updated_notable = parse_notable(item, to_dict=True)
-    delta = {field: updated_notable.get(field) for field in INCOMING_MIRRORED_FIELDS if updated_notable.get(field)}
-
-    if delta:
-        demisto.debug('notable {} delta: {}'.format(notable_id, delta))
-        if delta.get('status') == '5' and close_incident:
+    if updated_notable:
+        demisto.debug('notable {} data: {}'.format(notable_id, updated_notable))
+        if updated_notable.get('status') == '5' and close_incident:
             demisto.info('Closing incident related to notable {}'.format(notable_id))
             entries = [{
                 'Type': EntryType.NOTE,
@@ -1198,7 +1196,7 @@ def get_remote_data_command(service, args, close_incident):
     else:
         demisto.debug('no delta was found for notable {}'.format(notable_id))
 
-    return_results(GetRemoteDataResponse(mirrored_object=delta, entries=entries))
+    return_results(GetRemoteDataResponse(mirrored_object=updated_notable, entries=entries))
 
 
 def get_modified_remote_data_command(service, args):

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -44,7 +44,6 @@ MIRROR_DIRECTION = {
     'Incoming And Outgoing': 'Both'
 }
 OUTGOING_MIRRORED_FIELDS = ['comment', 'status', 'owner', 'urgency']
-# INCOMING_MIRRORED_FIELDS = ['comment', 'status', 'owner', 'urgency', 'status_label']
 
 # =========== Enrichment Mechanism Globals ===========
 ENABLED_ENRICHMENTS = params.get('enabled_enrichments', [])
@@ -1179,22 +1178,19 @@ def get_remote_data_command(service, args, close_incident):
 
     for item in results.ResultsReader(service.jobs.oneshot(search)):
         updated_notable = parse_notable(item, to_dict=True)
-    if updated_notable:
-        demisto.debug('notable {} data: {}'.format(notable_id, updated_notable))
-        if updated_notable.get('status') == '5' and close_incident:
-            demisto.info('Closing incident related to notable {}'.format(notable_id))
-            entries = [{
-                'Type': EntryType.NOTE,
-                'Contents': {
-                    'dbotIncidentClose': True,
-                    'closeReason': 'Notable event was closed on Splunk.'
-                },
-                'ContentsFormat': EntryFormat.JSON
-            }]
+    demisto.debug('notable {} data: {}'.format(notable_id, updated_notable))
+    if updated_notable.get('status') == '5' and close_incident:
+        demisto.info('Closing incident related to notable {}'.format(notable_id))
+        entries = [{
+            'Type': EntryType.NOTE,
+            'Contents': {
+                'dbotIncidentClose': True,
+                'closeReason': 'Notable event was closed on Splunk.'
+            },
+            'ContentsFormat': EntryFormat.JSON
+        }]
 
-        demisto.debug('Updated notable {}'.format(notable_id))
-    else:
-        demisto.debug('no delta was found for notable {}'.format(notable_id))
+    demisto.debug('Updated notable {}'.format(notable_id))
 
     return_results(GetRemoteDataResponse(mirrored_object=updated_notable, entries=entries))
 

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -840,7 +840,7 @@ def test_get_remote_data_command(mocker):
     splunk.get_remote_data_command(Service(), args, close_incident=False)
     results = demisto.results.call_args[0][0]
     assert demisto.results.call_count == 1
-    assert results == [{'status': '1'}]
+    assert results == [{'event_id': 'id', 'status': '1'}]
 
 
 def test_get_remote_data_command_close_incident(mocker):
@@ -864,7 +864,7 @@ def test_get_remote_data_command_close_incident(mocker):
     results = demisto.results.call_args[0][0]
     assert demisto.results.call_count == 1
     assert results == [
-        {'status': '5'},
+        {'event_id': 'id', 'status': '5'},
         {
             'Type': EntryType.NOTE,
             'Contents': {

--- a/Packs/SplunkPy/ReleaseNotes/2_3_7.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_3_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where the incoming mirror object missed some data.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.3.6",
+    "currentVersion": "2.3.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/47523

## Description
in  mirror in iteration - currently we return only few fields from the updated notable 
this lead to a bug when classifier is based on a field that missed in the mirror in object 
the classifier will fail to classify the mirrored in object as the key are missed
