### PR TITLE
Enable sending non-JSON formatted data in generic api requests

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
@@ -2436,6 +2436,7 @@ Generic call to ServiceNow api
 | --- | --- | --- |
 | method | action to be performed on path. Possible values are: GET, POST, PATCH, DELETE. Default is 0. | Required | 
 | path | the API path starting with forward slash (/). | Required | 
+| json_body | whether or not the request body is json. Possible values are: true, false. Default is false. | Optional |
 | body | json to send in body. | Optional | 
 | headers | json of headers to add. | Optional | 
 | sc_api | Service Catalog Call. Possible values are: true, false. Default is false. | Optional | 

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2670,7 +2670,7 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
     json_body = args.get("json_body", "true")
-   try:
+    try:
         body: Dict = json.loads(str(args.get("body", {})))
     except ValueError:
         body = args.get("body", "")

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2670,9 +2670,9 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
     json_body = args.get("json_body", "true")
-    if json_body == "true":
+   try:
         body: Dict = json.loads(str(args.get("body", {})))
-    else:
+    except ValueError:
         body = args.get("body", "")
     sc_api: bool = argToBoolean(args.get("sc_api", False))
     cr_api: bool = argToBoolean(args.get("cr_api", False))

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2673,7 +2673,7 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     if json_body == "true":
         body: Dict = json.loads(str(args.get("body", {})))
     else:
-        body = args.get("body")
+        body = args.get("body", "")
     sc_api: bool = argToBoolean(args.get("sc_api", False))
     cr_api: bool = argToBoolean(args.get("cr_api", False))
 

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2669,7 +2669,11 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     method = str(args.get("method"))
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
-    body: Dict = json.loads(str(args.get("body", {})))
+    json_body = args.get("json_body", "true")
+    if json_body == "true":
+        body: Dict = json.loads(str(args.get("body", {})))
+    else:
+        body = args.get("body")
     sc_api: bool = argToBoolean(args.get("sc_api", False))
     cr_api: bool = argToBoolean(args.get("cr_api", False))
 

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2669,7 +2669,6 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     method = str(args.get("method"))
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
-    json_body = args.get("json_body", "true")
     try:
         body: Dict = json.loads(str(args.get("body", {})))
     except ValueError:

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -11,14 +11,12 @@ configuration:
   name: credentials
   required: false
   type: 9
-- additionalinfo: Select this checkbox if to use OAuth 2.0 authentication. See (?)
-    for more information.
+- additionalinfo: Select this checkbox if to use OAuth 2.0 authentication. See (?) for more information.
   display: Use OAuth Login
   name: use_oauth
   required: false
   type: 8
-- additionalinfo: 'The ticket type can be: incident, problem, change_request, sc_request,
-    sc_task or sc_req_item.'
+- additionalinfo: 'The ticket type can be: incident, problem, change_request, sc_request, sc_task or sc_req_item.'
   defaultvalue: incident
   display: Default ticket type for running ticket commands and fetching incidents
   name: ticket_type
@@ -43,8 +41,7 @@ configuration:
   required: false
   type: 0
 - defaultvalue: 10 minutes
-  display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3
-    months, 1 year)
+  display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days, 3 months, 1 year)
   name: fetch_time
   required: false
   type: 0
@@ -56,8 +53,7 @@ configuration:
   required: false
   type: 0
 - defaultvalue: number
-  display: ServiceNow ticket column to be set as the incident name. Default is the
-    incident number
+  display: ServiceNow ticket column to be set as the incident name. Default is the incident number
   name: incident_name
   required: false
   type: 0
@@ -69,9 +65,7 @@ configuration:
   name: get_attachments
   required: false
   type: 8
-- additionalinfo: 'Choose the direction to mirror the incident: Incoming (from ServiceNow
-    to XSOAR), Outgoing (from XSOAR to ServiceNow), or Incoming and Outgoing (from/to
-    XSOAR and ServiceNow).'
+- additionalinfo: 'Choose the direction to mirror the incident: Incoming (from ServiceNow to XSOAR), Outgoing (from XSOAR to ServiceNow), or Incoming and Outgoing (from/to XSOAR and ServiceNow).'
   defaultvalue: None
   display: Incident Mirroring Direction
   name: mirror_direction
@@ -88,8 +82,7 @@ configuration:
   name: comment_tag
   required: false
   type: 0
