### PR TITLE
Add search command and change detonate URL playbook for HatchingTriage

### DIFF
--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -5,13 +5,26 @@ from CommonServerUserPython import *
 import json
 
 
+class IncorrectUsageError(Exception):
+    pass
+
+
 class Client(BaseClient):
     def __init__(self, base_url, *args, **kwarg):
         super().__init__(base_url, *args, **kwarg)
 
 
-def test_module(client: Client) -> str:
+def _get_behavioral_task_id(value):
+    if str(value).startswith("behavioral"):
+        return value
 
+    raise IncorrectUsageError(
+        "Task ID must be 'behavioral' followed by a number. "
+        "E.G: 'behavioral1'"
+    )
+
+
+def test_module(client: Client) -> str:
     r = client._http_request(
         "GET", "users", resp_type="response", ok_codes=(200, 401, 404)
     )
@@ -38,10 +51,10 @@ def query_samples(client, **args) -> CommandResults:
 
     r = client._http_request("GET", "samples", params=params)
 
-    results = CommandResults(
-        outputs_prefix="Triage.samples", outputs_key_field="id", outputs=r["data"]
+    return CommandResults(
+        outputs_prefix="Triage.samples", outputs_key_field="id",
+        outputs=r["data"]
     )
-    return results
 
 
 def submit_sample(client: Client, **args) -> CommandResults:
@@ -68,34 +81,33 @@ def submit_sample(client: Client, **args) -> CommandResults:
                 data={"_json": json.dumps(data)}, files=files
             )
     else:
-        return_error(
-            f'Type of sample needs to be selected, either "file" or "url", the selected type was: {data["kind"]}'
+        raise IncorrectUsageError(
+            f'Type of sample needs to be selected, either "file" or "url", '
+            f'the selected type was: {data["kind"]}'
         )
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.submissions", outputs_key_field="id", outputs=r
     )
-    return results
 
 
 def get_sample(client: Client, **args) -> CommandResults:
     sample_id = args.get("sample_id")
     r = client._http_request("GET", f"samples/{sample_id}")
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.samples", outputs_key_field="id", outputs=r
     )
-    return results
 
 
 def get_sample_summary(client: Client, **args) -> CommandResults:
     sample_id = args.get("sample_id")
     r = client._http_request("GET", f"samples/{sample_id}/summary")
 
-    results = CommandResults(
-        outputs_prefix="Triage.sample-summaries", outputs_key_field="sample", outputs=r
+    return CommandResults(
+        outputs_prefix="Triage.sample-summaries", outputs_key_field="sample",
+        outputs=r
     )
-    return results
 
 
 def delete_sample(client: Client, **args) -> str:
@@ -117,9 +129,10 @@ def set_sample_profile(client: Client, **args) -> str:
     }
     if args.get("profiles"):
         data.update({"profiles": [{"profile": args.get("profiles", "")}]})
-    data = json.dumps(data)
 
-    client._http_request("POST", f"samples/{sample_id}/profile", data=data)
+    client._http_request(
+        "POST", f"samples/{sample_id}/profile", data=json.dumps(data)
+    )
 
     return f"Profile successfully set for sample {sample_id}"
 
@@ -189,13 +202,7 @@ def get_report_triage(client: Client, **args) -> CommandResults:
     Outputs a score, should map to a DBot score
     """
     sample_id = args.get("sample_id")
-    task_id = args.get("task_id")
-    if not task_id.startswith("behavioral"):
-        return_error(
-            "Only behavioral reports can be retrieved with this command. "
-            "Task ID must be 'behavioral' followed by a number. "
-            "E.G: 'behavioral1'"
-        )
+    task_id = _get_behavioral_task_id(args.get("task_id"))
 
     r = client._http_request("GET", f"samples/{sample_id}/{task_id}/report_triage.json")
     score = 0
@@ -231,19 +238,17 @@ def get_report_triage(client: Client, **args) -> CommandResults:
             dbot_score=dbot_score
         )
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.sample.reports.triage",
         outputs_key_field="sample.id",
         outputs=r,
         indicator=indicator
     )
 
-    return results
-
 
 def get_kernel_monitor(client: Client, **args) -> dict:
     sample_id = args.get("sample_id")
-    task_id = args.get("task_id")
+    task_id = _get_behavioral_task_id(args.get("task_id"))
 
     r = client._http_request(
         "GET", f"samples/{sample_id}/{task_id}/logs/onemon.json", resp_type="text"
@@ -257,7 +262,7 @@ def get_kernel_monitor(client: Client, **args) -> dict:
 
 def get_pcap(client: Client, **args) -> dict:
     sample_id = args.get("sample_id")
-    task_id = args.get("task_id")
+    task_id = _get_behavioral_task_id(args.get("task_id"))
 
     r = client._http_request(
         "GET", f"samples/{sample_id}/{task_id}/dump.pcap", resp_type="response"
@@ -279,9 +284,7 @@ def get_dumped_files(client: Client, **args) -> dict:
         "GET", f"samples/{sample_id}/{task_id}/{file_name}", resp_type="content"
     )
 
-    results = fileResult(f"{file_name}", r)
-
-    return results
+    return fileResult(f"{file_name}", r)
 
 
 def get_users(client: Client, **args) -> CommandResults:
@@ -296,11 +299,9 @@ def get_users(client: Client, **args) -> CommandResults:
     if r.get("data"):
         r = r["data"]
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.users", outputs_key_field="id", outputs=r
     )
-
-    return results
 
 
 def create_user(client: Client, **args) -> CommandResults:
@@ -316,11 +317,9 @@ def create_user(client: Client, **args) -> CommandResults:
 
     r = client._http_request("POST", "users", data=data)
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.users", outputs_key_field="id", outputs=r
     )
-
-    return results
 
 
 def delete_user(client: Client, **args) -> str:
@@ -341,22 +340,18 @@ def create_apikey(client: Client, **args) -> CommandResults:
 
     r = client._http_request("POST", f"users/{userID}/apikeys", data=data)
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.apikey", outputs_key_field="key", outputs=r
     )
-
-    return results
 
 
 def get_apikey(client: Client, **args) -> CommandResults:
     userID = args.get("userID")
     r = client._http_request("GET", f"users/{userID}/apikeys")
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.apikey", outputs_key_field="key", outputs=r.get("data")
     )
-
-    return results
 
 
 def delete_apikey(client: Client, **args) -> str:
@@ -365,9 +360,7 @@ def delete_apikey(client: Client, **args) -> str:
 
     client._http_request("DELETE", f"users/{userID}/apikeys/{apiKeyName}")
 
-    results = f"API key {apiKeyName} was successfully deleted"
-
-    return results
+    return f"API key {apiKeyName} was successfully deleted"
 
 
 def get_profile(client: Client, **args) -> CommandResults:
@@ -383,11 +376,9 @@ def get_profile(client: Client, **args) -> CommandResults:
     if not profileID and r.get("data"):
         r = r["data"]
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.profiles", outputs_key_field="id", outputs=r
     )
-
-    return results
 
 
 def create_profile(client: Client, **args) -> CommandResults:
@@ -403,11 +394,9 @@ def create_profile(client: Client, **args) -> CommandResults:
 
     r = client._http_request("POST", "profiles", data=data)
 
-    results = CommandResults(
+    return CommandResults(
         outputs_prefix="Triage.profiles", outputs_key_field="id", outputs=r
     )
-
-    return results
 
 
 def update_profile(client: Client, **args) -> str:
@@ -425,9 +414,7 @@ def update_profile(client: Client, **args) -> str:
 
     client._http_request("PUT", f"profiles/{profileID}", data=json.dumps(data))
 
-    results = "Profile updated successfully"
-
-    return results
+    return "Profile updated successfully"
 
 
 def delete_profile(client: Client, **args) -> str:
@@ -435,9 +422,7 @@ def delete_profile(client: Client, **args) -> str:
 
     client._http_request("DELETE", f"profiles/{profileID}")
 
-    results = f"Profile {profileID} successfully deleted"
-
-    return results
+    return f"Profile {profileID} successfully deleted"
 
 
 def query_search(client, **args) -> CommandResults:
@@ -445,10 +430,11 @@ def query_search(client, **args) -> CommandResults:
 
     r = client._http_request("GET", "search", params=params)
 
-    results = CommandResults(
-        outputs_prefix="Triage.samples", outputs_key_field="id", outputs=r["data"]
+    return CommandResults(
+        outputs_prefix="Triage.samples", outputs_key_field="id",
+        outputs=r["data"]
     )
-    return results
+
 
 def main():
     params = demisto.params()
@@ -486,10 +472,15 @@ def main():
     }
 
     command = demisto.command()
-    if command in commands:
+    try:
+        if command not in commands:
+            raise IncorrectUsageError(
+                f"Command '{command}' is not available in this integration"
+            )
+
         return_results(commands[command](client, **args))  # type: ignore
-    else:
-        return_error(f"Command {command} is not available in this integration")
+    except Exception as e:
+        return_error(str(e))
 
 
 if __name__ in ["__main__", "__builtin__", "builtins"]:

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -190,9 +190,14 @@ def get_report_triage(client: Client, **args) -> CommandResults:
     """
     sample_id = args.get("sample_id")
     task_id = args.get("task_id")
