### PR TITLE
Add support to legacy SSL renegotiation

### DIFF
--- a/Packs/Base/.pack-ignore
+++ b/Packs/Base/.pack-ignore
@@ -61,3 +61,4 @@ Enums
 CustomIndicator
 Mutex
 SSLAdapter
+SSL

--- a/Packs/Base/.pack-ignore
+++ b/Packs/Base/.pack-ignore
@@ -60,3 +60,4 @@ EntryType
 Enums
 CustomIndicator
 Mutex
+SSLAdapter

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Added support for SSL legacy renegotiation.
+- Added support for SSL legacy renegotiation when enabling the *Trust any certificate* parameter.

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Add support in ***SSLAdapter*** to use SSL legacy renegotiation.

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Add support in ***SSLAdapter*** to use SSL legacy renegotiation.
+Add the support in  SSL legacy renegotiation, for ***SSLAdapter***.

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-Add support for SSL legacy renegotiation in ***SSLAdapter***.
+- Added support for SSL the legacy renegotiation.

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-Add the support in  SSL legacy renegotiation, for ***SSLAdapter***.
+Add support for SSL legacy renegotiation in ***SSLAdapter***.

--- a/Packs/Base/ReleaseNotes/1_31_45.md
+++ b/Packs/Base/ReleaseNotes/1_31_45.md
@@ -1,4 +1,4 @@
 
 #### Scripts
 ##### CommonServerPython
-- Added support for SSL the legacy renegotiation.
+- Added support for SSL legacy renegotiation.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -19,6 +19,7 @@ import traceback
 import types
 import urllib
 import gzip
+import ssl
 from random import randint
 import xml.etree.cElementTree as ET
 from collections import OrderedDict
@@ -8281,13 +8282,9 @@ if 'requests' in sys.modules:
                 :rtype: ``None``
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
-          
+
             def __init__(self) -> None:
-                # set the flag and set only if openssl v >= 3
-                # context.options |= 0x4                
-                import ssl
-                open_ssl_version = (3, 0, 0, 0)
-                if ssl.OPENSSL_VERSION_INFO > open_ssl_version:
+                if ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
                     self.context.options |= 0x4
                 super().__init__()
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8283,10 +8283,10 @@ if 'requests' in sys.modules:
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
 
-            # def __init__(self, verify: bool = True) -> None:
-            #     if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
-            #         self.context.options |= 0x4
-            #     super().__init__()
+            def __init__(self, verify: bool = True) -> None:
+                if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
+                    self.context.options |= 0x4
+                super().__init__()
 
             def init_poolmanager(self, *args, **kwargs):
                 kwargs['ssl_context'] = self.context

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -40,7 +40,7 @@ def __line__():
 
 # 42 - The line offset from the beggining of the file.
 _MODULES_LINE_MAPPING = {
-    'CommonServerPython': {'start': __line__() - 42, 'end': float('inf')},
+    'CommonServerPython': {'start': __line__() - 43, 'end': float('inf')},
 }
 
 
@@ -8283,10 +8283,10 @@ if 'requests' in sys.modules:
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
 
-            def __init__(self, verify: bool = True) -> None:
-                if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
-                    self.context.options |= 0x4
-                super().__init__()
+            # def __init__(self, verify: bool = True) -> None:
+            #     if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
+            #         self.context.options |= 0x4
+            #     super().__init__()
 
             def init_poolmanager(self, *args, **kwargs):
                 kwargs['ssl_context'] = self.context

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8283,8 +8283,8 @@ if 'requests' in sys.modules:
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
 
-            def __init__(self) -> None:
-                if ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
+            def __init__(self, verify: bool = True) -> None:
+                if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
                     self.context.options |= 0x4
                 super().__init__()
 
@@ -8350,7 +8350,7 @@ if 'requests' in sys.modules:
             # https://bugs.python.org/issue43998
 
             if IS_PY3 and PY_VER_MINOR >= 10 and not verify:
-                self._session.mount('https://', SSLAdapter())
+                self._session.mount('https://', SSLAdapter(verify=verify))
 
             if proxy:
                 ensure_proxy_has_http_prefix()
@@ -8441,7 +8441,7 @@ if 'requests' in sys.modules:
                 if self._verify:
                     https_adapter = http_adapter
                 elif IS_PY3 and PY_VER_MINOR >= 10:
-                    https_adapter = SSLAdapter(max_retries=retry)
+                    https_adapter = SSLAdapter(max_retries=retry, verify=self._verify)
                 else:
                     https_adapter = http_adapter
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8283,7 +8283,7 @@ if 'requests' in sys.modules:
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
 
-            def __init__(self, verify: bool = True) -> None:
+            def __init__(self, verify=True) -> None:
                 if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
                     self.context.options |= 0x4
                 super().__init__()

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8283,7 +8283,8 @@ if 'requests' in sys.modules:
             """
             context = create_urllib3_context(ciphers=CIPHERS_STRING)
 
-            def __init__(self, verify=True) -> None:
+            def __init__(self, verify=True):
+                # type: (bool) -> None
                 if not verify and ssl.OPENSSL_VERSION_INFO >= (3, 0, 0, 0):
                     self.context.options |= 0x4
                 super().__init__()

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8280,15 +8280,23 @@ if 'requests' in sys.modules:
                 :return: No data returned
                 :rtype: ``None``
             """
+            context = create_urllib3_context(ciphers=CIPHERS_STRING)
+          
+            def __init__(self) -> None:
+                # set the flag and set only if openssl v >= 3
+                # context.options |= 0x4                
+                import ssl
+                open_ssl_version = (3, 0, 0, 0)
+                if ssl.OPENSSL_VERSION_INFO > open_ssl_version:
+                    self.context.options |= 0x4
+                super().__init__()
 
             def init_poolmanager(self, *args, **kwargs):
-                context = create_urllib3_context(ciphers=CIPHERS_STRING)
-                kwargs['ssl_context'] = context
+                kwargs['ssl_context'] = self.context
                 return super(SSLAdapter, self).init_poolmanager(*args, **kwargs)
 
             def proxy_manager_for(self, *args, **kwargs):
-                context = create_urllib3_context(ciphers=CIPHERS_STRING)
-                kwargs['ssl_context'] = context
+                kwargs['ssl_context'] = self.context
                 return super(SSLAdapter, self).proxy_manager_for(*args, **kwargs)
 
     class BaseClient(object):

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.44",
+    "currentVersion": "1.31.45",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
OpenSSL version 3 and up will not support Legacy renegotiation. 
Added a flag in SSLAdapter to support it. 

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
