### PR TITLE
changing value of cs-falcon-device-count-ioc test playbook command

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -2537,7 +2537,7 @@ script:
     - description: Limit the vulnerabilities returned to specific properties. Each value must be enclosed in single quotes and placed immediately after the colon with no space. For example, 'filter=status:'open'+cve.id:['CVE-2013-3900','CVE-2021-1675']'
       name: filter
       required: false
-    - description: Unique agent identifier (AID) of a sensor. 
+    - description: Unique agent identifier (AID) of a sensor.
       name: aid
       isArray: true
       required: false
@@ -2859,7 +2859,7 @@ script:
     - contextPath: CrowdStrike.VulnerabilityHost.cve.id
       description: Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD).
       type: String
-  dockerimage: demisto/python3:3.10.9.40422
+  dockerimage: demisto/python3:3.10.9.42476
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_10_1.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_10_1.md
@@ -1,5 +1,4 @@
 
 #### Integrations
 ##### CrowdStrike Falcon
-- Fixed an issue in test playbook.
 - Updated the Docker image to: *demisto/python3:3.10.9.42476*.

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_10_1.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_10_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### CrowdStrike Falcon
+- Fixed an issue in test playbook.
+- Updated the Docker image to: *demisto/python3:3.10.9.42476*.

--- a/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
+++ b/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
@@ -739,7 +739,7 @@ tasks:
       type:
         simple: domain
       value:
-        simple: ynet.co.il
+        simple: google.com
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -774,14 +774,6 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isEqualNumber
-          left:
-            value:
-              simple: CrowdStrike.IOC.DeviceCount
-            iscontext: true
-          right:
-            value:
-              simple: "1"
       - - operator: isEqualString
           left:
             value:
@@ -789,7 +781,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: domain:ynet.co.il
+              simple: domain:google.com
       - - operator: isEqualString
           left:
             value:
@@ -805,7 +797,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: ynet.co.il
+              simple: google.com
     continueonerrortype: ""
     view: |-
       {

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.10.0",
+    "currentVersion": "1.10.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [X] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3986

## Description
Fixing the test playbook by changing the value paramter in the command 'cs-falcon-device-count-ioc' to google.com.
There isn't a command to create or get a list with devices.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [X] 6.0.0

## Does it break backward compatibility?
- [X] No

