### PR TITLE
Revert removal of "VirusTotal"

### DIFF
--- a/Tests/Marketplace/core_packs_list.json
+++ b/Tests/Marketplace/core_packs_list.json
@@ -24,6 +24,7 @@
     "ThreatIntelReports",
     "ThreatIntelligenceManagement",
     "Unit42Intel",
+    "VirusTotal",
     "Whois",
     "rasterize"
   ],

--- a/Tests/Marketplace/core_packs_mpv2_list.json
+++ b/Tests/Marketplace/core_packs_mpv2_list.json
@@ -20,6 +20,7 @@
     "Palo_Alto_Networks_WildFire",
     "ThreatIntelligenceManagement",
     "Unit42Intel",
+    "VirusTotal",
     "Whois",
     "rasterize"
   ],
@@ -44,6 +45,7 @@
     "Palo_Alto_Networks_WildFire",
     "ThreatIntelligenceManagement",
     "Unit42Intel",
+    "VirusTotal",
     "Whois",
     "rasterize"
   ]


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-hq.paloaltonetworks.local/browse/CIAC-5744

## Description
Revert the removal of the VirusTotal pack from the core_packs lists.

