### PR TITLE
Phishing add extraction rules

### DIFF
--- a/Packs/Phishing/IncidentTypes/Phishing.json
+++ b/Packs/Phishing/IncidentTypes/Phishing.json
@@ -593,6 +593,31 @@
 
     ]
    },
+   "reportedemailcc": {
+    "extractAsIsIndicatorTypeId": "",
+    "extractIndicatorTypesIDs": [],
+    "isExtractingAllIndicatorTypes": true
+   },
+   "reportedemailfrom": {
+    "extractAsIsIndicatorTypeId": "",
+    "extractIndicatorTypesIDs": [],
+    "isExtractingAllIndicatorTypes": true
+   },
+   "reportedemailmessageid": {
+    "extractAsIsIndicatorTypeId": "",
+    "extractIndicatorTypesIDs": [],
+    "isExtractingAllIndicatorTypes": false
+   },
+   "reportedemailsubject": {
+    "extractAsIsIndicatorTypeId": "",
+    "extractIndicatorTypesIDs": [],
+    "isExtractingAllIndicatorTypes": true
+   },
+   "reportedemailto": {
+    "extractAsIsIndicatorTypeId": "",
+    "extractIndicatorTypesIDs": [],
+    "isExtractingAllIndicatorTypes": true
+   },
    "reporteremailaddress": {
     "extractAsIsIndicatorTypeId": "",
     "isExtractingAllIndicatorTypes": false,

--- a/Packs/Phishing/ReleaseNotes/3_5_8.md
+++ b/Packs/Phishing/ReleaseNotes/3_5_8.md
@@ -1,0 +1,4 @@
+
+#### Incident Types
+
+- **Phishing** - Indicator extraction rules have been added to the following incident fields: Reported Email CC, Reported Email From, Reported Email Subject, and Reported Email To.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.5.7",
+    "currentVersion": "3.5.8",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-2658

## Description
Indicator extraction rules have been added to the following incident fields: Reported Email CC, Reported Email From, Reported Email Subject, and Reported Email To.
detailed in JIRA ticket added above.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
