### PR TITLE
TestCollect: log args, use branch correctly

### DIFF
--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -481,7 +481,7 @@ class BranchTestCollector(TestCollector):
         elif os.getenv('CONTRIB_BRANCH'):
             # gets files of unknown status
             contrib_diff: tuple[str, ...] = tuple(filter(lambda f: f.startswith('Packs/'), repo.untracked_files))
-            logger.info(f'contribution branch found, contrib-diff:\n' + '\n'.join(contrib_diff))
+            logger.info('contribution branch found, contrib-diff:\n' + '\n'.join(contrib_diff))
             changed_files.extend(contrib_diff)
 
         diff = repo.git.diff(previous_commit, current_commit, '--name-status')

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -679,7 +679,7 @@ if __name__ == '__main__':
     parser.add_argument('--service_account', help="Path to gcloud service account")
     args = parser.parse_args()
     args_string = '\n'.join(f'{k}={v}' for k, v in vars(args).items())
-    logger.debug(f'parsed args: {args_string}')
+    logger.debug(f'parsed args:\n{args_string}')
 
     marketplace = MarketplaceVersions(args.marketplace)
 

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -462,7 +462,7 @@ class BranchTestCollector(TestCollector):
 
     def _get_changed_files(self) -> tuple[str, ...]:
         repo = PATHS.content_repo
-        changed_files = []
+        changed_files: list[str] = []
 
         previous_commit = 'origin/master'
         current_commit = self.branch_name
@@ -488,7 +488,7 @@ class BranchTestCollector(TestCollector):
         logger.debug(f'raw changed files string:\n{diff}')
 
         # diff is formatted as `M  foo.json\n A  bar.py\n ...`, turning it into ('foo.json', 'bar.py', ...).
-        for line in filter(None, diff.splitlines()):
+        for line in diff.splitlines():
             try:
                 git_status, file_path = line.split()
             except ValueError:

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -20,6 +20,7 @@ from exceptions import (DeprecatedPackException, InvalidTestException,
                         PrivateTestException, SkippedPackException,
                         SkippedTestException, TestMissingFromIdSetException,
                         UnsupportedPackException)
+from git import Repo
 from id_set import IdSet
 from logger import logger
 from test_conf import TestConf