-- additionalinfo: Choose the tag to add to an entry to mirror it as a work note in
-    ServiceNow.
+- additionalinfo: Choose the tag to add to an entry to mirror it as a work note in ServiceNow.
   defaultvalue: work_notes
   display: Work Note Entry Tag
   name: work_notes_tag
@@ -107,36 +100,30 @@ configuration:
   name: file_tag_from_service_now
   required: false
   type: 0
-- additionalinfo: According to the timestamp in this field, records will be queried
-    to check for updates.
+- additionalinfo: According to the timestamp in this field, records will be queried to check for updates.
   defaultvalue: sys_updated_on
   display: Timestamp field to query for updates as part of the mirroring flow
   name: update_timestamp_field
   required: false
   type: 0
-- additionalinfo: If a greater number of incidents than the limit were modified, then
-    they won't be mirrored in.
+- additionalinfo: If a greater number of incidents than the limit were modified, then they won't be mirrored in.
   defaultvalue: '100'
   display: How many incidents to mirror incoming each time
   name: mirror_limit
   required: false
   type: 0
-- additionalinfo: "Custom (user defined) fields in the format: u_fieldname1,u_fieldname2\
-    \ custom fields start with a 'u_'. These fields will be included in the mirroring\
-    \ capabilities, if added here."
+- additionalinfo: "Custom (user defined) fields in the format: u_fieldname1,u_fieldname2 custom fields start with a 'u_'. These fields will be included in the mirroring capabilities, if added here."
   display: Custom Fields to Mirror
   name: custom_fields
   required: false
   type: 12
-- additionalinfo: When selected, closing the ServiceNow ticket is mirrored in Cortex
-    XSOAR.
+- additionalinfo: When selected, closing the ServiceNow ticket is mirrored in Cortex XSOAR.
   defaultvalue: 'false'
   display: Close Mirrored XSOAR Incident
   name: close_incident
   required: false
   type: 8
-- additionalinfo: Define how to close the mirrored tickets,
-    choose 'resolved' to enable reopening from the UI. Otherwise, choose 'closed'.
+- additionalinfo: Define how to close the mirrored tickets, choose 'resolved' to enable reopening from the UI. Otherwise, choose 'closed'.
   defaultvalue: None
   display: Mirrored ServiceNow Ticket closure method
   name: close_ticket_multiple_options
@@ -170,13 +157,11 @@ configuration:
   type: 19
 - defaultvalue: 0
   display: 'Advanced: Minutes to look back when fetching'
-  additionalinfo: Use this parameter to determine how long backward to look in the search for incidents
-    that were created before the last run time and did not match the query when they were created.
+  additionalinfo: Use this parameter to determine how long backward to look in the search for incidents that were created before the last run time and did not match the query when they were created.
   name: look_back
   required: false
   type: 0
-description: Use The ServiceNow IT Service Management (ITSM) solution to modernize
-  the way you manage and deliver services to your users.
+description: Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.
 display: ServiceNow v2
 name: ServiceNow v2
 script:
@@ -187,8 +172,7 @@ script:
       name: id
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -209,13 +193,11 @@ script:
       - 'false'
     - description: 'Custom fields on which to query. For example: state_code=AR;time_zone=PST.'
       name: custom_fields
-    - description: Additional fields to display in the War Room entry and incident
-        context.
+    - description: Additional fields to display in the War Room entry and incident context.
       isArray: true
       name: additional_fields
     - defaultValue: ;
-      description: The delimiter character to use as a separator for a list of fields
-        in an argument for this command. Default is ';'.
+      description: The delimiter character to use as a separator for a list of fields in an argument for this command. Default is ';'.
       name: fields_delimiter
     description: Retrieves ticket information by ticket ID.
     name: servicenow-get-ticket
@@ -293,8 +275,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       isArray: false
       name: ticket_type
       predefined:
@@ -309,8 +290,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket urgency. You can either select from the predefined options
-        or enter another value. For example, "Urgent" or "5".
+      description: Ticket urgency. You can either select from the predefined options or enter another value. For example, "Urgent" or "5".
       isArray: false
       name: urgency
       predefined:
@@ -321,8 +301,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket severity. You can either select from the predefined options
-        or enter another value. For example, "Urgent" or "5".
+      description: Ticket severity. You can either select from the predefined options or enter another value. For example, "Urgent" or "5".
       isArray: false
       name: severity
       predefined:
