### PR TITLE
Fix error to get script to work on particular MIME entity file type

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_6_71.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_6_71.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### ParseEmailFiles
+- Fixed an issue where the script errored on particular MIME entity file type

--- a/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFiles/ParseEmailFiles.py
@@ -3840,7 +3840,7 @@ def main():
 
         file_metadata = result[0]['FileMetadata']
         file_type = file_metadata.get('info', '') or file_metadata.get('type', '')
-        if 'MIME entity text, ISO-8859 text' in file_type:
+        if 'MIME entity text, ISO-8859 text' in file_type or 'MIME entity, ISO-8859 text' in file_type:
             file_type = 'application/pkcs7-mime'
 
     except Exception as ex:

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.6.70",
+    "currentVersion": "1.6.71",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://xsoar.ideas.aha.io/ideas/FR-I-2619

## Description
Modify conditional to get script to work for particular file type, `MIME entity, ISO-8859 text, with very long lines, with CRLF line terminators`. The conditional was previously checking for string `MIME entity text, ISO-8859 text`, which should have matched but did not, simply because of the extra word `text`.

I realize this script is deprecated, but it is an easy fix and would be useful for the customer. This script is actually easier to fix than `ParseEmailFilesV2`, which also errors on the same file, because `ParseEmailFilesV2` uses a third-party python library.

The customer who reported the issue is unable to share the file that triggers the error, but reach out to me and I can connect you with them if needed.

@trbharathwaj  @ValerieEsposito FYI

## Screenshots
![image](https://user-images.githubusercontent.com/91506078/171741665-691d2803-9aa2-428f-aa38-c5e998aba76e.png)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
