### PR TITLE
MITRE ATT&CK v2 handle incorrect attack-pattern 

### DIFF
--- a/Packs/FeedMitreAttackv2/Integrations/FeedMitreAttackv2/FeedMitreAttackv2.py
+++ b/Packs/FeedMitreAttackv2/Integrations/FeedMitreAttackv2/FeedMitreAttackv2.py
@@ -483,7 +483,7 @@ def attack_pattern_reputation_command(client, args):
             filter_by_name = [Filter('type', '=', 'attack-pattern'), Filter('name', '=', name)]
             mitre_data = get_mitre_data_by_filter(client, filter_by_name)
             if not mitre_data:
-                break
+                continue
 
             value = mitre_data.get('name')
 
@@ -497,7 +497,7 @@ def attack_pattern_reputation_command(client, args):
             filter_by_name = [Filter('type', '=', 'attack-pattern'), Filter('name', '=', parent)]
             mitre_data = get_mitre_data_by_filter(client, filter_by_name)
             if not mitre_data:
-                break
+                continue
             indicator_json = json.loads(str(mitre_data))
             parent_mitre_id = [external.get('external_id') for external in
                                indicator_json.get('external_references', [])
@@ -509,7 +509,7 @@ def attack_pattern_reputation_command(client, args):
             filter_by_name = [Filter('type', '=', 'attack-pattern'), Filter('name', '=', sub)]
             mitre_data = get_mitre_data_by_filter(client, filter_by_name)
             if not mitre_data:
-                break
+                continue
             indicator_json = json.loads(str(mitre_data))
             sub_mitre_id = [external.get('external_id') for external in
                             indicator_json.get('external_references', [])
@@ -522,7 +522,7 @@ def attack_pattern_reputation_command(client, args):
                             Filter("type", "=", "attack-pattern")]
             mitre_data = get_mitre_data_by_filter(client, mitre_filter)
             if not mitre_data:
-                break
+                continue
 
             value = f'{parent_name}: {mitre_data.get("name")}'
 

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_2.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### MITRE ATT&CK Feed v2
+- Fixed an issue in the command **attack-pattern** where providing an incorrect *attack_pattern* in a list would skip all subsequent valid attack_patterns.   

--- a/Packs/FeedMitreAttackv2/pack_metadata.json
+++ b/Packs/FeedMitreAttackv2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MITRE ATT&CK v2",
     "description": "Fetches indicators from MITRE ATT&CK.",
     "support": "xsoar",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3312

## Description
Fixed an issue in the command **attack-pattern** where providing an incorrect *attack_pattern* in a list would skip all subsequent valid attack_patterns.