### PR TITLE
[Autofocus Query Samples, Sessions and Tags - Test Playbook] Extend timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -655,7 +655,7 @@
             "integrations": "AutoFocus V2",
             "playbookID": "Autofocus Query Samples, Sessions and Tags Test Playbook",
             "fromversion": "4.5.0",
-            "timeout": 1000
+            "timeout": 1500
         },
         {
             "integrations": "HelloWorld",


### PR DESCRIPTION

## Related Issues
fixes:[ link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6084)

## Description
Extended timeout to 1500 from 1000
