### PR TITLE
[Stix Creator] Add Support For Mapping Similar Names to Common Indicator Types

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_21.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_21.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### StixCreator
+- Added support for *indicators* with keys that don't match the common indicator names, as long as their key contains a common indicator name, or their value matches the expected indicator value (e.g. 8.8.8.8 for ip).

--- a/Packs/CommonScripts/Scripts/StixCreator/README.md
+++ b/Packs/CommonScripts/Scripts/StixCreator/README.md
@@ -12,10 +12,10 @@ Gets a list of indicators from the indicators argument, and generates a JSON fil
 ## Inputs
 ---
 
-| **Argument Name** | **Description** |
-| --- | --- |
-| indicators | The JSON object of all indicators and their fields, indicator index mapped to the Cortex XSOAR indicator fields. |
-| doubleBackslash | Adds a second backslash to all existing backslashes in the value field. |
+| **Argument Name** | **Description**                                                                                                                                                                                                                                                                                                                                                    |
+| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| indicators | A JSON object of all indicators and their fields, indicator index mapped to XSOAR common indicator fields. Indicator keys that don't match the XSOAR common indicator names are also supported, if their key contains a common indicator name (e.g. "special-ip" will be mapped to **ip**), or their value matches the expected indicator value (e.g. 8.8.8.8 for ip). |
+| doubleBackslash | Adds a second backslash to all existing backslashes in the value field.                                                                                                                                                                                                                                                                                            |
 
 ## Outputs
 ---

--- a/Packs/CommonScripts/Scripts/StixCreator/StixCreator.py
+++ b/Packs/CommonScripts/Scripts/StixCreator/StixCreator.py
@@ -58,6 +58,16 @@ def hash_type(value: str) -> str:  # pragma: no cover
     return ''
 
 
+def guess_indicator_type(type_: str, val: str) -> str:
+    # try to guess by key
+    for sco in SCOs:
+        if sco in type_:
+            return sco
+
+    # try to auto_detect by value
+    return (auto_detect_indicator_type(val) or type_).lower()
+
+
 def main():
 
     user_args = demisto.args().get('indicators', 'Unknown')
@@ -111,6 +121,8 @@ def main():
             indicator_type = demisto_indicator_type.lower().replace("-", "")
             if indicator_type == 'file':
                 indicator_type = hash_type(value)
+            if indicator_type not in SCOs and indicator_type not in SDOs:
+                indicator_type = guess_indicator_type(indicator_type, value)
             indicator = Indicator(pattern=f"[{SCOs[indicator_type]} = '{value}']",
                                   pattern_type='stix',
                                   **kwargs)

--- a/Packs/CommonScripts/Scripts/StixCreator/StixCreator.yml
+++ b/Packs/CommonScripts/Scripts/StixCreator/StixCreator.yml
@@ -10,7 +10,7 @@ enabled: true
 args:
 - name: indicators
   required: true
-  description: A JSON object of all indicators and their fields, indicator index mapped to Demisto indicator fields.
+  description: A JSON object of all indicators and their fields, indicator index mapped to XSOAR common indicator fields. Indicator keys that don't match the XSOAR common indicator names are also supported, if their key contains a common indicator name (e.g. "special-ip" will be mapped to ip), or their value matches the expected indicator value (e.g. 8.8.8.8 for ip).
 - name: doubleBackslash
   default: true
   description: Adds a second backslash to all existing backslashes in the value field.

--- a/Packs/CommonScripts/Scripts/StixCreator/StixCreator_test.py
+++ b/Packs/CommonScripts/Scripts/StixCreator/StixCreator_test.py
@@ -1,7 +1,7 @@
 import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 import pytest
-from StixCreator import main
+from StixCreator import main, guess_indicator_type
 
 FILE_INDICATOR = \
     {
@@ -43,3 +43,14 @@ def test_stixCreator_with_indicators(mocker, indicators, stix_type):
     main()
     results = demisto.results.call_args[0]
     assert stix_type in results[0]['Contents']
+
+
+@pytest.mark.parametrize('k,v,exp', (
+    ('actually-ip', '', 'ip'),  # key detection
+    ('', '1.1.1.1', 'ip'),      # val detection (further tested in CSP_test.py)
+    ('sha1sh', '', 'sha1'),     # key detection
+    ('test', 't', 'test'),      # no detection
+))
+def test_guess_indicator_type(k, v, exp):
+    a = guess_indicator_type(k, v)
+    assert a == exp

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.20",
+    "currentVersion": "1.7.21",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-15341

## Description
Added support for *indicators* with keys that don't match the common indicator names, as long as their key contains a common indicator name, or their value matches the expected indicator value (e.g. 8.8.8.8 for IP).

## Does it break backward compatibility?
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
