### PR TITLE
Fix ShowCampaignRecipients Script

### DIFF
--- a/Packs/Campaign/ReleaseNotes/3_2_15.md
+++ b/Packs/Campaign/ReleaseNotes/3_2_15.md
@@ -2,3 +2,4 @@
 #### Scripts
 ##### ShowCampaignRecipients
 - Fixed an issue where **ShowCampaignRecipients** script showed empty recipient in layout.
+- Updated the Docker image to: *demisto/python3:3.10.8.36650*.

--- a/Packs/Campaign/ReleaseNotes/3_2_15.md
+++ b/Packs/Campaign/ReleaseNotes/3_2_15.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### ShowCampaignRecipients
+- Fixed an issue where **ShowCampaignRecipients** script showed empty recipient in layout.

--- a/Packs/Campaign/Scripts/ShowCampaignRecipients/ShowCampaignRecipients.py
+++ b/Packs/Campaign/Scripts/ShowCampaignRecipients/ShowCampaignRecipients.py
@@ -48,7 +48,7 @@ def get_campaign_recipients() -> str:
     if not recipients:
         return 'No incident recipients found.'
 
-    recipients_counter = Counter(recipients).most_common()  # type: ignore
+    recipients_counter = Counter(filter(None, recipients)).most_common()  # type: ignore
 
     recipients_table_content = [{"Email": item[0], "Number Of Appearances": item[1]} for item in recipients_counter]
     headers = ['Email', 'Number Of Appearances']

--- a/Packs/Campaign/Scripts/ShowCampaignRecipients/ShowCampaignRecipients.yml
+++ b/Packs/Campaign/Scripts/ShowCampaignRecipients/ShowCampaignRecipients.yml
@@ -11,7 +11,7 @@ enabled: true
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.1.27636
+dockerimage: demisto/python3:3.10.8.36650
 runas: DBotWeakRole
 fromversion: 5.5.0
 tests:

--- a/Packs/Campaign/pack_metadata.json
+++ b/Packs/Campaign/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing Campaign",
     "description": "This pack can help you find related phishing, spam or other types of email incidents and characterize campaigns.",
     "support": "xsoar",
-    "currentVersion": "3.2.14",
+    "currentVersion": "3.2.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4189

## Description
Fixed an issue with the `ShowCampaignRecipients` script, which showed empty strings (empty recipients) in the human readable.

## Screenshots
<img width="1563" alt="image" src="https://user-images.githubusercontent.com/45915502/198888654-2cd54324-ec46-4f60-9f65-57d007dd5d5b.png">


## Does it break backward compatibility?
   - [x] No
