### PR TITLE
Downgrade aella fromversion

### DIFF
--- a/Packs/Aella_StarLight/Integrations/AellaStarLight/AellaStarLight.yml
+++ b/Packs/Aella_StarLight/Integrations/AellaStarLight/AellaStarLight.yml
@@ -90,4 +90,4 @@ script:
   dockerimage: demisto/python3:3.10.10.47713
 tests:
 - No test
-fromversion: 6.8.0
+fromversion: 6.5.0

--- a/Packs/Aella_StarLight/ReleaseNotes/1_0_8.md
+++ b/Packs/Aella_StarLight/ReleaseNotes/1_0_8.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Aella Star Light
+- Fixed an issue where the integration wasn't supported by lower version machines.

--- a/Packs/Aella_StarLight/pack_metadata.json
+++ b/Packs/Aella_StarLight/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Aella Star Light",
     "description": "Aella Star Light Integration",
     "support": "community",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "Aella Star Light",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [21769159](https://code.pan.run/xsoar/content/-/jobs/21769159)

## Description
Fixed an issue where the integration wasn't supported by lower version machines.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
