### PR TITLE
better error when parsing response

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_51.md
+++ b/Packs/Base/ReleaseNotes/1_31_51.md
@@ -1,0 +1,3 @@
+#### Scripts
+##### CommonServerPython
+Improved the error shown when failing to parse a request response.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8614,8 +8614,8 @@ if 'requests' in sys.modules:
                         return res
                     return res
                 except ValueError as exception:
-                    raise DemistoException('Failed to parse json object from response: {}'
-                                           .format(res.content), exception, res)
+                    raise DemistoException('Failed to parse {} object from response: {}'
+                                           .format(resp_type, res.content), exception, res)
             except requests.exceptions.ConnectTimeout as exception:
                 err_msg = 'Connection Timeout Error - potential reasons might be that the Server URL parameter' \
                           ' is incorrect or that the Server is not accessible from your host.'

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.50",
+    "currentVersion": "1.31.51",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
when failing to parse a response, include the expected response type, not just `json`