@@ -274,6 +275,7 @@ class BranchTestCollector(TestCollector):
         :param private_pack_path: path to a pack, only used for content-private.
         """
         super().__init__(marketplace)
+        logger.debug(f'Created BranchTestCollector for {branch_name}')
         self.branch_name = branch_name
         self.service_account = service_account
         self.private_pack_path: Optional[Path] = private_pack_path
@@ -656,7 +658,7 @@ def output(result: Optional[CollectionResult]):
     pack_str = '\n'.join(packs)
     machine_str = ', '.join(sorted(map(str, machines)))
 
-    logger.info(f'collected {len(tests)} tests:\n{test_str}')
+    logger.info(f'collected {len(tests)} test playbooks:\n{test_str}')
     logger.info(f'collected {len(packs)} packs:\n{pack_str}')
     logger.info(f'collected {len(machines)} machines: {machine_str}')
 
@@ -666,7 +668,7 @@ def output(result: Optional[CollectionResult]):
 
 
 if __name__ == '__main__':
-    logger.info('TestCollector v20220814')
+    logger.info('TestCollector v20220817')
     sys.path.append(str(PATHS.content_path))
     parser = ArgumentParser()
     parser.add_argument('-n', '--nightly', type=str2bool, help='Is nightly')
@@ -675,23 +677,27 @@ if __name__ == '__main__':
     parser.add_argument('-mp', '--marketplace', type=MarketplaceVersions, help='marketplace version',
                         default='xsoar')
     parser.add_argument('--service_account', help="Path to gcloud service account")
-    options = parser.parse_args()
-    marketplace = MarketplaceVersions(options.marketplace)
+    args = parser.parse_args()
+    args_string = '\n'.join(f'{k}={v}' for k, v in vars(args).items())
+    logger.debug(f'parsed args: {args_string}')
+
+    marketplace = MarketplaceVersions(args.marketplace)
 
     collector: TestCollector
 
-    if options.changed_pack_path:
-        collector = BranchTestCollector('master', marketplace, options.service_account, options.changed_pack_path)
+    if args.changed_pack_path:
+        collector = BranchTestCollector('master', marketplace, args.service_account, args.changed_pack_path)
     else:
-        match (options.nightly, marketplace):
+        match (args.nightly, marketplace):
             case False, _:  # not nightly
-                collector = BranchTestCollector('master', marketplace, options.service_account)
+                branch_name = Repo(PATHS.content_path).active_branch.name
+                collector = BranchTestCollector(branch_name, marketplace, args.service_account)
             case True, MarketplaceVersions.XSOAR:
                 collector = XSOARNightlyTestCollector()
             case True, MarketplaceVersions.MarketplaceV2:
                 collector = XSIAMNightlyTestCollector()
             case _:
-                raise ValueError(f"unexpected values of (either) {marketplace=}, {options.nightly=}")
+                raise ValueError(f"unexpected values of (either) {marketplace=}, {args.nightly=}")
 
-    collected = collector.collect(run_nightly=options.nightly)
+    collected = collector.collect(run_nightly=args.nightly)
     output(collected)  # logs and writes to output files

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -13,7 +13,7 @@ from constants import (ALWAYS_INSTALLED_PACKS,
                        ONLY_INSTALL_PACK_FILE_TYPES, SANITY_TEST_TO_PACK,
                        SKIPPED_CONTENT_ITEMS, XSOAR_SANITY_TEST_NAMES)
 from demisto_sdk.commands.common.constants import FileType, MarketplaceVersions
-from demisto_sdk.commands.common.tools import find_type, run_command, str2bool
+from demisto_sdk.commands.common.tools import find_type, str2bool
 from exceptions import (DeprecatedPackException, InvalidTestException,
                         NonDictException, NoTestsConfiguredException,
                         NothingToCollectException, NotUnderPackException,
@@ -462,7 +462,8 @@ class BranchTestCollector(TestCollector):
         )
 
     def _get_changed_files(self) -> tuple[str, ...]:
-        contrib_diff = None  # overridden on contribution branches, added to the git diff.
+        repo = PATHS.content_repo
+        changed_files = []
 
         current_commit = self.branch_name
         previous_commit = 'origin/master'
@@ -472,36 +473,33 @@ class BranchTestCollector(TestCollector):
         if os.getenv('IFRA_ENV_TYPE') == 'Bucket-Upload':
             logger.info('bucket upload: getting last commit from index')
             previous_commit = get_last_commit_from_index(self.service_account)
-            current_commit = 'origin/master' if self.branch_name == 'master' else self.branch_name
+            if self.branch_name == 'master':
+                current_commit = 'origin/master'
 
         elif self.branch_name == 'master':
-            previous_commit, current_commit = run_command("git log -n 2 --pretty='%H'").replace("'", "").split()
+            previous_commit, current_commit = tuple(repo.iter_commits(max_count=2))
 
         elif os.getenv('CONTRIB_BRANCH'):
-            contrib_diff = run_command('git status -uall --porcelain -- Packs').replace('??', 'A')
-            logger.info(f'contribution branch, contribution diff:\n{contrib_diff}')
+            # gets files of unknown status
+            contrib_diff: tuple[str, ...] = tuple(filter(lambda f: f.startswith('Packs/'), repo.untracked_files))
+            logger.info(f'contribution branch found, contrib-diff:\n' + '\n'.join(contrib_diff))
+            changed_files.extend(contrib_diff)
 
-        diff_command = f'git diff --name-status {previous_commit}...{current_commit}'
-        logger.debug(f'running {diff_command}')
-
-        diff: str = run_command(diff_command)
-        logger.debug(f'Changed files:\n{diff}')
-
-        if contrib_diff:
-            logger.debug('adding contrib_diff to diff')
-            diff = f'{diff}\n{contrib_diff}'
-            logger.debug(f'diff is now\n{diff}')
+        diff = repo.git.diff(previous_commit, current_commit, '--name-status')
+        logger.debug(f'raw changed files string:\n{diff}')
 
         # diff is formatted as `M  foo.json\n A  bar.py\n ...`, turning it into ('foo.json', 'bar.py', ...).
-        files = []
         for line in filter(None, diff.splitlines()):
-            git_status, file_path = line.split()
+            try:
+                git_status, file_path = line.split()
+            except ValueError:
+                raise ValueError(f'unexpected line format (expected `<modifier>\t<file>`, got {line}')
             if git_status == 'D':  # git-deleted file
                 logger.warning(f'Found a file deleted from git {file_path}, '
                                f'skipping it as TestCollector cannot properly find the appropriate tests (by design)')
                 continue
-            files.append(file_path)  # non-deleted files (added, modified)
-        return tuple(files)
+            changed_files.append(file_path)  # non-deleted files (added, modified)
+        return tuple(changed_files)
 
 
 class UploadCollector(BranchTestCollector):

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -481,7 +481,7 @@ class BranchTestCollector(TestCollector):
             contrib_diff = run_command('git status -uall --porcelain -- Packs').replace('??', 'A')
             logger.info(f'contribution branch, contribution diff:\n{contrib_diff}')
 
-        diff_command = f'git diff --name-status {current_commit}...{previous_commit}'
+        diff_command = f'git diff --name-status {previous_commit}...{current_commit}'
         logger.debug(f'running {diff_command}')
 
         diff: str = run_command(diff_command)

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -476,7 +476,7 @@ class BranchTestCollector(TestCollector):
                 current_commit = 'origin/master'
 
         elif self.branch_name == 'master':
-            previous_commit, current_commit = tuple(repo.iter_commits(max_count=2))
+            current_commit, previous_commit = tuple(repo.iter_commits(max_count=2))
 
         elif os.getenv('CONTRIB_BRANCH'):
             # gets files of unknown status
@@ -484,7 +484,7 @@ class BranchTestCollector(TestCollector):
             logger.info('contribution branch found, contrib-diff:\n' + '\n'.join(contrib_diff))
             changed_files.extend(contrib_diff)
 
-        diff = repo.git.diff(previous_commit, current_commit, '--name-status')
+        diff = repo.git.diff(f'{previous_commit}...{current_commit}', '--name-status')
         logger.debug(f'raw changed files string:\n{diff}')
 
         # diff is formatted as `M  foo.json\n A  bar.py\n ...`, turning it into ('foo.json', 'bar.py', ...).

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -20,7 +20,6 @@ from exceptions import (DeprecatedPackException, InvalidTestException,
                         PrivateTestException, SkippedPackException,
                         SkippedTestException, TestMissingFromIdSetException,
                         UnsupportedPackException)
-from git import Repo
 from id_set import IdSet
 from logger import logger
 from test_conf import TestConf
@@ -688,7 +687,7 @@ if __name__ == '__main__':
     else:
         match (args.nightly, marketplace):
             case False, _:  # not nightly
-                branch_name = Repo(PATHS.content_path).active_branch.name
+                branch_name = PATHS.content_repo.active_branch.name
                 collector = BranchTestCollector(branch_name, marketplace, args.service_account)
             case True, MarketplaceVersions.XSOAR:
                 collector = XSOARNightlyTestCollector()

--- a/Tests/scripts/collect_tests/path_manager.py
+++ b/Tests/scripts/collect_tests/path_manager.py
@@ -3,6 +3,8 @@ from os import getenv
 from pathlib import Path
 from typing import Iterable, Union
 
+from git import Repo
+
 _SANITY_FILES_FOR_GLOB = (
     # if any of the files under this list (or descendants) is changed, and no other files are changed,
     # sanity test will be run. All other files NOT under /Packs are ignored.
@@ -24,6 +26,7 @@ class PathManager:
 
     def __init__(self, content_path: Path):
         self.content_path = content_path
+        self.content_repo = Repo(content_path)
         logging.debug(f'PathManager uses {self.content_path.resolve()=}, {PathManager.ARTIFACTS_PATH.resolve()=}')
 
         self.packs_path = self.content_path / 'Packs'

--- a/Tests/scripts/collect_tests/test_collect_tests.py
+++ b/Tests/scripts/collect_tests/test_collect_tests.py
@@ -312,7 +312,7 @@ def test_only_collect_pack_args():
 
 
 def test_only_collect_and_ignore_lists_are_disjoint():
-    from constants import ONLY_INSTALL_PACK_FILE_TYPES, IGNORED_FILE_TYPES
+    from constants import IGNORED_FILE_TYPES, ONLY_INSTALL_PACK_FILE_TYPES
     assert ONLY_INSTALL_PACK_FILE_TYPES.isdisjoint(IGNORED_FILE_TYPES)
 
 


### PR DESCRIPTION
- fixed a bug where incorrect files were gathered in `git diff`
- renamed `options` to args for readability
- added logs
- using gitpython `Repo` objects instead of raw git commands