### PR TITLE
Update ZeroTrustAnalyticsPlatform to 1.1.6

### DIFF
--- a/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/ZeroTrustAnalyticsPlatform.yml
+++ b/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/ZeroTrustAnalyticsPlatform.yml
@@ -126,7 +126,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.10.48392
+  dockerimage: demisto/python3:3.10.10.50695
 fromversion: 6.0.0
 defaultmapperin: ZeroTrustAnalyticsPlatform - Incoming Mapper
 defaultmapperout: ZeroTrustAnalyticsPlatform - Outgoing Mapper

--- a/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/ZeroTrustAnalyticsPlatform_test.py
+++ b/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/ZeroTrustAnalyticsPlatform_test.py
@@ -383,6 +383,35 @@ def test_update_remote_system_escalate(mocker):
     assert response == "1"
 
 
+def test_update_remote_system_escalate_and_comment(mocker):
+    # escalate should take priority over comment
+    client = get_test_client()
+    mocker.patch.object(client, "get_alert", return_value=alert_data()[0])
+    mocker.patch.object(client, "reassign_alert_to_org")
+    mocker.patch.object(client, "get_organizations", return_value=organization_data())
+    mocker.patch.object(client, "get_active_user", return_value=user_data())
+
+    client.close_incident = True
+    args = {
+        "remoteId": "1",
+        "status": 1,
+        "entries": [
+            {
+                "user": "test user",
+                "contents": "test contents",
+                "tags": [TEST_COMMENT_TAG, TEST_ESCALATE_TAG],
+            }
+        ],
+        "incidentChanged": False,
+    }
+    investigation = {}
+    response = update_remote_system(client, investigation, args)
+
+    client.reassign_alert_to_org.assert_called()
+
+    assert response == "1"
+
+
 def test_update_remote_system_closed(mocker):
     client = get_test_client()
     mocker.patch.object(client, "get_alert", return_value=alert_data()[0])

--- a/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/test_data/xsoar_data.py
+++ b/Packs/ZeroTrustAnalyticsPlatform/Integrations/ZeroTrustAnalyticsPlatform/test_data/xsoar_data.py
@@ -45,6 +45,7 @@ def alert_response():
             "xsoar_mirror_instance": "dummy_instance",
             "xsoar_mirror_id": "1",
             "xsoar_mirror_tags": ["comment_tag", "escalate_tag"],
+            "xsoar_input_tag": "input_tag",
         },
         {
             "datetime_created": "2021-05-11T20:09:50Z",
@@ -62,6 +63,7 @@ def alert_response():
             "xsoar_mirror_instance": "dummy_instance",
             "xsoar_mirror_id": "2",
             "xsoar_mirror_tags": ["comment_tag", "escalate_tag"],
+            "xsoar_input_tag": "input_tag",
         },
     ]
 
@@ -122,7 +124,7 @@ def comment_entries():
             "HumanReadable": "Test comment\n\nSent by Active User (test@test) via ZTAP",
             "ReadableContentsFormat": "text",
             "Note": True,
-            "Tags": [],
+            "Tags": ["input_tag"],
         },
         {
             "Type": 1,
@@ -131,6 +133,6 @@ def comment_entries():
             "HumanReadable": "Closing alert due to duplicate.\n\nSent by Active User (test@test) via ZTAP",
             "ReadableContentsFormat": "text",
             "Note": True,
-            "Tags": [],
+            "Tags": ["input_tag"],
         },
     ]

