### PR TITLE
Carbon Black Protect localApproval update bug fix

### DIFF
--- a/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
+++ b/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
@@ -544,9 +544,8 @@ def update_computer(id, name, computer_tag, description, policy_id, automatic_po
     :param template: True if computer is a template
     :return: Result json of the request
     """
-    raw_computer = get_computer(id)
 
-    body_params = raw_computer
+    body_params = get_computer(id)
     body_params['id'] = id if id else body_params.get('id')
     body_params['name'] = name if name else body_params.get('name')
     body_params['computerTag'] = computer_tag if computer_tag else body_params.get('computerTag')

--- a/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
+++ b/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
@@ -544,26 +544,26 @@ def update_computer(id, name, computer_tag, description, policy_id, automatic_po
     :param template: True if computer is a template
     :return: Result json of the request
     """
-    body_params = {
-        'id': id,
-        'name': name,
-        'computerTag': computer_tag,
-        'description': description,
-        'policyId': policy_id,
-        'automaticPolicy': automatic_policy,
-        'localApproval': local_approval,
-        'refreshFlags': refresh_flags,
-        'prioritized': prioritized,
-        'debugLevel': debug_level,
-        'kernelDebugLevel': kernel_debug_level,
-        'debugFlags': debug_flags,
-        'debugDuration': debug_duration,
-        'cCLevel': cclevel,
-        'cCFlags': ccflags,
-        'forceUpgrade': force_upgrade,
-        'template': template,
-    }
-    body_params = remove_keys_with_empty_value(body_params)
+    raw_computer = get_computer(id)
+
+    body_params = raw_computer
+    body_params['id'] = id if id else body_params.get('id')
+    body_params['name'] = name if name else body_params.get('name')
+    body_params['computerTag'] = computer_tag if computer_tag else body_params.get('computerTag')
+    body_params['description'] = description if description else body_params.get('description')
+    body_params['policyId'] = policy_id if policy_id else body_params.get('policyId')
+    body_params['automaticPolicy'] = automatic_policy if automatic_policy else body_params.get('automaticPolicy')
+    body_params['localApproval'] = local_approval if local_approval else body_params.get('localApproval')
+    body_params['refreshFlags'] = refresh_flags if refresh_flags else body_params.get('refreshFlags')
+    body_params['prioritized'] = prioritized if prioritized else body_params.get('prioritized')
+    body_params['debugLevel'] = debug_level if debug_level else body_params.get('debugLevel')
+    body_params['kernelDebugLevel'] = kernel_debug_level if kernel_debug_level else body_params.get('kernelDebugLevel')
+    body_params['debugFlags'] = debug_flags if debug_flags else body_params.get('debugFlags')
+    body_params['debugDuration'] = debug_duration if debug_duration else body_params.get('debugDuration')
+    body_params['ccLevel'] = cclevel if cclevel else body_params.get('ccLevel')
+    body_params['ccFlags'] = ccflags if ccflags else body_params.get('ccFlags')
+    body_params['forceUpgrade'] = force_upgrade if force_upgrade else body_params.get('forceUpgrade')
+    body_params['template'] = template if template else body_params.get('template')
 
     return http_request('POST', '/computer', data=body_params)
 

--- a/Packs/CarbonBlackProtect/ReleaseNotes/1_0_27.md
+++ b/Packs/CarbonBlackProtect/ReleaseNotes/1_0_27.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VMware Carbon Black App Control v2
+- Fixed an issue where the ***update_computer*** command did not update the **localApproval** argument.

--- a/Packs/CarbonBlackProtect/pack_metadata.json
+++ b/Packs/CarbonBlackProtect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Carbon Black Enterprise Protection",
     "description": "Carbon Black Enterprise Protection is a next-generation endpoint threat prevention solution to deliver a portfolio of protection policies, real-time visibility across environments, and comprehensive compliance rule sets in a single platform.",
     "support": "xsoar",
-    "currentVersion": "1.0.26",
+    "currentVersion": "1.0.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5315,7 +5315,8 @@
         "RSANetWitnessv115-Test": "Issue XDRSUP-12553",
         "TestCloudflareWAFPlaybook": "No instance",
         "DBot Build Phishing Classifier Test - Multiple Algorithms": "Issue 48350",
-        "Elasticsearch_v2_test-v8": "CRTX-61980"
+        "Elasticsearch_v2_test-v8": "CRTX-61980",
+        "Carbon Black Enterprise Protection V2 Test": "No credentials"
     },
     "skipped_integrations": {
         "_comment1": "~~~ NO INSTANCE ~~~",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-15430)

## Description
Carbon Black Protect have a bug in the API where you need to add certain keys in order to update localApproval key. We were not sure which keys are needed, so I added the following workaround:
before updating the computer, I do a GET request to get the computer fields, then I update the given arguments and send the POST request for updating the computer.

Tried it on the customer's environment and it worked fine.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
