### PR TITLE
Remote Access V2 system arg

### DIFF
--- a/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.yml
+++ b/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.yml
@@ -58,6 +58,24 @@ script:
       name: timeout
       required: false
       secret: false
+    - default: false
+      description: Additional system to run the command on.
+      isArray: false
+      name: system
+      required: false
+      secret: false
+    - default: false
+      description: Additional hostname to run the command on.
+      isArray: false
+      name: host
+      required: false
+      secret: false
+    - default: false
+      description: Port to run the command on. Argument "port" is supported only when providing "host" argument.
+      isArray: false
+      name: port
+      required: false
+      secret: false
     deprecated: false
     description: Run the specified command on the remote system with SSH.
     execution: true
@@ -117,6 +135,24 @@ script:
       name: entry
       required: false
       secret: false
+    - default: false
+      description: Additional system to run the command on.
+      isArray: false
+      name: system
+      required: false
+      secret: false
+    - default: false
+      description: Additional hostname to run the command on.
+      isArray: false
+      name: host
+      required: false
+      secret: false
+    - default: false
+      description: Port to run the command on. Argument "port" is supported only when providing "host" argument.
+      isArray: false
+      name: port
+      required: false
+      secret: false
     deprecated: false
     description: Copies the given file from Cortex XSOAR to the remote machine.
     execution: false
@@ -154,6 +190,24 @@ script:
         (Deprecated. Use file_path instead).
       isArray: false
       name: file
+      required: false
+      secret: false
+    - default: false
+      description: Additional system to run the command on.
+      isArray: false
+      name: system
+      required: false
+      secret: false
+    - default: false
+      description: Additional hostname to run the command on.
+      isArray: false
+      name: host
+      required: false
+      secret: false
+    - default: false
+      description: Port to run the command on. Argument "port" is supported only when providing "host" argument.
+      isArray: false
+      name: port
       required: false
       secret: false
     deprecated: false


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-13572)

## Description
Added system, host and port arguments to all commands. Maintained the behaviur from v1, that when providing a system to a commands, it runs on both the given system and the host that was given as an argument.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
