### PR TITLE
SplunkPy: raising exception only if no incident to create

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1155,7 +1155,9 @@ def run_enrichment_mechanism(service, integration_context, mapper):
     except Exception as e:
         err = 'Caught an exception while executing the enriching fetch mechanism. Additional Info: {}'.format(str(e))
         demisto.error(err)
-        raise e
+        # we throw excpetion only if there is no incident to create 
+        if not incidents:
+            raise e
 
     finally:
         store_incidents_for_mapping(incidents, integration_context)

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1155,7 +1155,7 @@ def run_enrichment_mechanism(service, integration_context, mapper):
     except Exception as e:
         err = 'Caught an exception while executing the enriching fetch mechanism. Additional Info: {}'.format(str(e))
         demisto.error(err)
-        # we throw excpetion only if there is no incident to create 
+        # we throw excpetion only if there is no incident to create
         if not incidents:
             raise e
 

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### SplunkPy
- - Fixed an issue where Notables was missed in case of error in the enrichment process.
+ - Fixed an issue where Notables were missed if an error occurred during the enrichment process.

--- a/Packs/SplunkPy/ReleaseNotes/2_4_6.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### SplunkPy
+ - Fixed an issue where Notables was missed in case of error in the enrichment process.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.4.5",
+    "currentVersion": "2.4.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-14577

## Description
if error occurred when run enrichment for fetched notables - ignore exception in order to create the fetched notables as regular incident
