### PR TITLE
Fix xdr hostname fetch incidents

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -637,9 +637,16 @@ def get_incident_extra_data_command(client, args):
     account_context_output = assign_params(**{
         'Username': incident.get('users', '')
     })
-    endpoint_context_output = assign_params(**{
-        'Hostname': incident.get('hosts', '')
-    })
+    endpoint_context_output = []
+    if hosts := incident.get('hosts'):
+        for host in hosts:
+            host_name, agent_id = host.split(':')
+            endpoint_context_output.append(
+                {
+                    'Hostname': host_name,
+                    'ID': agent_id
+                }
+            )
 
     context_output = {f'{INTEGRATION_CONTEXT_BRAND}.Incident(val.incident_id==obj.incident_id)': incident}
     if account_context_output:

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -250,12 +250,21 @@ def test_get_incident_extra_data(requests_mock):
 
     expected_output = {
         'PaloAltoNetworksXDR.Incident(val.incident_id==obj.incident_id)': expected_incident,
-        Common.File.CONTEXT_PATH: [{'Name': 'wildfire-test-pe-file.exe',
-                                    'SHA256': '8d5aec85593c85ecdc8d5ac601e163a1cc26d877f88c03e9e0e94c9dd4a38fca'}],
+        Common.File.CONTEXT_PATH: [
+            {
+                'Name': 'wildfire-test-pe-file.exe',
+                'SHA256': '8d5aec85593c85ecdc8d5ac601e163a1cc26d877f88c03e9e0e94c9dd4a38fca'
+            }
+        ],
         'Process(val.Name && val.Name == obj.Name)':
-            [{'Name': 'wildfire-test-pe-file.exe',
-              'CommandLine': '"C:\\Users\\Administrator\\Downloads\\wildfire-test-pe-file.exe"',
-              'Hostname': 'AAAAAA'}]
+            [
+                {
+                    'Name': 'wildfire-test-pe-file.exe',
+                    'CommandLine': '"C:\\Users\\Administrator\\Downloads\\wildfire-test-pe-file.exe"',
+                    'Hostname': 'AAAAAA'
+                }
+            ],
+        'Endpoint(val.Hostname==obj.Hostname)': [{'Hostname': 'AAAAAA', 'ID': '1234'}]
     }
     assert expected_output == outputs
 

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/test_data/get_incident_extra_data_host_id_array.json
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/test_data/get_incident_extra_data_host_id_array.json
@@ -21,7 +21,8 @@
             "manual_severity": null,
             "manual_description": null,
             "xdr_url": "https://demisto.hello.com/incident-view/1",
-            "starred": false
+            "starred": false,
+            "hosts": ["AAAAAA:1234"]
         },
         "alerts": {
             "total_count": 1,

--- a/Packs/CortexXDR/ReleaseNotes/4_10_27.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_10_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+
+- Fixed an issue in the **fetch-incidents** and the **xdr-get-incident-extra-data** command where the `Endpoint.Hostname` value returned to the context was invalid.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.10.26",
+    "currentVersion": "4.10.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/XSUP-22140

## Description
Fixed an issue in the **fetch-incidents** and the **xdr-get-incident-extra-data** command where the `Endpoint.Hostname` value returned to the context was invalid.

## Must have
- [x] Tests
- [ ] Documentation 