@@ -426,9 +405,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket's close code. Can be "Solved (Work Around)", "Solved (Permanently)",
-        "Solved Remotely (Work Around)", "Solved Remotely (Permanently)", "Not Solved
-        (Not Reproducible)", "Not Solved (Too Costly)", or "Closed/Resolved by Caller".
+      description: Ticket's close code. Can be "Solved (Work Around)", "Solved (Permanently)", "Solved Remotely (Work Around)", "Solved Remotely (Permanently)", "Not Solved (Not Reproducible)", "Not Solved (Too Costly)", or "Closed/Resolved by Caller".
       isArray: false
       name: close_code
       predefined:
@@ -539,8 +516,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Whether the ticket is solved in the knowledge base. Can be "true"
-        or "false".
+      description: Whether the ticket is solved in the knowledge base. Can be "true" or "false".
       isArray: false
       name: knowledge
       predefined:
@@ -607,8 +583,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'The date/time that the ticket was resolved, in the format: YYYY-MM-DD
-        HH:MM:SS.'
+      description: 'The date/time that the ticket was resolved, in the format: YYYY-MM-DD HH:MM:SS.'
       isArray: false
       name: resolved_at
       required: false
@@ -644,8 +619,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Last date/time that the system was updated, in the format: YYYY-MM-DD
-        HH:MM:SS.'
+      description: 'Last date/time that the system was updated, in the format: YYYY-MM-DD HH:MM:SS.'
       isArray: false
       name: sys_updated_on
       required: false
@@ -724,8 +698,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'Custom (user defined) fields in the format: fieldname1=value;fieldname2=value;
-        custom fields start with a "u_".'
+      description: 'Custom (user defined) fields in the format: fieldname1=value;fieldname2=value; custom fields start with a "u_".'
       isArray: false
       name: custom_fields
       required: false
@@ -733,8 +706,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: normal
-      description: Type of Change Request ticket. Can be "normal", "standard", or
-        "emergency". Default is "normal".
+      description: Type of Change Request ticket. Can be "normal", "standard", or "emergency". Default is "normal".
       isArray: false
       name: change_type
       predefined:
@@ -776,9 +748,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: 'false'
-      description: Flag that indicates whether to set field values using the display
-        value or the actual value. 'true' treats input values as the display value.
-        'false' treats input values as actual values. Default is false.
+      description: Flag that indicates whether to set field values using the display value or the actual value. 'true' treats input values as the display value. 'false' treats input values as actual values. Default is false.
       isArray: false
       name: input_display_value
       predefined:
@@ -788,8 +758,7 @@ script:
       secret: false
     - default: false
       defaultValue: ;
-      description: The delimiter character to use as a separator for a list of fields
-        in an argument for this command. Default is ';'.
+      description: The delimiter character to use as a separator for a list of fields in an argument for this command. Default is ';'.
       isArray: false
       name: fields_delimiter
       required: false
@@ -800,9 +769,9 @@ script:
       isArray: false
       name: business_criticality
       predefined:
-        - 3 - Non-Critical
-        - 2 - High
-        - 1 - Critical
+      - 3 - Non-Critical
+      - 2 - High
+      - 1 - Critical
       required: false
       secret: false
     - default: false
@@ -865,8 +834,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       isArray: false
       name: ticket_type
       predefined:
@@ -881,8 +849,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket urgency. You can either select from the predefined options
-        or enter another value. For example, "Urgent" or "5".
+      description: Ticket urgency. You can either select from the predefined options or enter another value. For example, "Urgent" or "5".
       isArray: false
       name: urgency
       predefined:
@@ -893,8 +860,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket severity. You can either select from the predefined options
-        or enter another value. For example, "Urgent" or "5".
+      description: Ticket severity. You can either select from the predefined options or enter another value. For example, "Urgent" or "5".
       isArray: false
       name: severity
       predefined:
@@ -943,8 +909,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'The ticket approval set date/time, in the format: "2016-07-02
-        21:51:11".'
+      description: 'The ticket approval set date/time, in the format: "2016-07-02 21:51:11".'
       isArray: false
       name: approval_set
       required: false
