### PR TITLE
[PAN-OS] - fix issue in the pan-os-push-to-device-group command

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -1171,7 +1171,8 @@ def panorama_push_to_device_group_command(args: dict):
                 'push_job_id': job_id,
                 'polling': argToBoolean(args.get('polling', False)),
                 'interval_in_seconds': arg_to_number(args.get('interval_in_seconds', 10)),
-                'description': description
+                'description': description,
+                'device-group': DEVICE_GROUP
             }
 
         return PollResult(

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -1947,13 +1947,15 @@ class TestPanoramaPushToDeviceGroupCommand:
         import Panorama
         from Panorama import panorama_push_to_device_group_command
         from CommonServerPython import ScheduledCommand
-        Panorama.DEVICE_GROUP = 'device-group-from-integration-params'
 
         args = {
             'description': 'a simple push',
             'polling': 'true',
             'device-group': 'device-group-from-command-arg'
         }
+
+        # mimcs the piece of code which decides which device-group will be set into DEVICE_GROUP parameter.
+        Panorama.DEVICE_GROUP = args.get('device-group') or 'device-group-from-integration-params'
 
         Panorama.API_KEY = 'APIKEY'
         mocker.patch.object(ScheduledCommand, 'raise_error_if_not_supported', return_value=None)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -1925,7 +1925,7 @@ class TestPanoramaPushToDeviceGroupCommand:
     def test_panorama_push_to_devices_command_with_polling(self, mocker, api_response_queue):
         """
         Given:
-            - pan-os-push-to-device-group command arguments
+            - pan-os-push-to-device-group command arguments including device-group.
             - a queue for api responses of the following:
                 1) first value in the queue is the panorama push to the device group api response
                 2) panorama job status api response which indicates job isn't done yet (different number each time)
@@ -1941,16 +1941,18 @@ class TestPanoramaPushToDeviceGroupCommand:
               that it returns the expected output.
             - make sure readable output is printed out only once.
             - make sure context output is returned only when polling is finished.
+            - make sure the device-group from argument overrides the device-group from parameter in context.
         """
         import requests
         import Panorama
         from Panorama import panorama_push_to_device_group_command
         from CommonServerPython import ScheduledCommand
-        Panorama.DEVICE_GROUP = 'device-group'
+        Panorama.DEVICE_GROUP = 'device-group-from-integration-params'
 
         args = {
             'description': 'a simple push',
-            'polling': 'true'
+            'polling': 'true',
+            'device-group': 'device-group-from-command-arg'
         }
 
         Panorama.API_KEY = 'APIKEY'
@@ -1974,6 +1976,7 @@ class TestPanoramaPushToDeviceGroupCommand:
             command_result = panorama_push_to_device_group_command(polling_args)
 
         assert command_result.outputs.get('JobID') == '123'
+        assert command_result.outputs.get('DeviceGroup') == 'device-group-from-command-arg'
         assert command_result.outputs.get('Status') == 'Completed'
         assert command_result.outputs.get('Details')
         assert command_result.outputs.get('Warnings')

--- a/Packs/PAN-OS/ReleaseNotes/1_16_3.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_16_3.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue where the ***pan-os-push-to-device-group*** command always returned into the context the *device-group* from integration parameters even if *device-group* argument was provided.
+- Updated the Docker image to: *demisto/pan-os-python:1.0.0.44853*.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.16.2",
+    "currentVersion": "1.16.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-20343

## Description
Fixed an issue where in the pan-os-push-to-device-group command, the device-group argument that is returned in context and human readable is always the one from integration parameters.

## Must have
- [x] Tests
- [ ] Documentation 
