### PR TITLE
add parameter to parse SQS body as json

### DIFF
--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
@@ -140,14 +140,19 @@ def purge_queue(args, client):
         return raise_error(e)
 
 
-def parse_incident_from_finding(message):
+def parse_incident_from_finding(message, parse_body_as_json=False):
     incident = {}
     incident['name'] = "SQS MessageId: " + message["MessageId"]
+    if parse_body_as_json:
+        try:
+            message["Body"] = json.loads(message["Body"])
+        except json.JSONDecodeError:
+            pass
     incident['rawJSON'] = json.dumps(message)
     return incident
 
 
-def fetch_incidents(aws_client, aws_queue_url, max_fetch):
+def fetch_incidents(aws_client, aws_queue_url, max_fetch, parse_body_as_json):
     try:
         client = aws_client.aws_session(service='sqs')
         receipt_handles = []  # type: list
@@ -171,7 +176,7 @@ def fetch_incidents(aws_client, aws_queue_url, max_fetch):
 
             for message in messages["Messages"]:
                 receipt_handles.append(message['ReceiptHandle'])
-                incidents.append(parse_incident_from_finding(message))
+                incidents.append(parse_incident_from_finding(message, parse_body_as_json))
                 if len(incidents) == max_fetch:
                     break
 
@@ -208,6 +213,7 @@ def main():
     retries = params.get('retries') or 5
     aws_queue_url = params.get('queueUrl')
     max_fetch = min(params.get('max_fetch', 10), 100)
+    parse_body_as_json = params.get('parse_body_as_json', False)
 
     commands = {
         'aws-sqs-get-queue-url': get_queue_url,
@@ -230,7 +236,7 @@ def main():
         if command == 'test-module':
             return_results(test_function(aws_client))
         elif demisto.command() == 'fetch-incidents':
-            fetch_incidents(aws_client, aws_queue_url, max_fetch)
+            fetch_incidents(aws_client, aws_queue_url, max_fetch, parse_body_as_json)
             sys.exit(0)
         elif command in commands:
             client = aws_client.aws_session(

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
@@ -146,7 +146,7 @@ def parse_incident_from_finding(message, parse_body_as_json=False):
     if parse_body_as_json:
         try:
             message["Body"] = json.loads(message["Body"])
-        except json.JSONDecodeError:
+        except json.decoder.JSONDecodeError:
             pass
     incident['rawJSON'] = json.dumps(message)
     return incident

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.py
@@ -146,7 +146,7 @@ def parse_incident_from_finding(message, parse_body_as_json=False):
     if parse_body_as_json:
         try:
             message["Body"] = json.loads(message["Body"])
-        except json.decoder.JSONDecodeError:
+        except Exception:
             pass
     incident['rawJSON'] = json.dumps(message)
     return incident

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
@@ -83,6 +83,10 @@ configuration:
   name: insecure
   required: false
   type: 8
+- display: Parse SQS message body as a JSON string
+  name: parse_body_as_string
+  required: false
+  type: 8
 script:
   script: ''
   type: python

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/README.md
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/README.md
@@ -11,7 +11,7 @@ For detailed instructions about setting up authentication, see: [AWS Integration
 3. Click **Add instance** to create and configure a new integration instance.
 
     | **Parameter** | **Description** | **Required** |
-    | --- |--------------| --- |
+    | --- | --- | --- |
     | defaultRegion | AWS Default Region | False        |
     | roleArn | Role Arn Role Arn | False        |
     | roleSessionName | Role Session Name | False        |

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/README.md
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/README.md
@@ -11,24 +11,25 @@ For detailed instructions about setting up authentication, see: [AWS Integration
 3. Click **Add instance** to create and configure a new integration instance.
 
     | **Parameter** | **Description** | **Required** |
-    | --- | --- | --- |
-    | defaultRegion | AWS Default Region | False |
-    | roleArn | Role Arn Role Arn | False |
-    | roleSessionName | Role Session Name | False |
-    | access_key | Access Key | False |
-    | secret_key | Secret Key | False |
-    | Role Session Duration |  | False |
-    | queueUrl | QueueURL | False |
-    | timeout | The time in seconds till a timeout exception is reached. You can specify just the read timeout (for example 60) or also the connect timeout followed after a comma (for example 60,10). If a connect timeout is not specified a default of 10 second will be used. | False |
-    | retries | T"The maximum number of retry attempts when connection or throttling errors are encountered. Set to 0 to disable retries. The default value is 5 and the limit is 10. Note: Increasing the number of retries will increase the execution time." More details about the retries strategy is available [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html). | False |
-    | Fetch incidents |  | False |
-    | max_fetch | Maximum incidents for one fetch | 10 |
-    | First fetch timestamp (&lt;number&gt; &lt;time unit&gt;, e.g., 12 hours, 7 days) |  | False |
-    | Incident type |  | False |
-    | Use system proxy settings |  | False |
-    | Trust any certificate (not secure) |  | False |
+    | --- |--------------| --- |
+    | defaultRegion | AWS Default Region | False        |
+    | roleArn | Role Arn Role Arn | False        |
+    | roleSessionName | Role Session Name | False        |
+    | access_key | Access Key | False        |
+    | secret_key | Secret Key | False        |
+    | Role Session Duration |  | False        |
+    | queueUrl | QueueURL | False        |
+    | timeout | The time in seconds till a timeout exception is reached. You can specify just the read timeout (for example 60) or also the connect timeout followed after a comma (for example 60,10). If a connect timeout is not specified a default of 10 second will be used. | False        |
+    | retries | T"The maximum number of retry attempts when connection or throttling errors are encountered. Set to 0 to disable retries. The default value is 5 and the limit is 10. Note: Increasing the number of retries will increase the execution time." More details about the retries strategy is available [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html). | False        |
+    | Fetch incidents |  | False        |
+    | max_fetch | Maximum incidents for one fetch | 10           |
+    | First fetch timestamp (&lt;number&gt; &lt;time unit&gt;, e.g., 12 hours, 7 days) |  | False        |
+    | Incident type |  | False        |
+    | Use system proxy settings |  | False        |
+    | Trust any certificate (not secure) |  | False        |
+    | parse_body_as_json | Parse SQS message body as a JSON string | False |
 
-6. Click **Test** to validate the URLs, token, and connection.
+4. Click **Test** to validate the URLs, token, and connection.
 
 ### There are three options to sign in to the service:
 1. Provide access key id and secret key id.

--- a/Packs/AWS-SQS/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_6.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### AWS - SQS
+- Add new parameter that will parse the SQS message `Body` field as JSON before creating the incident. 

--- a/Packs/AWS-SQS/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_6.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### AWS - SQS
-- Add new parameter that will parse the SQS message `Body` field as JSON before creating the incident. 
+- Add the *Parse SQS message body as a JSON string* parameter that will parse the SQS message **Body** field as JSON before creating the incident. 

--- a/Packs/AWS-SQS/pack_metadata.json
+++ b/Packs/AWS-SQS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - SQS",
     "description": "Amazon Web Services Simple Queuing Service (SQS)",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This adds a new parameter `parse_body_as_json` to the fetch incidents routine. When marked as `True` it will parse the `Body` field of the retrieved SQS message as a JSON string and convert it to a Python dictionary. When the message is then converted back to a JSON string and put into the `incident["rawJSON"]` field the message body will not be double-encoded. This will allow any mapper associated with the integration to not need to use a transform in order to parse the `Body` string.

Since not all SQS message `Body` values are JSON strings this parameter is left as optional, `False` by default, and wrapped in a `try/except` block that will return the `Body` field as-is to the incident.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
