### PR TITLE
AWS IAM group policy and tags

### DIFF
--- a/Packs/AWS-IAM/Integrations/AWS-IAM/AWS-IAM.yml
+++ b/Packs/AWS-IAM/Integrations/AWS-IAM/AWS-IAM.yml
@@ -2291,6 +2291,9 @@ script:
     - contextPath: AWS.IAM.Policy.Description
       description: A friendly description of the policy.
       type: string
+    - contextPath: AWS.IAM.Policy.AttachmentCount
+      description: The number of entities (users, groups, and roles) that the policy is attached to.
+      type: number
   - arguments:
     - default: false
       description: The name (friendly name, not ARN) of the user to list attached
@@ -2470,6 +2473,115 @@ script:
       description: Specifies whether the user is required to set a new password on
         next sign-in.
       type: Boolean
+  - arguments:
+    - name: groupName
+      description: The name of the group.
+      required: true
+    name: aws-iam-get-group
+    description: Returns a list of IAM users that are in the specified IAM group.
+    outputs:
+    - contextPath: AWS.IAM.Group.GroupName
+      description: Group name
+    - contextPath: AWS.IAM.Group.GroupId
+      description: Group ID
+  - arguments:
+    - name: userName
+      description: The name of the user.
+    - name: policyName
+      description: The name of the policy.
+    description: This grabs an inline policy for the specified user.
+    name: aws-iam-get-user-policy
+    outputs:
+    - contextPath: AWS.IAM.Users.PolicyDocument
+      description: The policy document.
+      type: string
+  - arguments:
+    - name: groupName
+      description: The name of the group the policy is associated with.
+    - name: policyName
+      description: The name of the policy document to get.
+    name: aws-iam-get-group-policy
+    description: Retrieves the specified inline policy document that is embedded in the specified IAM group.
+  - arguments:
+    - name: groupName
+      description: The name of the group to list policies for.
+      required: true
+    description: List the names of inline policies specified by the group
+    name: aws-iam-list-group-policies
+    outputs:
+    - contextPath: AWS.IAM.GroupPolicies.GroupName
+      description: Group name
+      type: string
+    - contextPath: AWS.IAM.GroupPolicies.PolicyName
+      description: Policy Name
+    - contextPath: AWS.IAM.Groups.InlinePoliciesMarker
+      description: When output is truncated, this element is present and contains the value to use for the Marker parameter in a subsequent pagination request.
+  - arguments:
+    - description: Policy document
+      name: policyDocument
+      required: true
+    - description: The name of the policy document.
+      name: policyName
+      required: true
+    - description: The name of the user to associate the policy with.
+      name: userName
+      required: true
+    description: Update inline user policy
+    execution: true
+    name: aws-iam-put-user-policy
+  - arguments:
+    - description: The name of the group to associate the policy with.
+      name: groupName
+      required: true
+    - description: The policy document.
+      name: policyDocument
+      required: true
+    - description: The name of the policy document.
+      name: policyName
+      required: true
+    description: Adds or updates an inline policy document that is embedded in the specified IAM group.
+    execution: true
+    name: aws-iam-put-group-policy
+  - arguments:
+    - description: The policy document.
+      name: policyDocument
+      required: true
+    - description: The name of the policy document.
+      name: policyName
+      required: true
+    - description: The name of the role to associate the policy with.
+      name: roleName
+      required: true
+    description: Adds or updates an inline policy document that is embedded in the specified IAM role.
+    execution: true
+    name: aws-iam-put-role-policy
+  - arguments:
+    - description: The name of the IAM role for which you want to see the list of tags.
+      name: roleName
+      required: true
+    description: Lists the tags that are attached to the specified role.
+    name: aws-iam-list-role-tags
+    outputs:
+    - contextPath: AWS.IAM.Tags
+      description: Tags for the role
+  - arguments:
+    - description: The name of the IAM user whose tags you want to see.
+      name: userName
+      required: true
+    description: 'Lists the tags that are attached to the specified IAM user. '
+    name: aws-iam-list-user-tags
+    outputs:
+    - contextPath: AWS.IAM.Tags
+      description: Tags for the user
+  - arguments:
+    - description: The ARN of the IAM customer managed policy whose tags you want to see.
+      name: policyArn
+      required: true
+    description: Lists the tags that are attached to the specified IAM customer managed policy.
+    name: aws-iam-list-policy-tags
+    outputs:
+    - contextPath: AWS.IAM.Tags
+      description: Tags from the policy
   dockerimage: demisto/boto3py3:1.0.0.35343
   feed: false
   isfetch: false

--- a/Packs/AWS-IAM/Integrations/AWS-IAM/AWS-IAM.yml
+++ b/Packs/AWS-IAM/Integrations/AWS-IAM/AWS-IAM.yml
@@ -2582,7 +2582,7 @@ script:
     outputs:
     - contextPath: AWS.IAM.Tags
       description: Tags from the policy
