### PR TITLE
APIVoid - add support in credential store

### DIFF
--- a/Packs/APIVoid/.pack-ignore
+++ b/Packs/APIVoid/.pack-ignore
@@ -1,5 +1,5 @@
 [file:APIVoid.yml]
-ignore=IN145,IN154
+ignore=IN154
 
 [known_words]
 APIVoid

--- a/Packs/APIVoid/Integrations/APIVoid/APIVoid.py
+++ b/Packs/APIVoid/Integrations/APIVoid/APIVoid.py
@@ -549,7 +549,7 @@ def main():
     # get the service API url (This is static for this service)
     base_url = API_ENDPOINT
 
-    apikey = params.get('apikey', None)
+    apikey = params.get('credentials', {}).get('password') or params.get('apikey', None)
 
     verify_certificate = not params.get('insecure', False)
     proxy = params.get('proxy', False)

--- a/Packs/APIVoid/Integrations/APIVoid/APIVoid.yml
+++ b/Packs/APIVoid/Integrations/APIVoid/APIVoid.yml
@@ -6,11 +6,17 @@ display: APIVoid
 category: Data Enrichment & Threat Intelligence
 description: APIVoid wraps up a number of services such as ipvoid & urlvoid
 configuration:
+- name: credentials
+  type: 9
+  required: false
+  displaypassword: API KEY
+  hiddenusername: true
 - display: API KEY
   name: apikey
   defaultvalue: ''
   type: 4
-  required: true
+  required: false
+  hidden: true
 - display: Good Reputation (Percentage)
   name: good
   defaultvalue: '10'
@@ -31,9 +37,9 @@ configuration:
   additionalinfo: If the percentage of detections is ABOVE this value, the indicator is considered BAD
 - display: Malicious
   name: malicious
-  defaultvalue: suspicious
   type: 15
   required: true
+  defaultvalue: suspicious
   options:
   - suspicious
   - bad
@@ -44,12 +50,11 @@ configuration:
   required: false
 - display: Use system proxy settings
   name: proxy
-  type: 8
   required: false
-- additionalinfo: Reliability of the source providing the intelligence data.
-  defaultvalue: C - Fairly reliable
-  display: Source Reliability
+  type: 8
+- defaultvalue: C - Fairly reliable
   name: integrationReliability
+  display: 'Source Reliability'
   options:
   - A+ - 3rd party enrichment
   - A - Completely reliable
@@ -60,16 +65,17 @@ configuration:
   - F - Reliability cannot be judged
   required: false
   type: 15
-- defaultvalue: indicatorType
+  additionalinfo: Reliability of the source providing the intelligence data.
+- defaultvalue: 'indicatorType'
   name: feedExpirationPolicy
   display: ''
+  required: false
+  type: 17
   options:
   - never
   - interval
   - indicatorType
   - suddenDeath
-  required: false
-  type: 17
 - defaultvalue: '20160'
   name: feedExpirationInterval
   display: ''

--- a/Packs/APIVoid/ReleaseNotes/1_0_27.md
+++ b/Packs/APIVoid/ReleaseNotes/1_0_27.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### APIVoid
+- Added the *API KEY* integration parameter to support credentials fetching object.

--- a/Packs/APIVoid/pack_metadata.json
+++ b/Packs/APIVoid/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "APIVoid",
     "description": "APIVoid wraps up a number of services such as ipvoid & urlvoid",
     "support": "xsoar",
-    "currentVersion": "1.0.26",
+    "currentVersion": "1.0.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 