### PR TITLE
Ignore domain look alike from email user

### DIFF
--- a/Packs/CommonScripts/Scripts/ExtractDomainAndFQDNFromUrlAndEmail/ExtractDomainAndFQDNFromUrlAndEmail.py
+++ b/Packs/CommonScripts/Scripts/ExtractDomainAndFQDNFromUrlAndEmail/ExtractDomainAndFQDNFromUrlAndEmail.py
@@ -90,8 +90,10 @@ def check_if_known_url(the_input):
 
 
 def extract_fqdn(the_input):
+    if the_input.endswith("@"):
+        return ''
     the_input = check_if_known_url(the_input)
-    # pre processing the input, removing excessive charecters
+    # pre-processing the input, removing excessive characters
     the_input = pre_process_input(the_input)
 
     # Not ATP Link or Proofpoint URL so just unescape

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
@@ -1,6 +1,16 @@
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
+import json
+
+def string_to_markdown(text):
+    text = json.loads(text)
+    md = ''
+    for key, values in text.items():
+        md += f"### {key}\n"
+        for value in values:
+            md += f"- {value}\n"
+    return md
 
 
 def read_file_with_encoding_detection(filePath, maxFileSize):
@@ -39,7 +49,7 @@ def extract_indicators_from_file(args):
         'Type': entryTypes['note'],
         'ContentsFormat': formats['text'],
         'Contents': indicators_hr,
-        'HumanReadable': indicators_hr
+        'HumanReadable': string_to_markdown(indicators_hr)
     }
 
 

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
@@ -3,13 +3,32 @@ from CommonServerPython import *
 from CommonServerUserPython import *
 import json
 
-def string_to_markdown(text):
-    text = json.loads(text)
-    md = ''
-    for key, values in text.items():
-        md += f"### {key}\n"
+
+def string_to_markdown(indicators: str) -> str:
+    """
+    Converts the JSON to a human-readable markdown structure
+
+    Args:
+        indicators (str): JSON of the indicators extracted by the server as a string.
+
+    Returns:
+        str: Markdown list of the indicators extracted
+    """
+    try:
+        indicators_dict = json.loads(indicators)
+
+        md = ''
+
+        for key, values in indicators_dict.items():
+            md += f"### {key}\n"
+
         for value in values:
             md += f"- {value}\n"
+
+    except json.JSONDecodeError:
+        demisto.error(f'JSON Decode failed on "{indicators}"')
+        md = f'JSON Decode failed on "{indicators}"'
+
     return md
 
 

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile.py
@@ -22,8 +22,8 @@ def string_to_markdown(indicators: str) -> str:
         for key, values in indicators_dict.items():
             md += f"### {key}\n"
 
-        for value in values:
-            md += f"- {value}\n"
+            for value in values:
+                md += f"- {value}\n"
 
     except json.JSONDecodeError:
         demisto.error(f'JSON Decode failed on "{indicators}"')

--- a/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile_test.py
+++ b/Packs/CommonScripts/Scripts/ExtractIndicatorsFromTextFile/ExtractIndicatorsFromTextFile_test.py
@@ -7,7 +7,7 @@ def execute_command(command, args):
     if command == 'getFilePath':
         return [{'Contents': {'path': './test_data/test_file.txt'}}]
     if command == "extractIndicators":
-        return [{'Contents': '1.1.1.1'}]
+        return [{'Contents': '{"IP": ["1.1.1.1"]}'}]
 
 
 def test_extract_indicators(mocker):
@@ -24,7 +24,7 @@ def test_extract_indicators(mocker):
     mocker.patch.object(demisto, 'executeCommand', side_effect=execute_command)
     args = {}
     results = extract_indicators_from_file(args)
-    assert {'Contents': '1.1.1.1', 'ContentsFormat': 'text', 'HumanReadable': '1.1.1.1', 'Type': 1} == results
+    assert {'Contents': '{"IP": ["1.1.1.1"]}', 'ContentsFormat': 'text', 'HumanReadable': '### IP\n- 1.1.1.1\n', 'Type': 1} == results
 
 
 def test_extract_indicators_no_file():
@@ -43,6 +43,11 @@ def test_extract_indicators_no_file():
         extract_indicators_from_file(args)
         if not e:
             assert False
+
+
+@pytest.mark.parametrize("input, output", [('{"IP": ["1.1.1.1"]}', '### IP\n- 1.1.1.1\n')])
+def test_string_to_markdown(input, output):
+    assert string_to_markdown(input) == output
 
 
 @pytest.mark.parametrize('filePath, res', [

--- a/Packs/CommonTypes/IndicatorTypes/reputation-domain.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-domain.json
@@ -6,7 +6,7 @@
     "sortValues": null,
     "commitMessage": "",
     "shouldCommit": false,
-    "regex": "(?i)(?P<scheme>(?:http|ftp|hxxp)s?(?:://|-3A__|%3A%2F%2F))?(?P<domain>(?:[\\p{L}\\d\\-–]+(?:\\.|\\[\\.\\]))+[\\p{L}]{2,})",
+    "regex": "(?i)(?P<scheme>(?:http|ftp|hxxp)s?(?:://|-3A__|%3A%2F%2F))?(?P<domain>(?:[\\p{L}\\d\\-–]+(?:\\.|\\[\\.\\]))+[\\p{L}]{2,})@?",
     "details": "Domain",
     "prevDetails": "Domain",
     "reputationScriptName": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-22404

## Description
At the moment if an email has a user name that looks like a domain we will extract it as such. This change should fix this issue by grabbing the "@" sign with the user name. That way the formatter knows its a user-name and not a domain and drops it.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
