### PR TITLE
EWSO365: use the new credentials first

### DIFF
--- a/Packs/EWS/Integrations/EWSO365/EWSO365.py
+++ b/Packs/EWS/Integrations/EWSO365/EWSO365.py
@@ -175,9 +175,9 @@ class EWSClient:
         :param insecure: Trust any certificate (not secure)
         """
 
-        client_id = kwargs.get('client_id') or kwargs.get('_client_id')
-        tenant_id = kwargs.get('tenant_id') or kwargs.get('_tenant_id')
-        client_secret = kwargs.get('client_secret') or (kwargs.get('credentials') or {}).get('password')
+        client_id = kwargs.get('_client_id') or kwargs.get('client_id')
+        tenant_id = kwargs.get('_tenant_id') or kwargs.get('tenant_id')
+        client_secret = (kwargs.get('credentials') or {}).get('password') or kwargs.get('client_secret')
         access_type = kwargs.get('access_type', IMPERSONATION) or IMPERSONATION
 
         if not client_secret:

--- a/Packs/EWS/Integrations/EWSO365/EWSO365_test.py
+++ b/Packs/EWS/Integrations/EWSO365/EWSO365_test.py
@@ -544,7 +544,7 @@ def test_invalid_params(mocker, params, expected_result):
     assert "Exception: " + expected_result in demisto.error.call_args[0][0]
 
 
-@pytest.mark.parametrize(argnames='old_credentials, new_credentials, expected', 
+@pytest.mark.parametrize(argnames='old_credentials, new_credentials, expected',
                          argvalues=[
                              ('old_client_secret', {'password': 'new_client_secret'}, 'new_client_secret'),
                              ('old_client_secret', None, 'old_client_secret')])
@@ -559,11 +559,9 @@ def test_credentials_with_old_secret(mocker, old_credentials, new_credentials, e
     """
     mocker.patch.object(EWSClient, '_EWSClient__prepare')
     client = EWSClient(default_target_mailbox='test',
-                       credentials=new_credentials, 
+                       credentials=new_credentials,
                        client_secret=old_credentials,
                        _client_id='new_client_id',
                        _tenant_id='new_tenant_id')
-    
-    assert client.ms_client.client_secret == expected
 
-    
+    assert client.ms_client.client_secret == expected

--- a/Packs/EWS/Integrations/EWSO365/EWSO365_test.py
+++ b/Packs/EWS/Integrations/EWSO365/EWSO365_test.py
@@ -8,7 +8,7 @@ from exchangelib.attachments import AttachmentId, ItemAttachment
 from exchangelib.items import Item, Message
 from freezegun import freeze_time
 
-from EWSO365 import (ExpandGroup, GetSearchableMailboxes, fetch_emails_as_incidents,
+from EWSO365 import (ExpandGroup, GetSearchableMailboxes, EWSClient, fetch_emails_as_incidents,
                      add_additional_headers, fetch_last_emails, find_folders,
                      get_expanded_group, get_searchable_mailboxes, handle_html,
                      handle_transient_files, parse_incident_from_item)
@@ -542,3 +542,28 @@ def test_invalid_params(mocker, params, expected_result):
     EWSO365.log_stream = None
 
     assert "Exception: " + expected_result in demisto.error.call_args[0][0]
+
+
+@pytest.mark.parametrize(argnames='old_credentials, new_credentials, expected', 
+                         argvalues=[
+                             ('old_client_secret', {'password': 'new_client_secret'}, 'new_client_secret'),
+                             ('old_client_secret', None, 'old_client_secret')])
+def test_credentials_with_old_secret(mocker, old_credentials, new_credentials, expected):
+    """
+    Given:
+      - Configuration contained credentials and old client_secret
+    When:
+      - init the MS client.
+    Then:
+      - Ensure the new credentials is taken if exist and old if new doesn't exist.
+    """
+    mocker.patch.object(EWSClient, '_EWSClient__prepare')
+    client = EWSClient(default_target_mailbox='test',
+                       credentials=new_credentials, 
+                       client_secret=old_credentials,
+                       _client_id='new_client_id',
+                       _tenant_id='new_tenant_id')
+    
+    assert client.ms_client.client_secret == expected
+
+    

--- a/Packs/EWS/ReleaseNotes/2_0_1.md
+++ b/Packs/EWS/ReleaseNotes/2_0_1.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### EWS O365
+- Fixed an issue where authentication failed due to deprecated authentication configuration. 

--- a/Packs/EWS/pack_metadata.json
+++ b/Packs/EWS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "EWS",
     "description": "Exchange Web Services and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "2.0.0",
+    "currentVersion": "2.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-18854

## Description
When customer have both - the old `client_secret` and the new `credentials` configured, we should take the new and ignore the old
as the old may be expired and user don't have the simple option to remove it

@MLainer1 FYI :)

## tests
failed pytest without fix:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/79846863/205514558-ea74ce38-9e97-48b1-a41e-4d556529052d.png">


succeeded pytest after fix:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/79846863/205514458-8177058e-a4b3-4efd-80e8-7dcebe6e9b82.png">


