### PR TITLE
Arkime ids argument in arkime-session-pcap-get command

### DIFF
--- a/Packs/Arkime/Integrations/Arkime/Arkime.py
+++ b/Packs/Arkime/Integrations/Arkime/Arkime.py
@@ -177,7 +177,7 @@ class Client(BaseClient):
         return response
 
     def sessions_pcap_request(self,
-                              ids: str,
+                              ids: Optional[str],
                               expression: Optional[str],
                               start_time: Optional[str],
                               stop_time: Optional[str]):
@@ -793,7 +793,7 @@ def sessions_csv_get_command(client: Client,
 
 
 def sessions_pcap_get_command(client: Client,
-                              ids: str,
+                              ids: str = None,
                               expression: str = None,
                               start_time: str = None,
                               stop_time: str = None) -> Dict:

--- a/Packs/Arkime/Integrations/Arkime/Arkime.yml
+++ b/Packs/Arkime/Integrations/Arkime/Arkime.yml
@@ -212,7 +212,7 @@ script:
     arguments:
     - name: ids
       description: The list of IDs to return.
-      required: true
+      required: false
       isArray: true
     - name: expression
       description: The search expression string.

--- a/Packs/Arkime/ReleaseNotes/1_0_9.md
+++ b/Packs/Arkime/ReleaseNotes/1_0_9.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Arkime
+- Updated the ids argument in ***arkime-session-pcap-get*** command to not be required.

--- a/Packs/Arkime/pack_metadata.json
+++ b/Packs/Arkime/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Arkime",
     "description": "Arkime (formerly Moloch) is a large scale, open source, indexed packet capture and search tool.",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Changing ids argument in ***arkime-session-pcap-get*** command from required to be not required.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
