### PR TITLE
TestCollect: do not raise on non-content files

### DIFF
--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -437,7 +437,7 @@ class BranchTestCollector(TestCollector):
             return self._collect_yml(path)  # checks for containing folder (content item type)
 
         else:
-            raise ValueError(f'Unexpected {file_type=} for {relative_path}')
+            raise NothingToCollectException(path, f'file type {file_type}' if file_type else 'unknown file type')
 
         if not content_item:
             raise RuntimeError(f'failed collecting {path} for an unknown reason')
@@ -658,7 +658,7 @@ def output(result: Optional[CollectionResult]):
 
 
 if __name__ == '__main__':
-    logger.info('TestCollector v2022-08-10')
+    logger.info('TestCollector v20220810.2')
     sys.path.append(str(PATHS.content_path))
     parser = ArgumentParser()
     parser.add_argument('-n', '--nightly', type=str2bool, help='Is nightly')

--- a/Tests/scripts/collect_tests/test_collect_tests.py
+++ b/Tests/scripts/collect_tests/test_collect_tests.py
@@ -310,16 +310,13 @@ def test_only_collect_pack(mocker, monkeypatch, file_type: collect_tests.FileTyp
 
 def test_invalid_content_item(mocker, monkeypatch):
     """
-    given:  a changed file that  _get_changed_files can not identify
+    given:  a changed file that _get_changed_files is not designed to collect
     when:   collecting tests
-    then:   make sure an appropriate error is raised
+    then:   make sure nothing is collected, and no exception is raised
     """
     # test mockers
     mocker.patch.object(BranchTestCollector, '_get_changed_files', return_value=('Packs/myPack/some_file',))
 
-    with pytest.raises(ValueError) as e:
-        # noinspection PyTypeChecker
-        _test(monkeypatch, case_mocker=MockerCases.H, run_nightly=False, collector_class=BranchTestCollector,
-              expected_tests=(), expected_packs=('myPack',), expected_machines=None,
-              collector_class_args=XSOAR_BRANCH_ARGS)
-    assert 'Unexpected file_type=None' in str(e.value)
+    _test(monkeypatch, case_mocker=MockerCases.H, run_nightly=False, collector_class=BranchTestCollector,
+          expected_tests=(), expected_packs=(), expected_machines=None,
+          collector_class_args=XSOAR_BRANCH_ARGS)


### PR DESCRIPTION
Changing behavior of non-content items to raise `NothingToCollectException`, similar to cases where unit tests are changed (pack is not collected)