### PR TITLE
Maltiverse fix bc

### DIFF
--- a/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.py
+++ b/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.py
@@ -5,11 +5,11 @@ from CommonServerUserPython import *
 ''' IMPORTS '''
 from typing import Tuple, Dict, Any
 from _collections import defaultdict
-import requests
+import urllib3
 import hashlib
 
 # Disable insecure warnings
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings()
 
 ''' CONSTANTS '''
 SERVER_URL = 'https://api.maltiverse.com'
@@ -387,14 +387,6 @@ def domain_command(client: Client, args: Dict[str, str]) -> Tuple[str, dict, Any
                       'Score': calculate_score(positive_detections, report.get('classification', ''), threshold),
                       'Reliability': client.reliability}
 
-        resolvedIP_info = {
-            'ResolvedIP':
-                {
-                    'IP': [report['resolved_ip'][i]['ip_addr'] for i in range(len(report['resolved_ip']))],
-                    'Timestamp': [report['resolved_ip'][i]['timestamp'] for i in range(len(report['resolved_ip']))]
-                }
-        }
-
         maltiverse_domain = {string_to_context_key(field): report.get(field, '') for field in
                              ['creation_time', 'modification_time', 'classification']
                              }
@@ -402,7 +394,6 @@ def domain_command(client: Client, args: Dict[str, str]) -> Tuple[str, dict, Any
         maltiverse_domain['Tags'] = create_tags(report.get('tag', ''))
         maltiverse_domain['Address'] = report.get('hostname', '')
         maltiverse_domain = {**maltiverse_domain, **blacklist_context}
-        maltiverse_domain = {**maltiverse_domain, **resolvedIP_info}
 
         context[outputPaths['domain']].append(outputs)
         context[DBOT_SCORE_KEY].append(dbot_score)
@@ -413,7 +404,6 @@ def domain_command(client: Client, args: Dict[str, str]) -> Tuple[str, dict, Any
         markdown += f'Domain Creation Time: **{report.get("creation_time", "")}**\n'
         markdown += f'Domain Modification Time: **{report.get("modification_time", "")}**\n'
         markdown += f'Maltiverse Classification: **{report.get("classification", "")}**\n'
-        markdown += f'Domain Resolved IP: {[report["resolved_ip"][i]["ip_addr"] for i in range(len(report["resolved_ip"]))]}'
 
         reports.append(report)
 

--- a/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.yml
+++ b/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.yml
@@ -395,7 +395,7 @@ script:
     - contextPath: File.Tags
       description: Attribute to label an IoC.
       type: String
-  dockerimage: demisto/python3:3.10.5.31928
+  dockerimage: demisto/python3:3.10.8.37233
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.yml
+++ b/Packs/Maltiverse/Integrations/Maltiverse/Maltiverse.yml
@@ -186,12 +186,6 @@ script:
     - contextPath: Maltiverse.Domain.TLD
       description: Top-level domain of the hostname.
       type: String
-    - contextPath: Maltiverse.Domain.ResolvedIP.IP
-      description: Stores an IP that was resolved by the domain.
-      type: String
-    - contextPath: Maltiverse.Domain.ResolvedIP.Timestamp
-      description: Stores a timestamp when an IP address has been resolved by the domain.
-      type: Date
     - contextPath: Domain.ThreatTypes
       description: A list with the description of the elements in the block list.
       type: Unknown

--- a/Packs/Maltiverse/Integrations/Maltiverse/README.md
+++ b/Packs/Maltiverse/Integrations/Maltiverse/README.md
@@ -1,5 +1,5 @@
 Analyze suspicious hashes, URLs, domains and IP addresses
-This integration was integrated and tested with version 1.0.0-oas3 of Maltiverse
+This integration was integrated and tested with version 1.1 of Maltiverse
 
 ## Use Cases
 ---

--- a/Packs/Maltiverse/Integrations/Maltiverse/README.md
+++ b/Packs/Maltiverse/Integrations/Maltiverse/README.md
@@ -112,10 +112,7 @@ Checks the reputation of a Domain
 | Maltiverse.Domain.Tags | String | Attribute to label an IoC | 
 | Maltiverse.Domain.ModificationTime | Date | Date when the IoC was updated for the last time | 
 | Maltiverse.Domain.CreationTime | Date | Date when a IoC was inserted for the first time | 
-| Maltiverse.Domain.TLD | String | Top level domain of the hostname | 
-| Maltiverse.Domain.ResolvedIP.IP | String | Stores an IP that was resolved by the domain | 
-| Maltiverse.Domain.ResolvedIP.Timestamp | Date | Stores an timestamp when an IP address has been resolved by the domain | 
-
+| Maltiverse.Domain.TLD | String | Top level domain of the hostname |
 
 ##### Command Example
 ```!domain domain=google.com```

--- a/Packs/Maltiverse/Integrations/Maltiverse/test_data/response_constants.py
+++ b/Packs/Maltiverse/Integrations/Maltiverse/test_data/response_constants.py
@@ -81,12 +81,6 @@ DOMAIN_RESPONSE = {
     'entropy': 2.6464393446710157,
     'hostname': 'google.com',
     'modification_time': '2020-04-03 10:41:04',
-    'resolved_ip': [
-        {
-            'ip_addr': '172.217.7.174',
-            'timestamp': '2019-03-17 12:57:27'
-        }
-    ],
     'tag': ['phishing'],
     'tld': 'com',
     'type': 'hostname'

--- a/Packs/Maltiverse/Integrations/Maltiverse/test_data/result_constants.py
+++ b/Packs/Maltiverse/Integrations/Maltiverse/test_data/result_constants.py
@@ -143,11 +143,7 @@ EXPECTED_DOMAIN_RESULT = {
                     'Ref': [2],
                     'Source': 'Maltiverse Research Team'
                 }
-            ],
-            'ResolvedIP': {
-                'IP': ['172.217.7.174'],
-                'Timestamp': ['2019-03-17 12:57:27']
-            }
+            ]
         }
     ]
 }

--- a/Packs/Maltiverse/ReleaseNotes/1_0_20.json
+++ b/Packs/Maltiverse/ReleaseNotes/1_0_20.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"emoved the ***Maltiverse.Domain.ResolvedIP.IP*** and ***Maltiverse.Domain.ResolvedIP.Timestamp*** outputs as they are not supported by the updated API version."}

--- a/Packs/Maltiverse/ReleaseNotes/1_0_20.md
+++ b/Packs/Maltiverse/ReleaseNotes/1_0_20.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Maltiverse
+- **Breaking changes**: Removed the ***Maltiverse.Domain.ResolvedIP.IP*** and ***Maltiverse.Domain.ResolvedIP.Timestamp*** outputs as they are not supported by the updated API version.
+- Updated the Docker image to: *demisto/python3:3.10.8.37233*.

--- a/Packs/Maltiverse/pack_metadata.json
+++ b/Packs/Maltiverse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Maltiverse",
     "description": "Maltiverse helps you to analyze suspicious hashes, URLs, domains, and IP addresses.",
     "support": "xsoar",
-    "currentVersion": "1.0.19",
+    "currentVersion": "1.0.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
The domain command is not returning the resolvedIP anymore in the new API version 1.1
Removed the outputs 

## Does it break backward compatibility?
   - [x] Yes

