### PR TITLE
Improved implementation of the fetch-incidents with  the look back parameter

### DIFF
--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
@@ -1165,8 +1165,8 @@ def get_file_path_command(client: Client, args: Dict) -> CommandResults:
 
 
 def fetch_incidents(client: Client, fetch_time: str, fetch_limit: str, last_run: Dict, look_back: int) -> Tuple[List, Dict]:
-    last_fetched_alert_create_time = last_run.get('last_fetched_alert_create_time') or last_run.get('time')
-    last_run.update({'time': last_fetched_alert_create_time})
+    if last_fetched_alert_create_time := last_run.get('last_fetched_alert_create_time'):
+        last_run.update({'time': last_fetched_alert_create_time})
     last_fetched_alert_id = last_run.get('last_fetched_alert_id', '')
     if not last_run.get('time'):
         last_run.update({'time': parse_date_range(fetch_time, date_format=DATE_FORMAT)[0]})

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
@@ -1170,6 +1170,8 @@ def fetch_incidents(client: Client, fetch_time: str, fetch_limit: str, last_run:
     last_fetched_alert_id = last_run.get('last_fetched_alert_id', '')
     latest_alert_id = last_fetched_alert_id
 
+    if last_run.get('time') and last_run['time'][-1] == 'Z':
+        last_run['time'] = last_run['time'][:-1]
     fetch_start_time, fetch_end_time = get_fetch_run_time_range(last_run=last_run, first_fetch=fetch_time,
                                                                 look_back=look_back, date_format=DATE_FORMAT) 
     demisto.debug(f'{fetch_start_time=}, {fetch_end_time=}')

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
@@ -1167,6 +1167,7 @@ def get_file_path_command(client: Client, args: Dict) -> CommandResults:
 def fetch_incidents(client: Client, fetch_time: str, fetch_limit: str, last_run: Dict, look_back: int) -> Tuple[List, Dict]:
     if last_fetched_alert_create_time := last_run.get('last_fetched_alert_create_time'):
         last_run.update({'time': last_fetched_alert_create_time})
+        del last_run['last_fetched_alert_create_time']
     last_fetched_alert_id = last_run.get('last_fetched_alert_id', '')
     latest_alert_id = last_fetched_alert_id
 

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.py
@@ -1337,8 +1337,13 @@ def main():
         elif demisto.command() == 'fetch-incidents':
             fetch_time = demisto.params().get('fetch_time', '3 days')
             fetch_limit = demisto.params().get('fetch_limit', '50')
+            look_back = arg_to_number(demisto.params().get('look_back', '0'))
             # Set and define the fetch incidents command to run after activated via integration settings.
-            incidents, last_run = fetch_incidents(client, fetch_time, fetch_limit, last_run=demisto.getLastRun())
+            incidents, last_run = fetch_incidents(client,
+                                                  fetch_time,
+                                                  fetch_limit,
+                                                  last_run=demisto.getLastRun(),
+                                                  look_back=look_back)
             demisto.incidents(incidents)
             demisto.setLastRun(last_run)
 

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR.yml
@@ -50,6 +50,13 @@ configuration:
     name: fetch_limit
     required: false
     type: 0
+  - defaultvalue: 0
+    display: 'Advanced: Time in minutes to look back when fetching emails'
+    additionalinfo: Use this parameter to determine how long backward to look in the search for incidents
+      that were created before the last run time and did not match the query when they were created.
+    name: look_back
+    required: false
+    type: 0
 description: VMware Carbon Black Enterprise EDR (formerly known as Carbon Black ThreatHunter)
   is an advanced threat hunting and incident response solution delivering continuous
   visibility for top security operations centers (SOCs) and incident response (IR)

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR_test.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR_test.py
@@ -175,32 +175,67 @@ def test_event_by_process_failing(mocker, requests_mock, demisto_args, expected_
 
 
 TESTS_FOR_FETCH_INCIDENT = [
-    ({'results': [
+    ([{'results': [
         {'id': 101, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 103, 'create_time': (datetime.utcnow() - timedelta(minutes=3)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]},
-     ['101', '102', '103', '104'], 0, {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}),
-    ({'results': [
+     {'results': [
         {'id': 101, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 103, 'create_time': (datetime.utcnow() - timedelta(minutes=3)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
-        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=20)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]},
-        ['101', '102', '103', '104'], 10, {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}),
-    ({'results': [
+        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]}],
+        ['101', '102', '103', '104'], ['101', '102', '103'],
+     0,
+     0,
+     {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+     False
+    ),
+    ([{'results': [
         {'id': 101, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
         {'id': 103, 'create_time': (datetime.utcnow() - timedelta(minutes=3)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
-        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=9)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]},
-        ['104'], 10,
-        {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z'),
-         'limit': 10,
-         'found_incident_ids': {101: 1662010329, 102: 1662010329, 103: 1662010329}})
+        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]},
+     {'results': [
+        {'id': 101, 'create_time': (datetime.utcnow() - timedelta(minutes=8)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=7)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 103, 'create_time': (datetime.utcnow() - timedelta(minutes=6)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 105, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 106, 'create_time': (datetime.utcnow() - timedelta(minutes=3)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 107, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 108, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]}],
+        ['101', '102', '103', '104'], ['105', '106', '107', '108'],
+     8,
+     10,
+     {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+     False
+    ),
+    ([{'results': [
+        {'id': 101, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]},
+     {'results': [
+        {'id': 102, 'create_time': (datetime.utcnow() - timedelta(minutes=7)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 103, 'create_time': (datetime.utcnow() - timedelta(minutes=6)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 104, 'create_time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 105, 'create_time': (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 106, 'create_time': (datetime.utcnow() - timedelta(minutes=3)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 107, 'create_time': (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+        {'id': 108, 'create_time': (datetime.utcnow() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z')}]}],
+        ['101', '102', '104'], ['103', '105', '106', '107', '108'],
+     7,
+     10,
+     {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+     True
+    )
 ]
 
 
-@pytest.mark.parametrize('incidents, expected_result, look_back, last_run', TESTS_FOR_FETCH_INCIDENT)
-def test_fetch_incident(mocker, incidents, expected_result, look_back, last_run):
+@pytest.mark.parametrize('incidents, expected_result1, expected_result2, found_incident_ids, \
+                          look_back, last_run, test_remove_old_incidents', TESTS_FOR_FETCH_INCIDENT)
+def test_fetch_incident(mocker, incidents, expected_result1, expected_result2,
+                        found_incident_ids, look_back, last_run, test_remove_old_incidents):
 
     client = cbe.Client(
         base_url='https://server_url.com',
@@ -208,7 +243,7 @@ def test_fetch_incident(mocker, incidents, expected_result, look_back, last_run)
         use_proxy=False,
         token=None,
         cb_org_key="123")
-    mocker.patch.object(client, 'search_alerts_request', return_value=incidents)
+    mocker.patch.object(client, 'search_alerts_request', side_effect=incidents)
     results, last_run = cbe.fetch_incidents(client,
                                             fetch_time='3 days',
                                             fetch_limit=10,
@@ -216,4 +251,16 @@ def test_fetch_incident(mocker, incidents, expected_result, look_back, last_run)
                                             look_back=look_back)
 
     for i in range(len(results)):
-        assert expected_result[i] in results[i]['name']
+        assert expected_result1[i] in results[i]['name']
+    if test_remove_old_incidents:
+        last_run['found_incident_ids'][101] = last_run['found_incident_ids'][101] - 10000
+    results, last_run = cbe.fetch_incidents(client,
+                                            fetch_time='3 days',
+                                            fetch_limit=10,
+                                            last_run=last_run,
+                                            look_back=look_back)
+    assert found_incident_ids == len(last_run.get('found_incident_ids', []))
+    assert len(expected_result2) == len(results)
+    for i in range(len(results)):
+        assert expected_result2[i] in results[i]['name']
+

--- a/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR_test.py
+++ b/Packs/CarbonBlackEnterpriseEDR/Integrations/CarbonBlackEnterpriseEDR/CarbonBlackEnterpriseEDR_test.py
@@ -188,7 +188,7 @@ TESTS_FOR_FETCH_INCIDENT = [
         ['101', '102', '103', '104'], ['101', '102', '103'],
      0,
      0,
-     {'time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
+     {'last_fetched_alert_create_time': (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%dT%H:%M:%S.000Z')},
      False
     ),
     ([{'results': [

--- a/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_20.md
+++ b/Packs/CarbonBlackEnterpriseEDR/ReleaseNotes/1_1_20.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### VMware Carbon Black Enterprise EDR
+- Added support for the *lookback* parameter in the ***fetch-incidents*** command to ensure fetching all incidents.

--- a/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
+++ b/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Carbon Black Cloud Enterprise EDR",
     "description": "Advanced threat hunting and incident response solution.",
     "support": "xsoar",
-    "currentVersion": "1.1.19",
+    "currentVersion": "1.1.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-11827

## Description
Added a look-back parameter to fetch events that entered the list of incidents in CarbonBlack after the fetch.


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [x] Tests
- [ ] Documentation 
