### PR TITLE
Added the limit argument to the aruba-clearpass-active-sessions-list command

### DIFF
--- a/Packs/HPEArubaClearPass/.pack-ignore
+++ b/Packs/HPEArubaClearPass/.pack-ignore
@@ -1,2 +1,7 @@
 [file:HPEArubaClearPass.yml]
 ignore=IN145
+
+[known_words]
+HPE
+ClearPass
+aruba-clearpass-active-sessions-list

--- a/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/HPEArubaClearPass.py
+++ b/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/HPEArubaClearPass.py
@@ -360,9 +360,10 @@ def get_active_sessions_list_command(client: Client, args: Dict[str, Any]) -> Co
     device_ip = args.get('device_ip')
     device_mac_address = args.get('device_mac_address')
     visitor_phone = args.get('visitor_phone')
+    limit = args.get('limit', 25)
 
     session_filter = sessions_filter_to_json_object(session_id, device_ip, device_mac_address, visitor_phone)
-    params = {"filter": session_filter}
+    params = {"filter": session_filter, "limit": limit}
 
     res = client.prepare_request(method='GET', params=params, url_suffix='session')
     readable_output, all_active_sessions_list = parse_items_response(res, parse_active_sessions_response)

--- a/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/HPEArubaClearPass.yml
+++ b/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/HPEArubaClearPass.yml
@@ -484,6 +484,13 @@ script:
       name: visitor_phone
       required: false
       secret: false
+    - default: false
+      description: Maximum number of items to return in the range of 1 – 1000. Default
+        is 25.
+      isArray: false
+      name: limit
+      required: false
+      secret: false
     deprecated: false
     description: Get a list of active sessions.
     execution: false

--- a/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/README.md
+++ b/Packs/HPEArubaClearPass/Integrations/HPEArubaClearPass/README.md
@@ -599,6 +599,8 @@ Get a list of active sessions.
 | device_ip | IP address of the client. | Optional | 
 | device_mac_address | MAC address of the client device. | Optional | 
 | visitor_phone | The visitor’s phone number. | Optional | 
+| limit | Maximum number of items to return in the range of 1 – 1000. Default is 25. | Optional | 
+
 
 
 #### Context Output

--- a/Packs/HPEArubaClearPass/ReleaseNotes/1_0_13.md
+++ b/Packs/HPEArubaClearPass/ReleaseNotes/1_0_13.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### HPE Aruba ClearPass
+- Added the **limit** argument to the ***aruba-clearpass-active-sessions-list*** command.

--- a/Packs/HPEArubaClearPass/pack_metadata.json
+++ b/Packs/HPEArubaClearPass/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HPE Aruba Clearpass",
     "description": "Aruba ClearPass Policy Manager provides role and device-based network access control for employees, contractors, and guests across any multivendor wired, wireless and VPN infrastructure.",
     "support": "xsoar",
-    "currentVersion": "1.0.12",
+    "currentVersion": "1.0.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: XSUP-15516

## Description
When a limit is not specified, the default is 25. Some customers may require more results.