### PR TITLE
Reverted the ID of the Default playbook back to playbook0

### DIFF
--- a/Packs/DefaultPlaybook/Playbooks/Default_8_0.yml
+++ b/Packs/DefaultPlaybook/Playbooks/Default_8_0.yml
@@ -1,4 +1,4 @@
-id: Default
+id: playbook0
 version: -1
 contentitemexportablefields:
   contentitemfields: {}

--- a/Packs/DefaultPlaybook/ReleaseNotes/1_1_1.md
+++ b/Packs/DefaultPlaybook/ReleaseNotes/1_1_1.md
@@ -1,0 +1,3 @@
+#### Playbooks
+##### Default
+- Reverted the ID change to preserve backward compatibility.

--- a/Packs/DefaultPlaybook/ReleaseNotes/1_1_1.md
+++ b/Packs/DefaultPlaybook/ReleaseNotes/1_1_1.md
@@ -1,3 +1,3 @@
 #### Playbooks
 ##### Default
-- Reverted the ID change to preserve backward compatibility.
+- Reverted the playbook ID change to preserve backward compatibility.

--- a/Packs/DefaultPlaybook/pack_metadata.json
+++ b/Packs/DefaultPlaybook/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Default Playbook",
     "description": "Got a unique incident? This Content Pack helps you automate the core steps of enrichment and severity calculation for any kind of incident.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-67675

## Description
A new version of the Default playbook was released starting in XSOAR 8.0.0.
However, that playbook conformed to the standard of setting the playbook ID the same as the Name. This caused issues due to server dependencies on the older ID.
Therefore we have to revert it.


@itayronen @shaniacht1 fyi