### PR TITLE
Fix newline in input name O365AllowNotFoundExchangeLocations

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Search_And_Delete_Emails_-_Generic_-_v2.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Search_And_Delete_Emails_-_Generic_-_v2.yml
@@ -760,8 +760,7 @@ inputs:
   required: false
   description: Used only in O365. Description of the compliance search.
   playbookInputQuery:
-- key: |
-    O365AllowNotFoundExchangeLocations
+- key: O365AllowNotFoundExchangeLocations
   value:
     simple: "false"
   required: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Remove newline from playbook input name **O365AllowNotFoundExchangeLocations**. The extra newline in the input name caused the playbook to not work as expected.

## Screenshots
Playbook input before change:

<img width="625" alt="Screen Shot 2022-04-29 at 7 45 02 PM" src="https://user-images.githubusercontent.com/91506078/166085783-3485c985-ae8c-443e-ab78-af8adfc2de34.png">

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
