### PR TITLE
GetFailedTasks get tenant name fix

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_10.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_10.md
@@ -1,0 +1,5 @@
+
+#### Scripts
+##### GetFailedTasks
+- Fixed an issue where multi-tenancy environments failed to execute the script due to an issue where the tenant name wasn't obtained automatically.
+

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
@@ -26,6 +26,21 @@ def get_rest_api_instance_to_use():
     return rest_api_instance_to_use
 
 
+def get_tenant_name():
+    """
+        Gets the tenant name from the server url.
+
+        Returns:
+         tenant name.
+    """
+    server_url = demisto.executeCommand("GetServerURL", {})[0].get('Contents')
+    tenant_name = ''
+    if '/acc_' in server_url:
+        tenant_name = server_url.split('acc_')[-1]
+
+    return tenant_name
+
+
 def get_failed_tasks_output(tasks: list, incident: dict):
     """
         Converts the failing task objects of an incident to context outputs.
@@ -65,21 +80,27 @@ def get_failed_tasks_output(tasks: list, incident: dict):
     return task_outputs, number_of_error_entries
 
 
-def get_incident_tasks_using_rest_api_instance(incident: dict, rest_api_instance: str):
+def get_incident_tasks_using_rest_api_instance(incident: dict, tenant_name: str, rest_api_instance: str):
     """
         Returns the failing task objects of an incident using the given rest API instance.
 
         Args:
             incident (dict): An incident object.
+            tenant_name (str): The tenant of the incident.
             rest_api_instance (str): A Demisto REST API instance name to use for fetching task details.
 
         Returns:
             List of the tasks given from the response.
     """
+    if tenant_name:
+        uri = f'acc_{tenant_name}/investigation/{str(incident["id"])}/workplan/tasks'
+    else:
+        uri = f'investigation/{str(incident["id"])}/workplan/tasks'
+
     response = demisto.executeCommand(
         "demisto-api-post",
         {
-            "uri": f'investigation/{str(incident["id"])}/workplan/tasks',
+            "uri": uri,
             "body": {
                 "states": ["Error"],
                 "types": ["regular", "condition", "collection"],
@@ -139,7 +160,8 @@ def get_incident_data(incident: dict, rest_api_instance: str = None):
             tuple of context outputs and total amount of related error entries
     """
     if rest_api_instance:
-        tasks = get_incident_tasks_using_rest_api_instance(incident, rest_api_instance)
+        tenant = get_tenant_name()
+        tasks = get_incident_tasks_using_rest_api_instance(incident, tenant, rest_api_instance)
     else:
         try:
             tasks = get_incident_tasks_using_internal_request(incident)
@@ -147,10 +169,11 @@ def get_incident_data(incident: dict, rest_api_instance: str = None):
             # using rest api call if using_internal_request fails on the following error:
             # ValueError: dial tcp connect: connection refused
             rest_api_instance = get_rest_api_instance_to_use()
+            tenant = get_tenant_name()
             if not rest_api_instance:
-                raise DemistoException('Could not find which Rest Api instance to use,'
+                raise DemistoException('Could not find which Rest API instance to use, '
                                        'Please specify the rest_api_instance argument.')
-            tasks = get_incident_tasks_using_rest_api_instance(incident, rest_api_instance)
+            tasks = get_incident_tasks_using_rest_api_instance(incident, tenant, rest_api_instance)
 
     task_outputs, tasks_error_entries_number = get_failed_tasks_output(tasks, incident)
     if task_outputs:

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
@@ -18,6 +18,7 @@ def test_get_failed_tasks(mocker, rest_api_instacne):
     mocker.patch.object(demisto, 'executeCommand', side_effect=mock_execute_command)
     mocker.patch.object(demisto, 'internalHttpRequest', return_value=INTERNAL_TASKS_RESULT)
     mocker.patch.object(demisto, 'results')
+    mocker.patch('GetFailedTasks.get_tenant_name', return_value='test')
 
     main()
 
@@ -108,6 +109,7 @@ def test_get_incident_data_using_rest_api_instance(mocker):
             - Validates that get_incident_tasks_using_rest_api_instance was called.
     """
     mock_res = mocker.patch('GetFailedTasks.get_incident_tasks_using_rest_api_instance', return_value=[])
+    mocker.patch('GetFailedTasks.get_tenant_name', return_value='test')
     result = get_incident_data(INCIDENTS_RESULT[0].get('Contents').get('data')[1], 'instance_mock')
     assert mock_res.call_count == 1
     assert result[0] == []
@@ -144,6 +146,7 @@ def test_get_incident_data_internal_http_request_fail(mocker):
     """
     internal_request_mock_res = mocker.patch('GetFailedTasks.get_incident_tasks_using_internal_request', side_effect=ValueError)
     mocker.patch('GetFailedTasks.get_rest_api_instance_to_use', return_value='instance_mock')
+    mocker.patch('GetFailedTasks.get_tenant_name', return_value='test')
     api_instanc_mock_res = mocker.patch('GetFailedTasks.get_incident_tasks_using_rest_api_instance', return_value=[])
 
     result = get_incident_data(INCIDENTS_RESULT[0].get('Contents').get('data')[1])

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/README.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/README.md
@@ -20,14 +20,14 @@ For more information, see the section about permissions here: [https://docs.palo
 ---
 This script is used in the following playbooks and scripts.
 * Integrations and Playbooks Health Check - Running Scripts
-
+    
 ## Inputs
 ---
 
 | **Argument Name** | **Description** |
 | --- | --- |
 | query | The query by which to retrieve failed tasks. Optional. The default value is "-status:closed" |
-| tenant_name | The tenant name. |
+| rest_api_instance | The Rest API instance to use. |
 | max_incidents | Maximum number of incidents to query. Maximum is 1000. |
 
 ## Outputs
@@ -35,4 +35,5 @@ This script is used in the following playbooks and scripts.
 There are no outputs for this script.
 
 ## Troubleshooting
-In order for the automation script to be able to retrieve the failed tasks, the API key configured in the Demisto REST API integration, need to be of a user with *Read* permissions to the queried incident.
+Multi tenant environments should be configured with Cortex Rest API instances when using this automation.
+In order for the automation script to be able to retrieve the failed tasks, the API key configured in the Cortex REST API integration, need to be of a user with *Read* permissions to the queried incident.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.3.9",
+    "currentVersion": "1.3.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Reverted some of the code that was removed [here](https://github.com/demisto/content/pull/21630). In case the user is using RestAPI in MT env, we should get the tenant name. CS also tested this version and confirmed it was working as expected.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
