### PR TITLE
Parse email files v2 update

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_11_45.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_11_45.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+- Fixed an issue where an eml file containing chinese characters was not decoded correctly.
+- Updated the Docker image to: *demisto/parse-emails:1.0.0.49746*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -116,4 +116,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.48881
+dockerimage: demisto/parse-emails:1.0.0.49746

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.11.44",
+    "currentVersion": "1.11.45",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-22015)

## Description
Fixed an issue where an eml file containing chinese characters was not decoded correctly.

