### PR TITLE
Autofocus fix

### DIFF
--- a/Packs/AutoFocus/Integrations/FeedAutofocus/FeedAutofocus.yml
+++ b/Packs/AutoFocus/Integrations/FeedAutofocus/FeedAutofocus.yml
@@ -11,7 +11,6 @@ configuration:
 - display: Indicator Feed
   name: indicator_feeds
   options:
-  - Daily Threat Feed
   - Custom Feed
   - Samples Feed
   required: true

--- a/Packs/AutoFocus/Integrations/FeedAutofocus/FeedAutofocus_description.md
+++ b/Packs/AutoFocus/Integrations/FeedAutofocus/FeedAutofocus_description.md
@@ -1,7 +1,7 @@
 ## AutoFocus Feed
 Gets Custom and Sample feeds from AutoFocus.
 
-**Note:** The `Daily Threat Feed` option is deprecated. Use the separate **AutoFocus Daily Feed** instead. 
+**Note:** The `Daily Threat Feed` option is deprecated. No available replacement.
 
 For more information see the [AutoFocus documentation](https://docs.paloaltonetworks.com/autofocus/autofocus-admin/autofocus-feeds.html).
 

--- a/Packs/AutoFocus/ReleaseNotes/2_0_15.md
+++ b/Packs/AutoFocus/ReleaseNotes/2_0_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AutoFocus Feed
+- The `Daily Threat Feed` option has been removed since it is deprecated.

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "2.0.14",
+    "currentVersion": "2.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://github.com/demisto/etc/issues/47834

## Description
- The `Daily Threat Feed` option has been removed since it is deprecated.
- Fixed the note in the detailed description regarding this option

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Documentation 
