### PR TITLE
Updated DBotPredictURLPhishing readme with security disclaimer

### DIFF
--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
@@ -3,7 +3,7 @@ Predict phishing URLs using a pre-trained model.
 ## Docker Security Recommendations
 ---
 
-This script is usually used to rasterize untrusted URLs, so we recommend following the instructions at the [Docker Network Hardening](https://xsoar.pan.dev/docs/reference/integrations/rasterize#docker-security-recommendations) under the Block Internal Network Access section.
+This script is used to rasterize usually untrusted URLs, so we recommend following the instructions at the [Docker Network Hardening](https://xsoar.pan.dev/docs/reference/integrations/rasterize#docker-security-recommendations) page under the Block Internal Network Access section.
 
 ## Script Data
 ---

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
@@ -1,5 +1,10 @@
 Predict phishing URLs using a pre-trained model.
 
+## Docker Security Recommendations
+---
+
+This script is usually used to rasterize untrusted URLs, so we recommend following the instructions at the [Docker Network Hardening](https://xsoar.pan.dev/docs/reference/integrations/rasterize#docker-security-recommendations) under the Block Internal Network Access section.
+
 ## Script Data
 ---
 

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
@@ -1,6 +1,6 @@
 Predict phishing URLs using a pre-trained model.
 
-## Docker Security Recommendations
+## Security Recommendations
 ---
 
 This script is used to rasterize usually untrusted URLs, so we recommend following the instructions at the [Docker Network Hardening](https://xsoar.pan.dev/docs/reference/integrations/rasterize#docker-security-recommendations) page under the Block Internal Network Access section.

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/README.md
@@ -3,7 +3,7 @@ Predict phishing URLs using a pre-trained model.
 ## Security Recommendations
 ---
 
-This script is used to rasterize usually untrusted URLs, so we recommend following the instructions at the [Docker Network Hardening](https://xsoar.pan.dev/docs/reference/integrations/rasterize#docker-security-recommendations) page under the Block Internal Network Access section.
+This script uses the [Rasterize](https://xsoar.pan.dev/docs/reference/integrations/rasterize) integration. If this script is used to rasterize untrusted URLs, we strongly recommend following the security recommendations included at the [Rasterize Documentation](https://xsoar.pan.dev/docs/reference/integrations/rasterize).
 
 ## Script Data
 ---


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3461

## Description
Added a security disclaimer as the DBotPredictURLPhishing script uses Rasterize which has a security recommendation for docker network hardening.
