### PR TITLE
Ms_defender_alerts_v2

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -1107,7 +1107,7 @@ class MsClient:
 
     def __init__(self, tenant_id, auth_id, enc_key, app_name, base_url, verify, proxy, self_deployed,
                  alert_severities_to_fetch, alert_status_to_fetch, alert_time_to_fetch, max_fetch,
-                 auth_type, redirect_uri, auth_code,
+                 auth_type, redirect_uri, auth_code, alert_detectionsource_to_fetch,
                  is_gcc: bool, certificate_thumbprint: Optional[str] = None, private_key: Optional[str] = None):
         client_args = assign_params(
             self_deployed=self_deployed,
@@ -1133,6 +1133,7 @@ class MsClient:
         self.alert_severities_to_fetch = alert_severities_to_fetch
         self.alert_status_to_fetch = alert_status_to_fetch
         self.alert_time_to_fetch = alert_time_to_fetch
+        self.alert_detectionsource_to_fetch = alert_detectionsource_to_fetch
         self.max_alerts_to_fetch = max_fetch
         self.is_gcc = is_gcc
 
@@ -3589,6 +3590,12 @@ def fetch_incidents(client: MsClient, last_run, fetch_evidence):
 
 def _get_incidents_query_params(client, fetch_evidence, last_fetch_time):
     filter_query = f'alertCreationTime+gt+{last_fetch_time}'
+    if client.alert_detectionsource_to_fetch:
+        sources = argToList(client.alert_detectionsource_to_fetch)
+        source_filter_list = [f"detectionSource+eq+'{source}'" for source in sources]
+        if len(source_filter_list) > 1:
+            source_filter_list = list(map(lambda x: f'({x})', source_filter_list))
+        filter_query = filter_query + ' and (' + ' or '.join(source_filter_list) + ')'
     if client.alert_status_to_fetch:
         statuses = argToList(client.alert_status_to_fetch)
         status_filter_list = [f"status+eq+'{status}'" for status in statuses]
@@ -5415,6 +5422,7 @@ def main():  # pragma: no cover
     alert_severities_to_fetch = params.get('fetch_severity')
     alert_status_to_fetch = params.get('fetch_status')
     alert_time_to_fetch = params.get('first_fetch_timestamp', '3 days')
+    alert_detectionsource_to_fetch = params.get('fetch_detectionsource')
     max_alert_to_fetch = arg_to_number(params.get('max_fetch', 50))
     fetch_evidence = argToBoolean(params.get('fetch_evidence', False))
     last_run = demisto.getLastRun()
@@ -5448,7 +5456,8 @@ def main():  # pragma: no cover
             proxy=proxy, self_deployed=self_deployed, alert_severities_to_fetch=alert_severities_to_fetch,
             alert_status_to_fetch=alert_status_to_fetch, alert_time_to_fetch=alert_time_to_fetch,
             max_fetch=max_alert_to_fetch, certificate_thumbprint=certificate_thumbprint, private_key=private_key,
-            is_gcc=is_gcc, auth_type=auth_type, auth_code=auth_code, redirect_uri=redirect_uri
+            is_gcc=is_gcc, auth_type=auth_type, auth_code=auth_code, redirect_uri=redirect_uri,
+            alert_detectionsource_to_fetch=alert_detectionsource_to_fetch,
         )
         if command == 'test-module':
             if auth_type == 'Authorization Code':

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -112,7 +112,7 @@ configuration:
   type: 16
   section: Collect
   advanced: true
-- display: 'DetectionSource to filter out alerts for fetching as incidents (not available for v2).'
+- display: 'DetectionSource to filter out alerts for fetching as incidents.'
   name: fetch_detectionsource
   required: false
   type: 16

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -112,7 +112,7 @@ configuration:
   type: 16
   section: Collect
   advanced: true
-- display: 'DetectionSource to filter out alerts for fetching as incidents.'
+- display: 'DetectionSource to filter out alerts for fetching as incidents (not available for v2).'
   name: fetch_detectionsource
   required: false
   type: 16
@@ -737,6 +737,15 @@ script:
       description: Flag for the rate limit retry.
       isArray: false
       name: ran_once_flag
+      required: false
+    - auto: PREDEFINED
+      default: false
+      description: Use the new alert v2 Enpoint
+      isArray: false
+      name: use_v2_endpoint
+      predefined:
+      - 'false'
+      - 'true'
       required: false
     deprecated: false
     description: Gets a list of alerts present on the system. Filtering can be done only on a single argument.
@@ -5220,6 +5229,15 @@ script:
       required: false
       isArray: false
       deprecated: true
+    - auto: PREDEFINED
+      default: false
+      description: Use the new alert v2 Enpoint
+      isArray: false
+      name: use_v2_endpoint
+      predefined:
+      - 'false'
+      - 'true'
+      required: false
     outputs:
     - contextPath: MicrosoftATP.Alert.ID
       description: The alert ID.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -112,6 +112,16 @@ configuration:
   type: 16
   section: Collect
   advanced: true
