### PR TITLE
CommonServerPython Fix API Metrics Supported Version

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_14.md
+++ b/Packs/Base/ReleaseNotes/1_31_14.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed an issue where API Metrics were unsupported for XSOAR versions 6.8.0 till 7.0.0.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -7072,7 +7072,7 @@ class ExecutionMetrics(object):
 
     @staticmethod
     def is_supported():
-        if is_demisto_version_ge('7.0.0'):
+        if is_demisto_version_ge('6.8.0'):
             return True
         return False
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -8097,7 +8097,7 @@ class TestIsMetricsSupportedByServer:
 
     def test_metrics_supported(self, mocker):
         """
-        Given: An XSOAR server running version 7.0.0
+        Given: An XSOAR server running version 6.8.0
         When: Testing that a server supports ExecutionMetrics
         Then: Assert that is_supported reports True
         """
@@ -8106,7 +8106,7 @@ class TestIsMetricsSupportedByServer:
             demisto,
             'demistoVersion',
             return_value={
-                'version': '7.0.0',
+                'version': '6.8.0',
                 'buildNumber': '50000'
             }
         )

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.13",
+    "currentVersion": "1.31.14",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: internal

## Description
So XSOAR API Metrics actually supports server versions _6.8.0_ and above. Not starting at 7.0.0. In my defense, we weren't sure exactly what version this was going to be and it changed quite a bit. Either way, I will wear my :shame_wizard: badge. @bakatzir Please accept this PR as retribution for my sins against `content`.

## Screenshots
![shame_wizard](https://user-images.githubusercontent.com/42912128/182015450-dade1c65-a16a-49f9-86b2-2a0aed68a7e4.png)

