### PR TITLE
Fixed dangling file reference in ReadPDFFileV2

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_17.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_17.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### ReadPDFFileV2
+- Updated the Docker image to: *demisto/readpdf:1.0.0.32561*.
+- Fixed dangling file reference

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
@@ -382,29 +382,29 @@ def get_urls_and_emails_from_pdf_annots(file_path):
     all_urls: Set[str] = set()
     all_emails: Set[str] = set()
 
-    pdf_file = open(file_path, 'rb')
-    pdf = PyPDF2.PdfFileReader(pdf_file)
-    pages_len = len(pdf.pages)
+    with open(file_path, 'rb') as pdf_file:
+        pdf = PyPDF2.PdfFileReader(pdf_file)
+        pages_len = len(pdf.pages)
 
-    # Goes over the PDF, page by page, and extracts urls and emails:
-    for page in range(pages_len):
-        page_sliced = pdf.pages[page]
-        page_object = page_sliced.get_object()
+        # Goes over the PDF, page by page, and extracts urls and emails:
+        for page in range(pages_len):
+            page_sliced = pdf.pages[page]
+            page_object = page_sliced.get_object()
 
-        # Extracts the PDF's Annots (Annotations and Commenting):
-        if annots := page_object.get('/Annots'):
-            if not isinstance(annots, PyPDF2.generic.ArrayObject):
-                annots = [annots]
+            # Extracts the PDF's Annots (Annotations and Commenting):
+            if annots := page_object.get('/Annots'):
+                if not isinstance(annots, PyPDF2.generic.ArrayObject):
+                    annots = [annots]
 
-            for annot in annots:
-                annot_objects = annot.get_object()
-                if not isinstance(annot_objects, PyPDF2.generic.ArrayObject):
-                    annot_objects = [annot_objects]
+                for annot in annots:
+                    annot_objects = annot.get_object()
+                    if not isinstance(annot_objects, PyPDF2.generic.ArrayObject):
+                        annot_objects = [annot_objects]
 
-                # Extracts URLs and Emails:
-                urls_set, emails_set = extract_urls_and_emails_from_annot_objects(annot_objects)
-                all_urls = all_urls.union(urls_set)
-                all_emails = all_emails.union(emails_set)
+                    # Extracts URLs and Emails:
+                    urls_set, emails_set = extract_urls_and_emails_from_annot_objects(annot_objects)
+                    all_urls = all_urls.union(urls_set)
+                    all_emails = all_emails.union(emails_set)
 
     # Logging:
     if len(all_urls) == 0:

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
@@ -127,7 +127,7 @@ tags:
 - ingestion
 timeout: '0'
 type: python
-dockerimage: demisto/readpdf:1.0.0.30663
+dockerimage: demisto/readpdf:1.0.0.32561
 runonce: false
 runas: DBotRole
 tests:

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.16",
+    "currentVersion": "1.7.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
When running ReadPDFFileV2 on an NFS/EFS file system (typically found on an HA setup of XSOAR), it will error out with OSError: [Errno 39] Directory not empty: 'ReadPDF'. This error is due to a file handle being left open in the code.

Since a file handle is left open, when the code runs line 520: shutil.rmtree(folder), the files in the folder are deleted but when the OS tries to delete the file with a file handle still open, it renames the files to .nfsXXXX until the file handle is closed. Since the script is holding it open, it won't close until the script ends. But the next step in shutil.rmtree(folder) is to remove the presumably empty folder, however due to the file rename instead of deletion, it fails because it is not empty.

Line 386: pdf_file = open(file_path, 'rb') opens the PDF file without using with and without closing the file when it is done. This is the line which is creating the dangling handle. The easiest fix is to change this line to use the normal with open(file, method) as file_handle: and indent the lines after so when the block finishes, the file handle is cleaned up automatically.

Reference for NFS file renaming: https://kb.netapp.com/Advice_and_Troubleshooting/Data_Storage_Software/ONTAP_OS/What_are_.nfsXXXX_files_and_how_do_I_delete_them%3F#:~:text=nfsXXXX%20are%20created%20by%20NFS,closed%20by%20the%20client%20process.

## Minimum version of Cortex XSOAR
- [X] 6.0.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No
