### PR TITLE
removed the required from the port arg and added varification in the …

### DIFF
--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -17,6 +17,8 @@ import dateparser
 import hashlib
 import json
 import ipaddress
+from distutils.version import LooseVersion
+
 
 # Disable insecure warnings
 urllib3.disable_warnings()
@@ -1085,6 +1087,16 @@ def main():
         err_msg: str = 'If using credentials, both username and password should be provided.'
         demisto.debug(err_msg)
         raise DemistoException(err_msg)
+
+    platform = demisto.demistoVersion.get("platform", 'xsoar')
+    if platform in ['xsoar', 'xsoar_hosted']:
+        demisto_version = demisto.demistoVersion.get('version')
+        if LooseVersion(demisto_version) < LooseVersion('8.0.0') and not params.get('longRunningPort'):
+            raise DemistoException('Please specify a Listen Port, in the integration configuration')
+
+        if int(demisto_version.split('.')[0]) < 8 and not params.get('longRunningPort'):
+            raise DemistoException('Please specify a Listen Port, in the integration configuration')
+
     command = demisto.command()
     demisto.debug(f'Command being called is {command}')
     commands = {

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -60,7 +60,6 @@ configuration:
 - additionalinfo: Runs the service on this port from within Cortex XSOAR. Requires a unique port for each long-running integration instance. Do not use the same port for multiple instances.
   display: Listen Port
   name: longRunningPort
-  required: true
   type: 0
   section: Connect
 - additionalinfo: For use with HTTPS - the certificate that the service should use.


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5245)

## Description
Turn the port parameter to be optional.  In Xsoar it will still be required and enforced by code and in XSAIM and Xsoar NG it will be optional. 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
