### PR TITLE
IOC Alert Trigger - Filter Fix

### DIFF
--- a/Packs/Core/ReleaseNotes/1_3_40.md
+++ b/Packs/Core/ReleaseNotes/1_3_40.md
@@ -1,0 +1,4 @@
+
+#### Triggers Recommendations
+
+- **IOC Alert** Changes the filter query from alert_source equals "XDR IOC" to "IOC"

--- a/Packs/Core/ReleaseNotes/1_3_40.md
+++ b/Packs/Core/ReleaseNotes/1_3_40.md
@@ -1,4 +1,5 @@
 
 #### Triggers Recommendations
 
-- **IOC Alert** Changes the filter query from alert_source equals "XDR IOC" to "IOC"
+- **IOC Alert** 
+- Changes the filter query from alert_source equals "XDR IOC" to "IOC"

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -1,0 +1,5 @@
+
+#### Triggers Recommendations
+
+- **IOC Alert** 
+- Changes the filter query from alert_source equals "XDR IOC" to "IOC"

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -1,6 +1,4 @@
 
 #### Triggers Recommendations
 
-- **IOC Alert** 
-
-- Changes the filter query from alert_source equals "XDR IOC" to "IOC"
+- **IOC Alert**

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -1,4 +1,6 @@
 
 #### Triggers Recommendations
 
-- **IOC Alert**
+**IOC Alert**
+
+- Changes the filter query from alert_source eq "XDR IOC" to "IOC"

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -1,6 +1,4 @@
 
 #### Triggers Recommendations
 
-**IOC Alert**
-
-- Changes the filter query from alert_source eq "XDR IOC" to "IOC"
+- **IOC Alert**

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -2,3 +2,4 @@
 #### Triggers Recommendations
 
 - **IOC Alert**
+  - Changes the filter query from alert_source equals "XDR IOC" to "IOC"

--- a/Packs/Core/ReleaseNotes/1_3_41.md
+++ b/Packs/Core/ReleaseNotes/1_3_41.md
@@ -2,4 +2,5 @@
 #### Triggers Recommendations
 
 - **IOC Alert** 
+
 - Changes the filter query from alert_source equals "XDR IOC" to "IOC"

--- a/Packs/Core/Triggers/Trigger_-_IOC_Alert.json
+++ b/Packs/Core/Triggers/Trigger_-_IOC_Alert.json
@@ -10,7 +10,7 @@
         {
             "SEARCH_FIELD": "alert_source",
             "SEARCH_TYPE": "EQ",
-            "SEARCH_VALUE": "XDR IOC"
+            "SEARCH_VALUE": "IOC"
         }
       ]
     }

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "1.3.39",
+    "currentVersion": "1.3.40",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "1.3.40",
+    "currentVersion": "1.3.41",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Changes the filter query from alert_source eq "XDR IOC" to alert_source eq "IOC"

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
