### PR TITLE
Switch CSM dockerimage to python3

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.yml
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.yml
@@ -14,7 +14,7 @@ scripttarget: 0
 dependson: {}
 timeout: 0s
 alt_dockerimages: # used for unit testing
-- demisto/python3:3.7.3.286
+- demisto/python:2.7.18.37800
 - demisto/python3:3.8.3.8494
 - demisto/python3:3.9.1.14969
 - demisto/python3:3.9.5.21272
@@ -24,4 +24,4 @@ tests:
 - Test-debug-mode
 - Test-CreateDBotScore-With-Reliability
 fromversion: 5.0.0
-dockerimage: demisto/python:2.7.18.37800
+dockerimage: demisto/python3:3.7.3.286


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [CIAC-4581](https://jira-hq.paloaltonetworks.local/browse/CIAC-4581),
relates: [CIAC-4595](https://jira-hq.paloaltonetworks.local/browse/CIAC-4595).

## Related PRs:
relates: [SDK PR](https://github.com/demisto/demisto-sdk/pull/2613/),
relates: [Content PR](https://github.com/demisto/content/pull/23366).

## Description
In this PR [CIAC-4581](https://jira-hq.paloaltonetworks.local/browse/CIAC-4581) I've added support for running tests on the native images as part of the demisto-sdk lint command. 
To determine if an integration/script is supported by the native images we check the 'dockerimage' key of the integration/script's yml. 
In order to run the commonserverpython on native images as part of our builds I'm switching between the python2.7 image that is defined as the docker image of the CSM (in the 'dockerimage' key) and one of the python3 images that are in the 'altdockerimages'. 


## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