+    if not task_id.startswith("behavioral"):
+        return_error(
+            "Only behavioral reports can be retrieved with this command. "
+            "Task ID must be 'behavioral' followed by a number. "
+            "E.G: 'behavioral1'"
+        )
 
     r = client._http_request("GET", f"samples/{sample_id}/{task_id}/report_triage.json")
-
     score = 0
     indicator: Any
     if 'sample' in r:
@@ -435,6 +440,16 @@ def delete_profile(client: Client, **args) -> str:
     return results
 
 
+def query_search(client, **args) -> CommandResults:
+    params = {"query": args.get("query")}
+
+    r = client._http_request("GET", "search", params=params)
+
+    results = CommandResults(
+        outputs_prefix="Triage.samples", outputs_key_field="id", outputs=r["data"]
+    )
+    return results
+
 def main():
     params = demisto.params()
     args = demisto.args()
@@ -447,6 +462,7 @@ def main():
     commands = {
         "test-module": test_module,
         "triage-query-samples": query_samples,
+        "triage-query-search": query_search,
         "triage-submit-sample": submit_sample,
         "triage-get-sample": get_sample,
         "triage-get-sample-summary": get_sample_summary,

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -699,6 +699,47 @@ script:
     execution: false
     name: triage-update-profile
     description: Update an existing profile
+  - name: triage-query-search
+    arguments:
+      - name: query
+        required: true
+        description: The search query for Triage
+    outputs:
+      - contextPath: Triage.submissions.completed
+        description: Date the sample analysis was completed
+        type: date
+      - contextPath: Triage.submissions.filename
+        description: Name of the file submitted
+        type: string
+      - contextPath: Triage.submissions.id
+        description: Unique identifier of the submission
+        type: string
+      - contextPath: Triage.submissions.kind
+        description: Type of analysis
+        type: string
+      - contextPath: Triage.submissions.private
+        description: If the submissions is private or publically viewable
+        type: boolean
+      - contextPath: Triage.submissions.status
+        description: Status of the submitted file
+        type: string
+      - contextPath: Triage.submissions.submitted
+        description: Date the sample was submitted
+        type: date
+      - contextPath: Triage.submissions.tasks.id
+        description: Array of tasks that have been applied to the sample (static, behavioral,
+          etc)
+        type: string
+      - contextPath: Triage.submissions.tasks.status
+        description: Status of the task
+        type: string
+      - contextPath: Triage.submissions.tasks.target
+        description: Sample the task is being run on
+        type: string
+      - contextPath: Triage.submissions.url
+        description: URL that was submitted
+        type: string
+    description: Get a list of private and public samples matching the search query
   - arguments:
     - default: false
       isArray: false

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -14,6 +14,7 @@ configuration:
   name: API Key
   required: true
   type: 4
+  additionalinfo: The API Key to use for the connection.
 - display: Verify SSL
   defaultvalue: 'true'
   name: Verify SSL
@@ -39,40 +40,39 @@ script:
     execution: false
     name: triage-query-samples
     outputs:
-      - contextPath: Triage.submissions.completed
-        description: Date the sample analysis was completed
-        type: Date
-      - contextPath: Triage.submissions.filename
-        description: Name of the file submitted
-        type: String
-      - contextPath: Triage.submissions.id
-        description: Unique identifier of the submission
-        type: String
-      - contextPath: Triage.submissions.kind
-        description: Type of analysis
-        type: String
-      - contextPath: Triage.submissions.private
-        description: If the submissions is private or publically viewable
-        type: Boolean
-      - contextPath: Triage.submissions.status
-        description: Status of the submitted file
-        type: String
-      - contextPath: Triage.submissions.submitted
-        description: Date the sample was submitted
-        type: Date
-      - contextPath: Triage.submissions.tasks.id
-        description: Array of tasks that have been applied to the sample (static, behavioral,
-          etc)
-        type: String
-      - contextPath: Triage.submissions.tasks.status
-        description: Status of the task
-        type: String
-      - contextPath: Triage.submissions.tasks.target
-        description: Sample the task is being run on
-        type: String
-      - contextPath: Triage.submissions.url
-        description: URL that was submitted
-        type: String
+    - contextPath: Triage.submissions.completed
+      description: Date the sample analysis was completed
+      type: Date
+    - contextPath: Triage.submissions.filename
+      description: Name of the file submitted
+      type: String
+    - contextPath: Triage.submissions.id
+      description: Unique identifier of the submission
+      type: String
+    - contextPath: Triage.submissions.kind
+      description: Type of analysis
+      type: String
+    - contextPath: Triage.submissions.private
+      description: If the submissions is private or publically viewable
+      type: Boolean
+    - contextPath: Triage.submissions.status
+      description: Status of the submitted file
+      type: String
+    - contextPath: Triage.submissions.submitted
+      description: Date the sample was submitted
+      type: Date
+    - contextPath: Triage.submissions.tasks.id
+      description: Array of tasks that have been applied to the sample (static, behavioral, etc)
+      type: String
+    - contextPath: Triage.submissions.tasks.status
+      description: Status of the task
+      type: String
+    - contextPath: Triage.submissions.tasks.target
+      description: Sample the task is being run on
+      type: String
+    - contextPath: Triage.submissions.url
+      description: URL that was submitted
+      type: String
     description: Get a list of all samples either private or public
   - arguments:
     - auto: PREDEFINED
@@ -98,15 +98,13 @@ script:
       required: false
       secret: false
     - default: false
-      description: Select what profile to run the sample with. Requires the user to
-        be registered with a company
+      description: Select what profile to run the sample with. Requires the user to be registered with a company
       isArray: false
       name: profiles
       required: false
       secret: false
     - default: false
-      description: Data to submit for analysis. For URLs give the URL. For files,
-        give the entry-id of the file
+      description: Data to submit for analysis. For URLs give the URL. For files, give the entry-id of the file
       isArray: false
       name: data
       required: true
@@ -116,24 +114,24 @@ script:
     execution: false
     name: triage-submit-sample
     outputs:
-      - contextPath: Triage.submissions.filename
-        description: Name of the submitted file
-        type: String
-      - contextPath: Triage.submissions.id
-        description: Unique identifier of the submission
-        type: String
-      - contextPath: Triage.submissions.kind
-        description: Type of sample to analyze
-        type: String
-      - contextPath: Triage.submissions.private
-        description: If the file is private or publicly viewable
-        type: Boolean
-      - contextPath: Triage.submissions.status
-        description: Status of the analysis of the submission
-        type: String
-      - contextPath: Triage.submissions.submitted
-        description: Date that the sample was submitted on
-        type: Date
+    - contextPath: Triage.submissions.filename
+      description: Name of the submitted file
+      type: String
+    - contextPath: Triage.submissions.id
+      description: Unique identifier of the submission
+      type: String
+    - contextPath: Triage.submissions.kind
+      description: Type of sample to analyze
+      type: String
+    - contextPath: Triage.submissions.private
+      description: If the file is private or publicly viewable
+      type: Boolean
+    - contextPath: Triage.submissions.status
+      description: Status of the analysis of the submission
+      type: String
+    - contextPath: Triage.submissions.submitted
+      description: Date that the sample was submitted on
+      type: Date
   - arguments:
     - default: false
       description: Sample's unique identifier, can be found using the query samples command
@@ -146,36 +144,36 @@ script:
     execution: false
     name: triage-get-sample
     outputs:
-      - contextPath: Triage.samples.completed
-        description: Date the sample analysis was completed
-        type: Date
-      - contextPath: Triage.samples.filename
-        description: Name of the submitted sample
-        type: String
-      - contextPath: Triage.samples.id
-        description: Unique identifier of the sample
-        type: String
-      - contextPath: Triage.samples.kind
-        description: Type of sample submitted
-        type: String
-      - contextPath: Triage.samples.private
-        description: State of the visibility of the sample
-        type: Boolean
-      - contextPath: Triage.samples.status
-        description: Current status of the sample analysis
-        type: String
-      - contextPath: Triage.samples.submitted
-        description: Date the sample was submitted
-        type: Date
-      - contextPath: Triage.samples.tasks.id
-        description: Task name that was applied to the sample
-        type: String
-      - contextPath: Triage.samples.tasks.status
-        description: Status of the task
-        type: String
-      - contextPath: Triage.samples.tasks.target
-        description: Target of the task, e.g. filename for file submissions
-        type: String
+    - contextPath: Triage.samples.completed
+      description: Date the sample analysis was completed
+      type: Date
+    - contextPath: Triage.samples.filename
+      description: Name of the submitted sample
+      type: String
+    - contextPath: Triage.samples.id
+      description: Unique identifier of the sample
+      type: String
+    - contextPath: Triage.samples.kind
+      description: Type of sample submitted
+      type: String
+    - contextPath: Triage.samples.private
+      description: State of the visibility of the sample
+      type: Boolean
+    - contextPath: Triage.samples.status
+      description: Current status of the sample analysis
+      type: String
+    - contextPath: Triage.samples.submitted
+      description: Date the sample was submitted
+      type: Date
+    - contextPath: Triage.samples.tasks.id
+      description: Task name that was applied to the sample
+      type: String
+    - contextPath: Triage.samples.tasks.status
+      description: Status of the task
+      type: String
+    - contextPath: Triage.samples.tasks.target
+      description: Target of the task, e.g. filename for file submissions
+      type: String
   - arguments:
     - default: false
       description: Sample's unique identifier, can be found using the query samples command
@@ -188,36 +186,36 @@ script:
     execution: false
     name: triage-get-sample-summary
     outputs:
-      - contextPath: Triage.sample-summaries.completed
-        description: Date the sample analysis was completed
-        type: Date
-      - contextPath: Triage.sample-summaries.created
-        description: Date the analysis report was created
-        type: Date
-      - contextPath: Triage.sample-summaries.custom
-        description: ''
-        type: String
-      - contextPath: Triage.sample-summaries.owner
-        description: ''
-        type: String
-      - contextPath: Triage.sample-summaries.sample
-        description: Unique identifier of the sample
-        type: String
-      - contextPath: Triage.sample-summaries.score
-        description: Score of the sample on a scale of 0 to 10
-        type: Number
-      - contextPath: Triage.sample-summaries.sha256
-        description: SHA256 of the sample
-        type: String
-      - contextPath: Triage.sample-summaries.status
-        description: Status of the analysis
-        type: String
-      - contextPath: Triage.sample-summaries.target
-        description: Target for analysis
-        type: String
-      - contextPath: Triage.sample-summaries.tasks
-        description: Tasks performed in the analysis
-        type: String
+    - contextPath: Triage.sample-summaries.completed
+      description: Date the sample analysis was completed
+      type: Date
+    - contextPath: Triage.sample-summaries.created
+      description: Date the analysis report was created
+      type: Date
+    - contextPath: Triage.sample-summaries.custom
+      description: ''
+      type: String
+    - contextPath: Triage.sample-summaries.owner
+      description: ''
+      type: String
+    - contextPath: Triage.sample-summaries.sample
+      description: Unique identifier of the sample
+      type: String
+    - contextPath: Triage.sample-summaries.score
+      description: Score of the sample on a scale of 0 to 10
+      type: Number
+    - contextPath: Triage.sample-summaries.sha256
+      description: SHA256 of the sample
+      type: String
+    - contextPath: Triage.sample-summaries.status
+      description: Status of the analysis
+      type: String
+    - contextPath: Triage.sample-summaries.target
+      description: Target for analysis
+      type: String
+    - contextPath: Triage.sample-summaries.tasks
+      description: Tasks performed in the analysis
+      type: String
   - arguments:
     - default: false
       isArray: false
@@ -247,8 +245,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: If submitting an archive file, select which files to analyze. Multiple
-        files can be specified with a comma seperator.Format is archive_file_name/sample_file.exe,archive_file_name/sample_file2.exe
+      description: If submitting an archive file, select which files to analyze. Multiple files can be specified with a comma seperator.Format is archive_file_name/sample_file.exe,archive_file_name/sample_file2.exe
       isArray: false
       name: pick
       required: false
@@ -260,8 +257,7 @@ script:
       required: false
       secret: false
     deprecated: false
-    description: When a sample is in the static_analysis status, a profile should
-      be selected in order to continue.
+    description: When a sample is in the static_analysis status, a profile should be selected in order to continue.
     execution: false
     name: triage-set-sample-profile
   - arguments:
@@ -276,36 +272,36 @@ script:
     description: Get the static analysis of a sample
     name: triage-get-static-report
     outputs:
-      - contextPath: Triage.sample.reports.static.analysis.reported
-        description: Date the sample was submitted
-        type: Unknown
-      - contextPath: DBotScore.Indicator
-        description: Triage analysis target
-        type: String
-      - contextPath: DBotScore.Type
-        description: The indicator type - File or URL
-        type: String
-      - contextPath: DBotScore.Vendor
-        description: The integration used to generate the indicator
-        type: String
-      - contextPath: DBotScore.Score
-        description: Analysis verdict as score from 1 to 10
-        type: Number
-      - contextPath: File.Name
-        description: The full file name (including file extension).
-        type: String
-      - contextPath: File.MD5
-        description: The MD5 hash of the file.
-        type: String
-      - contextPath: File.SHA1
-        description: The SHA1 hash of the file.
-        type: String
-      - contextPath: File.SHA256
-        description: The SHA1 hash of the file.
-        type: String
-      - contextPath: URL.Data
-        description: The URL
-        type: String
+    - contextPath: Triage.sample.reports.static.analysis.reported
+      description: Date the sample was submitted
+      type: Unknown
+    - contextPath: DBotScore.Indicator
+      description: Triage analysis target
+      type: String
+    - contextPath: DBotScore.Type
+      description: The indicator type - File or URL
+      type: String
+    - contextPath: DBotScore.Vendor
+      description: The integration used to generate the indicator
+      type: String
+    - contextPath: DBotScore.Score
+      description: Analysis verdict as score from 1 to 10
+      type: Number
+    - contextPath: File.Name
+      description: The full file name (including file extension).
+      type: String
+    - contextPath: File.MD5
+      description: The MD5 hash of the file.
+      type: String
+    - contextPath: File.SHA1
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: URL.Data
+      description: The URL
+      type: String
   - arguments:
     - default: false
       isArray: false
@@ -316,44 +312,44 @@ script:
     - default: false
       isArray: false
       name: task_id
-      description: Name of the task for the sample (e.g. behavioral1, static1, etc)
+      description: Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2)
       required: true
       secret: false
     deprecated: false
     execution: false
