### PR TITLE
Slack malformed users

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -2347,7 +2347,7 @@ def create_channel():
 def invite_to_channel():
     channel = demisto.args().get('channel')
     channel_id = demisto.args().get('channel_id', '')
-    users = argToList(demisto.args().get('users', []))
+    users = argToList(demisto.args().get('users', '[]').rstrip(', '))
 
     if not users:
         # Not raising an error here to preserve BC

--- a/Packs/Slack/ReleaseNotes/3_1_6.md
+++ b/Packs/Slack/ReleaseNotes/3_1_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v3
+- Improved the handling for a malformed list of users in the ***slack-invite-to-channel*** command.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.1.5",
+    "currentVersion": "3.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-15577

## Description
In some cases when using a custom script, it's possible to force feed the argument a mall formed list. To reduce customer friction, we now pre-format the argument.