@@ -999,9 +964,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Ticket's close code. Can be "Solved (Work Around)", "Solved (Permanently)",
-        "Solved Remotely (Work Around)", "Solved Remotely (Permanently)", "Not Solved
-        (Not Reproducible)", "Not Solved (Too Costly)", or "Closed/Resolved by Caller".
+      description: Ticket's close code. Can be "Solved (Work Around)", "Solved (Permanently)", "Solved Remotely (Work Around)", "Solved Remotely (Permanently)", "Not Solved (Not Reproducible)", "Not Solved (Too Costly)", or "Closed/Resolved by Caller".
       isArray: false
       name: close_code
       predefined:
@@ -1112,8 +1075,7 @@ script:
       secret: false
     - auto: PREDEFINED
       default: false
-      description: Whether the ticket is solved in the knowledge base. Can be "true"
-        or "false".
+      description: Whether the ticket is solved in the knowledge base. Can be "true" or "false".
       isArray: false
       name: knowledge
       predefined:
@@ -1295,8 +1257,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: 'Custom (user defined) fields in the format: fieldname1=value;fieldname2=value;
-        custom fields start with a "u_".'
+      description: 'Custom (user defined) fields in the format: fieldname1=value;fieldname2=value; custom fields start with a "u_".'
       isArray: false
       name: custom_fields
       required: false
@@ -1304,8 +1265,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: normal
-      description: Type of Change Request ticket. Can be "normal", "standard", or
-        "emergency". Default is "normal".
+      description: Type of Change Request ticket. Can be "normal", "standard", or "emergency". Default is "normal".
       isArray: false
       name: change_type
       predefined:
@@ -1341,9 +1301,7 @@ script:
     - auto: PREDEFINED
       default: false
       defaultValue: 'false'
-      description: Flag that indicates whether to set field values using the display
-        value or the actual value. 'true' treats input values as the display value.
-        'false' treats input values as actual values. Default is false.
+      description: Flag that indicates whether to set field values using the display value or the actual value. 'true' treats input values as the display value. 'false' treats input values as actual values. Default is false.
       isArray: false
       name: input_display_value
       predefined:
@@ -1353,8 +1311,7 @@ script:
       secret: false
     - default: false
       defaultValue: ;
-      description: The delimiter character to use as a separator for a list of fields
-        in an argument for this command. Default is ';'.
+      description: The delimiter character to use as a separator for a list of fields in an argument for this command. Default is ';'.
       isArray: false
       name: fields_delimiter
       required: false
@@ -1371,9 +1328,9 @@ script:
       isArray: false
       name: business_criticality
       predefined:
-        - 3 - Non-Critical
-        - 2 - High
-        - 1 - Critical
+      - 3 - Non-Critical
+      - 2 - High
+      - 1 - Critical
       required: false
       secret: false
     - default: false
@@ -1391,8 +1348,7 @@ script:
       name: id
       required: true
     - auto: PREDEFINED
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item", or "sn_si_incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item", or "sn_si_incident".
       name: ticket_type
       predefined:
       - incident
@@ -1410,8 +1366,7 @@ script:
       name: limit
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -1426,12 +1381,10 @@ script:
     - defaultValue: '0'
       description: Starting record index from which to begin retrieving records.
       name: offset
-    - description: Additional fields to present in the War Room entry and incident
-        context. Can be nested (in the form of field1.field2).
+    - description: Additional fields to present in the War Room entry and incident context. Can be nested (in the form of field1.field2).
       isArray: true
       name: additional_fields
-    - description: 'System parameters in the format: fieldname1=value;fieldname2=value.
-        For example: "sysparm_display_value=true;sysparm_exclude_reference_link=True"'
+    - description: 'System parameters in the format: fieldname1=value;fieldname2=value. For example: "sysparm_display_value=true;sysparm_exclude_reference_link=True"'
       name: system_params
     description: Retrieves ticket information according to the supplied query.
     name: servicenow-query-tickets
@@ -1446,9 +1399,7 @@ script:
       description: The date/time when the ticket was created.
       type: date
     - contextPath: Ticket.Assignee
-      description: Specifies the user assigned to complete the ticket. By default,
-        this field uses a reference qualifier to only display users with the ITIL
-        role.
+      description: Specifies the user assigned to complete the ticket. By default, this field uses a reference qualifier to only display users with the ITIL role.
       type: string
     - contextPath: Ticket.State
       description: Status of the ticket.
@@ -1460,8 +1411,7 @@ script:
       description: The display value of the ticket.
       type: string
     - contextPath: Ticket.Active
