### PR TITLE
Microsoft teams README remove backslash

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -33,9 +33,9 @@ In order to verify that the messaging endpoint is open as expected, you can surf
     ```
  - You must not set a certificate and/or private key if you are using the Cortex XSOAR rerouting setup.
  - Microsoft does not support self-signed certificates and requires a chain-trusted certificate issued by a trusted CA.
- In order to verify which certificate is used, run the following (replace <MESSAGING-ENDPOINT/> with the messaging endpoint):
+ In order to verify which certificate is used, run the following (replace <MESSAGING-ENDPOINT> with the messaging endpoint):
     ```
-     curl <MESSAGING-ENDPOINT/> -vI
+     curl <MESSAGING-ENDPOINT> -vI
     ```
      Make sure the output does not contain the following:
     ```

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -33,9 +33,9 @@ In order to verify that the messaging endpoint is open as expected, you can surf
     ```
  - You must not set a certificate and/or private key if you are using the Cortex XSOAR rerouting setup.
  - Microsoft does not support self-signed certificates and requires a chain-trusted certificate issued by a trusted CA.
- In order to verify which certificate is used, run the following (replace <MESSAGING-ENDPOINT> with the messaging endpoint):
+ In order to verify which certificate is used, run the following (replace {MESSAGING-ENDPOINT} with the messaging endpoint):
     ```
-     curl <MESSAGING-ENDPOINT> -vI
+     curl {MESSAGING-ENDPOINT} -vI
     ```
      Make sure the output does not contain the following:
     ```


### PR DESCRIPTION
**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Removed backslash from Microsoft teams README

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
