### PR TITLE
increase sqs message visibility timeout 

### DIFF
--- a/Packs/AWS-SQS/ReleaseNotes/1_2_8.md
+++ b/Packs/AWS-SQS/ReleaseNotes/1_2_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AWS - SQS
+- Fixed an issue where duplicates could be created during large fetches

--- a/Packs/AWS-SQS/pack_metadata.json
+++ b/Packs/AWS-SQS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - SQS",
     "description": "Amazon Web Services Simple Queuing Service (SQS)",
     "support": "xsoar",
-    "currentVersion": "1.2.7",
+    "currentVersion": "1.2.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The current implementation of the SQS fetch incidents has an error that occurs when the script takes longer than the visibility timeout of the receive message call, currently 5 seconds. Since the messages aren't removed from the queue until after they have been sent as incidents to XSOAR they can reappear during successive iterations of the while loop causing duplicate incidents to be created.

The proposed solution is to create the incidents and delete the queue messages during each iteration of the while loop while also increasing the visibility timeout to 30 seconds.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
