### PR TITLE
AutoFocus Feed fix

### DIFF
--- a/Packs/AutoFocus/Integrations/FeedAutofocus/README.md
+++ b/Packs/AutoFocus/Integrations/FeedAutofocus/README.md
@@ -3,6 +3,8 @@ For more information click [here](https://docs.paloaltonetworks.com/autofocus/au
 This Feed supports the AutoFocus Custom Feed and the AutoFocus Samples Feed.
 TIM customers that upgraded to version 6.2 or above, can have the API Key pre-configured in their main account so no additional input is needed. To use this feature, upgrade your license so it includes the license key.
 
+**Note:** The `Daily Threat Feed` option is deprecated. No available replacement.
+
 ## Configure AutoFocus Feed on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:[ link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-14421)

## Description
The daily feed of autofocus is deprecated. added this to the readme as well. There is no available replacement, as this endpoint is not being updated anymore (this was the reason to deprecate the daily feed)