### PR TITLE
Make summary retrieval command accept array and more

### DIFF
--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -67,6 +67,17 @@ def submit_sample(client: Client, **args) -> CommandResults:
         "interactive": argToBoolean(args.get("interactive", False))
     }
 
+    if args.get("password"):
+        data["password"] = args["password"]
+
+    if args.get("timeout"):
+        data.setdefault("defaults", {})["timeout"] = arg_to_number(
+            args["timeout"]
+        )
+
+    if args.get("network"):
+        data.setdefault("defaults", {})["network"] = args["network"]
+
     if args.get("profiles", []):
         profiles_data = []
         for i in args.get("profiles", "").split(","):
@@ -89,8 +100,8 @@ def submit_sample(client: Client, **args) -> CommandResults:
             )
     else:
         raise IncorrectUsageError(
-            f'Type of sample needs to be selected, either "file" or "url", '
-            f'the selected type was: {data["kind"]}'
+            f'Type of submission needs to be selected, either "file", "url", '
+            f'or fetch. The selected type was: {data["kind"]}'
         )
 
     return CommandResults(

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -62,7 +62,10 @@ def query_samples(client, **args) -> CommandResults:
 
 
 def submit_sample(client: Client, **args) -> CommandResults:
-    data = {"kind": args.get("kind"), "interactive": False}
+    data = {
+        "kind": args.get("kind"),
+        "interactive": argToBoolean(args.get("interactive", False))
+    }
 
     if args.get("profiles", []):
         profiles_data = []
@@ -152,7 +155,7 @@ def set_sample_profile(client: Client, **args) -> str:
 
 def get_static_report(client: Client, **args) -> CommandResults:
     """
-    Get's the static analysis report from a given sample
+    Gets the static analysis report for a given sample id
     """
     sample_id = args.get("sample_id")
 

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -105,12 +105,21 @@ def get_sample(client: Client, **args) -> CommandResults:
 
 
 def get_sample_summary(client: Client, **args) -> CommandResults:
-    sample_id = args.get("sample_id")
-    r = client._http_request("GET", f"samples/{sample_id}/summary")
+    outputs = []
+    for sample_id in argToList(args.get("sample_id", "")):
+        try:
+            res = client._http_request(
+                "GET", f"samples/{sample_id}/summary", ok_codes=(200,)
+            )
+        except DemistoException as e:
+            e.message += f" - Sample ID: {sample_id}"
+            raise
+
+        outputs.append(res)
 
     return CommandResults(
         outputs_prefix="Triage.sample-summaries", outputs_key_field="sample",
-        outputs=r
+        outputs=outputs
     )
 
 

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -182,7 +182,7 @@ script:
   - arguments:
     - default: false
       description: Sample's unique identifier, can be found using the query samples command
-      isArray: false
+      isArray: true
       name: sample_id
       required: true
       secret: false

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -109,11 +109,20 @@ script:
       required: false
       secret: false
     - default: false
-      description: Data to submit for analysis. For URLs give the URL. For files, give the entry-id of the file
+      description: Data to submit for analysis. For URLs and fetch, give the URL. For files, give the entry-id of the file
       isArray: false
       name: data
       required: true
       secret: false
+    - name: password
+      description: A password that may be used to decrypt the provided file, usually an archive
+      isArray: false
+    - name: timeout
+      description: The timeout in seconds of the behavioral analysis
+      isArray: false
+    - name: network
+      description: 'The type of network routing to use: internet, drop, tor, sim200, or sim404'
+      isArray: false
     deprecated: false
     description: Submits a file or url for analysis
     execution: false

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -121,8 +121,16 @@ script:
       description: The timeout in seconds of the behavioral analysis
       isArray: false
     - name: network
-      description: 'The type of network routing to use: internet, drop, tor, sim200, or sim404'
+      auto: PREDEFINED
+      description: The type of network routing to use
       isArray: false
+      predefined:
+      - internet
+      - drop
+      - tor
+      - sim200
+      - sim404
+      - nxdomain
     deprecated: false
     description: Submits a file or url for analysis
     execution: false
@@ -190,7 +198,7 @@ script:
       type: String
   - arguments:
     - default: false
-      description: Sample's unique identifier, can be found using the query samples command
+      description: One or more comma-separated unique sample identifiers. These can be found using the query samples command.
       isArray: true
       name: sample_id
       required: true
@@ -655,6 +663,9 @@ script:
       - drop
       - internet
       - proxy
+      - tor
+      - sim200
+      - sim404
       required: false
       secret: false
     deprecated: false

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -751,7 +751,7 @@ script:
     execution: false
     name: triage-delete-profile
     description: Update the profile with the specified ID or name. The stored profile is overwritten, so it is important that the submitted profile has all fields, with the exception of the ID
-  dockerimage: demisto/python3:3.10.8.36650
+  dockerimage: demisto/python3:3.10.9.42476
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
@@ -1,6 +1,9 @@
 #### Integrations
 ##### Hatching Triage
-- Add 'timeout', 'network', and 'password' arguments to triage-submit-sample command
-- Use 'interactive' argument for triage-submit-sample command
-- The sample_id argument for triage-get-sample-summary now accepts an array 
+- Added multiple new arguments to the ***triage-submit-sample*** command.
+  - Added the *timeout* argument, which makes it possible to specify a timeout in seconds for the behavioral analysis
+  - Added the *network* argument, which makes it possible to specify the type of network to use during the behavioral analysis
+  - Added the *password* argument, which may be used to specify the password for an encrypted file
+- Updated the ***triage-submit-sample*** command to actually use the *interactive* argument.
+- The *sample_id* argument for ***triage-get-sample-summary*** now accepts an array.
 - Update docker image tag to demisto/python3:3.10.9.42476

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
@@ -1,5 +1,6 @@
 #### Integrations
 ##### Hatching Triage
+- Add 'timeout', 'network', and 'password' arguments to triage-submit-sample command
 - Use 'interactive' argument for triage-submit-sample command
 - The sample_id argument for triage-get-sample-summary now accepts an array 
 - Update docker image tag to demisto/python3:3.10.9.42476

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_8.md
@@ -1,0 +1,5 @@
+#### Integrations
+##### Hatching Triage
+- Use 'interactive' argument for triage-submit-sample command
+- The sample_id argument for triage-get-sample-summary now accepts an array 
+- Update docker image tag to demisto/python3:3.10.9.42476

--- a/Packs/HatchingTriage/pack_metadata.json
+++ b/Packs/HatchingTriage/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Scalable malware sandbox",
     "support": "partner",
     "certification": "certified",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "Hatching",
     "url": "https://hatching.io/",
     "email": "support@hatching.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Makes the `triage-get-sample-summary` accept an array of sample IDs. This is so the command can be used in a Genericpolling block. This requires the command to be an array. This PR also updates the docker image version and causes the `interactive` argument for the `triage-submit-sample` command to actually be used, instead of ignored.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
