### PR TITLE
Add missing return types to BaseClient's `_http_request` method

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_17.md
+++ b/Packs/Base/ReleaseNotes/1_31_17.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Documentation and metadata improvements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8443,9 +8443,6 @@ if 'requests' in sys.modules:
                 The request codes to accept as OK, for example: (200, 201, 204). If you specify
                 "None", will use self._ok_codes.
 
-            :return: Depends on the resp_type parameter
-            :rtype: ``dict`` or ``str`` or ``requests.Response``
-
             :type retries: ``int``
             :param retries: How many retries should be made in case of a failure. when set to '0'- will fail on the first time
 
@@ -8480,13 +8477,15 @@ if 'requests' in sys.modules:
                 been exhausted.
 
             :type error_handler ``callable``
-            :param error_handler: Given an error entery, the error handler outputs the
+            :param error_handler: Given an error entry, the error handler outputs the
                 new formatted error message.
 
             :type empty_valid_codes: ``list``
             :param empty_valid_codes: A list of all valid status codes of empty responses (usually only 204, but
                 can vary)
 
+            :return: Depends on the resp_type parameter
+            :rtype: ``dict`` or ``str`` or ``bytes`` or ``xml.etree.ElementTree.Element`` or ``requests.Response``
             """
             try:
                 # Replace params if supplied

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.16",
+    "currentVersion": "1.31.17",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Add missing `bytes` and `Element` return types to `_http_request`.

## Screenshots
<img width="949" alt="Screen Shot 2022-08-22 at 16 49 47" src="https://user-images.githubusercontent.com/8832013/185950711-2683a3b2-32c8-4f21-8eca-c5625bf17113.png">

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No
