### PR TITLE
ms teams add support in credential store & fix

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -28,10 +28,10 @@ USE_SSL: bool = not PARAMS.get('insecure', False)
 APP: Flask = Flask('demisto-teams')
 PLAYGROUND_INVESTIGATION_TYPE: int = 9
 GRAPH_BASE_URL: str = 'https://graph.microsoft.com'
-PRIVATE_KEY = replace_spaces_in_credential(PARAMS.get('creds_certificate', {}).get('password', '')) \
-    or demisto.params().get('key', '')
 CERTIFICATE = replace_spaces_in_credential(PARAMS.get('creds_certificate', {}).get('identifier', '')) \
     or demisto.params().get('certificate', '')
+PRIVATE_KEY = replace_spaces_in_credential(PARAMS.get('creds_certificate', {}).get('password', '')) \
+    or demisto.params().get('key', '')
 
 INCIDENT_TYPE: str = PARAMS.get('incidentType', '')
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -21,13 +21,17 @@ requests.packages.urllib3.disable_warnings()  # type: ignore
 
 ''' GLOBAL VARIABLES'''
 PARAMS: dict = demisto.params()
-BOT_ID: str = PARAMS.get('credentials', {}).get('identifier') or PARAMS.get('bot_id', '')
-BOT_PASSWORD: str = PARAMS.get('credentials', {}).get('password') or PARAMS.get('bot_password', '')
+BOT_ID: str = PARAMS.get('credentials', {}).get('identifier', '') or PARAMS.get('bot_id', '')
+BOT_PASSWORD: str = PARAMS.get('credentials', {}).get('password', '') or PARAMS.get('bot_password', '')
 TENANT_ID: str = PARAMS.get('tenant_id', '')
 USE_SSL: bool = not PARAMS.get('insecure', False)
 APP: Flask = Flask('demisto-teams')
 PLAYGROUND_INVESTIGATION_TYPE: int = 9
 GRAPH_BASE_URL: str = 'https://graph.microsoft.com'
+PRIVATE_KEY = replace_spaces_in_credential(PARAMS.get('creds_certificate', {}).get('password', '')) \
+    or demisto.params().get('key', '')
+CERTIFICATE = replace_spaces_in_credential(PARAMS.get('creds_certificate', {}).get('identifier', '')) \
+    or demisto.params().get('certificate', '')
 
 INCIDENT_TYPE: str = PARAMS.get('incidentType', '')
 
@@ -765,7 +769,7 @@ def validate_auth_header(headers: dict) -> bool:
     decoded_payload = jwt.decode(jwt_token, public_key, options=options)
 
     audience_claim: str = decoded_payload.get('aud', '')
-    if audience_claim != demisto.params().get('bot_id'):
+    if audience_claim != BOT_ID:
         demisto.info('Authorization header validation - failed to verify audience_claim')
         return False
 
@@ -1752,7 +1756,7 @@ def create_personal_conversation(integration_context: dict, team_member_id: str)
     :param team_member_id: ID of team member to create a conversation with
     :return: ID of created conversation
     """
-    bot_id: str = demisto.params().get('bot_id', '')
+    bot_id: str = BOT_ID
     bot_name: str = integration_context.get('bot_name', '')
     tenant_id: str = integration_context.get('tenant_id', '')
     conversation: dict = {
@@ -2058,7 +2062,7 @@ def member_added_handler(integration_context: dict, request_body: dict, channel_
     :param channel_data: Microsoft Teams tenant, team and channel details
     :return: None
     """
-    bot_id = demisto.params().get('bot_id')
+    bot_id = BOT_ID
 
     team: dict = channel_data.get('team', {})
     team_id: str = team.get('id', '')
@@ -2336,7 +2340,7 @@ def ring_user():
         raise DemistoException("In order to use the 'microsoft-teams-ring-user' command, you need to use "
                                "the 'Client Credentials flow'.")
 
-    bot_id = demisto.params().get('bot_id')
+    bot_id = BOT_ID
     integration_context: dict = get_integration_context()
     tenant_id: str = integration_context.get('tenant_id', '')
     if not tenant_id:
