### PR TITLE
Added "no tests" to MITRE v1 (deprecated) integration

### DIFF
--- a/Packs/FeedMitreAttack/Integrations/FeedMitreAttack/FeedMitreAttack.yml
+++ b/Packs/FeedMitreAttack/Integrations/FeedMitreAttack/FeedMitreAttack.yml
@@ -157,5 +157,7 @@ script:
   feed: true
   runonce: false
   subtype: python3
+tests:
+- No test
 fromversion: 5.5.0
 autoUpdateDockerImage: false


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
