### PR TITLE
MicrosoftGraphMail - add support in credential store

### DIFF
--- a/Packs/GmailSingleUser/.pack-ignore
+++ b/Packs/GmailSingleUser/.pack-ignore
@@ -1,5 +1,5 @@
 [file:GmailSingleUser.yml]
-ignore=BA109,IN126,DS107,IN145
+ignore=BA109,IN126,DS107,IN124
 
 [file:README.md]
 ignore=RM106

--- a/Packs/GmailSingleUser/Integrations/GmailSingleUser/GmailSingleUser.py
+++ b/Packs/GmailSingleUser/Integrations/GmailSingleUser/GmailSingleUser.py
@@ -36,12 +36,12 @@ PROXIES = handle_proxy()
 DISABLE_SSL = params.get('insecure', False)
 FETCH_TIME = params.get('fetch_time', '1 days')
 MAX_FETCH = int(params.get('fetch_limit') or 50)
-AUTH_CODE = params.get('code')
+AUTH_CODE = params.get('auth_code_creds', {}).get('password') or params.get('code')
 AUTH_CODE_UNQUOTE_PREFIX = 'code='
 
 OOB_CLIENT_ID = "391797357217-pa6jda1554dbmlt3hbji2bivphl0j616.apps.googleusercontent.com"  # guardrails-disable-line
