### PR TITLE
Phishing v3 - DomainSquatting increase memory threshold

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4549,7 +4549,7 @@
                 "classifier_id": "EWS v2",
                 "incoming_mapper_id": "EWS v2-mapper"
             },
-            "memory_threshold": 300,
+            "memory_threshold": 400,
             "pid_threshold": 80
         },
         {


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-5973

## Description
Increasing the memory threshold for the `Phishing v3 - DomainSquatting+EML+MaliciousIndicators - Test` test playbook.
Link to the failure: https://code.pan.run/xsoar/content/-/jobs/22874506#L3757

## Screenshots

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
