### PR TITLE
[rasterize] Add Fallback When Chrome Webdriver fails

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -148,7 +148,7 @@ def init_driver(offline_mode=False):
         if offline_mode:
             driver.set_network_conditions(offline=True, latency=5, throughput=500 * 1024)
     except Exception as ex:
-        return_error(f'Unexpected exception: {ex}\nTrace:{traceback.format_exc()}')
+        raise DemistoException(f'Unexpected exception: {ex}\nTrace:{traceback.format_exc()}')
 
     demisto.debug('Creating chrome driver - COMPLETED')
     return driver

--- a/Packs/rasterize/ReleaseNotes/1_2_5.md
+++ b/Packs/rasterize/ReleaseNotes/1_2_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Rasterize
+- The integration will now fall back on Headless CLI when failing to initialize the Chrome Webdriver. 

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "1.2.4",
+    "currentVersion": "1.2.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-15681

## Description
The integration will now fall back on Headless CLI when failing to initialize the Chrome Webdriver.