### PR TITLE
 Removed the unsupported *fromServerVersion* field from Incident Fields

### DIFF
--- a/Packs/CortexXDR/IncidentFields/XDR_Modification_time.json
+++ b/Packs/CortexXDR/IncidentFields/XDR_Modification_time.json
@@ -3,7 +3,6 @@
     "version": -1,
     "modified": "2020-10-26T19:12:35.663958+02:00",
     "itemVersion": "",
-    "fromServerVersion": "",
     "toServerVersion": "",
     "name": "XDR Modification Time",
     "ownerOnly": false,

--- a/Packs/CortexXDR/ReleaseNotes/4_8_1.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_8_1.md
@@ -1,0 +1,4 @@
+
+#### Incident Fields
+- Removed the unsupported *fromServerVersion* field from the following Incident Fields:
+- **XDR Modification Time**

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.8.0",
+    "currentVersion": "4.8.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
