### PR TITLE
Add category filter for Feed Office 365

### DIFF
--- a/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365.py
+++ b/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365.py
@@ -9,23 +9,25 @@ from CommonServerPython import *
 urllib3.disable_warnings()
 INTEGRATION_NAME = 'Office 365'
 ALL_REGIONS_LIST = ['Worldwide', 'China', 'Germany', 'USGovDoD', 'USGovGCCHigh']
+ALL_CATEGORY_LIST = ['Optimize', 'Allow', 'Default']
 
 
-def build_region_list(config_region_list: list) -> list:
-    """Builds the region list for the feed.
-    If the config_region_list includes 'All',
-    it will add all the known regions to the list, and remove the string all.
+def build_region_or_category_list(param_list: list, all_config_list: list) -> list:
+    """Builds the region or category list for the feed.
+    If the param_list includes 'All',
+    it will add all the items from the 'all_config_list' to the list, and remove the string all.
 
     Args:
-        config_region_list: list of regions provided by integration configuration
+        param_list: list of regions or categories provided by integration configuration
+        all_config_list: list of all the regions or categories, to be added if All is chosen
 
     Returns:
-        list of regions
+        list of regions or categories
     """
-    if 'All' in config_region_list:
-        config_region_list.remove('All')
-        return list(set(config_region_list + ALL_REGIONS_LIST))
-    return config_region_list
+    if 'All' in param_list:
+        param_list.remove('All')
+        return list(set(param_list + all_config_list))
+    return param_list
 
 
 def build_urls_dict(regions_list: list, services_list: list, unique_id) -> List[Dict[str, Any]]:
@@ -63,7 +65,7 @@ class Client:
     https://techcommunity.microsoft.com/t5/Office-365-Blog/Announcing-Office-365-endpoint-categories-and-Office-365-IP/ba-p/177638
     """
 
-    def __init__(self, urls_list: list, insecure: bool = False, tags: Optional[list] = None,
+    def __init__(self, urls_list: list, category_list: list, insecure: bool = False, tags: Optional[list] = None,
                  tlp_color: Optional[str] = None):
         """
         Implements class for Office 365 feeds.
@@ -76,6 +78,7 @@ class Client:
         self.tags = [] if tags is None else tags
         self.tlp_color = tlp_color
         self._proxies = handle_proxy(proxy_param_name='proxy', checkbox_default_value=False)
+        self.category_list = category_list
 
     def build_iterator(self) -> List:
         """Retrieves all entries from the feed.
@@ -96,7 +99,9 @@ class Client:
                 )
                 response.raise_for_status()
                 data = response.json()
