### PR TITLE
Added AppendindicatorFieldWrapper script

### DIFF
--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.py
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.py
@@ -1,14 +1,6 @@
-"""Base Script for Cortex XSOAR (aka Demisto)
-
-This is an empty script with some basic structure according
-to the code conventions.
-
-MAKE SURE YOU REVIEW/REPLACE ALL THE COMMENTS MARKED AS "TODO"
-
-Developer Documentation: https://xsoar.pan.dev/docs/welcome
-Code Conventions: https://xsoar.pan.dev/docs/integrations/code-conventions
-Linting: https://xsoar.pan.dev/docs/integrations/linting
-
+"""
+A wrapper script to the 'AppendindicatorField' script, that enables adding tags to certain indicators.
+Note: You can use this script as a layout button that allows adding tags to indicators.
 """
 
 import demistomock as demisto
@@ -19,44 +11,48 @@ from typing import Dict, Any
 import traceback
 
 
-''' STANDALONE FUNCTION '''
-
-
-# TODO: REMOVE the following dummy function:
-def basescript_dummy(dummy: str) -> Dict[str, str]:
-    """Returns a simple python dict with the information provided
-    in the input (dummy).
-
-    :type dummy: ``str``
-    :param dummy: string to add in the dummy dict that is returned
-
-    :return: dict as {"dummy": dummy}
-    :rtype: ``str``
-    """
-
-    return {"dummy": dummy}
-# TODO: ADD HERE THE FUNCTIONS TO INTERACT WITH YOUR PRODUCT API
-
-
 ''' COMMAND FUNCTION '''
 
 
-# TODO: REMOVE the following dummy command function
-def basescript_dummy_command(args: Dict[str, Any]) -> CommandResults:
+def run_append_indicator_field_script(args: Dict[str, Any]) -> CommandResults:
+    """
+    Run the 'appendIndicatorField' script in order to add the given tags to the given indicators.
+    Args:
+        args: demisto args object containing the following arguments:
+              - indicators_values: The values of the indicators. For example, for an IP indicator, 1.1.1.1.
+              - tags: The values to add to the indicators tags.
 
-    dummy = args.get('dummy', None)
-    if not dummy:
-        raise ValueError('dummy not specified')
+    Returns: A CommandResults object contains the readable output string.
 
