### PR TITLE
AWS S3 - Add aws-s3-get-bucket-encryption command

### DIFF
--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.py
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.py
@@ -218,6 +218,26 @@ def put_public_access_block(args: Dict[str, Any], aws_client: AWSClient) -> Comm
     return CommandResults(readable_output=f"Couldn't apply public access block to the {args.get('bucket')} bucket")
 
 
+def get_bucket_encryption(args: Dict[str, Any], aws_client: AWSClient) -> CommandResults:
+    client = aws_client.aws_session(service=SERVICE, region=args.get('region'), role_arn=args.get('roleArn'),
+                                    role_session_name=args.get('roleSessionName'),
+                                    role_session_duration=args.get('roleSessionDuration'), )
+    kwargs = {'Bucket': args.get('bucket')}
+    if args.get('expectedBucketOwner') is not None:
+        kwargs.update({'ExpectedBucketOwner': args.get('expectedBucketOwner')})
+    try:
+        response = client.get_bucket_encryption(**kwargs)
+    except client.exceptions.ClientError as ex:
+        if ex.response.get('Error', {}).get('Code', '') != 'ServerSideEncryptionConfigurationNotFoundError':
+            raise ex
+        response = {}
+    data = {'BucketName': args.get('bucket'),
+            'ServerSideEncryptionConfiguration': response.get('ServerSideEncryptionConfiguration')}
+    human_readable = tableToMarkdown('AWS S3 Bucket Encryption', data)
+    return CommandResults(outputs=data, readable_output=human_readable, outputs_prefix='AWS.S3.Buckets',
+                          outputs_key_field='BucketName')
+
+
 def main():  # pragma: no cover
     params = demisto.params()
     aws_default_region = params.get('defaultRegion')
@@ -281,6 +301,9 @@ def main():  # pragma: no cover
 
         elif command == 'aws-s3-put-public-access-block':
             return_results(put_public_access_block(args, aws_client))
+
+        elif command == 'aws-s3-get-bucket-encryption':
+            return_results(get_bucket_encryption(args, aws_client))
         else:
             raise NotImplementedError(f'{command} command is not implemented.')
 

--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
@@ -645,7 +645,7 @@ script:
     description: Creates or modifies the PublicAccessBlock configuration for an Amazon S3 bucket.
     execution: false
     name: aws-s3-put-public-access-block
-  dockerimage: demisto/boto3py3:1.0.0.34229
+  dockerimage: demisto/boto3py3:1.0.0.34736
   isfetch: false
   runonce: false
   script: ''

--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
@@ -506,6 +506,32 @@ script:
     execution: false
     name: aws-s3-put-bucket-policy
   - arguments:
+    - description: The name of the bucket from which the server-side encryption configuration is retrieved.
+      name: bucket
+      required: true
+    - description: The account ID of the exepcted bucket owner.
+      name: expectedBucketOwner
+    - description: The AWS Region, if not specified the default region will be used.
+      name: region
+    - description: The Amazon Resource Name (ARN) of the role to assume.
+      name: roleArn
+    - description: An identifier for the assumed role session.
+      name: roleSessionName
+    - description: The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration setting for the role.
+      name: roleSessionDuration
+    description: Get AWS S3 Bucket Encryption
+    name: aws-s3-get-bucket-encryption
+    outputs:
+    - contextPath: AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.ApplyServerSideEncryptionByDefault.SSEAlgorithm
+      description: S3 Bucket Encryption SSE Algorithm.
+      type: string
+    - contextPath: AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.ApplyServerSideEncryptionByDefault.KMSMasterKeyID
+      description: S3 Bucket Encryption KMS Master Key ID.
+      type: string
+    - contextPath: AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.BucketKeyEnabled
+      description: S3 Bucket Encryption Key Enabled.
+      type: boolean
+  - arguments:
     - default: false
       description: Entry ID of the file to upload
       isArray: false
@@ -619,7 +645,7 @@ script:
     description: Creates or modifies the PublicAccessBlock configuration for an Amazon S3 bucket.
     execution: false
     name: aws-s3-put-public-access-block
-  dockerimage: demisto/boto3py3:1.0.0.33854
+  dockerimage: demisto/boto3py3:1.0.0.34229
   isfetch: false
   runonce: false
   script: ''

--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3_test.py
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3_test.py
@@ -47,6 +47,9 @@ class Boto3Client:
     def put_public_access_block(self):
         pass
 
