### PR TITLE
FuardiCore added an example of the url with the suffix

### DIFF
--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.py
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.py
@@ -10,7 +10,8 @@ from dateparser import parse
 from pytz import utc
 
 # Disable insecure warnings
-requests.packages.urllib3.disable_warnings()  # pylint: disable=no-member
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 ''' CONSTANTS '''
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'  # ISO8601 format with UTC, default in XSOAR

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.py
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.py
@@ -2,7 +2,6 @@ import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
 
-import requests
 from typing import Dict, Any, Tuple
 import base64
 import json

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
@@ -1267,7 +1267,7 @@ script:
         - contextPath: Endpoint.MACAddress
           description: The endpoint's MAC address.
           type: String
-  dockerimage: demisto/python3:3.10.4.30607
+  dockerimage: demisto/python3:3.10.9.42476
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
@@ -6,7 +6,7 @@ configuration:
   - name: base_url
     display: Server URL
     required: true
-    defaultvalue: https://example.com/
+    defaultvalue: https://example.com/api/v3.0/
     type: 0
     additionalinfo: null
   - display: Username

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/README.md
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/README.md
@@ -9,7 +9,7 @@ This integration was integrated and tested with version 3.0.0 of the GuardiCore 
 
     | **Parameter** | **Description** | **Required** |
     | --- | --- | --- |
-    | API Server URL |  | True |
+    | API Server URL | For example: `https://example.com/api/v3.0/` | True |
     | Username for API |  | True |
     | Password for API |  | True |
     | Source | Fetch incidents - Guardicore Source Incident Value | False |

--- a/Packs/GuardiCore/ReleaseNotes/2_0_6.md
+++ b/Packs/GuardiCore/ReleaseNotes/2_0_6.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### GuardiCore v2
-Documentation and metadata improvements.
+- Updated the Docker image to: *demisto/python3:3.10.9.42476*.
+- Documentation and metadata improvements.

--- a/Packs/GuardiCore/ReleaseNotes/2_0_6.md
+++ b/Packs/GuardiCore/ReleaseNotes/2_0_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### GuardiCore v2
+Documentation and metadata improvements.

--- a/Packs/GuardiCore/pack_metadata.json
+++ b/Packs/GuardiCore/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GuardiCore",
     "description": "Data center breach detection",
     "support": "xsoar",
-    "currentVersion": "2.0.5",
+    "currentVersion": "2.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:  https://github.com/demisto/content-docs/issues/1260
https://jira-hq.paloaltonetworks.local/browse/XSUP-12684

## Description
Added an example of the URL with the suffix `https://example.com/` => `https://example.com/api/v3.0/`

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
