### PR TITLE
[FlashPoint] - fix flaky unit-test

### DIFF
--- a/Packs/Flashpoint/Integrations/Flashpoint/Flashpoint_test.py
+++ b/Packs/Flashpoint/Integrations/Flashpoint/Flashpoint_test.py
@@ -6,6 +6,7 @@ import io
 import datetime
 import unittest
 from unittest.mock import patch
+from freezegun import freeze_time
 from CommonServerPython import arg_to_datetime
 from Flashpoint import Client, MESSAGES, MAX_PRODUCT, FILTER_DATE_VALUES, IS_FRESH_VALUES, MAX_PAGE_SIZE, \
     SORT_DATE_VALUES, SORT_ORDER_VALUES
@@ -699,6 +700,9 @@ class MyTestCase(unittest.TestCase):
     def test_prepare_args_for_compromised_credentials_when_valid_args_are_provided(self):
         """Test case scenario when the arguments provided are valid."""
         from Flashpoint import prepare_args_for_fetch_compromised_credentials
+
+        _start_freeze_time = freeze_time('2022-05-01 12:52:29')
+        _start_freeze_time.start()
 
         end_date = arg_to_datetime('now')
         end_date = datetime.datetime.timestamp(end_date)


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5599)

## Description
Fixed an issue where a unit-test in FlashPoint was flaky because it didn't freeze the datetime.

## Must have
- [x] Tests
- [ ] Documentation 
