### PR TITLE
Crowdstrike deprecated bug fix

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -1407,7 +1407,7 @@ def search_device(filter_operator='AND'):
     device_ids = raw_res.get('resources')
     if not device_ids:
         return None
-    return http_request('GET', '/devices/entities/devices/v1', params={'ids': device_ids})
+    return http_request('GET', '/devices/entities/devices/v2', params={'ids': device_ids})
 
 
 def behavior_to_entry_context(behavior):

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -3209,7 +3209,7 @@ def test_search_device_command(requests_mock):
         status_code=200,
     )
     requests_mock.get(
-        f'{SERVER_URL}/devices/entities/devices/v1?ids=meta&ids=resources&ids=errors',
+        f'{SERVER_URL}/devices/entities/devices/v2?ids=meta&ids=resources&ids=errors',
         json=test_data2,
         status_code=200,
     )
@@ -3278,7 +3278,7 @@ def test_get_endpint_command(requests_mock, mocker):
         status_code=200,
     )
     requests_mock.get(
-        f'{SERVER_URL}/devices/entities/devices/v1?ids=meta&ids=resources&ids=errors',
+        f'{SERVER_URL}/devices/entities/devices/v2?ids=meta&ids=resources&ids=errors',
         json=test_data2,
         status_code=200,
     )

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_9_5.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_9_5.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike Falcon
+- Fixed an issue where the ***cs-falcon-search-device*** command used a deprecated endpoint.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.9.4",
+    "currentVersion": "1.9.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-17003)

## Description
A session with the customer confirmed that the issue was due to a deprecated endpoint. I opened an [issue](https://jira-hq.paloaltonetworks.local/browse/CRTX-64739) for changing other v1 endpoints that should be deprecated in the future.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
