### PR TITLE
devcontainer: demisto-sdk write permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,8 +73,15 @@
 				"ms-python.black-formatter",
 				"LittleFoxTeam.vscode-python-test-adapter"
 			]
-	}
-},
+		},
+		"codespaces": {
+			"repositories": {
+				"demisto/demisto-sdk": {
+					"permissions": "write-all"
+				}
+			}
+		}
+	},
 // this is commented out until VSCode will fix self signed certificate issues
 // "features": {
 // 	"ghcr.io/devcontainers/features/docker-in-docker:1": {


### PR DESCRIPTION
Allows editing demisto-sdk files from a content devcontainer