### PR TITLE
Fix release notes in CommonScripts version 1.7.22

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_7_22.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_7_22.md
@@ -1,5 +1,5 @@
 
 #### Scripts
-##### **RepopulateFiles**
+##### RepopulateFiles
 - Updated the Docker image to: *demisto/python3:3.10.5.31928*.
 - Added the *AttachmentFile* context record to include only incident attachment files, in addition to all attachments and entry files in the *File* record.


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Fixed release notes that weren't written as in our templates and therefore didn't generated correctly in the marketplace.