### PR TITLE
added relationships prop to CustomIndicator

### DIFF
--- a/Packs/Base/ReleaseNotes/1_30_8.md
+++ b/Packs/Base/ReleaseNotes/1_30_8.md
@@ -1,0 +1,2 @@
+- **Base**
+- Added *relationships* parameter to **CustomIndicator** class.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -2837,7 +2837,7 @@ class Common(object):
 
     class CustomIndicator(Indicator):
 
-        def __init__(self, indicator_type, value, dbot_score, data, context_prefix):
+        def __init__(self, indicator_type, value, dbot_score, data, context_prefix, relationships):
             """
             :type indicator_type: ``Str``
             :param indicator_type: The name of the indicator type.
@@ -2854,6 +2854,9 @@ class Common(object):
             :type context_prefix: ``Str``
             :param context_prefix: Will be used as the context path prefix.
 
+            :type relationships: ``list of EntityRelationship``
+            :param relationships: List of relationships of the indicator.
+
             :return: None
             :rtype: ``None``
             """
@@ -2868,6 +2871,7 @@ class Common(object):
                 format(context_prefix=context_prefix)
 
             self.value = value
+            self.relationships = relationships
 
             if not isinstance(dbot_score, Common.DBotScore):
                 raise ValueError('dbot_score must be of type DBotScore')
@@ -2889,11 +2893,16 @@ class Common(object):
 
             ret_value = {
                 self.CONTEXT_PATH: custom_context
-            }
+            }  # type: Dict[str, Any]
 
             if self.dbot_score:
                 ret_value.update(self.dbot_score.to_context())
             ret_value[Common.DBotScore.get_context_path()]['Type'] = self.indicator_type
+
+            if self.relationships:
+                relationships_context = [relationship.to_context() for relationship in self.relationships if
+                                         relationship.to_context()]
+                ret_value['Relationships'] = relationships_context
 
             return ret_value
 
@@ -9863,7 +9872,7 @@ def get_pack_version(pack_name=''):
 
 
 def create_indicator_result_with_dbotscore_unknown(indicator, indicator_type, reliability=None,
-                                                   context_prefix=None, address_type=None):
+                                                   context_prefix=None, address_type=None, relationships=None):
     '''
     Used for cases where the api response to an indicator is not found,
     returns CommandResults with readable_output generic in this case, and indicator with DBotScore unknown
@@ -9882,6 +9891,9 @@ def create_indicator_result_with_dbotscore_unknown(indicator, indicator_type, re
 
     :type address_type: ``str``
     :param address_type: Use only in case that the indicator is Cryptocurrency
+
+    :type relationships: ``list of EntityRelationship``
+    :param relationships: List of relationships of the indicator.
 
     :rtype: ``CommandResults``
     :return: CommandResults
@@ -9948,7 +9960,9 @@ def create_indicator_result_with_dbotscore_unknown(indicator, indicator_type, re
                                             value=indicator,
                                             dbot_score=dbot_score,
                                             data={},
-                                            context_prefix=context_prefix)
+                                            context_prefix=context_prefix,
+                                            relationships=relationships
+                                            )
 
     indicator_type = indicator_type.upper()
     readable_output = tableToMarkdown(name='{}:'.format(integration_name),

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -668,6 +668,7 @@ class TestTableToMarkdown:
         assert 'header_2' not in table
         assert headers == ['header_1', 'header_2']
 
+    # Test fails locally because expected time is in UTC
     @staticmethod
     def test_date_fields_param():
         """
@@ -7166,7 +7167,7 @@ class TestCustomIndicator:
             score=Common.DBotScore.BAD,
             malicious_description='malicious!'
         )
-        indicator = Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix')
+        indicator = Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix', relationships=[])
         assert indicator.CONTEXT_PATH == 'prefix(val.value && val.value == obj.value)'
         assert indicator.param == 'value'
         assert indicator.value == 'test_value'
@@ -7186,7 +7187,7 @@ class TestCustomIndicator:
                 score=Common.DBotScore.BAD,
                 malicious_description='malicious!'
             )
-            Common.CustomIndicator('ip', 'test_value', dbot_score, {'param': 'value'}, 'prefix')
+            Common.CustomIndicator('ip', 'test_value', dbot_score, {'param': 'value'}, 'prefix', relationships=[])
 
     def test_custom_indicator_init_no_prefix(self):
         """
@@ -7203,7 +7204,7 @@ class TestCustomIndicator:
                 score=Common.DBotScore.BAD,
                 malicious_description='malicious!'
             )
-            Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, None)
+            Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, None, relationships=[])
 
     def test_custom_indicator_init_no_dbot_score(self):
         """
@@ -7214,7 +7215,7 @@ class TestCustomIndicator:
         with pytest.raises(ValueError):
             from CommonServerPython import Common
             dbot_score = ''
-            Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix')
+            Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix', relationships=[])
 
     def test_custom_indicator_to_context(self):
         """
@@ -7230,7 +7231,7 @@ class TestCustomIndicator:
             score=Common.DBotScore.BAD,
             malicious_description='malicious!'
         )
-        indicator = Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix')
+        indicator = Common.CustomIndicator('test', 'test_value', dbot_score, {'param': 'value'}, 'prefix', relationships=[])
         context = indicator.to_context()
         assert context['DBotScore(val.Indicator &&'
                        ' val.Indicator == obj.Indicator &&'
@@ -7253,7 +7254,7 @@ class TestCustomIndicator:
                 score=Common.DBotScore.BAD,
                 malicious_description='malicious!'
             )
-            Common.CustomIndicator('test', 'test_value', dbot_score, None, 'prefix')
+            Common.CustomIndicator('test', 'test_value', dbot_score, None, 'prefix', relationships=[])
 
     def test_custom_indicator_no_value(self):
         """
@@ -7270,7 +7271,7 @@ class TestCustomIndicator:
                 score=Common.DBotScore.BAD,
                 malicious_description='malicious!'
             )
-            Common.CustomIndicator('test', None, dbot_score, {'param': 'value'}, 'prefix')
+            Common.CustomIndicator('test', None, dbot_score, {'param': 'value'}, 'prefix', relationships=[])
 
 
 @pytest.mark.parametrize(

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.30.7",
+    "currentVersion": "1.30.8",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)


## Description
This PR adds a `relationships` property to `CustomIndicator` class to align with other  `Common` types (`IP`, `File`, etc).


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details: There are Integrations where `CustomIndicator` class is used: (1) inside `CustomIndicatorDemo` and (2) in `ACTIIndicatorQuery`. 

For the former, I'm adding a change to update the `CustomIndicator`.

The latter are aware of this breaking change as this issue was raised because of a need of theirs to create custom indicator and set up relationship simultaneously. So changes shouldn't
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
