### PR TITLE
Fixed issues where None is not evaluated properly.

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_57.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_57.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+##### SetAndHandleEmpty
+- Fixed an issue where "None" is set when `stringify` is `true`
+- Updated the Docker image to: *demisto/python3:3.10.7.33922*.
+##### If-Then-Else
+- Fixed an issue where `an empty string == None` is evaluated as False.

--- a/Packs/CommonScripts/Scripts/IfThenElse/IfThenElse.js
+++ b/Packs/CommonScripts/Scripts/IfThenElse/IfThenElse.js
@@ -72,11 +72,11 @@ function evaluate(operator, lhs, rhs, options) {
         }
         case "==": {
             [lhs, rhs] = lowerIfPossible(lhs, rhs, options.case_insensitive);
-            return lhs == rhs;
+            return (lhs === null ? "" : lhs) == (rhs === null ? "" : rhs);
         }
         case "!=": {
             [lhs, rhs] = lowerIfPossible(lhs, rhs, options.case_insensitive);
-            return lhs != rhs;
+            return (lhs === null ? "" : lhs) != (rhs === null ? "" : rhs);
         }
         case ">": {
             [lhs, rhs] = lowerIfPossible(lhs, rhs, options.case_insensitive);

--- a/Packs/CommonScripts/Scripts/SetAndHandleEmpty/README.md
+++ b/Packs/CommonScripts/Scripts/SetAndHandleEmpty/README.md
@@ -1,0 +1,29 @@
+Set a value in context under the key you entered. If no value is entered, the script doesn't do anything.
+
+This automation runs using the default Limited User role, unless you explicitly change the permissions.
+For more information, see the section about permissions here:
+https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-2/cortex-xsoar-admin/playbooks/automations.html
+
+## Script Data
+---
+
+| **Name** | **Description** |
+| --- | --- |
+| Script Type | python3 |
+| Tags | Utility |
+| Cortex XSOAR Version | 5.0.0 |
+
+## Inputs
+---
+
+| **Argument Name** | **Description** |
+| --- | --- |
+| key | The key to set in context. |
+| value | The value of the key to set in context. The value is usually a DQ expression. Can be an array. |
+| append | Whether to append the new context key to the existing context key. If "false", then the existing context key will be overwritten with the new context key. |
+| stringify | Whether to save the argument as a string. The default value is "false". |
+| force | Whether to force the creation of the context. The default value is "false". |
+
+## Outputs
+---
+There are no outputs for this script.

--- a/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty.py
+++ b/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty.py
@@ -5,6 +5,8 @@ from typing import Text
 
 def get_value(value, stringify=False):
     if stringify:
+        if value is None:
+            return ''
         return str(value)
     elif not value or not isinstance(value, (Text, bytes, bytearray)):
         return value

--- a/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty.yml
+++ b/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty.yml
@@ -45,6 +45,6 @@ scripttarget: 0
 script: '-'
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.1.25933
+dockerimage: demisto/python3:3.10.7.33922
 tests:
 - SetAndHandleEmpty test

--- a/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty_test.py
+++ b/Packs/CommonScripts/Scripts/SetAndHandleEmpty/SetAndHandleEmpty_test.py
@@ -26,6 +26,7 @@ data_test_set_and_handle_empty_with_value_and_stringify = [
     ('key', '{"key_inside": "val_inside"}', {'key': '{"key_inside": "val_inside"}'}),
     ('key', ["val0", "val1", "val2"], {'key': "['val0', 'val1', 'val2']"}),
     ('key', {"key_inside": "val_inside"}, {'key': "{'key_inside': 'val_inside'}"}),
+    ('key', None, {}),
 ]
 
 

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.56",
+    "currentVersion": "1.7.57",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
### If-Then-Else
Fixed an issue where "None" is set when `stringify` is `true`.

The condition below returns `not equal` in the current behavior, but it should return `equal`.
![image](https://user-images.githubusercontent.com/54964121/190889256-966a68e3-0751-48a7-9c92-3e6826bcfad4.png)
![image](https://user-images.githubusercontent.com/54964121/190889267-6a4f9709-b73b-4cfe-962f-386fccc3b62e.png)

### SetAndHandleEmpty
Fixed an issue where `an empty string == None` is evaluated as False.

Running `SetAndHandleEmpty` with the parameters below shouldn't set value to the key because the value is empty. But it actually sets `None` to the key in the current behavior.
![image](https://user-images.githubusercontent.com/54964121/190889379-bd151869-c04e-47f4-8e1f-a8553ce0046d.png)
![image](https://user-images.githubusercontent.com/54964121/190889427-a9b72c5b-3642-42d4-b7f4-70c6d44ed29f.png)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
