### PR TITLE
Fixed a bug with deleting email from the layout

### DIFF
--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
@@ -346,7 +346,7 @@
                             },
                             {
                                 "endCol": 2,
-                                "fieldId": "deleteemailfrombrand",
+                                "fieldId": "emaildeletefrombrand",
                                 "height": 22,
                                 "id": "51e6d7d0-af45-11ec-99c4-cfc9ad59fcf6",
                                 "index": 3,

--- a/Packs/Phishing/ReleaseNotes/3_2_4.md
+++ b/Packs/Phishing/ReleaseNotes/3_2_4.md
@@ -1,0 +1,4 @@
+
+#### Layouts
+##### Phishing Incident v3
+- %%UPDATE_RN%%

--- a/Packs/Phishing/ReleaseNotes/3_2_4.md
+++ b/Packs/Phishing/ReleaseNotes/3_2_4.md
@@ -1,4 +1,4 @@
 
 #### Layouts
 ##### Phishing Incident v3
-- %%UPDATE_RN%%
+- Fixed an issue where the integration brand from which the email should be deleted was not displayed in the layout.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.2.3",
+    "currentVersion": "3.2.4",
     "serverMinVersion": "6.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3195

## Description
Fixed an issue where the email brand from which emails should be deleted was not available for selection and was not shown in the layout.

## Minimum version of Cortex XSOAR
6.1.0

## Does it break backward compatibility?
No

