### PR TITLE
Fix JiraV2 integration

### DIFF
--- a/Packs/Jira/Integrations/JiraV2/JiraV2.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2.py
@@ -552,9 +552,9 @@ def get_project_id(project_key='', project_name=''):
     if not project_key and not project_name:
         return_error('You must provide at least one of the following: project_key or project_name')
 
-    result = jira_req('GET', 'rest/api/latest/issue/createmeta', resp_type='json')
+    result = jira_req('GET', 'rest/api/latest/project', resp_type='json')
 
-    for project in result.get('projects'):
+    for project in result:
         if project_key.lower() == project.get('key').lower() or project_name.lower() == project.get('name').lower():
             return project.get('id')
     return_error('Project not found')

--- a/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
+++ b/Packs/Jira/Integrations/JiraV2/JiraV2_test.py
@@ -37,6 +37,24 @@ def set_params(mocker):
     mocker.patch.object(demisto, "params", return_value=integration_params)
 
 
+def jira_req_side_effect(*args, **kwargs):
+    if args[1] == 'rest/api/latest/project':
+        return [{"id": "1234", "key": "testKey", "name": "testName"}]
+
+    return {
+        "self": "https://demistodev.atlassian.net/rest/api/2/user?accountId=1234",
+        "accountId": "1234",
+        "emailAddress": "admin@demistodev.com",
+        "displayName": "test",
+        "active": True,
+        "timeZone": "Asia/Jerusalem",
+        "locale": "en_US",
+        "groups": {"size": 1, "items": []},
+        "applicationRoles": {"size": 1, "items": []},
+        "expand": "groups,applicationRoles",
+    }
+
+
 @pytest.mark.parametrize(
     "args",
     [
@@ -49,20 +67,7 @@ def test_create_issue_command_after_fix_mandatory_args_issue(mocker, args):
     from JiraV2 import create_issue_command
 
     mocker.patch.object(demisto, "args", return_value=args)
-    user_data = {
-        "self": "https://demistodev.atlassian.net/rest/api/2/user?accountId=1234",
-        "accountId": "1234",
-        "emailAddress": "admin@demistodev.com",
-        "displayName": "test",
-        "active": True,
-        "timeZone": "Asia/Jerusalem",
-        "locale": "en_US",
-        "groups": {"size": 1, "items": []},
-        "applicationRoles": {"size": 1, "items": []},
-        "expand": "groups,applicationRoles",
-        "projects": [{"id": "1234", "key": "testKey", "name": "testName"}],
-    }
-    mocker.patch("JiraV2.jira_req", return_value=user_data)
+    mocker.patch("JiraV2.jira_req", side_effect=jira_req_side_effect)
     mocker.patch.object(demisto, "results")
     create_issue_command()
     assert demisto.results.call_count == 1

--- a/Packs/Jira/ReleaseNotes/2_0_12.md
+++ b/Packs/Jira/ReleaseNotes/2_0_12.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Atlassian Jira v2
+- Fixed an issue with Jira 9.1 API introduced by https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Cortex XSOAR incidents from Jira projects.",
     "support": "xsoar",
-    "currentVersion": "2.0.11",
+    "currentVersion": "2.0.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Because of https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html JiraV2 integration does not work with Jira 9.1. This should fix it and is compatible with Jira 8.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description

Because of https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html JiraV2 integration does not work with Jira 9.1. 

For example running `!jira-create-issue summary="Foo baz" projectKey="TEST"` return error:

```
jira-v2 returned an error
Command:
 !jira-create-issue summary="Foo baz" projectKey="CSIRTIT"

Reason
Status code: 404
Message: Issue Does Not Exist
```

This PR should fix this and is compatible with Jira 8.

## Screenshots
<img width="582" alt="Zrzut ekranu 2022-09-7 o 15 05 22" src="https://user-images.githubusercontent.com/339473/188885808-35286366-b5ec-4691-8cf3-d3b1a9b281b0.png">

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
