### PR TITLE
AlienVault OTX v2 - add support in credential store

### DIFF
--- a/Packs/AlienVault_OTX/.pack-ignore
+++ b/Packs/AlienVault_OTX/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AlienVault_OTX_v2.yml]
-ignore=BA108,BA109,IN145
+ignore=BA108,BA109
 
 [file:README.md]
 ignore=RM106

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
@@ -872,7 +872,7 @@ def main():
     proxy = params.get('proxy')
     default_threshold = int(params.get('default_threshold', 2))
     max_indicator_relationships = arg_to_number(params.get('max_indicator_relationships', 0))
-    token = params.get('api_token')
+    token = params.get('credentials', {}).get('password') or params.get('api_token')
     reliability = params.get('integrationReliability')
     reliability = reliability if reliability else DBotScoreReliability.C
     if DBotScoreReliability.is_valid_type(reliability):

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.py
@@ -872,7 +872,7 @@ def main():
     proxy = params.get('proxy')
     default_threshold = int(params.get('default_threshold', 2))
     max_indicator_relationships = arg_to_number(params.get('max_indicator_relationships', 0))
-    token = params.get('credentials', {}).get('password') or params.get('api_token')
+    token = params.get('credentials', {}).get('password', '') or params.get('api_token', '')
     reliability = params.get('integrationReliability')
     reliability = reliability if reliability else DBotScoreReliability.C
     if DBotScoreReliability.is_valid_type(reliability):

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
@@ -8,27 +8,33 @@ configuration:
   name: url
   required: true
   type: 0
+- name: credentials
+  required: false
+  type: 9
+  displaypassword: API Token
+  hiddenusername: true
 - display: API Token
   name: api_token
   required: false
   type: 4
+  hidden: true
 - defaultvalue: '2'
-  display: Indicator Threshold. The minimum number of pulses to consider the indicator
-    as malicious.
+  display: Indicator Threshold. The minimum number of pulses to consider the indicator as malicious.
   name: default_threshold
   required: false
   type: 0
-- defaultvalue: '10'
+- additionalinfo: If not provided, no relationships will be added. This field is relevant only for url, file hash and ip / domain indicators.
+  defaultvalue: '10'
   display: Maximum number of relationships for indicators
   name: max_indicator_relationships
   required: false
   type: 0
-  additionalinfo: If not provided, no relationships will be added. This field is relevant
-    only for url, file hash and ip / domain indicators.
-- additionalinfo: Reliability of the source providing the intelligence data.
-  defaultvalue: C - Fairly reliable
+- defaultvalue: 'C - Fairly reliable'
+  additionalinfo: Reliability of the source providing the intelligence data.
   display: Source Reliability
   name: integrationReliability
+  required: true
+  type: 15
   options:
   - A+ - 3rd party enrichment
   - A - Completely reliable
@@ -37,14 +43,12 @@ configuration:
   - D - Not usually reliable
   - E - Unreliable
   - F - Reliability cannot be judged
-  required: true
-  type: 15
-- defaultvalue: 'true'
-  additionalinfo: Create relationships between indicators as part of Enrichment.
-  display: Create relationships
+- display: Create relationships
   name: create_relationships
   required: false
   type: 8
+  defaultvalue: 'true'
+  additionalinfo: Create relationships between indicators as part of Enrichment.
 - display: Trust any certificate (not secure)
   name: insecure
   required: false
@@ -66,9 +70,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the IP address
-        is considered as malicious. If the threshold is not specified, the default
-        indicator threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the IP address is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -88,8 +90,7 @@ script:
       description: The country where the IP address is located.
       type: String
     - contextPath: IP.Geo.Location
-      description: 'The geolocation where the IP address is located, in the format:
-        latitude:longitude.'
+      description: 'The geolocation where the IP address is located, in the format: latitude:longitude.'
       type: String
     - contextPath: AlienVaultOTX.IP.Reputation
       description: The reputation of the IP address.
@@ -132,9 +133,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the domain
-        is considered as malicious. If the threshold is not specified, the default
-        indicator threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the domain is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -188,9 +187,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the IP address
-        is considered as malicious. If the threshold is not specified, the default
-        indicator threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the IP address is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -229,9 +226,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the host
-        name is considered as malicious. If the threshold is not specified, the default
-        indicator threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the host name is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -273,9 +268,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the file
-        is considered as malicious. If the threshold is not specified, the default
-        indicator threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the file is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -298,8 +291,7 @@ script:
       description: IDs of pulses which are marked as malicious.
       type: String
     - contextPath: File.Type
-      description: The file type, as determined by libmagic (same as displayed in
-        file entries).
+      description: The file type, as determined by libmagic (same as displayed in file entries).
       type: String
     - contextPath: File.Size
       description: The size of the file in bytes.
@@ -342,9 +334,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the CVE is
-        considered as malicious. If the threshold is not specified, the default indicator
-        threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the CVE is considered as malicious. If the threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false
@@ -384,8 +374,7 @@ script:
   - arguments:
     - auto: PREDEFINED
       default: false
-      description: 'The indicator type. Can be: "IPv4", "IPv6", "domain", "hostname",
-        or "url".'
+      description: 'The indicator type. Can be: "IPv4", "IPv6", "domain", "hostname", or "url".'
       isArray: false
       name: indicator_type
       predefined:
@@ -562,9 +551,7 @@ script:
       required: true
       secret: false
     - default: false
-      description: If the number of pulses is bigger than the threshold, the URL is
-        considered as malicious. If threshold is not specified, the default indicator
-        threshold is used, which is configured in the instance settings.
+      description: If the number of pulses is bigger than the threshold, the URL is considered as malicious. If threshold is not specified, the default indicator threshold is used, which is configured in the instance settings.
       isArray: false
       name: threshold
       required: false

--- a/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
+++ b/Packs/AlienVault_OTX/Integrations/AlienVault_OTX_v2/AlienVault_OTX_v2.yml
@@ -9,7 +9,6 @@ configuration:
   required: true
   type: 0
 - name: credentials
-  required: false
   type: 9
   displaypassword: API Token
   hiddenusername: true

--- a/Packs/AlienVault_OTX/ReleaseNotes/1_1_28.md
+++ b/Packs/AlienVault_OTX/ReleaseNotes/1_1_28.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### AlienVault OTX v2
+- Added the *API Token* integration parameter to support credentials fetching object.

--- a/Packs/AlienVault_OTX/pack_metadata.json
+++ b/Packs/AlienVault_OTX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AlienVault OTX",
     "description": "Query Indicators of Compromise in AlienVault OTX.",
     "support": "xsoar",
-    "currentVersion": "1.1.27",
+    "currentVersion": "1.1.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 