### PR TITLE
[Extract Indicators From File - Generic v2] - Increase timeout from 350 to 700

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -2681,7 +2681,7 @@
                 "Image OCR",
                 "Rasterize"
             ],
-            "timeout": 350,
+            "timeout": 700,
             "memory_threshold": 200,
             "fromversion": "4.5.0"
         },


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6081)

## Description
Increase Extract Indicators From File - Generic v2 - Test timeout from 350 to 700.