### PR TITLE
FireEyeETP fix unittest

### DIFF
--- a/Packs/FireEyeETP/Integrations/FireEyeETP/FireEyeETP_test.py
+++ b/Packs/FireEyeETP/Integrations/FireEyeETP/FireEyeETP_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 import demistomock as demisto
 import FireEyeETP
@@ -77,16 +76,15 @@ def test_fetch_incident_by_status_messages(mocker):
     Then:
         - Ensure one incident was fetched as expected
     """
-    iso_format = "%Y-%m-%dT%H:%M:%S.%f"
-    current_time = datetime.now().strftime(iso_format)
     alerts = {'meta': {'fromLastModifiedOn': {'end': ''}},
               'data': [
         {'attributes': {'email': {'status': 'delivered (retroactive)', 'headers': {'subject': ''}},
-                        'alert': {'timestamp': current_time}}}]}
+                        'alert': {'timestamp': '2023-02-09T19:34:17'}}}]}
     expected_incidents = {'email': {'status': 'delivered (retroactive)', 'headers': {'subject': ''}},
-                          'alert': {'timestamp': current_time}}
+                          'alert': {'timestamp': '2023-02-09T19:34:17'}}
+    last_run = {'last_modified': '2023-02-08T19:34:17', 'last_created': '2023-02-08T19:34:17'}
     mocker.patch.object(FireEyeETP, 'MESSAGE_STATUS', ['delivered (retroactive)'])
-    mocker.patch('FireEyeETP.demisto.getLastRun', return_value={})
+    mocker.patch('FireEyeETP.demisto.getLastRun', return_value=last_run)
     mocker.patch('FireEyeETP.get_alerts_request', return_value=alerts)
     res = mocker.patch('FireEyeETP.demisto.incidents')
     FireEyeETP.fetch_incidents()
@@ -102,14 +100,13 @@ def test_fetch_incident_by_status_messages_mismatch_status(mocker):
     Then:
         - Ensure no incidents were fetched as expected
     """
-    iso_format = "%Y-%m-%dT%H:%M:%S.%f"
-    current_time = datetime.now().strftime(iso_format)
     alerts = {'meta': {'fromLastModifiedOn': {'end': ''}},
               'data': [
         {'attributes': {'email': {'status': 'deleted', 'headers': {'subject': ''}},
-                        'alert': {'timestamp': current_time}}}]}
+                        'alert': {'timestamp': '2023-02-09T19:34:17'}}}]}
+    last_run = {'last_modified': '2023-02-08T19:34:17', 'last_created': '2023-02-08T19:34:17'}
     mocker.patch.object(FireEyeETP, 'MESSAGE_STATUS', ['delivered (retroactive)'])
-    mocker.patch('FireEyeETP.demisto.getLastRun', return_value={})
+    mocker.patch('FireEyeETP.demisto.getLastRun', return_value=last_run)
     mocker.patch('FireEyeETP.get_alerts_request', return_value=alerts)
     res = mocker.patch('FireEyeETP.demisto.incidents')
     FireEyeETP.fetch_incidents()
@@ -125,21 +122,20 @@ def test_fetch_incident_by_status_messages_with_two_status(mocker):
     Then:
         - Ensure 2 incidents were fetched as expected
     """
-    iso_format = "%Y-%m-%dT%H:%M:%S.%f"
-    current_time = datetime.now().strftime(iso_format)
     alerts = {'meta': {'fromLastModifiedOn': {'end': ''}},
               'data': [
         {'attributes': {'email': {'status': 'delivered (retroactive)', 'headers': {'subject': ''}},
-                        'alert': {'timestamp': current_time}}},
+                        'alert': {'timestamp': '2023-02-09T19:34:17'}}},
         {'attributes': {'email': {'status': 'deleted', 'headers': {'subject': ''}},
-                        'alert': {'timestamp': current_time}}}
+                        'alert': {'timestamp': '2023-02-09T19:34:17'}}}
     ]}
     expected_incidents = [
         {"email": {"status": "delivered (retroactive)", "headers": {"subject": ""}},
-         "alert": {"timestamp": current_time}},
-        {"email": {"status": "deleted", "headers": {"subject": ""}}, "alert": {"timestamp": current_time}}]
+         "alert": {"timestamp": '2023-02-09T19:34:17'}},
+        {"email": {"status": "deleted", "headers": {"subject": ""}}, "alert": {"timestamp": '2023-02-09T19:34:17'}}]
+    last_run = {'last_modified': '2023-02-08T19:34:17', 'last_created': '2023-02-08T19:34:17'}
     mocker.patch.object(FireEyeETP, 'MESSAGE_STATUS', ['delivered (retroactive)', 'deleted'])
-    mocker.patch('FireEyeETP.demisto.getLastRun', return_value={})
+    mocker.patch('FireEyeETP.demisto.getLastRun', return_value=last_run)
     mocker.patch('FireEyeETP.get_alerts_request', return_value=alerts)
     res = mocker.patch('FireEyeETP.demisto.incidents')
     FireEyeETP.fetch_incidents()


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5659)

## Description
Unittest was fixed after nightly failed.

## Screenshots
In the ticket.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