-    # Call the standalone function and get the raw response
-    result = basescript_dummy(dummy)
+    """
+    indicators_values = argToList(args.get('indicators_values'))
+    tags = argToList(args.get('tags'))
+
+    # Handle missing arguments:
+    err_msg_prefix = 'Failed to execute AppendindicatorFieldWrapper. Error:'
+    if not indicators_values:
+        err_msg = f'{err_msg_prefix} Indicators values were not specified.'
+        demisto.error(err_msg)
+        readable_output = err_msg
+
+    elif not tags:
+        err_msg = f'{err_msg_prefix} Tags were not specified.'
+        demisto.error(err_msg)
+        readable_output = err_msg
+
+    else:
+        # Run 'appendIndicatorField' script:
+        execute_command('appendIndicatorField',
+                        {'indicatorsValues': indicators_values, 'field': 'tags', 'fieldValue': tags})
+
+        readable_output = tableToMarkdown('The following tags were added successfully:',
+                                          [{'Indicator': indicator, 'Tags': tags} for indicator in indicators_values])
 
     return CommandResults(
         outputs_prefix='AppendindicatorFieldWrapper',
         outputs_key_field='',
-        outputs=result,
+        readable_output=readable_output
     )
-# TODO: ADD additional command functions that translate XSOAR inputs/outputs
 
 
 ''' MAIN FUNCTION '''
@@ -64,8 +60,8 @@ def basescript_dummy_command(args: Dict[str, Any]) -> CommandResults:
 
 def main():
     try:
-        # TODO: replace the invoked command function with yours
-        return_results(basescript_dummy_command(demisto.args()))
+        return_results(run_append_indicator_field_script(demisto.args()))
+
     except Exception as ex:
         demisto.error(traceback.format_exc())  # print the traceback
         return_error(f'Failed to execute AppendindicatorFieldWrapper. Error: {str(ex)}')

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.py
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.py
@@ -1,0 +1,78 @@
+"""Base Script for Cortex XSOAR (aka Demisto)
+
+This is an empty script with some basic structure according
+to the code conventions.
+
+MAKE SURE YOU REVIEW/REPLACE ALL THE COMMENTS MARKED AS "TODO"
+
+Developer Documentation: https://xsoar.pan.dev/docs/welcome
+Code Conventions: https://xsoar.pan.dev/docs/integrations/code-conventions
+Linting: https://xsoar.pan.dev/docs/integrations/linting
+
+"""
+
+import demistomock as demisto
+from CommonServerPython import *
+from CommonServerUserPython import *
+
+from typing import Dict, Any
+import traceback
+
+
+''' STANDALONE FUNCTION '''
+
+
+# TODO: REMOVE the following dummy function:
+def basescript_dummy(dummy: str) -> Dict[str, str]:
+    """Returns a simple python dict with the information provided
+    in the input (dummy).
+
+    :type dummy: ``str``
+    :param dummy: string to add in the dummy dict that is returned
+
+    :return: dict as {"dummy": dummy}
+    :rtype: ``str``
+    """
+
+    return {"dummy": dummy}
+# TODO: ADD HERE THE FUNCTIONS TO INTERACT WITH YOUR PRODUCT API
+
+
+''' COMMAND FUNCTION '''
+
+
+# TODO: REMOVE the following dummy command function
+def basescript_dummy_command(args: Dict[str, Any]) -> CommandResults:
+
+    dummy = args.get('dummy', None)
+    if not dummy:
+        raise ValueError('dummy not specified')
+
+    # Call the standalone function and get the raw response
+    result = basescript_dummy(dummy)
+
+    return CommandResults(
+        outputs_prefix='AppendindicatorFieldWrapper',
+        outputs_key_field='',
+        outputs=result,
+    )
+# TODO: ADD additional command functions that translate XSOAR inputs/outputs
+
+
+''' MAIN FUNCTION '''
+
+
+def main():
+    try:
+        # TODO: replace the invoked command function with yours
+        return_results(basescript_dummy_command(demisto.args()))
+    except Exception as ex:
+        demisto.error(traceback.format_exc())  # print the traceback
+        return_error(f'Failed to execute AppendindicatorFieldWrapper. Error: {str(ex)}')
+
+
+''' ENTRY POINT '''
+
+
+if __name__ in ('__main__', '__builtin__', 'builtins'):
+    main()

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.yml
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.yml
@@ -1,0 +1,28 @@
+args:
+- default: false
+  description: '[Enter a description of the argument, including any important information
+    users need to know, for example, default values.]'
+  isArray: false
+  name: dummy
+  required: true
+  secret: false
+comment: '[Enter a description of the script, including what function it performs
+  and any important information users need to know, for example required permissions.]'
+commonfields:
+  id: AppendindicatorFieldWrapper
+  version: -1
+enabled: false
+name: AppendindicatorFieldWrapper
+outputs:
+- contextPath: BaseScript.Output
+  description: '[Enter a description of the data returned in this output.]'
+  type: String
+script: '-'
+system: false
+tags:
+- basescript
+timeout: '0'
+type: python
+subtype: python3
+dockerimage: demisto/python3:3.9.7.24076
+fromversion: 6.5.0

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.yml
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper.yml
@@ -1,28 +1,32 @@
 args:
 - default: false
-  description: '[Enter a description of the argument, including any important information
-    users need to know, for example, default values.]'
-  isArray: false
-  name: dummy
+  description: A comma-separated list of indicators values. For example, for IP indicators,
+    "1.1.1.1,2.2.2.2".
+  isArray: true
+  name: indicators_values
   required: true
   secret: false
-comment: '[Enter a description of the script, including what function it performs
-  and any important information users need to know, for example required permissions.]'
+- default: false
+  description: A comma-separated list of tags to add to the indicators. For example,
+    "tag1,tag2,tag3".
+  isArray: true
+  name: tags
+  required: true
+  secret: false
+comment: "A wrapper script to the 'AppendindicatorField' script, that enables adding\
+  \ tags to certain indicators.\nNote: You can use this script as a layout button\
+  \ that allows adding tags to indicators. "
 commonfields:
   id: AppendindicatorFieldWrapper
   version: -1
 enabled: false
 name: AppendindicatorFieldWrapper
-outputs:
-- contextPath: BaseScript.Output
-  description: '[Enter a description of the data returned in this output.]'
-  type: String
 script: '-'
+subtype: python3
 system: false
 tags:
 - basescript
 timeout: '0'
 type: python
-subtype: python3
 dockerimage: demisto/python3:3.9.7.24076
-fromversion: 6.5.0
+fromversion: 6.2.0

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper_test.py
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper_test.py
@@ -1,0 +1,39 @@
+"""Base Script for Cortex XSOAR - Unit Tests file
+
+Pytest Unit Tests: all funcion names must start with "test_"
+
+More details: https://xsoar.pan.dev/docs/integrations/unit-testing
+
+MAKE SURE YOU REVIEW/REPLACE ALL THE COMMENTS MARKED AS "TODO"
+
+"""
+
+import json
+import io
+
+
+def util_load_json(path):
+    with io.open(path, mode='r', encoding='utf-8') as f:
+        return json.loads(f.read())
+
+
+# TODO: REMOVE the following dummy unit test function
+def test_basescript_dummy():
+    """Tests helloworld-say-hello command function.
+
+    Checks the output of the command function with the expected output.
+
+    No mock is needed here because the say_hello_command does not call
+    any external API.
+    """
+    from BaseScript import basescript_dummy_command
+
+    args = {
+        'dummy': 'this is a dummy response'
+    }
+    response = basescript_dummy_command(args)
+
+    mock_response = util_load_json('test_data/basescript-dummy.json')
+
+    assert response.outputs == mock_response
+# TODO: ADD HERE your unit tests

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper_test.py
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/AppendindicatorFieldWrapper_test.py
@@ -1,39 +1,53 @@
-"""Base Script for Cortex XSOAR - Unit Tests file
-
-Pytest Unit Tests: all funcion names must start with "test_"
-
-More details: https://xsoar.pan.dev/docs/integrations/unit-testing
-
-MAKE SURE YOU REVIEW/REPLACE ALL THE COMMENTS MARKED AS "TODO"
-
-"""
-
-import json
-import io
+import demistomock as demisto
+import pytest
 
 
-def util_load_json(path):
-    with io.open(path, mode='r', encoding='utf-8') as f:
-        return json.loads(f.read())
-
-
-# TODO: REMOVE the following dummy unit test function
-def test_basescript_dummy():
-    """Tests helloworld-say-hello command function.
-
-    Checks the output of the command function with the expected output.
-
-    No mock is needed here because the say_hello_command does not call
-    any external API.
+def test_run_append_indicator_field_script():
     """
-    from BaseScript import basescript_dummy_command
+    Given:
+        Demisto args object containing:
+            - A comma-separated list of Indicators values.
+            - A comma-separated list of tags to append to the given indicators.
+    When:
+        Running the 'run_append_indicator_field_script' function.
+    Then:
+        Verify that the readable output is as expected.
 
-    args = {
-        'dummy': 'this is a dummy response'
-    }
-    response = basescript_dummy_command(args)
+    """
+    from AppendindicatorFieldWrapper import run_append_indicator_field_script
 
