### PR TITLE
removed "Delete Context Subplaybook Test" from nightly

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4722,10 +4722,6 @@
             "fromversion": "5.0.0"
         },
         {
-            "playbookID": "Delete Context Subplaybook Test",
-            "fromversion": "5.0.0"
-        },
-        {
             "playbookID": "TruSTAR v2-Test",
             "fromversion": "5.0.0",
             "integrations": [


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Removed "Delete Context Subplaybook Test" from nightly as this playbook should run as a sub-playbook of another playbook.


## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No
