### PR TITLE
[PAN-OS] - remove "PAN-OS Create Or Edit Rule Test" TP

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -3996,13 +3996,6 @@
             ]
         },
         {
-            "playbookID": "PAN-OS Create Or Edit Rule Test",
-            "fromversion": "6.1.0",
-            "integrations": [
-                "Panorama"
-            ]
-        },
-        {
             "playbookID": "GoogleCloudSCC-Test",
             "fromversion": "5.0.0",
             "integrations": [


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The `PAN-OS Create Or Edit Rule Test` test-playbook should not be executed on its own, its  a sub-playbook for the `palo_alto_panorama_test_pb` test-playbook which will soon be updated to be executed without this playbook.
This test fails on nightly because of the following error:
```
There are 9 instances of Panorama, please select one of them by using the instance_name argument in conf.json. The options are.....:
```

it also fails in the gitlab build for any pan-os build ([example](https://code.pan.run/xsoar/content/-/jobs/16638505))

