### PR TITLE
Slack - Remove preview messages after answering questions

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1301,12 +1301,12 @@ async def process_entitlement_reply(
         requests.post(response_url, json={'text': entitlement_reply, 'replace_original': True})
     else:
         await send_slack_request_async(client=ASYNC_CLIENT, method='chat.update',
-                                    body={
-                                        'channel': channel,
-                                        'ts': message_ts,
-                                        'text': entitlement_reply,
-                                        'blocks': []
-                                    })
+                                       body={
+                                           'channel': channel,
+                                           'ts': message_ts,
+                                           'text': entitlement_reply,
+                                           'blocks': []
+                                       })
 
 
 def is_dm(channel: str) -> bool:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1275,12 +1275,20 @@ def search_text_for_entitlement(text: str, user: AsyncSlackResponse) -> str:
         return ''
 
 
-async def process_entitlement_reply(entitlement_reply: str, user_id: str, action_text: str, channel: str, message_ts: str):
+async def process_entitlement_reply(
+    entitlement_reply: str,
+    user_id: str,
+    action_text: str,
+    response_url: str | None = None,
+    channel: str | None = None,
+    message_ts: str | None = None
+):
     """
     Triggered when an entitlement reply is found, this function will update the original message with the reply message.
     :param entitlement_reply: str: The text to update the asking question with.
     :param user_id: str: ID of the user who answered the entitlement
     :param action_text: str: The text attached to the button, used for string replacement.
+    :param response_url: str: The response URL to use for the update.
     :param channel: str: The channel ID of where the question exists.
     :param message_ts: str: The timestamp of the message. Acts as a unique ID.
     :return: None
@@ -1289,13 +1297,16 @@ async def process_entitlement_reply(entitlement_reply: str, user_id: str, action
         entitlement_reply = entitlement_reply.replace('{user}', f'<@{user_id}>')
     if '{response}' in entitlement_reply and action_text:
         entitlement_reply = entitlement_reply.replace('{response}', str(action_text))
-    await send_slack_request_async(client=ASYNC_CLIENT, method='chat.update',
-                                   body={
-                                       'channel': channel,
-                                       'ts': message_ts,
-                                       'text': entitlement_reply,
-                                       'blocks': []
-                                   })
+    if response_url:
+        requests.post(response_url, json={'text': entitlement_reply, 'replace_original': True})
+    else:
+        await send_slack_request_async(client=ASYNC_CLIENT, method='chat.update',
+                                    body={
+                                        'channel': channel,
+                                        'ts': message_ts,
+                                        'text': entitlement_reply,
+                                        'blocks': []
+                                    })
 
 
 def is_dm(channel: str) -> bool:
@@ -1446,6 +1457,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
         message_ts = message.get('ts', '')
         actions = data.get('actions', [])
         state = data.get('state', {})
+        response_url = data.get('response_url', '')
         quick_check_payload = json.dumps(data)
 
         # Check if the message is from a bot so we can quit processing ASAP
@@ -1503,7 +1515,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
                         err_message = f'Error submitting context command to server. Check your API Key: {err}'
                         demisto.updateModuleHealth(err_message)
             if entitlement_reply:
-                await process_entitlement_reply(entitlement_reply, user_id, action_text, channel, message_ts)
+                await process_entitlement_reply(entitlement_reply, user_id, action_text, response_url=response_url)
                 reset_listener_health()
                 return
 
@@ -1535,7 +1547,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
             user = await get_user_details(user_id=user_id)
             entitlement_reply = await check_and_handle_entitlement(text, user, thread)  # type: ignore
             if entitlement_reply:
-                await process_entitlement_reply(entitlement_reply, user_id, action_text, channel, message_ts)
+                await process_entitlement_reply(entitlement_reply, user_id, action_text, channel=channel, message_ts=message_ts)
                 reset_listener_health()
                 return
 

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.yml
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.yml
@@ -630,7 +630,7 @@ script:
     - contextPath: Slack.Thread.Text
       description: The text the message was updated with.
       type: String
-  dockerimage: demisto/slackv3:1.0.0.45719
+  dockerimage: demisto/slackv3:1.0.0.48936
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/Slack/ReleaseNotes/3_1_23.md
+++ b/Packs/Slack/ReleaseNotes/3_1_23.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### Slack v3
+- Updated the Docker image to: *demisto/slackv3:1.0.0.48936*.
 
 - Fixed an issue where the preview images were not removed after answering questions in the Slack channel.

--- a/Packs/Slack/ReleaseNotes/3_1_23.md
+++ b/Packs/Slack/ReleaseNotes/3_1_23.md
@@ -3,5 +3,4 @@
 
 ##### Slack v3
 - Updated the Docker image to: *demisto/slackv3:1.0.0.48936*.
-
 - Fixed an issue where the preview images were not removed after answering questions in the Slack channel.

--- a/Packs/Slack/ReleaseNotes/3_1_23.md
+++ b/Packs/Slack/ReleaseNotes/3_1_23.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Slack v3
+
+- Fixed an issue where the preview images were not removed after answering questions in the Slack channel.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.1.22",
+    "currentVersion": "3.1.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-21481?filter=-1
## Description
When answering questions, use the `response_url` to edit the message instead of `chat.update` endpoint. This way it will rerender the text again and remove the previews.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
