### PR TITLE
AnsibleLinux: remove the default search_path

### DIFF
--- a/Packs/AnsibleLinux/Integrations/AnsibleLinux/AnsibleLinux.yml
+++ b/Packs/AnsibleLinux/Integrations/AnsibleLinux/AnsibleLinux.yml
@@ -1821,8 +1821,7 @@ script:
     - defaultValue: Reboot initiated by Ansible
       description: Message to display to users before reboot.
       name: msg
-    - defaultValue: '[''/sbin'', ''/usr/sbin'', ''/usr/local/sbin'']'
-      description: 'Paths to search on the remote machine for the `shutdown` command.
+    - description: 'Paths to search on the remote machine for the `shutdown` command.
         `Only` these paths will be searched for the `shutdown` command. `PATH` is
         ignored in the remote node when searching for the `shutdown` command.'
       isArray: true

--- a/Packs/AnsibleLinux/ReleaseNotes/1_0_5.md
+++ b/Packs/AnsibleLinux/ReleaseNotes/1_0_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Linux
+- Fixed an issue where the ***linux-reboot*** command failed if using the default **search_path**. 

--- a/Packs/AnsibleLinux/pack_metadata.json
+++ b/Packs/AnsibleLinux/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Ansible Linux",
     "description": "Manage and control Linux hosts.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-14132

## Description
default search_path cause issue to customer if no search_path is specified
remove it as this default is already are the default by Ansible
see https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html#parameter-search_paths
