### PR TITLE
Tim   indicator relationships playboox   disable auto extract

### DIFF
--- a/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Indicator_Relationships_Analysis.yml
+++ b/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Indicator_Relationships_Analysis.yml
@@ -122,6 +122,7 @@ tasks:
           accessor: EntityB
           transformers:
           - operator: uniq
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -173,6 +174,7 @@ tasks:
           accessor: EntityB
           transformers:
           - operator: uniq
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -224,6 +226,7 @@ tasks:
           accessor: EntityB
           transformers:
           - operator: uniq
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -275,6 +278,7 @@ tasks:
           accessor: EntityB
           transformers:
           - operator: uniq
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -532,6 +536,7 @@ tasks:
       limit:
         complex:
           root: inputs.LimitResults
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -573,6 +578,7 @@ tasks:
       limit:
         complex:
           root: inputs.LimitResults
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -873,6 +879,7 @@ tasks:
           accessor: EntityB
           transformers:
           - operator: uniq
+    reputationcalc: 1
     separatecontext: false
     continueonerrortype: ""
     view: |-

--- a/Packs/TIM_Processing/ReleaseNotes/1_1_14.md
+++ b/Packs/TIM_Processing/ReleaseNotes/1_1_14.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### TIM - Indicator Relationships Analysis
+- Indicators auto-extract is disabled

--- a/Packs/TIM_Processing/ReleaseNotes/1_1_14.md
+++ b/Packs/TIM_Processing/ReleaseNotes/1_1_14.md
@@ -1,4 +1,4 @@
 
 #### Playbooks
 ##### TIM - Indicator Relationships Analysis
-- Indicators auto-extract is disabled
+- Changed auto-extract to 'None'.

--- a/Packs/TIM_Processing/pack_metadata.json
+++ b/Packs/TIM_Processing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TIM - Indicator Auto-Processing",
     "description": "Too many threat feeds? This Content Pack automates the processing of indicators at scale, significantly reducing busywork for your analysts.",
     "support": "xsoar",
-    "currentVersion": "1.1.13",
+    "currentVersion": "1.1.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
disable indicators auto-extract

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.8.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
