### PR TITLE
workaround for azure security center tpb nightly failure

### DIFF
--- a/Packs/AzureSecurityCenter/Integrations/AzureSecurityCenter_v2/AzureSecurityCenter_v2.yml
+++ b/Packs/AzureSecurityCenter/Integrations/AzureSecurityCenter_v2/AzureSecurityCenter_v2.yml
@@ -4,7 +4,7 @@ commonfields:
   version: -1
 configuration:
 - defaultvalue: https://management.azure.com/
-  display: Microsoft Azure Management URL
+  display: Microsoft Azure Management URLa
   name: server_url
   required: false
   type: 0

--- a/Packs/AzureSecurityCenter/Integrations/AzureSecurityCenter_v2/AzureSecurityCenter_v2.yml
+++ b/Packs/AzureSecurityCenter/Integrations/AzureSecurityCenter_v2/AzureSecurityCenter_v2.yml
@@ -4,7 +4,7 @@ commonfields:
   version: -1
 configuration:
 - defaultvalue: https://management.azure.com/
-  display: Microsoft Azure Management URLa
+  display: Microsoft Azure Management URL
   name: server_url
   required: false
   type: 0
@@ -528,7 +528,7 @@ script:
     - contextPath: Azure.Securescore.weight
       description: The relative weight for each subscription.
       type: String
-  dockerimage: demisto/crypto:1.0.0.36225
+  dockerimage: demisto/crypto:1.0.0.42817
   isfetch: false
   longRunning: false
   longRunningPort: false

--- a/Packs/AzureSecurityCenter/ReleaseNotes/1_3_6.md
+++ b/Packs/AzureSecurityCenter/ReleaseNotes/1_3_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Defender for Cloud
+- Updated the Docker image to: *demisto/crypto:1.0.0.42817*.

--- a/Packs/AzureSecurityCenter/TestPlaybooks/playbook-AzureSCTestPlaybook.yml
+++ b/Packs/AzureSecurityCenter/TestPlaybooks/playbook-AzureSCTestPlaybook.yml
@@ -5,19 +5,19 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: bc3d4f03-06bb-4d3f-89c6-92b3dbf72c00
+    taskid: 4b1d827a-ab81-41e7-882f-0cd6986d629b
     type: start
     task:
-      id: bc3d4f03-06bb-4d3f-89c6-92b3dbf72c00
+      id: 4b1d827a-ab81-41e7-882f-0cd6986d629b
       version: -1
       name: ""
       iscommand: false
       brand: ""
-      description: ''
     nexttasks:
       '#none#':
       - "1"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -34,10 +34,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: 54be4c1e-bf44-4cee-8535-cb1334e6a633
+    taskid: d0a0afb0-de7c-4fd8-8d01-66b1caeb616b
     type: regular
     task:
-      id: 54be4c1e-bf44-4cee-8535-cb1334e6a633
+      id: d0a0afb0-de7c-4fd8-8d01-66b1caeb616b
       version: -1
       name: azure-sc-list-aps
       description: Lists auto provisioning settings in the subscription.
@@ -49,6 +49,7 @@ tasks:
       '#none#':
       - "2"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -65,10 +66,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: 0ba02cf8-862a-4f60-8502-41bde0bd47fa
+    taskid: e470784b-6f0d-4774-85a6-2662de70811d
     type: regular
     task:
-      id: 0ba02cf8-862a-4f60-8502-41bde0bd47fa
+      id: e470784b-6f0d-4774-85a6-2662de70811d
       version: -1
       name: azure-sc-get-aps
       description: Returns details of a specific auto provisioning setting.
@@ -83,6 +84,7 @@ tasks:
       setting_name:
         simple: ${AzureSecurityCenter.AutoProvisioningSetting.Name}
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -99,10 +101,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: b389eb60-22af-484a-8bd1-6db69f54ea14
+    taskid: 89f91ff0-a26a-4be3-85d9-18f38f8b303d
     type: regular
     task:
-      id: b389eb60-22af-484a-8bd1-6db69f54ea14
+      id: 89f91ff0-a26a-4be3-85d9-18f38f8b303d
       version: -1
       name: azure-sc-list-alert
       description: Lists alerts for the subscription according to the specified filters.
@@ -112,11 +114,12 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "9"
+      - "11"
     scriptarguments:
       asc_location:
         simple: centralus
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
@@ -133,10 +136,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: fc03a1a4-213d-41ad-8cf8-292cf12412b3
+    taskid: 15394a33-9884-4402-8559-30dd38b7bbf6
     type: regular
     task:
-      id: fc03a1a4-213d-41ad-8cf8-292cf12412b3
+      id: 15394a33-9884-4402-8559-30dd38b7bbf6
       version: -1
       name: azure-sc-list-jit
       description: Lists all policies for protecting resources using Just-in-Time
@@ -149,11 +152,12 @@ tasks:
       '#none#':
       - "5"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 895
+          "y": 1035
         }
       }
     note: false
@@ -165,10 +169,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: 5e5dd517-22c6-4bb7-8f22-fc32dbf51b01
+    taskid: 85d65fbf-0fc3-434c-849f-78a63056a174
     type: regular
     task:
