### PR TITLE
Allow the review_release_notes workflow to run on external PRs

### DIFF
--- a/.github/workflows/review-release-notes.yml
+++ b/.github/workflows/review-release-notes.yml
@@ -4,7 +4,6 @@ on: pull_request
 jobs:
   release_notes_review:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Removed the if condition from the review-release-notes workflow, to allow it's run on external PRs (from forked repositories).
This change will add this step to the builds of contributors' external PRs.

I think there should be no security reason (or any reason) to prevent the running of this workflow in external PRs - @yaakovi, @ShahafBenYakir, @DinaMeylakh  - please correct me if I'm wrong.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
