### PR TITLE
destroy_instances.py - download the entire server log zip

### DIFF
--- a/Tests/scripts/destroy_instances.py
+++ b/Tests/scripts/destroy_instances.py
@@ -1,12 +1,13 @@
 import json
 import logging
 import os
-import subprocess
+import shutil
 import sys
 
 import Tests.scripts.awsinstancetool.aws_functions as aws_functions  # pylint: disable=E0611,E0401
 
 from Tests.scripts.utils.log_util import install_logging
+import demisto_client
 
 
 def main():
@@ -21,40 +22,17 @@ def main():
     filtered_results = [env_result for env_result in env_results if env_result["Role"] == instance_role]
     for env in filtered_results:
         logging.info(f'Downloading server log from {env.get("Role", "Unknown role")}')
-        ssh_chmod_string = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {}@{} ' \
-                           '"sudo chmod -R 755 /var/log/demisto"'
-        # tar tends to misbehave when writing a file that is being written to, so we copy it to a temporary location
-        ssh_tar_string = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {}@{} ' \
-                         '"cp -r /var/log/demisto /tmp/log_copy && tar -czvf /tmp/server_logs.tar.gz /tmp/log_copy"'
-        scp_string = 'scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' \
-                     '{}@{}:/tmp/server_logs.tar.gz {} || echo "WARN: Failed downloading server.log"'
-
-        try:
-            logging.debug(f'Changing permissions of folder /var/log/demisto on server {env["InstanceDNS"]}')
-            subprocess.check_output(
-                ssh_chmod_string.format(env["SSHuser"], env["InstanceDNS"]), shell=True)
-
-        except subprocess.CalledProcessError:
-            logging.exception(f'Failed changing permissions of folder /var/log/demisto on server {env["InstanceDNS"]}')
-
-        try:
-            logging.debug('creating logs.tar.gz on server')
-            subprocess.check_output(ssh_tar_string.format(env["SSHuser"], env["InstanceDNS"]), shell=True)
-
-        except subprocess.CalledProcessError:
-            logging.exception(f'Failed creating server log tar on server {env["InstanceDNS"]}')
-
         try:
             logging.debug(f'Downloading server logs from server {env["InstanceDNS"]}')
-            server_ip = env["InstanceDNS"].split('.')[0]
-            subprocess.check_output(
-                scp_string.format(
-                    env["SSHuser"],
-                    env["InstanceDNS"],
-                    f"{circle_aritfact}/server_{env['Role'].replace(' ', '')}_{server_ip}_logs.tar.gz"),
-                shell=True)
+            dmst_client = demisto_client.configure(base_url=f'https://localhost:{env["TunnelPort"]}')
+            tmp_file_path, _, _ = dmst_client.generic_request('/log/bundle', 'GET', response_type='file')
 
-        except subprocess.CalledProcessError:
+            server_ip = env["InstanceDNS"].split('.')[0]
+            logs_dst = f"{circle_aritfact}/server_{env['Role'].replace(' ', '')}_{server_ip}_logs.tar.gz"
+            copy_dst = shutil.copy(tmp_file_path, logs_dst)
+            logging.info(f'Server logs saved in: {copy_dst}')
+
+        except Exception:
             logging.exception(f'Failed downloading server logs from server {env["InstanceDNS"]}')
 
         if time_to_live:


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3971

## Description
instead of save only the server.log - download the entire log zip using the REST API


