### PR TITLE
Fixed bug in test-module in MicrosoftGraphAPI

### DIFF
--- a/Packs/MicrosoftGraphAPI/Integrations/MicrosoftGraphAPI/MicrosoftGraphAPI_test.py
+++ b/Packs/MicrosoftGraphAPI/Integrations/MicrosoftGraphAPI/MicrosoftGraphAPI_test.py
@@ -123,3 +123,29 @@ def test_generic_command_no_content(requests_mock, client):
     }
     res = generic_command(client, args)
     assert res
+
+
+@pytest.mark.parametrize('params', [
+    {'app_id': 'app_id', 'tenant_id': 'tenant_id', 'credentials': {'password': 'password'}},
+    {'app_id': 'app_id', 'tenant_id': 'tenant_id', 'app_secret': 'password'}
+])
+def test_test_module(mocker, params):
+    """
+    Given:
+        - Parameter credentials instead of the app_secret (in self-deployed mode).
+    When:
+        - Running the test-module command.
+    Then:
+        - Ensure the command doesn't fails on ValueError (as for device-flow mode).
+    """
+    from MicrosoftGraphAPI import demisto, main, MicrosoftClient
+
+    mocker.patch.object(demisto, 'command', return_value='test-module')
+    mocker.patch.object(demisto, 'params', return_value=params)
+    mocker.patch.object(MicrosoftClient, 'get_access_token')
+    mocker.patch.object(demisto, 'results')
+
+    main()
+
+    result = demisto.results.call_args[0][0]
+    assert result == 'ok'


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed an issue where the **test-module** fails in self-deployed authentication mode when the *credentials* parameter is given instead of the *app_secret* parameter.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
