### PR TITLE
adding `context_key` to the `ConvertTableToHTML` script

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_10_39.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_10_39.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### ConvertTableToHTML
+- Added the **context_key** argument so you can set your own context output key.

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.js
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.js
@@ -1,11 +1,11 @@
-if (args.headers) {
-    headers = args.headers.split(",");
-} else {
-    headers = []
-}
+headers = args.headers ? args.headers.split(",") : [];
 if (args.table) {
-    return {Type: entryTypes.note, Contents: '', ContentsFormat: formats.text,
+    ec = {};
+    ec[args.context_key || 'HTMLTable'] = tableToHTML(args.title, args.table, headers);
+    return {
+        Type: entryTypes.note, Contents: '', ContentsFormat: formats.text,
         HumanReadable: tableToMarkdown(args.title, args.table, headers),
-        EntryContext: {HTMLTable: tableToHTML(args.title, args.table, headers)}};
+        EntryContext: ec
+    };
 }
 return 'Data does not exist';

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
@@ -15,7 +15,7 @@ args:
   description: The table to convert to HTML
   isArray: true
 - name: context_key
-  default: true
+  defaultValue: HTMLTable
   description: "The context key for the converted HTML table (default is: HTMLTable)."
 - name: title
   default: false

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
@@ -14,6 +14,10 @@ args:
   default: true
   description: The table to convert to HTML
   isArray: true
+- name: context_key
+  default: true
+  description: "The context key for the converted HTML table (default is: HTMLTable)."
+  defaultvalue: HTMLTable
 - name: title
   default: false
   description: The optional title for the table

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
@@ -17,7 +17,6 @@ args:
 - name: context_key
   default: true
   description: "The context key for the converted HTML table (default is: HTMLTable)."
-  defaultvalue: HTMLTable
 - name: title
   default: false
   description: The optional title for the table

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/ConvertTableToHTML.yml
@@ -30,4 +30,4 @@ outputs:
 scripttarget: 0
 fromversion: 5.0.0
 tests:
-- No tests
+- ConvertTableToHTML - TEST

--- a/Packs/CommonScripts/Scripts/ConvertTableToHTML/README.md
+++ b/Packs/CommonScripts/Scripts/ConvertTableToHTML/README.md
@@ -15,6 +15,7 @@ Converts an array in to a HTML table.
 | --- | --- |
 | table | The table to convert to HTML. |
 | title | The optional title for the table. |
+| context_key | The context key for the converted HTML table (default is: HTMLTable). |
 
 ## Outputs
 ---

--- a/Packs/CommonScripts/TestPlaybooks/ConvertTableToHTML_-_TEST.yml
+++ b/Packs/CommonScripts/TestPlaybooks/ConvertTableToHTML_-_TEST.yml
@@ -1,0 +1,235 @@
+id: ConvertTableToHTML - TEST
+version: -1
+name: ConvertTableToHTML - TEST
+starttaskid: "0"
+tasks:
+  "0":
+    id: "0"
+    taskid: 8f7f76ee-762f-431b-8979-aaac1f851914
+    type: start
+    task:
+      id: 8f7f76ee-762f-431b-8979-aaac1f851914
+      version: -1
+      name: ""
+      iscommand: false
+      brand: ""
+      description: ''
+    nexttasks:
+      '#none#':
+      - "1"
+      - "2"
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "1":
+    id: "1"
+    taskid: a562232f-4fa7-4c19-8bcd-fb9f926a7c09
+    type: regular
+    task:
+      id: a562232f-4fa7-4c19-8bcd-fb9f926a7c09
+      version: -1
+      name: ConvertTableToHTML with default context path
+      description: Converts a given array to an HTML table
+      scriptName: ConvertTableToHTML
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      context_key:
+        simple: KEY
+      headers:
+        simple: "N"
+      table:
+        simple: '[1,2,3]'
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 480,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "2":
+    id: "2"
+    taskid: bd5b2516-dd36-4b3a-8e42-993b279f72f8
+    type: regular
+    task:
+      id: bd5b2516-dd36-4b3a-8e42-993b279f72f8
+      version: -1
+      name: ConvertTableToHTML with default context path
+      description: Converts a given array to an HTML table
+      scriptName: ConvertTableToHTML
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "3"
+    scriptarguments:
+      headers:
+        simple: "N"
+      table:
+        simple: '[1,2,3]'
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 195
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "3":
+    id: "3"
+    taskid: 2d0c6267-2341-460e-89ec-f4e0f97de67b
+    type: condition
+    task:
+      id: 2d0c6267-2341-460e-89ec-f4e0f97de67b
+      version: -1
+      name: verify outputs eq
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "5"
+      "yes":
+      - "4"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              simple: HTMLTable
+            iscontext: true
+          right:
+            value:
+              simple: KEY
+            iscontext: true
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "4":
+    id: "4"
+    taskid: f911f3f0-281a-41a0-8c2f-993759ac1655
+    type: title
+    task:
+      id: f911f3f0-281a-41a0-8c2f-993759ac1655
+      version: -1
+      name: Done
+      type: title
+      iscommand: false
+      brand: ""
+      description: ''
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 720
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "5":
+    id: "5"
+    taskid: 9f99c2b5-ed10-43ad-8142-1b0432d358f8
+    type: regular
+    task:
+      id: 9f99c2b5-ed10-43ad-8142-1b0432d358f8
+      version: -1
+      name: error
+      description: Prints an error entry with a given message
+      scriptName: PrintErrorEntry
+      type: regular
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "4"
+    scriptarguments:
+      message:
+        simple: error
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 377.5,
+          "y": 545
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 735,
+        "width": 810,
+        "x": 50,
+        "y": 50
+      }
+    }
+  }
+inputs: []
+outputs: []
+fromversion: 6.5.0
+description: ''

--- a/Packs/CommonScripts/TestPlaybooks/ConvertTableToHTML_-_TEST.yml
+++ b/Packs/CommonScripts/TestPlaybooks/ConvertTableToHTML_-_TEST.yml
@@ -41,7 +41,7 @@ tasks:
     task:
       id: a562232f-4fa7-4c19-8bcd-fb9f926a7c09
       version: -1
-      name: ConvertTableToHTML with default context path
+      name: ConvertTableToHTML with context_key argument
       description: Converts a given array to an HTML table
       scriptName: ConvertTableToHTML
       type: regular

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.10.37",
+    "currentVersion": "1.10.39",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4730

## Description
added the new argument `context_key` to the `ConvertTableToHTML` script so you can set your own context output key.
default remains `HTMLTable`.

## Minimum version of Cortex XSOAR
- [x] 5.0.0

## Does it break backward compatibility?
   - [x] No