### PR TITLE
fix parameter reference for sqs parse body as json

### DIFF
--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
@@ -84,7 +84,7 @@ configuration:
   required: false
   type: 8
 - display: Parse SQS message body as a JSON string
-  name: parse_body_as_string
+  name: parse_body_as_json
   required: false
   type: 8
 script:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
The parameter in the yaml file to indicate the SQS body should be parsed as JSON is `parse_body_as_string` but the script is looking for `parse_body_as_json`.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
