### PR TITLE
Fixed Collection tag for integrations with isfetchevents

### DIFF
--- a/Tests/Marketplace/Tests/marketplace_services_test.py
+++ b/Tests/Marketplace/Tests/marketplace_services_test.py
@@ -496,8 +496,8 @@ class TestHelperFunctions:
                                   'Playbook', False, False),
 
                                  # Check is_siem for integration
-                                 ({'id': 'some-id', 'isfetchevents': True}, 'Integration', False, True),
-                                 ({'id': 'some-id', 'isfetchevents': False}, 'Integration', False, False),
+                                 ({'id': 'some-id', 'script': {'isfetchevents': True}}, 'Integration', False, True),
+                                 ({'id': 'some-id', 'script': {'isfetchevents': False}}, 'Integration', False, False),
 
                                  # Check is_siem for rules
                                  ({'id': 'some-id', 'rules': ''}, 'ParsingRule', False, True),

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -483,7 +483,7 @@ class Pack(object):
         if yaml_type == 'Integration':
             if yaml_content.get('script', {}).get('feed', False) is True:
                 self._is_feed = True
-            if yaml_content.get('isfetchevents', False) is True:
+            if yaml_content.get('script', {}).get('isfetchevents', False) is True:
                 self._is_siem = True
         if yaml_type == 'Playbook':
             if yaml_content.get('name').startswith('TIM '):

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -479,7 +479,6 @@ class Pack(object):
         Returns:
             Doesn't return
         """
-
         if yaml_type == 'Integration':
             if yaml_content.get('script', {}).get('feed', False) is True:
                 self._is_feed = True

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -479,6 +479,7 @@ class Pack(object):
         Returns:
             Doesn't return
         """
+
         if yaml_type == 'Integration':
             if yaml_content.get('script', {}).get('feed', False) is True:
                 self._is_feed = True


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-2974)

## Description
Fixed the check for a siem pack by checking if the integration have the `isfetchevents` field under `script` and not in the root file.

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
