### PR TITLE
Remove native:dev image for Intezer V2

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -1,7 +1,7 @@
 {
-   "native_images":{
-      "native:8.1":{
-         "supported_docker_images":[
+   "native_images": {
+      "native:8.1": {
+         "supported_docker_images": [
             "python3",
             "python3-deb",
             "python3-ubi",
@@ -31,8 +31,8 @@
          ],
          "docker_ref": "demisto/py3-native:8.1.0.40949"
       },
-      "native:dev":{
-         "supported_docker_images":[
+      "native:dev": {
+         "supported_docker_images": [
             "python3",
             "python3-deb",
             "python3-ubi",
@@ -62,80 +62,79 @@
          ]
       }
    },
-   "ignored_content_items":[
+   "ignored_content_items": [
       {
-         "id":"UnzipFile",
-         "reason":"Issue: CIAC-5246 - Failed unit-test: test_unrar_no_password.",
-         "ignored_native_images":[
-            "native:8.1",
-            "native:dev"
-         ]
-      },
-      {
-         "id":"DockerHardeningCheck",
-         "reason":"Issue: CIAC-5248 - Failed unit-test: get_default_gateway (ip command does not exist).",
-         "ignored_native_images":[
-            "native:8.1",
-            "native:dev"
-         ]
-      },
-      {
-         "id":"FetchIndicatorsFromFile",
-         "reason":"issue: CIAC-5243 - ElementTree object (xml) in python3.9 has getiterator attribute while in python 3.10 this attribute does not exist - causing unit tests failures.",
-         "ignored_native_images":[
-            "native:8.1",
-            "native:dev"
-         ]
-      },
-      {
-         "id":"Traps",
-         "reason":"Integration is Deprecated.",
+         "id": "UnzipFile",
+         "reason": "Issue: CIAC-5246 - Failed unit-test: test_unrar_no_password.",
          "ignored_native_images": [
             "native:8.1",
             "native:dev"
          ]
       },
       {
-         "id":"Rasterize",
-         "reason":"Issue: CRTX-72338.",
-         "ignored_native_images":[
-            "native:8.1"
-         ]
-      },
-      {
-         "id":"Intezer v2",
-         "reason":"Issue: CIAC-5241.",
-         "ignored_native_images":[
-            "native:dev",
-            "native:8.1"
-         ]
-      },
-      {
-         "id":"PDFUnlocker",
-         "reason":"Issue: CIAC-5247.",
-         "ignored_native_images":[
-            "native:dev"
-         ]
-      },
-      {
-         "id":"FindEmailCampaign",
-         "reason":"Issue: CIAC-5249 - pylint error.",
-         "ignored_native_images":[
+         "id": "DockerHardeningCheck",
+         "reason": "Issue: CIAC-5248 - Failed unit-test: get_default_gateway (ip command does not exist).",
+         "ignored_native_images": [
             "native:8.1",
             "native:dev"
          ]
       },
       {
-         "id":"RegexExtractAll",
-         "reason":"Issue: CIAC-5259 - pylint error.",
-         "ignored_native_images":[
+         "id": "FetchIndicatorsFromFile",
+         "reason": "issue: CIAC-5243 - ElementTree object (xml) in python3.9 has getiterator attribute while in python 3.10 this attribute does not exist - causing unit tests failures.",
+         "ignored_native_images": [
+            "native:8.1",
+            "native:dev"
+         ]
+      },
+      {
+         "id": "Traps",
+         "reason": "Integration is Deprecated.",
+         "ignored_native_images": [
+            "native:8.1",
+            "native:dev"
+         ]
+      },
+      {
+         "id": "Rasterize",
+         "reason": "Issue: CRTX-72338.",
+         "ignored_native_images": [
+            "native:8.1"
+         ]
+      },
+      {
+         "id": "Intezer v2",
+         "reason": "Issue: CIAC-5241.",
+         "ignored_native_images": [
+            "native:8.1"
+         ]
+      },
+      {
+         "id": "PDFUnlocker",
+         "reason": "Issue: CIAC-5247.",
+         "ignored_native_images": [
+            "native:dev"
+         ]
+      },
+      {
+         "id": "FindEmailCampaign",
+         "reason": "Issue: CIAC-5249 - pylint error.",
+         "ignored_native_images": [
+            "native:8.1",
+            "native:dev"
+         ]
+      },
+      {
+         "id": "RegexExtractAll",
+         "reason": "Issue: CIAC-5259 - pylint error.",
+         "ignored_native_images": [
             "native:8.1"
          ]
       }
    ],
    "flags_versions_mapping": {
-      "native:dev" : "native:dev",
-      "native:ga" : "native:8.1",
-      "native:maintenance" : ""
+      "native:dev": "native:dev",
+      "native:ga": "native:8.1",
+      "native:maintenance": ""
    }
 }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5241

## Description
Remove the `native:dev` from ignore for Intezer V2. See https://jira-hq.paloaltonetworks.local/browse/CIAC-5241 for more details.
