### PR TITLE
[VirusTotal] Deprecate outdated VirusTotal V2 integration

### DIFF
--- a/Packs/VirusTotal/Integrations/VirusTotal/VirusTotal.yml
+++ b/Packs/VirusTotal/Integrations/VirusTotal/VirusTotal.yml
@@ -2,11 +2,11 @@ commonfields:
   id: VirusTotal
   version: -1
 name: VirusTotal
-display: VirusTotal
+display: VirusTotal (Deprecated)
+deprecated: true
 fromversion: 5.5.0
 category: Data Enrichment & Threat Intelligence
-description: VirusTotal has been updated to VirusTotal (API v3). Please use the updated
-  version instead. Analyze suspicious hashes, URLs, domains and IP addresses.
+description: Deprecated. Use VirusTotalV3 integration instead.
 configuration:
 - display: Server URL (e.g. https://192.168.0.1)
   name: Server

--- a/Packs/VirusTotal/ReleaseNotes/2_4_8.md
+++ b/Packs/VirusTotal/ReleaseNotes/2_4_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VirusTotal
+- Deprecate VirusTotal V2 integration in favor of VirusTotalV3.

--- a/Packs/VirusTotal/ReleaseNotes/2_4_8.md
+++ b/Packs/VirusTotal/ReleaseNotes/2_4_8.md
@@ -1,4 +1,4 @@
 
 #### Integrations
-##### VirusTotal
+##### VirusTotal (Deprecated)
 - Deprecate VirusTotal V2 integration in favor of VirusTotalV3.

--- a/Packs/VirusTotal/pack_metadata.json
+++ b/Packs/VirusTotal/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VirusTotal",
     "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
     "support": "partner",
-    "currentVersion": "2.4.7",
+    "currentVersion": "2.4.8",
     "author": "VirusTotal",
     "url": "https://www.virustotal.com",
     "email": "contact@virustotal.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Deprecation action for the VirusTotal integration. Use VirusTotalV3 instead.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
