### PR TITLE
Test XDR Playbook execute script commands - increase test timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -767,7 +767,7 @@
             "integrations": "Cortex XDR - IR",
             "playbookID": "Test XDR Playbook execute script commands",
             "fromversion": "4.1.0",
-            "timeout": 2500
+            "timeout": 3000
         },
         {
             "integrations": "Cortex XDR - IR",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5603)

## Description
Increase Test XDR Playbook execute script commands timeout from 2500 to 3000.
