### PR TITLE
add close mirrored XSOAR offenses and user query params comment

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -1772,7 +1772,7 @@ def get_incidents_long_running_execution(client: Client, offenses_per_fetch: int
                 enrich_offense_with_events,
                 client=client,
                 offense=offense,
-                fetch_mode=str(fetch_mode),
+                fetch_mode=fetch_mode,  # type: ignore
                 events_columns=events_columns,
                 events_limit=events_limit,
             ))

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -1772,7 +1772,7 @@ def get_incidents_long_running_execution(client: Client, offenses_per_fetch: int
                 enrich_offense_with_events,
                 client=client,
                 offense=offense,
-                fetch_mode=fetch_mode,
+                fetch_mode=str(fetch_mode),
                 events_columns=events_columns,
                 events_limit=events_limit,
             ))

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -62,7 +62,7 @@ configuration:
   name: query
   required: false
   type: 0
-  additionalinfo: Define a query to determine which offenses to fetch. E.g., "severity >= 4 AND id > 5 AND status=OPEN". When configuring status="OPEN" - closed mirrored XSOAR incident won't work.
+  additionalinfo: Define a query to determine which offenses to fetch. E.g., "severity >= 4 AND id > 5". filtering by status in the query may result in unexpected behavior when changing an incident's status.
 - defaultvalue: IPs And Assets
   display: 'Incidents Enrichment'
   name: enrichment

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -2771,7 +2771,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.7.33922
+  dockerimage: demisto/python3:3.10.8.36650
   feed: false
   isfetch: false
   isremotesyncin: true

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -62,7 +62,7 @@ configuration:
   name: query
   required: false
   type: 0
-  additionalinfo: Define a query to determine which offenses to fetch. E.g., "severity >= 4 AND id > 5 AND status=OPEN".
+  additionalinfo: Define a query to determine which offenses to fetch. E.g., "severity >= 4 AND id > 5 AND status=OPEN". When configuring status="OPEN" - closed mirrored XSOAR incident won't work.
 - defaultvalue: IPs And Assets
   display: 'Incidents Enrichment'
   name: enrichment

--- a/Packs/QRadar/Integrations/QRadar_v3/README.md
+++ b/Packs/QRadar/Integrations/QRadar_v3/README.md
@@ -16,7 +16,7 @@ This integration was integrated and tested with API versions 10.1-14.0 on QRadar
     | Fetch mode |  | True |
     | Retry events fetch | Whenever enabled, the integration retries to fetch all events if the number of events fetched is less than `event_count`. Default number of tries is 3, but can be configured via the Advanced Parameter: EVENTS_SEARCH_TRIES. e.g EVENTS_SEARCH_TRIES=5. | False |
     | Number of offenses to pull per API call (max 50) |  | False |
-    | Query to fetch offenses | Define a query to determine which offenses to fetch. E.g., "severity &amp;gt;= 4 AND id &amp;gt; 5 AND status=OPEN". When configuring status="OPEN" - closed mirrored XSOAR incident won't work.| False |
+    | Query to fetch offenses | Define a query to determine which offenses to fetch. E.g., "severity >= 4 AND id > 5". filtering by status in the query may result in unexpected behavior when changing an incident's status.| False |
     | First fetch time | how long to look back while fetching incidents on the first fetch \(&amp;lt;number&amp;gt; &amp;lt;time unit&amp;gt;, e.g., 12 hours, 7 days\) | False |
     | Incidents Enrichment | IPs enrichment transforms IDs of the IPs of the offense to IP values. Asset enrichment adds correlated assets to the fetched offenses. | True |
     | Incidents Enrichment | IP enrichment transforms IDs of the IPs of the offense to IP values. Asset enrichment adds correlated assets to the fetched offenses. | True |

--- a/Packs/QRadar/Integrations/QRadar_v3/README.md
+++ b/Packs/QRadar/Integrations/QRadar_v3/README.md
@@ -16,13 +16,13 @@ This integration was integrated and tested with API versions 10.1-14.0 on QRadar
     | Fetch mode |  | True |
     | Retry events fetch | Whenever enabled, the integration retries to fetch all events if the number of events fetched is less than `event_count`. Default number of tries is 3, but can be configured via the Advanced Parameter: EVENTS_SEARCH_TRIES. e.g EVENTS_SEARCH_TRIES=5. | False |
     | Number of offenses to pull per API call (max 50) |  | False |
-    | Query to fetch offenses | Define a query to determine which offenses to fetch. E.g., "severity &amp;gt;= 4 AND id &amp;gt; 5 AND status=OPEN". | False |
+    | Query to fetch offenses | Define a query to determine which offenses to fetch. E.g., "severity &amp;gt;= 4 AND id &amp;gt; 5 AND status=OPEN". When configuring status="OPEN" - closed mirrored XSOAR incident won't work.| False |
     | First fetch time | how long to look back while fetching incidents on the first fetch \(&amp;lt;number&amp;gt; &amp;lt;time unit&amp;gt;, e.g., 12 hours, 7 days\) | False |
     | Incidents Enrichment | IPs enrichment transforms IDs of the IPs of the offense to IP values. Asset enrichment adds correlated assets to the fetched offenses. | True |
     | Incidents Enrichment | IP enrichment transforms IDs of the IPs of the offense to IP values. Asset enrichment adds correlated assets to the fetched offenses. | True |
     | Event fields to return from the events query (WARNING: This parameter is correlated to the incoming mapper and changing the values may adversely affect mapping). | The parameter uses the AQL SELECT syntax. For more information, see: https://www.ibm.com/support/knowledgecenter/en/SS42VS_7.4/com.ibm.qradar.doc/c_aql_intro.html | False |
     | Mirroring Options | How mirroring from QRadar to Cortex XSOAR should be done. | False |
-    | Close Mirrored XSOAR Incident | When selected, closing the QRadar offense is mirrored in Cortex XSOAR. | False |
+    | Close Mirrored XSOAR Incident | When selected, closing the QRadar offense is mirrored in Cortex XSOAR. Can't be used with "status=OPEN" query. | False |
     | The number of incoming incidents to mirror each time | Maximum number of incoming incidents to mirror each time. | False |
     | Advanced Parameters | Comma-separated configuration for advanced parameter values. E.g., EVENTS_INTERVAL_SECS=20,FETCH_SLEEP=5 | False |
     | Trust any certificate (not secure) |  | False |

--- a/Packs/QRadar/ReleaseNotes/2_3_2.md
+++ b/Packs/QRadar/ReleaseNotes/2_3_2.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### IBM QRadar v3
+- Documentation and metadata improvements.

--- a/Packs/QRadar/ReleaseNotes/2_3_2.md
+++ b/Packs/QRadar/ReleaseNotes/2_3_2.md
@@ -1,3 +1,4 @@
 #### Integrations
 ##### IBM QRadar v3
+- Updated the Docker image to: *demisto/python3:3.10.8.36650*.
 - Documentation and metadata improvements.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.3.1",
+    "currentVersion": "2.3.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-17968](https://jira-hq.paloaltonetworks.local/browse/XSUP-17968)

## Description
Added notes related to the close mirrored XSOAR offenses and user query params - close mirrored XSOAR offenses won't work if user query contains "stats=OPEN".

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No