### PR TITLE
fix microsoft defender flaky test playbook

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/TestPlaybooks/playbook-Microsoft_Defender_Advanced_Threat_Protection-Test.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/TestPlaybooks/playbook-Microsoft_Defender_Advanced_Threat_Protection-Test.yml
@@ -1276,7 +1276,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "55"
+      - "8"
     scriptarguments:
       machine_id:
         complex:
@@ -1296,54 +1296,6 @@ tasks:
         "position": {
           "x": 910,
           "y": 1770
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
-    isoversize: false
-    isautoswitchedtoquietmode: false
-  "55":
-    id: "55"
-    taskid: 72616323-5fe2-44a6-878a-91f674ee97a3
-    type: condition
-    task:
-      id: 72616323-5fe2-44a6-878a-91f674ee97a3
-      version: -1
-      name: Assert logged on users
-      type: condition
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "yes":
-      - "8"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: containsGeneral
-          left:
-            value:
-              simple: MicrosoftATP.MachineUser.ID
-            iscontext: true
-          right:
-            value:
-              simple: demisto
-      - - operator: startWith
-          left:
-            value:
-              simple: MicrosoftATP.MachineUser.MachineID
-            iscontext: true
-          right:
-            value:
-              simple: "4899036"
-    view: |-
-      {
-        "position": {
-          "x": 910,
-          "y": 1945
         }
       }
     note: false


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
following this [PR](https://github.com/demisto/content/pull/20383)

Fixed an issue where Microsoft defender test playbook sometimes returns that there are logged users on the machines and sometimes not, this causes the test playbook to be flaky, hence will check now only if the 'Get Machine logged on users' will return an error if not, instead of checking whether it has a context output. if it does not return an error, command is working as expected even when there aren't any logged on users in the the environment 

## Screenshots
before: 
<img width="1713" alt="image" src="https://user-images.githubusercontent.com/53861351/183058118-07e72ece-32bf-4ade-9b09-e8e47f9f01b8.png">

after:

<img width="1713" alt="image" src="https://user-images.githubusercontent.com/53861351/183058181-ccb0d3ad-e46a-43bf-88d9-d7dbbc199414.png">

after running:

<img width="1713" alt="image" src="https://user-images.githubusercontent.com/53861351/183058213-5e1e5518-e570-4126-b8d0-a98230e59bee.png">

