### PR TITLE
[SlackV3] TestPB - Increase timeout from 400 to 600

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -751,7 +751,7 @@
             "integrations": "SlackV3",
             "playbookID": "SlackV3 TestPB",
             "instance_names": "cached",
-            "timeout": 400,
+            "timeout": 600,
             "pid_threshold": 8,
             "fromversion": "5.5.0"
         },


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6018)

## Description
Increase SlackV3 TestPB timeout from 400 to 600.