### PR TITLE
export IOC service - better readme

### DIFF
--- a/Packs/EDL/README.md
+++ b/Packs/EDL/README.md
@@ -2,7 +2,3 @@ Simple, manual process to modify external dynamic lists (EDLs) in Cortex <~XSOAR
 
 Note: This pack does not perform indicator type validation at this time. Indicators will be added to the EDL exactly as entered.
 
-## What does this pack do?
-Manually add/remove an inputted list of indicators to/from a given EDL.
-
-


### PR DESCRIPTION
removed `what does this pack do` section, as we explain it beforehand.
![image](https://user-images.githubusercontent.com/37335599/179747303-25619928-1661-4257-9344-13527e9cf5f7.png)
