### PR TITLE
Microsoft Teams: add generate login uri command

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -2498,6 +2498,21 @@ def test_module():
     return_results('ok')
 
 
+def generate_login_url_command():
+    login_url = f'https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/authorize?' \
+                f'response_type=code&scope=offline_access%20https://graph.microsoft.com/.default' \
+                f'&client_id={BOT_ID}&redirect_uri={REDIRECT_URI}'
+
+    result_msg = f"""### Authorization instructions
+1. Click on the [login URL]({login_url}) to sign in and grant Cortex XSOAR permissions for your Azure Service Management.
+You will be automatically redirected to a link with the following structure:
+```REDIRECT_URI?code=AUTH_CODE&session_state=SESSION_STATE```
+2. Copy the `AUTH_CODE` (without the `code=` prefix, and the `session_state` parameter)
+and paste it in your instance configuration under the **Authorization code** parameter.
+    """
+    return_results(CommandResults(readable_output=result_msg))
+
+
 def main():
     """ COMMANDS MANAGER / SWITCH PANEL """
     demisto.debug("Main started...")
@@ -2517,7 +2532,8 @@ def main():
         'microsoft-teams-add-user-to-channel': add_user_to_channel_command,
         'microsoft-teams-create-meeting': create_meeting_command,
         'microsoft-teams-channel-user-list': channel_user_list_command,
-        'microsoft-teams-user-remove-from-channel': user_remove_from_channel_command
+        'microsoft-teams-user-remove-from-channel': user_remove_from_channel_command,
+        'microsoft-teams-generate-login-url': generate_login_url_command
 
     }
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -725,6 +725,10 @@ script:
       required: true
     description: Updates the chat name. It can only be set for group chats.
     name: microsoft-teams-chat-update
+  - description: Generate the login url used for Authorization code flow.
+    execution: false
+    name: microsoft-teams-generate-login-url
+    arguments: []
   dockerimage: demisto/teams:1.0.0.48135
   feed: false
   isfetch: false

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_commands.txt
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_commands.txt
@@ -14,3 +14,4 @@
 !microsoft-teams-chat-list filter="topic eq 'testing'"
 !microsoft-teams-chat-message-list chat="example chat" order_by=createdDateTime
 !microsoft-teams-chat-update chat="example chat" chat_name="update chat_name"
+!microsoft-teams-generate-login-url

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -2212,3 +2212,41 @@ def test_get_chat_id_and_type(mocker, requests_mock):
     with pytest.raises(ValueError) as e:
         get_chat_id_and_type('unknown')
     assert str(e.value) == "Could not find chat: unknown"
+
+
+def test_generate_login_url(mocker):
+    """
+    Given:
+        - Self-deployed are true and auth code are the auth flow
+    When:
+        - Calling function microsoft-teams-generate-login-url
+    Then:
+        - Ensure the generated url are as expected.
+    """
+    # prepare
+    import demistomock as demisto
+    from MicrosoftTeams import main
+    import MicrosoftTeams
+
+    redirect_uri = 'redirect_uri'
+    tenant_id = 'tenant_id'
+    client_id = 'client_id'
+    mocked_params = {
+        'REDIRECT_URI': redirect_uri,
+        'AUTH_TYPE': 'Authorization Code',
+        'TENANT_ID': tenant_id,
+        'BOT_ID': client_id
+    }
+    mocker.patch.dict(MicrosoftTeams.__dict__, MicrosoftTeams.__dict__ | mocked_params)
+    mocker.patch.object(demisto, 'command', return_value='microsoft-teams-generate-login-url')
+    mocker.patch.object(MicrosoftTeams, 'return_results')
+
+    # call
+    main()
+
+    # assert
+    expected_url = f'[login URL](https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?' \
+                   'response_type=code&scope=offline_access%20https://graph.microsoft.com/.default' \
+                   f'&client_id={client_id}&redirect_uri={redirect_uri})'
+    res = MicrosoftTeams.return_results.call_args[0][0].readable_output
+    assert expected_url in res

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -2238,8 +2238,9 @@ def test_generate_login_url(mocker):
         'BOT_ID': client_id
     }
     mocker.patch.dict(MicrosoftTeams.__dict__, MicrosoftTeams.__dict__ | mocked_params)
-    mocker.patch.object(demisto, 'command', return_value='microsoft-teams-generate-login-url')
     mocker.patch.object(MicrosoftTeams, 'return_results')
+    mocker.patch.object(MicrosoftTeams, 'support_multithreading')
+    mocker.patch.object(demisto, 'command', return_value='microsoft-teams-generate-login-url')
 
     # call
     main()

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -1055,7 +1055,32 @@ There is no context output for this command.
 ##### Human Readable Output
 >✅ Success!
 
+### microsoft-teams-generate-login-url
+***
+Generate the login url used for Authorization code flow.
 
+
+#### Base Command
+
+`microsoft-teams-generate-login-url`
+#### Input
+
+There are no input arguments for this command.
+
+#### Context Output
+
+There is no context output for this command.
+#### Command example
+```!microsoft-teams-generate-login-url```
+#### Human Readable Output
+
+>### Authorization instructions
+>1. Click on the [login URL]() to sign in and grant Cortex XSOAR permissions for your Azure Service Management.
+>You will be automatically redirected to a link with the following structure:
+>```REDIRECT_URI?code=AUTH_CODE&session_state=SESSION_STATE```
+>2. Copy the `AUTH_CODE` (without the `code=` prefix, and the `session_state` parameter)
+>and paste it in your instance configuration under the **Authorization code** parameter.
+>
 ## Running commands from Microsoft Teams
 You can run Cortex XSOAR commands, according to the user permissions, from Microsoft Teams in a mirrored investigation channel.
 

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_4_6.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_4_6.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Microsoft Teams
+Added the ***microsoft-teams-generate-login-url*** command to easily get the auth code.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.4.5",
+    "currentVersion": "1.4.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
 https://jira-hq.paloaltonetworks.local/browse/CIAC-1268

## Description
After the Auth code flow implemented for Microsoft Teams in https://github.com/demisto/content/pull/23665
added the `microsoft-teams-generate-login-url` command