### PR TITLE
Updating "cs-falcon-update-incident-comment" new command

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -2896,6 +2896,16 @@ script:
     - contextPath: CrowdStrike.VulnerabilityHost.cve.id
       description: Unique identifier for a vulnerability as cataloged in the National Vulnerability Database (NVD).
       type: String
+  - arguments:
+    - description: A comma-separated list of incident IDs.
+      isArray: true
+      name: ids
+      required: true
+    - description: A comment added to the CrowdStrike incident.
+      name: comment
+      required: true
+    description: Updates CrowdStrike Incident with the comment.
+    name: cs-falcon-update-incident-comment
   dockerimage: demisto/python3:3.10.10.48392
   isfetch: true
   ismappable: true


### PR DESCRIPTION
This new command has two arguments:
1. ids -> mandatory:true, is array:true, description:"A comma-separated list of incident IDs."
2. comment -> mandatory:true, description:"A comment which should be added to the CrowdStrike incident."