-      description: Specifies whether work is still being done on a task or whether
-        the work for the task is complete.
+      description: Specifies whether work is still being done on a task or whether the work for the task is complete.
       type: boolean
     - contextPath: Ticket.AdditionalComments
       description: Comments about the task record.
@@ -1481,8 +1431,7 @@ script:
       required: true
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -1491,12 +1440,10 @@ script:
       - sc_request
       - sc_task
       - sn_si_incident
-    - description: The actual link to publish in ServiceNow ticket, in a valid URL
-        format, for example, http://www.demisto.com.
+    - description: The actual link to publish in ServiceNow ticket, in a valid URL format, for example, http://www.demisto.com.
       name: link
       required: true
-    - description: Whether to publish the link as comment on the ticket. Can be "true"
-        or "false". If false will publish the link as WorkNote.
+    - description: Whether to publish the link as comment on the ticket. Can be "true" or "false". If false will publish the link as WorkNote.
       name: post-as-comment
     - description: The text to represent the link.
       name: text
@@ -1508,8 +1455,7 @@ script:
       required: true
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -1523,8 +1469,7 @@ script:
       required: true
     - auto: PREDEFINED
       defaultValue: 'false'
-      description: Whether to publish the note as comment on the ticket. Can be "true"
-        or "false". Default is "false".
+      description: Whether to publish the note as comment on the ticket. Can be "true" or "false". Default is "false".
       name: post-as-comment
       predefined:
       - 'true'
@@ -1537,8 +1482,7 @@ script:
       required: true
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -1550,8 +1494,7 @@ script:
     - description: War Room entry ID that includes the file.
       name: file_id
       required: true
-    - description: Filename of the uploaded file to override the existing file name
-        in the entry.
+    - description: Filename of the uploaded file to override the existing file name in the entry.
       name: file_name
     description: Uploads a file to the specified ticket.
     name: servicenow-upload-file
@@ -1569,8 +1512,7 @@ script:
     - description: Record System ID.
       name: id
       required: true
-    - description: Comma-separated list of table fields to display and output to the
-        context. For example, name,tag,company. ID field is added by default.
+    - description: Comma-separated list of table fields to display and output to the context. For example, name,tag,company. ID field is added by default.
       name: fields
     - description: The name of the table from which to get the record.
       name: table_name
@@ -1582,12 +1524,10 @@ script:
       description: The unique record identifier for the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedBy
-      description: A string field that indicates the user who most recently updated
-        the record.
+      description: A string field that indicates the user who most recently updated the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedAt
-      description: A time-stamp field that indicates the date and time of the most
-        recent update.
+      description: A time-stamp field that indicates the date and time of the most recent update.
       type: date
     - contextPath: ServiceNow.Record.CreatedBy
       description: A string field that indicates the user who created the record.
@@ -1602,18 +1542,15 @@ script:
     - defaultValue: '10'
       description: The maximum number of tickets to retrieve.
       name: limit
-    - description: The query to run. For more information about querying in ServiceNow,
-        see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+    - description: The query to run. For more information about querying in ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
       name: query
-    - description: Comma-separated list of table fields to display and output to the
-        context. For example, name,tag,company. ID field is added by default.
+    - description: Comma-separated list of table fields to display and output to the context. For example, name,tag,company. ID field is added by default.
       isArray: true
       name: fields
     - defaultValue: '0'
       description: Starting record index from which to begin retrieving records.
       name: offset
-    - description: 'System parameters in the format: fieldname1=value;fieldname2=value.
-        For example: "sysparm_display_value=true&sysparm_exclude_reference_link=True"'
+    - description: 'System parameters in the format: fieldname1=value;fieldname2=value. For example: "sysparm_display_value=true&sysparm_exclude_reference_link=True"'
       name: system_params
     description: Queries the specified table in ServiceNow.
     name: servicenow-query-table
@@ -1622,12 +1559,10 @@ script:
       description: The unique record identifier for the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedBy
-      description: A string field that indicates the user who most recently updated
-        the record.
+      description: A string field that indicates the user who most recently updated the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedAt
-      description: A time-stamp field that indicates the date and time of the most
-        recent update.
+      description: A time-stamp field that indicates the date and time of the most recent update.
       type: date
     - contextPath: ServiceNow.Record.CreatedBy
       description: A string field that indicates the user who created the record.
