### PR TITLE
Awake Security: Fix python3 issue where map returns an iterator instead of a list

### DIFF
--- a/Packs/AwakeSecurity/Integrations/AwakeSecurity/AwakeSecurity.py
+++ b/Packs/AwakeSecurity/Integrations/AwakeSecurity/AwakeSecurity.py
@@ -418,7 +418,7 @@ def fetchIncidents():
                 "EndTime": endTimeString,
                 "rawJSON": json.dumps(matchingThreatBehavior),
             }
-        demisto.incidents(map(toIncident, matchingThreatBehaviors))
+        demisto.incidents(list(map(toIncident, matchingThreatBehaviors)))
         # Don't increase the low-water-mark until we actually find incidents
         #
         # This is a precaution because incidents sometimes appear in an old time

--- a/Packs/AwakeSecurity/ReleaseNotes/1_0_19.md
+++ b/Packs/AwakeSecurity/ReleaseNotes/1_0_19.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Awake Security
+
+- Fixed fetch incidents when using python3 docker container by converting the return type of the map function into a list.

--- a/Packs/AwakeSecurity/pack_metadata.json
+++ b/Packs/AwakeSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Awake Security",
     "description": "Network Traffic Analysis",
     "support": "xsoar",
-    "currentVersion": "1.0.18",
+    "currentVersion": "1.0.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION



<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
In Python2.7, map returns a list, but in 3, it returns an iterator and fails like this:
```
   File "<string>", line 443, in <module>
   File "<string>", line 422, in fetchIncidents
   File "<string>", line 288, in incidents
   File "/usr/local/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
   File "/usr/local/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
   File "/usr/local/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
   File "/usr/local/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
 TypeError: Object of type map is not JSON serializable
 ```

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
