### PR TITLE
Elasticsearch v2 incident timestamp fix

### DIFF
--- a/Packs/Elasticsearch/.pack-ignore
+++ b/Packs/Elasticsearch/.pack-ignore
@@ -1,2 +1,4 @@
 [file:Elasticsearch_v2.yml]
 ignore=IN126,BA108,BA109
+[known_words]
+Elasticsearch

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
@@ -578,6 +578,9 @@ def format_to_iso(date_string):
     Returns:
         str. A date string in the format: YYYY-MM-DDThh:mm:ssZ
     """
+    if '.' in date_string:
+        date_string = date_string.split('.')[0]
+
     if len(date_string) > 19 and not date_string.endswith('Z'):
         date_string = date_string[:-6]
 

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -30,7 +30,7 @@ ES_V6_RESPONSE = {
                 '_id': '123',
                 '_score': 1.3862944,
                 '_source': {
-                    'Date': '2019-08-29T14:45:00Z'
+                    'Date': '2019-08-29T14:45:00.123Z'
                 }
             }, {
                 '_index': 'users',
@@ -148,7 +148,7 @@ MOCK_ES6_SEARCH_CONTEXT = str({
             '_type': '_doc',
             '_id': '123',
             '_score': 1.3862944,
-            '_source': {'Date': '2019-08-29T14:45:00Z'}
+            '_source': {'Date': '2019-08-29T14:45:00.123Z'}
         },
         {
             '_index': 'users',
@@ -166,7 +166,7 @@ MOCK_ES6_HIT_CONTEXT = str([
         '_id': '123',
         '_type': '_doc',
         '_score': 1.3862944,
-        'Date': '2019-08-29T14:45:00Z'
+        'Date': '2019-08-29T14:45:00.123Z'
     },
     {
         '_index': 'users',
@@ -245,14 +245,14 @@ MOCK_ES6_INCIDETNS = str([
                    '"_type": "_doc", '
                    '"_id": "123", '
                    '"_score": 1.3862944, '
-                   '"_source": {"Date": "2019-08-29T14:45:00Z"}'
+                   '"_source": {"Date": "2019-08-29T14:45:00.123Z"}'
                    '}',
         'occurred': '2019-08-29T14:45:00Z',
         'labels':
             [
                 {
                     'type': 'Date',
-                    'value': '2019-08-29T14:45:00Z'
+                    'value': '2019-08-29T14:45:00.123Z'
                 }
             ]
     }, {
@@ -283,7 +283,7 @@ MOCK_ES6_INCIDETNS_WITHOUT_LABELS = str([
                    '"_type": "_doc", '
                    '"_id": "123", '
                    '"_score": 1.3862944, '
-                   '"_source": {"Date": "2019-08-29T14:45:00Z"}'
+                   '"_source": {"Date": "2019-08-29T14:45:00.123Z"}'
                    '}',
         'occurred': '2019-08-29T14:45:00Z',
     }, {

--- a/Packs/Elasticsearch/ReleaseNotes/1_2_8.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_2_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Elasticsearch v2
+- Fixed an issue where timestamp with milliseconds wasn't parsed properly in **fetch incidents**.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.2.7",
+    "currentVersion": "1.2.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/47854)

## Description
When the index is a date with a decimal ending ( e.g "2022-04-06T10:23:29.571Z"), the date is not parsed properly.