+- display: 'DetectionSource to filter out alerts for fetching as incidents.'
+  name: fetch_detectionsource
+  required: false
+  type: 16
+  options:
+  - CustomDetection
+  - CustomerTI
+  - EDR
+  - MDO
+  - Antivirus
 - defaultvalue: Informational,Low,Medium,High
   display: 'Severity to filter out alerts for fetching as incidents. Comma-separated lists are supported, e.g., Medium,High.'
   name: fetch_severity

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection_test.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection_test.py
@@ -219,11 +219,15 @@ def test_get_domain_alerts_command(mocker):
 
 
 def test_get_alert_data(mocker):
-    from MicrosoftDefenderAdvancedThreatProtection import get_alert_data
+    from MicrosoftDefenderAdvancedThreatProtection import get_alert_data, get_alert_data_v2
     mocker.patch.object(client_mocker, 'get_alert_by_id', return_value=SINGLE_ALERT_API_RESPONSE)
     res = get_alert_data(SINGLE_ALERT_API_RESPONSE)
     assert res['ID'] == '123'
     assert res['Title'] == 'Network connection to a risky host'
+    mocker.patch.object(client_mocker, 'get_alert_by_id', return_value=SINGLE_ALERT_API_RESPONSE_v2)
+    res_v2 = get_alert_data_v2(SINGLE_ALERT_API_RESPONSE_v2)
+    assert res_v2['ID'] == '123'
+    assert res_v2['Title'] == 'Suspicious execution of hidden file'
 
 
 def test_get_domain_machine_command(mocker):
@@ -585,6 +589,46 @@ SINGLE_ALERT_API_RESPONSE = {
     "lastUpdateTime": "2019-11-03T23:55:52.6Z",
     "resolvedTime": None,
     "machineId": "123abc",
+    "comments": [
+        {
+            "comment": "test comment for docs",
+            "createdBy": "test@test.com",
+            "createdTime": "2019-11-05T14:08:37.8404534Z"
+        }
+
+    ]
+}
+
+SINGLE_ALERT_API_RESPONSE_v2 = {
+    "id": "123",
+    "providerAlertId": "123",
+    "incidentId": 123456,
+    "assignedTo": None,
+    "severity": "Low",
+    "status": "New",
+    "classification": "unknown",
+    "determination": 'unknown',
+    "serviceSource": "microsoftDefenderForEndpoint",
+    "detectionSource": "antivirus",
+    "detectorId": "456",
+    "tenantId": "abc",
+    "category": "DefenseEvasion",
+    "actorDisplayName": None,
+    "threatDisplayName": None,
+    "threatFamilyName": None,
+    "mitreTechniques": [
+        "T1564.001"
+    ],
+    "title": "Suspicious execution of hidden file",
+    "description": "A hidden file has been launched. This activity could indicate a compromised host. Attackers often hide files associated with malicious tools to evade file system inspection and defenses.",
+    "recommendedActions": "Collect artifacts and determine scope\n�\tReview the machine timeline for suspicious activities that may have occurred before and after the time of the alert, and record additional related artifacts (files, IPs/URLs) \n�\tLook for the presence of relevant artifacts on other systems. Identify commonalities and differences between potentially compromised systems.\n�\tSubmit relevant files for deep analysis and review resulting detailed behavioral information.\n�\tSubmit undetected files to the MMPC malware portal\n\nInitiate containment & mitigation \n�\tContact the user to verify intent and initiate local remediation actions as needed.\n�\tUpdate AV signatures and run a full scan. The scan might reveal and remove previously-undetected malware components.\n�\tEnsure that the machine has the latest security updates. In particular, ensure that you have installed the latest software, web browser, and Operating System versions.\n�\tIf credential theft is suspected, reset all relevant users passwords.\n�\tBlock communication with relevant URLs or IPs at the organization�s perimeter.",
+    "alertWebUrl": "https://security.microsoft.com/alerts/123",
+    "incidentWebUrl": "https://security.microsoft.com/incidents/123456",
+    "createdDateTime": "2021-04-27T12:19:27.7211305Z",
+    "firstActivityDateTime": "2021-04-26T07:45:50.116Z",
+    "lastActivityDateTime": "2021-05-02T07:56:58.222Z",
+    "lastUpdateDateTime": "2019-11-03T23:55:52.6Z",
+    "resolvedDateTime": None,
     "comments": [
         {
             "comment": "test comment for docs",

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_15_7.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_15_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Defender for Endpoint
+- Added *use_v2_endpoint* argument in the ***microsoft-atp-get-alert-by-id*** and ***microsoft-atp-list-alerts*** commands to support alerts v2 endpoint.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.15.6",
+    "currentVersion": "1.15.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Microsoft released its alterts v2 endpoint in december, which has includes additional sources of alerts (e.g. microsoftDefenderForOffice365) and other fields (e.g. recommended Actions) then the endpoint before. 
https://learn.microsoft.com/en-us/graph/api/security-list-alerts_v2?view=graph-rest-1.0&tabs=http

In addition included the fetch alerts filter changes from this pr, which never made it to live even though they were approved: https://github.com/demisto/content/pull/21976

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
