### PR TITLE
"Isolate Endpoint - Generic" Playbook Deprecation

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Isolate_Endpoint_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Isolate_Endpoint_-_Generic.yml
@@ -1,10 +1,8 @@
 id: Isolate Endpoint - Generic
 version: -1
 name: Isolate Endpoint - Generic
-description: |-
-  This playbook isolates a given endpoint using the following integrations:
-  - Carbon Black Enterprise Response
-  - Palo Alto Networks Traps
+deprecated: true
+description: Deprecated. Use the "Isolate Endpoint - Generic V2" playbook instead.
 starttaskid: "0"
 tasks:
   "0":

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_46.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_46.md
@@ -1,0 +1,5 @@
+
+#### Playbooks
+
+##### Isolate Endpoint - Generic
+- Deprecated. Use the "Isolate Endpoint - Generic V2" playbook instead.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.45",
+    "currentVersion": "2.3.46",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4886)

## Description
Deprecate `Isolate Endpoint - Generic` playbook, which is replaced by `Isolate Endpoint - Generic V2`.