-    description: Retrieves the generated Triage Report for a single task
+    description: Retrieves the generated Triage behavioral report for a single task
     name: triage-get-report-triage
     outputs:
-      - contextPath: Triage.sample.reports.triage
-        description: Triage report of the submitted sample
-        type: Unknown
-      - contextPath: DBotScore.Indicator
-        description: Triage analysis target
-        type: String
-      - contextPath: DBotScore.Type
-        description: The indicator type - File or URL
-        type: String
-      - contextPath: DBotScore.Vendor
-        description: The integration used to generate the indicator
-        type: String
-      - contextPath: DBotScore.Score
-        description: Analysis verdict as score from 1 to 10
-        type: Number
-      - contextPath: File.Name
-        description: The full file name (including file extension).
-        type: String
-      - contextPath: File.MD5
-        description: The MD5 hash of the file.
-        type: String
-      - contextPath: File.SHA1
-        description: The SHA1 hash of the file.
-        type: String
-      - contextPath: File.SHA256
-        description: The SHA1 hash of the file.
-        type: String
-      - contextPath: URL.Data
-        description: The URL
-        type: String
+    - contextPath: Triage.sample.reports.triage
+      description: Triage report of the submitted sample
+      type: Unknown
+    - contextPath: DBotScore.Indicator
+      description: Triage analysis target
+      type: String
+    - contextPath: DBotScore.Type
+      description: The indicator type - File or URL
+      type: String
+    - contextPath: DBotScore.Vendor
+      description: The integration used to generate the indicator
+      type: String
+    - contextPath: DBotScore.Score
+      description: Analysis verdict as score from 1 to 10
+      type: Number
+    - contextPath: File.Name
+      description: The full file name (including file extension).
+      type: String
+    - contextPath: File.MD5
+      description: The MD5 hash of the file.
+      type: String
+    - contextPath: File.SHA1
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: File.SHA256
+      description: The SHA1 hash of the file.
+      type: String
+    - contextPath: URL.Data
+      description: The URL
+      type: String
   - arguments:
     - default: false
       isArray: false
