### PR TITLE
ews-mail-sender-reply-to-bug

### DIFF
--- a/Packs/EWSMailSender/.pack-ignore
+++ b/Packs/EWSMailSender/.pack-ignore
@@ -3,3 +3,6 @@ ignore=auto-test
 
 [file:EWSMailSender.yml]
 ignore=IN135
+
+[known_words]
+inReply

--- a/Packs/EWSMailSender/.secrets-ignore
+++ b/Packs/EWSMailSender/.secrets-ignore
@@ -1,0 +1,4 @@
+test@gmail.com
+test1@gmail.com
+test2@gmail.com
+test3@gmail.com

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
@@ -121,8 +121,19 @@ def get_account(account_email):
     return response
 
 
-def send_email_to_mailbox(account, to, subject, body, bcc=None, cc=None, reply_to=None,
-                          html_body=None, attachments=[], raw_message=None, from_address=None):
+def send_email_to_mailbox(
+    account: Account,
+    to: List[str],
+    subject: str,
+    body: str,
+    bcc: List[str],
+    cc: List[str],
+    reply_to: List[str],
+    html_body: Optional[str] = None,
+    attachments: Optional[List[str]] = None,
+    raw_message: Optional[str] = None,
+    from_address: Optional[str] = None
+):
     """
     Send an email to a mailbox.
 
@@ -132,7 +143,16 @@ def send_email_to_mailbox(account, to, subject, body, bcc=None, cc=None, reply_t
         subject (str): subject of the mail.
         body (str): body of the email.
         reply_to (list[str]): list of emails of which to reply to from the sent email.
+        bcc (list[str]): list of email addresses for the 'bcc' field.
+        cc (list[str]): list of email addresses for the 'cc' field.
+        html_body (str): HTML formatted content (body) of the email to be sent. This argument
+            overrides the "body" argument.
+        attachments (list[str]): list of names of attachments to send.
+        raw_message (str): Raw email message from MimeContent type.
+        from_address (str): the email address from which to reply.
     """
