### PR TITLE
TestCollection: fix default value

### DIFF
--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -662,7 +662,7 @@ def output(result: Optional[CollectionResult]):
 
 
 if __name__ == '__main__':
-    logger.info('TestCollector v20220811')
+    logger.info('TestCollector v20220811.2')
     sys.path.append(str(PATHS.content_path))
     parser = ArgumentParser()
     parser.add_argument('-n', '--nightly', type=str2bool, help='Is nightly')

--- a/Tests/scripts/collect_tests/utils.py
+++ b/Tests/scripts/collect_tests/utils.py
@@ -191,7 +191,7 @@ class ContentItem(DictFileBased):
         super().__init__(path)
         self.pack_path = find_pack_folder(self.path)
         self.deprecated = self.get('deprecated', warn_if_missing=False)
-        self._tests = self.get('tests', warn_if_missing=False)
+        self._tests = self.get('tests', default=(), warn_if_missing=False)
 
     @property
     def id_(self) -> Optional[str]:  # Optional as pack_metadata (for example) doesn't have this field


### PR DESCRIPTION
self._tests was [none if missing](https://code.pan.run/xsoar/content/-/jobs/15412043#L3327), now it's an empty tuple