### PR TITLE
Added 2 new fields to ContextData of get_script_execution_results_command

### DIFF
--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.py
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.py
@@ -2721,6 +2721,29 @@ def get_script_execution_status_command(client: Client, args: Dict) -> List[Comm
     return command_results
 
 
+def parse_get_script_execution_results(results: List[Dict]) -> List[Dict]:
+    parsed_results = []
+    api_keys = ['endpoint_name',
+                'endpoint_ip_address',
+                'endpoint_status',
+                'domain',
+                'endpoint_id',
+                'execution_status',
+                'return_value',
+                'standard_output',
+                'retrieved_files',
+                'failed_files',
+                'retention_date']
+    for result in results:
+        result_keys = result.keys()
+        difference_keys = list(set(result_keys) - set(api_keys))
+        for key in difference_keys:
+            parsed_results.append(result.copy())
+            parsed_results[-1]['command'] = key
+            parsed_results[-1]['command_output'] = result[key]
+    return parsed_results
+
+
 def get_script_execution_results_command(client: Client, args: Dict) -> List[CommandResults]:
     action_ids = argToList(args.get('action_id', ''))
     command_results = []
@@ -2729,7 +2752,7 @@ def get_script_execution_results_command(client: Client, args: Dict) -> List[Com
         results = response.get('reply', {}).get('results')
         context = {
             'action_id': int(action_id),
-            'results': results,
+            'results': parse_get_script_execution_results(results),
         }
         command_results.append(CommandResults(
             readable_output=tableToMarkdown(f'Script Execution Results - {action_id}', results),

--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR_test.py
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR_test.py
@@ -2540,3 +2540,18 @@ def test_get_dynamic_analysis(requests_mock):
     response = get_dynamic_analysis_command(client, args)
     dynamic_analysis = response.outputs[0]
     assert dynamic_analysis.get('causalityId') == 'AAA'
+
+
+def test_parse_get_script_execution_results():
+    from CortexCoreIR import parse_get_script_execution_results
+    results = [{'endpoint_name': 'endpoint_name', 'endpoint_ip_address': ['1.1.1.1'], 'endpoint_status': 'endpoint_status',
+                'domain': 'env', 'endpoint_id': 'endpoint_id', 'execution_status': 'COMPLETED_SUCCESSFULLY',
+                'standard_output': 'Running command "command_executed"', 'retrieved_files': 0, 'failed_files': 0,
+                'retention_date': None, 'command_executed': ['command_output']}]
+    res = parse_get_script_execution_results(results)
+    expected_res = [{'endpoint_name': 'endpoint_name', 'endpoint_ip_address': ['1.1.1.1'], 'endpoint_status': 'endpoint_status',
+                     'domain': 'env', 'endpoint_id': 'endpoint_id', 'execution_status': 'COMPLETED_SUCCESSFULLY',
+                     'standard_output': 'Running command "command_executed"', 'retrieved_files': 0, 'failed_files': 0,
+                     'retention_date': None, 'command_executed': ['command_output'], 'command': 'command_executed',
+                     'command_output': ['command_output']}]
+    assert res == expected_res


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://github.com/demisto/etc/issues/48013

## Description
Added 'command' and 'command_outputs' fields to the context data of 'core-get-script-execution-results'.

## Screenshots
<img width="528" alt="image" src="https://user-images.githubusercontent.com/89336697/163836151-0d9e7e0e-9924-43e8-bf74-ad0312c951b5.png">

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