-CLIENT_ID = params.get('client_id') or OOB_CLIENT_ID
-CLIENT_SECRET = params.get('client_secret')
+CLIENT_ID = params.get('credentials', {}).get('identifier') or params.get('client_id') or OOB_CLIENT_ID
+CLIENT_SECRET = params.get('credentials', {}).get('password') or params.get('client_secret')
 REDIRECT_URI = params.get('redirect_uri')
 TOKEN_URL = "https://www.googleapis.com/oauth2/v4/token"
 TOKEN_FORM_HEADERS = {

--- a/Packs/GmailSingleUser/Integrations/GmailSingleUser/GmailSingleUser.yml
+++ b/Packs/GmailSingleUser/Integrations/GmailSingleUser/GmailSingleUser.yml
@@ -17,27 +17,41 @@ configuration:
   defaultvalue:
   additionalinfo: Allows you to specify the e-mail address from which to send e-mails from.
 - display: "Client ID"
+  name: credentials
+  required: false
+  type: 9
+  displaypassword: "Client Secret"
+- display: "Client ID"
   name: client_id
   required: false
   type: 0
   defaultvalue:
   additionalinfo: "Required. Not relevant for deprecated GSuite Apps setup - see Help section"
+  hidden: true
 - display: "Client Secret"
   name: client_secret
   required: false
   type: 4
   defaultvalue:
   additionalinfo: "Required. Not relevant for deprecated GSuite Apps setup - see Help section"
+  hidden: true
 - display: "Auth Redirect URI"
   name: redirect_uri
   required: false
   type: 0
   defaultvalue: https://oproxy.demisto.ninja/authcode
   additionalinfo: "Requited. Not relevant for deprecated GSuite Apps setup - see Help section"
+- display: ''
+  name: auth_code_creds
+  required: false
+  type: 9
+  displaypassword: "Auth Code (run the !gmail-auth-link command to start the auth flow - see Help section)"
+  hiddenusername: true
 - display: "Auth Code (run the !gmail-auth-link command to start the auth flow - see Help section)"
   name: code
   required: false
   type: 4
+  hidden: true
   defaultvalue:
   additionalinfo:
 - display: Incident type
@@ -52,20 +66,20 @@ configuration:
   name: fetch_time
   required: false
   type: 0
-  defaultvalue: 1 days
+  defaultvalue: "1 days"
   additionalinfo:
-- defaultvalue:
-  display: Events query (e.g., "from:example@demisto.com")
-  additionalinfo:
+- display: Events query (e.g., "from:example@demisto.com")
   name: query
   required: false
   type: 0
-- display: Maximum number of emails to pull per fetch
-  name: fetch_limit
+  additionalinfo:
+  defaultvalue:
+- name: fetch_limit
+  display: Maximum number of emails to pull per fetch
   required: false
   type: 0
-  defaultvalue: "50"
   additionalinfo: A maximum of 200 emails per fetch (even if a higher number is configured). Default is 50.
+  defaultvalue: "50"
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -101,9 +115,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: Subject of the email to be sent. Should be the same as the subject
-        of the email you are replying to in order for the reply to be a part of the
-        same conversation.
+      description: Subject of the email to be sent. Should be the same as the subject of the email you are replying to in order for the reply to be a part of the same conversation.
       isArray: false
       name: subject
       required: true
@@ -121,8 +133,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: A comma-separated list of IDs of War Room entries that contain
-        the files that need to be attached to the email.
+      description: A comma-separated list of IDs of War Room entries that contain the files that need to be attached to the email.
       isArray: true
       name: attachIDs
       required: false
@@ -188,8 +199,7 @@ script:
       required: false
       secret: false
     - default: false
-      description: 'A comma-separated list of additional headers in the format: headerName=headerValue.
-      For example: "headerName1=headerValue1,headerName2=headerValue2".'
+      description: 'A comma-separated list of additional headers in the format: headerName=headerValue. For example: "headerName1=headerValue1,headerName2=headerValue2".'
       isArray: true
       name: additionalHeader
       required: false
@@ -408,7 +418,7 @@ script:
     description: Retrieves attachments from a sent Gmail message.
     execution: false
     name: gmail-get-attachments
-  dockerimage: demisto/google-api-py3:1.0.0.41312
+  dockerimage: demisto/google-api-py3:1.0.0.42729
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/GmailSingleUser/ReleaseNotes/1_3_4.md
+++ b/Packs/GmailSingleUser/ReleaseNotes/1_3_4.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Gmail Single User
+- Added the *Client ID*, *Client Secret* and *Auth Code*  integration parameters to support credentials fetching object.
+- Updated the Docker image to: *demisto/google-api-py3:1.0.0.42729*.

--- a/Packs/GmailSingleUser/pack_metadata.json
+++ b/Packs/GmailSingleUser/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Gmail Single User",
     "description": "Gmail API using OAuth 2.0.",
     "support": "xsoar",
-    "currentVersion": "1.3.3",
+    "currentVersion": "1.3.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftGraphMail/.pack-ignore
+++ b/Packs/MicrosoftGraphMail/.pack-ignore
@@ -1,5 +1,5 @@
 [file:MicrosoftGraphMail.yml]
-ignore=IN126,DS107,IN145,IN124
+ignore=IN126,DS107,IN124
 
 [file:playbook-MicrosoftGraphMail-Test.yml]
 ignore=auto-test

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.py
@@ -2075,8 +2075,8 @@ def main():
     ok_codes: tuple = (200, 201, 202, 204)
     use_ssl: bool = not argToBoolean(params.get('insecure', False))
     proxy: bool = params.get('proxy', False)
-    certificate_thumbprint: str = params.get('certificate_thumbprint', '')
-    private_key: str = params.get('private_key', '')
+    certificate_thumbprint: str = params.get('creds_certificate', {}).get('identifier') or params.get('certificate_thumbprint', '')
+    private_key: str = params.get('creds_certificate', {}).get('password') or params.get('private_key', '')
 
     if not self_deployed and not enc_key:
         raise DemistoException('Key must be provided. For further information see '

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -32,19 +32,27 @@ configuration:
   required: false
   type: 9
   section: Connect
+  hiddenusername: true
+- display: Certificate Thumbprint
+  name: creds_certificate
+  required: false
+  type: 9
+  section: Connect
+  displaypassword: Private Key
 - additionalinfo: Used for certificate authentication. As appears in the "Certificates & secrets" page of the app.
   display: Certificate Thumbprint
   name: certificate_thumbprint
   required: false
   type: 4
   section: Connect
-- additionalinfo: Used for certificate authentication. The private key of the registered certificate.
-  display: Private Key
-  hiddenusername: true
+  hidden: true
+- display: Private Key
   name: private_key
   required: false
   type: 14
   section: Connect
+  additionalinfo: Used for certificate authentication. The private key of the registered certificate.
+  hidden: true
 - display: Fetch incidents
   name: isFetch
   required: false
@@ -63,27 +71,27 @@ configuration:
   required: false
   type: 0
   section: Collect
-- defaultvalue: 15 minutes
+- additionalinfo: <number> <time unit>, for example 12 hours, 7 days.
+  defaultvalue: '15 minutes'
   display: First fetch timestamp
-  additionalinfo: <number> <time unit>, for example 12 hours, 7 days.
   name: first_fetch
   required: false
   type: 0
   section: Collect
-- additionalinfo: The timeout of the HTTP requests sent to Microsoft Graph API (in seconds).
-  defaultvalue: '10'
+- defaultvalue: '10'
   display: HTTP Timeout
   name: timeout
   required: false
   type: 0
   section: Connect
+  additionalinfo: The timeout of the HTTP requests sent to Microsoft Graph API (in seconds).
   advanced: true
-- defaultvalue: '50'
-  display: Maximum number of emails to pull per fetch
+- display: Maximum number of emails to pull per fetch
   name: fetch_limit
   required: false
   type: 0
   section: Collect
+  defaultvalue: '50'
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -134,15 +142,15 @@ configuration:
   section: Connect
   advanced: true
 - display: Token or Tenant ID - see Detailed Instructions (?) (Deprecated)
-  hidden: true
   name: tenant_id
-  required: false
   type: 4
   section: Connect
   advanced: true
+  hidden: true
+  required: false
 - additionalinfo: If not active, only a preview of the email will be fetched.
   defaultvalue: 'false'
-  display: Display full email body
+  display: 'Display full email body'
   name: display_full_email_body
   type: 8
   section: Collect
@@ -1375,7 +1383,7 @@ script:
       - Read
       - Unread
     description: Update the status of an email to read / unread.
-  dockerimage: demisto/crypto:1.0.0.40696
+  dockerimage: demisto/crypto:1.0.0.42817
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_4_1.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_4_1.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### O365 Outlook Mail (Using Graph API)
+- Added the *Certificate Thumbprint* and *Private Key* integration parameters to support credentials fetching object.
+- Updated the Docker image to: *demisto/crypto:1.0.0.42817*.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.4.0",
+    "currentVersion": "1.4.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 