### PR TITLE
Fixed OktaOAG pack name

### DIFF
--- a/Packs/OktaOAG/pack_metadata.json
+++ b/Packs/OktaOAG/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "Okta Okta Access Gateway",
+    "name": "Okta Access Gateway",
     "description": "Okta Access Gateway is a reverse proxy based virtual application, designed to secure web applications that don't natively support SAML or OIDC.",
     "support": "xsoar",
     "currentVersion": "1.0.0",

--- a/Packs/Tableau/README.md
+++ b/Packs/Tableau/README.md
@@ -1,3 +1,5 @@
+# Tableau
+
 This pack includes XSIAM content. 
 
 ## Collect Events from Vendor


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)


## Description
This PR was created to fix Okta OAG name in XSIAM marketplace.


## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

