### PR TITLE
Fix Splunk auth issue

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1347,7 +1347,7 @@ def update_remote_system_command(args, params, service, auth_token, mapper):
             demisto.debug('Sending update request to Splunk for notable {}, data: {}'.format(notable_id, changed_data))
             base_url = 'https://' + params['host'] + ':' + params['port'] + '/'
             try:
-                session_key = service.token if not auth_token else None
+                session_key = get_auth_session_key(service) if not auth_token else None
                 response_info = update_notable_events(
                     baseurl=base_url, comment=changed_data['comment'], status=changed_data['status'],
                     urgency=changed_data['urgency'], owner=changed_data['owner'], eventIDs=[notable_id],
@@ -2561,6 +2561,13 @@ def get_kv_store_config(kv_store):
     return '\n'.join(readable)
 
 
+def get_auth_session_key(service):
+    """
+    Get the session key or token for POST request based on whether the Splunk basic auth are true or not
+    """
+    return service and service.basic and service._auth_headers[0][1] or service.token
+
+
 def extract_indicator(indicator_path, _dict_objects):
     indicators = []
     indicator_paths = indicator_path.split('.')
@@ -2669,7 +2676,8 @@ def main():
     elif command == 'splunk-submit-event':
         splunk_submit_event_command(service)
     elif command == 'splunk-notable-event-edit':
-        splunk_edit_notable_event_command(base_url, service and service.token, auth_token, demisto.args())
+        token = get_auth_session_key(service)
+        splunk_edit_notable_event_command(base_url, token, auth_token, demisto.args())
     elif command == 'splunk-submit-event-hec':
         splunk_submit_event_hec_command()
     elif command == 'splunk-job-status':

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -848,7 +848,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk:1.0.0.32879
+  dockerimage: demisto/splunksdk:1.0.0.33029
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -1010,6 +1010,8 @@ def test_update_remote_system(args, params, call_count, success, mocker, request
     class Service:
         def __init__(self):
             self.token = 'fake_token'
+            self.basic = True
+            self._auth_headers = [('Authentication', self.token)]
 
     mocker.patch.object(demisto, 'info')
     mocker.patch.object(demisto, 'debug')

--- a/Packs/SplunkPy/ReleaseNotes/2_4_9.md
+++ b/Packs/SplunkPy/ReleaseNotes/2_4_9.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### SplunkPy
+- Fixed an issue where the ***splunk-notable-event-edit*** command failed.
+- Updated the Docker image to: *demisto/splunksdk:1.0.0.33029*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "2.4.8",
+    "currentVersion": "2.4.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/SplunkPyPreRelease/Integrations/SplunkPyPreRelease/SplunkPyPreRelease.py
+++ b/Packs/SplunkPyPreRelease/Integrations/SplunkPyPreRelease/SplunkPyPreRelease.py
@@ -2200,7 +2200,7 @@ def splunk_edit_notable_event_command(service, auth_token):
     params = demisto.params()
 
     base_url = 'https://' + params['host'] + ':' + params['port'] + '/'
-    sessionKey = service.token if not auth_token else None
+    sessionKey = get_auth_session_key(service) if not auth_token else None
 
     eventIDs = None
     if demisto.get(demisto.args(), 'eventIDs'):
@@ -2472,6 +2472,13 @@ def get_kv_store_config(kv_store):
     for _key, val in keys.items():
         readable.append('| {} | {} |'.format(_key, val))
     return '\n'.join(readable)
+
+
+def get_auth_session_key(service):
+    """
+    Get the session key or token for POST request based on whether the Splunk basic auth are true or not
+    """
+    return service and service.basic and service._auth_headers[0][1] or service.token
 
 
 def extract_indicator(indicator_path, _dict_objects):

--- a/Packs/SplunkPyPreRelease/Integrations/SplunkPyPreRelease/SplunkPyPreRelease.yml
+++ b/Packs/SplunkPyPreRelease/Integrations/SplunkPyPreRelease/SplunkPyPreRelease.yml
@@ -792,7 +792,7 @@ script:
   - name: splunk-reset-enriching-fetch-mechanism
     arguments: []
     description: Resets the enrichment mechanism of fetched notables.
-  dockerimage: demisto/splunksdk:1.0.0.32388
+  dockerimage: demisto/splunksdk:1.0.0.33029
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SplunkPyPreRelease/ReleaseNotes/1_0_13.md
+++ b/Packs/SplunkPyPreRelease/ReleaseNotes/1_0_13.md
@@ -1,6 +1,6 @@
 
 #### Integrations
-##### SplunkPy
+##### SplunkPy Prerelease (Beta)
 - Fixed an issue where the ***splunk-notable-event-edit*** command failed.
 - Fixed an issue where the integation failed to authenticate with token.
 - Updated the Docker image to: *demisto/splunksdk:1.0.0.33029*.

--- a/Packs/SplunkPyPreRelease/pack_metadata.json
+++ b/Packs/SplunkPyPreRelease/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk Prerelease",
     "description": "Run queries on Splunk servers - pre release version.",
     "support": "xsoar",
-    "currentVersion": "1.0.12",
+    "currentVersion": "1.0.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-15601
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-15603

## Description
When using `basic=true` in the Splunk connection - the token stored in are wrong 
we shouldn't use it in this case in the command like `splunk-notable-event-edit`

