### PR TITLE
SearchIncidents v2 - add the limit argument

### DIFF
--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
@@ -117,6 +117,13 @@ args:
   required: false
   secret: false
 - default: false
+  description: The maximum number of incidents to be returned.
+  isArray: false
+  name: limit
+  required: false
+  secret: false
+  defaultValue: '100'
+- default: false
   description: Sort in format of field.asc,field.desc,...
   isArray: false
   name: sort


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-21958)

## Description
Fixed an issue where pagination was introduced in this PR that caused almost all the incidents to be fetched without taking consideration of limit. 

## Must have
- [x] Tests
- [ ] Documentation 
