### PR TITLE
Comparing server versions did not work as expected

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_54.md
+++ b/Packs/Base/ReleaseNotes/1_31_54.md
@@ -1,0 +1,3 @@
+#### Scripts
+##### CommonServer
+Fixed an issue where comparing server versions did not work as expected.

--- a/Packs/Base/Scripts/CommonServer/CommonServer.js
+++ b/Packs/Base/Scripts/CommonServer/CommonServer.js
@@ -1960,13 +1960,38 @@ function getDemistoVersion() {
         throw 'Failed retriving server version - ' + ex;
     }
 }
+/**
+ * Compare between two versions.
+ * @param {string} a - version.
+ * @param {string} b - version.
+ * @return {Integer} if A is bigger returns 1, if B is bigger returns -1,
+ * if they are equal returns 0.
+ */
+function compareVersions(a, b) {
+  if (a === b) {
+    return 0;
+  }
+  a_version = a.split('.')
+  b_version = b.split('.')
+  for (var i=0; i < a_version.length; i++) {
+      // A bigger than B
+      if (parseInt(a_version[i]) > parseInt(b_version[i])) {
+          return 1;
+      }
+      // B bigger than A
+      if (parseInt(a_version[i]) < parseInt(b_version[i])) {
+          return -1;
+      }
+  }
+}
 function isDemistoVersionGE(version, buildNumber) {
     var serverVersion = {};
     try {
         serverVersion = getDemistoVersion();
-        if (serverVersion.version > version) {
+        var versionComparison = compareVersions(serverVersion.version, version)
+        if (versionComparison > 0) {
             return true;
-        } else if (serverVersion.version === version) {
+        } else if (versionComparison === 0) {
             if (buildNumber) {
                 var intBuildNumber = parseInt(serverVersion.buildNumber);
                 if (isNaN(intBuildNumber)) {

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.53",
+    "currentVersion": "1.31.54",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-20016

## Description
Comparing server versions did not work as expected.


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
