### PR TITLE
remove where is the egg from marketplace

### DIFF
--- a/Packs/WhereIsTheEgg/pack_metadata.json
+++ b/Packs/WhereIsTheEgg/pack_metadata.json
@@ -2,6 +2,7 @@
     "name": "Where is the egg?",
     "description": "Don't ask, just try.",
     "support": "xsoar",
+    "hidden": true,
     "currentVersion": "1.0.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Tests/Marketplace/core_packs_list.json
+++ b/Tests/Marketplace/core_packs_list.json
@@ -5,7 +5,6 @@
   "DemistoLocking",
   "Malware",
   "ImageOCR",
-  "WhereIsTheEgg",
   "AutoFocus",
   "UrlScan",
   "Active_Directory_Query",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CRTX-61096)

## Description
Remove Where is the Egg pack

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
