### PR TITLE
PANW products code-owners fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,14 +23,14 @@
 /Tests/scripts/collect_tests_and_content_packs.py @dorschw
 
 # PANW Products
-/Packs/PaloAltoNetworksIoT/Integrations/* @bakatzir
-/Packs/PaloAltoNetworksIoT3rdParty/Integrations/* @bakatzir
-/Packs/Palo_Alto_Networks_Enterprise_DLP/* @DeanArbel
-/Packs/PAN-OS/Integrations/* @GuyAfik
-/Packs/PrismaAccess/Integrations/* @bakatzir
-/Packs/PrismaCloudCompute/Integrations/* @GuyAfik
-/Packs/PrismaCloud/Integrations/* @bakatzir
-/Packs/PrismaSaasSecurity/Integrations/* @yaakovpraisler
+/Packs/PaloAltoNetworksIoT/Integrations/ @bakatzir
+/Packs/PaloAltoNetworksIoT3rdParty/Integrations/ @bakatzir
+/Packs/Palo_Alto_Networks_Enterprise_DLP/ @DeanArbel
+/Packs/PAN-OS/Integrations/ @GuyAfik
+/Packs/PrismaAccess/Integrations/ @bakatzir
+/Packs/PrismaCloudCompute/Integrations/ @GuyAfik
+/Packs/PrismaCloud/Integrations/ @bakatzir
+/Packs/PrismaSaasSecurity/Integrations/ @yaakovpraisler
 
 # Important Integrations
 /Packs/Jira/Integrations/JiraV2/* @demisto/content-leaders


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed an issue where for PANW products the code-owners was not triggerd.

See this example PR(s) which didn't trigger the code owners at all. 

1) https://github.com/demisto/content/pull/19710
2) https://github.com/demisto/content/pull/19773

from docs:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

`
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com
`

`
# In this example, @doctocat owns any files in the build/logs
# directory at the root of the repository and any of its
# subdirectories.
/build/logs/ @doctocat
`

we should use option 2.