+    def get_bucket_encryption(self):
+        pass
+
 
 class paginator:
     def paginate(self):
@@ -284,3 +287,26 @@ def test_put_public_access_block_command(mocker, res, excepted):
 
     res = AWS_S3.put_public_access_block(args, client)
     assert res.readable_output == f"{excepted} public access block to the {args.get('bucket')} bucket"
+
+
+def test_get_bucket_encryption(mocker):
+    """
+    Given:
+    - A bucket name.
+    When:
+    - Calling get_bucket_encryption method.
+    Then:
+    - Ensure that the bucket encryption was successfully retrieved.
+    """
+    from CommonServerPython import tableToMarkdown
+    args = {'bucket': 'test_bucket'}
+    args.update(TEST_PARAMS)
+    encryption = {'Rules': [{'ApplyServerSideEncryptionByDefault': {'SSEAlgorithm': 'AES256'}}]}
+    response = {'ServerSideEncryptionConfiguration': encryption}
+    mocker.patch.object(AWSClient, "aws_session", return_value=Boto3Client())
+    mocker.patch.object(Boto3Client, "get_bucket_encryption", return_value=response)
+
+    client = AWSClient()
+    data = [{'BucketName': args.get('bucket'), 'ServerSideEncryptionConfiguration': encryption}]
+    res = AWS_S3.get_bucket_encryption(args, client)
+    assert tableToMarkdown('AWS S3 Bucket Encryption', data) == res.readable_output

--- a/Packs/AWS-S3/Integrations/AWS-S3/README.md
+++ b/Packs/AWS-S3/Integrations/AWS-S3/README.md
@@ -419,3 +419,60 @@ There is no context output for this command.
 #### Human Readable Output
 
 Successfully applied public access block to the {bucket} bucket.
+
+### aws-s3-get-bucket-encryption
+***
+Get AWS S3 Bucket Encryption
+
+#### Base Command
+
+`aws-s3-get-bucket-encryption`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| bucket | The name of the bucket from which the server-side encryption configuration is retrieved. | Required |
+| expectedBucketOwner | The account ID of the exepcted bucket owner. | Optional |
+| region | The AWS Region, if not specified the default region will be used. | Optional |
+| roleArn | The Amazon Resource Name (ARN) of the role to assume. | Optional |
+| roleSessionName | An identifier for the assumed role session. | Optional |
+| roleSessionDuration | The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration setting for the role. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.ApplyServerSideEncryptionByDefault.SSEAlgorithm | String | S3 Bucket Encryption SSE Algorithm. |
+| AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.ApplyServerSideEncryptionByDefault.KMSMasterKeyID | String | S3 Bucket Encryption KMS Master Key ID. |
+| AWS.S3.Buckets.BucketName.ServerSideEncryptionConfiguration.Rules.BucketKeyEnabled | Boolean | S3 Bucket Encryption Key Enabled. |
+
+#### Command Example
+
+``` !aws-s3-put-public-access-block bucket="bucket name" BlockPublicAcls=True IgnorePublicAcls=False BlockPublicPolicy=True RestrictPublicBuckets=True```
+
+
+#### Context Example
+
+```
+{
+    "AWS": {
+        "S3": {
+            "Buckets": [
+                {
+                    "BucketName": "bucket-a",
+                    "ServerSideEncryptionConfiguration": {
+                        "Rules": [
+                            {
+                                "ApplyServerSideEncryptionByDefault": {
+                                    "SSEAlgorithm": "AES256"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+```

--- a/Packs/AWS-S3/ReleaseNotes/1_2_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_2_3.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### AWS - S3
 - Added the **aws-s3-get-bucket-encryption** command.
+- Upgraded the Docker image to *demisto/boto3py3:1.0.0.34229*.

--- a/Packs/AWS-S3/ReleaseNotes/1_2_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_2_3.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### AWS - S3
 - Added the **aws-s3-get-bucket-encryption** command.
-- Upgraded the Docker image to *demisto/boto3py3:1.0.0.34229*.
+- Upgraded the Docker image to *demisto/boto3py3:1.0.0.34736*.

--- a/Packs/AWS-S3/ReleaseNotes/1_2_3.md
+++ b/Packs/AWS-S3/ReleaseNotes/1_2_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AWS - S3
+- Added the **aws-s3-get-bucket-encryption** command.

