### PR TITLE
remove mitre-attack from docker native image config

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -39,13 +39,6 @@
          "ignored_native_images":[
             "native:8.1"
          ]
-      },
-      {
-         "id":"MITRE ATT&CK v2",
-         "reason":"Failed testplaybook FeedMitreAttackv2_test: taxii2 module prints out warnings messages",
-         "ignored_native_images":[
-            "native:8.1"
-         ]
       }
    ]
 }


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Removing the feed mitre attack integration from ignored images for the native-image-config 8.1 as a fix was merged in this PR: https://github.com/demisto/content/pull/22564
