### PR TITLE
URLSCAN - The scan visibility of submitted URLs is no longer public by …

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -7,6 +7,7 @@ import json as JSON
 import time
 from urllib.parse import urlparse
 
+import urllib3
 import requests
 from requests.utils import quote  # type: ignore
 
@@ -17,7 +18,7 @@ except ImportError:
     from queue import Queue  # type: ignore
 
 # disable insecure warnings
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings()
 
 '''GLOBAL VARS'''
 BLACKLISTED_URL_ERROR_MESSAGE = 'The submitted domain is on our blacklist. ' \

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -247,6 +247,9 @@ def urlscan_submit_url(client, url):
         if demisto.args().get('public') == 'public':
             submission_dict['visibility'] = 'public'
     elif demisto.params().get('is_public') is True:
+        # this parameter is now hidden and it is default value is false.
+        # Hence, we do not expect to be entering this code block,
+        # and it is merely here for Backward Compatibility reasons.
         submission_dict['visibility'] = 'public'
 
     submission_dict['url'] = url
@@ -774,7 +777,9 @@ def main():
     params = demisto.params()
 
     api_key = params.get('apikey') or (params.get('creds_apikey') or {}).get('password', '')
-    scan_visibility = params.get('scan_visibility')
+    # to safeguard the visibility of the scan,
+    # if the customer did not choose a visibility, we will set it to private by default.
+    scan_visibility = params.get('scan_visibility', 'private')
     threshold = int(params.get('url_threshold', '1'))
     use_ssl = not params.get('insecure', False)
     reliability = params.get('integrationReliability')

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -9,7 +9,7 @@ configuration:
   type: 9
   hiddenusername: true
   display: ''
-- additionalinfo: Determines the visibility level of the scan. This will override the 'public submissions' setting.
+- additionalinfo: Determines the visibility level of the scan.
   display: Scan Visibility
   name: scan_visibility
   options:
@@ -32,6 +32,22 @@ configuration:
   - F - Reliability cannot be judged
   required: true
   type: 15
+- defaultvalue: '1'
+  display: URL Threshold. Minimum number of positive results from urlscan.io to consider the URL malicious.
+  name: url_threshold
+  required: false
+  type: 0
+- display: User Agent
+  name: useragent
+  type: 0
+  required: false
+  additionalinfo: User Agent to perform requests
+- defaultvalue: 'true'
+  additionalinfo: Create relationships between indicators as part of Enrichment.
+  display: Create relationships
+  name: create_relationships
+  required: false
+  type: 8
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -40,27 +56,12 @@ configuration:
   name: proxy
   required: false
   type: 8
-- defaultvalue: '1'
-  display: URL Threshold. Minimum number of positive results from urlscan.io to consider the URL malicious.
-  name: url_threshold
-  required: false
-  type: 0
-- defaultvalue: 'true'
+- defaultvalue: 'false'
   display: Enable public submissions by default.
   name: is_public
   required: false
   type: 8
-- defaultvalue: 'true'
-  additionalinfo: Create relationships between indicators as part of Enrichment.
-  display: Create relationships
-  name: create_relationships
-  required: false
-  type: 8
-- display: User Agent
-  name: useragent
-  type: 0
-  required: false
-  additionalinfo: User Agent to perform requests
+  hidden: true
 - display: API Key (only required for scanning URLs)
   name: apikey
   required: false
@@ -432,7 +433,7 @@ script:
   script: ''
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.7.35188
+  dockerimage: demisto/python3:3.10.8.37233
 fromversion: 5.0.0
 tests:
 - urlscan_malicious_Test

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -16,7 +16,7 @@ configuration:
   - public
   - private
   - unlisted
-  required: false
+  required: true
   type: 15
 - additionalinfo: Reliability of the source providing the intelligence data.
   defaultvalue: C - Fairly reliable

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_description.md
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_description.md
@@ -1,2 +1,5 @@
-This integration checks domain information from the urlscan.io Database.  
-This is a free service with an API key required. contact urlscan.io to obtain one.
+This integration checks domain information from the urlscan.io Database.
+In order to submit URLs to scan, an API key is required.
+We recommend submitting the URLs as private or unlisted, 
+as publicly listed submitted URLs will be available to the public.
+Contact urlscan.io to obtain an API key.

--- a/Packs/UrlScan/ReleaseNotes/1_2_1.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### urlscan.io
+- The scan visibility of submitted URLs is no longer public by default.
+- Updated the Docker image to *demisto/python3:3.10.8.37233*.

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
relates to: https://jira-hq.paloaltonetworks.local/browse/CIAC-4525

## Desc
This will require a force merge, as we are change the defaultvalue of the is_public param from True to False.
and
scan_visibility is now required:true