### PR TITLE
Rasterize - Changed the output to be "png" instead of "jpeg"

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -519,7 +519,7 @@ def rasterize_email_command():
 
     w, h = check_width_and_height(w, h)  # Check that the width and height meet the safeguard limit
 
-    file_name = f'{file_name}.{"pdf" if r_type == RasterizeType.PDF else "jpeg"}'  # type: ignore
+    file_name = f'{file_name}.{"pdf" if r_type == RasterizeType.PDF else "png"}'  # type: ignore
     with open('htmlBody.html', 'w', encoding='utf-8-sig') as f:
         f.write(f'<html style="background:white";>{html_body}</html>')
     path = f'file://{os.path.realpath(f.name)}'

--- a/Packs/rasterize/ReleaseNotes/1_2_2.md
+++ b/Packs/rasterize/ReleaseNotes/1_2_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Rasterize
+- Fixed an issue in ***rasterize-email*** where the output was 'jpeg' instead of 'png'.

--- a/Packs/rasterize/TestPlaybooks/playbook-Rasterize_Test.yml
+++ b/Packs/rasterize/TestPlaybooks/playbook-Rasterize_Test.yml
@@ -620,7 +620,7 @@ tasks:
                 iscontext: true
               right:
                 value:
-                  simple: image/jpeg
+                  simple: image/png
               ignorecase: true
             - operator: isEqualString
               left:

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-14769)

## Description
Fixed an issue in rasterize-email where the output was 'jpeg' type instead of 'png' type.

## Screenshots
Before:
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/89336697/180658117-713b631f-6151-4c75-96dc-0437f33f53bd.png">

After:
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/89336697/180658126-cb797721-bdc1-4231-be98-3db304e564d4.png">

Fixed an issue in rasterize-email where the output was 'jpeg' instead of 'png'.
## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
