### PR TITLE
Add ERROR to indicate file was changed

### DIFF
--- a/Tests/scripts/is_file_up_to_date.sh
+++ b/Tests/scripts/is_file_up_to_date.sh
@@ -3,10 +3,10 @@ FILE_TO_CHECK=$1
 BRANCH=$2
 
 # Checks if there's any diff from master
-if [[ `git diff origin/master -- ${FILE_TO_CHECK}` ]]; then
+if [[ $(git diff origin/master -- ${FILE_TO_CHECK}) ]]; then
     # Checks if part of the branch's changes
-    if [[ -z `git diff origin/master..."$BRANCH" --name-only -- ${FILE_TO_CHECK}` ]]; then
-        echo "${FILE_TO_CHECK} has been changed. Merge from master"
+    if [[ -z $(git diff origin/master..."$BRANCH" --name-only -- ${FILE_TO_CHECK}) ]]; then
+        echo "ERROR: ${FILE_TO_CHECK} has been changed. Merge from master"
         if [[ $BRANCH =~ pull/[0-9]+ ]]; then
           echo "Run ./Utils/git_pull_master_into_fork.sh or merge manually from upstream demisto content"
         fi


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
As discussed in [this thread](https://panw-global.slack.com/archives/G011E63JXPB/p1651054031148029?thread_ts=1650878743.581249&cid=G011E63JXPB), we need a better indication that there's an error in the build when a file has changed and needs to be updated.

Removed backticks and replaced with `$(...)` as backticks are deprecated in `bash`. See http://mywiki.wooledge.org/BashFAQ/082.

## Screenshots
![image](https://user-images.githubusercontent.com/85439776/165546634-5779a977-1755-4c3e-9d81-d6f0de28a8a9.png)

