### PR TITLE
Add deprecated file_hash

### DIFF
--- a/Packs/CheckPointSandBlast/Integrations/CheckPointSandBlast/CheckPointSandBlast.yml
+++ b/Packs/CheckPointSandBlast/Integrations/CheckPointSandBlast/CheckPointSandBlast.yml
@@ -289,6 +289,11 @@ script:
       isArray: false
       name: file_name
       required: false
+    - description: 'File hash to query. Accepted digests are: md5, sha1 and sha256. Only md5 returns FOUND status.'
+      deprecated: true
+      isArray: false
+      name: file_hash
+      required: false
     - auto: PREDEFINED
       defaultValue: All
       description: The features to use on the file.

--- a/Packs/CheckPointSandBlast/ReleaseNotes/1_0_3.md
+++ b/Packs/CheckPointSandBlast/ReleaseNotes/1_0_3.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Check Point Threat Emulation (SandBlast)
+- Fixed a bug where uploading a file would poll unnecessarily.

--- a/Packs/CheckPointSandBlast/pack_metadata.json
+++ b/Packs/CheckPointSandBlast/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Check Point Threat Emulation (SandBlast)",
     "description": "Upload files using polling, the service supports Microsoft Office files, as well as PDF, SWF, archives and executables. Active content will be cleaned from any documents that you upload (Microsoft Office and PDF files only). Query on existing IOCs, file status, analysis, reports. Download files from the database. Supports both appliance and cloud. Supported Threat Emulation versions are any R80x.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: XSUP-18979

## Description
The argument was set but since it isnt in the yml it gets ignored. Adding as deprecated because we want this param to be hidden; it shouldnt ever be manually set. 
Ideally the query function should have been the one with polling, not upload
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
