### PR TITLE
[CrowdStrike OpenAPI] Update cs-devices-ran-on api version

### DIFF
--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
@@ -1007,7 +1007,7 @@ class Client:
 
         headers = self.cs_client._headers
 
-        response = self.cs_client.http_request('get', 'devices/entities/devices/v1', params=params, headers=headers)
+        response = self.cs_client.http_request('get', 'devices/entities/devices/v2', params=params, headers=headers)
 
         return response
 

--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.yml
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.yml
@@ -3252,7 +3252,7 @@ script:
       name: offset
       required: false
     description: Find hosts that have observed a given custom IOC. For details about
-      those hosts, use GET /devices/entities/devices/v1
+      those hosts, use GET /devices/entities/devices/v2
     name: cs-devices-ran-on
     outputs:
     - contextPath: CrowdStrike.apiMsaReplyDevicesRanOn.errors.code

--- a/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_13.md
+++ b/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_13.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### CrowdStrike OpenAPI (Beta)
+- Update API used in **cs-devices-ran-on** command to the latest API version. 

--- a/Packs/CrowdStrikeOpenAPI/pack_metadata.json
+++ b/Packs/CrowdStrikeOpenAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike OpenAPI",
     "description": "Use the CrowdStrike OpenAPI integration to interact with CrowdStrike APIs that do not have dedicated integrations in Cortex XSOAR, for example, CrowdStrike FalconX, etc.",
     "support": "xsoar",
-    "currentVersion": "1.0.12",
+    "currentVersion": "1.0.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Description
Updated cs-devices-ran-on to use the latest API: /devices/entities/devices/v2, as the older API is due to depreciation.

## Screenshots
![image](https://user-images.githubusercontent.com/20818773/209184484-50fd180c-2f41-47d1-ab18-1c3632a6bcf5.png)
