### PR TITLE
pack-ignore PB110

### DIFF
--- a/Packs/CommonPlaybooks/.pack-ignore
+++ b/Packs/CommonPlaybooks/.pack-ignore
@@ -5,7 +5,7 @@ ignore=BA101
 ignore=BA101
 
 [file:playbook-Detonate_URL_-_Generic.yml]
-ignore=BA101,PB110
+ignore=BA101
 
 [file:playbook-Get_File_Sample_From_Path_-_Generic.yml]
 ignore=BA101


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
PB110 was removed from playbook-Detonate_URL_-_Generic.yml

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
