### PR TITLE
Fix alerts mapping xdrbruteverdict

### DIFF
--- a/Packs/CortexXDR/Playbooks/playbook-Cortex_XDR_-_Possible_External_RDP_Brute-Force_-_Set_Verdict.yml
+++ b/Packs/CortexXDR/Playbooks/playbook-Cortex_XDR_-_Possible_External_RDP_Brute-Force_-_Set_Verdict.yml
@@ -299,7 +299,7 @@ tasks:
     timertriggers: []
     ignoreworker: false
     fieldMapping:
-    - incidentfield: XDR Related Alerts
+    - incidentfield: XDR Alert Search Results
       output:
         complex:
           root: inputs.RelatedAlerts

--- a/Packs/CortexXDR/ReleaseNotes/4_10_8.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_10_8.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Cortex XDR - Possible External RDP Brute-Force - Set Verdict
+- Swapped the "XDR Related Alerts" incident field with "XDR Alert Search Results" field to accommodate the layout.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.10.7",
+    "currentVersion": "4.10.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Swapped the "XDR Related Alerts" incident field with "XDR Alert Search Results" field to accommodate the layout.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