@@ -364,7 +360,7 @@ script:
     - default: false
       isArray: false
       name: task_id
-      description: Name of the task for the sample (e.g. behavioral1, static1, etc)
+      description: Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2)
       required: true
       secret: false
     deprecated: false
@@ -381,7 +377,7 @@ script:
     - default: false
       isArray: false
       name: task_id
-      description: Name of the task for the sample (e.g. behavioral1, static1, etc)
+      description: Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2)
       required: true
       secret: false
     deprecated: false
@@ -419,30 +415,30 @@ script:
       required: false
       secret: false
     outputs:
-      - contextPath: Triage.users.company_id
-        description: Company unique identifier
-        type: String
-      - contextPath: Triage.users.created_at
-        description: Date users account was created
-        type: Date
-      - contextPath: Triage.users.email
-        description: Users email
-        type: String
-      - contextPath: Triage.users.email_confirmed_at
-        description: Date user confirmed their email/account
-        type: Date
-      - contextPath: Triage.users.first_name
-        description: Users first name
-        type: String
-      - contextPath: Triage.users.id
-        description: Users unique identifier
-        type: String
-      - contextPath: Triage.users.last_name
-        description: Users last name
-        type: String
-      - contextPath: Triage.users.permissions
-        description: Users permissions
-        type: String
+    - contextPath: Triage.users.company_id
+      description: Company unique identifier
+      type: String
+    - contextPath: Triage.users.created_at
+      description: Date users account was created
+      type: Date
+    - contextPath: Triage.users.email
+      description: Users email
+      type: String
+    - contextPath: Triage.users.email_confirmed_at
+      description: Date user confirmed their email/account
+      type: Date
+    - contextPath: Triage.users.first_name
+      description: Users first name
+      type: String
+    - contextPath: Triage.users.id
+      description: Users unique identifier
+      type: String
+    - contextPath: Triage.users.last_name
+      description: Users last name
+      type: String
+    - contextPath: Triage.users.permissions
+      description: Users permissions
+      type: String
     deprecated: false
     execution: false
     name: triage-get-users
@@ -491,30 +487,30 @@ script:
     execution: false
     name: triage-create-user
     outputs:
-      - contextPath: Triage.users.company_id
-        description: Company unique identifier
-        type: String
-      - contextPath: Triage.users.created_at
-        description: Date users account was created
-        type: Date
-      - contextPath: Triage.users.email
-        description: Users email
-        type: String
-      - contextPath: Triage.users.email_confirmed_at
-        description: Date user confirmed their email/account
-        type: Date
-      - contextPath: Triage.users.first_name
-        description: Users first name
-        type: String
-      - contextPath: Triage.users.id
-        description: Users unique identifier
-        type: String
-      - contextPath: Triage.users.last_name
-        description: Users last name
-        type: String
-      - contextPath: Triage.users.permissions
-        description: Users permissions
-        type: String
+    - contextPath: Triage.users.company_id
+      description: Company unique identifier
+      type: String
+    - contextPath: Triage.users.created_at
+      description: Date users account was created
+      type: Date
+    - contextPath: Triage.users.email
+      description: Users email
+      type: String
+    - contextPath: Triage.users.email_confirmed_at
+      description: Date user confirmed their email/account
+      type: Date
+    - contextPath: Triage.users.first_name
+      description: Users first name
+      type: String
+    - contextPath: Triage.users.id
+      description: Users unique identifier
+      type: String
+    - contextPath: Triage.users.last_name
+      description: Users last name
+      type: String
+    - contextPath: Triage.users.permissions
+      description: Users permissions
+      type: String
     description: Creates a new user and returns it. The user will become a member of the company the requesting user is a member of
   - arguments:
     - default: false
@@ -545,12 +541,12 @@ script:
     execution: false
     name: triage-create-api-key
     outputs:
-      - contextPath: Triage.apikey.key
-        description: API Key
-        type: String
-      - contextPath: Triage.apikey.name
-        description: Name of the API Key
-        type: String
+    - contextPath: Triage.apikey.key
+      description: API Key
+      type: String
+    - contextPath: Triage.apikey.name
+      description: Name of the API Key
+      type: String
     description: Creates a new key can be used to make API calls on behalf of the specified user. The user should have been granted the access_api permission beforehand
   - arguments:
     - default: false
@@ -563,12 +559,12 @@ script:
     execution: false
     name: triage-get-api-key
     outputs:
-      - contextPath: Triage.apikey.key
-        description: API Key
-        type: String
-      - contextPath: Triage.apikey.name
-        description: Name of the API Key
-        type: String
+    - contextPath: Triage.apikey.key
+      description: API Key
+      type: String
+    - contextPath: Triage.apikey.name
+      description: Name of the API Key
+      type: String
     description: Lists all API keys that the user has.
   - arguments:
     - default: false
@@ -598,24 +594,24 @@ script:
     execution: false
     name: triage-get-profiles
     outputs:
-      - contextPath: Triage.profiles..id
-        description: Unique identifier of the profile
-        type: String
-      - contextPath: Triage.profiles..name
-        description: Name of the profile
-        type: String
-      - contextPath: Triage.profiles..network
-        description: Network configuration
-        type: String
-      - contextPath: Triage.profiles..options.browser
-        description: Browser options
-        type: String
-      - contextPath: Triage.profiles..tags
-        description: Applied tags
-        type: String
-      - contextPath: Triage.profiles..timeout
-        description: Max run time of the profile
-        type: Number
+    - contextPath: Triage.profiles..id
+      description: Unique identifier of the profile
+      type: String
+    - contextPath: Triage.profiles..name
+      description: Name of the profile
+      type: String
+    - contextPath: Triage.profiles..network
+      description: Network configuration
+      type: String
+    - contextPath: Triage.profiles..options.browser
+      description: Browser options
+      type: String
+    - contextPath: Triage.profiles..tags
+      description: Applied tags
+      type: String
+    - contextPath: Triage.profiles..timeout
+      description: Max run time of the profile
+      type: Number
     description: List all profiles that your company has
   - arguments:
     - default: false
