### PR TITLE
Improve xsiam build - Run xsiam flow only when tests were found. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@
 .gitlab/ci/* @esharf
 .gitlab/* @esharf
 .gitlab-ci.yml @esharf
+/Tests/scripts/wait_in_line_for_xsiam_env.sh @daryakoval
 
 # SDK Related
 .gitlab/ci/sdk-nightly.yml @dorschw

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -328,7 +328,8 @@ slack-notify-nightly-build:
     - exit $EXIT_CODE
   after_script:
     - |
-      if ! [ -z "$XSIAM_CHOSEN_MACHINE_ID" ] then
+      if ! [ -z "$XSIAM_CHOSEN_MACHINE_ID" ]
+      then
         echo "Job finished, removing lock file"
         gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY" > auth.out 2>&1
         gsutil rm "gs://xsoar-ci-artifacts/content-locks-xsiam/*-lock-$CI_JOB_ID"

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -286,7 +286,7 @@ slack-notify-nightly-build:
     - EXIT_CODE=0
     - !reference [.download-demisto-conf]
 
-    - section_start "Are there tests to run?"
+    - section_start "Are there tests to run?" --collapsed
     - |
       if ! [[ -s $ARTIFACTS_FOLDER/content_packs_to_install.txt || -s $ARTIFACTS_FOLDER/filter_file.txt ]]; then
         # The files are empty.
@@ -295,7 +295,7 @@ slack-notify-nightly-build:
       fi
     - section_end "Are there tests to run?"
 
-    - section_start "Lock XSIAM Machine"
+    - section_start "Lock XSIAM Machine" --collapsed
     - cp "$ARTIFACTS_FOLDER/filter_file.txt" "./artifacts/filter_file.txt"
     - echo "Authenticating GCP"
     - gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY" > auth.out 2>&1
@@ -305,7 +305,7 @@ slack-notify-nightly-build:
     - echo "XSIAM chosen_machine_id is $XSIAM_CHOSEN_MACHINE_ID"
     - section_end "Lock XSIAM Machine"
 
-    - section_start "Clean XSIAM Machine"
+    - section_start "Clean XSIAM Machine" --collapsed
     - ./Tests/scripts/uninstall_packs_and_reset_bucket_xsiam.sh
     - section_end "Clean XSIAM Machine"
 
@@ -325,8 +325,8 @@ slack-notify-nightly-build:
         cp ./Tests/succeeded_tests.txt $ARTIFACTS_FOLDER/succeeded_tests.txt
       fi
     - section_end "Run Tests"
-    - exit $EXIT_CODE
-  after_script:
+
+    - section_start "After script" --collapsed
     - |
       if ! [ -z "$XSIAM_CHOSEN_MACHINE_ID" ]
       then
@@ -335,6 +335,8 @@ slack-notify-nightly-build:
         gsutil rm "gs://xsoar-ci-artifacts/content-locks-xsiam/*-lock-$CI_JOB_ID"
         echo "Finished removing lock file"
       fi
+    - section_end "After script"
+    - exit $EXIT_CODE
 
 
 xsiam_server_master:

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -286,6 +286,10 @@ slack-notify-nightly-build:
     - EXIT_CODE=0
     - !reference [.download-demisto-conf]
 
+    - section_start "Are there tests to run?"
+    -
+    - section_end "Are there tests to run?"
+
     - section_start "Lock XSIAM Machine"
     - cp "$ARTIFACTS_FOLDER/filter_file.txt" "./artifacts/filter_file.txt"
     - echo "Authenticating GCP"

--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -287,7 +287,12 @@ slack-notify-nightly-build:
     - !reference [.download-demisto-conf]
 
     - section_start "Are there tests to run?"
-    -
+    - |
+      if ! [[ -s $ARTIFACTS_FOLDER/content_packs_to_install.txt || -s $ARTIFACTS_FOLDER/filter_file.txt ]]; then
+        # The files are empty.
+        echo "Not running XSIAM instance flow, no tests to run were found."
+        exit $EXIT_CODE
+      fi
     - section_end "Are there tests to run?"
 
     - section_start "Lock XSIAM Machine"
@@ -322,10 +327,13 @@ slack-notify-nightly-build:
     - section_end "Run Tests"
     - exit $EXIT_CODE
   after_script:
-    - echo "Job finished, removing lock file"
-    - gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY" > auth.out 2>&1
-    - gsutil rm "gs://xsoar-ci-artifacts/content-locks-xsiam/*-lock-$CI_JOB_ID"
-    - echo "Finished removing lock file"
+    - |
+      if ! [ -z "$XSIAM_CHOSEN_MACHINE_ID" ] then
+        echo "Job finished, removing lock file"
+        gcloud auth activate-service-account --key-file="$GCS_ARTIFACTS_KEY" > auth.out 2>&1
+        gsutil rm "gs://xsoar-ci-artifacts/content-locks-xsiam/*-lock-$CI_JOB_ID"
+        echo "Finished removing lock file"
+      fi
 
 
 xsiam_server_master:


### PR DESCRIPTION
Improve xsiam build:
- Run xsiam flow only when tests were found. 
- Run after script only if xsiam machine was locked.