### PR TITLE
ignored snow errors

### DIFF
--- a/Packs/ServiceNow/.pack-ignore
+++ b/Packs/ServiceNow/.pack-ignore
@@ -1,5 +1,5 @@
 [file:ServiceNowv2.yml]
-ignore=IN126,IN135,IN124
+ignore=IN126,IN135,IN124,IN139
 
 [file:playbook-Create_ServiceNow_Ticket.yml]
 ignore=PB106
@@ -28,6 +28,8 @@ ignore=BA101
 [file:classifier-mapper-outgoing-ServiceNow.json]
 ignore=BA101
 [file:incidentfield-ServiceNow_Ticket_Number.json]
+ignore=IF100
+[file:incidentfield-ServiceNow_Ticket_ID.json]
 ignore=IF100
 
 [known_words]


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Ignoring IF100 and IN139 errors to prevent the following validate failures before merging [this](https://github.com/demisto/demisto-sdk/pull/2740) PR:
```
[ERROR]: Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml: [IN139] - This is a core pack with an integration that contains the word incident in the following commands' name or argument:
command's name: [] 
command's argument: {'servicenow-create-ticket': ['parent_incident', 'incident_state'], 'servicenow-update-ticket': ['parent_incident', 'incident_state']}

[ERROR]: Packs/ServiceNow/IncidentFields/incidentfield-ServiceNow_Ticket_ID.json: [IF100] - The words: ['Ticket'] cannot be used as a name.
```

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
