### PR TITLE
Adding credential support.

### DIFF
--- a/Packs/Axonius/Integrations/Axonius/Axonius.py
+++ b/Packs/Axonius/Integrations/Axonius/Axonius.py
@@ -275,8 +275,8 @@ def main():
     command: str = demisto.command()
 
     url: str = params["ax_url"]
-    key: str = params["ax_key"]
-    secret: str = params["ax_secret"]
+    key: str = params.get('credentials', {}).get('identifier')
+    secret: str = params.get('credentials', {}).get('password')
     certverify: bool = not params.get("insecure", False)
 
     handle_proxy()  # noqa: F821, F405

--- a/Packs/Axonius/Integrations/Axonius/Axonius.yml
+++ b/Packs/Axonius/Integrations/Axonius/Axonius.yml
@@ -7,8 +7,8 @@ configuration:
   name: ax_url
   required: true
   type: 0
-- display: api-key
-  displaypassword: api-secret
+- display: API Key
+  displaypassword: API Secret
   name: credentials
   type: 9
   required: true

--- a/Packs/Axonius/Integrations/Axonius/Axonius.yml
+++ b/Packs/Axonius/Integrations/Axonius/Axonius.yml
@@ -7,14 +7,11 @@ configuration:
   name: ax_url
   required: true
   type: 0
-- display: Axonius API Key
-  name: ax_key
+- display: api-key
+  displaypassword: api-secret
+  name: credentials
+  type: 9
   required: true
-  type: 0
-- display: Axonius API Secret
-  name: ax_secret
-  required: true
-  type: 4
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -737,7 +734,7 @@ script:
     - contextPath: Axonius.tags
       description: Axonius Tags
       type: Unknown
-  dockerimage: demisto/axonius:1.0.0.30481
+  dockerimage: demisto/axonius:1.0.0.40908
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/Axonius/ReleaseNotes/1_0_7.md
+++ b/Packs/Axonius/ReleaseNotes/1_0_7.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Axonius
+Modifying the integration to support pulling an api-key and api-secret from credentials.
+Bumping the docker version to use our latest api client.

--- a/Packs/Axonius/ReleaseNotes/1_0_7.md
+++ b/Packs/Axonius/ReleaseNotes/1_0_7.md
@@ -1,5 +1,5 @@
 
 #### Integrations
 ##### Axonius
-Modifying the integration to support pulling an api-key and api-secret from credentials.
-Bumping the docker version to use our latest api client.
+- Modifying the integration configuration params to use *API Key* and *API secret* instead of *ax_key* and *ax_secret*.
+- Updated the Docker image to: *demisto/axonius:1.0.0.40908*.

--- a/Packs/Axonius/ReleaseNotes/1_0_7.md
+++ b/Packs/Axonius/ReleaseNotes/1_0_7.md
@@ -1,5 +1,7 @@
 
 #### Integrations
 ##### Axonius
-- Modifying the integration configuration params to use *API Key* and *API secret* instead of *ax_key* and *ax_secret*.
+- To support the use of credentials we are modifying the integration configuration params to use *API Key* and *API Secret* instead of *ax_key* and *ax_secret*.
+  - *NOTE:* This is a breaking change. All users will have to re-enter their API credentials.
 - Updated the Docker image to: *demisto/axonius:1.0.0.40908*.
+

--- a/Packs/Axonius/ReleaseNotes/1_1_0.json
+++ b/Packs/Axonius/ReleaseNotes/1_1_0.json
@@ -1,0 +1,1 @@
+{"breakingChanges": true, "breakingChangesNotes": "To support the use of credentials we are modifying the integration configuration params to use API Key and API Secret instead of ax_key and ax_secret. This is a breaking change. All users will have to re-enter their API credentials."}

--- a/Packs/Axonius/ReleaseNotes/1_1_0.md
+++ b/Packs/Axonius/ReleaseNotes/1_1_0.md
@@ -1,7 +1,8 @@
 
 #### Integrations
 ##### Axonius
+- Updated the Docker image to: *demisto/axonius:1.0.0.40908*.
 - To support the use of credentials we are modifying the integration configuration params to use *API Key* and *API Secret* instead of *ax_key* and *ax_secret*.
   - *NOTE:* This is a breaking change. All users will have to re-enter their API credentials.
-- Updated the Docker image to: *demisto/axonius:1.0.0.40908*.
+
 

--- a/Packs/Axonius/pack_metadata.json
+++ b/Packs/Axonius/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Axonius",
     "description": "Enrichment for devices and users in your environment.",
     "support": "partner",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Axonius",
     "url": "https://docs.axonius.com",
     "email": "support@axonius.com",

--- a/Packs/Axonius/pack_metadata.json
+++ b/Packs/Axonius/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Axonius",
     "description": "Enrichment for devices and users in your environment.",
     "support": "partner",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.1.0",
     "author": "Axonius",
     "url": "https://docs.axonius.com",
     "email": "support@axonius.com",


### PR DESCRIPTION
Modifying the integration to support pulling an api-key and api-secret from credentials. Bumping the docker version to use our latest api client.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Modifying the integration to support pulling an api-key and api-secret from credentials.
Bumping the docker version to use our latest api client.

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [x] 5.0.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [x ] Yes
       - Further details: Original fields being used for api-key and api-secret were removed in favor of using a single field to support credentials.
   - [ ] No