--- a/Packs/AWS-S3/TestPlaybooks/playbook-AWS-S3Test.yml
+++ b/Packs/AWS-S3/TestPlaybooks/playbook-AWS-S3Test.yml
@@ -5,10 +5,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: f5ea5ed0-c190-4dfc-8e07-eb2b9a3c9032
+    taskid: a9ad3c63-47ff-4a65-8564-4a83ad27621b
     type: start
     task:
-      id: f5ea5ed0-c190-4dfc-8e07-eb2b9a3c9032
+      id: a9ad3c63-47ff-4a65-8564-4a83ad27621b
       version: -1
       name: ""
       iscommand: false
@@ -27,12 +27,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: c3a6d97c-43a0-47fc-86ff-1010d041451a
+    taskid: 6dcb3947-2bb8-46b3-829f-c51d01ffbb0c
     type: regular
     task:
-      id: c3a6d97c-43a0-47fc-86ff-1010d041451a
+      id: 6dcb3947-2bb8-46b3-829f-c51d01ffbb0c
       version: -1
       name: aws-s3-list-buckets
       description: List all S3 buckets in AWS account
@@ -43,11 +47,6 @@ tasks:
     nexttasks:
       '#none#':
       - "7"
-    scriptarguments:
-      region: {}
-      roleArn: {}
-      roleSessionDuration: {}
-      roleSessionName: {}
     separatecontext: false
     view: |-
       {
@@ -59,12 +58,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: 94f5f6c0-cfdc-4179-81dd-e449cb853e87
+    taskid: fc75291c-3704-46dc-8e1a-446659321da8
     type: regular
     task:
-      id: 94f5f6c0-cfdc-4179-81dd-e449cb853e87
+      id: fc75291c-3704-46dc-8e1a-446659321da8
       version: -1
       name: aws-s3-upload-file
       description: Upload file to S3 bucket
@@ -82,10 +85,6 @@ tasks:
         simple: ${File.EntryID}
       key:
         simple: ${File.Name}
-      region: {}
-      roleArn: {}
-      roleSessionDuration: {}
-      roleSessionName: {}
     separatecontext: false
     view: |-
       {
@@ -97,12 +96,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: b1c7f24b-bc8c-45d5-8d84-2bdd6431d363
+    taskid: 4e122b5b-33c9-48e5-80bf-27f964c37064
     type: regular
     task:
-      id: b1c7f24b-bc8c-45d5-8d84-2bdd6431d363
+      id: 4e122b5b-33c9-48e5-80bf-27f964c37064
       version: -1
       name: aws-s3-download-file
       description: Download a file from S3 bucket to war room.
@@ -118,10 +121,6 @@ tasks:
         simple: demisto-test1234
       key:
         simple: binks
-      region: {}
-      roleArn: {}
-      roleSessionDuration: {}
-      roleSessionName: {}
     separatecontext: false
     view: |-
       {
@@ -133,12 +132,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: ec4798c4-992d-450c-8e2d-e05880ffb394
+    taskid: 5e8005fe-3861-4b66-8de7-aa62475a33ae
     type: regular
     task:
-      id: ec4798c4-992d-450c-8e2d-e05880ffb394
+      id: 5e8005fe-3861-4b66-8de7-aa62475a33ae
       version: -1
       name: aws-s3-get-bucket-policy
       description: Get AWS S3 Bucket Policy
@@ -146,13 +149,12 @@ tasks:
       type: regular
       iscommand: true
       brand: AWS - S3
+    nexttasks:
+      '#none#':
+      - "9"
     scriptarguments:
       bucket:
         simple: demisto-test1234
-      region: {}
-      roleArn: {}
-      roleSessionDuration: {}
-      roleSessionName: {}
     separatecontext: false
     view: |-
       {
@@ -164,12 +166,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: 877f95f8-cfb5-4346-87f6-81af40c129cc
+    taskid: 774f7a1c-d98b-450d-8f08-35e1e16710f8
     type: regular
     task:
-      id: 877f95f8-cfb5-4346-87f6-81af40c129cc
+      id: 774f7a1c-d98b-450d-8f08-35e1e16710f8
       version: -1
       name: aws-s3-list-bucket-objects
       description: List object in S3 bucket.
@@ -183,10 +189,6 @@ tasks:
     scriptarguments:
       bucket:
         simple: demisto-test1234
-      region: {}
-      roleArn: {}
-      roleSessionDuration: {}
-      roleSessionName: {}
     separatecontext: false
     view: |-
       {
@@ -198,12 +200,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 3d24876e-3af0-45e8-8663-3a0561d9997e
+    taskid: e25274b1-91cd-4291-8967-958e6a80eb40
     type: regular
     task:
-      id: 3d24876e-3af0-45e8-8663-3a0561d9997e
+      id: e25274b1-91cd-4291-8967-958e6a80eb40
       version: -1
       name: http
       description: Sends http request. Returns the response as json.
@@ -215,21 +221,14 @@ tasks:
       '#none#':
       - "3"
     scriptarguments:
-      body: {}
       filename:
         simple: file_to_upload
-      headers: {}
-      insecure: {}
       method:
         simple: GET
-      password: {}
-      proxy: {}
       saveAsFile:
         simple: "yes"
-      unsecure: {}
       url:
-        simple: https://upload.wikimedia.org/wikipedia/en/4/4b/Jjportrait.jpg  # disable-secrets-detection
-      username: {}
+        simple: https://upload.wikimedia.org/wikipedia/en/4/4b/Jjportrait.jpg
     separatecontext: false
     view: |-
       {
@@ -241,12 +240,16 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: 3f0d0d52-94d6-4f71-87e4-3ed36137c98b
+    taskid: 38fc3e2c-de3d-4251-8802-c55157ea0379
     type: regular
     task:
-      id: 3f0d0d52-94d6-4f71-87e4-3ed36137c98b
+      id: 38fc3e2c-de3d-4251-8802-c55157ea0379
       version: -1
       name: DeleteContext
       description: Delete field from context
@@ -260,10 +263,6 @@ tasks:
     scriptarguments:
       all:
         simple: "yes"
-      index: {}
-      key: {}
-      keysToKeep: {}
-      subplaybook: {}
     separatecontext: false
     view: |-
       {
@@ -275,12 +274,44 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "9":
+    id: "9"
+    taskid: 04c113c8-b2fd-4e20-809c-69c9e404e008
+    type: regular
+    task:
+      id: 04c113c8-b2fd-4e20-809c-69c9e404e008
+      version: -1
+      name: aws-s3-get-bucket-encryption
+      description: Get AWS S3 Bucket Encryption
+      script: AWS - S3|||aws-s3-get-bucket-encryption
+      type: regular
+      iscommand: true
+      brand: AWS - S3
+    separatecontext: false
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 1230
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1225,
+        "height": 1385,
         "width": 380,
         "x": 50,
         "y": -60
@@ -289,4 +320,3 @@ view: |-
   }
 inputs: []
 outputs: []
-fromversion: 5.0.0

--- a/Packs/AWS-S3/TestPlaybooks/playbook-AWS-S3Test.yml
+++ b/Packs/AWS-S3/TestPlaybooks/playbook-AWS-S3Test.yml
@@ -13,6 +13,7 @@ tasks:
       name: ""
       iscommand: false
       brand: ""
+      description: ''
     nexttasks:
       '#none#':
       - "8"
@@ -149,9 +150,6 @@ tasks:
       type: regular
       iscommand: true
       brand: AWS - S3
-    nexttasks:
-      '#none#':
-      - "9"
     scriptarguments:
       bucket:
         simple: demisto-test1234
@@ -166,6 +164,9 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    nexttasks:
+      '#none#':
+      - "9"
     skipunavailable: false
     quietmode: 0
     isoversize: false
@@ -228,7 +229,7 @@ tasks:
       saveAsFile:
         simple: "yes"
       url:
-        simple: https://upload.wikimedia.org/wikipedia/en/4/4b/Jjportrait.jpg
+        simple: https://upload.wikimedia.org/wikipedia/en/4/4b/Jjportrait.jpg  # disable-secrets-detection
     separatecontext: false
     view: |-
       {
@@ -320,3 +321,5 @@ view: |-
   }
 inputs: []
 outputs: []
+fromversion: 5.0.0
+description: ''

--- a/Packs/AWS-S3/pack_metadata.json
+++ b/Packs/AWS-S3/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - S3",
     "description": "Amazon Web Services Simple Storage Service (S3)",
     "support": "xsoar",
-    "currentVersion": "1.2.2",
+    "currentVersion": "1.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description

Adds a `aws-s3-get-bucket-encryption` command to the AWS S3 integration.

## Screenshots
![image](https://user-images.githubusercontent.com/943597/186490764-416cc42f-23b6-4372-b402-624c8ead6b18.png)

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
