### PR TITLE
Teams workaround

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1625,7 +1625,7 @@ def messages() -> Response:
             elif conversation_type == 'personal':
                 demisto.info('Got direct message to the bot')
                 demisto.debug(f"Text is : {request_body.get('text')}")
-                if request_body.get("membersAdded",  []):
+                if request_body.get("membersAdded", []):
                     demisto.debug("the bot was added to a one-to-one chat")
                 direct_message_handler(integration_context, request_body, conversation, formatted_message)
             else:

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1616,7 +1616,8 @@ def messages() -> Response:
             if event_type == 'teamMemberAdded':
                 demisto.info('New Microsoft Teams team member was added')
                 member_added_handler(integration_context, request_body, channel_data)
-                demisto.debug(f'Updated integration context: {json.dumps(get_integration_context().get("teams"))}')
+                demisto.debug(f'Updated team in the integration context. '
+                              f'Current saved teams: {json.dumps(get_integration_context().get("teams"))}')
             elif value:
                 # In TeamsAsk process
                 demisto.info('Got response from user in MicrosoftTeamsAsk process')

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -1407,9 +1407,12 @@ def member_added_handler(integration_context: dict, request_body: dict, channel_
         if bot_id in member_id:
             # The bot was added to a team, caching team ID and team members
             demisto.info(f'The bot was added to team {team_name}')
-            integration_context['tenant_id'] = tenant_id
-            integration_context['bot_name'] = recipient_name
-            break
+        else:
+            demisto.info(f'Someone was added to team {team_name}')
+        integration_context['tenant_id'] = tenant_id
+        integration_context['bot_name'] = recipient_name
+        break
+
     team_members: list = get_team_members(service_url, team_id)
 
     found_team: bool = False
@@ -1613,12 +1616,16 @@ def messages() -> Response:
             if event_type == 'teamMemberAdded':
                 demisto.info('New Microsoft Teams team member was added')
                 member_added_handler(integration_context, request_body, channel_data)
+                demisto.debug(f'Updated integration context: {json.dumps(get_integration_context().get("teams"))}')
             elif value:
                 # In TeamsAsk process
                 demisto.info('Got response from user in MicrosoftTeamsAsk process')
                 entitlement_handler(integration_context, request_body, value, conversation_id)
             elif conversation_type == 'personal':
                 demisto.info('Got direct message to the bot')
+                demisto.debug(f"Text is : {request_body.get('text')}")
+                if request_body.get("membersAdded",  []):
+                    demisto.debug("the bot was added to a one-to-one chat")
                 direct_message_handler(integration_context, request_body, conversation, formatted_message)
             else:
                 demisto.info('Got message mentioning the bot')

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -224,7 +224,7 @@ script:
     - contextPath: MicrosoftTeams.CreateMeeting.participantDisplayName
       description: The display name of the participants.
       type: String
-  dockerimage: demisto/teams:1.0.0.39896
+  dockerimage: demisto/teams:1.0.0.43500
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -272,7 +272,7 @@ Note: in step 5, if you choose **Use existing app registration**, make sure to d
 
 ## Known Limitations
 ---
-In some cases, you might encounter a problem, where no communication is created between Teams and the messaging endpoint, when adding a bot to the team, you can workaround this problem, by adding any member to the team the bot was added to, it's supposed to trigger a communication and solve the issue.
+In some cases, you might encounter a problem, where no communication is created between Teams and the messaging endpoint, when adding a bot to the team. You can workaround this problem by adding any member to the team the bot was added to. It's supposed to trigger a communication and solve the issue.
 
 ## Commands
 You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -270,6 +270,10 @@ Note: in step 5, if you choose **Use existing app registration**, make sure to d
 5. Click **Set up** and configure the new app.
 
 
+## Known Limitations
+---
+In some cases, you might encounter a problem, where no communication is created between Teams and the messaging endpoint, when adding a bot to the team, you can workaround this problem, by adding any member to the team the bot was added to, it's supposed to trigger a communication and solve the issue.
+
 ## Commands
 You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Teams
+- Added a workaround for the problem of not creating a communication when a bot is added to a team.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Microsoft Teams
-Added a workaround for the problem of not creating communication when a bot is added to a team.
+- Added a workaround for the problem of not creating communication when a bot is added to a team.
+- Updated the Docker image to *demisto/teams:1.0.0.43500*.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_2_10.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### Microsoft Teams
-- Added a workaround for the problem of not creating a communication when a bot is added to a team.
+Added a workaround for the problem of not creating communication when a bot is added to a team.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.2.9",
+    "currentVersion": "1.2.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-18583

## Description
added a workaround for the problem of not creating a communication when the bot is added to a team.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
