### PR TITLE
[Circle CI Validation] Add `set -x` Flag to Validation Script

### DIFF
--- a/Tests/scripts/validate.sh
+++ b/Tests/scripts/validate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 echo "CI_COMMIT_BRANCH: $CI_COMMIT_BRANCH CI: $CI DEMISTO_README_VALIDATION: $DEMISTO_README_VALIDATION"
 if [[ $CI_COMMIT_BRANCH = master ]] || [[ -n "${NIGHTLY}" ]] || [[ -n "${BUCKET_UPLOAD}" ]] || [[ -n "${DEMISTO_SDK_NIGHTLY}" ]]; then


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This PR adds Bash's `set -x` flag to the validate.sh script, which is used by our CircleCI validation build.
This flag makes the terminal echo every command it runs before it runs it (with the actual values of variables if variables are involved).
Using this flag is a common practice in CI/CD jobs, as it allows easier debugging and troubleshooting in case there are issues.

An example can be seen on the `Validate Files and Yaml` step of this PR here:
https://app.circleci.com/pipelines/github/demisto/content/238505/workflows/c7980ae0-113e-436c-a058-442824b5df39/jobs/672710

For example, now it is possible to see what SDK command was used to run validate:
<img width="1422" alt="Screenshot 2023-02-23 at 18 53 13" src="https://user-images.githubusercontent.com/8832013/220975583-74d51030-7487-47ba-8632-bd58de9558b3.png">