@@ -1639,23 +1574,19 @@ script:
     - description: The name of the table in which to create a record.
       name: table_name
       required: true
-    - description: 'Fields and their values to create the record with, in the format:
-        fieldname1=value;fieldname2=value;...'
+    - description: 'Fields and their values to create the record with, in the format: fieldname1=value;fieldname2=value;...'
       name: fields
     - description: 'Custom (user defined) fields in the format: fieldname1=value;fieldname2=value;...'
       name: custom_fields
     - auto: PREDEFINED
       defaultValue: 'false'
-      description: Flag that indicates whether to set field values using the display
-        value or the actual value. 'true' treats input value as the display value.
-        'false' treats input values as actual values. Default is false.
+      description: Flag that indicates whether to set field values using the display value or the actual value. 'true' treats input value as the display value. 'false' treats input values as actual values. Default is false.
       name: input_display_value
       predefined:
       - 'false'
       - 'true'
     - defaultValue: ;
-      description: The delimiter character to use as a separator for a list of fields
-        in an argument for this command. Default is ';'.
+      description: The delimiter character to use as a separator for a list of fields in an argument for this command. Default is ';'.
       name: fields_delimiter
     description: Creates a new record in the specified ServiceNow table.
     name: servicenow-create-record
@@ -1664,12 +1595,10 @@ script:
       description: The unique record identifier for the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedBy
-      description: A string field that indicates the user who most recently updated
-        the record.
+      description: A string field that indicates the user who most recently updated the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedAt
-      description: A time-stamp field that indicates the date and time of the most
-        recent update.
+      description: A time-stamp field that indicates the date and time of the most recent update.
       type: date
     - contextPath: ServiceNow.Record.CreatedBy
       description: A string field that indicates the user who created the record.
@@ -1684,24 +1613,19 @@ script:
     - description: The system ID of the ticket to update.
       name: id
       required: true
-    - description: 'Fields and their values to update in the record, in the format:
-        fieldname1=value;fieldname2=value;...'
+    - description: 'Fields and their values to update in the record, in the format: fieldname1=value;fieldname2=value;...'
       name: fields
-    - description: 'Custom (user defined) fields and their values to update in the
-        record, in the format: fieldname1=value;fieldname2=value;...'
+    - description: 'Custom (user defined) fields and their values to update in the record, in the format: fieldname1=value;fieldname2=value;...'
       name: custom_fields
     - auto: PREDEFINED
       defaultValue: 'false'
-      description: Flag that indicates whether to set field values using the display
-        value or the actual value. 'true' treats input value as the display value.
-        'false' treats input values as actual values. Default is false.
+      description: Flag that indicates whether to set field values using the display value or the actual value. 'true' treats input value as the display value. 'false' treats input values as actual values. Default is false.
       name: input_display_value
       predefined:
       - 'false'
       - 'true'
     - defaultValue: ;
-      description: The delimiter character to use as a separator for a list of fields
-        in an argument for this command. Default is ';'.
+      description: The delimiter character to use as a separator for a list of fields in an argument for this command. Default is ';'.
       name: fields_delimiter
     - description: A comma-separated list of fields to clear.
       isArray: true
@@ -1713,12 +1637,10 @@ script:
       description: The unique record identifier for the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedBy
-      description: A string field that indicates the user who most recently updated
-        the record.
+      description: A string field that indicates the user who most recently updated the record.
       type: string
     - contextPath: ServiceNow.Record.UpdatedAt
-      description: A time-stamp field that indicates the date and time of the most
-        recent update.
+      description: A time-stamp field that indicates the date and time of the most recent update.
       type: date
     - contextPath: ServiceNow.Record.CreatedBy
       description: A string field that indicates the user who created the record.
@@ -1750,8 +1672,7 @@ script:
       name: computer_id
     - description: Query by computer name.
       name: computer_name
-    - description: Query by specified query, for more information about querying in
-        ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+    - description: Query by specified query, for more information about querying in ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
       name: query
     - description: Query by asset tag.
       name: asset_tag
@@ -1802,8 +1723,7 @@ script:
       name: group_id
     - description: Query by group name.
       name: group_name
-    - description: Query by specified query, for more information about querying in
-        ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+    - description: Query by specified query, for more information about querying in ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
       name: query
     - defaultValue: '10'
       description: Maximum number of query results. Default is 10.
