### PR TITLE
Fix o365 ssl error

### DIFF
--- a/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.ps1
+++ b/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.ps1
@@ -648,6 +648,11 @@ function Main {
 
     try
     {
+        if($insecure){
+            # disable the certificate verification in case the instance configured to trusting any certificate
+            Disable-WSManCertVerification -All
+        }
+
         # Creating Compliance and search client
         $oauth2_client = [OAuth2DeviceCodeClient]::CreateClientFromIntegrationContext($insecure, $no_proxy)
         # Refreshing tokens if expired

--- a/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.ps1
+++ b/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.ps1
@@ -652,6 +652,9 @@ function Main {
             # disable the certificate verification in case the instance configured to trusting any certificate
             Disable-WSManCertVerification -All
         }
+        else{
+            Enable-WSManCertVerification -All
+        }
 
         # Creating Compliance and search client
         $oauth2_client = [OAuth2DeviceCodeClient]::CreateClientFromIntegrationContext($insecure, $no_proxy)

--- a/Packs/Office365AndAzureAuditLog/ReleaseNotes/1_0_3.md
+++ b/Packs/Office365AndAzureAuditLog/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Policy And Compliance (Audit Log)
+- Fixed an issue where the ***o365-auditlog-auth-test*** command failed on SSL certificate verification.

--- a/Packs/Office365AndAzureAuditLog/pack_metadata.json
+++ b/Packs/Office365AndAzureAuditLog/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Office 365 and Azure (Audit Log)",
     "description": "Search the unified audit log to view user and administrator activity in your organization.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-16793

## Description
the pwsh command `New-PSSessionOption` failed on certificate verification even if integration configured to `trust any certificate`

fix it by run the `Disable-WSManCertVerification -All` or `Enable-WSManCertVerification -All` command
depending on the `trust any certificate` value
see: https://github.com/MicrosoftDocs/azure-docs/issues/68262#issuecomment-801417688

## Screenshots
before the fix:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/79846863/191710786-42595b0a-db8d-425f-ab70-9dc8f5a00a79.png">

after fix:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/79846863/191710847-efe48854-fa43-4f66-b38d-13fb9f1861f9.png">


