### PR TITLE
fixed the apimodules path in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,8 @@
 		"shd101wyy.markdown-preview-enhanced",
 		"Gruntfuggly.todo-tree",
 		"redhat.vscode-yaml",
-		"PKief.material-icon-theme"
+		"PKief.material-icon-theme",
+		"KevinRose.vsc-python-indent"
 	],
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_PATH": "${localWorkspaceFolder}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,5 +64,5 @@
 		"git": "os-provided",
 		"github-cli": "latest"
 	},
-	"onCreateCommand": "touch ${containerWorkspaceFolder}/CommonServerUserPython.py && echo 'export PYTHONPATH=$(printf '%s: ' ${containerWorkspaceFolder}/Packs/ApiModules/Scripts/*):$PYTHONPATH' >> ~/.zshrc && echo 'export MYPYPATH=$(printf '%s: ' ${containerWorkspaceFolder}/Packs/ApiModules/Scripts/*):$MYPYPATH' >> ~/.zshrc && pipx install demisto-sdk --force && NO_HOOKS=1 .hooks/bootstrap"
+	"onCreateCommand": "touch ${containerWorkspaceFolder}/CommonServerUserPython.py && echo 'export PYTHONPATH=$(printf '%s:' ${containerWorkspaceFolder}/Packs/ApiModules/Scripts/*):$PYTHONPATH' >> ~/.zshrc && echo 'export MYPYPATH=$(printf '%s:' ${containerWorkspaceFolder}/Packs/ApiModules/Scripts/*):$MYPYPATH' >> ~/.zshrc && pipx install demisto-sdk --force && NO_HOOKS=1 .hooks/bootstrap"
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,7 +13,14 @@
         "GitHub.vscode-pull-request-github",
         "eamodio.gitlens",
         "ms-azuretools.vscode-docker",
-        "ms-vscode-remote.remote-containers"
+        "ms-vscode-remote.remote-containers",
+        "njpwerner.autodocstring",
+        "mikestead.dotenv",
+        "yzhang.markdown-all-in-one",
+        "shd101wyy.markdown-preview-enhanced",
+        "ms-vscode.powershell",
+        "KevinRose.vsc-python-indent",
+        "redhat.vscode-yaml",
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": [


### PR DESCRIPTION

## Contributing to Cortex XSOAR Content

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
- The APIModules path had an extra space, removed it
- Added extensions to extensions.json
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