@@ -642,33 +638,33 @@ script:
       name: network
       description: Network configuration the profile should use
       predefined:
-        - drop
-        - internet
-        - proxy
+      - drop
+      - internet
+      - proxy
       required: false
       secret: false
     deprecated: false
     execution: false
     name: triage-create-profile
     outputs:
-      - contextPath: Triage.profiles.id
-        description: Profile unique identifier
-        type: String
-      - contextPath: Triage.profiles.name
-        description: Profile name
-        type: String
-      - contextPath: Triage.profiles.network
-        description: Profile network configuration
-        type: String
-      - contextPath: Triage.profiles.options
-        description: Profile options
-        type: Unknown
-      - contextPath: Triage.profiles.tags
-        description: Profile tags
-        type: String
-      - contextPath: Triage.profiles.timeout
-        description: Profile max run time
-        type: Number
+    - contextPath: Triage.profiles.id
+      description: Profile unique identifier
+      type: String
+    - contextPath: Triage.profiles.name
+      description: Profile name
+      type: String
+    - contextPath: Triage.profiles.network
+      description: Profile network configuration
+      type: String
+    - contextPath: Triage.profiles.options
+      description: Profile options
+      type: Unknown
+    - contextPath: Triage.profiles.tags
+      description: Profile tags
+      type: String
+    - contextPath: Triage.profiles.timeout
+      description: Profile max run time
+      type: Number
     description: Create a new profile
   - arguments:
     - default: false
@@ -699,47 +695,46 @@ script:
     execution: false
     name: triage-update-profile
     description: Update an existing profile
-  - name: triage-query-search
-    arguments:
-      - name: query
-        required: true
-        description: The search query for Triage
-    outputs:
-      - contextPath: Triage.submissions.completed
-        description: Date the sample analysis was completed
-        type: date
-      - contextPath: Triage.submissions.filename
-        description: Name of the file submitted
-        type: string
-      - contextPath: Triage.submissions.id
-        description: Unique identifier of the submission
-        type: string
-      - contextPath: Triage.submissions.kind
-        description: Type of analysis
-        type: string
-      - contextPath: Triage.submissions.private
-        description: If the submissions is private or publically viewable
-        type: boolean
-      - contextPath: Triage.submissions.status
-        description: Status of the submitted file
-        type: string
-      - contextPath: Triage.submissions.submitted
-        description: Date the sample was submitted
-        type: date
-      - contextPath: Triage.submissions.tasks.id
-        description: Array of tasks that have been applied to the sample (static, behavioral,
-          etc)
-        type: string
-      - contextPath: Triage.submissions.tasks.status
-        description: Status of the task
-        type: string
-      - contextPath: Triage.submissions.tasks.target
-        description: Sample the task is being run on
-        type: string
-      - contextPath: Triage.submissions.url
-        description: URL that was submitted
-        type: string
+  - arguments:
+    - name: query
+      description: The search query for Triage
+      required: true
+    name: triage-query-search
     description: Get a list of private and public samples matching the search query
+    outputs:
+    - contextPath: Triage.samples.completed
+      description: Date the sample analysis was completed
+      type: date
+    - contextPath: Triage.samples.filename
+      description: Name of the file submitted
+      type: string
+    - contextPath: Triage.samples.id
+      description: Unique identifier of the submission
+      type: string
+    - contextPath: Triage.samples.kind
+      description: Type of analysis
+      type: string
+    - contextPath: Triage.samples.private
+      description: If the submissions is private or publically viewable
+      type: boolean
+    - contextPath: Triage.samples.status
+      description: Status of the submitted file
+      type: string
+    - contextPath: Triage.samples.submitted
+      description: Date the sample was submitted
+      type: date
+    - contextPath: Triage.samples.tasks.id
+      description: Array of tasks that have been applied to the sample (static, behavioral, etc)
+      type: string
+    - contextPath: Triage.samples.tasks.status
+      description: Status of the task
+      type: string
+    - contextPath: Triage.samples.tasks.target
+      description: Sample the task is being run on
+      type: string
+    - contextPath: Triage.samples.url
+      description: URL that was submitted
+      type: string
   - arguments:
     - default: false
       isArray: false
@@ -751,7 +746,7 @@ script:
     execution: false
     name: triage-delete-profile
     description: Update the profile with the specified ID or name. The stored profile is overwritten, so it is important that the submitted profile has all fields, with the exception of the ID
-  dockerimage: demisto/python3:3.9.8.24399
+  dockerimage: demisto/python3:3.10.5.31928
   feed: false
   isfetch: false
   longRunning: false
@@ -760,3 +755,5 @@ script:
   script: '-'
   subtype: python3
   type: python
