### PR TITLE
PAN-OS Integration - New Command Bugfixes

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -9240,6 +9240,7 @@ class ObjectGetter:
         "SecurityProfileGroup": SecurityProfileGroup,
         "SecurityRule": SecurityRule,
         "NatRule": NatRule,
+        "LogForwardingProfile": LogForwardingProfile,
     }
 
     @staticmethod

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -7943,6 +7943,11 @@ class Topology:
         :param device: Either Panorama or Firewall Pandevice instance
         """
         if isinstance(device, Panorama):
+            if device.serial:
+                serial_number_or_hostname = device.serial
+            else:
+                serial_number_or_hostname = device.hostname
+
             # Check if HA is active and if so, what the system state is.
             panorama_ha_state_result = run_op_command(device, "show high-availability state")
             enabled = panorama_ha_state_result.find("./result/enabled")
@@ -7952,7 +7957,7 @@ class Topology:
                     state = find_text_in_element(panorama_ha_state_result, "./result/group/local-info/state")
                     if "active" in state:
                         # TODO: Work out how to get the Panorama peer serial..
-                        self.ha_active_devices[device.serial] = "peer serial not implemented here.."
+                        self.ha_active_devices[serial_number_or_hostname] = "peer serial not implemented here.."
                         self.get_all_child_firewalls(device)
                         return
                 else:
@@ -7961,8 +7966,8 @@ class Topology:
                 self.get_all_child_firewalls(device)
 
             # This is a bit of a hack - if no ha, treat it as active
-            self.ha_active_devices[device.serial] = "STANDALONE"
-            self.panorama_objects[device.serial] = device
+            self.ha_active_devices[serial_number_or_hostname] = "STANDALONE"
+            self.panorama_objects[serial_number_or_hostname] = device
 
             return
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -8015,7 +8015,12 @@ class Topology:
         # This means we don't need to refresh the state.
         for device in self.all(filter_str):
             if self.ha_active_devices:
-                if device.serial in self.ha_active_devices:
+                # Handle case of no SN or hostname
+                serial_or_hostname = device.serial
+                if not serial_or_hostname:
+                    serial_or_hostname = device.hostname
+
+                if serial_or_hostname in self.ha_active_devices:
                     yield device
             else:
                 status = device.refresh_ha_active()

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -7943,10 +7943,7 @@ class Topology:
         :param device: Either Panorama or Firewall Pandevice instance
         """
         if isinstance(device, Panorama):
-            if device.serial:
-                serial_number_or_hostname = device.serial
-            else:
-                serial_number_or_hostname = device.hostname
+            serial_number_or_hostname = device.serial if device.serial else device.hostname
 
             # Check if HA is active and if so, what the system state is.
             panorama_ha_state_result = run_op_command(device, "show high-availability state")

--- a/Packs/PAN-OS/ReleaseNotes/1_14_14.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_14.md
@@ -1,5 +1,4 @@
 
 #### Integrations
 ##### Palo Alto Networks PAN-OS
-- Fixed issue when Panorama systems are used in target arguments for certain commands
-- Added `LogForwardingProfile` to list of objects supported by `pan-os-config-get-objects`
+- Fixed an issue where Panorama systems are used in target arguments for certain commands.

--- a/Packs/PAN-OS/ReleaseNotes/1_14_14.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_14_14.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed issue when Panorama systems are used in target arguments for certain commands
+- Added `LogForwardingProfile` to list of objects supported by `pan-os-config-get-objects`

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.14.13",
+    "currentVersion": "1.14.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
This is a bugfix for some minor issues;

* Commands that were using `get_single_device()` in the topology class would fail if the target was Panorama. This is because the pan-os-python SDK does not populate the device serial number for Panorama instances. This affected the following commands;
   * pan-os-platform-reboot

To fix this issue, I've set the topology discovery function `add_device_object` to store the hostname in the relevant dictionaries instead of the serial number - this means the device dicts will always be keyed by Hostname for Panorama devices and Serial Number by firewalls. I've also updated the retrieval functions to reflect this. Previously, this was simply failing and literal `None` was being stored in the dictionary as the key for Panorama devices..

* LogForwardingProfile was specified as a valid option in the object command but was not implemented.

The fix for this was just to add the object type into the supported object dictionary. 