### PR TITLE
Fix typo in inputs description for pan-os-custom-block-rule

### DIFF
--- a/Packs/PAN-OS/.pack-ignore
+++ b/Packs/PAN-OS/.pack-ignore
@@ -25,3 +25,4 @@ ignore=auto-test
 [known_words]
 pcaps
 FW
+dst

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -1460,14 +1460,14 @@ script:
       name: profile_setting
     - auto: PREDEFINED
       defaultValue: bottom
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
       - after
       - top
       - bottom
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     description: Creates a policy rule.
     execution: true

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -1604,7 +1604,7 @@ script:
       name: rulename
       required: true
     - auto: PREDEFINED
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "afer", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -1561,14 +1561,14 @@ script:
       name: tags
     - auto: PREDEFINED
       defaultValue: bottom
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
       - after
       - top
       - bottom
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     description: Creates a custom block policy rule.
     execution: true
@@ -1604,7 +1604,7 @@ script:
       name: rulename
       required: true
     - auto: PREDEFINED
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "afer", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
@@ -1612,7 +1612,7 @@ script:
       - top
       - bottom
       required: true
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     - auto: PREDEFINED
       description: The rule location. Mandatory for Panorama instances.
@@ -4792,14 +4792,14 @@ script:
       name: profile_setting
     - auto: PREDEFINED
       defaultValue: bottom
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
       - after
       - top
       - bottom
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     description: Creates a policy rule.
     execution: true
@@ -4892,14 +4892,14 @@ script:
       name: tags
     - auto: PREDEFINED
       defaultValue: bottom
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
       - after
       - top
       - bottom
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     description: Creates a custom block policy rule.
     execution: true
@@ -4934,7 +4934,7 @@ script:
       name: rulename
       required: true
     - auto: PREDEFINED
-      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument.
+      description: Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument.
       name: where
       predefined:
       - before
@@ -4942,7 +4942,7 @@ script:
       - top
       - bottom
       required: true
-    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument.
+    - description: The destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument.
       name: dst
     - auto: PREDEFINED
       description: The rule location. Mandatory for Panorama instances.

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -2247,8 +2247,8 @@ Creates a custom block policy rule.
 | log_forwarding | Log forwarding profile. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 | tags | Tags for which to use for the custom block policy rule. | Optional | 
-| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. | Optional | 
-| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument. | Optional |
+| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument. | Optional | 
+| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument. | Optional |
 
 #### Context Output
 
@@ -2299,8 +2299,8 @@ Changes the location of a policy rule.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | rulename | Name of the rule to move. | Required | 
-| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. | Required | 
-| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument. | Optional | 
+| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument. | Required | 
+| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument. | Optional | 
 | pre_post | Rule location. Mandatory for Panorama instances. | Optional | 
 | device-group | The device group for which to return addresses for the rule (Panorama instances). | Optional | 
 

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -2179,8 +2179,8 @@ Creates a policy rule.
 | tags | Rule tags to create. | Optional | 
 | category | A comma-separated list of URL categories. | Optional |
 | profile_setting | A profile setting group. | Optional | 
-| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "top" or "bottom", you need to supply the "dst" argument. | Optional | 
-| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "top" or "bottom" in the "where" argument. | Optional |
+| where | Where to move the rule. Can be "before", "after", "top", or "bottom". If you specify "before" or "after", you need to supply the "dst" argument. | Optional | 
+| dst | Destination rule relative to the rule that you are moving. This field is only relevant if you specify "before" or "after" in the "where" argument. | Optional |
 
 #### Context Output
 

--- a/Packs/PAN-OS/ReleaseNotes/1_14_12.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_12.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Palo Alto Networks PAN-OS
-- Fixed an issue in the documentation of the **where** and **dst** parameters.
+- Documentation and metadata improvements.

--- a/Packs/PAN-OS/ReleaseNotes/1_14_12.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_12.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue in the documentation of the **where** and **dst** parameters.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.14.11",
+    "currentVersion": "1.14.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
There is a typo in the bloc "Panorama - Create custom block rule" for the "where" and "dst" inputs descriptions.

The "dst" input must be filled only if you choose "before" or "after" in the "where" input, but it says "top" or "bottom".

## Screenshots
![image](https://user-images.githubusercontent.com/22448610/180421982-fa933f57-b21f-4336-bb48-aad01db45105.png)

![image](https://user-images.githubusercontent.com/22448610/180421813-c012c918-9044-488b-9124-766bd81c19b5.png)

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
