### PR TITLE
More EDL logs

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_79.md
+++ b/Packs/Base/ReleaseNotes/1_31_79.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+- Fixed an issue where profiling dump functionality could not be used in long running integrations that use Flask applications.

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.78",
+    "currentVersion": "1.31.79",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -1128,6 +1128,5 @@ def main():
 from NGINXApiModule import *  # noqa: E402
 
 if __name__ in ['__main__', '__builtin__', 'builtins']:
-    with APP.app_context():
-        register_signal_handler_profiling_dump(profiling_dump_rows_limit=PROFILING_DUMP_ROWS_LIMIT)
+    register_signal_handler_profiling_dump(profiling_dump_rows_limit=PROFILING_DUMP_ROWS_LIMIT)
     main()

--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -236,6 +236,20 @@ def iterable_to_str(iterable: Iterable, delimiter: str = '\n') -> str:
     return str_res
 
 
+def log_iocs_file_data(formatted_indicators: str, max_length: int = 100) -> None:
+    """Prints a debug log of the first `max_length` characters in the formatted indicators data.
+
+    Args:
+        formatted_indicators (str): The IOCs formatted data.
+        max_length (int, optional): max # of chars to print. Defaults to 100.
+    """
+    if formatted_indicators:
+        truncated_data = formatted_indicators[:max_length]
+        demisto.debug(f"Formatted IOC data (first {max_length} characters):\n{truncated_data}")
+    else:
+        demisto.debug("No data from IOC search.")
+
+
 def create_new_edl(request_args: RequestArguments) -> str:
     """
     Gets indicators from XSOAR server using IndicatorsSearcher and formats them
@@ -252,6 +266,7 @@ def create_new_edl(request_args: RequestArguments) -> str:
         size=PAGE_SIZE,
         limit=limit
     )
+    demisto.debug(f"Creating a new EDL file in {request_args.out_format} format")
     formatted_indicators = ''
     if request_args.out_format == FORMAT_TEXT:
         if request_args.drop_invalids or request_args.collapse_ips != "Don't Collapse":
@@ -274,6 +289,7 @@ def create_new_edl(request_args: RequestArguments) -> str:
         new_iocs_file.seek(0)
         formatted_indicators = new_iocs_file.read()
     new_iocs_file.close()
+    log_iocs_file_data(formatted_indicators)
     return formatted_indicators
 
 
@@ -337,6 +353,7 @@ def get_indicators_to_format(indicator_searcher: IndicatorsSearcher, request_arg
     except Exception as e:
         demisto.error(f'Error parsing the following indicator: {ioc.get("value")}\n{e}')
 
+    demisto.debug(f"Completed IOC search & format, found {ioc_counter} IOCs.")
     if request_args.out_format == FORMAT_JSON:
         f.write(']')
     elif request_args.out_format == FORMAT_PROXYSG:
@@ -755,6 +772,7 @@ def get_edl_on_demand():
             file.write(edl)
         set_integration_context(ctx)
     else:
+        demisto.debug("Reading EDL data from cache")
         with open(EDL_ON_DEMAND_CACHE_PATH, 'r') as file:
             edl = file.read()
     return edl
@@ -1110,4 +1128,6 @@ def main():
 from NGINXApiModule import *  # noqa: E402
 
 if __name__ in ['__main__', '__builtin__', 'builtins']:
+    with APP.app_context():
+        register_signal_handler_profiling_dump(profiling_dump_rows_limit=PROFILING_DUMP_ROWS_LIMIT)
     main()

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -540,7 +540,7 @@ script:
     deprecated: false
     description: Updates values stored in the List (only available On-Demand).
     execution: false
-  dockerimage: demisto/flask-nginx:1.0.0.43509
+  dockerimage: demisto/flask-nginx:1.0.0.49636
   feed: false
   isfetch: false
   longRunning: true

--- a/Packs/EDL/ReleaseNotes/3_1_20.md
+++ b/Packs/EDL/ReleaseNotes/3_1_20.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### Generic Export Indicators Service
+- Added logs for debugging purposes.

--- a/Packs/EDL/ReleaseNotes/3_1_20.md
+++ b/Packs/EDL/ReleaseNotes/3_1_20.md
@@ -2,3 +2,4 @@
 #### Integrations
 ##### Generic Export Indicators Service
 - Added logs for debugging purposes.
+- Updated the docker image to: *demisto/flask-nginx:1.0.0.49636*.

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Export Indicators Service",
     "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to ANY other product in your network, such as your firewall, agent or SIEM. This pack is built for ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
-    "currentVersion": "3.1.19",
+    "currentVersion": "3.1.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-hq.paloaltonetworks.local/browse/XSUP-22216
relates: https://jira-hq.paloaltonetworks.local/browse/XSUP-19830

## Description
- Added debug logs and the profiling dump functionality to EDL integration.
- Fixed an issue where profiling dump functionality could not be used in long running integrations that use Flask applications.

## Screenshots
Debug logs:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/38749041/226361987-65a4e671-6d8b-4bdc-88e1-dbb7a59ed159.png">

Profiling dump:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/38749041/226361245-42932200-587f-4396-b9af-5e402904d109.png">
<img width="968" alt="image" src="https://user-images.githubusercontent.com/38749041/226361198-f7aacfc3-6d0f-446f-9e30-75a8c0d7dfb1.png">
<img width="921" alt="image" src="https://user-images.githubusercontent.com/38749041/226361310-53522575-3150-4145-b23f-9dd940cfa16a.png">


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
