### PR TITLE
skip Interzer v2 in native ga

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -106,7 +106,8 @@
          "id":"Intezer v2",
          "reason":"Issue: CIAC-5241.",
          "ignored_native_images":[
-            "native:dev"
+            "native:dev",
+            "native:8.1"
          ]
       },
       {


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/CIAC-5241

## Description
skip IntezerV2 in native:ga cause it fails


