### PR TITLE
Zscaler - add support in credential store

### DIFF
--- a/Packs/Zscaler/.pack-ignore
+++ b/Packs/Zscaler/.pack-ignore
@@ -1,8 +1,5 @@
 [file:README.md]
 ignore=RM104,RM106
 
-[file:Zscaler.yml]
-ignore=IN145
-
 [known_words]
 requestTimeout

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
@@ -20,7 +20,9 @@ SUSPICIOUS_CATEGORIES = ['SUSPICIOUS_DESTINATION', 'SPYWARE_OR_ADWARE']
 CLOUD_NAME = demisto.params()['cloud']
 USERNAME = demisto.params()['credentials']['identifier']
 PASSWORD = demisto.params()['credentials']['password']
-API_KEY = str(demisto.params()['key'])
+API_KEY = str(demisto.params().get('creds_key', {}).get('password', '')) or str(demisto.params().get('key', ''))
+if not API_KEY:
+    raise Exception('API Key is missing. Please provide an API Key.')
 BASE_URL = CLOUD_NAME + '/api/v1'
 USE_SSL = not demisto.params().get('insecure', False)
 PROXY = demisto.params().get('proxy', True)
@@ -63,11 +65,11 @@ AUTO_ACTIVATE_CHANGES_COMMANDS = (
 )
 
 ''' HANDLE PROXY '''
-if not PROXY:  # pragma: no cover
-    del os.environ['HTTP_PROXY']
-    del os.environ['HTTPS_PROXY']
-    del os.environ['http_proxy']
-    del os.environ['https_proxy']
+# if not PROXY:  # pragma: no cover
+#     del os.environ['HTTP_PROXY']
+#     del os.environ['HTTPS_PROXY']
+#     del os.environ['http_proxy']
+#     del os.environ['https_proxy']
 
 ''' HELPER CLASSES '''
 

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
@@ -65,11 +65,11 @@ AUTO_ACTIVATE_CHANGES_COMMANDS = (
 )
 
 ''' HANDLE PROXY '''
-# if not PROXY:  # pragma: no cover
-#     del os.environ['HTTP_PROXY']
-#     del os.environ['HTTPS_PROXY']
-#     del os.environ['http_proxy']
-#     del os.environ['https_proxy']
+if not PROXY:  # pragma: no cover
+    del os.environ['HTTP_PROXY']
+    del os.environ['HTTPS_PROXY']
+    del os.environ['http_proxy']
+    del os.environ['https_proxy']
 
 ''' HELPER CLASSES '''
 

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.yml
@@ -11,14 +11,21 @@ configuration:
   name: credentials
   required: true
   type: 9
+- name: creds_key
+  required: false
+  type: 9
+  displaypassword: API Key
+  hiddenusername: true
 - display: API Key
   name: key
-  required: true
   type: 4
+  hidden: true
 - additionalinfo: Reliability of the source providing the intelligence data.
-  defaultvalue: C - Fairly reliable
+  defaultvalue: 'C - Fairly reliable'
   display: Source Reliability
   name: reliability
+  required: false
+  type: 15
   options:
   - A+ - 3rd party enrichment
   - A - Completely reliable
@@ -27,20 +34,18 @@ configuration:
   - D - Not usually reliable
   - E - Unreliable
   - F - Reliability cannot be judged
-  type: 15
-  required: false
 - additionalinfo: If enabled, the integration will log out after executing each command.
   defaultvalue: 'true'
   display: Auto Logout
   name: auto_logout
   required: false
   type: 8
-- additionalinfo: If enabled, the integration will activate the command changes after each execution. If disabled, use the 'zscaler-activate-changes' command to activate Zscaler command changes.
-  defaultvalue: 'true'
-  display: Auto Activate Changes
+- display: Auto Activate Changes
   name: auto_activate
   required: false
   type: 8
+  additionalinfo: If enabled, the integration will activate the command changes after each execution. If disabled, use the 'zscaler-activate-changes' command to activate Zscaler command changes.
+  defaultvalue: 'true'
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -471,7 +476,7 @@ script:
   runonce: false
   script: ''
   subtype: python3
-  dockerimage: demisto/python3:3.10.8.37753
+  dockerimage: demisto/python3:3.10.9.42476
   type: python
 fromversion: 5.0.0
 tests:

--- a/Packs/Zscaler/ReleaseNotes/1_3_6.md
+++ b/Packs/Zscaler/ReleaseNotes/1_3_6.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Zscaler Internet Access
+- Added the *API Key* integration parameter to support credentials fetching object.
+- Updated the Docker image to: *demisto/python3:3.10.9.42476*.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zscaler Internet Access",
     "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
     "support": "xsoar",
-    "currentVersion": "1.3.5",
+    "currentVersion": "1.3.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 