### PR TITLE
create a new search if polling from qradar fails

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -1549,8 +1549,7 @@ def poll_offense_events(client: Client,
             f'Error while fetching offense {offense_id} events, search_id: {search_id}. Error details: {str(e)} \n'
             f'{traceback.format_exc()}')
         time.sleep(FAILURE_SLEEP)
-        # return WAIT because it's probably a temporary error due to QRadar service
-        return [], QueryStatus.WAIT.value
+        return [], QueryStatus.ERROR.value
 
 
 def poll_offense_events_with_retry(client: Client, search_id: str, offense_id: int,

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3_test.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3_test.py
@@ -347,7 +347,7 @@ def test_create_single_asset_for_offense_enrichment():
                            None,
                            None,
                            None,
-                           ([], QueryStatus.WAIT.value))
+                           ([], QueryStatus.ERROR.value))
                           ])
 def test_poll_offense_events_with_retry(requests_mock, status_exception, status_response, results_response, search_id,
                                         expected):

--- a/Packs/QRadar/ReleaseNotes/2_2_8.md
+++ b/Packs/QRadar/ReleaseNotes/2_2_8.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### IBM QRadar v3
+- Fixed an issue where the search query deleted from `QRadar` when polling for the results. 
+- Updated the Docker image to: *demisto/python3:3.10.5.31928*.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.2.7",
+    "currentVersion": "2.2.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5315,8 +5315,7 @@
         "SymantecEndpointProtection_Test": "Issue 30157",
         "RSANetWitnessv115-Test": "Issue XDRSUP-12553",
         "TestCloudflareWAFPlaybook": "No instance",
-        "DBot Build Phishing Classifier Test - Multiple Algorithms": "Issue 48350",
-        "SplunkPy_KV_commands_requests_handler": "CIAC-3669"
+        "DBot Build Phishing Classifier Test - Multiple Algorithms": "Issue 48350"
     },
     "skipped_integrations": {
         "_comment1": "~~~ NO INSTANCE ~~~",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-14218

## Description
Fixed an issue where the search query is deleted from QRadar. We should create a new search in this case and not poll for the same search over and over.
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
