### PR TITLE
remove o365 check for pyEWS_Test

### DIFF
--- a/Packs/EWS/Integrations/EWSO365/EWSO365.yml
+++ b/Packs/EWS/Integrations/EWSO365/EWSO365.yml
@@ -1244,7 +1244,6 @@ script:
   subtype: python3
   type: python
 tests:
-- pyEWS_Test
 - EWS search-mailbox test
 fromversion: 5.0.0
 defaultclassifier: EWS v2

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -1825,7 +1825,7 @@
             "timeout": 500
         },
         {
-            "integrations": ["EWS v2", "EWSO365"],
+            "integrations": "EWS v2",
             "playbookID": "pyEWS_Test",
             "instance_names": "ewv2_regular",
             "is_mockable": false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
During this [SDK fix](https://github.com/demisto/content/pull/21835), o365 was added for pyEWS_Test, but after looking into it , it doesn't seem like this tpb was meant to test this integration (has conditions regarding specific items that exist for EWS V2 but to for EWSO365).
Removed this link.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
