### PR TITLE
Fix jobs-done-check fails on sync-buckets-between-projects

### DIFF
--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -532,7 +532,6 @@ sync-buckets-between-projects:
     - |
       if [[ -z "$GCS_XSOAR_CONTENT_DEV_KEY" ]] || [[ -z "$GCS_XSOAR_CONTENT_PROD_KEY" ]]; then
         echo "GCS_XSOAR_CONTENT_DEV_KEY or GCS_XSOAR_CONTENT_PROD_KEY not set, cannot perform sync"
-        job-done
         exit 1
       else
         gcloud auth activate-service-account --key-file="$GCS_XSOAR_CONTENT_DEV_KEY"
@@ -554,4 +553,5 @@ sync-buckets-between-projects:
         gsutil -m rsync -r gs://xpanse-dist gs://marketplace-xpanse-prod-us
 
         echo "Bucket sync completed"
+        job-done
       fi


### PR DESCRIPTION
Shouldn't it be like I did? 
Failed here: 
https://code.pan.run/xsoar/content/-/pipelines/4452019

We are doing the job-done only if it was done successfully right? 