--- a/Packs/ZeroTrustAnalyticsPlatform/Layouts/layoutscontainer-ZTAP_Alert.json
+++ b/Packs/ZeroTrustAnalyticsPlatform/Layouts/layoutscontainer-ZTAP_Alert.json
@@ -431,7 +431,7 @@
             {
                 "hidden": false,
                 "id": "yuellml8sw",
-                "name": "ZTAP",
+                "name": "ZTAP Info",
                 "sections": [
                     {
                         "displayType": "ROW",
@@ -552,6 +552,33 @@
                     }
                 ],
                 "type": "custom"
+            },
+            {
+                "id": "vkiwzwurkm",
+                "name": "ZTAP Timeline",
+                "type": "custom",
+                "hidden": false,
+                "sections": [
+                    {
+                        "description": "",
+                        "h": 4,
+                        "hideName": false,
+                        "i": "caseinfoid-3dd5bde0-c427-11ed-b1be-ef2101b9822e",
+                        "items": [],
+                        "maxW": 3,
+                        "minH": 1,
+                        "minW": 1,
+                        "moved": false,
+                        "name": "Timeline",
+                        "query": "ZTAPViewTimeline",
+                        "queryType": "script",
+                        "static": false,
+                        "type": "dynamic",
+                        "w": 3,
+                        "x": 0,
+                        "y": 0
+                    }
+                ]
             },
             {
                 "id": "warRoom",

--- a/Packs/ZeroTrustAnalyticsPlatform/ReleaseNotes/1_1_6.md
+++ b/Packs/ZeroTrustAnalyticsPlatform/ReleaseNotes/1_1_6.md
@@ -1,5 +1,20 @@
 
 #### Integrations
 ##### ZeroTrustAnalyticsPlatform
-- Add ZTAPViewTimeline script
+- Updated the Docker image to: *demisto/python3:3.10.10.50695*.
 - Fix outbound tag priority (escalation now takes priority over comments)
+
+#### Scripts
+
+##### New: ZTAPViewTimeline
+
+- View notes only relating to ZTAP
+
+
+#### Layouts
+
+##### ZTAP Alert
+
+- Update original section to "ZTAP Info"
+- Add additional section for "ZTAP Timeline"
+

--- a/Packs/ZeroTrustAnalyticsPlatform/ReleaseNotes/1_1_6.md
+++ b/Packs/ZeroTrustAnalyticsPlatform/ReleaseNotes/1_1_6.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### ZeroTrustAnalyticsPlatform
+- Add ZTAPViewTimeline script
+- Fix outbound tag priority (escalation now takes priority over comments)

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/README.md
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/README.md
@@ -1,0 +1,21 @@
+View notes only relating to ZTAP.
+
+## Script Data
+
+---
+
+| **Name** | **Description** |
+| --- | --- |
+| Script Type | python3 |
+| Tags | ztap |
+| Cortex XSOAR Version | 6.0.0 |
+
+## Inputs
+
+---
+There are no inputs for this script.
+
+## Outputs
+
+---
+There are no outputs for this script.

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.py
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.py
@@ -1,0 +1,89 @@
+from CommonServerPython import *
+
+from typing import Dict, Any
+import traceback
+
+""" STANDALONE FUNCTION """
+
+
+def view_timeline(notes, ztap_tags) -> str:
+    table_name = "Timeline"
+    headers = ["Time", "Message"]
+
+    fields = []
+    for note in notes:
+        message = None
+
+        # Filter out notes that do not relate to ZTAP
+        tags = note.get("Tags") or []
+        if all(tag not in ztap_tags for tag in tags):
+            continue
+
+        if note.get("ContentsFormat") == "text":
+            message = note.get("Contents")
+            occurred = note.get("Metadata").get("created")
+
+        if note.get("ContentsFormat") == "markdown":
+            message = note.get("Contents")
+            occurred = note.get("Metadata").get("created")
+
+        if message:
+            fields.append({"Time": occurred, "Message": message})
+
+    fields.sort(key=lambda f: f["Time"], reverse=True)
+
+    if fields:
+        output = tableToMarkdown(table_name, fields, headers=headers)
+    else:
+        output = "No ZTAP timeline"
+
+    return output
+
+
+""" COMMAND FUNCTION """
+
+
+def view_timeline_command(args: Dict[str, Any]) -> CommandResults:
+    incident = demisto.incident()
+    input_tag = incident.get("CustomFields").get("ztapinputtag")
+    output_tags = incident.get("dbotMirrorTags")
+
+    ztap_tags = []
+    if input_tag:
+        ztap_tags.append(input_tag)
+    ztap_tags.extend(output_tags)
+
+    entries = demisto.executeCommand(
+        "getEntries", {"filter": {"categories": ["notes"]}}
+    )
+
+    if not entries:
+        entries = []
+
+    # Call the standalone function and get the raw response
+    result = view_timeline(entries, ztap_tags)
+
+    return CommandResults(
+        outputs_prefix="ZTAPviewTimeline",
+        outputs_key_field="",
+        outputs=[result],
+        readable_output=result,
+    )
+
+
+""" MAIN FUNCTION """
+
+
+def main():
+    try:
+        return_results(view_timeline_command(demisto.args()))
+    except Exception as ex:
+        demisto.error(traceback.format_exc())  # print the traceback
+        return_error(f"Failed to execute BaseScript. Error: {str(ex)}")
+
+
+""" ENTRY POINT """
+
+
+if __name__ in ("__main__", "__builtin__", "builtins"):
+    main()

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.yml
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.yml
@@ -1,0 +1,18 @@
+args: []
+comment: Deprecated. Comment ingestion simplified and audit log ingestion removed. No available replacement. Adds unmarked log/comment notes as evidence in the timeline.
+commonfields:
+  id: ZTAPViewTimeline
+  version: -1
+enabled: false
+deprecated: true
+name: ZTAPViewTimeline
+script: ''
+subtype: python3
+tags:
+- ztap
+type: python
+runas: DBotWeakRole
+dockerimage: demisto/python3:3.9.7.24076
+tests:
+- No tests (auto formatted)
+fromversion: 6.0.0

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.yml
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline.yml
@@ -1,10 +1,10 @@
 args: []
-comment: Deprecated. Comment ingestion simplified and audit log ingestion removed. No available replacement. Adds unmarked log/comment notes as evidence in the timeline.
+comment: View notes only relating to ZTAP.
 commonfields:
   id: ZTAPViewTimeline
   version: -1
 enabled: false
-deprecated: true
+deprecated: false
 name: ZTAPViewTimeline
 script: ''
 subtype: python3
@@ -12,7 +12,7 @@ tags:
 - ztap
 type: python
 runas: DBotWeakRole
-dockerimage: demisto/python3:3.9.7.24076
+dockerimage: demisto/python3:3.10.10.50695
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline_test.py
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/ZTAPViewTimeline_test.py
@@ -1,0 +1,23 @@
+import json
+import io
+
+
+def util_load_json(path):
+    with io.open(path, mode="r", encoding="utf-8") as f:
+        return json.loads(f.read())
+
+
+def util_load_raw(path):
+    with io.open(path, mode="r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_view_timeline(mocker):
+    from ZTAPViewTimeline import view_timeline
+
+    ztap_tags = ["ztap", "comment", "escalate"]
+    entries = util_load_json("test_data/entries.json")
+    output = view_timeline(entries, ztap_tags)
+
+    mock_output = util_load_raw("test_data/output.md")
+    assert output == mock_output

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/test_data/entries.json
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/test_data/entries.json
@@ -1,0 +1,47 @@
+[
+    {
+        "ContentsFormat": "text",
+        "Contents": "Escalating alert.\nMore information.",
+        "ID": "3@100",
+        "Tags": ["ztap"],
+        "Metadata": {
+          "created": "2021-07-01T00:00:02Z"
+        }
+    },
+    {
+        "ContentsFormat": "markdown",
+        "Contents": "Uploaded a file.\nMore information.",
+        "ID": "4@100",
+        "Tags": ["ztap"],
+        "Metadata": {
+          "created": "2021-07-01T00:00:03Z"
+        }
+    },
+    {
+        "ContentsFormat": "text",
+        "Contents": "Comment.\nMore information.",
+        "ID": "5@100",
+        "Tags": ["comment"],
+        "Metadata": {
+          "created": "2021-07-01T00:00:04Z"
+        }
+    },
+    {
+        "ContentsFormat": "text",
+        "Contents": "Escalation.\nMore information.",
+        "ID": "6@100",
+        "Tags": ["escalate"],
+        "Metadata": {
+          "created": "2021-07-01T00:00:05Z"
+        }
+    },
+    {
+        "ContentsFormat": "text",
+        "Contents": "Internal note.\nMore information.",
+        "ID": "7@100",
+        "Tags": null,
+        "Metadata": {
+          "created": "2021-07-01T00:00:06Z"
+        }
+    }
+]

--- a/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/test_data/output.md
+++ b/Packs/ZeroTrustAnalyticsPlatform/Scripts/ZTAPViewTimeline/test_data/output.md
@@ -1,0 +1,7 @@
+### Timeline
+|Time|Message|
+|---|---|
+| 2021-07-01T00:00:05Z | Escalation.<br>More information. |
+| 2021-07-01T00:00:04Z | Comment.<br>More information. |
+| 2021-07-01T00:00:03Z | Uploaded a file.<br>More information. |
+| 2021-07-01T00:00:02Z | Escalating alert.<br>More information. |

--- a/Packs/ZeroTrustAnalyticsPlatform/pack_metadata.json
+++ b/Packs/ZeroTrustAnalyticsPlatform/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zero Trust Analytics Platform",
     "description": "Provides view of raised alerts within ZTAP.",
     "support": "partner",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Critical Start",
     "url": "https://support.criticalstart.com/",
     "email": "support@criticalstart.com",


### PR DESCRIPTION
Add view timeline script
* Add back input tag to differentiate ztap input notes
* Add script to view ZTAP timeline
* Add page to view ZTAP timeline
* Fix sync tag priority (escalate should take precidence)

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

## Description
Notes that inbound/outbound sync can be difficult to filter in the default view. Add a view to filter this information.
Outbound tag priority was backwards (escalation should happen if selected).

## Screenshots

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
