### PR TITLE
Add GetErrors PB Error Handling Utility Script

### DIFF
--- a/Packs/CommonScripts/.pack-ignore
+++ b/Packs/CommonScripts/.pack-ignore
@@ -76,3 +76,4 @@ ParseEmailFiles
 ParseEmailFilesV2
 RTF
 msg
+lastCompletedTaskEntries

--- a/Packs/CommonScripts/ReleaseNotes/1_7_0.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_0.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### New: GetErrorsFromEntry
+- Added the GetErrorsFromEntry utility script meant to be used in conjunction with the Playbook Error Handling feature introduced in platform version 6.8.0.

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -11,7 +11,7 @@ def get_errors(entries: List) -> List[str]:
         entries (List[List[Dict]]): multiples entries of results of demisto.executeCommand()
 
     Returns:
-        (string): Error message extracted from the demisto.executeCommand() result
+        (List[str]): Error messages extracted from error entries
     """
     error_messages = []
     for entry in entries:

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -30,8 +30,11 @@ def main():
         args = demisto.args()
         # the entry_id argument can be a list of entry ids or a single entry id
         entry_ids = args.get('entry_id', demisto.get(demisto.context(), 'lastCompletedTaskEntries'))
+        entry_ids = argToList(entry_ids)
+
         entries = [demisto.executeCommand('getEntry', {'id': entry_id}) for entry_id in entry_ids]
         error_messages = get_errors(entries)
+
         return_results(CommandResults(
             readable_output='\n'.join(error_messages),
             outputs_prefix='ErrorEntries',

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -29,6 +29,7 @@ def main():
     try:
         args = demisto.args()
         # the entry_id argument can be a list of entry ids or a single entry id
+        entry_ids = args.get('entry_id', demisto.get(demisto.context(), 'lastCompletedTaskEntries'))
         entries = [demisto.executeCommand('getEntry', {'id': entry_id}) for entry_id in entry_ids]
         error_messages = get_errors(entries)
         return_results(CommandResults(

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -1,0 +1,44 @@
+import demistomock as demisto  # noqa: F401
+from CommonServerPython import *  # noqa: F401
+
+
+def get_errors(entries):
+    """
+        entries should be a list of demisto entries
+
+        :type entries: ``list``
+        :param entries: multiples entries of results of demisto.executeCommand()
+
+        :return: Error message extracted from the demisto.executeCommand() result
+        :rtype: ``string``
+    """
+    error_messages = []
+    for entry in entries:
+        assert len(entry) == 1
+        entry_details = entry[0]
+        is_error_entry = isinstance(entry_details, dict) and entry_details['Type'] == entryTypes['error']
+        if is_error_entry:
+            demisto.debug(f'error entry contents: "{entry_details["Contents"]}"')
+            error_messages.append(entry_details['Contents'])
+
+    return error_messages
+
+
+def main():
+    try:
+        args = demisto.args()
+        entry_ids = args.get('entry_id')
+        entries = [demisto.executeCommand('getEntry', {'id': entry_id}) for entry_id in entry_ids]
+        error_messages = get_errors(entries)
+        return_results(CommandResults(
+            readable_output='\n'.join(error_messages),
+            outputs_prefix='ErrorEntries',
+            outputs=error_messages,
+            raw_response=error_messages,
+        ))
+    except Exception as e:
+        return_error(f'Failed to fetch errors for the given entry id(s). Problem: {str(e)}')
+
+
+if __name__ in ('__main__', '__builtin__', 'builtins'):
+    main()

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -2,9 +2,7 @@ import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 
 
-def get_errors(entries):
-    """
-        entries should be a list of demisto entries
+def get_errors(entries: List) -> List[str]:
 
         :type entries: ``list``
         :param entries: multiples entries of results of demisto.executeCommand()

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -3,12 +3,15 @@ from CommonServerPython import *  # noqa: F401
 
 
 def get_errors(entries: List) -> List[str]:
+    """Extracts error entry contents
 
-        :type entries: ``list``
-        :param entries: multiples entries of results of demisto.executeCommand()
+    The entries argument should be a list of demisto entries
 
-        :return: Error message extracted from the demisto.executeCommand() result
-        :rtype: ``string``
+    Args:
+        entries (List[List[Dict]]): multiples entries of results of demisto.executeCommand()
+
+    Returns:
+        (string): Error message extracted from the demisto.executeCommand() result
     """
     error_messages = []
     for entry in entries:

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.py
@@ -28,7 +28,7 @@ def get_errors(entries: List) -> List[str]:
 def main():
     try:
         args = demisto.args()
