### PR TITLE
[SlackV3 TestPB] - Extend timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -756,7 +756,7 @@
             "integrations": "SlackV3",
             "playbookID": "SlackV3 TestPB",
             "instance_names": "cached",
-            "timeout": 600,
+            "timeout": 800,
             "pid_threshold": 8,
             "fromversion": "5.5.0"
         },


### PR DESCRIPTION

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6083)

## Description
Changed timeout to 800 from 600