@@ -1834,8 +1754,7 @@ script:
       name: user_id
     - description: Query by username.
       name: user_name
-    - description: Query by specified query, for more information about querying in
-        ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+    - description: Query by specified query, for more information about querying in ServiceNow, see https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
       name: query
     - defaultValue: '10'
       description: Maximum number of query results. Default is 10.
@@ -1865,8 +1784,7 @@ script:
       description: Date/time the user was last updated.
       type: date
   - arguments:
-    - description: 'The table label, for example: Asset, Incident, IP address, and
-        so on.'
+    - description: 'The table label, for example: Asset, Incident, IP address, and so on.'
       name: label
       required: true
     - defaultValue: '10'
@@ -1897,8 +1815,7 @@ script:
     - defaultValue: '0'
       description: Offset of the ticket notes.
       name: offset
-    description: Gets notes from the specified ServiceNow ticket. "Read permissions"
-      are required for the sys_journal_field table.
+    description: Gets notes from the specified ServiceNow ticket. "Read permissions" are required for the sys_journal_field table.
     name: servicenow-get-ticket-notes
     outputs:
     - contextPath: ServiceNow.Ticket.ID
@@ -1920,8 +1837,7 @@ script:
     - description: Ticket System ID.
       name: id
       required: true
-    - description: Tag system ID. Can be retrieved using the "!servicenow-query-table
-        table_name=label fields=name,active,sys_id" command.
+    - description: Tag system ID. Can be retrieved using the "!servicenow-query-table table_name=label fields=name,active,sys_id" command.
       name: tag_id
       required: true
     - description: 'Tag title. For example: "Incident - INC000001".'
@@ -1929,8 +1845,7 @@ script:
       required: true
     - auto: PREDEFINED
       defaultValue: incident
-      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request",
-        "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
+      description: Ticket type. Can be "incident", "problem", "change_request", "sc_request", "sc_task", "sc_req_item" or "sn_si_incident". Default is "incident".
       name: ticket_type
       predefined:
       - incident
@@ -1940,9 +1855,7 @@ script:
       - sc_task
       - sc_req_item
       - sn_si_incident
-    description: Adds a tag to a ticket. The added tag entry will be visible in the
-      label_entry table and can be retrieved using the "!servicenow-query-table table_name=label_entry
-      fields=title,table,sys_id,id_display,id_type" command.
+    description: Adds a tag to a ticket. The added tag entry will be visible in the label_entry table and can be retrieved using the "!servicenow-query-table table_name=label_entry fields=title,table,sys_id,id_display,id_type" command.
     name: servicenow-add-tag
     outputs:
     - contextPath: ServiceNow.Ticket.ID
@@ -2016,9 +1929,7 @@ script:
     - description: Quantity of the item to order.
       name: quantity
       required: true
-    - description: If there are mandatory variables defined for the item, they must
-        be passed to the endpoint. Can be retrieved using the !servicenow-get-item-details
-        command. For example, var1=value1;var2=value2.
+    - description: If there are mandatory variables defined for the item, they must be passed to the endpoint. Can be retrieved using the !servicenow-get-item-details command. For example, var1=value1;var2=value2.
       name: variables
     description: Orders the specified catalog item.
     name: servicenow-create-item-order
@@ -2030,8 +1941,7 @@ script:
       description: Number of the generated request.
       type: String
   - arguments:
-    - description: Queue ID. Can be retrieved using the "!servicenow-query-table table_name=awa_queue
-        fields=name,number,order" command.
+    - description: Queue ID. Can be retrieved using the "!servicenow-query-table table_name=awa_queue fields=name,number,order" command.
       name: queue_id
       required: true
     - defaultValue: incident
@@ -2040,9 +1950,7 @@ script:
     - description: Document ID.
       name: document_id
       required: true
-    description: Documents a route to a queue. Requires an installation of the Advanced
-      Work Assignments plugin. An active queue and service channel to the designated
-      table.
+    description: Documents a route to a queue. Requires an installation of the Advanced Work Assignments plugin. An active queue and service channel to the designated table.
     name: servicenow-document-route-to-queue
     outputs:
     - contextPath: ServiceNow.WorkItem.WorkItemID
@@ -2058,8 +1966,7 @@ script:
       description: Unique ID of the queue on which to route a document.
       type: String
     - contextPath: ServiceNow.WorkItem.DisplayName