-    mock_response = util_load_json('test_data/basescript-dummy.json')
+    indicators_values = 'test_indicator1,test_indicator2'
+    tags = 'test_tag1,test_tag2'
+    args = {'indicators_values': indicators_values, 'tags': tags}
+    response = run_append_indicator_field_script(args)
 
-    assert response.outputs == mock_response
-# TODO: ADD HERE your unit tests
+    assert response.readable_output == '### The following tags were added successfully:\n|Indicator|Tags|\n' \
+                                       '|---|---|\n| test_indicator1 | test_tag1,<br>test_tag2 |\n| test_indicator2 |' \
+                                       ' test_tag1,<br>test_tag2 |\n'
+
+
+@pytest.mark.parametrize('args, expected_err_message', [
+    ({'indicators_values': '', 'tags': 'test_tag1,test_tag2'}, 'Indicators values were not specified.'),
+    ({'indicators_values': 'test_indicator1,test_indicator2', 'tags': ''}, 'Tags were not specified.')
+])
+def test_missing_arguments(mocker, args, expected_err_message):
+    """
+        Given:
+            1. Demisto args object containing an empty string as the Indicator values argument, and a
+               comma-separated list of tags to append to the indicators.
+               An error message about missing indicators.
+
+            2. Demisto args object containing an empty string as the Tags argument, and a
+               comma-separated list of indicators values.
+               An error message about missing tags.
+        When:
+            Running the 'run_append_indicator_field_script' function.
+
+        Then:
+            Verify that the expected error message is returned as the readable output.
+        """
+    from AppendindicatorFieldWrapper import run_append_indicator_field_script
+    mocker.patch.object(demisto, 'error', return_value=None)
+    response = run_append_indicator_field_script(args)
+
+    assert response.readable_output == f'Failed to execute AppendindicatorFieldWrapper. Error: {expected_err_message}'

--- a/Packs/Malware/Scripts/AppendindicatorFieldWrapper/README.md
+++ b/Packs/Malware/Scripts/AppendindicatorFieldWrapper/README.md
@@ -1,0 +1,5 @@
+This README contains the full documentation for your script.
+
+You auto-generate this README file from your script YML file using the `demisto-sdk generate-docs` command.
+
+For more information see the [documentation article](https://xsoar.pan.dev/docs/integrations/integration-docs).


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [48180](https://github.com/demisto/etc/issues/48180).

## Description
The AppendindicatorFieldWrapper script was written as a content workaround for the server bug described here: [47577](https://github.com/demisto/etc/issues/47577).
The script is a wrapper for the 'AppendindicatorField' script that enables adding tags to certain indicators.
The security teams can now use this script to add tags to indicators from a button of an incident layout.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
