### PR TITLE
CRTX-64873: Display current date instead of N/A in generated reports

### DIFF
--- a/Packs/CaseManagement-Generic/ReleaseNotes/1_3_1.md
+++ b/Packs/CaseManagement-Generic/ReleaseNotes/1_3_1.md
@@ -1,0 +1,4 @@
+#### Reports
+##### Case Report
+- Fixed an issue where the creation date was N/A.
+

--- a/Packs/CaseManagement-Generic/Reports/report-CaseReport.json
+++ b/Packs/CaseManagement-Generic/Reports/report-CaseReport.json
@@ -301,7 +301,6 @@
             "data": null,
             "layout": {
                 "columnPos": 0,
-                "format": "MMMM Do YYYY, h:mm:ss a z",
                 "h": 1,
                 "i": "581de1ac-d26e-4e28-992b-8bc6dbee4fea",
                 "rowPos": 3,
@@ -310,7 +309,9 @@
                     "marginBottom": 12,
                     "textAlign": "left"
                 },
-                "w": 12
+                "w": 12,
+                "format": "MMMM Do YYYY, h:mm:ss a z",
+                "useCurrentTime": true
             },
             "query": {},
             "titleStyle": null,

--- a/Packs/CaseManagement-Generic/pack_metadata.json
+++ b/Packs/CaseManagement-Generic/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CaseManagement-Generic",
     "description": "Case Management - Beta\n\nBuilt by the Cortex Customer Success Team to provide quick deployment of Case Management with XSOAR",
     "support": "community",
-    "currentVersion": "1.3.0",
+    "currentVersion": "1.3.1",
     "author": "Cortex XSOAR Customer Success",
     "url": "",
     "email": "",

--- a/Packs/CommonReports/ReleaseNotes/1_0_2.md
+++ b/Packs/CommonReports/ReleaseNotes/1_0_2.md
@@ -1,0 +1,13 @@
+#### Reports
+##### Investigation Summary
+- Fixed an issue where the creation date was N/A.
+##### Daily incidents
+- Fixed an issue where the creation date was N/A.
+##### Late Incidents
+- Fixed an issue where the creation date was N/A.
+##### Shift summary report
+- Fixed an issue where the creation date was N/A.
+##### Mean time to Resolve by Incident Owner (Last 2 Quarters)
+- Fixed an issue where the creation date was N/A.
+##### Mean time to Resolve by Incident Type (Last 2 Quarters)
+- Fixed an issue where the creation date was N/A.

--- a/Packs/CommonReports/Reports/report-MTTRbyIncidentType2Quar.json
+++ b/Packs/CommonReports/Reports/report-MTTRbyIncidentType2Quar.json
@@ -142,7 +142,8 @@
      "fontStyle": "italic",
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/Reports/report-MTTRbyOwner2Quar.json
+++ b/Packs/CommonReports/Reports/report-MTTRbyOwner2Quar.json
@@ -142,7 +142,8 @@
      "fontStyle": "italic",
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/Reports/report-ShiftSummary.json
+++ b/Packs/CommonReports/Reports/report-ShiftSummary.json
@@ -142,7 +142,8 @@
             "fontStyle": "italic",
             "marginBottom:": 12
           },
-          "format": "MMMM Do YYYY, h:mm:ss a z"
+          "format": "MMMM Do YYYY, h:mm:ss a z",
+          "useCurrentTime": true
         }
       },
       {

--- a/Packs/CommonReports/Reports/report-csv-dailyIncidentReport.json
+++ b/Packs/CommonReports/Reports/report-csv-dailyIncidentReport.json
@@ -135,7 +135,8 @@
      "fontStyle": "italic",
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/Reports/report-docx-investigationSummaryReport.json
+++ b/Packs/CommonReports/Reports/report-docx-investigationSummaryReport.json
@@ -214,7 +214,8 @@
      "fontSize": 12,
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {
@@ -546,7 +547,8 @@
      "fontSize": 16,
      "marginBottom:": 12
     },
-    "format": "Do MMM YYYY"
+    "format": "Do MMM YYYY",
+    "useCurrentTime": true
    }
   },
   {
@@ -565,7 +567,8 @@
      "fontSize": 16,
      "marginBottom:": 12
     },
-    "format": "Do MMM YYYY"
+    "format": "Do MMM YYYY",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/Reports/report-investigationSummaryReport.json
+++ b/Packs/CommonReports/Reports/report-investigationSummaryReport.json
@@ -214,7 +214,8 @@
      "fontSize": 12,
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {
@@ -546,7 +547,8 @@
      "fontSize": 16,
      "marginBottom:": 12
     },
-    "format": "Do MMM YYYY"
+    "format": "Do MMM YYYY",
+    "useCurrentTime": true
    }
   },
   {
@@ -565,7 +567,8 @@
      "fontSize": 16,
      "marginBottom:": 12
     },
-    "format": "Do MMM YYYY"
+    "format": "Do MMM YYYY",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/Reports/report-lateIncidentsReport.json
+++ b/Packs/CommonReports/Reports/report-lateIncidentsReport.json
@@ -142,7 +142,8 @@
      "fontStyle": "italic",
      "marginBottom:": 12
     },
-    "format": "MMMM Do YYYY, h:mm:ss a z"
+    "format": "MMMM Do YYYY, h:mm:ss a z",
+    "useCurrentTime": true
    }
   },
   {

--- a/Packs/CommonReports/pack_metadata.json
+++ b/Packs/CommonReports/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Reports",
     "description": "Frequently used reports pack.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Related PR: https://github.com/demisto/sane-reports/pull/230

## Notes
The fix also requires latest sane-reports (at least 1.31.30) pack and the latest client

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CRTX-64873)
