### PR TITLE
Changed author for OctoxLabs Pack

### DIFF
--- a/Packs/OctoxLabs/pack_metadata.json
+++ b/Packs/OctoxLabs/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Octox Labs Cyber Security Asset Management platform",
     "support": "partner",
     "currentVersion": "1.0.0",
-    "author": "ahmetkotan",
+    "author": "OctoxLabs",
     "url": "https://octoxlabs.com",
     "email": "info@octoxlabs.com",
     "categories": [


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4341

## Description
OctoxLabs Pack currently shows GitHub username as author instead of the company/product name. This PR changes the username to the company name.

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No
