### PR TITLE
update rn for CommonTypes 3.2.40

### DIFF
--- a/Packs/CommonTypes/ReleaseNotes/3_2_40.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_2_40.md
@@ -5,5 +5,5 @@
 - **Applications** - changed the type from *longText* to *markdown*
 - **Note:** 
   - In order for the changes to take effect, server versions < 6.8 should re-install the *CommonTypes* pack. If any warnings appear, click the *Install anyway* button.
-  - Re-installing the pack would reset existing configurations for those types configured. For example, incident type configured for a certain playbook would no longer be configured to use.
+  - Re-installing the pack would reset existing configurations for those types configured. For example, an incident type configured for a certain playbook would no longer be configured.
   - Any configuration attached to types from *CommonTypes* pack would need to be re-configured.

--- a/Packs/CommonTypes/ReleaseNotes/3_2_40.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_2_40.md
@@ -3,4 +3,7 @@
 - **Groups** - changed the type from *longText* to *markdown*
 - **Short Description** - changed the type from *longText* to *markdown*
 - **Applications** - changed the type from *longText* to *markdown*
-- **Note:** In order for the changes to take effect, server versions < 6.8 should re-install the *CommonTypes* pack. If any warnings appear, click the *Install anyway* button.
+- **Note:** 
+  - In order for the changes to take effect, server versions < 6.8 should re-install the *CommonTypes* pack. If any warnings appear, click the *Install anyway* button.
+  - Re-installing the pack would reset existing configurations for those types configured. For example, incident type configured for a certain playbook would no longer be configured to use.
+  - Any configuration attached to types from *CommonTypes* pack would need to be re-configured.

--- a/Packs/CommonTypes/ReleaseNotes/3_2_40.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_2_40.md
@@ -3,4 +3,4 @@
 - **Groups** - changed the type from *longText* to *markdown*
 - **Short Description** - changed the type from *longText* to *markdown*
 - **Applications** - changed the type from *longText* to *markdown*
-- **Note:** In order for the changes to take effect, server versions < 6.8 should re-install the *CommonTypes* pack.
+- **Note:** In order for the changes to take effect, server versions < 6.8 should re-install the *CommonTypes* pack. If any warnings appear, click the *Install anyway* button.


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[link](https://panw-global.slack.com/archives/C011J0AP7J8/p1658175578351409)

## Description
Update the release-notes of the `CommonTypes` (3.2.40) so in case as below customers should install the `CommonTypes` anyway
<img width="674" alt="image" src="https://user-images.githubusercontent.com/53861351/179684157-8591221d-a231-43d8-8760-c0b026d921bb.png">

