### PR TITLE
Googledrive fixes

### DIFF
--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -77,7 +77,7 @@ COMMAND_SCOPES: Dict[str, List[str]] = {
         'https://www.googleapis.com/auth/drive.file',
         'https://www.googleapis.com/auth/drive.appdata',
         'https://www.googleapis.com/auth/drive.scripts',
-        'https://www.googleapis.com/auth/drive.,etadata',
+        'https://www.googleapis.com/auth/drive.metadata',
     ],
     'FILE_DELETE': [
         'https://www.googleapis.com/auth/drive',
@@ -1097,12 +1097,15 @@ def prepare_single_file_human_readable(outputs_context: Dict[str, Any], args: Di
 
 
 def prepare_file_command_request(client: 'GSuiteClient', args: Dict[str, str], scopes: List[str]) -> Dict[str, Any]:
-
-    http_request_params: Dict[str, str] = {}
-
     # user_id can be overridden in the args
     user_id = args.get('user_id') or client.user_id
     client.set_authorized_http(scopes=scopes, subject=user_id)
+
+    # Prepare generic HTTP request params
+    http_request_params: Dict[str, str] = assign_params(
+        supportsAllDrives=args.get('supports_all_drives'),
+        fields='*',
+    )
 
     return {
         'http_request_params': http_request_params,

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -1097,15 +1097,14 @@ def prepare_single_file_human_readable(outputs_context: Dict[str, Any], args: Di
 
 
 def prepare_file_command_request(client: 'GSuiteClient', args: Dict[str, str], scopes: List[str]) -> Dict[str, Any]:
-    # user_id can be overridden in the args
-    user_id = args.get('user_id') or client.user_id
-    client.set_authorized_http(scopes=scopes, subject=user_id)
-
     # Prepare generic HTTP request params
     http_request_params: Dict[str, str] = assign_params(
         supportsAllDrives=args.get('supports_all_drives'),
-        fields='*',
     )
+
+    # user_id can be overridden in the args
+    user_id = args.get('user_id') or client.user_id
+    client.set_authorized_http(scopes=scopes, subject=user_id)
 
     return {
         'http_request_params': http_request_params,

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -3208,6 +3208,18 @@ script:
         command.
       required: false
       isArray: false
+    - auto: PREDEFINED
+      default: false
+      defaultValue: "false"
+      description: 'Whether the requesting application supports both My Drives and
+        shared drives. Possible values: "true" and "false".'
+      isArray: false
+      name: supports_all_drives
+      predefined:
+        - "true"
+        - "false"
+      required: false
+      secret: false
   dockerimage: demisto/googleapi-python3:1.0.0.34951
   feed: false
   isfetch: true

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -3220,7 +3220,7 @@ script:
         - "false"
       required: false
       secret: false
-  dockerimage: demisto/googleapi-python3:1.0.0.34951
+  dockerimage: demisto/googleapi-python3:1.0.0.36486
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1225,6 +1225,7 @@ Delete a permission.
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
 | user_id | The user's primary email address. | Optional | 
 | permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values: "true" and "false". Possible values are: true, false. Default is false. | Optional | 
 
 
 #### Context Output

--- a/Packs/GoogleDrive/ReleaseNotes/1_2_19.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_2_19.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Google Drive
+- Added the **support-all-drives** argument to the ***google-drive-file-permission-delete*** command.
+- Updated the Docker image to: *demisto/googleapi-python3:1.0.0.36486*.

--- a/Packs/GoogleDrive/pack_metadata.json
+++ b/Packs/GoogleDrive/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Drive",
     "description": "Google Drive allows users to store files on their servers, synchronize files across devices, and share files. This integration helps you to create a new drive, query past activity and view change logs performed by the users, as well as list drives and files, and manage their permissions.",
     "support": "xsoar",
-    "currentVersion": "1.2.18",
+    "currentVersion": "1.2.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
@@ -10,7 +10,9 @@
     "categories": [
         "IT Services"
     ],
-    "tags": ["Data Source"],
+    "tags": [
+        "Data Source"
+    ],
     "useCases": [],
     "keywords": [],
     "githubUser": [],


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-17862

## Description
Added the `support-all-drives` argument to the `google-drive-file-permission-delete` command
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
