### PR TITLE
[VirusTotal] Deprecate outdated VirusTotal-Private_API

### DIFF
--- a/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.yml
+++ b/Packs/VirusTotal-Private_API/Integrations/VirusTotal-Private_API/VirusTotal-Private_API.yml
@@ -59,9 +59,10 @@ configuration:
   name: fullResponseGlobal
   required: false
   type: 8
-description: Analyze suspicious hashes, URLs, domains and IP addresses
-display: VirusTotal - Private API
+description: Deprecated. Use VirusTotalV3 or VirusTotal_V3_Premium integrations from VirusTotal pack instead.
+display: VirusTotal - Private API (Deprecated)
 name: VirusTotal - Private API
+deprecated: true
 script:
   commands:
   - arguments:

--- a/Packs/VirusTotal-Private_API/Playbooks/playbook-File_Enrichment_-_Virus_Total_Private_API.yml
+++ b/Packs/VirusTotal-Private_API/Playbooks/playbook-File_Enrichment_-_Virus_Total_Private_API.yml
@@ -1,7 +1,8 @@
 id: file_enrichment_-_virus_total_private_api
 version: -1
 name: File Enrichment - Virus Total Private API
-description: Get file information using the Virus Total Private API integration.
+description: Deprecated. Use Packs/VirusTotal/Playbooks/File_Enrichment_-_Virus_Total_v3.yml instead.
+deprecated: true
 fromversion: 5.0.0
 starttaskid: "0"
 tasks:

--- a/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_16.md
+++ b/Packs/VirusTotal-Private_API/ReleaseNotes/1_0_16.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### VirusTotal - Private API
+- Deprecate pack in favor of Packs/VirusTotal.

--- a/Packs/VirusTotal-Private_API/pack_metadata.json
+++ b/Packs/VirusTotal-Private_API/pack_metadata.json
@@ -1,8 +1,8 @@
 {
-    "name": "VirusTotal - Private API",
-    "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
+    "name": "VirusTotal - Private API (Deprecated)",
+    "description": "Deprecated. Use VirusTotalV3 or VirusTotal_V3_Premium integrations from VirusTotal pack instead.",
     "support": "partner",
-    "currentVersion": "1.0.15",
+    "currentVersion": "1.0.16",
     "author": "VirusTotal",
     "url": "https://www.virustotal.com",
     "email": "contact@virustotal.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Deprecation action for the VirusTotal-Private_API. Use Packs/VirusTotal pack instead

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
