### PR TITLE
Changed the command 'get_quarantined_file_command'

### DIFF
--- a/Packs/Netskope/Integrations/NetskopeAPIv1/NetskopeAPIv1.py
+++ b/Packs/Netskope/Integrations/NetskopeAPIv1/NetskopeAPIv1.py
@@ -582,11 +582,12 @@ def get_quarantined_file_command(client: Client, args: Dict[str, str]) -> Comman
 
     quarantine_profile_id = args['quarantine_profile_id']
     file_id = args['file_id']
-
+    file_name = args['file_name']
+    
     response = client.get_quarantined_file_request(quarantine_profile_id=quarantine_profile_id,
                                                    file_id=file_id)
 
-    return fileResult(filename=f'{file_id}.zip', data=response, file_type=EntryType.FILE)
+    return fileResult(filename=file_name, data=response, file_type=EntryType.FILE)
 
 
 def update_quarantined_file_command(client: Client, args: Dict[str, str]) -> CommandResults:


### PR DESCRIPTION
Changed the command 'get_quarantined_file_command' as the file extension was hard coded in the name, so it would not work ('filename=f'{file_id}.zip',).

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Changed the command 'get_quarantined_file_command' as the file name has the extension hard coded so it will not work. Added the file_name arg (can be pulled by 'netskope-quarantined-file-list' or elsewhere).

## Screenshots


## Minimum version of Cortex XSOAR
- [ x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
