### PR TITLE
New docker image for Splunk (Splunk-sdk version 1.7.0 -> 1.6.4)

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -848,7 +848,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk:1.0.0.32388
+  dockerimage: demisto/splunksdk:1.0.0.24033
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -848,7 +848,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk:1.0.0.24033
+  dockerimage: devdemisto/splunksdk:1.0.0.32878
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -848,7 +848,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: splunk user mapping.
       type: String
-  dockerimage: devdemisto/splunksdk:1.0.0.32878
+  dockerimage: demisto/splunksdk:1.0.0.32879
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Updated the Docker image to: *devdemisto/splunksdk:1.0.0.32878*.
+- Fixed an issue where **splunk-search** command failed.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,5 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Updated the Docker image to: *demisto/splunksdk:1.0.0.32879*.
-- Fixed an issue where **splunk-search** command failed.
+ - Fixed an issue where Notables were missed if an error occurred during the enrichment process.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+- Revert the docker image to: *demisto/splunksdk:1.0.0.24033* due to a problem that exists in SplunkPy 1.7.0 version.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### SplunkPy
+- Updated the Docker image to: *demisto/splunksdk:1.0.0.32879*.
 - Fixed an issue where **splunk-search** command failed.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
-- Revert the docker image to: *demisto/splunksdk:1.0.0.24033* due to a problem that exists in SplunkPy 1.7.0 version.
+- Updated the Docker image to: *devdemisto/splunksdk:1.0.0.32878*.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_7.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_7.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where **splunk-search** command failed.
+- Updated the Docker image to: *demisto/splunksdk:1.0.0.32879*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.4.5",
+    "currentVersion": "2.4.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.4.6",
+    "currentVersion": "2.4.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
New docker image with 1.6.4 splunk-sdk version, due to a problem in splunk-sdk 1.7.0 version.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
