### PR TITLE
Mark defaultRegion param as mandatory

### DIFF
--- a/Packs/AWS-GuardDuty/Integrations/AWSGuardDuty/AWSGuardDuty.yml
+++ b/Packs/AWS-GuardDuty/Integrations/AWSGuardDuty/AWSGuardDuty.yml
@@ -5,7 +5,7 @@ commonfields:
 configuration:
 - display: AWS Default Region
   name: defaultRegion
-  required: false
+  required: true
   type: 0
 - display: Role Arn
   name: roleArn

--- a/Packs/AWS-GuardDuty/Integrations/AWSGuardDuty/README.md
+++ b/Packs/AWS-GuardDuty/Integrations/AWSGuardDuty/README.md
@@ -19,7 +19,7 @@ the [Amazon AWS Integrations Configuration Guide](https://xsoar.pan.dev/docs/ref
 
    | **Parameter** | **Required** |
           | --- | --- |
-   | AWS Default Region | False |
+   | AWS Default Region | True |
    | Role Arn | False |
    | Fetch incidents | False |
    | Incident type | False |

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.json
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"The AWS Default Region parameter is mandatory now."}

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### AWS - GuardDuty
-- Mark defaultRegion parameter as mandatory
+- Fixed an issue where the **AWS Default Region** parameter was not mandatory even though it is required for configuring an instance of the integration. 

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AWS - GuardDuty
+- Mark defaultRegion parameter as mandatory

--- a/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
+++ b/Packs/AWS-GuardDuty/ReleaseNotes/1_2_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### AWS - GuardDuty
-- Fixed an issue where the **AWS Default Region** parameter was not mandatory even though it is required for configuring an instance of the integration. 
+Fixed an issue where the *AWS Default Region* parameter was not mandatory even though it is required for configuring an instance of the integration. 

--- a/Packs/AWS-GuardDuty/pack_metadata.json
+++ b/Packs/AWS-GuardDuty/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - GuardDuty",
     "description": "Amazon Web Services Guard Duty Service (gd)",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Mark defaultRegion param as mandatory because, as customer pointed out, the Test will not pass unless a defaultRegion is specified.

Note: I got validation error `IN116` on this change, but it was unclear from the error message how to fix the error.

## Screenshots
![Screen Shot 2022-06-03 at 9 36 26 AM](https://user-images.githubusercontent.com/91506078/171892700-cf0f0824-ff51-41b0-b9c5-c45cfbcdea73.png)

## Minimum version of Cortex XSOAR
- [X] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [X] Yes
       - Further details: Possibly: if there is something I am missing where the integration could work without defaultRegion specified. If the reviewer has access to a GuardDuty test environment and could validate, that would be helpful. In the event of backward compatibility concerns, we should at least update the integration `README` to say this param is required.
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
