### PR TITLE
Adding error logging for wait_until_server_ready

### DIFF
--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -45,7 +45,8 @@ def download_cloud_init_logs_from_server(ip: str) -> None:
         check_output(f'scp {SSH_USER}@{ip}:{cloud_init_log_path} '
                      f'{ARTIFACTS_FOLDER}/{ip}-cloud_init.log'.split())
     except Exception as e:
-        logging.exception(f'Could not download cloud-init file from server {ip}:\nerr:{e.stderr}\nstdout:{e.output}\nreturncode:{e.returncode}\ncmd:{e.cmd}.')
+        logging.exception(f'Could not download cloud-init file from server {ip}:\n{e.stderr=}\n{e.output=}\n'
+                          f'{e.returncode=}\n{e.cmd=}.')
 
 
 def docker_login(ip: str) -> None:
@@ -63,7 +64,8 @@ def docker_login(ip: str) -> None:
             f'login --username {docker_username} --password-stdin'.split(),
             input=docker_password.encode())
     except Exception as e:
-        logging.exception(f'Could not login to {container_engine_type} on server {ip}:\nerr:{e.stderr}\nstdout:{e.output}\nreturncode:{e.returncode}\ncmd:{e.cmd}.')
+        logging.exception(f'Could not login to {container_engine_type} on server {ip}:\n{e.stderr=}\n{e.output=}\n'
+                          f'{e.returncode=}\n{e.cmd=}.')
 
 
 def main():

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -45,7 +45,7 @@ def download_cloud_init_logs_from_server(ip: str) -> None:
         check_output(f'scp {SSH_USER}@{ip}:{cloud_init_log_path} '
                      f'{ARTIFACTS_FOLDER}/{ip}-cloud_init.log'.split())
     except Exception as e:
-        logging.exception(f'Could not download cloud-init file from server {ip}:\n{str(e)}.')
+        logging.exception(f'Could not download cloud-init file from server {ip}:\nerr:{e.stderr}\nstdout:{e.output}\nreturncode:{e.returncode}\ncmd:{e.cmd}.')
 
 
 def docker_login(ip: str) -> None:
@@ -63,7 +63,7 @@ def docker_login(ip: str) -> None:
             f'login --username {docker_username} --password-stdin'.split(),
             input=docker_password.encode())
     except Exception as e:
-        logging.exception(f'Could not login to {container_engine_type} on server {ip}:\n{str(e)}')
+        logging.exception(f'Could not login to {container_engine_type} on server {ip}:\nerr:{e.stderr}\nstdout:{e.output}\nreturncode:{e.returncode}\ncmd:{e.cmd}.')
 
 
 def main():

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -62,8 +62,9 @@ def docker_login(ip: str) -> None:
             f'ssh {SSH_USER}@{ip} cd /home/demisto && sudo -u demisto {container_engine_type} '
             f'login --username {docker_username} --password-stdin'.split(),
             input=docker_password.encode())
-    except Exception:
+    except Exception as e:
         logging.exception(f'Could not login to {container_engine_type} on server {ip}')
+        logging.exception(f'while handling the rquest, encountered the following error: {str(e)}')
 
 
 def main():

--- a/Tests/scripts/wait_until_server_ready.py
+++ b/Tests/scripts/wait_until_server_ready.py
@@ -44,8 +44,8 @@ def download_cloud_init_logs_from_server(ip: str) -> None:
         # downloading cloud-init logs to artifacts
         check_output(f'scp {SSH_USER}@{ip}:{cloud_init_log_path} '
                      f'{ARTIFACTS_FOLDER}/{ip}-cloud_init.log'.split())
-    except Exception:
-        logging.exception(f'Could not download cloud-init file from server {ip}.')
+    except Exception as e:
+        logging.exception(f'Could not download cloud-init file from server {ip}:\n{str(e)}.')
 
 
 def docker_login(ip: str) -> None:
@@ -63,8 +63,7 @@ def docker_login(ip: str) -> None:
             f'login --username {docker_username} --password-stdin'.split(),
             input=docker_password.encode())
     except Exception as e:
-        logging.exception(f'Could not login to {container_engine_type} on server {ip}')
-        logging.exception(f'while handling the rquest, encountered the following error: {str(e)}')
+        logging.exception(f'Could not login to {container_engine_type} on server {ip}:\n{str(e)}')
 
 
 def main():


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Adding more logs to wait_until_server_ready to get more information in case there's failure with SDK step [demisto-sdk-nightly:run-commands-against-instance](https://www.google.com/url?q=https://code.pan.run/xsoar/content/-/jobs/22176808&sa=D&source=editors&ust=1677405923576537&usg=AOvVaw3n8y_cA3K8qvn0BP9cgEFP)