### PR TITLE
Fix Jira first fetch

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -1004,7 +1004,7 @@ def fetch_incidents(query, id_offset, should_get_attachments, should_get_comment
         if fetch_by_created:
             query = f'{query} AND created>-1m'
 
-    res = run_query(query, 0, max_results)
+    res = run_query(query, '', max_results)
     if res:
         curr_id = int(id_offset)
         for ticket in res.get('issues'):

--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -1000,11 +1000,11 @@ def fetch_incidents(query, id_offset, should_get_attachments, should_get_comment
         query = f'{query} AND created>=\"{formatted_minute_to_fetch}\"'
     else:
         if id_offset:
-            query = f'{query} AND id >= {id_offset}'
+            query = f'{query} AND id >= {id_offset} ORDER BY id ASC'
         if fetch_by_created:
             query = f'{query} AND created>-1m'
 
-    res = run_query(query, '', max_results)
+    res = run_query(query, 0, max_results)
     if res:
         curr_id = int(id_offset)
         for ticket in res.get('issues'):

--- a/Packs/Jira/ReleaseNotes/2_0_5.md
+++ b/Packs/Jira/ReleaseNotes/2_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Atlassian Jira v2
+- Fixed an issue where **fetch-incidents** fetched only 50 existing incidents while there were more existing incidents to fetch.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Cortex XSOAR incidents from Jira projects.",
     "support": "xsoar",
-    "currentVersion": "2.0.4",
+    "currentVersion": "2.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-13542

## Description
When the integration is configured to start fetch and there are more then 50 incidents to fetch, then it will fetch only the latest 50 incident because the original query gets the issues in descending order, and in the next fetch it uses the last issue id to filter, so any older ticket that were expected to be fetched were missed.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
