### PR TITLE
[Time Components] Add `freeze_time` to unit test to make it consistent

### DIFF
--- a/Packs/FiltersAndTransformers/Scripts/TimeComponents/TimeComponents_test.py
+++ b/Packs/FiltersAndTransformers/Scripts/TimeComponents/TimeComponents_test.py
@@ -14,6 +14,7 @@ class TestTimeComponents:
         now = datetime(2022, 1, 23, 12, 34, 56, tzinfo=timezone.utc)
         assert now == TimeComponents.parse_date_time_value('now').astimezone(timezone.utc)
 
+    @freezegun.freeze_time('2022-01-23 12:34:56')
     def test_main(self, mocker, monkeypatch):
         with open('./test_data/test.json', 'r') as f:
             test_list = json.load(f)

--- a/Packs/FiltersAndTransformers/Scripts/TimeComponents/test_data/test.json
+++ b/Packs/FiltersAndTransformers/Scripts/TimeComponents/test_data/test.json
@@ -82,7 +82,7 @@
       "period_12_clock": "PM",
       "time_zone_hhmm": "-0400",
       "time_zone_offset": -240.0,
-      "time_zone_abbreviations": ["AST", "CDT", "EDT"],
+      "time_zone_abbreviations": ["AST"],
       "unix_epoch_time": 1642868625,
       "iso_8601": "2022-01-22T12:23:45-04:00",
       "y-m-d": "2022-1-22",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5982)

## Description
It appears that the values of `time_zone_abbreviations` can change according to whether we're on daylight savings time.
What caused the original issue (mentioned in the ticket), seems to be that daylight savings time changed on 12/03, and with that, some timezones ("CDT" and "EDT") were changed to UTC-4 from UTC-5, which is what the test checked for.

"AST" on the other hand, probably has no change to daylight savings (there is a daylight savings variation with a different name - "ADT"), which is why it remain with or without daylight savings.

This issue has been resolved by locking the date using `freezegun.freeze_time`