+tests:
+- No tests (auto formatted)

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/README.md
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/README.md
@@ -1,0 +1,594 @@
+Submit a high volume of samples to run in a sandbox and view reports
+This integration was integrated and tested with version xx of Hatching Triage
+
+## Configure Hatching Triage on Cortex XSOAR
+
+1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
+2. Search for Hatching Triage.
+3. Click **Add instance** to create and configure a new integration instance.
+
+    | **Parameter** | **Description** | **Required** |
+    | --- | --- | --- |
+    | API URL | Private url is https://private.tria.ge/api/v0/ | True |
+    | API Key | The API Key to use for the connection. | True |
+    | Verify SSL |  | False |
+
+4. Click **Test** to validate the URLs, token, and connection.
+## Commands
+You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
+After you successfully execute a command, a DBot message appears in the War Room with the command details.
+### triage-query-samples
+***
+Get a list of all samples either private or public
+
+
+#### Base Command
+
+`triage-query-samples`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| subset | Get samples from either private or public reports. Possible values are: owned, public. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.submissions.completed | Date | Date the sample analysis was completed | 
+| Triage.submissions.filename | String | Name of the file submitted | 
+| Triage.submissions.id | String | Unique identifier of the submission | 
+| Triage.submissions.kind | String | Type of analysis | 
+| Triage.submissions.private | Boolean | If the submissions is private or publically viewable | 
+| Triage.submissions.status | String | Status of the submitted file | 
+| Triage.submissions.submitted | Date | Date the sample was submitted | 
+| Triage.submissions.tasks.id | String | Array of tasks that have been applied to the sample \(static, behavioral, etc\) | 
+| Triage.submissions.tasks.status | String | Status of the task | 
+| Triage.submissions.tasks.target | String | Sample the task is being run on | 
+| Triage.submissions.url | String | URL that was submitted | 
+
+### triage-submit-sample
+***
+Submits a file or url for analysis
+
+
+#### Base Command
+
+`triage-submit-sample`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| kind | Select if sample is a URL, file, or a file that should be fetched from a URL. Possible values are: url, file, fetch. | Required | 
+| interactive | Choose if the sample should be interacted with in the GUI glovebox. Possible values are: false, true. Default is false. | Optional | 
+| profiles | Select what profile to run the sample with. Requires the user to be registered with a company. | Optional | 
+| data | Data to submit for analysis. For URLs give the URL. For files, give the entry-id of the file. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.submissions.filename | String | Name of the submitted file | 
+| Triage.submissions.id | String | Unique identifier of the submission | 
+| Triage.submissions.kind | String | Type of sample to analyze | 
+| Triage.submissions.private | Boolean | If the file is private or publicly viewable | 
+| Triage.submissions.status | String | Status of the analysis of the submission | 
+| Triage.submissions.submitted | Date | Date that the sample was submitted on | 
+
+#### Command example
+```!triage-submit-sample data="4@1" kind="file"```
+#### Human Readable Output
+
+
+
+### triage-get-sample
+***
+Pulls back basic information about the sample id given
+
+
+#### Base Command
+
+`triage-get-sample`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.samples.completed | Date | Date the sample analysis was completed | 
+| Triage.samples.filename | String | Name of the submitted sample | 
+| Triage.samples.id | String | Unique identifier of the sample | 
+| Triage.samples.kind | String | Type of sample submitted | 
+| Triage.samples.private | Boolean | State of the visibility of the sample | 
+| Triage.samples.status | String | Current status of the sample analysis | 
+| Triage.samples.submitted | Date | Date the sample was submitted | 
+| Triage.samples.tasks.id | String | Task name that was applied to the sample | 
+| Triage.samples.tasks.status | String | Status of the task | 
+| Triage.samples.tasks.target | String | Target of the task, e.g. filename for file submissions | 
+
+### triage-get-sample-summary
+***
+Gets a summary report of the sample id provided
+
+
+#### Base Command
+
+`triage-get-sample-summary`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.sample-summaries.completed | Date | Date the sample analysis was completed | 
+| Triage.sample-summaries.created | Date | Date the analysis report was created | 
+| Triage.sample-summaries.custom | String |  | 
+| Triage.sample-summaries.owner | String |  | 
+| Triage.sample-summaries.sample | String | Unique identifier of the sample | 
+| Triage.sample-summaries.score | Number | Score of the sample on a scale of 0 to 10 | 
+| Triage.sample-summaries.sha256 | String | SHA256 of the sample | 
+| Triage.sample-summaries.status | String | Status of the analysis | 
+| Triage.sample-summaries.target | String | Target for analysis | 
+| Triage.sample-summaries.tasks | String | Tasks performed in the analysis | 
+
+#### Command example
+```!triage-get-sample-summary sample_id="220807-d5sxnaebbx"```
+#### Human Readable Output
+
+
+
+### triage-delete-sample
+***
+Deletes a sample from the sandbox
+
+
+#### Base Command
+
+`triage-delete-sample`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-set-sample-profile
+***
+When a sample is in the static_analysis status, a profile should be selected in order to continue.
+
+
+#### Base Command
+
+`triage-set-sample-profile`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+| auto | Let Triage automatically select a profile, default is True. Possible values are: true, false. | Optional | 
+| pick | If submitting an archive file, select which files to analyze. Multiple files can be specified with a comma seperator.Format is archive_file_name/sample_file.exe,archive_file_name/sample_file2.exe. | Optional | 
+| profiles | Profile ID to use. | Optional | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-get-static-report
+***
+Get the static analysis of a sample
+
+
+#### Base Command
+
+`triage-get-static-report`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.sample.reports.static.analysis.reported | Unknown | Date the sample was submitted | 
+| DBotScore.Indicator | String | Triage analysis target | 
+| DBotScore.Type | String | The indicator type - File or URL | 
+| DBotScore.Vendor | String | The integration used to generate the indicator | 
+| DBotScore.Score | Number | Analysis verdict as score from 1 to 10 | 
+| File.Name | String | The full file name \(including file extension\). | 
+| File.MD5 | String | The MD5 hash of the file. | 
+| File.SHA1 | String | The SHA1 hash of the file. | 
+| File.SHA256 | String | The SHA1 hash of the file. | 
+| URL.Data | String | The URL | 
+
+#### Command example
+```!triage-get-static-report sample_id="220807-d5sxnaebbx"```
+#### Human Readable Output
+
+
+
+### triage-get-report-triage
+***
+Retrieves the generated Triage behavioral report for a single task
+
+
+#### Base Command
+
+`triage-get-report-triage`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+| task_id | Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2). | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.sample.reports.triage | Unknown | Triage report of the submitted sample | 
+| DBotScore.Indicator | String | Triage analysis target | 
+| DBotScore.Type | String | The indicator type - File or URL | 
+| DBotScore.Vendor | String | The integration used to generate the indicator | 
+| DBotScore.Score | Number | Analysis verdict as score from 1 to 10 | 
+| File.Name | String | The full file name \(including file extension\). | 
+| File.MD5 | String | The MD5 hash of the file. | 
+| File.SHA1 | String | The SHA1 hash of the file. | 
+| File.SHA256 | String | The SHA1 hash of the file. | 
+| URL.Data | String | The URL | 
+
+#### Command example
+```!triage-get-report-triage sample_id="220807-d5sxnaebbx" task_id="behavioral1"```
+#### Human Readable Output
+
+
+
+### triage-get-kernel-monitor
+***
+Retrieves the output of the kernel monitor
+
+
+#### Base Command
+
+`triage-get-kernel-monitor`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+| task_id | Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2). | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-get-pcap
+***
+Retrieves the PCAP of the analysis for further manual analysis
+
+
+#### Base Command
+
+`triage-get-pcap`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+| task_id | Name of a behavioral task part of the sample analysis (e.g. behavioral1, behavioral2). | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-get-dumped-file
+***
+Retrieves files dumped by the sample. The names can be found under the "dumped" section from the triage report output
+
+
+#### Base Command
+
+`triage-get-dumped-file`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| sample_id | Sample's unique identifier, can be found using the query samples command. | Required | 
+| task_id | Name of the task for the sample (e.g. behavioral1, static1, etc). | Required | 
+| file_name | Name of the dumped file. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-get-users
+***
+Return all users within the company as a paginated list. Returns a single user if a userID is provided
+
+
+#### Base Command
+
+`triage-get-users`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userID | Unique identifier of the user. Leave blank to query for all users. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.users.company_id | String | Company unique identifier | 
+| Triage.users.created_at | Date | Date users account was created | 
+| Triage.users.email | String | Users email | 
+| Triage.users.email_confirmed_at | Date | Date user confirmed their email/account | 
+| Triage.users.first_name | String | Users first name | 
+| Triage.users.id | String | Users unique identifier | 
+| Triage.users.last_name | String | Users last name | 
+| Triage.users.permissions | String | Users permissions | 
+
+### triage-create-user
+***
+Creates a new user and returns it. The user will become a member of the company the requesting user is a member of
+
+
+#### Base Command
+
+`triage-create-user`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| username | Users username, usually their email. | Required | 
+| firstName | Users first name. | Required | 
+| lastName | Users last name. | Required | 
+| password | Users password. | Required | 
+| permissions | Users permissions. Possible values are: view_samples, submit_samples, delete_samples, edit_profiles, access_api, manage_machines, manage_company. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.users.company_id | String | Company unique identifier | 
+| Triage.users.created_at | Date | Date users account was created | 
+| Triage.users.email | String | Users email | 
+| Triage.users.email_confirmed_at | Date | Date user confirmed their email/account | 
+| Triage.users.first_name | String | Users first name | 
+| Triage.users.id | String | Users unique identifier | 
+| Triage.users.last_name | String | Users last name | 
+| Triage.users.permissions | String | Users permissions | 
+
+### triage-delete-user
+***
+Delete a user and all associated data, invalidating any sessions and removing their API keys. Any samples submitted by this user are kept
+
+
+#### Base Command
+
+`triage-delete-user`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userID | Users unique identifier, can be found by querying for all users. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-create-api-key
+***
+Creates a new key can be used to make API calls on behalf of the specified user. The user should have been granted the access_api permission beforehand
+
+
+#### Base Command
+
+`triage-create-api-key`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userID | Users unique identifier, can be found by querying for all users. | Required | 
+| name | Name of the API key. Default is Created from XSOAR. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.apikey.key | String | API Key | 
+| Triage.apikey.name | String | Name of the API Key | 
+
+### triage-get-api-key
+***
+Lists all API keys that the user has.
+
+
+#### Base Command
+
+`triage-get-api-key`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userID | Users unique identifier, can be found by querying for all users. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.apikey.key | String | API Key | 
+| Triage.apikey.name | String | Name of the API Key | 
+
+### triage-delete-api-key
+***
+Delete the user's API key with the specified name
+
+
+#### Base Command
+
+`triage-delete-api-key`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userID | Users unique identifier, can be found by querying for all users. | Required | 
+| name | Name of the API key to delete. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-get-profiles
+***
+List all profiles that your company has
+
+
+#### Base Command
+
+`triage-get-profiles`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| profileID | Unique identifier of the profile, can be found by querying for all profiles. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.profiles..id | String | Unique identifier of the profile | 
+| Triage.profiles..name | String | Name of the profile | 
+| Triage.profiles..network | String | Network configuration | 
+| Triage.profiles..options.browser | String | Browser options | 
+| Triage.profiles..tags | String | Applied tags | 
+| Triage.profiles..timeout | Number | Max run time of the profile | 
+
+### triage-create-profile
+***
+Create a new profile
+
+
+#### Base Command
+
+`triage-create-profile`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| name | Name of the profile to create. | Required | 
+| tags | Tags to apply to the profile. | Required | 
+| timeout | Length of time the profile should run for. | Optional | 
+| network | Network configuration the profile should use. Possible values are: drop, internet, proxy. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.profiles.id | String | Profile unique identifier | 
+| Triage.profiles.name | String | Profile name | 
+| Triage.profiles.network | String | Profile network configuration | 
+| Triage.profiles.options | Unknown | Profile options | 
+| Triage.profiles.tags | String | Profile tags | 
+| Triage.profiles.timeout | Number | Profile max run time | 
+
+### triage-update-profile
+***
+Update an existing profile
+
+
+#### Base Command
+
+`triage-update-profile`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| profileID | Unique identifier of the profile to update. | Required | 
+| name | Name of the profile. | Required | 
+| tags | Tags to apply to the profile. | Required | 
+| timeout | Length of time the profile should run for. | Optional | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### triage-query-search
+***
+Get a list of private and public samples matching the search query
+
+
+#### Base Command
+
+`triage-query-search`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| query | The search query for Triage. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Triage.samples.completed | date | Date the sample analysis was completed | 
+| Triage.samples.filename | string | Name of the file submitted | 
+| Triage.samples.id | string | Unique identifier of the submission | 
+| Triage.samples.kind | string | Type of analysis | 
+| Triage.samples.private | boolean | If the submissions is private or publically viewable | 
+| Triage.samples.status | string | Status of the submitted file | 
+| Triage.samples.submitted | date | Date the sample was submitted | 
+| Triage.samples.tasks.id | string | Array of tasks that have been applied to the sample \(static, behavioral, etc\) | 
+| Triage.samples.tasks.status | string | Status of the task | 
+| Triage.samples.tasks.target | string | Sample the task is being run on | 
+| Triage.samples.url | string | URL that was submitted | 
+
+#### Command example
+```!triage-query-search query="tag:stealer AND tag:spyware"```
+#### Human Readable Output
+
+
+
+### triage-delete-profile
+***
+Update the profile with the specified ID or name. The stored profile is overwritten, so it is important that the submitted profile has all fields, with the exception of the ID
+
+
+#### Base Command
+
+`triage-delete-profile`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| profileID | Unique identifier of the profile to delete. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/command_examples.txt
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/command_examples.txt
@@ -1,0 +1,5 @@
+!triage-submit-sample data="4@1" kind="file"
+!triage-get-sample-summary sample_id="220807-d5sxnaebbx"
+!triage-get-static-report sample_id="220807-d5sxnaebbx"
+!triage-get-report-triage sample_id="220807-d5sxnaebbx" task_id="behavioral1"
+!triage-query-search query="tag:stealer AND tag:spyware"

