### PR TITLE
Added cgroups v2 support to DockerHardeningScript

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_4.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_4.md
@@ -2,5 +2,5 @@
 #### Scripts
 ##### DockerHardeningCheck
 - Added support for cgroups v2
-- Fixed support for memory check_type=allocate
+- Fixed an issue where memory check_type was incorrect.
 - Updated the Docker image to: demisto/python3:3.10.4.30607

--- a/Packs/CommonScripts/ReleaseNotes/1_7_4.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_4.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+##### DockerHardeningCheck
+- Added support for cgroups v2
+- Fixed support for memory check_type=allocate
+- Updated the Docker image to: demisto/python3:3.10.4.30607

--- a/Packs/CommonScripts/Scripts/DockerHardeningCheck/DockerHardeningCheck.yml
+++ b/Packs/CommonScripts/Scripts/DockerHardeningCheck/DockerHardeningCheck.yml
@@ -6,40 +6,35 @@ script: ''
 type: python
 tags:
 - Utility
-comment: 'Checks if the Docker container running this script has been hardened according
-  to the recommended settings at: https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/docker/docker-hardening-guide.html'
+comment: 'Checks if the Docker container running this script has been hardened according to the recommended settings at: https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-0/cortex-xsoar-admin/docker/docker-hardening-guide.html'
 enabled: true
 args:
 - name: memory
-  description: The amount of memory to check. Can specify in bytes or append MB/GB
-    for Mega/Giga bytes. Default is 1 GB.
+  description: The amount of memory to check. Can specify in bytes or append MB/GB for Mega/Giga bytes. Default is 1 GB.
   defaultValue: 1GB
 - name: memory_check
   auto: PREDEFINED
   predefined:
   - cgroup
   - allocate
-  description: 'The memory check type to perform: cgroup - check memory cgroup configuration,
-    allocate - try allocating actual memory and verify that the allocation fails.
-    Note the allocate test  on some configurations may cause the container to be killed
-    by the linux memory manager and the whole test will then time out.'
+  description: 'The memory check type to perform: cgroup - check memory cgroup configuration, allocate - try allocating actual memory and verify that the allocation fails. Note the allocate test  on some configurations may cause the container to be killed by the linux memory manager and the whole test will then time out.'
   defaultValue: cgroup
 - name: pids
   description: The maximum number of PIDs to check.
-  defaultValue: "256"
+  defaultValue: '256'
 - name: fds_soft
   description: The soft file descriptor limit to check.
-  defaultValue: "1024"
+  defaultValue: '1024'
 - name: fds_hard
   description: The hard file descriptor limit to check.
-  defaultValue: "8192"
+  defaultValue: '8192'
 - name: cpus
   description: The number of CPUs limit to check.
-  defaultValue: "1"
+  defaultValue: '1'
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.9.8.24399
+dockerimage: demisto/python3:3.10.4.30607
 runas: DBotWeakRole
 fromversion: 5.0.0
 tests:

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.3",
+    "currentVersion": "1.7.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
- Added support for cgroups v2
- Fixed support for memory check_type=allocate
- Updated the Docker image to: demisto/python3:3.10.4.30607

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Description
When using Ubuntu 22.04 the memory check was failing due to Ubuntu changing to cgroups v2. The file path with the max RAM value was changed to a shared path. This update adds support for cgroups v2 without removing support for cgroups v1.

While adding this support, I noticed the memory_check argument options did not match the code for allocate. I updated the code to use the `allocate` option instead of `allocation`. If a user supplied `allocate` like the argument list options supplied, the cgroup check was actually being used.

## Minimum version of Cortex XSOAR
- [X] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
