### PR TITLE
Include hrefs provided by API in formatted results

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -391,6 +391,12 @@ def format_results(client, uuid, use_url_as_name):
             for ip in scan_lists.get('ips'):
                 feed_related_indicators.append({'value': ip, 'type': 'IP'})
         IP_HEADERS = ['Count', 'IP', 'ASN']
+    if 'links' in scan_data:
+        links = []
+        for o in scan_data['links']:
+            if 'href' in o:
+                links.append(o['href'])
+        cont['links'] = links
     # add redirected URLs
     if 'requests' in scan_data:
         redirected_urls = []

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -441,7 +441,7 @@ script:
   script: ''
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.8.37233
+  dockerimage: demisto/python3:3.10.8.39276
 fromversion: 5.0.0
 tests:
 - urlscan_malicious_Test

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
@@ -108,7 +108,7 @@ def test_format_results_check_lists(mocker):
     with open('./test_data/capitalne.json', 'r') as f:
         response_data = json.loads(f.read())
 
-    mocker.patch('UrlScan.urlscan_submit_request', return_value=(response_data,'',''))
+    mocker.patch('UrlScan.urlscan_submit_request', return_value=(response_data, '', ''))
     mocker.patch.object(demisto, 'results', return_value='')
     command_results_inputs = mocker.patch('UrlScan.CommandResults')
 

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
@@ -99,3 +99,23 @@ def test_urlscan_submit_url(requests_mock, mocker):
 
     metrics = response[1]
     assert metrics.execution_metrics == [{'Type': 'QuotaError', 'APICallsCount': 2}]
+
+
+def test_format_results_check_lists(mocker):
+    from UrlScan import format_results, Client
+    client = Client()
+
+    with open('./test_data/capitalne.json', 'r') as f:
+        response_data = json.loads(f.read())
+
+    mocker.patch('UrlScan.urlscan_submit_request', return_value=(response_data,'',''))
+    mocker.patch.object(demisto, 'results', return_value='')
+    command_results_inputs = mocker.patch('UrlScan.CommandResults')
+
+    format_results(client, 'uuid', '')
+    outputs = command_results_inputs.call_args[1]['outputs']['URLScan(val.URL && val.URL == obj.URL)']
+    assert outputs.get('links') == [
+        "http://capitalne.com/home",
+        "http://capitalne.com/about",
+        "https://urlscan.io/"
+    ]

--- a/Packs/UrlScan/Integrations/UrlScan/test_data/capitalne.json
+++ b/Packs/UrlScan/Integrations/UrlScan/test_data/capitalne.json
@@ -51,7 +51,21 @@
     ],
     "cookies": [],
     "console": [],
-    "links": [],
+    "links": [
+        {
+            "href": "http://capitalne.com/home",
+            "text": "home"
+        },
+        {
+            "href": "http://capitalne.com/about",
+            "text": "about"
+        },
+        {
+            "href": "https://urlscan.io/",
+            "text": "URLScan"
+
+        }
+    ],
     "timing": {
       "beginNavigation": "2020-07-23T15:21:15.008Z",
       "frameStartedLoading": "2020-07-23T15:21:31.534Z",

--- a/Packs/UrlScan/ReleaseNotes/1_2_4.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_4.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Added the content of hrefs in the HTML of the scanned site to the playbook context when running the "url" automation

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.2.3",
+    "currentVersion": "1.2.4",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Make the URLScan Integration add the content of hrefs in the HTML of the scanned site to the playbook context when running the "url" automation

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
