### PR TITLE
[playbook-CrowdStrikeFalcon-Test] - changed 'Get Behavior' to get id from context 

### DIFF
--- a/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
+++ b/Packs/CrowdStrikeFalcon/TestPlaybooks/playbook-CrowdStrikeFalcon-Test.yml
@@ -164,7 +164,11 @@ tasks:
       - "5"
     scriptarguments:
       behavior_id:
-        simple: "10197"
+        complex:
+          root: CrowdStrike.Detection.Behavior
+          accessor: ID
+          transformers:
+          - operator: FirstArrayElement
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -188,7 +192,7 @@ tasks:
     task:
       id: c0347b2c-e8fe-46d6-89d2-ed9e4cd4602f
       version: -1
-      name: Assert 'suspicious_activity' scenario
+      name: Assert scenario is not empty
       type: condition
       iscommand: false
       brand: ""
@@ -199,16 +203,13 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isEqualString
+      - - operator: isNotEmpty
           left:
             value:
               complex:
                 root: CrowdStrike
                 accessor: Behavior.Scenario
             iscontext: true
-          right:
-            value:
-              simple: suspicious_activity
     continueonerrortype: ""
     view: |-
       {


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6134)

## Description
Changed so that **cs-falcon-get-behavior** will not get a fixed id, but from the context data.

## Screenshots
**Before**
![SCR-20230330-nqid](https://user-images.githubusercontent.com/90556466/228835237-efb1c8ff-11bc-4d13-810d-3679c5d84870.png)
![SCR-20230330-nqnj](https://user-images.githubusercontent.com/90556466/228835273-692b4a0d-cfce-4f56-a005-7a41eef44feb.png)
**After**
![SCR-20230330-nrph](https://user-images.githubusercontent.com/90556466/228836096-d3e433cf-58a7-4886-8670-dc530193d215.png)
![SCR-20230330-nrrr](https://user-images.githubusercontent.com/90556466/228836120-6d0530c2-9f46-4f78-816a-43f6fd7e8b33.png)

