### PR TITLE
IPQualityScore Encoding and Results Bug Fixes

### DIFF
--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
@@ -105,7 +105,8 @@ def email_command(client, args, email_suspicious_score_threshold, email_maliciou
     emails = argToList(args.get("email"), ",")
     results = []
     for email in emails:
-        result = client.get_email_reputation(email)
+        email_encoded = urllib.parse.quote(email, safe="")
+        result = client.get_email_reputation(email_encoded)
         result['address'] = email
 
         human_readable = tableToMarkdown(f"IPQualityScore Results for {email}", result, result.keys())

--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
@@ -151,9 +151,9 @@ def url_command(client, args, url_suspicious_score_threshold, url_malicious_scor
 
         human_readable = tableToMarkdown(f"IPQualityScore Results for {url}", result, result.keys())
 
-        if result.get('fraud_score', 0) >= url_malicious_score_threshold:
+        if result.get('risk_score', 0) >= url_malicious_score_threshold:
             score = 3
-        elif result.get('fraud_score', 0) >= url_suspicious_score_threshold:
+        elif result.get('risk_score', 0) >= url_suspicious_score_threshold:
             score = 2
         else:
             score = 0

--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
@@ -1,12 +1,13 @@
 import urllib.parse
+import warnings
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
-from requests.packages import urllib3
+
 ''' IMPORTS '''
 
 # Disable insecure warnings
-requests.packages.urllib3.disable_warnings()
+warnings.filterwarnings('ignore', message='Unverified HTTPS request')
 
 ''' CONSTANTS '''
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.py
@@ -2,6 +2,7 @@ import urllib.parse
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
+from requests.packages import urllib3
 ''' IMPORTS '''
 
 # Disable insecure warnings

--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.yml
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore.yml
@@ -422,7 +422,7 @@ script:
     - contextPath: URL.Malicious.Vendor
       description: The vendor reporting the URL as malicious.
       type: String
-  dockerimage: demisto/python3:3.9.8.24399
+  dockerimage: demisto/python3:3.10.10.48392
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore_test.py
+++ b/Packs/IPQualityScore/Integrations/IPQualityScore/IPQualityScore_test.py
@@ -27,7 +27,7 @@ def test_ip_command(requests_mock):
 def test_email_command(requests_mock):
     from IPQualityScore import Client, email_command
     mock_response = util_load_json('test_data/email_response.json')
-    requests_mock.get('https://ipqualityscore.com/api/json/email/api_key_here/someone@gmail.com', json=mock_response)
+    requests_mock.get('https://ipqualityscore.com/api/json/email/api_key_here/someone%40gmail.com', json=mock_response)
     client = Client(
         base_url='https://ipqualityscore.com/api/json/email/api_key_here',
         verify=False)

--- a/Packs/IPQualityScore/ReleaseNotes/1_0_6.md
+++ b/Packs/IPQualityScore/ReleaseNotes/1_0_6.md
@@ -1,0 +1,5 @@
+#### Integrations
+##### IPQualityScore
+- Bug fixes for two issues:
+    - The URL lookup functionality currently doesn't pull the correct value. It should pull risk_score instead of fraud_score.
+    - The Email lookup functionality did not URL encode all emails. This could lead to malformed results. The Email lookup functionality now encodes all emails.

--- a/Packs/IPQualityScore/pack_metadata.json
+++ b/Packs/IPQualityScore/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IPQualityScore (IPQS) Threat Risk Scoring",
     "description": "Detect threats with real-time risk scoring by IPQS. Playbook analyzes IP addresses, email addresses, and domains or URLs for high risk behavior.",
     "support": "partner",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "IPQualityScore",
     "url": "https://www.ipqualityscore.com",
     "email": "support@ipqualityscore.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "directories": {
     "doc": "docs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Bug fixes for two issues:
- The URL lookup functionality currently doesn't pull the correct value. It should pull risk_score instead of fraud_score.
- The Email lookup functionality did not URL encode all emails. This could lead to malformed results. The Email lookup functionality now encodes all emails.

## Screenshots
N/A

## Minimum version of Cortex XSOAR
- [ x ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ x ] No

## Must have
- [ ] Tests
- [ ] Documentation 
