### PR TITLE
CONF_PATH converted to relative path

### DIFF
--- a/Tests/scripts/utils/get_modified_files_for_testing.py
+++ b/Tests/scripts/utils/get_modified_files_for_testing.py
@@ -8,6 +8,7 @@ from Tests.scripts.utils.log_util import install_logging
 from Tests.scripts.utils import logging_wrapper as logging
 
 import demisto_sdk.commands.common.constants as constants
+from demisto_sdk.commands.common.tools import get_content_path
 # TODO: remove try except clause when demisto-sdk 1.7.3 is released
 try:
     import demisto_sdk.commands.common.content_constant_paths as content_constant_paths
@@ -70,7 +71,8 @@ def resolve_type(file_path: str) -> Optional[FileType]:
     """
     # if conf.json file
     # TODO: remove if when demisto-sdk 1.7.3 is released
-    if checked_type(file_path, [content_constant_paths.CONF_PATH.as_posix() if IS_UP_TO_DATE else constants.CONF_PATH]):
+    if checked_type(file_path, [content_constant_paths.CONF_PATH.relative_to(get_content_path()).as_posix()
+                                if IS_UP_TO_DATE else constants.CONF_PATH]):
         return FileType.CONF_JSON
     # landingPage_sections.json file
     if checked_type(file_path, [LANDING_PAGE_SECTIONS_JSON_PATH]):

--- a/Tests/scripts/utils/get_modified_files_for_testing.py
+++ b/Tests/scripts/utils/get_modified_files_for_testing.py
@@ -71,7 +71,7 @@ def resolve_type(file_path: str) -> Optional[FileType]:
     """
     # if conf.json file
     # TODO: remove if when demisto-sdk 1.7.3 is released
-    if checked_type(file_path, [content_constant_paths.CONF_PATH.relative_to(get_content_path()).as_posix()
+    if checked_type(file_path, [str(content_constant_paths.CONF_PATH.relative_to(get_content_path()))
                                 if IS_UP_TO_DATE else constants.CONF_PATH]):
         return FileType.CONF_JSON
     # landingPage_sections.json file


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
After this PR in the demisto-sdk (https://github.com/demisto/demisto-sdk/pull/2281), all the content path moved to use pathlib instead of relative paths in string.
However, we still parse relative string in content unit tests.
This PR converts the path from the SDK to the relative path related to content, and fixes the unit test.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
