### PR TITLE
carbon black integration netconn local ip remote ip fix

### DIFF
--- a/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
+++ b/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
@@ -1,4 +1,5 @@
 import dateparser
+import struct
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *  # noqa
@@ -68,6 +69,15 @@ class filemod_complete(ProcessEventDetail):
             entry['file_type'] = self.FILE_TYPE.get(entry.get('file_type', ''), '')
         return self.fields
 
+class netconn_complete():
+    def __init__(self, fields):
+        self.fields = fields
+
+    def format(self):
+        for entry in self.fields:
+            entry['remote_ip'] = socket.inet_ntoa(struct.pack('>i', entry['remote_ip']))
+            entry['local_ip'] = socket.inet_ntoa(struct.pack('>i', entry['local_ip']))
+        return self.fields
 
 class modload_complete(ProcessEventDetail):
     FIELDS = ['event_time', 'loaded_module_md5', 'loaded_module_full_path']
@@ -229,7 +239,8 @@ class Client(BaseClient):
 
     def get_formatted_ProcessEventDetail(self, process_json: dict):
         complex_fields = {'filemod_complete': filemod_complete, 'modload_complete': modload_complete,
-                          'regmod_complete': regmod_complete, 'crossproc_complete': crossproc_complete}
+                          'regmod_complete': regmod_complete, 'crossproc_complete': crossproc_complete
+                          'netconn_complete':netconn_complete}
         formatted_json = {}
         for field in process_json:
             if field in complex_fields:

--- a/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
+++ b/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
@@ -239,7 +239,7 @@ class Client(BaseClient):
 
     def get_formatted_ProcessEventDetail(self, process_json: dict):
         complex_fields = {'filemod_complete': filemod_complete, 'modload_complete': modload_complete,
-                          'regmod_complete': regmod_complete, 'crossproc_complete': crossproc_complete
+                          'regmod_complete': regmod_complete, 'crossproc_complete': crossproc_complete,
                           'netconn_complete':netconn_complete}
         formatted_json = {}
         for field in process_json:

--- a/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
+++ b/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
@@ -75,8 +75,10 @@ class netconn_complete():
 
     def format(self):
         for entry in self.fields:
-            entry['remote_ip'] = socket.inet_ntoa(struct.pack('>i', entry['remote_ip']))
-            entry['local_ip'] = socket.inet_ntoa(struct.pack('>i', entry['local_ip']))
+            # to avoid ff:00 like entries
+            if isinstance(entry['remote_ip'], int) and isinstance(entry['local_ip'], int):
+                entry['remote_ip'] = socket.inet_ntoa(struct.pack('>i', entry['remote_ip']))
+                entry['local_ip'] = socket.inet_ntoa(struct.pack('>i', entry['local_ip']))
         return self.fields
 
 class modload_complete(ProcessEventDetail):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[netconn_complete response](https://developer.carbonblack.com/reference/enterprise-response/6.3/rest-api/#netconn_complete)

## Description
There are two different formats for netconn_complete. The v1 API returns an array of pipe delimited strings:

"2013-09-16 07:11:59.000000|-1979811809|80|6|dl.javafx.com|true"

    field 0: event time
    field 1: remote IP address as a 32-bit signed long (host byte order)
    field 2: remote port
    field 3: protocol: 6 is TCP, 17 is UDP
    field 4: domain name associated with the IP address, from the client’s perspective at the time of the network connection
    field 5: boolean “true” if the connection was outbound; “false” if the connection was inbound

The v2 API and newer return an array of JSON objects:

[{"domain": "login.live.com",
  "proto": 6,
  "local_port": 49240,
  "timestamp": "2017-01-11T16:20:04.892Z",
  "local_ip": 167772448,
  "direction": "true",
  "remote_port": 80,
  "remote_ip": -2080555708},
  ...
]

Since the request is made to v3 there is no parser implemented for netconn_complete. The caveat to this however is that IPs are in integer format. With this commit IPs now look the way they are supposed to

## Screenshots
After the change
![image](https://user-images.githubusercontent.com/49711791/162949864-6f103e57-9c0a-4bbe-89c9-7b7c79180844.png)
the screenshot is clipped as it contains sensitive information


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