-      description: 'Name of the document to be routed by this work item, for example:
-        case record.'
+      description: 'Name of the document to be routed by this work item, for example: case record.'
       type: String
   - arguments: []
     description: Returns the list of fields for an incident type.
@@ -2071,8 +1978,7 @@ script:
     - description: Retrieve entries that were created after lastUpdate.
       name: lastUpdate
       required: true
-    description: Get remote data from a remote incident. This method does not update
-      the current incident, and should be used for debugging purposes.
+    description: Get remote data from a remote incident. This method does not update the current incident, and should be used for debugging purposes.
     name: get-remote-data
   - arguments:
     - description: The username to use for login.
@@ -2083,21 +1989,15 @@ script:
       name: password
       required: true
       secret: true
-    description: This function should be used once before running any command when
-      using OAuth2 authentication.
+    description: This function should be used once before running any command when using OAuth2 authentication.
     name: servicenow-oauth-login
   - arguments: []
     description: Test the instance configuration when using OAuth2 authentication.
     name: servicenow-oauth-test
   - arguments:
-    - description: Date string in local time representing the last time the incident
-        was updated. The incident is only returned if it was modified after the last
-        update time.
+    - description: Date string in local time representing the last time the incident was updated. The incident is only returned if it was modified after the last update time.
       name: lastUpdate
-    description: Gets the list of incidents that were modified since the last update
-      time. Note that this method is here for debugging purposes. The get-modified-remote-data
-      command is used as part of a Mirroring feature, which is available from version
-      6.1.
+    description: Gets the list of incidents that were modified since the last update time. Note that this method is here for debugging purposes. The get-modified-remote-data command is used as part of a Mirroring feature, which is available from version 6.1.
     name: get-modified-remote-data
   - arguments:
     - description: Template for creating a standard change request.
@@ -2203,7 +2103,7 @@ script:
     - contextPath: ServiceNow.Generic.Response
       description: Generic response to servicenow api
       type: string
-  dockerimage: demisto/python3:3.10.8.36650
+  dockerimage: demisto/python3:3.10.8.37753
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -2179,14 +2179,7 @@ script:
     - description: the API path starting with forward slash (/)
       name: path
       required: true
-    - auto: PREDEFINED
-      defaultValue: 'true'
-      description: is the body json formatted
-      name: json_body
-      predefined:
-      - 'true'
-      - 'false'
-    - description: data to send in body
+    - description: data to send in body, can be json
       name: body
     - description: json of headers to add
       name: headers

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -2179,7 +2179,13 @@ script:
     - description: the API path starting with forward slash (/)
       name: path
       required: true
-    - description: json to send in body
+    - auto: PREDEFINED
+      defaultValue: 'true'
+      description: is the body json formatted
+      predefined:
+      - 'true'
+      - 'false'
+    - description: data to send in body
       name: body
     - description: json of headers to add
       name: headers

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -2182,6 +2182,7 @@ script:
     - auto: PREDEFINED
       defaultValue: 'true'
       description: is the body json formatted
+      name: json_body
       predefined:
       - 'true'
       - 'false'

--- a/Packs/ServiceNow/ReleaseNotes/2_5_0.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_0.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### ServiceNow v2
-Enable sending non-JSON formatted data in generic API requests. This is done by intruducing a new argument to servicenow-generic-api-call while keeping sane defaults to ensure backwards compatibility.
+- Enable sending non-JSON formatted data in generic API requests.

--- a/Packs/ServiceNow/ReleaseNotes/2_5_0.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_0.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### ServiceNow v2
+- Updated the Docker image to: *demisto/python3:3.10.8.37753*.
 - Enable sending non-JSON formatted data in generic API requests.

--- a/Packs/ServiceNow/ReleaseNotes/2_5_0.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_0.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### ServiceNow v2
+Enable sending non-JSON formatted data in generic API requests. This is done by intruducing a new argument to servicenow-generic-api-call while keeping sane defaults to ensure backwards compatibility.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.4.1",
+    "currentVersion": "2.5.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Added a new command argument to servicenow-generic-api-call and modified the the generic_api_call_command function to handle the new argument. Sane default value and functionality ensures backwards compatibility.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Enable seding non-JSON formatted data in servicenow-generic-api-call

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [X] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [X] No

## Must have
- [ ] Tests
- [ ] Documentation 
