### PR TITLE
Fixed an issue where default value of None is converted to "None" in string.

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_57.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_57.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### SetIfEmpty
+- Fixed an issue where default value of None is converted to "None" in string.
+- Updated the Docker image to: *demisto/python3:3.10.7.33922*.

--- a/Packs/CommonScripts/Scripts/SetIfEmpty/README.md
+++ b/Packs/CommonScripts/Scripts/SetIfEmpty/README.md
@@ -1,0 +1,23 @@
+Checks an object for an empty value and returns a pre-set default value.
+
+## Script Data
+---
+
+| **Name** | **Description** |
+| --- | --- |
+| Script Type | python3 |
+| Tags | transformer, general, entirelist |
+| Cortex XSOAR Version | 5.0.0 |
+
+## Inputs
+---
+
+| **Argument Name** | **Description** |
+| --- | --- |
+| value | The object value to check, if empty. |
+| defaultValue | The new value to return if the original value was empty. |
+| applyIfEmpty | If set to true, empty strings, arrays and dictionaries and the strings "None" and "Null" are considered empty entities and the default value is returned. |
+
+## Outputs
+---
+There are no outputs for this script.

--- a/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty.py
+++ b/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty.py
@@ -10,7 +10,9 @@ def get_value_to_set(args):
     if value is None or (apply_if_empty and is_value_empty(value)):
         value = args.get('defaultValue')
 
-    if isinstance(value, list):
+    if value is None:
+        return []
+    elif isinstance(value, list):
         for i, item in enumerate(value):
             value[i] = encode_string_results(item)
 

--- a/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty.yml
+++ b/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty.yml
@@ -41,4 +41,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - SetIfEmpty - non-ascii chars - Test
-dockerimage: demisto/python3:3.9.7.24076
+dockerimage: demisto/python3:3.10.7.33922

--- a/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty_test.py
+++ b/Packs/CommonScripts/Scripts/SetIfEmpty/SetIfEmpty_test.py
@@ -111,3 +111,18 @@ def test_when_value_is_null_or_none_string_and_default_value():
 
     result = get_value_to_set({'value': ["Null"], 'defaultValue': s, 'applyIfEmpty': 'true'})
     assert s == result
+
+
+def test_when_value_is_null_or_none_string_and_default_value_is_null():
+    s = None
+    result = get_value_to_set({'value': ["None"], 'defaultValue': s, 'applyIfEmpty': 'true'})
+    assert [] == result
+
+    result = get_value_to_set({'value': ["none"], 'defaultValue': s, 'applyIfEmpty': 'true'})
+    assert [] == result
+
+    result = get_value_to_set({'value': ["NULL"], 'defaultValue': s, 'applyIfEmpty': 'true'})
+    assert [] == result
+
+    result = get_value_to_set({'value': ["Null"], 'defaultValue': s, 'applyIfEmpty': 'true'})
+    assert [] == result

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.56",
+    "currentVersion": "1.7.57",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
When default value is None, it's converted to "None" in string, not None.

## Screenshots
Without any transformers, `None` value comes with: 
![image](https://user-images.githubusercontent.com/54964121/190854044-7b888282-50be-4a99-8154-56179652d6f5.png)

The current behavior of setting default value of None is:
![image](https://user-images.githubusercontent.com/54964121/190853975-4a3f58ee-5394-4012-b43d-d9dadb47683a.png)
You can see that `None` is converted to "None" in string.

The fixed code comes with:
![image](https://user-images.githubusercontent.com/54964121/190853981-92899012-51a4-43d4-b768-0c515424ef49.png)


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
