### PR TITLE
fixed the link of the playbook image in virus total v3

### DIFF
--- a/Packs/VirusTotal/Playbooks/File_Enrichment_-_Virus_Total_v3_README.md
+++ b/Packs/VirusTotal/Playbooks/File_Enrichment_-_Virus_Total_v3_README.md
@@ -108,4 +108,4 @@ This playbook does not use any scripts.
 
 ## Playbook Image
 ---
-![File Enrichment - Virus Total (API v3)](https://raw.githubusercontent.com/demisto/content/9b3fb3fa0faff3ca873ccbb564be801ce405b749/Packs/VirusTotal/doc_files/File_Enrichment_-_Virus_Total_(API_v3).png)
+![File Enrichment - Virus Total (API v3)](https://raw.githubusercontent.com/demisto/content/master/Packs/VirusTotal/doc_files/File_Enrichment_-_Virus_Total_(API_v3).png)

--- a/Packs/VirusTotal/Playbooks/File_Enrichment_-_Virus_Total_v3_README.md
+++ b/Packs/VirusTotal/Playbooks/File_Enrichment_-_Virus_Total_v3_README.md
@@ -108,4 +108,4 @@ This playbook does not use any scripts.
 
 ## Playbook Image
 ---
-![File Enrichment - Virus Total (API v3)](../doc_files/File_Enrichment_-_Virus_Total_(API_v3).png)
+![File Enrichment - Virus Total (API v3)](https://raw.githubusercontent.com/demisto/content/9b3fb3fa0faff3ca873ccbb564be801ce405b749/Packs/VirusTotal/doc_files/File_Enrichment_-_Virus_Total_(API_v3).png)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fixed the link to the playbook image in virus total v3 to fix the build in content docs.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
