### PR TITLE
Fix file enrichment v2

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2.yml
@@ -1,5 +1,14 @@
 id: File Enrichment - Generic v2
-version: -1
+version: 9
+contentitemexportablefields:
+  contentitemfields:
+    packID: CommonPlaybooks
+    packName: Common Playbooks
+    itemVersion: 2.3.8
+    fromServerVersion: 5.0.0
+    toServerVersion: ""
+    definitionid: ""
+vcShouldKeepItemLegacyProdMachine: false
 name: File Enrichment - Generic v2
 description: |-
   Enrich a file using one or more integrations.
@@ -17,11 +26,11 @@ tasks:
       name: ""
       iscommand: false
       brand: ""
-      description: ""
     nexttasks:
-      "#none#":
-        - "31"
+      '#none#':
+      - "31"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -47,8 +56,8 @@ tasks:
       type: title
       iscommand: false
       brand: ""
-      description: ""
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -76,23 +85,24 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#default#":
-        - "7"
-      yes:
-        - "27"
+      '#default#':
+      - "7"
+      "yes":
+      - "27"
     scriptarguments:
       value:
         simple: ${File.SHA256}
     separatecontext: false
     conditions:
-      - label: yes
-        condition:
-          - - operator: isExists
-              left:
-                value:
-                  complex:
-                    root: inputs.SHA256
-                iscontext: true
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: inputs.SHA256
+            iscontext: true
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -115,45 +125,47 @@ tasks:
       id: 0783a3a6-5d8b-48f1-8dee-f3f0ef62defc
       version: -1
       name: Is Cylance Protect v2 enabled?
-      description: Checks if there is an active instance of the Cylance Protect v2 integration enabled.
+      description: Checks if there is an active instance of the Cylance Protect v2
+        integration enabled.
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
-      "#default#":
-        - "7"
-      yes:
-        - "28"
+      '#default#':
+      - "7"
+      "yes":
+      - "28"
     separatecontext: false
     conditions:
-      - label: yes
-        condition:
-          - - operator: isExists
-              left:
-                value:
-                  complex:
-                    root: modules
-                    filters:
-                      - - operator: isEqualString
-                          left:
-                            value:
-                              simple: modules.brand
-                            iscontext: true
-                          right:
-                            value:
-                              simple: Cylance Protect v2
-                          ignorecase: true
-                      - - operator: isEqualString
-                          left:
-                            value:
-                              simple: modules.state
-                            iscontext: true
-                          right:
-                            value:
-                              simple: active
-                          ignorecase: true
-                    accessor: brand
-                iscontext: true
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: modules
+                filters:
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Cylance Protect v2
+                    ignorecase: true
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.state
+                      iscontext: true
+                    right:
+                      value:
+                        simple: active
+                    ignorecase: true
+                accessor: brand
+            iscontext: true
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -182,17 +194,18 @@ tasks:
       iscommand: true
       brand: Cylance Protect v2
     nexttasks:
-      "#none#":
-        - "7"
+      '#none#':
+      - "7"
     scriptarguments:
       sha256:
         complex:
           root: inputs.SHA256
           transformers:
-            - operator: uniq
+          - operator: uniq
     reputationcalc: 1
-    continueonerror: true
     separatecontext: false
+    continueonerror: true
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -205,52 +218,6 @@ tasks:
     ignoreworker: false
     skipunavailable: false
     quietmode: 0
