### PR TITLE
Removed unnecessary proxy constructor arg

### DIFF
--- a/Packs/TrendMicroVisionOne/Integrations/TrendMicroVisionOne/TrendMicroVisionOne.py
+++ b/Packs/TrendMicroVisionOne/Integrations/TrendMicroVisionOne/TrendMicroVisionOne.py
@@ -181,7 +181,6 @@ class Client(BaseClient):
         """
         self.base_url = base_url
         self.api_key = api_key
-        self.proxy = proxy
         self.status = None
 
         super().__init__(base_url=base_url, proxy=proxy)

--- a/Packs/TrendMicroVisionOne/ReleaseNotes/1_2_1.md
+++ b/Packs/TrendMicroVisionOne/ReleaseNotes/1_2_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Trend Micro Vision One
+- Improved implementation of *Client* subclass by removing the *proxy* constructor argument.

--- a/Packs/TrendMicroVisionOne/pack_metadata.json
+++ b/Packs/TrendMicroVisionOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Trend Micro Vision One",
     "description": "Trend Micro Vision One is a purpose-built threat defense platform that provides added value and new benefits beyond XDR solutions, allowing you to see more and respond faster. Providing deep and broad extended detection and response(XDR) capabilities that collect and automatically correlate data across multiple security layers\u2014email, endpoints, servers, cloud workloads, and networks\u2014Trend Micro Vision One prevents the majority of attacks with automated protection.",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "serverMinVersion": "6.2.0",
     "author": "Trend Micro",
     "url": "https://success.trendmicro.com",

--- a/Tests/known_words.txt
+++ b/Tests/known_words.txt
@@ -191,3 +191,4 @@ html
 maxPages
 cs-fx-upload-file
 lookback
+subclass


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/content/pull/20012

## Description
Removed unnecessary `proxy` constructor arg from `BaseClient` subclass in TrendMicro VisionOne integration.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
