### PR TITLE
Command-Line Analysis - changed playbook input to optional

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Command-Line_Analysis.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Command-Line_Analysis.yml
@@ -1573,7 +1573,7 @@ view: |-
 inputs:
 - key: Commandline
   value: {}
-  required: true
+  required: false
   description: The command line.
   playbookInputQuery:
 outputs:

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_20.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_20.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Command-Line Analysis
+- Changed the **Commandline** input from mandatory to optional, thus preventing the playbook from failing if the input is not satisfied.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.19",
+    "currentVersion": "2.3.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/known_words.txt
+++ b/Tests/known_words.txt
@@ -82,6 +82,7 @@ CTI
 SCC
 IPinfo
 QRadarFullSearch
+Commandline
 ServiceNow
 OAuth
 Qualys


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4855

## Description
Fixed an issue where the playbook input was mandatory, which caused the playbook to fail. This behavior was undesired in cases where the playbook was used as a subplaybook, and a commandline input was sometimes not provided.

## Does it break backward compatibility?
No
