### PR TITLE
Fixed the description of "playbook-Cloud_Response_-_AWS" playbook.

### DIFF
--- a/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Cloud_Response_-_AWS.yml
+++ b/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Cloud_Response_-_AWS.yml
@@ -2,7 +2,7 @@ id: Cloud Response - AWS
 version: -1
 name: Cloud Response - AWS
 description: |-
-  This playbook provides response actions to Azure. The following are available for execution automatically/manually:
+  This playbook provides response actions to AWS. The following are available for execution automatically/manually:
    - Resource remediation:
      - Terminate the instance
      - Stop the instance

--- a/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Cloud_Response_-_AWS_README.md
+++ b/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Cloud_Response_-_AWS_README.md
@@ -1,4 +1,4 @@
-This playbook provides response actions to Azure. The following are available for execution automatically/manually:
+This playbook provides response actions to AWS. The following are available for execution automatically/manually:
  - Resource remediation:
    - Terminate the instance
    - Stop the instance

--- a/Packs/AWS-Enrichment-Remediation/ReleaseNotes/1_0_2.md
+++ b/Packs/AWS-Enrichment-Remediation/ReleaseNotes/1_0_2.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Cloud Response - AWS
+- Fixed the playbook description.

--- a/Packs/AWS-Enrichment-Remediation/pack_metadata.json
+++ b/Packs/AWS-Enrichment-Remediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS Enrichment and Remediation",
     "description": "Playbooks using multiple AWS content packs for enrichment and remediation purposes",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-69741?filter=-2

## Description
This playbook provides response actions to AWS and not Azure as mentioned in the playbook description on YML and README files.
