### PR TITLE
[Cortex XDR] Replace usage of deprecated `Isolate Endpoint - Generic` playbook

### DIFF
--- a/Packs/CortexXDR/Playbooks/Cortex_XDR_-_Port_Scan.yml
+++ b/Packs/CortexXDR/Playbooks/Cortex_XDR_-_Port_Scan.yml
@@ -1602,12 +1602,11 @@ tasks:
     task:
       id: b69262ea-4383-4218-824b-e13233a2c5a1
       version: -1
-      name: Isolate Endpoint - Generic
+      name: Isolate Endpoint - Generic V2
       description: |-
-        This playbook isolates a given endpoint using the following integrations:
-        - Carbon Black Enterprise Response
-        - Palo Alto Networks Traps
-      playbookName: Isolate Endpoint - Generic
+        This playbook isolates a given endpoint using various endpoint product integrations.
+        Make sure to provide valid playbook inputs for the integration you are using.
+      playbookName: Isolate Endpoint - Generic V2
       type: playbook
       iscommand: false
       brand: ""
@@ -1615,27 +1614,21 @@ tasks:
       '#none#':
       - "61"
     scriptarguments:
-      EndpointId:
-        complex:
-          root: PaloAltoNetworksXDREndpoint
-          filters:
-          - - operator: in
-              left:
-                value:
-                  simple: PaloAltoNetworksXDREndpoint.endpoint_name
-                iscontext: true
-              right:
-                value:
-                  simple: AttackerHostnames
-                iscontext: true
-          accessor: endpoint_id
-          transformers:
-          - operator: uniq
-      Hostname:
+      Endpoint_hostname:
         complex:
           root: AttackerHostnames
           transformers:
           - operator: uniq
+      Endpoint_id:
+        complex:
+          root: |2-
+
+            PaloAltoNetworksXDREndpoint
+          accessor: endpoint_id
+      Endpoint_ip:
+        complex:
+          root: IP
+          accessor: Address
     separatecontext: true
     loop:
       iscommand: false

--- a/Packs/CortexXDR/Playbooks/Cortex_XDR_-_Port_Scan_README.md
+++ b/Packs/CortexXDR/Playbooks/Cortex_XDR_-_Port_Scan_README.md
@@ -13,36 +13,35 @@ Investigates a Cortex XDR incident containing internal port scan alerts. The pla
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
-* IP Enrichment - Internal - Generic v2
-* Isolate Endpoint - Generic
 * Block IP - Generic v3
-* PANW - Hunting and threat detection by indicator type V2
+* IP Enrichment - Internal - Generic v2
 * Block File - Generic v2
+* Isolate Endpoint - Generic V2
 * Calculate Severity - Generic v2
+* PANW - Hunting and threat detection by indicator type V2
 
 ### Integrations
 * CortexXDRIR
 
 ### Scripts
-* StopScheduledTask
 * AssignAnalystToIncident
-* XDRSyncScript
 * IsIPInRanges
+* StopScheduledTask
 * SetAndHandleEmpty
+* XDRSyncScript
 
 ### Commands
-* xdr-update-incident
-* setIncident
-* xdr-get-endpoints
-* send-mail
 * closeInvestigation
+* xdr-get-endpoints
+* xdr-update-incident
+* send-mail
+* setIncident
 
 ## Playbook Inputs
 ---
 
 | **Name** | **Description** | **Default Value** | **Required** |
 | --- | --- | --- | --- |
-| WhitelistedPorts | A list of comma-separated ports that should not be blocked even if used in an attack. |  | Optional |
 | BlockAttackerIP | Whether attacking IPs should be automatically blocked using firewalls. | False | Optional |
 | WhitelistedHostnames | A list of comma-separated hostnames that should not be isolated even if used in an attack. | AdminPC | Optional |
 | EmailAddressesToNotify | A list of comma-separated values of email addresses that should receive a notification about compromised hosts. |  | Optional |

--- a/Packs/CortexXDR/ReleaseNotes/4_10_14.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_10_14.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### Cortex XDR - Port Scan
+- Switch usage of deprecated **Isolate Endpoint - Generic** playbook with the **Isolate Endpoint - Generic V2** playbook.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.10.13",
+    "currentVersion": "4.10.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-4886)

## Description
Replace usage of the deprecated `Isolate Endpoint - Generic` playbook with `Isolate Endpoint - Generic V2`.