### PR TITLE
Update DeveloperTools in bucket

### DIFF
--- a/Packs/DeveloperTools/ReleaseNotes/1_2_30.md
+++ b/Packs/DeveloperTools/ReleaseNotes/1_2_30.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### WaitAndCompleteTask
+- Updated the Docker image to: *demisto/python3:3.10.9.42476*.

--- a/Packs/DeveloperTools/Scripts/WaitAndCompleteTask/WaitAndCompleteTask.yml
+++ b/Packs/DeveloperTools/Scripts/WaitAndCompleteTask/WaitAndCompleteTask.yml
@@ -77,7 +77,7 @@ tags:
 timeout: 2400
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.4.30607
+dockerimage: demisto/python3:3.10.9.42476
 fromversion: 6.1.0
 tests:
 - No tests (auto formatted)

--- a/Packs/DeveloperTools/pack_metadata.json
+++ b/Packs/DeveloperTools/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Developer Tools",
     "description": "Basic tools for content development.",
     "support": "xsoar",
-    "currentVersion": "1.2.29",
+    "currentVersion": "1.2.30",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
In order for nightly to pass after deprecating d2, DeveloperTools should be it's last version in the marketplace-dist bucket (since their dependency was resolved). Because deleting the dependency in pack_metadata.json did not cause a new version, the pack did not update in the marketplace. Therefore any new version of the pack will cause the dependency to be resolved in the marketplace. I updated one of the python dockerimages in the pack in order to complete this.

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4539)

