### PR TITLE
remove file enrichment configurations from conf.json

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1274,10 +1274,8 @@
         {
             "playbookID": "URL Enrichment - Generic v2 - Test",
             "integrations": [
-                "Rasterize",
-                "VirusTotal - Private API"
+                "Rasterize"
             ],
-            "instance_names": "virus_total_private_api_general",
             "timeout": 500,
             "pid_threshold": 12
         },


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
After consulting @idovandijk, we decided to remove VT configurations from **URL Enrichment - Generic v2 - Test** configurations in conf.json as the integration is deprecated.
we also decided to create a new ticket in Jira to find a proper replacement for the vt task.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