-        entry_ids = args.get('entry_id')
+        # the entry_id argument can be a list of entry ids or a single entry id
         entries = [demisto.executeCommand('getEntry', {'id': entry_id}) for entry_id in entry_ids]
         error_messages = get_errors(entries)
         return_results(CommandResults(

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.yml
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.yml
@@ -10,7 +10,7 @@ comment: Get the error(s) associated with a given entry/entries. Use ${lastCompl
 enabled: true
 args:
 - name: entry_id
-  required: true
+  required: false
   default: true
   description: Entry to check
   isArray: true

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.yml
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry.yml
@@ -1,0 +1,27 @@
+commonfields:
+  id: GetErrorsFromEntry
+  version: -1
+name: GetErrorsFromEntry
+script: ''
+type: python
+tags:
+- Utility
+comment: Get the error(s) associated with a given entry/entries. Use ${lastCompletedTaskEntries} to check the previous task entries. The automation will return an array of the error contents from those entries.
+enabled: true
+args:
+- name: entry_id
+  required: true
+  default: true
+  description: Entry to check
+  isArray: true
+outputs:
+- contextPath: ErrorEntries
+  description: Contents of the errors associated with the entry/entries
+scripttarget: 0
+subtype: python3
+runonce: false
+dockerimage: demisto/python3:3.10.4.29342
+runas: DBotWeakRole
+fromversion: 6.2.0
+tests:
+- No tests (auto formatted)

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry_test.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry_test.py
@@ -1,0 +1,84 @@
+from GetErrorsFromEntry import get_errors, main
+import demistomock as demisto  # noqa: F401
+from CommonServerPython import entryTypes, CommandResults  # noqa: F401
+
+
+ERROR_ENTRY_1 = [{'Contents': 'This is the error message 1', 'Type': entryTypes['error']}]
+ERROR_ENTRY_2 = [{'Contents': 'This is the error message 2', 'Type': entryTypes['error']}]
+STD_ENTRY = [{'Contents': 'This is the standard message', 'Type': 0}]
+ERROR_ENTRIES = [
+    ERROR_ENTRY_1,
+    ERROR_ENTRY_2,
+    STD_ENTRY
+]
+
+WITHOUT_ERROR_ENTRIES = [
+    STD_ENTRY,
+    STD_ENTRY,
+    STD_ENTRY
+]
+
+
+def test_main(mocker):
+    """
+    Tests the full flow of the script
+
+
+    Given:
+        - Entries data
+
+    When:
+        - Two are for error entries and one is for a standard entry
+
+    Then:
+        - Verify the two error entries' contents are returned
+    """
+    mocker.patch.object(demisto, 'args',
+                        return_value={'entry_id': ['err_entry_id_1', 'err_entry_id_2', 'std_entry_id_1']})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=ERROR_ENTRIES)
+    demisto_args = mocker.spy(demisto, 'args')
+    demisto_results = mocker.spy(demisto, 'results')
+
+    main()
+
+    demisto_args.assert_called_once()
+    expected_error_msgs = ['This is the error message 1', 'This is the error message 2']
+    expected_results = CommandResults(
+        readable_output='\n'.join(expected_error_msgs),
+        outputs_prefix='ErrorEntries',
+        outputs=expected_error_msgs,
+        raw_response=expected_error_msgs,
+    ).to_context()
+    demisto_results.assert_called_once_with(expected_results)
+
+
+def test_get_errors_with_error_entries():
+    """
+    Given:
+        - Entries data
+
+    When:
+        - One or more of the entries' types are error type
+
+    Then:
+        - Verify the error entries' contents are returned
+    """
+    error_messages = get_errors(ERROR_ENTRIES)
+    assert len(error_messages) == 2
+    assert error_messages[0] == 'This is the error message 1'
+    assert error_messages[1] == 'This is the error message 2'
+
+
+def test_get_errors_without_error_entries():
+    """
+    Given:
+        - Entries data
+
+    When:
+        - None of the entries' types are error type
+
+    Then:
+        - Verify that no error messages are returned
+    """
+    error_messages = get_errors(WITHOUT_ERROR_ENTRIES)
+    assert len(error_messages) == 0

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry_test.py
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/GetErrorsFromEntry_test.py
@@ -19,7 +19,7 @@ WITHOUT_ERROR_ENTRIES = [
 ]
 
 
-def test_main(mocker):
+def test_main_with_explicitly_passed_argument_as_list(mocker):
     """
     Tests the full flow of the script
 
@@ -29,12 +29,86 @@ def test_main(mocker):
 
     When:
         - Two are for error entries and one is for a standard entry
+        - Entry ids are explicitly passed as an argument
+        - Passed argument is a list
 
     Then:
         - Verify the two error entries' contents are returned
     """
     mocker.patch.object(demisto, 'args',
                         return_value={'entry_id': ['err_entry_id_1', 'err_entry_id_2', 'std_entry_id_1']})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=ERROR_ENTRIES)
+    demisto_args = mocker.spy(demisto, 'args')
+    demisto_results = mocker.spy(demisto, 'results')
+
+    main()
+
+    demisto_args.assert_called_once()
+    expected_error_msgs = ['This is the error message 1', 'This is the error message 2']
+    expected_results = CommandResults(
+        readable_output='\n'.join(expected_error_msgs),
+        outputs_prefix='ErrorEntries',
+        outputs=expected_error_msgs,
+        raw_response=expected_error_msgs,
+    ).to_context()
+    demisto_results.assert_called_once_with(expected_results)
+
+
+def test_main_with_explicitly_passed_argument_as_string(mocker):
+    """
+    Tests the full flow of the script
+
+
+    Given:
+        - Entries data
+
+    When:
+        - Two are for error entries and one is for a standard entry
+        - Entry ids are explicitly passed as an argument
+        - Passed argument is a comma-separated string
+
+    Then:
+        - Verify the two error entries' contents are returned
+    """
+    mocker.patch.object(demisto, 'args',
+                        return_value={'entry_id': 'err_entry_id_1, err_entry_id_2, std_entry_id_1'})
+    mocker.patch.object(demisto, 'executeCommand', side_effect=ERROR_ENTRIES)
+    demisto_args = mocker.spy(demisto, 'args')
+    demisto_results = mocker.spy(demisto, 'results')
+
+    main()
+
+    demisto_args.assert_called_once()
+    expected_error_msgs = ['This is the error message 1', 'This is the error message 2']
+    expected_results = CommandResults(
+        readable_output='\n'.join(expected_error_msgs),
+        outputs_prefix='ErrorEntries',
+        outputs=expected_error_msgs,
+        raw_response=expected_error_msgs,
+    ).to_context()
+    demisto_results.assert_called_once_with(expected_results)
+
+
+def test_main_without_explicitly_passed_argument(mocker):
+    """
+    Tests the full flow of the script
+
+
+    Given:
+        - Entries data
+        - No argument is provided
+        - lastCompletedTaskEntries exists in the context
+
+    When:
+        - Two are for error entries and one is for a standard entry
+
+    Then:
+        - Verify the two error entries' contents are returned
+    """
+    mocker.patch.object(demisto, 'args',
+                        return_value={})
+    mocker.patch.object(demisto, 'context', return_value={'lastCompletedTaskEntries': [
+                        'err_entry_id_1', 'err_entry_id_2', 'std_entry_id_1']})
     mocker.patch.object(demisto, 'executeCommand', side_effect=ERROR_ENTRIES)
     demisto_args = mocker.spy(demisto, 'args')
     demisto_results = mocker.spy(demisto, 'results')

--- a/Packs/CommonScripts/Scripts/GetErrorsFromEntry/README.md
+++ b/Packs/CommonScripts/Scripts/GetErrorsFromEntry/README.md
@@ -1,0 +1,24 @@
+Get the error(s) associated with a given entry/entries. Use ${lastCompletedTaskEntries} to check the previous task entries. The automation will return an array of the error contents from those entries.
+
+## Script Data
+---
+
+| **Name** | **Description** |
+| --- | --- |
+| Script Type | python3 |
+| Tags | Utility |
+| Cortex XSOAR Version | 6.2.0 |
+
+## Inputs
+---
+
+| **Argument Name** | **Description** |
+| --- | --- |
+| entry_id | Entry to check |
+
+## Outputs
+---
+
+| **Path** | **Description** | **Type** |
+| --- | --- | --- |
+| ErrorEntries | Contents of the errors associated with the entry/entries | Unknown |

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.6.70",
+    "currentVersion": "1.7.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-2953

## Description
Adds an automation called `GetErrors` that similarly to the `isError` automation, accepts `${lastCompletedTaskEntries}` as input, checks the entries for errors, and returns the error messages from those entries if they were indeed errors.

## Minimum version of Cortex XSOAR
- [x] 6.2.0

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
