### PR TITLE
Visibility fix

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -42,7 +42,7 @@ RELATIONSHIP_TYPE = {
 
 
 class Client:
-    def __init__(self, api_key='', scan_visibility='public', threshold=None, use_ssl=False, reliability=DBotScoreReliability.C):
+    def __init__(self, api_key='', scan_visibility=None, threshold=None, use_ssl=False, reliability=DBotScoreReliability.C):
         self.base_url = 'https://urlscan.io/api/v1/'
         self.api_key = api_key
         self.threshold = threshold

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -143,7 +143,6 @@ script:
       required: false
       secret: false
     - auto: PREDEFINED
-      defaultValue: 'public'
       description: The submission visibility. If specified, overrides the 'public' parameter.
       predefined:
         - public
@@ -267,7 +266,6 @@ script:
       required: true
       secret: false
     - auto: PREDEFINED
-      defaultValue: 'public'
       description: The submission visibility. If specified, overrides the 'public' parameter.
       predefined:
         - public

--- a/Packs/UrlScan/ReleaseNotes/1_1_20.md
+++ b/Packs/UrlScan/ReleaseNotes/1_1_20.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Fix the *scan_visibility* argument to the ***url*** and ***urlscan-submit*** commands. This argument previously defaulted to `public`, overriding any other visibility settings by default, including the integration-wide *scan_visibility* parameter. It is now left empty by default, thus properly respecting other arguments, parameters, and service provider-side settings related to visibility.

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.1.19",
+    "currentVersion": "1.1.20",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
In v1.1.17, the *scan_visibility* argument was introduced for the ***url*** and ***urlscan-submit*** commands, alongside an integration-wide *scan_visibility* parameter. The argument for the two commands had been configured to have a default value of `public`, and this argument overrides all other settings related to visibility. This meant that all other visibility settings (such as the *public* argument, the *is_public* integration parameter, and the urlscan.io service provider-side default visibility setting) were implicitly rendered ineffectual. Consequently, for all command invocations that did not explicitly provide a value for this newly introduced argument, all scans have since been executed with visibility `public`.

This change removes the default values for these new arguments, restoring expected behavior in existing deployments.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
