### PR TITLE
Cybereason Fetch Incidents Fix

### DIFF
--- a/Packs/Cybereason/Integrations/Cybereason/Cybereason.py
+++ b/Packs/Cybereason/Integrations/Cybereason/Cybereason.py
@@ -1321,7 +1321,7 @@ def fetch_incidents():
             simple_values.pop('iconBase64', None)
             simple_values.pop('malopActivityTypes', None)
             malop_update_time = dict_safe_get(simple_values, ['malopLastUpdateTime', 'values', 0])
-            if malop_update_time > max_update_time:
+            if int(malop_update_time) > int(max_update_time):
                 max_update_time = malop_update_time
 
             incident = malop_to_incident(malop)

--- a/Packs/Cybereason/Integrations/Cybereason/Cybereason.yml
+++ b/Packs/Cybereason/Integrations/Cybereason/Cybereason.yml
@@ -707,7 +707,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.7.33922
+  dockerimage: demisto/python3:3.10.7.35188
 tests:
 - Cybereason Test
 fromversion: 5.0.0

--- a/Packs/Cybereason/ReleaseNotes/1_0_23.md
+++ b/Packs/Cybereason/ReleaseNotes/1_0_23.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cybereason
+- Fixed an issue with fetch incidents last run time.

--- a/Packs/Cybereason/ReleaseNotes/1_0_23.md
+++ b/Packs/Cybereason/ReleaseNotes/1_0_23.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Cybereason
-- Fixed an issue with fetch incidents last run time.
+- Fixed an issue where **fetch-incidents** failed to run.
 - Updated the Docker image to: *demisto/python3:3.10.7.35188*.

--- a/Packs/Cybereason/ReleaseNotes/1_0_23.md
+++ b/Packs/Cybereason/ReleaseNotes/1_0_23.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Cybereason
 - Fixed an issue with fetch incidents last run time.
+- Updated the Docker image to: *demisto/python3:3.10.7.35188*.

--- a/Packs/Cybereason/pack_metadata.json
+++ b/Packs/Cybereason/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cybereason",
     "description": "Endpoint detection and response to manage and query malops, connections and processes.",
     "support": "xsoar",
-    "currentVersion": "1.0.22",
+    "currentVersion": "1.0.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-17334)

## Description
When updating to python3, the comparison in the fetch between new incidents to the last updated time was between a str and an int.  

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