--- a/Packs/HatchingTriage/Playbooks/playbook-Detonate_URL_-_Hatching_Triage.yml
+++ b/Packs/HatchingTriage/Playbooks/playbook-Detonate_URL_-_Hatching_Triage.yml
@@ -1,25 +1,25 @@
 id: Detonate URL - Hatching Triage
 version: -1
-contentitemexportablefields:
-  contentitemfields: {}
+fromversion: 6.2.0
+vcShouldKeepItemLegacyProdMachine: false
 name: Detonate URL - Hatching Triage
 description: Detonating URL with Hatching Triage.
 starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: ac486e14-1500-41db-8579-c2acb8b805ef
+    taskid: bc1fedf4-af24-48ac-89b1-1748107d1329
     type: start
     task:
-      id: ac486e14-1500-41db-8579-c2acb8b805ef
+      id: bc1fedf4-af24-48ac-89b1-1748107d1329
       version: -1
       name: ""
       description: starting test
       iscommand: false
       brand: ""
     nexttasks:
-      "#none#":
-        - "1"
+      '#none#':
+      - "1"
     separatecontext: false
     view: |-
       {
@@ -37,10 +37,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: 6fe76277-78da-4060-80e6-7510e4714e54
+    taskid: 15fb19a6-b9ad-4925-84fc-e6eff859e02a
     type: condition
     task:
-      id: 6fe76277-78da-4060-80e6-7510e4714e54
+      id: 15fb19a6-b9ad-4925-84fc-e6eff859e02a
       version: -1
       name: Is there any active Hatching Triage instance?
       description: Check for active instance
@@ -48,40 +48,40 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#default#":
-        - "6"
-      yes:
-        - "2"
+      '#default#':
+      - "6"
+      "yes":
+      - "2"
     separatecontext: false
     conditions:
-      - label: yes
-        condition:
-          - - operator: isExists
-              left:
-                value:
-                  complex:
-                    root: modules
-                    filters:
-                      - - operator: isEqualString
-                          left:
-                            value:
-                              simple: modules.brand
-                            iscontext: true
-                          right:
-                            value:
-                              simple: Hatching Triage
-                      - - operator: isEqualString
-                          left:
-                            value:
-                              simple: modules.state
-                            iscontext: true
-                          right:
-                            value:
-                              simple: active
-                    accessor: brand
-                iscontext: true
-              right:
-                value: {}
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Hatching Triage
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+                accessor: brand
+            iscontext: true
+          right:
+            value: {}
     view: |-
       {
         "position": {
@@ -98,10 +98,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: 93a33cc8-1959-49e6-8bde-49bf5dd9b550
+    taskid: e08b576d-2e34-4f21-88dd-dfe541fd7692
     type: condition
     task:
-      id: 93a33cc8-1959-49e6-8bde-49bf5dd9b550
+      id: e08b576d-2e34-4f21-88dd-dfe541fd7692
       version: -1
       name: Is there a URL?
       description: Check for URL
@@ -109,21 +109,21 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#default#":
-        - "6"
-      yes:
-        - "3"
+      '#default#':
+      - "6"
+      "yes":
+      - "3"
     separatecontext: false
     conditions:
-      - label: yes
-        condition:
-          - - operator: isExists
-              left:
-                value:
-                  simple: inputs.URL
-                iscontext: true
-              right:
-                value: {}
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              simple: inputs.URL
+            iscontext: true
+          right:
+            value: {}
     view: |-
       {
         "position": {
@@ -140,10 +140,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: ff206737-1a1f-4024-89d7-49c9afcd24fd
+    taskid: 96d46dcd-29e5-4e9c-8541-b7f16a505703
     type: regular
     task:
-      id: ff206737-1a1f-4024-89d7-49c9afcd24fd
+      id: 96d46dcd-29e5-4e9c-8541-b7f16a505703
       version: -1
       name: Send URL to Hatching Triage
       description: Submits a file or URL for analysis
@@ -152,8 +152,8 @@ tasks:
       iscommand: true
       brand: Hatching Triage
     nexttasks:
-      "#none#":
-        - "8"
+      '#none#':
+      - "8"
     scriptarguments:
       data:
         simple: ${inputs.URL}
@@ -176,10 +176,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: 49607d61-d347-454e-82d3-3a5222fec11a
+    taskid: 9f8a0368-98b5-4afe-8bfe-b1e5bd25bbb0
     type: playbook
     task:
-      id: 49607d61-d347-454e-82d3-3a5222fec11a
+      id: 9f8a0368-98b5-4afe-8bfe-b1e5bd25bbb0
       version: -1
       name: GenericPolling
       description: |-
@@ -195,8 +195,8 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#none#":
-        - "7"
+      '#none#':
+      - "7"
     scriptarguments:
       Ids:
         simple: ${Triage.submissions.id}
@@ -209,7 +209,7 @@ tasks:
       Timeout:
         simple: ${inputs.timeout}
       dt:
-        simple: Triage.sample-summaries(val.status=='reported')
+        simple: Triage.sample-summaries(val.status!=='reported').sample
     separatecontext: true
     loop:
       iscommand: false
@@ -232,13 +232,13 @@ tasks:
     isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: bee9857d-c4a9-4e9f-8939-822514c68078
+    taskid: 229f4061-9b02-4089-84e4-734e00a35d1a
     type: title
     task:
-      id: bee9857d-c4a9-4e9f-8939-822514c68078
+      id: 229f4061-9b02-4089-84e4-734e00a35d1a
       version: -1
       name: Done
-      description: "-"
+      description: '-'
       type: title
       iscommand: false
       brand: ""
@@ -259,10 +259,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: b76b27db-e95d-4178-827b-7bcbb45bbb4d
+    taskid: b2935177-bc59-4bb4-8274-e5f47f15bd95
     type: regular
     task:
-      id: b76b27db-e95d-4178-827b-7bcbb45bbb4d
+      id: b2935177-bc59-4bb4-8274-e5f47f15bd95
       version: -1
       name: Get task report
       description: Gets a summary report of the sample ID provided
@@ -271,8 +271,8 @@ tasks:
       iscommand: true
       brand: Hatching Triage
     nexttasks:
-      "#none#":
-        - "6"
+      '#none#':
+      - "6"
     scriptarguments:
       sample_id:
         simple: ${Triage.submissions.id}
@@ -293,10 +293,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: 26314852-2b16-4e29-84f7-47fa57ecfe90
+    taskid: 7c8b02ea-b9e8-4054-86ad-d2ffdc319d84
     type: regular
     task:
-      id: 26314852-2b16-4e29-84f7-47fa57ecfe90
+      id: 7c8b02ea-b9e8-4054-86ad-d2ffdc319d84
       version: -1
       name: Sleep (let the sandbox create the task)
       description: sleep
@@ -305,8 +305,8 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#none#":
-        - "9"
+      '#none#':
+      - "9"
     scriptarguments:
       seconds:
         simple: "5"
@@ -327,10 +327,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "9":
     id: "9"
-    taskid: 63fdd375-6640-48dc-82b0-f9727db684bf
+    taskid: 55574304-9525-46b5-84e7-06c51df3d9e6
     type: regular
     task:
-      id: 63fdd375-6640-48dc-82b0-f9727db684bf
+      id: 55574304-9525-46b5-84e7-06c51df3d9e6
       version: -1
       name: View task
       description: Gets a summary report of the sample ID provided
@@ -339,8 +339,8 @@ tasks:
       iscommand: true
       brand: Hatching Triage
     nexttasks:
-      "#none#":
-        - "4"
+      '#none#':
+      - "4"
     scriptarguments:
       sample_id:
         simple: ${Triage.submissions.id}
@@ -372,54 +372,51 @@ view: |-
     }
   }
 inputs:
-  - key: URL
-    value:
-      complex:
-        root: URL
-        accessor: Data
-    required: false
-    description: URL to detonate.
-    playbookInputQuery:
-  - key: interval
-    value:
-      simple: "1"
-    required: false
-    description: How often to poll for results.
-    playbookInputQuery:
-  - key: timeout
-    value:
-      simple: "10"
-    required: false
-    description: How long to wait before giving up waiting for results.
-    playbookInputQuery:
+- key: URL
+  value:
+    complex:
+      root: URL
+      accessor: Data
+  required: false
+  description: URL to detonate.
+  playbookInputQuery: null
+- key: interval
+  value:
+    simple: "1"
+  required: false
+  description: How often to poll for results.
+  playbookInputQuery: null
+- key: timeout
+  value:
+    simple: "10"
+  required: false
+  description: How long to wait before giving up waiting for results.
+  playbookInputQuery: null
 outputs:
-  - contextPath: Triage.sample-summaries.completed
-    description: Date the sample analysis was completed.
-  - contextPath: Triage.sample-summaries.created
-    description: Date the analysis report was created.
-  - contextPath: Triage.sample-summaries.custom
-    description: Custom sample analysis.
-  - contextPath: Triage.sample-summaries.owner
-    description: Owner of the sample analysis.
-    type: unknown
-  - contextPath: Triage.sample-summaries.sample
-    description: Unique identifier of the sample,
-    type: unknown
-  - contextPath: Triage.sample-summaries.score
-    description: Score of the sample on a scale of 0 to 10.
-    type: unknown
-  - contextPath: Triage.sample-summaries.sha256
-    description: SHA256 hash of the sample.
-    type: unknown
-  - contextPath: Triage.sample-summaries.status
-    description: Status of the analysis.
-    type: unknown
-  - contextPath: Triage.sample-summaries.target
-    description: Target for the analysis.
-    type: unknown
-  - contextPath: Triage.sample-summaries.tasks
-    description: Tasks performed in the analysis.
-    type: unknown
-tests:
-  - No tests (auto formatted)
-fromversion: 6.2.0
+- contextPath: Triage.sample-summaries.completed
+  description: Date the sample analysis was completed.
+- contextPath: Triage.sample-summaries.created
+  description: Date the analysis report was created.
+- contextPath: Triage.sample-summaries.custom
+  description: Custom sample analysis.
+- contextPath: Triage.sample-summaries.owner
+  description: Owner of the sample analysis.
+  type: unknown
+- contextPath: Triage.sample-summaries.sample
+  description: Unique identifier of the sample,
+  type: unknown
+- contextPath: Triage.sample-summaries.score
+  description: Score of the sample on a scale of 0 to 10.
+  type: unknown
+- contextPath: Triage.sample-summaries.sha256
+  description: SHA256 hash of the sample.
+  type: unknown
+- contextPath: Triage.sample-summaries.status
+  description: Status of the analysis.
+  type: unknown
+- contextPath: Triage.sample-summaries.target
+  description: Target for the analysis.
+  type: unknown
+- contextPath: Triage.sample-summaries.tasks
+  description: Tasks performed in the analysis.
+  type: unknown

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_6.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_6.md
@@ -4,6 +4,6 @@
 
 #### Integrations
 ##### Hatching Triage
-- Fixed broken file submit.
-- Use original filename instead of file id when submitting.
-- Add fetch submission support.
+- Add triage-query-search command.
+- Add examples for some commands.
+- Check if correct task_id type is provided in commands.

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_6.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_6.md
@@ -1,0 +1,9 @@
+#### Playbooks
+##### Detonate URL - Hatching Triage
+- Change generic poll usage. Poll more than once.
+
+#### Integrations
+##### Hatching Triage
+- Fixed broken file submit.
+- Use original filename instead of file id when submitting.
+- Add fetch submission support.

--- a/Packs/HatchingTriage/pack_metadata.json
+++ b/Packs/HatchingTriage/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Scalable malware sandbox",
     "support": "partner",
     "certification": "certified",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Hatching",
     "url": "https://hatching.io/",
     "email": "support@hatching.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
* Adds the `triage-query-search` command to be able to use Triage search (https://tria.ge/docs/cloud-api/search/).
* The Detonate URL playbook genericpolling did not seem to work properly. It stopped polling after a single poll. It looked like this was caused by the "dt" not returning a sample ID until it had to stop. It now returns a sample ID until the analysis status is 'reported'.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
