### PR TITLE
CrowdStrike_Falcon_X_-Test-Detonate_URL playbook timeout update

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4472,7 +4472,7 @@
             "integrations": [
                 "CrowdStrike Falcon X"
             ],
-            "timeout": 2000
+            "timeout": 2500
         },
         {
             "playbookID": "CrowdStrike_Falcon_X_-Test-Detonate_File",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6019)

## Description
This playbook failed in Nightly due to timeout
