### PR TITLE
NGFW Fixes

### DIFF
--- a/Packs/Core/Playbooks/playbook-NGFW_Scan.yml
+++ b/Packs/Core/Playbooks/playbook-NGFW_Scan.yml
@@ -93,8 +93,7 @@ tasks:
           left:
             value:
               complex:
-                root: alert
-                accessor: hostip
+                root: inputs.scannerIP
             iscontext: true
           right:
             value:
@@ -1310,7 +1309,7 @@ inputs:
   value:
     complex:
       root: alert
-      accessor: hostip
+      accessor: localip
   required: false
   description: The scanner IP address.
   playbookInputQuery:

--- a/Packs/Core/Playbooks/playbook-NGFW_Scan_README.md
+++ b/Packs/Core/Playbooks/playbook-NGFW_Scan_README.md
@@ -108,7 +108,7 @@ This playbook uses the following sub-playbooks, integrations, and scripts.
 
 | **Name** | **Description** | **Default Value** | **Required** |
 | --- | --- | --- | --- |
-| scannerIP | The IP address of the scanner. | alert.hostip | Optional |
+| scannerIP | The IP address of the scanner. | alert.localip | Optional |
 | blockKnownScanner | Whether to block the IP address based on previously seen scanning alerts. | true | Optional |
 | AutoCloseAlert | Whether to close the alert automatically or manually, after an analyst's review. | false | Optional |
 | AutoRecovery | Whether to execute the Recovery playbook. | false | Optional |

--- a/Packs/Core/ReleaseNotes/1_3_34.md
+++ b/Packs/Core/ReleaseNotes/1_3_34.md
@@ -1,0 +1,5 @@
+
+#### Playbooks
+##### NGFW Scan
+- Changes the default input of the 'scannerIP' input from alert.hostip to alert.localip
+- Fixed the 'scannerIP' input usage in task 4

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "1.3.33",
+    "currentVersion": "1.3.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-21394)

## Description
Fixes the 'scannerIP' input usage in task 4
Changes the default value of the 'scannerIP' input to 'alert.localip'

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0
- [x] 6.6.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
