### PR TITLE
Proofpoint Threat Response - add support in credential store

### DIFF
--- a/Packs/ProofpointThreatResponse/.pack-ignore
+++ b/Packs/ProofpointThreatResponse/.pack-ignore
@@ -1,5 +1,5 @@
 [file:ProofpointThreatResponse.yml]
-ignore=IN126,IN145
+ignore=IN126
 
 [file:README.md]
 ignore=RM104

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.py
@@ -15,7 +15,7 @@ TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 BASE_URL = demisto.params().get('url')
 if BASE_URL and BASE_URL[-1] != '/':
     BASE_URL += '/'
-API_KEY = demisto.params().get('apikey')
+API_KEY = demisto.params().get('credentials', {}).get('password') or demisto.params().get('apikey')
 VERIFY_CERTIFICATE = not demisto.params().get('insecure')
 # How many time before the first fetch to retrieve incidents
 FIRST_FETCH, _ = parse_date_range(demisto.params().get('first_fetch', '12 hours') or '12 hours',

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.yml
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponse/ProofpointThreatResponse.yml
@@ -7,19 +7,25 @@ configuration:
   name: url
   required: true
   type: 0
+- name: credentials
+  required: false
+  type: 9
+  displaypassword: API Key
+  hiddenusername: true
 - display: API Key
   name: apikey
-  required: true
+  required: false
   type: 4
+  hidden: true
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
   type: 8
-- defaultvalue: 'false'
-  display: Use system proxy settings
+- display: Use system proxy settings
   name: proxy
   required: false
   type: 8
+  defaultvalue: 'false'
 - display: Fetch incidents
   name: isFetch
   required: false
@@ -28,24 +34,24 @@ configuration:
   name: incidentType
   required: false
   type: 13
-- additionalinfo: The time range for the initial data fetch. If timeout errors occur, consider changing this value.
-  defaultvalue: 12 hours
+- defaultvalue: '12 hours'
   display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)
-  hidden: false
   name: first_fetch
   required: false
   type: 0
+  additionalinfo: The time range for the initial data fetch. If timeout errors occur, consider changing this value.
+  hidden: false
 - defaultvalue: '50'
   display: Fetch limit - maximum number of incidents per fetch
   name: fetch_limit
   required: false
   type: 0
-- defaultvalue: 6 hours
-  additionalinfo: The time range between create_after and created_before that is sent to the API when fetching older incidents. If timeout errors occur, consider changing this value.
-  display: Fetch delta - The delta time in each batch. e.g. 1 hour, 3 minutes.
+- display: Fetch delta - The delta time in each batch. e.g. 1 hour, 3 minutes.
   name: fetch_delta
   required: false
   type: 0
+  defaultvalue: 6 hours
+  additionalinfo: The time range between create_after and created_before that is sent to the API when fetching older incidents. If timeout errors occur, consider changing this value.
 - display: Fetch incidents with specific event sources. Can be a list of comma separated values.
   name: event_sources
   required: false
@@ -56,14 +62,14 @@ configuration:
   type: 0
 - display: Fetch incident with specific states.
   name: states
+  required: false
+  type: 16
   options:
   - new
   - open
   - assigned
   - closed
   - ignored
-  required: false
-  type: 16
 - additionalinfo: You can find this value by navigating to Sources -> JSON event source -> POST URL.
   display: POST URL of the JSON alert source.
   hidden: false
@@ -895,7 +901,7 @@ script:
   script: '-'
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.8.39276
+  dockerimage: demisto/python3:3.10.9.42476
 tests:
 - No test - beta_integration
 beta: true

--- a/Packs/ProofpointThreatResponse/ReleaseNotes/2_0_5.md
+++ b/Packs/ProofpointThreatResponse/ReleaseNotes/2_0_5.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Proofpoint Threat Response (Beta)
+- Added the *API Key* integration parameter to support credentials fetching object.
+- Updated the Docker image to: *demisto/python3:3.10.9.42476*.

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Threat Response",
     "description": "Use the Proofpoint Threat Response integration to orchestrate and automate incident response.",
     "support": "xsoar",
-    "currentVersion": "2.0.4",
+    "currentVersion": "2.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 