### PR TITLE
Fix pan os edit address group bug

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -1925,6 +1925,11 @@ def panorama_edit_address_group_command(args: dict):
             addresses = list(set(element_to_add + address_group_list))
         else:
             addresses = [item for item in address_group_list if item not in element_to_remove]
+            if not addresses:
+                raise DemistoException(
+                    f'cannot remove {address_group_list} addresses from address group {address_group_name}, '
+                    f'address-group {address_group_name} must have at least one address in its configuration'
+                )
         addresses_param = add_argument_list(addresses, 'member', False)
         addresses_path = f"{XPATH_OBJECTS}address-group/entry[@name=\'{address_group_name}\']/static"
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -9346,7 +9346,7 @@ script:
     description: Deletes an application-group
     name: pan-os-delete-application-group
     outputs: []
-  dockerimage: demisto/pan-os-python:1.0.0.45072
+  dockerimage: demisto/pan-os-python:1.0.0.45668
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -1302,11 +1302,11 @@ class TestPanoramaEditRuleCommand:
         }
 
 
-def test_panorama_edit_address_group_command_main_flow(mocker):
+def test_panorama_edit_address_group_command_main_flow_edit_description(mocker):
     """
     Given
      - integrations parameters.
-     - pan-os-edit-address-group command arguments including device_group
+     - pan-os-edit-address-group command arguments including device_group and description to add.
 
     When -
         running the pan-os-edit-address-group command through the main flow
@@ -1342,6 +1342,54 @@ def test_panorama_edit_address_group_command_main_flow(mocker):
         'response': {'@status': 'success', '@code': '20', 'msg': 'command succeeded'}
     }
     assert res.call_args.args[0]['HumanReadable'] == 'Address Group test was edited successfully.'
+
+
+def test_panorama_edit_address_group_command_main_flow_remove_address(mocker):
+    """
+    Given
+     - integrations parameters.
+     - pan-os-edit-address-group command arguments including an address to remove.
+
+    When -
+        running the pan-os-edit-address-group command through the main flow
+
+    Then
+     - make sure the context output is returned as expected.
+     - make sure the body request is sent as expected.
+    """
+    from Panorama import main
+
+    mocker.patch.object(demisto, 'params', return_value=integration_panorama_params)
+    mocker.patch.object(
+        demisto,
+        'args',
+        return_value={'name': 'test', 'device-group': 'Shared', 'type': 'static', 'element_to_remove': '5.5.5.5'}
+    )
+
+    mocker.patch.object(demisto, 'command', return_value='pan-os-edit-address-group')
+    request_mock = mocker.patch(
+        'Panorama.http_request',
+        side_effect=[
+            {
+                'response': {
+                    '@status': 'success', 'result': {
+                        'entry': {
+                            '@name': 'test5',
+                            'static': {'member': ['5.5.5.5']},
+                            'description': 'dfdf'
+                        }
+                    }
+                }
+            },
+            {'response': {'@status': 'success', '@code': '20', 'msg': 'command succeeded'}}
+        ]
+    )
+
+    res = mocker.patch('demistomock.results')
+    main()
+
+    assert request_mock.call_args.kwargs['body']
+
 
 
 @pytest.mark.parametrize(

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -1344,7 +1344,7 @@ def test_panorama_edit_address_group_command_main_flow_edit_description(mocker):
     assert res.call_args.args[0]['HumanReadable'] == 'Address Group test was edited successfully.'
 
 
-def test_panorama_edit_address_group_command_main_flow_remove_single_address(mocker):
+def test_panorama_edit_address_group_command_remove_single_address(mocker):
     """
     Given
      - pan-os-edit-address-group command arguments including a single address to remove.
@@ -1382,7 +1382,6 @@ def test_panorama_edit_address_group_command_main_flow_remove_single_address(moc
     assert exc_info.type == DemistoException
     assert exc_info.value.message == "cannot remove ['5.5.5.5'] addresses from address group test, " \
                                      "address-group test must have at least one address in its configuration"
-
 
 
 @pytest.mark.parametrize(

--- a/Packs/PAN-OS/ReleaseNotes/1_16_5.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_16_5.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Palo Alto Networks PAN-OS
+- Fixed an issue where the ***pan-os-edit-address-group*** command failed when trying to delete all addresses from its configuration on an ambiguous error.
+- ***pan-os-edit-address-group*** command will now return an informative error message if trying to delete all addresses from its configuration. 

--- a/Packs/PAN-OS/ReleaseNotes/1_16_5.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_16_5.md
@@ -2,3 +2,4 @@
 ##### Palo Alto Networks PAN-OS
 - Fixed an issue where the ***pan-os-edit-address-group*** command failed when trying to delete all addresses from its configuration on an ambiguous error.
 - ***pan-os-edit-address-group*** command will now return an informative error message if trying to delete all addresses from its configuration. 
+- Updated the Docker image to: *demisto/pan-os-python:1.0.0.45668*.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.16.4",
+    "currentVersion": "1.16.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-20715)

## Description
Fixed an issue where in case trying to remove all addresses from an address group, then command fails on ambiguous error rather than saying the real issue.

*Note*: its not possible to remove all addresses from an address group, address group must at least have one address in its configuration.

## Must have
- [x] Tests
- [ ] Documentation 