-      id: 5e5dd517-22c6-4bb7-8f22-fc32dbf51b01
+      id: 85d65fbf-0fc3-434c-849f-78a63056a174
       version: -1
       name: azure-sc-list-location
       description: The location of the responsible ASC of the specific subscription.
@@ -181,11 +185,12 @@ tasks:
       '#none#':
       - "6"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1070
+          "y": 1210
         }
       }
     note: false
@@ -197,10 +202,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: d9522e7a-384c-46e7-8219-ff348cc35d22
+    taskid: fefe1a7a-8dc8-46d5-8aa1-13010e9095a0
     type: regular
     task:
-      id: d9522e7a-384c-46e7-8219-ff348cc35d22
+      id: fefe1a7a-8dc8-46d5-8aa1-13010e9095a0
       version: -1
       name: azure-sc-list-storage
       description: Lists all the storage accounts available under the subscription.
@@ -212,11 +217,12 @@ tasks:
       '#none#':
       - "7"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1245
+          "y": 1385
         }
       }
     note: false
@@ -228,10 +234,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 2b0b8474-4d96-4603-84f8-4fe501d2116a
+    taskid: fc9fe2d0-ad2c-4ba8-8d00-948b3d1ad01a
     type: regular
     task:
-      id: 2b0b8474-4d96-4603-84f8-4fe501d2116a
+      id: fc9fe2d0-ad2c-4ba8-8d00-948b3d1ad01a
       version: -1
       name: azure-sc-update-aps
       description: Updates a specific auto provisioning setting.
@@ -248,11 +254,12 @@ tasks:
       setting_name:
         simple: default
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1420
+          "y": 1560
         }
       }
     note: false
@@ -264,10 +271,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: d6af1cb9-4845-42e6-8b7c-43b91a68bc6e
+    taskid: d02710a7-17ff-4058-8821-45b72c29c7c8
     type: regular
     task:
-      id: d6af1cb9-4845-42e6-8b7c-43b91a68bc6e
+      id: d02710a7-17ff-4058-8821-45b72c29c7c8
       version: -1
       name: azure-list-subscriptions
       description: Lists available subscriptions for this application.
@@ -279,11 +286,12 @@ tasks:
       '#none#':
       - "10"
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1595
+          "y": 1735
         }
       }
     note: false
@@ -295,10 +303,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "9":
     id: "9"
-    taskid: 7cfb5ba1-c7a0-4638-8385-9681dbde59e2
+    taskid: a6adf7cc-361d-4643-8ea6-891ba05b17fb
     type: regular
     task:
-      id: 7cfb5ba1-c7a0-4638-8385-9681dbde59e2
+      id: a6adf7cc-361d-4643-8ea6-891ba05b17fb
       version: -1
       name: azure-sc-get-alert
       description: Get an alert that is associated a resource group or a subscription.
@@ -319,11 +327,12 @@ tasks:
       asc_location:
         simple: centralus
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 720
+          "y": 870
         }
       }
     note: false
@@ -335,10 +344,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "10":
     id: "10"
-    taskid: 6089a836-2ce7-45cc-8ce7-d116d6693190
+    taskid: a419e7b3-a9f0-46ff-8431-86fb4aa7fa18
     type: regular
     task:
-      id: 6089a836-2ce7-45cc-8ce7-d116d6693190
+      id: a419e7b3-a9f0-46ff-8431-86fb4aa7fa18
       version: -1
       name: azure-get-secure-score
       description: Retrieve the Secure Score for the provided subscription and score
@@ -348,11 +357,54 @@ tasks:
       iscommand: true
       brand: ""
     separatecontext: false
+    continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1760
+          "y": 1900
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "11":
+    id: "11"
+    taskid: 021c974c-6524-474b-85cd-991186266d42
+    type: condition
+    task:
+      id: 021c974c-6524-474b-85cd-991186266d42
+      version: -1
+      name: Is List empty?
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "9"
+      "yes":
+      - "4"
+    separatecontext: false
+    defaultassigneecomplex:
+      simple: ${AzureSecurityCenter.Alert}
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotExists
+          left:
+            value:
+              simple: AzureSecurityCenter.Alert
+            iscontext: true
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 50,
+          "y": 700
         }
       }
     note: false
@@ -367,7 +419,7 @@ view: |-
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1805,
+        "height": 1945,
         "width": 380,
         "x": 50,
         "y": 50

--- a/Packs/AzureSecurityCenter/pack_metadata.json
+++ b/Packs/AzureSecurityCenter/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Cloud",
     "description": "Unified security management and advanced threat protection across hybrid cloud workloads.",
     "support": "xsoar",
-    "currentVersion": "1.3.5",
+    "currentVersion": "1.3.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-5066](https://jira-hq.paloaltonetworks.local/browse/CIAC-5066)

## Description
From looking into the nightly failure, it seems like the list command is not always retrieving alerts / the alerts are being deleted before being reached, therefore a workaround was created to skip the cases where the first element of the list is null.
## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
