### PR TITLE
Alibaba fix fetch no events

### DIFF
--- a/Packs/AlibabaActionTrail/Integrations/AlibabaActionTrailEventCollector/AlibabaActionTrailEventCollector.py
+++ b/Packs/AlibabaActionTrail/Integrations/AlibabaActionTrailEventCollector/AlibabaActionTrailEventCollector.py
@@ -199,7 +199,8 @@ def main():
 
             if command == 'fetch-events':
                 send_events_to_xsiam(events, vendor=VENDOR, product=PRODUCT)
-                demisto.setLastRun(AlibabaGetEvents.get_last_run(events))
+                if events:
+                    demisto.setLastRun(AlibabaGetEvents.get_last_run(events))
 
             elif command == 'alibaba-get-events':
                 command_results = CommandResults(

--- a/Packs/AlibabaActionTrail/Integrations/AlibabaActionTrailEventCollector/AlibabaActionTrailEventCollector.yml
+++ b/Packs/AlibabaActionTrail/Integrations/AlibabaActionTrailEventCollector/AlibabaActionTrailEventCollector.yml
@@ -70,7 +70,7 @@ script:
       - 'True'
       - 'False'
       required: true
-  dockerimage: demisto/fastapi:1.0.0.32142
+  dockerimage: demisto/fastapi:1.0.0.34291
   runonce: false
   isfetchevents: true
   subtype: python3

--- a/Packs/AlibabaActionTrail/ReleaseNotes/1_0_2.md
+++ b/Packs/AlibabaActionTrail/ReleaseNotes/1_0_2.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Alibaba Action Trail Event Collector
-Fixed a bug in the **fetch-events** which failed to save the integration last run data in case no new events were received.
+- Fixed a bug in the **fetch-events** which failed to save the integration last run data in case no new events were received.
+- Updated the Docker image to: *demisto/fastapi:1.0.0.34291*.

--- a/Packs/AlibabaActionTrail/ReleaseNotes/1_0_2.md
+++ b/Packs/AlibabaActionTrail/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Alibaba Action Trail Event Collector
+Fixed a bug in the **fetch-events** which failed to save the integration last run data in case no new events were received.

--- a/Packs/AlibabaActionTrail/pack_metadata.json
+++ b/Packs/AlibabaActionTrail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Alibaba Action Trail",
     "description": "An Integration Pack to fetch Alibaba action trail events.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4296

## Description
The AlibabaGetEvents.get_last_run fails when no events are sent to it, this is why the fetch is failing when there are no new events.

