### PR TITLE
Add missing scope to SlackV3 manifest

### DIFF
--- a/Packs/Slack/doc_files/SlackV3_app_manifest.yml
+++ b/Packs/Slack/doc_files/SlackV3_app_manifest.yml
@@ -31,6 +31,7 @@ oauth_config:
       - groups:read
       - groups:write
       - im:history
+      - im:write
       - mpim:history
       - mpim:read
       - mpim:write


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-20927

## Description
Missing the `im:write` scope