### PR TITLE
Fix Test XDR Playbook general commands fails Nightly

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -779,7 +779,7 @@
             "integrations": "Cortex XDR - IR",
             "playbookID": "Test XDR Playbook general commands",
             "fromversion": "4.1.0",
-            "timeout": 1200
+            "timeout": 2500
         },
         {
             "integrations": "Cortex XDR - IR",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6029?jql=project%20%3D%20CIAC%20AND%20issuetype%20%3D%20Bug

## Description
Fixing Test XDR Playbook general commands that has been failing in the Nightly, by extending the timeout to 2500.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
-[x] 5.0.0
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
