### PR TITLE
[Elasticsearch v2] - Added fetch history

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
@@ -514,7 +514,8 @@ def results_to_incidents_timestamp(response, last_fetch):
                 inc = {
                     'name': 'Elasticsearch: Index: ' + str(hit.get('_index')) + ", ID: " + str(hit.get('_id')),
                     'rawJSON': json.dumps(hit),
-                    'occurred': hit_date.isoformat() + 'Z'
+                    'occurred': hit_date.isoformat() + 'Z',
+                    'dbotMirrorId': hit.get('_id')
                 }
 
                 if MAP_LABELS:
@@ -558,7 +559,8 @@ def results_to_incidents_datetime(response, last_fetch):
                     # parse function returns iso format sometimes as YYYY-MM-DDThh:mm:ss+00:00
                     # and sometimes as YYYY-MM-DDThh:mm:ss
                     # we want to return format: YYYY-MM-DDThh:mm:ssZ in our incidents
-                    'occurred': format_to_iso(hit_date.isoformat())
+                    'occurred': format_to_iso(hit_date.isoformat()),
+                    'dbotMirrorId': hit.get('_id')
                 }
 
                 if MAP_LABELS:

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -320,7 +320,7 @@ script:
     name: get-mapping-fields
     description: Returns the schema of the index to fetch from. This commmand should
       be used for debugging purposes.
-  dockerimage: demisto/py3-tools:1.0.0.31193
+  dockerimage: demisto/py3-tools:1.0.0.32758
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -188,6 +188,7 @@ MOCK_ES7_INCIDENTS = str([
                    '"_source": {"Date": "2019-08-27T18:00:00Z"}'
                    '}',
         'occurred': '2019-08-27T18:00:00Z',
+        'dbotMirrorId': '123',
         'labels': [
             {
                 'type': 'Date',
@@ -204,6 +205,7 @@ MOCK_ES7_INCIDENTS = str([
                    '"_source": {"Date": "2019-08-27T18:01:25.343212Z"}'
                    '}',
         'occurred': '2019-08-27T18:01:25Z',
+        'dbotMirrorId': '456',
         'labels': [
             {
                 'type': 'Date',
@@ -223,7 +225,8 @@ MOCK_ES7_INCIDENTS_WITHOUT_LABELS = str([
                    '"_score": 0.6814878, '
                    '"_source": {"Date": "2019-08-27T18:00:00Z"}'
                    '}',
-        'occurred': '2019-08-27T18:00:00Z'
+        'occurred': '2019-08-27T18:00:00Z',
+        'dbotMirrorId': '123'
     }, {
         'name': 'Elasticsearch: Index: customer, ID: 456',
         'rawJSON': '{'
@@ -233,7 +236,8 @@ MOCK_ES7_INCIDENTS_WITHOUT_LABELS = str([
                    '"_score": 0.6814878, '
                    '"_source": {"Date": "2019-08-27T18:01:25.343212Z"}'
                    '}',
-        'occurred': '2019-08-27T18:01:25Z'
+        'occurred': '2019-08-27T18:01:25Z',
+        'dbotMirrorId': '456'
     }
 ])
 
@@ -248,6 +252,7 @@ MOCK_ES6_INCIDETNS = str([
                    '"_source": {"Date": "2019-08-29T14:45:00.123Z"}'
                    '}',
         'occurred': '2019-08-29T14:45:00Z',
+        'dbotMirrorId': '123',
         'labels':
             [
                 {
@@ -265,6 +270,7 @@ MOCK_ES6_INCIDETNS = str([
                    '"_source": {"Date": "2019-08-29T14:46:00.123456Z"}'
                    '}',
         'occurred': '2019-08-29T14:46:00Z',
+        'dbotMirrorId': '456',
         'labels':
             [
                 {
@@ -286,6 +292,7 @@ MOCK_ES6_INCIDETNS_WITHOUT_LABELS = str([
                    '"_source": {"Date": "2019-08-29T14:45:00.123Z"}'
                    '}',
         'occurred': '2019-08-29T14:45:00Z',
+        'dbotMirrorId': '123'
     }, {
         'name': 'Elasticsearch: Index: users, ID: 456',
         'rawJSON': '{'
@@ -296,6 +303,7 @@ MOCK_ES6_INCIDETNS_WITHOUT_LABELS = str([
                    '"_source": {"Date": "2019-08-29T14:46:00.123456Z"}'
                    '}',
         'occurred': '2019-08-29T14:46:00Z',
+        'dbotMirrorId': '456'
     }
 ])
 
@@ -347,6 +355,7 @@ MOCK_ES7_INCIDENTS_FROM_TIMESTAMP = str([
                    '"_source": {"Date": "1572502634"}'
                    '}',
         'occurred': '2019-10-31T06:17:14Z',
+        'dbotMirrorId': '123',
         'labels': [
             {
                 'type': 'Date',
@@ -363,6 +372,7 @@ MOCK_ES7_INCIDENTS_FROM_TIMESTAMP = str([
                    '"_source": {"Date": "1572502640"}'
                    '}',
         'occurred': '2019-10-31T06:17:20Z',
+        'dbotMirrorId': '456',
         'labels': [
             {
                 'type': 'Date',
@@ -383,6 +393,7 @@ MOCK_ES7_INCIDENTS_FROM_TIMESTAMP_WITHOUT_LABELS = str([
                    '"_source": {"Date": "1572502634"}'
                    '}',
         'occurred': '2019-10-31T06:17:14Z',
+        'dbotMirrorId': '123'
     }, {
         'name': 'Elasticsearch: Index: customer, ID: 456',
         'rawJSON': '{'
@@ -393,6 +404,7 @@ MOCK_ES7_INCIDENTS_FROM_TIMESTAMP_WITHOUT_LABELS = str([
                    '"_source": {"Date": "1572502640"}'
                    '}',
         'occurred': '2019-10-31T06:17:20Z',
+        'dbotMirrorId': '456'
     }
 ])
 

--- a/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Elasticsearch v2
+- Added support for viewing the IDs of the fetched messages in the *Source IDs* column of the fetch history modal (supported in XSOAR version 6.8.0 and above).

--- a/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Elasticsearch v2
 - Added support for viewing the IDs of the fetched messages in the *Source IDs* column of the fetch history modal (supported in XSOAR version 6.8.0 and above).
-- Updated the Docker image to: *demisto/py3-tools:1.0.0.327583*.
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.32758*.

--- a/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_2_15.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Elasticsearch v2
 - Added support for viewing the IDs of the fetched messages in the *Source IDs* column of the fetch history modal (supported in XSOAR version 6.8.0 and above).
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.327583*.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.2.14",
+    "currentVersion": "1.2.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-3814](https://jira-hq.paloaltonetworks.local/browse/CIAC-3814)

## Description
Added the advanced feature fetch-history to the fetch-incident command in Elasticsearch v2 integration.

## Screenshots
Paste here any images that will help the reviewer
<img width="1332" alt="Screen Shot 2022-08-17 at 12 57 18" src="https://user-images.githubusercontent.com/59408745/185091294-a7ecfdd8-52a2-41f8-b7ef-f2f9ed2dcc71.png">