-                indicators = [i for i in data if 'ips' in i or 'urls' in i]  # filter empty entries and add metadata]
+                # filter empty entries and category param, add metadata
+                indicators = [i for i in data if ('ips' in i or 'urls' in i)
+                              and i.get('category') in self.category_list]
                 for i in indicators:  # add relevant fields of services
                     i.update({
                         'Region': region,
@@ -253,8 +258,9 @@ def main():
     """
     params = demisto.params()
     unique_id = str(uuid.uuid4())
-    regions_list = build_region_list(argToList(params.get('regions')))
+    regions_list = build_region_or_category_list(argToList(params.get('regions')), ALL_REGIONS_LIST)
     services_list = argToList(params.get('services'))
+    category_list = build_region_or_category_list(argToList(params.get('category')), ALL_CATEGORY_LIST)
     urls_list = build_urls_dict(regions_list, services_list, unique_id)
     use_ssl = not params.get('insecure', False)
     tags = argToList(params.get('feedTags'))
@@ -264,7 +270,7 @@ def main():
     demisto.info(f'Command being called is {command}')
 
     try:
-        client = Client(urls_list, use_ssl, tags, tlp_color)
+        client = Client(urls_list, category_list, use_ssl, tags, tlp_color)
         commands: Dict[str, Callable[[Client, Dict[str, str]], Tuple[str, Dict[Any, Any], Dict[Any, Any]]]] = {
             'test-module': test_module,
             'office365-get-indicators': get_indicators_command

--- a/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365.yml
+++ b/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365.yml
@@ -9,6 +9,16 @@ configuration:
   required: false
   type: 8
 - defaultvalue: All
+  display: Category
+  name: category
+  options:
+  - All
+  - Optimize
+  - Allow
+  - Default
+  required: true
+  type: 16
+- defaultvalue: All
   display: Regions
   name: regions
   options:

--- a/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365_test.py
+++ b/Packs/FeedOffice365/Integrations/FeedOffice365/FeedOffice365_test.py
@@ -1,11 +1,33 @@
 import pytest
 import requests_mock
 
-from FeedOffice365 import Client, get_indicators_command, fetch_indicators_command, build_region_list, ALL_REGIONS_LIST
+from FeedOffice365 import Client, get_indicators_command, fetch_indicators_command, build_region_or_category_list, \
+    ALL_REGIONS_LIST, ALL_CATEGORY_LIST
 from test_data.feed_data import RESPONSE_DATA
 
 
-def test_fetch_indicators_command():
+@pytest.mark.parametrize('category_list, expected_indicators', [
+    (ALL_CATEGORY_LIST, 10),
+    (['Optimize'], 6),
+    (['Allow'], 0)
+])
+def test_fetch_indicators_command(category_list, expected_indicators):
+    """
+    Given:
+    - Global feed url and category list.
+    (A) - Full category list.
+    (B) - Category list containing only Optimize.
+    (C) - Category list containing only Allow.
+
+    When:
+     - Fetching incidents.
+
+    Then:
+     - Ensure that the incidents returned are as expected.
+     (A) - all incidents from response are handled and returned.
+     (B) - only incidents with 'Optimize' category are returned.
+    (C) - Empty list as there aren't any indicators with 'Allow' category.
+    """
     with requests_mock.Mocker() as mock:
         url_dict = {
             "FeedURL": 'https://endpoints.office.com/endpoints/worldwide',
@@ -13,9 +35,9 @@ def test_fetch_indicators_command():
             "Service": 'Any'
         }
         mock.get(url_dict.get('FeedURL'), json=RESPONSE_DATA)
-        client = Client([url_dict])
+        client = Client([url_dict], category_list)
         indicators = fetch_indicators_command(client)
-        assert len(indicators) == 10
+        assert len(indicators) == expected_indicators
 
 
 @pytest.mark.parametrize('command, args, response, length', [
@@ -29,7 +51,7 @@ def test_commands(command, args, response, length, mocker):
         "Region": 'Worldwide',
         "Service": 'Any'
     }
-    client = Client(urls_list=[url_dict], insecure=False)
+    client = Client(urls_list=[url_dict], category_list=ALL_CATEGORY_LIST, insecure=False)
     mocker.patch.object(client, 'build_iterator', return_value=response)
     human_readable, indicators_ec, raw_json = command(client, args)
     indicators = raw_json.get('raw_response')
@@ -63,29 +85,32 @@ class TestFeedTags:
         Then:
         - Validate the tags supplied exists in the indicators
         """
-        client = Client(self.urls, False, tags)
+        client = Client(self.urls, ALL_CATEGORY_LIST, False, tags)
         mocker.patch.object(client, 'build_iterator', return_value=RESPONSE_DATA)
         _, _, raw_json = get_indicators_command(client, {'limit': 2, 'indicator_type': 'IPs'})
         assert tags == raw_json.get('raw_response')[0]['fields']['tags']
 
 
-@pytest.mark.parametrize('config_region_list, response', [
-    (['All'], ALL_REGIONS_LIST),
-    (['All', 'my_region'], ALL_REGIONS_LIST + ['my_region']),
-    (['my_region'], ['my_region'])
+@pytest.mark.parametrize('param_list, all_config_list, response', [
+    (['All'], ALL_REGIONS_LIST, ALL_REGIONS_LIST),
+    (['All', 'my_region'], ALL_REGIONS_LIST, ALL_REGIONS_LIST + ['my_region']),
+    (['my_region'], ALL_REGIONS_LIST, ['my_region']),
+    (['All'], ALL_CATEGORY_LIST, ALL_CATEGORY_LIST),
+    (['All', 'Optimize', 'my_category'], ALL_CATEGORY_LIST, ALL_CATEGORY_LIST + ['my_category']),
+    (['my_category'], ALL_CATEGORY_LIST, ['my_category']),
 ])  # noqa: E124
-def test_build_region_list(config_region_list, response):
+def test_build_region_or_category_list(param_list, all_config_list, response):
     """
     Given:
-    - region lists provided by configurations
+    - region or category lists provided by configurations
     When:
-    - building the region list with build_region_list()
+    - building the region or category list with build_region_or_category_list()
     Then:
-    - Formatted region list will be returned:
+    - Formatted list will be returned:
         in cases 'All' item is in the config list,
-        the returned region list will include 'ALL_REGIONS_LIST', and 'All' will be removed.
+        the returned list will include all_config_list, and 'All' will be removed.
     """
-    region_list = build_region_list(config_region_list)
+    region_list = build_region_or_category_list(param_list, all_config_list)
     region_list.sort()
     response.sort()
     assert region_list == response


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue ](https://jira-hq.paloaltonetworks.local/browse/CIAC-825)

## Description
Add a filter by Category field, for indicators from Feed Office 365.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [ ] Documentation 