@@ -2395,8 +2399,8 @@ def long_running_loop():
     The infinite loop which runs the mirror loop and the bot app in two different threads
     """
     while True:
-        certificate: str = demisto.params().get('certificate', '')
-        private_key: str = demisto.params().get('key', '')
+        certificate: str = CERTIFICATE
+        private_key: str = PRIVATE_KEY
 
         certificate_path = str()
         private_key_path = str()

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -65,10 +65,8 @@ configuration:
 - name: creds_certificate
   display: Certificate (Required for HTTPS)
   required: false
-  defaultvalue:
   type: 9
   displaypassword: Private Key (Required for HTTPS)
-  hiddenusername: false
   section: Connect
   advanced: true
 - display: Certificate (Required for HTTPS)

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -62,18 +62,29 @@ configuration:
   type: 0
   defaultvalue: General
   section: Connect
+- name: creds_certificate
+  display: Certificate (Required for HTTPS)
+  required: false
+  defaultvalue:
+  type: 9
+  displaypassword: Private Key (Required for HTTPS)
+  hiddenusername: false
+  section: Connect
+  advanced: true
 - display: Certificate (Required for HTTPS)
   name: certificate
   required: false
   type: 12
   section: Connect
   advanced: true
+  hidden: true
 - display: Private Key (Required for HTTPS)
   name: key
   required: false
   type: 14
   section: Connect
   advanced: true
+  hidden: true
 - display: Minimum incident severity to send notifications to Teams by
   name: min_incident_severity
   required: false

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -62,13 +62,13 @@ configuration:
   type: 0
   defaultvalue: General
   section: Connect
-- name: creds_certificate
-  display: Certificate (Required for HTTPS)
+- display: Certificate (Required for HTTPS)
+  name: creds_certificate
   required: false
   type: 9
-  displaypassword: Private Key (Required for HTTPS)
   section: Connect
   advanced: true
+  displaypassword: Private Key (Required for HTTPS)
 - display: Certificate (Required for HTTPS)
   name: certificate
   required: false
@@ -738,7 +738,7 @@ script:
     execution: false
     name: microsoft-teams-generate-login-url
     arguments: []
-  dockerimage: demisto/teams:1.0.0.48135
+  dockerimage: demisto/teams:1.0.0.48817
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -468,13 +468,7 @@ def test_send_message_with_user(mocker, requests_mock):
 
     mocker.patch.object(demisto, 'results')
 
-    mocker.patch.object(
-        demisto,
-        'params',
-        return_value={
-            'bot_id': bot_id
-        }
-    )
+    mocker.patch("MicrosoftTeams.BOT_ID", new=bot_id)
     mocker.patch.object(
         demisto,
         'args',
@@ -682,13 +676,7 @@ def test_send_message_with_adaptive_card(mocker, requests_mock):
 def test_sending_message_using_email_address(mocker, requests_mock):
     mocker.patch.object(demisto, 'results')
     # verify message is sent properly given email with uppercase letters to send to
-    mocker.patch.object(
-        demisto,
-        'params',
-        return_value={
-            'bot_id': bot_id
-        }
-    )
+    mocker.patch("MicrosoftTeams.BOT_ID", new=bot_id)
     mocker.patch.object(
         demisto,
         'args',

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_4_7.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_4_7.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+##### Microsoft Teams
+- Fixed an issue where the *Bot ID* parameter wasn't parsed correctly after upgrading from pack version 1.4.5. 
+- Added the following integration parameters to support credentials fetching object.
+  - *Certificate*
+  - *Private Key*

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_4_7.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_4_7.md
@@ -5,3 +5,4 @@
 - Added the following integration parameters to support credentials fetching object.
   - *Certificate*
   - *Private Key*
+- Updated the Docker image to *demisto/teams:1.0.0.48817*.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.4.6",
+    "currentVersion": "1.4.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
- Fixed an issue where the *Bot ID* parameter wasn't parsed correctly after upgrading from pack version 1.4.5. 
- Added the following integration parameters to support credentials fetching object.
  - *Certificate*
  - *Private Key*