+    if not attachments:
+        attachments = []
     message_body = HTMLBody(html_body) if html_body else body
     m = Message(
         account=account,
@@ -209,10 +229,10 @@ def send_email(to, subject, body="", bcc=None, cc=None, replyTo=None, htmlBody=N
                attachIDs="", attachCIDs="", attachNames="", from_mailbox=None, manualAttachObj=None,
                raw_message=None, from_address=None):
     account = get_account(from_mailbox or ACCOUNT_EMAIL)
-    bcc: Optional[List[str]] = argToList(bcc)
-    cc: Optional[List[str]] = argToList(cc)
-    to: Optional[List[str]] = argToList(to)
-    reply_to: Optional[List[str]] = argToList(replyTo)
+    bcc: List[str] = argToList(bcc)
+    cc: List[str] = argToList(cc)
+    to: List[str] = argToList(to)
+    reply_to: List[str] = argToList(replyTo)
     manualAttachObj = manualAttachObj if manualAttachObj is not None else []
     subject = subject[:252] + '...' if len(subject) > 255 else subject
 

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
@@ -207,8 +207,10 @@ def send_email(to, subject, body="", bcc=None, cc=None, replyTo=None, htmlBody=N
 
     attachments, attachments_names = process_attachments(attachCIDs, attachIDs, attachNames, manualAttachObj)
 
-    send_email_to_mailbox(account, to, subject, body, bcc, cc, replyTo, htmlBody, attachments, raw_message,
-                          from_address)
+    send_email_to_mailbox(
+        account=account, to=to, subject=subject, body=body, bcc=bcc, cc=cc, reply_to=replyTo,
+        html_body=htmlBody, attachments=attachments, raw_message=raw_message, from_address=from_address
+    )
     result_object = {
         'from': account.primary_smtp_address,
         'to': to,

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
@@ -123,6 +123,16 @@ def get_account(account_email):
 
 def send_email_to_mailbox(account, to, subject, body, bcc=None, cc=None, reply_to=None,
                           html_body=None, attachments=[], raw_message=None, from_address=None):
+    """
+    Send an email to a mailbox.
+
+    Args:
+        account (Account): account from which to send an email.
+        to (list[str]): a list of emails to send an email.
+        subject (str): subject of the mail.
+        body (str): body of the email.
+        reply_to (list[str]): list of emails of which to reply to from the sent email.
+    """
     message_body = HTMLBody(html_body) if html_body else body
     m = Message(
         account=account,

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
@@ -199,10 +199,10 @@ def send_email(to, subject, body="", bcc=None, cc=None, replyTo=None, htmlBody=N
                attachIDs="", attachCIDs="", attachNames="", from_mailbox=None, manualAttachObj=None,
                raw_message=None, from_address=None):
     account = get_account(from_mailbox or ACCOUNT_EMAIL)
-    bcc: Optional[list[str]] = argToList(bcc)
-    cc: Optional[list[str]] = argToList(cc)
-    to: Optional[list[str]] = argToList(to)
-    reply_to: Optional[list[str]] = argToList(replyTo)
+    bcc: Optional[List[str]] = argToList(bcc)
+    cc: Optional[List[str]] = argToList(cc)
+    to: Optional[List[str]] = argToList(to)
+    reply_to: Optional[List[str]] = argToList(replyTo)
     manualAttachObj = manualAttachObj if manualAttachObj is not None else []
     subject = subject[:252] + '...' if len(subject) > 255 else subject
 

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender.py
@@ -199,16 +199,17 @@ def send_email(to, subject, body="", bcc=None, cc=None, replyTo=None, htmlBody=N
                attachIDs="", attachCIDs="", attachNames="", from_mailbox=None, manualAttachObj=None,
                raw_message=None, from_address=None):
     account = get_account(from_mailbox or ACCOUNT_EMAIL)
-    bcc = bcc.split(",") if bcc else None
-    cc = cc.split(",") if cc else None
-    to = to.split(",") if to else None
+    bcc: Optional[list[str]] = argToList(bcc)
+    cc: Optional[list[str]] = argToList(cc)
+    to: Optional[list[str]] = argToList(to)
+    reply_to: Optional[list[str]] = argToList(replyTo)
     manualAttachObj = manualAttachObj if manualAttachObj is not None else []
     subject = subject[:252] + '...' if len(subject) > 255 else subject
 
     attachments, attachments_names = process_attachments(attachCIDs, attachIDs, attachNames, manualAttachObj)
 
     send_email_to_mailbox(
-        account=account, to=to, subject=subject, body=body, bcc=bcc, cc=cc, reply_to=replyTo,
+        account=account, to=to, subject=subject, body=body, bcc=bcc, cc=cc, reply_to=reply_to,
         html_body=htmlBody, attachments=attachments, raw_message=raw_message, from_address=from_address
     )
     result_object = {

--- a/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender_test.py
+++ b/Packs/EWSMailSender/Integrations/EWSMailSender/EWSMailSender_test.py
@@ -7,7 +7,8 @@ from exchangelib.errors import UnauthorizedError
 
 
 class MockAccount:
-    def __init__(self, error):
+    def __init__(self, primary_smtp_address="", error=401):
+        self.primary_smtp_address = primary_smtp_address
         self.error = error
 
     @property
@@ -39,7 +40,7 @@ def test_get_account_unauthorized_error(mocker):
         Verify we've tried 3 times to create an account
         And we put it to the debug.log
     """
-    mocker.patch.object(EWSMailSender, 'Account', return_value=MockAccount(401))
+    mocker.patch.object(EWSMailSender, 'Account', return_value=MockAccount(error=401))
     demisto_debug = mocker.patch.object(demisto, 'debug')
 
     EWSMailSender.get_account('test@test.com')
@@ -57,7 +58,7 @@ def test_get_account_not_found_error(mocker):
         Verify we do not try 3 times to create an Account
         And the debug.log is empty
     """
-    mocker.patch.object(EWSMailSender, 'Account', return_value=MockAccount(404))
+    mocker.patch.object(EWSMailSender, 'Account', return_value=MockAccount(error=404))
     demisto_debug = mocker.patch.object(demisto, 'debug')
 
     with pytest.raises(Exception) as e:
@@ -65,3 +66,28 @@ def test_get_account_not_found_error(mocker):
 
     assert str(e.value) == 'Page not found'
     assert not demisto_debug.call_args
+
+
+def test_send_mail(mocker):
+    """
+    Given -
+        to, subject and replyTo arguments to send an email.
+
+    When -
+        trying to send an email
+
+    Then -
+        verify the context output is returned correctly and that the 'to' and 'replyTo' arguments were sent
+        as a list of strings.
+    """
+    from EWSMailSender import send_email
+    mocker.patch.object(EWSMailSender, 'Account', return_value=MockAccount(primary_smtp_address="test@gmail.com"))
+    send_email_mocker = mocker.patch.object(EWSMailSender, 'send_email_to_mailbox')
+    result = send_email(to="test@gmail.com", subject="test", replyTo="test1@gmail.com,test2@gmail.com,test3@gmail.com")
+    assert send_email_mocker.call_args.kwargs.get('to') == ['test@gmail.com']
+    assert send_email_mocker.call_args.kwargs.get('reply_to') == [
+        'test1@gmail.com', 'test2@gmail.com', 'test3@gmail.com'
+    ]
+    assert result.get('Contents') == {
+        'from': 'test@gmail.com', 'to': ['test@gmail.com'], 'subject': 'test', 'attachments': []
+    }

--- a/Packs/EWSMailSender/ReleaseNotes/1_1_8.md
+++ b/Packs/EWSMailSender/ReleaseNotes/1_1_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### EWS Mail Sender
+- Fixed an issue in the ***send-mail*** command where the *inReply* argument was not parsed correctly.

--- a/Packs/EWSMailSender/pack_metadata.json
+++ b/Packs/EWSMailSender/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "EWS Mail Sender",
     "description": "Exchange Web Services and Office 365 Email Sender. Note: this Integration supports Office 365 basic authentication only. If you are using Office 365, we recommend using the EWS O365 Integration instead, which supports modern authentication (oauth2).",
     "support": "xsoar",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fixes an issue where the ```replyTo``` argument is being passed as a string while it should be passed as a list of strings.

## Must have
- [x] Tests
- [ ] Documentation 
