### PR TITLE
Modified the function get_lists to get extended information

### DIFF
--- a/Packs/McAfeeWebGateway/Integrations/McAfeeWebGateway/McAfeeWebGateway.js
+++ b/Packs/McAfeeWebGateway/Integrations/McAfeeWebGateway/McAfeeWebGateway.js
@@ -141,7 +141,7 @@ function get_lists() {
         logout();
     }
 
-    lists = JSON.parse(x2j(res));
+    var lists = JSON.parse(x2j(res));
     list_names = [];
     
     for (var i in lists.feed.entry) {

--- a/Packs/McAfeeWebGateway/Integrations/McAfeeWebGateway/McAfeeWebGateway.js
+++ b/Packs/McAfeeWebGateway/Integrations/McAfeeWebGateway/McAfeeWebGateway.js
@@ -12,7 +12,13 @@ function sendRequest(method, url_suffix, headers, body) {
         headers.Accept = ['application/mwg+xml'];
     }
     if (!("Content-Type" in headers)) {
-        headers['Content-Type'] = ['application/mwg+xml'];
+        if (url_suffix == "/list") {
+            // If we set the content to XML we get full information of the lists.
+            headers.Accept = ['application/xml'];
+            headers['Content-Type'] = ['application/xml'];
+        } else {
+            headers['Content-Type'] = ['application/mwg+xml'];
+        }
     }
     headers.Cookie = ['JSESSIONID=' + session_id];
 
@@ -135,15 +141,15 @@ function get_lists() {
         logout();
     }
 
-    res = res.split('\n');
+    lists = JSON.parse(x2j(res));
     list_names = [];
-    for (var i in res) {
-        if (res[i]) {
+    
+    for (var i in lists.feed.entry) {
             list_names.push({
                 Index : i,
-                Name : res[i]
+                Name : lists.feed.entry[i].title,
+                McAfeeID: lists.feed.entry[i].id
             });
-        }
     }
 
     return createEntry(list_names, {
@@ -151,7 +157,8 @@ function get_lists() {
         title : 'All available lists',
         data : [
             {to : 'Index', from : 'Index'},
-            {to : 'Name', from : 'Name'}
+            {to : 'Name', from : 'Name'},
+            {to : 'McAfeeId', from: 'McAfeeId' }
         ],
     });
 }

--- a/Packs/McAfeeWebGateway/ReleaseNotes/1_0_2.md
+++ b/Packs/McAfeeWebGateway/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### McAfee Web Gateway
+- Changed the get_lists function to retrieve the name and the internal ID of the lists.

--- a/Packs/McAfeeWebGateway/pack_metadata.json
+++ b/Packs/McAfeeWebGateway/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "McAfee Web Gateway",
     "description": "Blacklist/Whitelist handling",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
With this change, the command mwg-get-available-lists now shows the internal McAfee ID and also the Name assigned to the List. 
This is very useful when trying to get a specific list ID when you only know the referenced name.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: Nothing 

## Description
With this change, the command mwg-get-available-lists now shows the internal McAfee ID and also the Name assigned to the List. 
This is very useful when trying to get a specific list ID when you only know the referenced name.

## Screenshots
Paste here any images that will help the reviewer

![image](https://user-images.githubusercontent.com/590758/163388500-4d8dc286-0e86-4dcd-bdc4-8a1f46fb0651.png)


## Minimum version of Cortex XSOAR
- [x ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ x] No

## Must have
- [ ] Tests
- [ ] Documentation 
