### PR TITLE
upgraded sleep time when unistalling packs

### DIFF
--- a/Tests/Marketplace/search_and_uninstall_pack.py
+++ b/Tests/Marketplace/search_and_uninstall_pack.py
@@ -154,7 +154,7 @@ def wait_for_uninstallation_to_complete(client: demisto_client, retries: int = 3
                                 'packs. Aborting.')
             logging.info(f'The process of uninstalling all packs is not over! There are still {len(installed_packs)} '
                          f'packs installed. Sleeping for 10 seconds.')
-            sleep(10)
+            sleep(60)
             installed_packs = get_all_installed_packs(client)
             retry = retry + 1
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4814

## Description
The uninstall failed on timeout after nightly that installed too much packs.
## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
