### PR TITLE
took out force

### DIFF
--- a/Utils/github_workflow_scripts/sync_contrib_base.py
+++ b/Utils/github_workflow_scripts/sync_contrib_base.py
@@ -59,7 +59,7 @@ def get_branch_names_with_contrib(repo: Repository) -> List[str]:  # noqa: E999
 def update_branch(content_repo, branch_name, master_sha):
     git_ref = content_repo.get_git_ref(f'heads/{branch_name}')
     print(f'Updating branch "{branch_name}" to sha "{master_sha}"')
-    git_ref.edit(master_sha, force=True)
+    git_ref.edit(master_sha)
 
 
 def main():


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: **CIAC-5186**

## Description
A race condition was being caused where editing and then immediately merging a pr would trigger this workflow to run, merge, and then this workflow would ovverride the branch with the master commit. Setting force to false will cause only fast-forwarding changes to be accepted

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
