### PR TITLE
DeleteContext fix nested key

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_6_70.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_6_70.md
@@ -1,0 +1,2 @@
+- **CommonScripts**
+- Fixed an issue in ***DeleteContext*** when the *key* argument supplied was nested/dot structure, the key was not found.

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -1,3 +1,19 @@
+Object.byString = function(o, s) {
+    s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
+    s = s.replace(/^\./, '');           // strip a leading dot
+    var a = s.split('.');
+    for (var i = 0, n = a.length; i < n; ++i) {
+        var k = a[i];
+        if (k in o) {
+            o = o[k];
+        } else {
+            return;
+        }
+    }
+    return o;
+}
+
+
 function errorEntry(text) {
     return  {
         ContentsFormat: formats.text,
@@ -5,6 +21,8 @@ function errorEntry(text) {
         Contents: text
     };
 }
+
+
 
 var fieldsToDelete;
 var shouldDeleteAll = (args.all === 'yes');
@@ -84,12 +102,23 @@ if (shouldDeleteAll) {
     if (isNaN(index)) {
         return errorEntry("Invalid index " + args.index)
     }
-    var contextVal = invContext[args.key];
-    if (!contextVal) {
-        return "Key [" + args.key + "] was not found.";
-    }
-    if (!Array.isArray(contextVal)) {
-        contextVal = [contextVal];
+    
+    var contextVal;
+    
+    // Check if key references a nested object
+    if (args.key.indexOf(".") !== -1) {
+        
+        contextVal = Object.byString(invContext, args.key)
+        
+    } else {
+    
+        contextVal = invContext[args.key];
+        if (!contextVal) {
+            return "Key [" + args.key + "] was not found.";
+        }
+        if (!Array.isArray(contextVal)) {
+            contextVal = [contextVal];
+        }
     }
 
     if (index < 0 || index >= contextVal.length) {

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -1,16 +1,19 @@
-Object.byString = function(o, s) {
-    s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
-    s = s.replace(/^\./, '');           // strip a leading dot
-    var a = s.split('.');
-    for (var i = 0, n = a.length; i < n; ++i) {
-        var k = a[i];
-        if (k in o) {
-            o = o[k];
+Object.byString = function(object, string_path) {
+    // Convert indices to props
+    string_path = string_path.replace(/\[(\w+)\]/g, '.$1');
+    
+    // strip a leading dot
+    string_path = string_path.replace(/^\./, '');
+    var nested_paths = string_path.split('.');
+    for (var i = 0, n = nested_paths.length; i < n; ++i) {
+        var key = nested_paths[i];
+        if (key in object) {
+            object = object[key];
         } else {
             return;
         }
     }
-    return o;
+    return object;
 }
 
 

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.6.69",
+    "currentVersion": "1.6.70",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

## Related Issues
[CIAC-3012](https://jira-hq.paloaltonetworks.local/browse/CIAC-3012)

## Description

When running the DeleteContext command with a nested path and an index, the command returns an error indicating that the key was not found.

### To reproduce:

1. Create a simple list/array in context:

```python
!Set key="Marketplace.SubscriptionService.Transaction" value="[{\"key1\": \"value1\"}, {\"key2\": \"value2\"}]"
```

2. Attempt to delete the 1st index:

```python
!DeleteContext key="Marketplace.SubscriptionService.Transaction" index=1
```

### Expected

Index 1 to be deleted from array in specified key.

### Actual

```
Key [Marketplace.SubscriptionService.Transaction] was not found.
```

I believe the issue lies in this line:

```javascript
var contextVal = invContext[args.key];
```

Because we're attempting to get the investigation context for a key "Marketplace.SubscriptionService.Transaction":

```javascript
var contextVal = invContext["Marketplace.SubscriptionService.Transaction"];
```

Instead, we should be be accessing the array as so:

```javascript
var contextVal = invContext["Marketplace"].SubscriptionService.Transaction;
```

Using CommonScripts version 1.6.65 2979078.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
