### PR TITLE
Fix missing else path in first task

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Domain_Enrichment_-_Generic_v2.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Domain_Enrichment_-_Generic_v2.yml
@@ -56,6 +56,8 @@ tasks:
       - "32"
       - "33"
       - "31"
+      '#default#':
+      - "24"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -543,5 +545,5 @@ outputs:
 tests:
 - Domain Enrichment - Generic v2 - Test
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_49.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_49.md
@@ -3,4 +3,4 @@
 
 ##### Domain Enrichment - Generic v2
 
-- Fixed an issue caused by a missing else path for task in playbook.
+- Fixed an issue caused by a missing else path for task "Is there a domain to enrich?" (no. 16) in playbook.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_49.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_49.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Domain Enrichment - Generic v2
+
+- Fixed an issue caused by a missing else path for task in playbook.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.48",
+    "currentVersion": "2.3.49",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA 

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**-->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-22403)
https://jira-hq.paloaltonetworks.local/browse/XSUP-22403

## Description
Fix missing `else` path in first task of the playbook

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.9.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