-  dockerimage: demisto/boto3py3:1.0.0.35343
+  dockerimage: demisto/boto3py3:1.0.0.35436
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/AWS-IAM/Integrations/AWS-IAM/README.md
+++ b/Packs/AWS-IAM/Integrations/AWS-IAM/README.md
@@ -1572,6 +1572,7 @@ Retrieves information about the specified managed policy, including the policy's
 | AWS.IAM.Policy.Arn | string | The Amazon Resource Name (ARN). ARNs are unique identifiers for Amazon Web Services resources. | 
 | AWS.IAM.Policy.Path | string | The path to the policy. | 
 | AWS.IAM.Policy.Description | string | A friendly description of the policy. | 
+| AWS.IAM.Policy.AttachmentCount | number | The number of entities \(users, groups, and roles\) that the policy is attached to. | 
 
 #### Command Example
 ``` !aws-iam-get-policy policyName=testPolicy```
@@ -1689,3 +1690,211 @@ Lists all managed policies that are attached to the specified IAM user.
 #### Command Example
 ``` !aws-iam-get-user-login-profile userName=testUser```
 
+### aws-iam-get-group
+***
+Returns a list of IAM users that are in the specified IAM group.
+
+
+#### Base Command
+
+`aws-iam-get-group`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| groupName | The name of the group. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.Group.GroupName | unknown | Group name | 
+| AWS.IAM.Group.GroupId | unknown | Group ID | 
+
+### aws-iam-get-user-policy
+***
+This grabs an inline policy for the specified user.
+
+
+#### Base Command
+
+`aws-iam-get-user-policy`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userName | The name of the user. | Optional | 
+| policyName | The name of the policy. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.Users.PolicyDocument | string | The policy document. | 
+
+### aws-iam-get-group-policy
+***
+Retrieves the specified inline policy document that is embedded in the specified IAM group.
+
+
+#### Base Command
+
+`aws-iam-get-group-policy`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| groupName | The name of the group the policy is associated with. | Optional | 
+| policyName | The name of the policy document to get. | Optional | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### aws-iam-list-group-policies
+***
+List the names of inline policies specified by the group
+
+
+#### Base Command
+
+`aws-iam-list-group-policies`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| groupName | The name of the group to list policies for. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.GroupPolicies.GroupName | string | Group name | 
+| AWS.IAM.GroupPolicies.PolicyName | unknown | Policy Name | 
+| AWS.IAM.Groups.InlinePoliciesMarker | unknown | When output is truncated, this element is present and contains the value to use for the Marker parameter in a subsequent pagination request. | 
+
+### aws-iam-put-user-policy
+***
+Update inline user policy
+
+
+#### Base Command
+
+`aws-iam-put-user-policy`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| policyDocument | Policy document. | Required | 
+| policyName | The name of the policy document. | Required | 
+| userName | The name of the user to associate the policy with. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### aws-iam-put-group-policy
+***
+Adds or updates an inline policy document that is embedded in the specified IAM group.
+
+
+#### Base Command
+
+`aws-iam-put-group-policy`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| groupName | The name of the group to associate the policy with. | Required | 
+| policyDocument | The policy document. | Required | 
+| policyName | The name of the policy document. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### aws-iam-put-role-policy
+***
+Adds or updates an inline policy document that is embedded in the specified IAM role.
+
+
+#### Base Command
+
+`aws-iam-put-role-policy`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| policyDocument | The policy document. | Required | 
+| policyName | The name of the policy document. | Required | 
+| roleName | The name of the role to associate the policy with. | Required | 
+
+
+#### Context Output
+
+There is no context output for this command.
+### aws-iam-list-role-tags
+***
+Lists the tags that are attached to the specified role.
+
+
+#### Base Command
+
+`aws-iam-list-role-tags`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| roleName | The name of the IAM role for which you want to see the list of tags. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.Tags | unknown | Tags for the role | 
+
+### aws-iam-list-user-tags
+***
+Lists the tags that are attached to the specified IAM user. 
+
+
+#### Base Command
+
+`aws-iam-list-user-tags`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| userName | The name of the IAM user whose tags you want to see. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.Tags | unknown | Tags for the user | 
+
+### aws-iam-list-policy-tags
+***
+Lists the tags that are attached to the specified IAM customer managed policy.
+
+
+#### Base Command
+
+`aws-iam-list-policy-tags`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| policyArn | The ARN of the IAM customer managed policy whose tags you want to see. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.IAM.Tags | unknown | Tags from the policy | 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description

Adding the following commands
- aws-iam-get-group
- aws-iam-list-group-policies
- aws-iam-get-user-policy
- aws-iam-get-group-policy
- aws-iam-put-user-policy
- aws-iam-put-group-policy
- aws-iam-put-role-policy
- aws-iam-list-role-tags
- aws-iam-list-user-tags
- aws-iam-list-policy-tags

Also expanding the get-policy command adding attachment count that shows the number of entities (users, groups, and roles) that the policy is attached to per https://docs.aws.amazon.com/cli/latest/reference/iam/get-policy.html#output

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
