### PR TITLE
Bugfix http request return values

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -142,7 +142,7 @@ def http_request(client, method, url_suffix, json=None, retries=0):
         response_json['is_error'] = True
         response_json['error_string'] = 'Error in API call to URLScan.io [%d] - %s: %s' % (r.status_code, r.reason,
                                                                                            error_description)
-        return response_json, ErrorTypes.GENERAL_ERROR
+        return response_json, ErrorTypes.GENERAL_ERROR, None
     return r.json(), None, None
 
 

--- a/Packs/UrlScan/ReleaseNotes/1_1_27.md
+++ b/Packs/UrlScan/ReleaseNotes/1_1_27.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Fixed a bug where errors in HTTP API calls to urlscan could sometimes cause ValueErrors to be thrown by the integration, aborting execution


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A customer encountered an issue where the integration was throwing `ValueError: not enough values to unpack (expected 3, got 2)` in `urlscan_submit_url`. This was caused by the `http_request` function not always returning exactly 3 values (probably an oversight introduced during a previous change: Add API Metrics Support to UrlScan (#19442)

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
