### PR TITLE
Update on-push with new docker rule

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -1,7 +1,13 @@
+# This rule is to not run the build for docker update branches (for non-nightly packs)
+.filter-non-nightly-docker-updates-rule:
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^demisto\/([^n]|n($|[^i]|i($|[^g]|g($|[^h]))))[^\/]*$/'
+      when: never
+
 .push-rule:
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/'
-
 
 trigger-private-build:
   tags:
@@ -11,6 +17,7 @@ trigger-private-build:
   extends:
     - .default-job-settings
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_COMMIT_BRANCH =~ /pull\/[0-9]+/'
       when: never
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/'
@@ -47,6 +54,7 @@ stop-running-pipelines:
   variables:
     master_branch_name: master
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push)$/ && $CI_COMMIT_BRANCH != $master_branch_name'
   script:
     - section_start "Stop running piplines on current branch"
@@ -107,6 +115,7 @@ validate-content-conf:
   extends:
     - .default-job-settings
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: "$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/"
     - if: "$NIGHTLY"
   cache:
@@ -225,7 +234,9 @@ mpv2-prepare-testing-bucket:
     ENV_RESULTS_PATH: "${ARTIFACTS_FOLDER_XSOAR}/env_results.json"
     SERVER_TYPE: "XSOAR"
   stage: run-instances
-  needs: ["xsoar-prepare-testing-bucket"]
+  needs:
+    - job: xsoar-prepare-testing-bucket
+      optional: true
   script:
     - EXIT_CODE=0
     - !reference [.download-demisto-conf]
@@ -273,24 +284,27 @@ mpv2-prepare-testing-bucket:
 
 xsoar_server_6_5:
   extends: .test_content_on_xsoar_server_instances_base
-  #  No need to trigger in case of release branch
+  #  No need to trigger in case of release branch or docker update branches (non-nightly packs)
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
   variables:
     INSTANCE_ROLE: "Server 6.5"
 
 xsoar_server_6_6:
   extends: .test_content_on_xsoar_server_instances_base
-  #  No need to trigger in case of release branch
+  #  No need to trigger in case of release branch or docker update branches (non-nightly packs)
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
   variables:
     INSTANCE_ROLE: "Server 6.6"
 
 xsoar_server_6_8:
   extends: .test_content_on_xsoar_server_instances_base
-  #  No need to trigger in case of release branch
+  #  No need to trigger in case of release branch or docker update branches (non-nightly packs)
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
   variables:
     INSTANCE_ROLE: "Server 6.8"
@@ -298,8 +312,9 @@ xsoar_server_6_8:
 xsoar_server_master:
   extends:
     - .test_content_on_xsoar_server_instances_base
-  #  No need to trigger in case of release branch
+  #  No need to trigger in case of release branch or docker update branches (non-nightly packs)
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
     - if: '$NIGHTLY'
       when: always
@@ -329,9 +344,31 @@ jobs-done-check-nightly:
 
 jobs-done-check-on-push:
   extends:
-    - .jobs-done-check
     - .push-rule
-  needs: ['run-unittests-and-lint', 'trigger-private-build', 'validate-content-conf', 'mpv2-prepare-testing-bucket', 'xpanse-prepare-testing-bucket', 'xsoar-prepare-testing-bucket', 'xsiam_server_ga', 'xsoar_server_6_5', 'xsoar_server_6_6', 'xsoar_server_6_8', 'xsoar_server_master']
+    - .jobs-done-check
+  needs:
+    - job: run-unittests-and-lint
+      optional: true
+    - job: trigger-private-build
+      optional: true
+    - job: validate-content-conf
+      optional: true
+    - job: mpv2-prepare-testing-bucket
+      optional: true
+    - job: xpanse-prepare-testing-bucket
+      optional: true
+    - job: xsoar-prepare-testing-bucket
+      optional: true
+    - job: xsiam_server_ga
+      optional: true
+    - job: xsoar_server_6_5
+      optional: true
+    - job: xsoar_server_6_6
+      optional: true
+    - job: xsoar_server_6_8
+      optional: true
+    - job: xsoar_server_master
+      optional: true
   tags:
     - gke
 
@@ -455,6 +492,7 @@ xsiam_server_ga:
   extends:
     - .test_content_on_cloud_server_instances_base
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
     - if: '$NIGHTLY'
       when: always
@@ -472,12 +510,15 @@ xsiam_server_ga:
     GCS_MACHINES_BUCKET: "marketplace-v2-dist-dev/upload-flow/builds-xsiam"
     SERVER_TYPE: "XSIAM"
     MARKETPLACE_NAME: "marketplacev2"
-  needs: ["mpv2-prepare-testing-bucket"]
+  needs:
+    - job: mpv2-prepare-testing-bucket
+      optional: true
 
 xsoar_ng_server_ga:
   extends:
     - .test_content_on_cloud_server_instances_base
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/ && $CI_COMMIT_BRANCH !~ /^[0-9]{2}\.[0-9]{1,2}\.[0-9]$/'
       when: always
   variables:
@@ -493,7 +534,9 @@ xsoar_ng_server_ga:
     GCS_MACHINES_BUCKET: "marketplace-dist-dev/upload-flow/builds-xsoar-ng"
     SERVER_TYPE: "XSIAM"
     MARKETPLACE_NAME: "xsoar"
-  needs: ["xsoar-prepare-testing-bucket"]
+  needs:
+    - job: xsoar-prepare-testing-bucket
+      optional: true
   allow_failure: true
 
 
@@ -503,6 +546,7 @@ test-upload-flow:
   extends:
     - .default-job-settings
   rules:
+    - !reference [.filter-non-nightly-docker-updates-rule, rules]
     - if: '$CI_PIPELINE_SOURCE =~ /^(push|contrib)$/'
   variables:
     ALL_BUCKETS: "$GCS_MARKET_BUCKET_DEV,$GCS_MARKET_V2_BUCKET_DEV"


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4276

## Description
Added a rule to not run the build on docker updates for non-nightly packs only.

## Screenshots
Example of a non-nightly branch:
<img width="563" alt="image" src="https://user-images.githubusercontent.com/45915502/219332295-d89bdeae-09d6-4fa8-b73d-bc50f5eba140.png">

Regular branch (stays the same):
<img width="1451" alt="image" src="https://user-images.githubusercontent.com/45915502/219332523-f8c0fe38-4008-460b-bec7-415341f38b24.png">


