### PR TITLE
change xdm.network.http.user_agent in xdm.source.user_agent zscaler

### DIFF
--- a/Packs/Zscaler/ModelingRules/ZscalerModelingRule_1_3/ZscalerModelingRule_1_3.xif
+++ b/Packs/Zscaler/ModelingRules/ZscalerModelingRule_1_3/ZscalerModelingRule_1_3.xif
@@ -22,7 +22,7 @@ alter
 	xdm.alert.name = cs5,
 	xdm.alert.severity = to_string(cn1),
 	xdm.observer.name = _reporting_device_name,
-	xdm.network.http.user_agent = requestClientApplication,
+	xdm.source.user_agent = requestClientApplication,
 	xdm.target.interface = destinationServiceName,
 	xdm.source.ipv4 = sourceTranslatedAddress,
 	xdm.event.type = ZscalerNSSWeblogURLClass,


### PR DESCRIPTION
## Status
- [] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Description
**xdm.network.http.user_agent** field has been removed from XDM schema due to application with **xdm.source.user_agent zscaler**

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X ] No
