### PR TITLE
Temporarily fix for Zendesk v2 lint failure 

### DIFF
--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -37,6 +37,8 @@ run-validations-upload-flow:
 
 
 run-unittests-and-lint-upload-flow:
+  cache:
+    policy: push
   extends:
     - .run-unittests-and-lint
     - .bucket-upload-rule


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: link to the issue

## Description
Temporarily fix for Zendesk v2 lint failure.
the issue is probably in some python library that isn’t updated.

Passing UT build: https://code.pan.run/xsoar/content/-/jobs/17253176