-    isoversize: false
-    isautoswitchedtoquietmode: false
-  "29":
-    id: "29"
-    taskid: be6126b7-0676-4b5f-88d2-a257f8dfa4e3
-    type: playbook
-    task:
-      id: be6126b7-0676-4b5f-88d2-a257f8dfa4e3
-      version: -1
-      name: File Enrichment - Virus Total Private API
-      description: Get file information using the Virus Total Private API integration.
-      playbookName: File Enrichment - Virus Total Private API
-      type: playbook
-      iscommand: false
-      brand: ""
-    nexttasks:
-      "#none#":
-        - "7"
-    separatecontext: true
-    loop:
-      iscommand: false
-      exitCondition: ""
-      wait: 1
-      max: 0
-    view: |-
-      {
-        "position": {
-          "x": 940,
-          "y": 180
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: true
-    quietmode: 0
-    scriptarguments:
-      MD5:
-        complex:
-          root: inputs.MD5
-      SHA1:
-        complex:
-          root: inputs.SHA1
-      SHA256:
-        complex:
-          root: inputs.SHA256
     isoversize: false
     isautoswitchedtoquietmode: false
   "30":
@@ -267,26 +234,27 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#none#":
-        - "7"
+      '#none#':
+      - "7"
     scriptarguments:
       FileHash:
         complex:
           root: inputs.SHA256
           transformers:
-            - operator: append
-              args:
-                item:
-                  value:
-                    simple: inputs.SHA1
-                  iscontext: true
-            - operator: append
-              args:
-                item:
-                  value:
-                    simple: inputs.MD5
-                  iscontext: true
+          - operator: append
+            args:
+              item:
+                value:
+                  simple: inputs.SHA1
+                iscontext: true
+          - operator: append
+            args:
+              item:
+                value:
+                  simple: inputs.MD5
+                iscontext: true
     separatecontext: true
+    continueonerrortype: ""
     loop:
       iscommand: false
       exitCondition: ""
@@ -295,7 +263,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 1390,
+          "x": 1100,
           "y": 180
         }
       }
@@ -319,37 +287,37 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      "#default#":
-        - "7"
-      yes:
-        - "25"
-        - "29"
-        - "30"
+      '#default#':
+      - "7"
+      "yes":
+      - "25"
+      - "30"
     scriptarguments:
       value:
         simple: ${File.SHA256}
     separatecontext: false
     conditions:
-      - label: yes
-        condition:
-          - - operator: isExists
-              left:
-                value:
-                  complex:
-                    root: inputs.SHA256
-                iscontext: true
-              right:
-                value: {}
-            - operator: isExists
-              left:
-                value:
-                  simple: inputs.SHA1
-                iscontext: true
-            - operator: isExists
-              left:
-                value:
-                  simple: inputs.MD5
-                iscontext: true
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: inputs.SHA256
+            iscontext: true
+          right:
+            value: {}
+        - operator: isExists
+          left:
+            value:
+              simple: inputs.SHA1
+            iscontext: true
+        - operator: isExists
+          left:
+            value:
+              simple: inputs.MD5
+            iscontext: true
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -364,6 +332,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+system: true
 view: |-
   {
     "linkLabelsPosition": {
@@ -376,100 +345,80 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1065,
-        "width": 1300,
+        "width": 1010,
         "x": 470,
         "y": -130
       }
     }
   }
 inputs:
-  - key: MD5
-    value:
-      complex:
-        root: File.MD5
-        transformers:
-          - operator: uniq
-        filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: File.MD5
-                iscontext: true
-    required: false
-    description: File MD5 hash to enrich.
-    playbookInputQuery:
-  - key: SHA256
-    value:
-      complex:
-        root: File.SHA256
-        transformers:
-          - operator: uniq
-        filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: File.SHA256
-                iscontext: true
-    required: false
-    description: The file SHA256 hash to enrich.
-    playbookInputQuery:
-  - key: SHA1
-    value:
-      complex:
-        root: File.SHA1
-        transformers:
-          - operator: uniq
-        filters:
-          - - operator: isNotEmpty
-              left:
-                value:
-                  simple: File.SHA1
-                iscontext: true
-    required: false
-    description: The file SHA1 hash to enrich.
-    playbookInputQuery:
+- key: MD5
+  value:
+    complex:
+      root: File
+      accessor: MD5
+      transformers:
+      - operator: uniq
+  required: false
+  description: File MD5 hash to enrich.
+  playbookInputQuery: null
+- key: SHA256
+  value:
+    complex:
+      root: File
+      accessor: SHA256
+      transformers:
+      - operator: uniq
+  required: false
+  description: The file SHA256 hash to enrich.
+  playbookInputQuery: null
+- key: SHA1
+  value:
+    complex:
+      root: File
+      accessor: SHA1
+      transformers:
+      - operator: uniq
+  required: false
+  description: The file SHA1 hash to enrich.
+  playbookInputQuery: null
 outputs:
-  - contextPath: DBotScore.Indicator
-    description: The indicator that was tested.
-    type: string
-  - contextPath: DBotScore.Type
-    description: The indicator type.
-    type: string
-  - contextPath: File.SHA1
-    description: SHA1 hash of the file.
-    type: string
-  - contextPath: File.SHA256
-    description: SHA256 hash of the file.
-    type: string
-  - contextPath: File.Malicious.Vendor
-    description: For malicious files, the vendor that made the decision.
-    type: string
-  - contextPath: File.MD5
-    description: MD5 hash of the file.
-    type: string
-  - contextPath: DBotScore
-    description: The DBotScore object.
-    type: unknown
-  - contextPath: File
-    description: The file object
-    type: unknown
-  - contextPath: DBotScore.Vendor
-    description: Vendor used to calculate the score.
-    type: string
-  - contextPath: DBotScore.Score
-    description: The actual score.
-    type: number
-  - contextPath: File.VirusTotal.Scans
-    description: The scan object.
-    type: unknown
-  - contextPath: File.VirusTotal.Scans.Source
-    description: Vendor that scanned this hash.
-  - contextPath: File.VirusTotal.Scans.Detected
-    description: Whether a scan was detected for this hash (True/False).
-  - contextPath: File.VirusTotal.Scans.Result
-    description: Scan result for this hash - signature, etc.
-fromversion: 5.0.0
-tests:
-  - File Enrichment - Generic v2 - Test
-contentitemexportablefields:
-  contentitemfields: {}
+- contextPath: DBotScore.Indicator
+  description: The indicator that was tested.
+  type: string
+- contextPath: DBotScore.Type
+  description: The indicator type.
+  type: string
+- contextPath: File.SHA1
+  description: SHA1 hash of the file.
+  type: string
+- contextPath: File.SHA256
+  description: SHA256 hash of the file.
+  type: string
+- contextPath: File.Malicious.Vendor
+  description: For malicious files, the vendor that made the decision.
+  type: string
+- contextPath: File.MD5
+  description: MD5 hash of the file.
+  type: string
+- contextPath: DBotScore
+  description: The DBotScore object.
+  type: unknown
+- contextPath: File
+  description: The file object
+  type: unknown
+- contextPath: DBotScore.Vendor
+  description: Vendor used to calculate the score.
+  type: string
+- contextPath: DBotScore.Score
+  description: The actual score.
+  type: number
+- contextPath: File.VirusTotal.Scans
+  description: The scan object.
+  type: unknown
+- contextPath: File.VirusTotal.Scans.Source
+  description: Vendor that scanned this hash.
+- contextPath: File.VirusTotal.Scans.Detected
+  description: Whether a scan was detected for this hash (True/False).
+- contextPath: File.VirusTotal.Scans.Result
+  description: Scan result for this hash - signature, etc.

--- a/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2.yml
@@ -1,14 +1,5 @@
 id: File Enrichment - Generic v2
-version: 9
-contentitemexportablefields:
-  contentitemfields:
-    packID: CommonPlaybooks
-    packName: Common Playbooks
-    itemVersion: 2.3.8
-    fromServerVersion: 5.0.0
-    toServerVersion: ""
-    definitionid: ""
-vcShouldKeepItemLegacyProdMachine: false
+version: -1
 name: File Enrichment - Generic v2
 description: |-
   Enrich a file using one or more integrations.
@@ -26,11 +17,11 @@ tasks:
       name: ""
       iscommand: false
       brand: ""
+      description: ''
     nexttasks:
-      '#none#':
+      "#none#":
       - "31"
     separatecontext: false
-    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -45,6 +36,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "7":
     id: "7"
     taskid: 89ce26db-58e9-4a6d-88f2-d6810e458ee2
@@ -56,8 +48,8 @@ tasks:
       type: title
       iscommand: false
       brand: ""
+      description: ''
     separatecontext: false
-    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -72,6 +64,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "25":
     id: "25"
     taskid: 339fc232-e5d0-468b-87ea-cf8d41ea0ca6
@@ -85,16 +78,16 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      '#default#':
+      "#default#":
       - "7"
-      "yes":
+      yes:
       - "27"
     scriptarguments:
       value:
         simple: ${File.SHA256}
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: yes
       condition:
       - - operator: isExists
           left:
@@ -102,7 +95,6 @@ tasks:
               complex:
                 root: inputs.SHA256
             iscontext: true
-    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -117,6 +109,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "27":
     id: "27"
     taskid: 0783a3a6-5d8b-48f1-8dee-f3f0ef62defc
@@ -125,19 +118,18 @@ tasks:
       id: 0783a3a6-5d8b-48f1-8dee-f3f0ef62defc
       version: -1
       name: Is Cylance Protect v2 enabled?
