### PR TITLE
Phishing   remove listener from enrichment

### DIFF
--- a/Packs/Phishing/Playbooks/Phishing_-_Generic_v3.yml
+++ b/Packs/Phishing/Playbooks/Phishing_-_Generic_v3.yml
@@ -1665,6 +1665,15 @@ tasks:
                 value:
                   simple: incident.reporteremailaddress
                 iscontext: true
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: Account.Email.Address
+                iscontext: true
+              right:
+                value:
+                  simple: ListenerMailbox
+                iscontext: true
           transformers:
           - operator: uniq
       Hostname:

--- a/Packs/Phishing/ReleaseNotes/3_5_5.md
+++ b/Packs/Phishing/ReleaseNotes/3_5_5.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Phishing - Generic v3
+
+- Listener mailbox has been excluded from enrichment tasks.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.5.4",
+    "currentVersion": "3.5.5",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5644)

## Description
Listener mailbox has been excluded from enrichment tasks.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

