### PR TITLE
AD Query v2 bug fix

### DIFF
--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
@@ -784,7 +784,7 @@ script:
       name: basedn
     description: Updates attributes of an existing Active Directory group.
     name: ad-update-group
-  dockerimage: demisto/py3-tools:0.0.1.29493
+  dockerimage: demisto/py3-tools:0.0.1.30065
   runonce: false
   ismappable: true
   isremotesyncout: true

--- a/Packs/Active_Directory_Query/ReleaseNotes/1_4_12.md
+++ b/Packs/Active_Directory_Query/ReleaseNotes/1_4_12.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Active Directory Query v2
+- Fixed and issue where the integration failed on SSL error.
+- Updated the Docker image to: *demisto/py3-tools:0.0.1.30065*.

--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Active Directory Query",
     "description": "Active Directory Query integration enables you to access and manage Active Directory objects (users, contacts, and computers).",
     "support": "xsoar",
-    "currentVersion": "1.4.11",
+    "currentVersion": "1.4.12",
     "author": "Cortex XSOAR",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-12371)

## Description
Fixed an issue when the AD query v2 failed on:
`ldap3.core.exceptions.LDAPSocketOpenError: ('unable to open socket', [(LDAPSocketOpenError('socket ssl wrapping error: [Errno 104] Connection reset by peer'), ('x.x.x.x', 636)), (LDAPSocketOpenError('socket ssl wrapping error: [Errno 104] Connection reset by peer'), ('x.x.x.x', 636)), (LDAPSocketOpenError('socket ssl wrapping error: [Errno 104] Connection reset by peer'), ('x.x.x.x', 636))])/`

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
