### PR TITLE
Core prevalence human readable fix

### DIFF
--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.py
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.py
@@ -127,7 +127,7 @@ def handle_prevalence_command(client: Client, command: str, args: dict):
     return CommandResults(
         readable_output=tableToMarkdown(string_to_table_header(f'{command_type} Prevalence'),
                                         [{
-                                            key_names_in_response[command_type]: item.get('args', {}).get(
+                                            key_names_in_response[command_type]: item.get(
                                                 key_names_in_response[command_type]),
                                             'Prevalence': item.get('value')
                                         } for item in res],

--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
@@ -3533,7 +3533,7 @@ script:
   script: '-'
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.6.33415
+  dockerimage: demisto/python3:3.10.7.33922
 tests:
 - No tests
 fromversion: 6.2.0

--- a/Packs/Core/ReleaseNotes/1_3_10.md
+++ b/Packs/Core/ReleaseNotes/1_3_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Investigation & Response
+- Fixed an issue where the indicator value was not shown in the war room when using ***core-prevalence*** commands

--- a/Packs/Core/ReleaseNotes/1_3_10.md
+++ b/Packs/Core/ReleaseNotes/1_3_10.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Investigation & Response
 - Fixed an issue where the indicator value was not shown in the war room when using ***core-prevalence*** commands
+- Updated the Docker image to: *demisto/python3:3.10.7.33922*.

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "1.3.9",
+    "currentVersion": "1.3.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [  In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fixed an issue where the indicator value was not shown in the war room when using core-prevalence commands

Before fix:
<img width="983" alt="image" src="https://user-images.githubusercontent.com/38375556/190904106-07c1f5df-57fd-44f1-9d57-c84e4f8c0a80.png">

After fix:
<img width="908" alt="image" src="https://user-images.githubusercontent.com/38375556/190904095-e1890d8e-6c62-402a-9732-97993bee3918.png">

FYI @altmannyarden 
