### PR TITLE
Fix VSCode broken SVG shield on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/demisto/content.svg?style=svg)](https://circleci.com/gh/demisto/content)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/demisto/content.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/demisto/content/context:python)
-[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/demisto/content)
+[![Open in Visual Studio Code](https://img.shields.io/badge/Open%20in%20Visual%20Studio%20Code-0078d7.svg?&logo=visual-studio-code)](https://open.vscode.dev/demisto/content)
 
 [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=git@github.com:demisto/content.git)
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fix "Open in Visual Studio Code" broken shield on README.

## Screenshots
### Before:
<img width="895" alt="Screenshot #1" src="https://user-images.githubusercontent.com/8832013/180639510-707e7416-d59f-4271-b6fb-4d228a850483.png">

### After:
<img width="895" alt="Screenshot #2" src="https://user-images.githubusercontent.com/8832013/180639404-d5c99b7d-fd74-4cb6-8444-dc74a8bc6843.png">