### PR TITLE
NGFW scannerIP input usage fix

### DIFF
--- a/Packs/Core/Playbooks/playbook-NGFW_Scan.yml
+++ b/Packs/Core/Playbooks/playbook-NGFW_Scan.yml
@@ -93,8 +93,7 @@ tasks:
           left:
             value:
               complex:
-                root: alert
-                accessor: hostip
+                root: inputs.scannerIP
             iscontext: true
           right:
             value:
@@ -1310,7 +1309,7 @@ inputs:
   value:
     complex:
       root: alert
-      accessor: hostip
+      accessor: localip
   required: false
   description: The scanner IP address.
   playbookInputQuery:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue
](https://jira-hq.paloaltonetworks.local/browse/XSUP-21394)
## Description
Changed the OOTB scannerIP input to alert.localip
Fixed the 'scannerIP' input usage in task 4.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0
- [x] 6.6.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
