### PR TITLE
Changed phishing to assign less-busy-user instead of administrator

### DIFF
--- a/Packs/Phishing/Playbooks/Phishing_-_Generic_v3.yml
+++ b/Packs/Phishing/Playbooks/Phishing_-_Generic_v3.yml
@@ -51,6 +51,8 @@ tasks:
       '#none#':
       - "15"
     scriptarguments:
+      assignBy:
+        simple: less-busy-user
       onCall:
         complex:
           root: inputs.OnCall
@@ -2783,8 +2785,7 @@ view: |-
   }
 inputs:
 - key: Role
-  value:
-    simple: Administrator
+  value: {}
   required: true
   description: The default role to assign the incident to.
   playbookInputQuery:

--- a/Packs/Phishing/ReleaseNotes/3_3_11.md
+++ b/Packs/Phishing/ReleaseNotes/3_3_11.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Phishing - Generic v3
+- Changed the playbook to assign a less busy analyst instead of the administrator.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.3.10",
+    "currentVersion": "3.3.11",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related to: https://jira-hq.paloaltonetworks.local/browse/CRTX-70287

## Description
Changed the task that assigns an analyst to assign a "less-busy-user" instead of the user with the role of Administrator.

## Does it break backward compatibility?
No
