### PR TITLE
fix the documentation url in panorama README

### DIFF
--- a/Packs/BPA/Integrations/BPA/BPA_description.md
+++ b/Packs/BPA/Integrations/BPA/BPA_description.md
@@ -5,4 +5,4 @@ To obtain an API Access Token for BPA, go to https://customersuccess.paloaltonet
 To obtain an API Key for Panorama, run the following REST command and copy the key:  
 https://[PanoramaIP]/api/?type=keygen&user=[user]&password=[password]
 
-For more information, visit the [Palo Alto Networks documentation](https://www.paloaltonetworks.com/documentation).
+For more information, visit the [Palo Alto Networks documentation](https://docs.paloaltonetworks.com/panorama).

--- a/Packs/BPA/ReleaseNotes/1_2_15.md
+++ b/Packs/BPA/ReleaseNotes/1_2_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Palo Alto Networks BPA
+Documentation and metadata improvements.

--- a/Packs/BPA/pack_metadata.json
+++ b/Packs/BPA/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Best Practice Assessment (BPA) by Palo Alto Networks",
     "description": "Palo Alto Networks Best Practice Assessment (BPA) analyzes NGFW and Panorama configurations and compares them to the best practices.",
     "support": "xsoar",
-    "currentVersion": "1.2.14",
+    "currentVersion": "1.2.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-19411

## Description
Replace the document link from `https://docs.paloaltonetworks.com/documentation` to `https://docs.paloaltonetworks.com/panorama`

## Screenshots
Before he fix:
![Screen Shot 2022-12-14 at 12 53 42](https://user-images.githubusercontent.com/78307768/207576997-20837e71-fb59-4b6f-9bce-778db6925a6a.png)

After the fix:
![Screen Shot 2022-12-14 at 12 56 38](https://user-images.githubusercontent.com/78307768/207577065-776b9430-d222-4749-986e-19ca4a3a6170.png)


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
