### PR TITLE
[Fix] splunk-kv-store-collection-search-entry not working with values containing substring "limit"

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -2577,7 +2577,7 @@ def get_store_data(service):
     for store in stores:
         store = service.kvstore[store]
         query = build_kv_store_query(store, args)
-        if 'limit' not in query:
+        if isinstance(query, (str, unicode)):
             query = {'query': query}
         yield store.data.query(**query)
 

--- a/Packs/SplunkPy/ReleaseNotes/2_4_4.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where **splunk-kv-store-collection-search-entry** command failed when limit was provided in *query*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.4.3",
+    "currentVersion": "2.4.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-12964

## Description
Fixed an issue where **splunk-kv-store-collection-search-entry** command failed when limit was provided in *query*.