### PR TITLE
Github - Fix Modeling Rule 

### DIFF
--- a/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.xif
+++ b/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.xif
@@ -2,7 +2,7 @@
 filter action in("oauth_application*","org_credential_authorization*")
 | alter XDM.Auth.Client.user.username = actor,
         XDM.Auth.Client.location.country = json_extract_scalar(actor_location, "$.country_code"),
-        XDM.Auth.event_timestamp = created_at,
+        XDM.Auth.event_timestamp = timestamp_seconds(to_integer(divide(created_at, 1000))),
         XDM.Auth.original_event_type = action;
 
 [MODEL: dataset=github_github_audit_raw, model=Audit]
@@ -11,5 +11,5 @@ filter action in("org*","role*","account*","advisory_credit*","billing*","busine
         XDM.Audit.identity.name = org,
         XDM.Audit.project = repo,
         XDM.Audit.TriggeredBy.identity.name = actor,
-        XDM.Audit.event_timestamp = created_at,
+        XDM.Audit.event_timestamp = timestamp_seconds(to_integer(divide(created_at, 1000))),
         XDM.Audit.original_event_type = action;

--- a/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.yml
+++ b/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.yml
@@ -19,7 +19,7 @@ schema: |-
         "is_array": false
       },
       "created_at": {
-        "type": "datetime",
+        "type": "int",
         "is_array": false
       },
       "actor": {

--- a/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.yml
+++ b/Packs/GitHub/ModelingRules/GithubModelingRules/GithubModelingRules.yml
@@ -19,7 +19,7 @@ schema: |-
         "is_array": false
       },
       "created_at": {
-        "type": "int",
+        "type": "datetime",
         "is_array": false
       },
       "actor": {

--- a/Packs/GitHub/ReleaseNotes/2_0_2.md
+++ b/Packs/GitHub/ReleaseNotes/2_0_2.md
@@ -1,4 +1,4 @@
 
 #### Modeling Rules
 - **Github Modeling Rule**
-- Fixed an issue where the **created_at** field was wrong.
+- Fixed an issue where the **created_at** field type was wrong.

--- a/Packs/GitHub/ReleaseNotes/2_0_2.md
+++ b/Packs/GitHub/ReleaseNotes/2_0_2.md
@@ -1,0 +1,4 @@
+
+#### Modeling Rules
+- **Github Modeling Rule**
+- Fixed an issue where the **created_at** field was wrong.

--- a/Packs/GitHub/pack_metadata.json
+++ b/Packs/GitHub/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GitHub",
     "description": "Manage GitHub issues and pull requests directly from Cortex XSOAR",
     "support": "xsoar",
-    "currentVersion": "2.0.1",
+    "currentVersion": "2.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Update `created_at` field type to `datetime`
To convert the field `created_at` to `datetime` I used the functions:
- timestamp_seconds
- to_integer
- divide

Because the value of `created_at` is miliseconds so `1653391014592` converted to `May 24th 2022 14:16:55` by this line:
`timestamp_seconds(to_integer(divide(created_at, 1000)))`

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
