### PR TITLE
update integration fromversion (workaround)

### DIFF
--- a/Packs/AzureFirewall/Integrations/AzureFirewall/AzureFirewall.yml
+++ b/Packs/AzureFirewall/Integrations/AzureFirewall/AzureFirewall.yml
@@ -1511,6 +1511,6 @@ script:
   script: '-'
   subtype: python3
   type: python
-fromversion: 6.2.0
+fromversion: 6.1.0
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: failing upload

## Description
pack contains a single integration with `fromversion: 6.2.0` causing the pack minimum version to be 6.2.0.
when the upload pipeline tried to install it on 6.1, it fails to install and blocks the upload.

**This PR is a workaround and we will fix the upload flow to better handle those cases.**

In addition, it did not fail the branch build since it did not spin a 6.1 machine: https://github.com/demisto/content/pull/18856

