### PR TITLE
Fix panorama pcap bug

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -3506,10 +3506,14 @@ def panorama_get_pcap_command(args: dict):
     serial_no = args.get('serialNo')
     session_id = args.get('sessionID')
     device_name = args.get('deviceName')
-    serial_number = args.get('serialNumber')
 
+    serial_number = args.get('serialNumber')
     if VSYS and serial_number:
         raise Exception('The serialNumber argument can only be used in a Panorama instance configuration')
+    elif DEVICE_GROUP and not serial_number and pcap_type != 'threat-pcap':
+        raise Exception('PCAP listing is only supported on Panorama with the serialNumber argument.')
+    elif serial_number and pcap_type != 'threat-pcap':
+        params['target'] = serial_number
 
     file_name = None
     if pcap_id:
@@ -3529,8 +3533,6 @@ def panorama_get_pcap_command(args: dict):
     if search_time:
         search_time = validate_search_time(search_time)
         params['search-time'] = search_time
-    if serial_number:
-        params['target'] = serial_number
 
     # set file name to the current time if from/to were not specified
     if not file_name:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -3507,13 +3507,8 @@ def panorama_get_pcap_command(args: dict):
     session_id = args.get('sessionID')
     device_name = args.get('deviceName')
 
-    serial_number = args.get('serialNumber')
-    if VSYS and serial_number:
+    if VSYS and serial_no:
         raise Exception('The serialNumber argument can only be used in a Panorama instance configuration')
-    elif DEVICE_GROUP and not serial_number:
-        raise Exception('PCAP listing is only supported on Panorama with the serialNumber argument.')
-    elif serial_number:
-        params['target'] = serial_number
 
     file_name = None
     if pcap_id:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -3506,8 +3506,9 @@ def panorama_get_pcap_command(args: dict):
     serial_no = args.get('serialNo')
     session_id = args.get('sessionID')
     device_name = args.get('deviceName')
+    serial_number = args.get('serialNumber')
 
-    if VSYS and serial_no:
+    if VSYS and serial_number:
         raise Exception('The serialNumber argument can only be used in a Panorama instance configuration')
 
     file_name = None
@@ -3528,6 +3529,8 @@ def panorama_get_pcap_command(args: dict):
     if search_time:
         search_time = validate_search_time(search_time)
         params['search-time'] = search_time
+    if serial_number:
+        params['target'] = serial_number
 
     # set file name to the current time if from/to were not specified
     if not file_name:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -5335,7 +5335,6 @@ script:
       required: true
     - description: The serial number of the firewall to download the PCAP from.
       name: serialNumber
-      deprecated: true
     - description: The file name for the PCAP type ('dlp-pcap', 'filter-pcap', or 'application-pcap'). Required for 'filter-pcap'.
       name: from
     - description: The new name for the PCAP file after downloading. If this argument

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -5335,6 +5335,7 @@ script:
       required: true
     - description: The serial number of the firewall to download the PCAP from.
       name: serialNumber
+      deprecated: true
     - description: The file name for the PCAP type ('dlp-pcap', 'filter-pcap', or 'application-pcap'). Required for 'filter-pcap'.
       name: from
     - description: The new name for the PCAP file after downloading. If this argument

--- a/Packs/PAN-OS/ReleaseNotes/1_14_5.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_5.md
@@ -1,3 +1,3 @@
 #### Integrations
 ##### Palo Alto Networks PAN-OS
-- Fixed an issue where the **pan-os-get-pcap** command failed even when there were pcaps available in the firewall.
+- Fixed an issue where the **pan-os-get-pcap** command failed even when there were threat pcaps available in the firewall.

--- a/Packs/PAN-OS/ReleaseNotes/1_14_5.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_5.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue where the **pan-os-get-pcap** command failed even when there were pcaps available in the firewall.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.14.4",
+    "currentVersion": "1.14.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-13902)

## Description
This PR fixes an issue where in panorama integration when trying to retrieve threat pcap files, it fails even in cases where those pcaps actually exist in the firewall.


