### PR TITLE
skip firewall test playbooks

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5187,6 +5187,8 @@
         }
     ],
     "skipped_tests": {
+        "Panorama Query Logs - Test": "issues with firewall environment configuration - CIAC-3459",
+        "palo_alto_firewall_test_pb": "issues with firewall environment configuration - CIAC-3459",
         "Test - CrowdStrike Falcon": "to merge https://github.com/demisto/content/pull/19250",
         "MISP V2 Test": "The integration is deprecated as we released MISP V3",
         "Github IAM - Test Playbook": "Issue 32383",


### PR DESCRIPTION
skip firewall test-playbooks due to env issues

will be resolved by [firewall-test-playbooks-failures-issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3459)