### PR TITLE
remove audit type widget from xsoar ng

### DIFF
--- a/Packs/CommonWidgets/ReleaseNotes/1_2_12.md
+++ b/Packs/CommonWidgets/ReleaseNotes/1_2_12.md
@@ -1,0 +1,4 @@
+
+#### Widgets
+##### Incidents Dropped in Preprocessing
+- Removed from XSOAR 8.x

--- a/Packs/CommonWidgets/Widgets/widget-IncidentsDroppedInPreprocessing.json
+++ b/Packs/CommonWidgets/Widgets/widget-IncidentsDroppedInPreprocessing.json
@@ -2,6 +2,7 @@
  "id": "incidents-dropped-in-preprocessing",
  "version": -1,
  "fromVersion": "5.0.0",
+ "toVersion": "7.9.9",
  "name": "Incidents Dropped in Preprocessing",
  "dataType": "audit",
  "category": "incidents",

--- a/Packs/CommonWidgets/pack_metadata.json
+++ b/Packs/CommonWidgets/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Widgets",
     "description": "Frequently used widgets pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.11",
+    "currentVersion": "1.2.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CRTX-71910)

## Description
remove audit type widget from xsoar ng

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
