### PR TITLE
Set timeout for install packs on XSIAM - Hot Fix

### DIFF
--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -660,7 +660,7 @@ def search_and_install_packs_and_their_dependencies(pack_ids: list,
             pool.submit(search_pack_and_its_dependencies,
                         client, pack_id, packs_to_install, installation_request_body, lock)
 
-    request_timeout = 1800 if host.startswith('qa2-test') else 999999   # hot-fix for xsiam packs install issue
+    request_timeout = 1800 if host and host.startswith('qa2-test') else 999999   # hot-fix for xsiam packs install issue
 
     install_packs(client, host, installation_request_body, request_timeout)
 

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -664,5 +664,4 @@ def search_and_install_packs_and_their_dependencies(pack_ids: list,
 
     install_packs(client, host, installation_request_body, request_timeout)
 
-
     return packs_to_install, SUCCESS_FLAG

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -660,6 +660,9 @@ def search_and_install_packs_and_their_dependencies(pack_ids: list,
             pool.submit(search_pack_and_its_dependencies,
                         client, pack_id, packs_to_install, installation_request_body, lock)
 
-    install_packs(client, host, installation_request_body)
+    request_timeout = 1800 if host.startswith('qa2-test') else 999999   # hot-fix for xsiam packs install issue
+
+    install_packs(client, host, installation_request_body, request_timeout)
+
 
     return packs_to_install, SUCCESS_FLAG


### PR DESCRIPTION
There is starvation of XSIAM build machines. We have only 3 XSIAM machines, but much more builds.
Currently XSIAM nightly is broken. Sending an API call to install packs not responding for a long time. 
As a hotfix I set a timeout - install packs on XSIAM will fail on timeout after 30 minutes. 