-      description: Checks if there is an active instance of the Cylance Protect v2
-        integration enabled.
+      description: Checks if there is an active instance of the Cylance Protect v2 integration enabled.
       type: condition
       iscommand: false
       brand: ""
     nexttasks:
-      '#default#':
+      "#default#":
       - "7"
-      "yes":
+      yes:
       - "28"
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: yes
       condition:
       - - operator: isExists
           left:
@@ -165,7 +157,6 @@ tasks:
                     ignorecase: true
                 accessor: brand
             iscontext: true
-    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -180,6 +171,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "28":
     id: "28"
     taskid: ff014724-3ad2-4ce2-8578-5106c126e76b
@@ -194,7 +186,7 @@ tasks:
       iscommand: true
       brand: Cylance Protect v2
     nexttasks:
-      '#none#':
+      "#none#":
       - "7"
     scriptarguments:
       sha256:
@@ -203,9 +195,8 @@ tasks:
           transformers:
           - operator: uniq
     reputationcalc: 1
-    separatecontext: false
     continueonerror: true
-    continueonerrortype: ""
+    separatecontext: false
     view: |-
       {
         "position": {
@@ -220,6 +211,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "30":
     id: "30"
     taskid: f030af26-2985-453a-88bf-4f1dcc536fab
@@ -234,7 +226,7 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      '#none#':
+      "#none#":
       - "7"
     scriptarguments:
       FileHash:
@@ -254,7 +246,6 @@ tasks:
                   simple: inputs.MD5
                 iscontext: true
     separatecontext: true
-    continueonerrortype: ""
     loop:
       iscommand: false
       exitCondition: ""
@@ -274,6 +265,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "31":
     id: "31"
     taskid: cf0cb24c-31c1-4d7d-815b-d203e44b1f44
@@ -287,9 +279,9 @@ tasks:
       iscommand: false
       brand: ""
     nexttasks:
-      '#default#':
+      "#default#":
       - "7"
-      "yes":
+      yes:
       - "25"
       - "30"
     scriptarguments:
@@ -297,7 +289,7 @@ tasks:
         simple: ${File.SHA256}
     separatecontext: false
     conditions:
-    - label: "yes"
+    - label: yes
       condition:
       - - operator: isExists
           left:
@@ -317,7 +309,6 @@ tasks:
             value:
               simple: inputs.MD5
             iscontext: true
-    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -332,7 +323,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
-system: true
+    continueonerrortype: ""
 view: |-
   {
     "linkLabelsPosition": {
@@ -356,32 +347,32 @@ inputs:
   value:
     complex:
       root: File
-      accessor: MD5
       transformers:
       - operator: uniq
+      accessor: MD5
   required: false
   description: File MD5 hash to enrich.
-  playbookInputQuery: null
+  playbookInputQuery:
 - key: SHA256
   value:
     complex:
       root: File
-      accessor: SHA256
       transformers:
       - operator: uniq
+      accessor: SHA256
   required: false
   description: The file SHA256 hash to enrich.
-  playbookInputQuery: null
+  playbookInputQuery:
 - key: SHA1
   value:
     complex:
       root: File
-      accessor: SHA1
       transformers:
       - operator: uniq
+      accessor: SHA1
   required: false
   description: The file SHA1 hash to enrich.
-  playbookInputQuery: null
+  playbookInputQuery:
 outputs:
 - contextPath: DBotScore.Indicator
   description: The indicator that was tested.
@@ -422,3 +413,9 @@ outputs:
   description: Whether a scan was detected for this hash (True/False).
 - contextPath: File.VirusTotal.Scans.Result
   description: Scan result for this hash - signature, etc.
+fromversion: 5.0.0
+tests:
+- File Enrichment - Generic v2 - Test
+contentitemexportablefields:
+  contentitemfields: {}
+system: true

--- a/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-File_Enrichment_-_Generic_v2_README.md
@@ -3,59 +3,49 @@ Enrich a file using one or more integrations.
 - Provide threat information
 
 ## Dependencies
-
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
-
-- File Enrichment - Virus Total (API v3)
-- File Enrichment - Virus Total Private API
+* File Enrichment - Virus Total (API v3)
 
 ### Integrations
-
-- Cylance Protect v2
+* Cylance Protect v2
 
 ### Scripts
-
 This playbook does not use any scripts.
 
 ### Commands
-
-- cylance-protect-get-threat
+* cylance-protect-get-threat
 
 ## Playbook Inputs
-
 ---
 
-| **Name** | **Description**                 | **Default Value** | **Required** |
-| -------- | ------------------------------- | ----------------- | ------------ |
-| MD5      | File MD5 hash to enrich.        | File.MD5.None     | Optional     |
-| SHA256   | The file SHA256 hash to enrich. | File.SHA256.None  | Optional     |
-| SHA1     | The file SHA1 hash to enrich.   | File.SHA1.None    | Optional     |
+| **Name** | **Description** | **Default Value** | **Required** |
+| --- | --- | --- | --- |
+| MD5 | File MD5 hash to enrich. | File.MD5 | Optional |
+| SHA256 | The file SHA256 hash to enrich. | File.SHA256 | Optional |
+| SHA1 | The file SHA1 hash to enrich. | File.SHA1 | Optional |
 
 ## Playbook Outputs
-
 ---
 
-| **Path**                       | **Description**                                           | **Type** |
-| ------------------------------ | --------------------------------------------------------- | -------- |
-| DBotScore.Indicator            | The indicator that was tested.                            | string   |
-| DBotScore.Type                 | The indicator type.                                       | string   |
-| File.SHA1                      | SHA1 hash of the file.                                    | string   |
-| File.SHA256                    | SHA256 hash of the file.                                  | string   |
-| File.Malicious.Vendor          | For malicious files, the vendor that made the decision.   | string   |
-| File.MD5                       | MD5 hash of the file.                                     | string   |
-| DBotScore                      | The DBotScore object.                                     | unknown  |
-| File                           | The file object                                           | unknown  |
-| DBotScore.Vendor               | Vendor used to calculate the score.                       | string   |
-| DBotScore.Score                | The actual score.                                         | number   |
-| File.VirusTotal.Scans          | The scan object.                                          | unknown  |
-| File.VirusTotal.Scans.Source   | Vendor that scanned this hash.                            | unknown  |
-| File.VirusTotal.Scans.Detected | Whether a scan was detected for this hash \(True/False\). | unknown  |
-| File.VirusTotal.Scans.Result   | Scan result for this hash - signature, etc.               | unknown  |
+| **Path** | **Description** | **Type** |
+| --- | --- | --- |
+| DBotScore.Indicator | The indicator that was tested. | string |
+| DBotScore.Type | The indicator type. | string |
+| File.SHA1 | SHA1 hash of the file. | string |
+| File.SHA256 | SHA256 hash of the file. | string |
+| File.Malicious.Vendor | For malicious files, the vendor that made the decision. | string |
+| File.MD5 | MD5 hash of the file. | string |
+| DBotScore | The DBotScore object. | unknown |
+| File | The file object | unknown |
+| DBotScore.Vendor | Vendor used to calculate the score. | string |
+| DBotScore.Score | The actual score. | number |
+| File.VirusTotal.Scans | The scan object. | unknown |
+| File.VirusTotal.Scans.Source | Vendor that scanned this hash. | unknown |
+| File.VirusTotal.Scans.Detected | Whether a scan was detected for this hash \(True/False\). | unknown |
+| File.VirusTotal.Scans.Result | Scan result for this hash - signature, etc. | unknown |
 
 ## Playbook Image
-
 ---
-
 ![File Enrichment - Generic v2](../doc_files/File_Enrichment_-_Generic_v2.png)

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_9.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_9.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### File Enrichment - Generic v2
+- Fixed an issue where the playbook was using a deprecated playbook.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_9.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_9.md
@@ -1,4 +1,4 @@
 
 #### Playbooks
 ##### File Enrichment - Generic v2
-- Fixed an issue where the playbook was using a deprecated playbook.
+- Fixed an issue where the playbook was using a deprecated subplaybook.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.8",
+    "currentVersion": "2.3.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2480,9 +2480,9 @@
         },
         {
             "playbookID": "File Enrichment - Generic v2 - Test",
-            "instance_names": "virus_total_private_api_general",
+            "instance_names": "virus_total_v3",
             "integrations": [
-                "VirusTotal - Private API",
+                "VirusTotal (API v3)",
                 "Cylance Protect v2"
             ],
             "is_mockable": false


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Removed vt step from file enrichment - generic v2 as it's a deprecated playbook.
Also added vt3 instance to replace the vt instance for file enrichment generic v2.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No
