### PR TITLE
Jira Link Workflow Regex Improvement

### DIFF
--- a/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
+++ b/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
@@ -40,21 +40,21 @@ def find_fixed_issue_in_body(body_text, is_merged):
     Getting the issues url in the PR's body as part of `fixing: <issue>` format.
     Return list of issues found: [{"link": link, "id": issue_id}]
     """
-    fixed_jira_issues = [(x.group(1), x.group(2)) for x in re.finditer(JIRA_FIXED_ISSUE_REGEX, body_text)]
-    related_jira_issue = [(x.group(1), x.group(2)) for x in re.finditer(JIRA_RELATED_ISSUE_REGEX, body_text)]
-    print(f'Detected {related_jira_issue=}')
-
     # If a PR is not merged, we just add the pr link to all the linked issues using Gold.
     # If the PR is merged, we only send issues that should be closed by it.
     # Assuming If the PR was merged, all the related links were fetched when the PR last edited.
-    fixed_issue = [{"link": link, "id": issue_id} for link, issue_id in fixed_jira_issues]
-    related_issue = []
+    issues = [
+        {"link": x.group(1), "id": x.group(2)} for x in re.finditer(JIRA_FIXED_ISSUE_REGEX, body_text)
+    ]
 
     if not is_merged:
-        print("Not merging, getting related issues.")
-        related_issue = [{"link": link, "id": issue_id} for link, issue_id in related_jira_issue]
+        print(f"Not merging, collecting related issues.")
 
-    return fixed_issue + related_issue
+        issues.extend([
+            {"link": x.group(1), "id": x.group(2)} for x in re.finditer(JIRA_RELATED_ISSUE_REGEX, body_text)
+        ])
+
+    return issues
 
 
 def trigger_generic_webhook(options):

--- a/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
+++ b/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
@@ -8,7 +8,7 @@ import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 JIRA_URL_REGEX = \
-    r"(?:\[.+\]\()?(?P<url>https?:\/\/jira-hq\.paloaltonetworks\.local\/browse\/(?P<issue_id>[a-zA-Z][a-zA-Z0-9]+-[0-9]+))"
+    r"(?:\[.+\]\()?(?P<url>https?:\/\/jira-hq\.paloaltonetworks\.local\/browse\/(?P<issue_key>[a-zA-Z][a-zA-Z0-9]+-[0-9]+))"
 JIRA_FIXED_ISSUE_REGEX = rf"(?i)fixes:\s*{JIRA_URL_REGEX}"
 JIRA_RELATED_ISSUE_REGEX = rf"(?i)relates:\s*{JIRA_URL_REGEX}"
 GENERIC_WEBHOOK_NAME = "GenericWebhook_link_pr_to_jira"

--- a/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
+++ b/Utils/github_workflow_scripts/jira_integration_scripts/link_pr_to_jira_issue.py
@@ -70,10 +70,7 @@ def trigger_generic_webhook(options):
     print(f"Detected Pr: {pr_title=}, {pr_link=}, {pr_body=}")
 
     # Handle cases where the PR did not intend to add links:
-    if ("fixes:" not in pr_body.lower()
-            and "relates:" not in pr_body.lower()
-            and "fixed:" not in pr_body.lower()
-            and "related:" not in pr_body.lower()):
+    if not any(x.casefold() in pr_body.casefold() for x in ("fixes:", "relates:", "fixed:", "related:")):
         print("Did not detect Jira linking pattern.")
         return
 


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5963)

## Description
This PR improves the regex for matching Jira URLs on GitHub PRs.

The new regex:
1. Is case-insensitive (both for `fixes` / `relates`, and for the URL itself).
2. Captures `http` scheme URLs (when entering our Jira instance with `http` it redirects to `https`, so while an `http` URL usage is unlikely in a PR, it's still valid).
3. Has escaping for the `.` character, which was missing from the URL.

Usage of `re.findall` which returns strings or a tuple of strings if there are match groups, is replaced with `re.finditer`, which returns `Match` objects and allows much more control and includes additional metadata for the found items.

Plus a few minor improvements to the code (mostly aesthetic, the behavior is mostly unchanged).

[Previous Regex (regex101)](https://regex101.com/r/8FWrOE/1)
[New Regex (regex101)](https://regex101.com/r/0Huq7z/1)