### PR TITLE
ReadPDFFileV2 bug fix

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_2.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_2.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### ReadPDFFileV2
+- Fixed an issue where some PDF files failed on `Could not find object` error.
+- Updated the Docker image to: *demisto/readpdf:1.0.0.30663*.

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
@@ -349,7 +349,14 @@ def extract_urls_and_emails_from_annot_objects(annot_objects):
 
     for annot_object in annot_objects:
         if isinstance(annot_object, PyPDF2.generic.IndirectObject):
-            annot_object = annot_object.get_object()
+            try:
+                annot_object = annot_object.get_object()
+            except Exception as e:
+                if "Could not find object" in str(e):
+                    demisto.error(f'annot.get_object() encountered an error: {e}.\n Skipping without failure.')
+                    continue
+                else:
+                    demisto.error(f'annot.get_object() encountered an error: {e}.')
 
         extracted_object = extract_url_from_annot_object(annot_object)
         # Separates URLs and Emails:
@@ -390,12 +397,7 @@ def get_urls_and_emails_from_pdf_annots(file_path):
                 annots = [annots]
 
             for annot in annots:
-                try:
-                    annot_objects = annot.get_object()
-                # There is a bug in PyPDF2, failed when converting an empty byte to an int in the get_object() function
-                except ValueError as e:
-                    demisto.error(f'annot.get_object() encountered an error: {e}.\n Skipping without failure.')
-                    continue
+                annot_objects = annot.get_object()
                 if not isinstance(annot_objects, PyPDF2.generic.ArrayObject):
                     annot_objects = [annot_objects]
 

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
@@ -127,7 +127,7 @@ tags:
 - ingestion
 timeout: '0'
 type: python
-dockerimage: demisto/readpdf:1.0.0.29961
+dockerimage: demisto/readpdf:1.0.0.30663
 runonce: false
 runas: DBotRole
 tests:

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.1",
+    "currentVersion": "1.7.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-13059

## Description
- Fixed an issue where some PDF files failed on `Could not find object` error.
![Screen Shot 2022-06-12 at 15 10 58](https://user-images.githubusercontent.com/54398957/173232508-70072b50-a05f-470e-b6d2-be87e11cb350.png)

