### PR TITLE
Deprecate ansible symantec log rhythm feed malware domain list mc afee esm recorded future

### DIFF
--- a/Packs/Ansible_Powered_Integrations/Playbooks/playbook-Wait_Until_Windows_Host_Online.yml
+++ b/Packs/Ansible_Powered_Integrations/Playbooks/playbook-Wait_Until_Windows_Host_Online.yml
@@ -191,3 +191,4 @@ tests:
 fromversion: 6.0.0
 description: Deprecated. Use "Wait Until Windows Host Online v2" playbook from the Ansible Microsoft Windows Pack instead.
 deprecated: true
+hidden: true

--- a/Packs/Ansible_Powered_Integrations/Playbooks/playbook-Windows_Application_Deployment.yml
+++ b/Packs/Ansible_Powered_Integrations/Playbooks/playbook-Windows_Application_Deployment.yml
@@ -692,3 +692,4 @@ tests:
 fromversion: 6.0.0
 description: Deprecated. Use "Windows Application Deployment v2" playbook from the Ansible Microsoft Windows Pack instead.
 deprecated: true
+hidden: true

--- a/Packs/Ansible_Powered_Integrations/ReleaseNotes/2_0_2.md
+++ b/Packs/Ansible_Powered_Integrations/ReleaseNotes/2_0_2.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+##### Wait Until Windows Host Online
+- Deprecated.
+##### Windows Application Deployment
+- Deprecated.

--- a/Packs/Ansible_Powered_Integrations/pack_metadata.json
+++ b/Packs/Ansible_Powered_Integrations/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Ansible Powered Integrations (Deprecated)",
     "description": "Run Ansible modules as native XSOAR commands with these agent-less integrations:\nMicrosoft Windows Host\nLinux Host\nCisco IOS\nCisco NX-OS\nOpenSSL\nACME\nDNS\nKubernetes\nVMware vSphere\nAzure Compute\nAzure Networking\nHetzner Cloud\nAlibaba Cloud\n",
     "support": "community",
-    "currentVersion": "2.0.1",
+    "currentVersion": "2.0.2",
     "author": "Serge Bakharev",
     "url": "https://github.com/SergeBakharev/Ansible-for-XSOAR",
     "email": "serge.bakharev@gmail.com",

--- a/Packs/Ansible_Powered_Integrations/pack_metadata.json
+++ b/Packs/Ansible_Powered_Integrations/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "Ansible Powered Integrations",
+    "name": "Ansible Powered Integrations (Deprecated)",
     "description": "Run Ansible modules as native XSOAR commands with these agent-less integrations:\nMicrosoft Windows Host\nLinux Host\nCisco IOS\nCisco NX-OS\nOpenSSL\nACME\nDNS\nKubernetes\nVMware vSphere\nAzure Compute\nAzure Networking\nHetzner Cloud\nAlibaba Cloud\n",
     "support": "community",
     "currentVersion": "2.0.1",

--- a/Packs/FeedMalwareDomainList/pack_metadata.json
+++ b/Packs/FeedMalwareDomainList/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "MalwareDomainList Feed",
+    "name": "MalwareDomainList Feed (Deprecated)",
     "description": "Indicators feed from MalwareDomainList",
     "support": "xsoar",
     "currentVersion": "1.1.7",

--- a/Packs/LogRhythm/pack_metadata.json
+++ b/Packs/LogRhythm/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "LogRhythm",
+    "name": "LogRhythm (Deprecated)",
     "description": "Deprecated. Use LogRhythmRest pack instead.",
     "support": "xsoar",
     "currentVersion": "1.0.1",

--- a/Packs/McAfee_ESM-v10/pack_metadata.json
+++ b/Packs/McAfee_ESM-v10/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "McAfee ESM v10 and v11",
+    "name": "McAfee ESM v10 and v11 (Deprecated)",
     "description": "Run queries and receive alarms from Intel Security ESM. Support version 10 and above.",
     "support": "xsoar",
     "currentVersion": "1.0.7",

--- a/Packs/Recorded_Future/ReleaseNotes/1_1_4.md
+++ b/Packs/Recorded_Future/ReleaseNotes/1_1_4.md
@@ -1,0 +1,12 @@
+
+#### Scripts
+##### RecordedFutureDomainRiskList
+- Deprecated.
+##### RecordedFutureVulnerabilityRiskList
+- Deprecated.
+##### RecordedFutureHashRiskList
+- Deprecated.
+##### RecordedFutureIPRiskList
+- Deprecated.
+##### RecordedFutureURLRiskList
+- Deprecated.

--- a/Packs/Recorded_Future/Scripts/script-RecordedFutureDomainRiskList.yml
+++ b/Packs/Recorded_Future/Scripts/script-RecordedFutureDomainRiskList.yml
@@ -129,4 +129,5 @@ runonce: false
 tests:
 - No test - fetches indicators
 fromversion: 5.0.0
+deprecated: true
 dockerimage: demisto/python:2.7.18.24398

--- a/Packs/Recorded_Future/Scripts/script-RecordedFutureHashRiskList.yml
+++ b/Packs/Recorded_Future/Scripts/script-RecordedFutureHashRiskList.yml
@@ -117,4 +117,5 @@ runonce: false
 tests:
 - No test - fetches indicators
 fromversion: 5.0.0
+deprecated: true
 dockerimage: demisto/python:2.7.18.24398

--- a/Packs/Recorded_Future/Scripts/script-RecordedFutureIPRiskList.yml
+++ b/Packs/Recorded_Future/Scripts/script-RecordedFutureIPRiskList.yml
@@ -129,4 +129,5 @@ runonce: false
 tests:
 - No test - fetches indicators
 fromversion: 5.0.0
+deprecated: true
 dockerimage: demisto/python:2.7.18.24398

--- a/Packs/Recorded_Future/Scripts/script-RecordedFutureURLRiskList.yml
+++ b/Packs/Recorded_Future/Scripts/script-RecordedFutureURLRiskList.yml
@@ -128,4 +128,5 @@ runonce: false
 tests:
 - No test - fetches indicators
 fromversion: 5.0.0
+deprecated: true
 dockerimage: demisto/python:2.7.18.24398

--- a/Packs/Recorded_Future/Scripts/script-RecordedFutureVulnerabilityRiskList.yml
+++ b/Packs/Recorded_Future/Scripts/script-RecordedFutureVulnerabilityRiskList.yml
@@ -129,4 +129,5 @@ runonce: false
 tests:
 - No test - fetches indicators
 fromversion: 5.0.0
+deprecated: true
 dockerimage: demisto/python:2.7.18.24398

--- a/Packs/Recorded_Future/pack_metadata.json
+++ b/Packs/Recorded_Future/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "Recorded Future",
+    "name": "Recorded Future (Deprecated)",
     "description": "Unique threat intel technology that automatically serves up relevant insights in real time.",
     "support": "xsoar",
     "currentVersion": "1.1.3",

--- a/Packs/Recorded_Future/pack_metadata.json
+++ b/Packs/Recorded_Future/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Recorded Future (Deprecated)",
     "description": "Unique threat intel technology that automatically serves up relevant insights in real time.",
     "support": "xsoar",
-    "currentVersion": "1.1.3",
+    "currentVersion": "1.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-2987)

## Description
deprecate the following packs content items of the following packs:

Ansible_Powered_Integrations
Symantec_Deepsight
LogRhythm
FeedMalwareDomainList
McAfee_ESM-v10
Recorded_Future