### PR TITLE
Mirroring in CS Falcon: dded the mirror mapping

### DIFF
--- a/Packs/CrowdStrikeFalcon/Classifiers/classifier-CrowdStrike_Falcon_Mapper_6.5.json
+++ b/Packs/CrowdStrikeFalcon/Classifiers/classifier-CrowdStrike_Falcon_Mapper_6.5.json
@@ -134,6 +134,18 @@
                             }
                         ]
                     }
+                },
+				"dbotMirrorDirection": {
+					"simple": "mirror_direction"
+				},
+				"dbotMirrorId": {
+					"simple": "detection_id"
+				},
+				"dbotMirrorInstance": {
+					"simple": "mirror_instance"
+				},
+                "IncomingMirrorError": {
+                  "simple": "in_mirror_error"
                 }
             }
         },
@@ -245,7 +257,19 @@
 							}
 						]
 					}
-				}
+				},
+				"dbotMirrorDirection": {
+					"simple": "mirror_direction"
+				},
+				"dbotMirrorId": {
+					"simple": "incident_id"
+				},
+				"dbotMirrorInstance": {
+					"simple": "mirror_instance"
+				},
+                "IncomingMirrorError": {
+                  "simple": "in_mirror_error"
+                }
             }
         },
         "Malware": {

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_8_10.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_8_10.md
@@ -1,0 +1,4 @@
+
+#### Mappers
+##### CrowdStrike Falcon Mapper
+- Fixed an issue where mirroring did not work.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.8.9",
+    "currentVersion": "1.8.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-14608

## Description
When added the new mapper for version >= 6.5, the mapping for the mirror fields are missed 
this lead to stop the mirror 

## Minimum version of Cortex XSOAR
- [x] 6.5.0

