### PR TITLE
Email regex and formatter fix - Unicode point issue

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_10_8.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_10_8.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### ExtractEmailV2
-- %%UPDATE_RN%%
+- Fixed an issue where emails were formatted wrong due to unicode.

--- a/Packs/CommonScripts/ReleaseNotes/1_10_8.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_10_8.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### ExtractEmailV2
+- %%UPDATE_RN%%

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting.py
@@ -1,6 +1,7 @@
 import demistomock as demisto
 from CommonServerPython import *  # lgtm [py/polluting-import]
 
+
 import re
 
 # Negative lookahead - Verify the pattern does not end with the listed file extensions. Separated by |
@@ -21,6 +22,11 @@ VALID_ADDRESS_FORMAT = r"[a-z0-9.!#$%&'*+-/=?^_`{|}~]{1,64}\[?@]?[a-z0-9.-]{1,25
 VALID_ADDRESS_REGEX = VALID_EXTENSION + VALID_ADDRESS_FORMAT
 
 
+def remove_unicode_points(email_address: str) -> str:
+    unipoint = re.compile("\\\\u[a-f0-9]{4}")
+    return re.sub(unipoint, '', email_address)
+
+
 def verify_is_email(email_address: str) -> bool:
     try:
         return re.match(VALID_ADDRESS_REGEX, email_address, re.IGNORECASE) is not None
@@ -31,8 +37,10 @@ def verify_is_email(email_address: str) -> bool:
 def main():
     emails = argToList(demisto.args().get('input'))
 
+    clean_emails = [remove_unicode_points(address) for address in emails]
+
     list_results = [email_address.replace("[@]", "@").replace("[.]", ".") if verify_is_email(email_address) else ''
-                    for email_address in emails]
+                    for email_address in clean_emails]
 
     if list_results:
         return_results(list_results)

--- a/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractEmailFormatting/ExtractEmailFormatting_test.py
@@ -1,4 +1,4 @@
-from ExtractEmailFormatting import verify_is_email, main
+from ExtractEmailFormatting import verify_is_email, main, remove_unicode_points
 import pytest
 import demistomock as demisto
 
@@ -39,6 +39,19 @@ def test_verify_is_email(address, valid):
     - Checks if it's an email address or not
     """
     assert verify_is_email(address) is valid
+
+
+@pytest.mark.parametrize('input,output', [  # noqa: E501 disable-secrets-detection
+    # no processing needed
+    ('\\u003ctest@test.com', 'test@test.com'),
+])  # noqa: E124
+
+def test_extract_email(input, output):
+    extracted_fqdn = remove_unicode_points(input)
+    # extracted_domain = extract_fqdn_or_domain(input, is_domain=True)
+
+    assert extracted_fqdn == output
+    # assert extracted_domain == domain
 
 
 ARGS = {

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.10.7",
+    "currentVersion": "1.10.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CommonTypes/IndicatorTypes/reputation-email.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-email.json
@@ -7,7 +7,7 @@
   "commitMessage": "",
   "shouldPublish": false,
   "shouldCommit": false,
-  "regex": "\\b[A-Za-z0-9.!#$%&'*+\\/=?^_`{|}~\\p{L}-]{1,64}\\[?@]?[A-Za-z0-9\\p{L}.-]{1,255}\\[?\\.]?[A-Za-z]{2,}\\b",
+  "regex": "(?:(?:\\\\|\\^{3})u[a-f0-9]{4})?([\\\\A-Za-z0-9.!#$%&'*+\\/=?^_`{|}~\\p{L}-]{1,64}\\[?@]?[A-Za-z0-9\\p{L}.-]{1,255}\\[?\\.]?[A-Za-z]{2,})\\b",
   "details": "Email",
   "prevDetails": "Email",
   "reputationScriptName": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Emails were extracted from raw email with partial unicode points.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No