### PR TITLE
remove double contributor credits

### DIFF
--- a/Packs/EmailCommunication/README.md
+++ b/Packs/EmailCommunication/README.md
@@ -26,9 +26,3 @@ This pack includes, out of the box, a full layout, scripts, and incident fields.
 _For more information about the pack, visit our [Cortex XSOAR Developer Docs](https://xsoar.pan.dev/docs/reference/packs/email-communication)
 
 ![Email_Communication_layout](https://raw.githubusercontent.com/demisto/content/master/Packs/EmailCommunication/doc_files/Email_Communication_layout.png)
-### Pack Contributors:
-
----
- - Mike Rizzo
-
-Contributions are welcome and appreciated. For more info, visit our [Contribution Guide](https://xsoar.pan.dev/docs/contributing/contributing).


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


Contributot credits were shown twice because they were added to the contributors.md and the readme.md. removed from readme.

## Screenshots
<img width="850" alt="image" src="https://user-images.githubusercontent.com/19407287/174629092-302b55d5-983f-46ba-8a20-91a839d29d73.png">
