### PR TITLE
Slack thread entitlement hotfix

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1534,9 +1534,10 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
         if thread:
             user = await get_user_details(user_id=user_id)
             entitlement_reply = await check_and_handle_entitlement(text, user, thread)  # type: ignore
-            await process_entitlement_reply(entitlement_reply, user_id, action_text, channel, message_ts)
-            reset_listener_health()
-            return
+            if entitlement_reply:
+                await process_entitlement_reply(entitlement_reply, user_id, action_text, channel, message_ts)
+                reset_listener_health()
+                return
 
         # If a message has made it here, we need to check if the message is being mirrored. If not, we will ignore it.
         if MIRRORING_ENABLED:

--- a/Packs/Slack/ReleaseNotes/3_1_20.md
+++ b/Packs/Slack/ReleaseNotes/3_1_20.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Slack v3
+- Fixed an issue where all threads were processed as entitlement replies.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.1.19",
+    "currentVersion": "3.1.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-20735

## Description
Change to the listener logic resulted in all threads being treated as a reply. Changed this to re-add the missing validation.