### PR TITLE
Deprecate XDR IR Commands

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.yml
@@ -837,8 +837,8 @@ script:
       - 'false'
       required: false
       secret: false
-    deprecated: false
-    description: Isolates the specified endpoint. This command will be deprecated soon, use `xdr-endpoint-isolate` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-endpoint-isolate` instead.
     execution: true
     name: xdr-isolate-endpoint
     outputs:
@@ -900,8 +900,8 @@ script:
       description: Isolates the specified endpoint.
       type: String
     polling: true
-  - deprecated: false
-    description: Reverses the isolation of an endpoint. This command will be deprecated soon, use `xdr-endpoint-unisolate` instead.
+  - deprecated: true
+    description: Deprecated. Use `xdr-endpoint-unisolate` instead.
     execution: true
     name: xdr-unisolate-endpoint
     outputs:
@@ -1850,8 +1850,8 @@ script:
     execution: false
     name: xdr-file-quarantine
     polling: true
-  - deprecated: false
-    description: Quarantines a file on selected endpoints. This command will be deprecated soon, use `xdr-file-quarantine` instead.
+  - deprecated: true
+    description: Deprecated. Use `xdr-file-quarantine` instead.
     execution: false
     name: xdr-quarantine-files
     arguments:
@@ -1964,8 +1964,8 @@ script:
       name: endpoint_id
       required: false
       secret: false
-    deprecated: false
-    description: Restores a quarantined file on requested endpoints. This command will be deprecated soon, use `xdr-file-restore` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-file-restore` instead.
     execution: false
     name: xdr-restore-file
   - arguments:
@@ -2199,8 +2199,8 @@ script:
       - 'false'
       required: false
       secret: false
-    deprecated: false
-    description: Runs a scan on a selected endpoint. This command will be deprecated soon, use `xdr-endpoint-scan-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-endpoint-scan-execute` instead.
     execution: true
     name: xdr-endpoint-scan
     outputs:
@@ -2741,8 +2741,8 @@ script:
       name: generic_file_path
       required: false
       secret: false
