### PR TITLE
Fixed an issue where checking domains raises an error with 'NoneType'…

### DIFF
--- a/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.py
@@ -1489,9 +1489,9 @@ def search_domain_command(domain, reliability, create_relationships):
                 domain=domain_name,
                 dbot_score=dbot_score,
                 # Converting date format from YYYY-MM-DD to DD-MM-YYYY due to a parsing problem on the server later
-                creation_date="-".join(indicator.get("whoisDomainCreationDate").split("-")[::-1]),
-                expiration_date="-".join(indicator.get('whoisDomainExpireDate').split("-")[::-1]),
-                updated_date="-".join(indicator.get('whoisDomainUpdateDate').split("-")[::-1]),
+                creation_date="-".join((indicator.get("whoisDomainCreationDate") or '').split("-")[::-1]),
+                expiration_date="-".join((indicator.get('whoisDomainExpireDate') or '').split("-")[::-1]),
+                updated_date="-".join((indicator.get('whoisDomainUpdateDate') or '').split("-")[::-1]),
                 admin_email=indicator.get('whoisAdminEmail'),
                 admin_name=indicator.get('whoisAdminName'),
                 admin_country=indicator.get('whoisAdminCountry'),

--- a/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.yml
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2.yml
@@ -1385,7 +1385,7 @@ script:
     - contextPath: Domain.Name
       description: The domain name.
       type: String
-  dockerimage: demisto/python3:3.10.6.33415
+  dockerimage: demisto/python3:3.10.7.33922
   isfetch: false
   longRunning: false
   longRunningPort: false

--- a/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2_test.py
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/AutofocusV2_test.py
@@ -483,6 +483,30 @@ def test_search_file_command(mock_response, file_hash, expected_results):
     assert results[0].outputs.get('IndicatorValue') in expected_results
 
 
+@pytest.mark.parametrize(argnames='mock_response, domain',
+                         argvalues=[('autofocus_domain_response', 'mail16.amadeus.net')])
+def test_search_domain_command(mock_response, domain):
+    """
+     Given:
+         - A domain.
+     When:
+         - When running search_domain_command.
+     Then:
+         - Ensure the indicator contains the correct domain.
+     """
+
+    from AutofocusV2 import search_domain_command
+
+    with open(f'test_data/{mock_response}.json') as f:
+        response = json.load(f)
+
+    with requests_mock.Mocker() as m:
+        m.get('https://autofocus.paloaltonetworks.com/api/v1.0/tic', json=response)
+        results = search_domain_command(domain, None, False)
+
+    assert results[0].indicator.domain == domain
+
+
 @pytest.mark.parametrize(argnames='ioc_type, ioc_val',
                          argvalues=[('url', 'test_url'),
                                     ('domain', 'test_domain'),

--- a/Packs/AutoFocus/Integrations/AutofocusV2/test_data/autofocus_domain_response.json
+++ b/Packs/AutoFocus/Integrations/AutofocusV2/test_data/autofocus_domain_response.json
@@ -1,0 +1,33 @@
+{
+  "indicator": {
+    "indicatorValue": "mail16.amadeus.net",
+    "indicatorType": "DOMAIN",
+    "summaryGenerationTs": 1663488050591,
+    "firstSeenTsGlobal": null,
+    "lastSeenTsGlobal": null,
+    "latestPanVerdicts": {
+      "PAN_DB": "BENIGN"
+    },
+    "seenByDataSourceIds": [],
+    "whoisAdminCountry": null,
+    "whoisAdminEmail": null,
+    "whoisAdminName": null,
+    "whoisDomainCreationDate": null,
+    "whoisDomainExpireDate": null,
+    "whoisDomainUpdateDate": null,
+    "whoisRegistrar": null,
+    "whoisRegistrarUrl": null,
+    "whoisRegistrant": null,
+    "wildfireRelatedSampleVerdictCounts": {}
+  },
+  "tags": [],
+  "bucketInfo": {
+    "minutePoints": 200,
+    "dailyPoints": 100000,
+    "minuteBucketStart": "2022-09-18 08:00:39",
+    "dailyBucketStart": "2022-09-17 19:29:02",
+    "minutePointsRemaining": 198,
+    "dailyPointsRemaining": 87031,
+    "waitInSeconds": 0
+  }
+}

--- a/Packs/AutoFocus/ReleaseNotes/2_0_25.md
+++ b/Packs/AutoFocus/ReleaseNotes/2_0_25.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Palo Alto Networks AutoFocus v2
+- Fixed an issue where checking domains raises an error with 'NoneType' object has no attribute 'split'
+- Updated the Docker image to: *demisto/python3:3.10.7.33922*.

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "2.0.24",
+    "currentVersion": "2.0.25",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
… object has no attribute 'split'

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
None

## Description
When checking some domains (e.g. `mail16.amadeus.net`), it raises an error with `'NoneType' object has no attribute 'split'`

## Screenshots
![image](https://user-images.githubusercontent.com/54964121/190595341-918801a0-75ee-4b75-a6ec-8ed12f409db9.png)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
