### PR TITLE
JiraV2: use the data value instead delta for mirroring 

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -1242,7 +1242,9 @@ def update_remote_system_command(args):
         if remote_args.delta and remote_args.incident_changed:
             demisto.debug(f'Got the following delta keys {str(list(remote_args.delta.keys()))} to update Jira '
                           f'incident {remote_id}')
-            edit_issue_command(remote_id, mirroring=True, **remote_args.delta)
+            # take the val from data as it's the updated value
+            delta = {k: remote_args.data[k] for k in remote_args.delta.keys()}
+            edit_issue_command(remote_id, mirroring=True, **delta)
 
         else:
             demisto.debug(f'Skipping updating remote incident fields [{remote_id}] '

--- a/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
@@ -401,7 +401,7 @@ def test_update_remote_system_delta(mocker):
         {
             "incidentChanged": "17757",
             "remoteId": "17757",
-            "data": {"summary": "data"},
+            "data": {"summary": "data", "not_changes_key": "not_changes_val"},
             "delta": {"summary": "changes"},
         }
     )

--- a/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
@@ -391,6 +391,7 @@ def test_update_remote_system_delta(mocker):
     Then:
         - The issue in Jira has the new summary.
     """
+    import JiraV2
     from JiraV2 import update_remote_system_command
 
     mocker.patch("JiraV2.edit_issue_command", return_value="")
@@ -400,10 +401,12 @@ def test_update_remote_system_delta(mocker):
         {
             "incidentChanged": "17757",
             "remoteId": "17757",
+            "data": {"summary": "data"},
             "delta": {"summary": "changes"},
         }
     )
     assert res == "17757"
+    assert JiraV2.edit_issue_command.call_args[1]['summary'] == 'data'
 
 
 def test_get_mapping_fields(mocker):

--- a/Packs/Jira/ReleaseNotes/2_0_9.md
+++ b/Packs/Jira/ReleaseNotes/2_0_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Atlassian Jira v2
+- Fixed an issue where mirror out not work as expected.

--- a/Packs/Jira/ReleaseNotes/2_0_9.md
+++ b/Packs/Jira/ReleaseNotes/2_0_9.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Atlassian Jira v2
-- Fixed an issue where mirror out not work as expected.
+- Fixed an issue where the mirror out did not work as expected.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Cortex XSOAR incidents from Jira projects.",
     "support": "xsoar",
-    "currentVersion": "2.0.8",
+    "currentVersion": "2.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-14620

## Description
When mirror out mapper contain mapping for `incident status` the value in `delta` obj for this are empty 
while the data in the `data` obj are correct

server issue 
but as we can solve it via integration code - this PR contain the fix

@yaakovi need to open ticket for Server team? 

