### PR TITLE
CoreIRApiModule - An exception was added in case link is None

### DIFF
--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
@@ -1080,6 +1080,8 @@ class CoreClient(BaseClient):
         link = response.get('reply', {}).get('DATA')
         # If the link is None, the API call will result in a 'Connection Timeout Error', so we raise an exception
         if not link:
+            demisto.debug(f'Failed getting response from /scripts/get_script_execution_results_files, {action_id=},'
+                          f' {endpoint_id=}')
             raise DemistoException('File not found.')
         return self._http_request(
             method='GET',

--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
@@ -1080,9 +1080,7 @@ class CoreClient(BaseClient):
         link = response.get('reply', {}).get('DATA')
         # If the link is None, the API call will result in a 'Connection Timeout Error', so we raise an exception
         if not link:
-            demisto.debug(f'Failed getting response from /scripts/get_script_execution_results_files, {action_id=},'
-                          f' {endpoint_id=}')
-            raise DemistoException('File not found.')
+            raise DemistoException(f'Failed getting response files for {action_id=}, {endpoint_id=}')
         return self._http_request(
             method='GET',
             full_url=link,

--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
@@ -1078,6 +1078,9 @@ class CoreClient(BaseClient):
             timeout=self.timeout,
         )
         link = response.get('reply', {}).get('DATA')
+        # If the link is None, the API call will result in a 'Connection Timeout Error', so we raise an exception
+        if not link:
+            raise DemistoException('File not found.')
         return self._http_request(
             method='GET',
             full_url=link,


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-21419)

## Description
If the link is None, the API call will result in a 'connection timed out error', so we raise an exception.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
