### PR TITLE
Update JiraV2.py

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -728,16 +728,16 @@ def create_issue_command():
 
 
 def edit_issue_command(issue_id, mirroring=False, headers=None, status=None, transition=None, **kwargs):
-    url = f'rest/api/latest/issue/{issue_id}/'
-    issue = get_issue_fields(mirroring=mirroring, **kwargs)
-    #jira_req('PUT', url, json.dumps(issue))
+    issue = get_issue_fields(mirroring=mirroring, **kwargs)    
     if status and transition:
         return_error("Please provide only status or transition, but not both.")
     elif status:
         edit_status(issue_id, status, issue)
     elif transition:
         edit_transition(issue_id, transition, issue)
-
+    else:
+        url = f'rest/api/latest/issue/{issue_id}/'
+        jira_req('PUT', url, json.dumps(issue))
     return get_issue(issue_id, headers, is_update=True)
 
 
@@ -750,8 +750,7 @@ def edit_status(issue_id, status, issue):
         if transition.lower() == status.lower():
             url = f'rest/api/latest/issue/{issue_id}/transitions?expand=transitions.fields'
             issue['transition'] = {"id": str(j_res.get('transitions')[i].get('id'))}
-            #json_body = {"transition": {"id": str(j_res.get('transitions')[i].get('id'))}}
-            return jira_req('POST', url, json.dumps(json_body))
+            return jira_req('POST', url, json.dumps(issue))
 
     return_error(f'Status "{status}" not found. \nValid transitions are: {transitions} \n')
 
@@ -779,7 +778,6 @@ def edit_transition(issue_id, transition_name, issue):
         if transition.get('name') == transition_name:
             url = f'rest/api/latest/issue/{issue_id}/transitions?expand=transitions.fields'
             issue['transition'] = {"id": transition.get("id")}
-            #json_body = {"transition": {"id": transition.get("id")}}
             return jira_req('POST', url, json.dumps(issue))
 
     return_error(f'Transitions "{transition_name}" not found. \nValid transitions are: {transitions_data} \n')


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
With the current version, it's impossible to add a resolution to a Jira ticket when transitioning to Closed, since the issueJson field is being added to the initial PUT request, but the resolution field has to be part of the transition POST request. This fix will make it possible to transition a Jira ticket to closed AND set the resolution field using issueJson.
An example that doesn't work with the current solution, but works with this fix:

```
!jira-edit-issue issueId="3723610" issueJson="{
    \"update\": {
        \"comment\": [
            {
                \"add\": {
                    \"body\": \"Bug has been fixed.\"
                }
            }
        ]
    },
    \"fields\": {        
        \"resolution\": {
            \"name\": \"Done\"
        }
    }
}" transition="Closed" using="jira-v2" raw-response="true"
```

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
