### PR TITLE
skip collect_tests test data

### DIFF
--- a/Tests/scripts/collect_tests/path_manager.py
+++ b/Tests/scripts/collect_tests/path_manager.py
@@ -44,6 +44,7 @@ def _calculate_excluded_files(content_path: Path) -> set[Path]:
             'Tests/scripts/infrastructure_tests',
             'Tests/Marketplace/Tests',
             'Tests/tests',
+            'Tests/scripts/collect_tests',
             'Tests/setup',
             'Tests/sdknightly',
             'Tests/known_words.txt',


### PR DESCRIPTION
skip the `collect_tests` folder when collecting tests