### PR TITLE
Threat grid artifacts bug fix

### DIFF
--- a/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.py
@@ -1,9 +1,10 @@
 import requests
+import urllib3
 
 import demistomock as demisto
 from CommonServerPython import *
 
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings()
 
 if not demisto.getParam('proxy'):
     del os.environ['HTTP_PROXY']

--- a/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.py
@@ -1011,12 +1011,14 @@ def feeds_helper(name):
     requested_feed = name_conversion[name] if name in name_conversion else name
     url = SUB_API + 'iocs/feeds/' + requested_feed
     r = req('GET', url, params=handle_filters())
+    content = json.loads(r.content.decode('utf-8')) if isinstance(r.content, bytes) else r.content,
+
     demisto.results([
         {
             'Type': entryTypes['note'],
             'EntryContext': {},
             'HumanReadable': 'Your feeds ' + name + ' file download request has been completed successfully',
-            'Contents': r.content,
+            'Contents': content,
             'ContentsFormat': formats['json']
         },
         fileResult(url, r.content)

--- a/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.yml
+++ b/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid.yml
@@ -1009,7 +1009,7 @@ script:
       description: File containing result
     description: Returns data regarding the analysis processes
   runonce: false
-  dockerimage: demisto/python3:3.10.7.35188
+  dockerimage: demisto/python3:3.10.8.37233
 tests:
 - ThreatGridTest
 fromversion: 5.0.0

--- a/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid_test.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid_test.py
@@ -111,3 +111,17 @@ def test_create_analysis_json_human_readable(mocker, test_dict, expected_result)
     mocker.patch('ThreatGrid.tableToMarkdown', return_value='test')
     create_analysis_json_human_readable(test_dict)
     assert test_dict == expected_result
+
+
+def test_feed_helper_byte_response(mocker):
+    from ThreatGrid import feeds_helper
+    class MockResponse:
+        def __init__(self):
+            self.content = b'{"api_version":2,"id":1234,"request_id":"req-7","data":{"items":[{"path":"w.dll","sample_id":"123","severity":100,"aid":1}],"items_per_page":1000}}'
+
+    res = MockResponse()
+    mocker.patch('ThreatGrid.req', return_value=res)
+    demisto_results_mocker = mocker.patch.object(demisto, 'results')
+
+    feeds_helper('artifacts')
+    assert demisto_results_mocker.call_args[0][0][0]['Contents'][0]['id'] == 1234

--- a/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid_test.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGrid/ThreatGrid_test.py
@@ -115,9 +115,12 @@ def test_create_analysis_json_human_readable(mocker, test_dict, expected_result)
 
 def test_feed_helper_byte_response(mocker):
     from ThreatGrid import feeds_helper
+
     class MockResponse:
         def __init__(self):
-            self.content = b'{"api_version":2,"id":1234,"request_id":"req-7","data":{"items":[{"path":"w.dll","sample_id":"123","severity":100,"aid":1}],"items_per_page":1000}}'
+            self.content = b'{"api_version":2,"id":1234,"request_id":"req-7","data":' \
+                           b'{"items":[{"path":"w.dll","sample_id":"123","severity":100,"aid":1}],' \
+                           b'"items_per_page":1000}}'
 
     res = MockResponse()
     mocker.patch('ThreatGrid.req', return_value=res)

--- a/Packs/ThreatGrid/ReleaseNotes/1_2_18.md
+++ b/Packs/ThreatGrid/ReleaseNotes/1_2_18.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Cisco Threat Grid
-Fixed an issue where the ***threat-grid-feeds-artifacts*** command was not properly parsing the response content.
+- Updated the Docker image to: *demisto/python3:3.10.8.37233*.
+- Fixed an issue where the ***threat-grid-feeds-artifacts*** command was not properly parsing the response content.

--- a/Packs/ThreatGrid/ReleaseNotes/1_2_18.md
+++ b/Packs/ThreatGrid/ReleaseNotes/1_2_18.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Cisco Threat Grid
+Fixed an issue where the ***threat-grid-feeds-artifacts*** command was not properly parsing the response content.

--- a/Packs/ThreatGrid/TestPlaybooks/playbook-Threat_Grid_Test.yml
+++ b/Packs/ThreatGrid/TestPlaybooks/playbook-Threat_Grid_Test.yml
@@ -256,7 +256,7 @@ tasks:
       left:
         simple: ${ThreatGrid.User.Role}
       right:
-        simple: org-admin
+        simple: user
     results:
     - AreValuesEqual
     separatecontext: false

--- a/Packs/ThreatGrid/pack_metadata.json
+++ b/Packs/ThreatGrid/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Secure Malware Analytics",
     "description": "Query and upload samples to Cisco threat grid.",
     "support": "xsoar",
-    "currentVersion": "1.2.17",
+    "currentVersion": "1.2.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5415,7 +5415,6 @@
         "carbonblackprotection": "License expired",
         "icebrg": "Issue 14312",
         "Freshdesk": "Trial account expired",
-        "Threat Grid": "Issue 16197",
         "Kafka V2": "Can not connect to instance from remote",
         "KafkaV3": "Can not connect to instance from remote",
         "Check Point Sandblast": "Issue 15948",


### PR DESCRIPTION
Contents in demisto.results is expecting a JSON object but a Bytes object was returned from API call causing the error.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-17652)

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
