### PR TITLE
AWS-S3 add additional api commands

### DIFF
--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.py
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.py
@@ -123,7 +123,7 @@ def get_bucket_policy_status_command(args, aws_client):
         {'BucketName': args.get('bucket'), 'IsPublic': policy.get('IsPublic'), 'Json': response.get('PolicyStatus')}
     )
     human_readable = tableToMarkdown('AWS S3 Bucket Policy Status', data)
-    return CommandResults(readable_output=human_readable, outputs_prefix='AWS.S3.Buckets',
+    return CommandResults(readable_output=human_readable, outputs_prefix='AWS.S3.Buckets.PolicyStatus',
                           outputs_key_field='BucketName', outputs=data)
 
 

--- a/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
+++ b/Packs/AWS-S3/Integrations/AWS-S3/AWS-S3.yml
@@ -645,6 +645,79 @@ script:
     description: Creates or modifies the PublicAccessBlock configuration for an Amazon S3 bucket.
     execution: false
     name: aws-s3-put-public-access-block
+  - arguments:
+      - description: Name of the bucket
+        name: bucket
+        required: true
+      - description: The AWS Region, if not specified the default region will be used.
+        name: region
+      - description: The Amazon Resource Name (ARN) of the role to assume
+        name: roleArn
+      - description: An identifier for the assumed role session.
+        name: roleSessionName
+      - description: The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration for the role.
+        name: roleSessionDuration
+    description: Gets the Tags for a particular bucket.
+    name: aws-s3-get-bucket-tags
+    outputs:
+      - contextPath: AWS.S3.Buckets.BucketName
+        description: The name of the Bucket
+      - contextPath: AWS.S3.Buckets.Tags
+        description: The list of Tags from the Bucket, in Key:Value pairs.
+  - arguments:
+      - description: Name of the bucket.
+        name: bucket
+        required: true
+    description: Get the AWS S3 Bucket ACL
+    name: aws-s3-get-bucket-acl
+    outputs:
+      - contextPath: AWS.S3.Buckets.Acl.Owner
+        description: Owner of the bucket
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.BucketName
+        description: Name of the bucket
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.DisplayName
+        description: Display name of grantee
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.EmailAddress
+        description: Email of grantee
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.Type
+        description: Type of grant
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.URI
+        description: URI of grantee
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.Permission
+        description: Permission granted
+        type: string
+      - contextPath: AWS.S3.Buckets.Acl.Json
+        description: Json string
+        type: string
+  - arguments:
+      - description: Name of the bucket.
+        name: bucket
+        required: true
+    description: Remove the Public Access Block configuration from a bucket
+    execution: true
+    name: aws-s3-delete-public-access-block
+  - arguments:
+      - description: Name of the bucket.
+        name: bucket
+        required: true
+    description: Get the policy status of an S3 bucket
+    name: aws-s3-get-bucket-policy-status
+    outputs:
+      - contextPath: AWS.S3.Buckets.PolicyStatus.BucketName
+        description: Name of the bucket
+        type: string
+      - contextPath: AWS.S3.Buckets.PolicyStatus.IsPublic
+        description: Does the policy allow public access?
+        type: boolean
+      - contextPath: AWS.S3.Buckets.PolicyStatus.Json
+        description: JSON string of PolicyStatus
+        type: string
   dockerimage: demisto/boto3py3:1.0.0.37317
   isfetch: false
   runonce: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description

Adding the following commands

- aws-s3-get-bucket-policy-status
- aws-s3-get-bucket-tags
- aws-s3-delete-public-access-block
- aws-s3-get-bucket-acl

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
