### PR TITLE
TestCollect: fixed another default value

### DIFF
--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -427,7 +427,7 @@ class BranchTestCollector(TestCollector):
                 FileType.MAPPER: (self.conf.incoming_mapper_to_test, CollectionReason.MAPPER_CHANGED),
                 FileType.CLASSIFIER: (self.conf.classifier_to_test, CollectionReason.CLASSIFIER_CHANGED),
             }[file_type]
-            if not (tests := source.get(content_item)):  # type: ignore[call-overload]
+            if not (tests := source.get(content_item, ())):  # type: ignore[call-overload]
                 reason = CollectionReason.NON_CODE_FILE_CHANGED
                 reason_description = f'no specific tests for {relative_path} were found'
 
@@ -662,7 +662,7 @@ def output(result: Optional[CollectionResult]):
 
 
 if __name__ == '__main__':
-    logger.info('TestCollector v20220811.2')
+    logger.info('TestCollector v20220811.3')
     sys.path.append(str(PATHS.content_path))
     parser = ArgumentParser()
     parser.add_argument('-n', '--nightly', type=str2bool, help='Is nightly')

--- a/Tests/scripts/collect_tests/id_set.py
+++ b/Tests/scripts/collect_tests/id_set.py
@@ -21,7 +21,7 @@ class IdSetItem(DictBased):
         self.id_: Optional[str] = id_  # None for packs, as they don't have it.
         self.file_path_str: str = self.get('file_path', warn_if_missing=False)  # packs have no file_path value
         self.path: Optional[Path] = Path(self.file_path_str) if self.file_path_str else None
-        self.name: str = self.get('name', '', warning_comment=self.path or '')
+        self.name: str = self.get('name', '', warning_comment=self.file_path_str or '')
 
         # None for packs, that have no id.
         self.pack_id: Optional[str] = self.get('pack', warning_comment=self.file_path_str) if id_ else None


### PR DESCRIPTION
- added default `.get` value to avoid cases where the get result would be iterated-on (see [this failure](https://code.pan.run/xsoar/content/-/jobs/15453757#L4152))
- changed some warning to use a string instead str(Path) in `IdSetItem`s