-    deprecated: false
-    description: Retrieves files from selected endpoints. This command will be deprecated soon, use `xdr-file-retrieve` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-file-retrieve` instead.
     execution: false
     name: xdr-retrieve-files
     outputs:
@@ -3004,8 +3004,8 @@ script:
       name: snippet_code
       required: true
       secret: false
-    deprecated: false
-    description: Initiates a new endpoint script execution action using the provided snippet code. This command will be deprecated soon, use `xdr-snippet-code-script-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-snippet-code-script-execute` instead.
     execution: false
     name: xdr-run-snippet-code-script
     outputs:
@@ -3245,8 +3245,8 @@ script:
       name: timeout
       required: false
       secret: false
-    deprecated: false
-    description: Initiates a new endpoint script execution of shell commands. This command will be deprecated soon, use `xdr-script-commands-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-script-commands-execute` instead.
     execution: false
     name: xdr-run-script-execute-commands
     outputs:
@@ -3339,8 +3339,8 @@ script:
       name: timeout
       required: false
       secret: false
-    deprecated: false
-    description: Initiates a new endpoint script execution to delete the specified file. This command will be deprecated soon, use `xdr-file-delete-script-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-file-delete-script-execute` instead.
     execution: false
     name: xdr-run-script-delete-file
     outputs:
@@ -3433,8 +3433,8 @@ script:
       name: timeout
       required: false
       secret: false
-    deprecated: false
-    description: Initiates a new endpoint script execution to check if file exists. This command will be deprecated soon, use `xdr-file-exist-script-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-file-exist-script-execute` instead.
     execution: false
     name: xdr-run-script-file-exists
     outputs:
@@ -3527,8 +3527,8 @@ script:
       name: timeout
       required: false
       secret: false
-    deprecated: false
-    description: Initiates a new endpoint script execution kill process. This command will be deprecated soon, use `xdr-kill-process-script-execute` instead.
+    deprecated: true
+    description: Deprecated. Use `xdr-kill-process-script-execute` instead.
     execution: false
     name: xdr-run-script-kill-process
     outputs:

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/README.md
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/README.md
@@ -824,35 +824,6 @@ Isolates the specified endpoint.
 | --- | --- | --- |
 | PaloAltoNetworksXDR.Isolation.endpoint_id | String | The endpoint ID. | 
 
-### xdr-isolate-endpoint
-***
-Isolates the specified endpoint. This command will be deprecated soon, use `xdr-endpoint-isolate` instead.
-
-
-#### Base Command
-
-`xdr-isolate-endpoint`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_id | The endpoint ID (string) to isolate. You can retrieve the string from the xdr-get-endpoints command. | Required | 
-| suppress_disconnected_endpoint_error | Whether to suppress an error when trying to isolate a disconnected endpoint. When sets to false, an error will be returned. Possible values are: true, false. Default is false. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.Isolation.endpoint_id | String | The endpoint ID. | 
-
-##### Command Example
-```!xdr-isolate-endpoint endpoint_id="f8a2f58846b542579c12090652e79f3d"```
-
-##### Human Readable Output
-Endpoint f8a2f58846b542579c12090652e79f3d has isolated successfully
-
 ### xdr-endpoint-unisolate
 ***
 Reverses the isolation of an endpoint.
@@ -871,29 +842,6 @@ Reverses the isolation of an endpoint.
 | interval_in_seconds | Interval in seconds between each poll. | Optional | 
 | timeout_in_seconds | Polling timeout in seconds. | Optional | 
 | action_id | For polling use. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.UnIsolation.endpoint_id | String | Isolates the specified endpoint. | 
-
-### xdr-unisolate-endpoint
-***
-Reverses the isolation of an endpoint. This command will be deprecated soon, use `xdr-endpoint-unisolate` instead.
-
-
-#### Base Command
-
-`xdr-unisolate-endpoint`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_id | The endpoint ID (string) for which to reverse the isolation. You can retrieve it from the xdr-get-endpoints command. | Required | 
-| suppress_disconnected_endpoint_error | Whether to suppress an error when trying to unisolate a disconnected endpoint. When sets to false, an error will be returned. Possible values are: true, false. Default is false. | Optional | 
 
 
 #### Context Output
@@ -1412,27 +1360,7 @@ Quarantines a file on selected endpoints. You can select up to 1000 endpoints.
 #### Context Output
 
 There is no context output for this command.
-### xdr-quarantine-files
-***
-Quarantines a file on selected endpoints. This command will be deprecated soon, use `xdr-file-quarantine` instead.
 
-
-#### Base Command
-
-`xdr-quarantine-files`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_id_list | List of endpoint IDs. | Required | 
-| file_path | String that represents the path of the file you want to quarantine. | Required | 
-| file_hash | String that represents the file’s hash. Must be a valid SHA256 hash. | Required | 
-
-
-#### Context Output
-
-There is no context output for this command.
 ### xdr-get-quarantine-status
 ***
 Retrieves the quarantine status for a selected file.
@@ -1476,26 +1404,7 @@ Restores a quarantined file on requested endpoints.
 #### Context Output
 
 There is no context output for this command.
-### xdr-restore-file
-***
-Restores a quarantined file on requested endpoints. This command will be deprecated soon, use `xdr-file-restore` instead.
 
-
-#### Base Command
-
-`xdr-restore-file`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| file_hash | String that represents the file in hash. Must be a valid SHA256 hash. | Required | 
-| endpoint_id | String that represents the endpoint ID. If you do not enter a specific endpoint ID, the request will run restore on all endpoints which relate to the quarantined file you defined. | Optional | 
-
-
-#### Context Output
-
-There is no context output for this command.
 ### xdr-endpoint-scan-execute
 ***
 Runs a scan on a selected endpoint. To scan all endpoints, run this command with argument all=true. Do note that scanning all the endpoints may cause performance issues and latency.
@@ -1532,42 +1441,7 @@ Runs a scan on a selected endpoint. To scan all endpoints, run this command with
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | PaloAltoNetworksXDR.endpointScan.actionId | Number | The action ID of the scan request. | 
-| PaloAltoNetworksXDR.endpointScan.aborted | Boolean | Was the scan aborted. | 
-
-### xdr-endpoint-scan
-***
-Runs a scan on a selected endpoint. This command will be deprecated soon, use `xdr-endpoint-scan-execute` instead.
-
-
-#### Base Command
-
-`xdr-endpoint-scan`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_id_list | List of endpoint IDs. | Optional | 
-| dist_name | Name of the distribution list. | Optional | 
-| gte_first_seen | Epoch timestamp in milliseconds. | Optional | 
-| gte_last_seen | Epoch timestamp in milliseconds. | Optional | 
-| lte_first_seen | Epoch timestamp in milliseconds. | Optional | 
-| lte_last_seen | Epoch timestamp in milliseconds. | Optional | 
-| ip_list | List of IP addresses. | Optional | 
-| group_name | Name of the endpoint group. | Optional | 
-| platform | Type of operating system. Possible values are: windows, linux, macos, android. | Optional | 
-| alias | Endpoint alias name. | Optional | 
-| isolate | Whether an endpoint has been isolated. Can be "isolated" or "unisolated". Possible values are: isolated, unisolated. | Optional | 
-| hostname | Name of the host. | Optional | 
-| all | Whether to scan all of the endpoints or not. Default is false. Scanning all of the endpoints may cause performance issues and latency. Possible values are: true, false. Default is false. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.endpointScan.actionId | Number | The action ID of the scan request. | 
-| PaloAltoNetworksXDR.endpointScan.aborted | Boolean | Was the scan aborted. | 
+| PaloAltoNetworksXDR.endpointScan.aborted | Boolean | Was the scan aborted. |
 
 ### xdr-endpoint-scan-abort
 ***
@@ -1813,56 +1687,7 @@ Retrieves files from selected endpoints. You can retrieve up to 20 files, from n
 | PaloAltoNetworksXDR.RetrievedFiles.action_id | string | ID of the action to retrieve files from selected endpoints. | 
 | PaloAltoNetworksXDR.RetrievedFiles.endpoint_id | string | Endpoint ID. Added only when the operation is successful.| 
 | PaloAltoNetworksXDR.RetrievedFiles.file_link | string | Link to the file. Added only when the operation is successful. | 
-| PaloAltoNetworksXDR.RetrievedFiles.status | string | The action status. Added only when the operation is unsuccessful. | 
-
-### xdr-retrieve-files
-***
-Retrieves files from selected endpoints. This command will be deprecated soon, use `xdr-file-retrieve` instead.
-
-
-#### Base Command
-
-`xdr-retrieve-files`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. | Required | 
-| windows_file_paths | A comma-separated list of file paths on the Windows platform. | Optional | 
-| linux_file_paths | A comma-separated list of file paths on the Linux platform. | Optional | 
-| mac_file_paths | A comma-separated list of file paths on the Mac platform. | Optional | 
-| generic_file_path | A comma-separated list of file paths in any platform. Can be used instead of the mac/windows/linux file paths. The order of the files path list must be parallel to the endpoints list order, therefore, the first file path in the list is related to the first endpoint and so on. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.RetrievedFiles.action_id | string | ID of the action to retrieve files from selected endpoints. | 
-
-#### Command Examples
-```!xdr-retrieve-files endpoint_ids=aeec6a2cc92e46fab3b6f621722e9916 windows_file_paths="C:\Users\demisto\Desktop\demisto.txt"```
-```!xdr-retrieve-files endpoint_ids=aeec6a2cc92e46fab3b6f621722e9916 generic_file_path="C:\Users\demisto\Desktop\demisto.txt"```
-
-#### Context Example
-```
-{
-    "PaloAltoNetworksXDR": {
-        "retrievedFiles": {
-            "actionId": 2056
-        }
-    }
-}
-```
-
-#### Human Readable Output
-
->### Retrieve files
->|Action Id|
->|---|
->| 2056 |
-
+| PaloAltoNetworksXDR.RetrievedFiles.status | string | The action status. Added only when the operation is unsuccessful. |
 
 ### xdr-retrieve-file-details
 ***
@@ -2026,31 +1851,7 @@ Initiates a new endpoint script execution action using the provided snippet code
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
-
-### xdr-run-snippet-code-script
-***
-Initiates a new endpoint script execution action using the provided snippet code. This command will be deprecated soon, use `xdr-snippet-code-script-execute` instead.
-
-
-#### Base Command
-
-`xdr-run-snippet-code-script`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. Can be retrieved by running the xdr-get-endpoints command. | Required | 
-| snippet_code | Section of a script you want to initiate on an endpoint (e.g., print("7")). | Required | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
+| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. |
 
 ### xdr-get-script-execution-status
 ***
@@ -2176,31 +1977,6 @@ Initiate a new endpoint script execution of shell commands.
 | PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
 | PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
 
-### xdr-run-script-execute-commands
-***
-Initiate a new endpoint script execution of shell commands. This command will be deprecated soon, use `xdr-script-commands-execute` instead.
-
-
-#### Base Command
-
-`xdr-run-script-execute-commands`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. Can be retrieved by running the xdr-get-endpoints command. | Required | 
-| commands | Comma-separated list of shell commands to execute. | Required | 
-| timeout | The timeout in seconds for this execution. Default is 600. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
-
 ### xdr-file-delete-script-execute
 ***
 Initiates a new endpoint script execution to delete the specified file.
@@ -2227,32 +2003,7 @@ Initiates a new endpoint script execution to delete the specified file.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
-
-### xdr-run-script-delete-file
-***
-Initiates a new endpoint script execution to delete the specified file. This command will be deprecated soon, use `xdr-file-delete-script-execute` instead.
-
-
-#### Base Command
-
-`xdr-run-script-delete-file`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. Can be retrieved by running the xdr-get-endpoints command. | Required | 
-| file_path | Paths of the files to delete, in a comma-separated list. Paths of the files to check for existence. All of the given file paths will run on all of the endpoints. | Required | 
-| timeout | The timeout in seconds for this execution. Default is 600. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
+| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. |
 
 ### xdr-file-exist-script-execute
 ***
@@ -2280,32 +2031,7 @@ Initiates a new endpoint script execution to check if file exists.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
-
-### xdr-run-script-file-exists
-***
-Initiates a new endpoint script execution to check if file exists. This command will be deprecated soon, use `xdr-file-exist-script-execute` instead.
-
-
-#### Base Command
-
-`xdr-run-script-file-exists`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. Can be retrieved by running the xdr-get-endpoints command. | Required | 
-| file_path | Paths of the files to check for existence, in a comma-separated list. All of the given file paths will run on all of the endpoints. | Required | 
-| timeout | The timeout in seconds for this execution. Default is 600. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
+| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. |
 
 ### xdr-kill-process-script-execute
 ***
@@ -2326,31 +2052,6 @@ Initiates a new endpoint script execution kill process.
 | interval_in_seconds | Interval in seconds between each poll. | Optional | 
 | timeout_in_seconds | Polling timeout in seconds. | Optional | 
 | action_id | For polling use. | Optional | 
-
-
-#### Context Output
-
-| **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| PaloAltoNetworksXDR.ScriptRun.action_id | Number | ID of the action initiated. | 
-| PaloAltoNetworksXDR.ScriptRun.endpoints_count | Number | Number of endpoints the action was initiated on. | 
-
-### xdr-run-script-kill-process
-***
-Initiates a new endpoint script execution kill process. This command will be deprecated soon, use `xdr-kill-process-script-execute` instead.
-
-
-#### Base Command
-
-`xdr-run-script-kill-process`
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| incident_id | Allows to link the response action to the incident that triggered it. | Optional | 
-| endpoint_ids | Comma-separated list of endpoint IDs. Can be retrieved by running the xdr-get-endpoints command. | Required | 
-| process_name | Names of processes to kill. Will kill all of the given processes on all of the endpoints. | Required | 
-| timeout | The timeout in seconds for this execution. Default is 600. | Optional | 
 
 
 #### Context Output

--- a/Packs/CortexXDR/ReleaseNotes/4_8_5.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_8_5.md
@@ -1,14 +1,14 @@
 
 #### Integrations
 ##### Palo Alto Networks Cortex XDR - Investigation and Response
-- Command ***xdr-run-script-kill-process*** is deprecated. Use ***xdr-kill-process-script-execute*** instead.
-- Command ***xdr-quarantine-files*** is deprecated. Use ***xdr-file-quarantine*** instead.
-- Command ***xdr-retrieve-files*** is deprecated. Use ***xdr-file-retrieve*** instead.
-- Command ***xdr-restore-file*** is deprecated. Use ***xdr-file-restore*** instead.
-- Command ***xdr-run-script-delete-file*** is deprecated. Use ***xdr-file-delete-script-execute*** instead.
-- Command ***xdr-isolate-endpoint*** is deprecated. Use ***xdr-endpoint-isolate*** instead.
-- Command ***xdr-run-script-execute-commands*** is deprecated. Use ***xdr-script-commands-execute*** instead.
-- Command ***xdr-run-script-file-exists*** is deprecated. Use ***xdr-file-exist-script-execute*** instead.
-- Command ***xdr-endpoint-scan*** is deprecated. Use ***xdr-endpoint-scan-execute*** instead.
-- Command ***xdr-unisolate-endpoint*** is deprecated. Use ***xdr-endpoint-unisolate*** instead.
-- Command ***xdr-run-snippet-code-script*** is deprecated. Use ***xdr-snippet-code-script-execute*** instead.
+- Deprecated the command ***xdr-run-script-kill-process***. Use ***xdr-kill-process-script-execute*** instead.
+- Deprecated the command ***xdr-quarantine-files***. Use ***xdr-file-quarantine*** instead.
+- Deprecated the command ***xdr-retrieve-files***. Use ***xdr-file-retrieve*** instead.
+- Deprecated the command ***xdr-restore-file***. Use ***xdr-file-restore*** instead.
+- Deprecated the command ***xdr-run-script-delete-file***. Use ***xdr-file-delete-script-execute*** instead.
+- Deprecated the command ***xdr-isolate-endpoint***. Use ***xdr-endpoint-isolate*** instead.
+- Deprecated the command ***xdr-run-script-execute-commands***. Use ***xdr-script-commands-execute*** instead.
+- Deprecated the command ***xdr-run-script-file-exists***. Use ***xdr-file-exist-script-execute*** instead.
+- Deprecated the command ***xdr-endpoint-scan***. Use ***xdr-endpoint-scan-execute*** instead.
+- Deprecated the command ***xdr-unisolate-endpoint***. Use ***xdr-endpoint-unisolate*** instead.
+- Deprecated the command ***xdr-run-snippet-code-script***. Use ***xdr-snippet-code-script-execute*** instead.

--- a/Packs/CortexXDR/ReleaseNotes/4_8_5.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_8_5.md
@@ -1,0 +1,14 @@
+
+#### Integrations
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+- Command ***xdr-run-script-kill-process*** is deprecated. Use ***xdr-kill-process-script-execute*** instead.
+- Command ***xdr-quarantine-files*** is deprecated. Use ***xdr-file-quarantine*** instead.
+- Command ***xdr-retrieve-files*** is deprecated. Use ***xdr-file-retrieve*** instead.
+- Command ***xdr-restore-file*** is deprecated. Use ***xdr-file-restore*** instead.
+- Command ***xdr-run-script-delete-file*** is deprecated. Use ***xdr-file-delete-script-execute*** instead.
+- Command ***xdr-isolate-endpoint*** is deprecated. Use ***xdr-endpoint-isolate*** instead.
+- Command ***xdr-run-script-execute-commands*** is deprecated. Use ***xdr-script-commands-execute*** instead.
+- Command ***xdr-run-script-file-exists*** is deprecated. Use ***xdr-file-exist-script-execute*** instead.
+- Command ***xdr-endpoint-scan*** is deprecated. Use ***xdr-endpoint-scan-execute*** instead.
+- Command ***xdr-unisolate-endpoint*** is deprecated. Use ***xdr-endpoint-unisolate*** instead.
+- Command ***xdr-run-snippet-code-script*** is deprecated. Use ***xdr-snippet-code-script-execute*** instead.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Palo Alto Networks Cortex XDR - Investigation and Response",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.8.4",
+    "currentVersion": "4.8.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Deprecate commands for the XDR IR pack.

## Issue
https://jira-hq.paloaltonetworks.local/browse/CIAC-2072

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
