### PR TITLE
[Mail Listener] First Fetch not Fetching All Mails in Given Time

### DIFF
--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -297,6 +297,12 @@ def fetch_mails(client: IMAPClient,
                                                uid_to_fetch_from)
         demisto.debug(f'Searching for email messages with criteria: {messages_query}')
         messages_uids = client.search(messages_query)
+        # first fetch takes last page only (workaround as first_fetch filter is date accurate)
+        if message_id == 1:
+            messages_uids = messages_uids[limit * -1:]
+        else:
+            messages_uids = messages_uids[:limit]
+
     mails_fetched = []
     messages_fetched = []
     demisto.debug(f'Messages to fetch: {messages_uids}')
@@ -315,8 +321,6 @@ def fetch_mails(client: IMAPClient,
                 int(email_message_object.id) > int(uid_to_fetch_from):
             mails_fetched.append(email_message_object)
             messages_fetched.append(email_message_object.id)
-            if len(mails_fetched) >= limit:
-                break
         elif email_message_object.date is None:
             demisto.error(f"Skipping email with ID {email_message_object.message_id},"
                           f" it doesn't include a date field that shows when was it received.")

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -298,7 +298,7 @@ def fetch_mails(client: IMAPClient,
         demisto.debug(f'Searching for email messages with criteria: {messages_query}')
         messages_uids = client.search(messages_query)
         # first fetch takes last page only (workaround as first_fetch filter is date accurate)
-        if message_id == 1:
+        if uid_to_fetch_from == 1:
             messages_uids = messages_uids[limit * -1:]
         else:
             messages_uids = messages_uids[:limit]

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -296,7 +296,7 @@ def fetch_mails(client: IMAPClient,
                                                permitted_from_domains,
                                                uid_to_fetch_from)
         demisto.debug(f'Searching for email messages with criteria: {messages_query}')
-        messages_uids = client.search(messages_query)[:limit]
+        messages_uids = client.search(messages_query)
     mails_fetched = []
     messages_fetched = []
     demisto.debug(f'Messages to fetch: {messages_uids}')
@@ -315,6 +315,8 @@ def fetch_mails(client: IMAPClient,
                 int(email_message_object.id) > int(uid_to_fetch_from):
             mails_fetched.append(email_message_object)
             messages_fetched.append(email_message_object.id)
+            if len(mails_fetched) >= limit:
+                break
         elif email_message_object.date is None:
             demisto.error(f"Skipping email with ID {email_message_object.message_id},"
                           f" it doesn't include a date field that shows when was it received.")
@@ -403,7 +405,8 @@ def list_emails(client: IMAPClient,
                 first_fetch_time: str,
                 with_headers: bool,
                 permitted_from_addresses: str,
-                permitted_from_domains: str) -> CommandResults:
+                permitted_from_domains: str,
+                _limit: int,) -> CommandResults:
     """
     Lists all emails that can be fetched with the given configuration and return a preview version of them.
     Args:
@@ -412,6 +415,7 @@ def list_emails(client: IMAPClient,
         with_headers: Whether to add headers to the search query
         permitted_from_addresses: A string representation of list of mail addresses to fetch from
         permitted_from_domains: A string representation list of domains to fetch from
+        _limit: Upper limit as set in the integration params.
 
     Returns:
         The Subject, Date, To, From and ID of the fetched mails wrapped in command results object.
@@ -422,7 +426,8 @@ def list_emails(client: IMAPClient,
                                       time_to_fetch_from=fetch_time,
                                       with_headers=with_headers,
                                       permitted_from_addresses=permitted_from_addresses,
-                                      permitted_from_domains=permitted_from_domains)
+                                      permitted_from_domains=permitted_from_domains,
+                                      limit=_limit)
     results = [{'Subject': email.subject,
                 'Date': email.date.isoformat(),
                 'To': email.to,
@@ -491,7 +496,8 @@ def main():
                                            first_fetch_time=first_fetch_time,
                                            with_headers=with_headers,
                                            permitted_from_addresses=permitted_from_addresses,
-                                           permitted_from_domains=permitted_from_domains))
+                                           permitted_from_domains=permitted_from_domains,
+                                           _limit=limit))
             elif demisto.command() == 'mail-listener-get-email':
                 return_results(get_email(client=client,
                                          message_id=args.get('message-id')))

--- a/Packs/MailListener/Integrations/MailListenerV2/README.md
+++ b/Packs/MailListener/Integrations/MailListenerV2/README.md
@@ -199,5 +199,5 @@ There is no context output for this command.
 ```
 
 ## Additional Information
-In the first fetch iteration, it might take a few minutes for email messages to be ingested due to filter limitations on the IMAP client.
-Some emails may be skipped and not fetched as incidents, due to the fact that they are lacking the date field that shows the time when the email was received.
+In the first fetch iteration, some emails may be skipped and not fetched as incidents - the integration will fetch just the last available emails for the given day, as set in *The maximum number of incidents to fetch each time* and *First fetch time*. This behavior is due to the fact that IMAP time filter is limited to day based filter.
+Subsequent fetch iterations should fetch emails as they are received, without further issue.

--- a/Packs/MailListener/ReleaseNotes/1_0_15.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Mail Listener v2
+- Fixed an issue where no mails are fetched when the parameter *The maximum number of incidents to fetch each time* is less than all mails received on the day of *First fetch time*.

--- a/Packs/MailListener/pack_metadata.json
+++ b/Packs/MailListener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mail Listener",
     "description": "Listen to a mailbox, enable incident triggering via e-mail",
     "support": "xsoar",
-    "currentVersion": "1.0.14",
+    "currentVersion": "1.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-13841

## Description
Fixed an issue where no mails are fetched when the parameter *The maximum number of incidents to fetch each time* is less than all mails received on the day of *First fetch time*.