### PR TITLE
HelloWorld - add support in credential store

### DIFF
--- a/Packs/HelloWorld/.pack-ignore
+++ b/Packs/HelloWorld/.pack-ignore
@@ -8,7 +8,7 @@ ignore=BA110
 ignore=BA101
 
 [file:HelloWorld.yml]
-ignore=BA111,IN145
+ignore=BA111
 
 [file:classifier-HelloWorld.json]
 ignore=BA101

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.py
@@ -1307,7 +1307,7 @@ def main() -> None:
     args = demisto.args()
     command = demisto.command()
 
-    api_key = params.get('apikey')
+    api_key = params.get('credentials', {}).get('password')
 
     # get the service API url
     base_url = urljoin(params.get('url'), '/api/v1')

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -42,10 +42,11 @@ configuration:
   required: false
   type: 0
   section: Collect
-- display: API Key
-  name: apikey
+- displaypassword: API Key
+  name: credentials
   required: true
-  type: 4
+  type: 9
+  hiddenusername: true
   section: Connect
 - defaultvalue: '65'
   display: Score threshold for IP reputation command

--- a/Packs/HelloWorld/ReleaseNotes/1_2_16.json
+++ b/Packs/HelloWorld/ReleaseNotes/1_2_16.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"This update is only possible if you do not have a configured instance of this integration, otherwise you will have to delete the existing instance to update the integration"}

--- a/Packs/HelloWorld/ReleaseNotes/1_2_16.md
+++ b/Packs/HelloWorld/ReleaseNotes/1_2_16.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### HelloWorld
+- Added the *API Key* integration parameter to support credentials fetching object.

--- a/Packs/HelloWorld/pack_metadata.json
+++ b/Packs/HelloWorld/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HelloWorld",
     "description": "This is the Hello World integration for getting started.",
     "support": "community",
-    "currentVersion": "1.2.15",
+    "currentVersion": "1.2.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4767)

## Description
Change the type of credentials, from type 4 to type 9.

## Does it break backward compatibility?
   - [x] Yes
       - In the configuration, the type of the API Key parameter was changed from type 4 to type 9. Those who have a configured instance will not be able to update the pack
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 