### PR TITLE
Symantec DLP Integration - Support environments with no custom attributes defined

### DIFF
--- a/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.py
+++ b/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.py
@@ -409,7 +409,7 @@ def get_common_incident_details(static_attributes: dict, editable_attributes: di
     static_attributes.pop('incidentId')
     editable_attributes.pop('incidentId')
     incident_info_map_editable.pop('severityId')
-    editable_attributes.pop('customAttributeGroups')
+    editable_attributes.pop('customAttributeGroups', [])
     incident_details.update(incident_info_map_static)
     incident_details.update(incident_info_map_editable)
 

--- a/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
+++ b/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
@@ -590,7 +590,7 @@ script:
     - contextPath: SymantecDLP.IncidentRemediationStatus.name
       description: The name of the remediation status.
       type: String
-  dockerimage: demisto/python3:3.10.9.43882
+  dockerimage: demisto/python3:3.10.9.44472
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
+++ b/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
@@ -590,7 +590,7 @@ script:
     - contextPath: SymantecDLP.IncidentRemediationStatus.name
       description: The name of the remediation status.
       type: String
-  dockerimage: demisto/python3:3.10.5.31928
+  dockerimage: demisto/python3:3.10.9.43882
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Symantec Data Loss Prevention v2
 - Fixed an issue where an environment without custom attributes caused errors while fetching incidents
-- Updated the Docker image to: *demisto/python3:3.10.9.43882*
+- Updated the Docker image to: *demisto/python3:3.10.9.44472*

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Symantec Data Loss Prevention v2
+- %%UPDATE_RN%%

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
@@ -2,4 +2,4 @@
 #### Integrations
 ##### Symantec Data Loss Prevention v2
 - Fixed an issue where an environment without custom attributes caused errors while fetching incidents
-- Update the Docker image to: _demisto/python3:3.10.9.43882_
+- Updated the Docker image to: *demisto/python3:3.10.9.43882*

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_7.md
@@ -1,4 +1,5 @@
 
 #### Integrations
 ##### Symantec Data Loss Prevention v2
-- %%UPDATE_RN%%
+- Fixed an issue where an environment without custom attributes caused errors while fetching incidents
+- Update the Docker image to: _demisto/python3:3.10.9.43882_

--- a/Packs/SymantecDLP/pack_metadata.json
+++ b/Packs/SymantecDLP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Symantec Data Loss Prevention",
     "description": "Symantec Data Loss Prevention enables you to discover, monitor and protect your sensitive corporate information.",
     "support": "xsoar",
-    "currentVersion": "2.0.6",
+    "currentVersion": "2.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Ran into an issue where an environment with no custom attributes causes failures on incident fetching. Python's dictionary.pop() takes a second parameter to default what it returns if the key is not found...since the integration code defaults the .get() for the 'customAttributeGroups' key, it should also default the .pop() for removing it from the dictionary. Code test in our environment solves the issue and successfully fetches incidents.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
