### PR TITLE
Little fix for the description of Server URL parameter.

### DIFF
--- a/Packs/IBMResilientSystems/Integrations/IBMResilientSystems/IBMResilientSystems.yml
+++ b/Packs/IBMResilientSystems/Integrations/IBMResilientSystems/IBMResilientSystems.yml
@@ -3,7 +3,7 @@ commonfields:
   id: IBM Resilient Systems
   version: -1
 configuration:
-- display: Server URL (e.g. 192.168.0.1)
+- display: Server URL (e.g. https://192.168.0.1:443 , please specify the port number)
   name: server
   required: true
   type: 0

--- a/Packs/IBMResilientSystems/Integrations/IBMResilientSystems/IBMResilientSystems.yml
+++ b/Packs/IBMResilientSystems/Integrations/IBMResilientSystems/IBMResilientSystems.yml
@@ -3,7 +3,7 @@ commonfields:
   id: IBM Resilient Systems
   version: -1
 configuration:
-- display: Server URL (e.g. https://192.168.0.1:443 , please specify the port number)
+- display: Server URL (e.g., https://192.168.0.1:443. Need to specify the port number.)
   name: server
   required: true
   type: 0

--- a/Packs/IBMResilientSystems/ReleaseNotes/1_0_10.md
+++ b/Packs/IBMResilientSystems/ReleaseNotes/1_0_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### IBM Resilient Systems
+- Documentation and metadata improvements.

--- a/Packs/IBMResilientSystems/pack_metadata.json
+++ b/Packs/IBMResilientSystems/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM Resilient Systems",
     "description": "Case management that enables visibility across your tools for continual IR improvement",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
If you check the code below:

URL = demisto.params()['server'][:-1] if demisto.params()['server'].endswith('/') else demisto.params()['server']
URL = URL.replace('http://', '').replace('https://', '')
SERVER, PORT = URL.rsplit(":", 1)

We will use rsplit to get SERVER and PORT from URL. But the original description of URL will let customers put ip or hostname only and get the following error message: Script failed to run: Error: [Traceback (most recent call last): File "<string>", line 35, in <module> ValueError: need more than 1 value to unpack ] (2604) (2603)

The customers without programming capability will have no idea how to solve it.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
