### PR TITLE
[QRadar v3] Ignore missing value when deleting reference set value

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -2834,7 +2834,12 @@ def qradar_reference_set_value_delete_command(client: Client, args: Dict) -> Com
         value = get_time_parameter(original_value, epoch_format=True)
 
     # if this call fails, raise an error and stop command execution
-    response = client.reference_set_value_delete(ref_name, value)
+    try:
+        response = client.reference_set_value_delete(ref_name, value)
+    except DemistoException as e:
+        response = str(e)
+        if f"Set {ref_name} does not contain value {value}" not in response:
+            raise e
     human_readable = f'### value: {original_value} of reference: {ref_name} was deleted successfully'
 
     return CommandResults(

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -2930,7 +2930,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.10.48392
+  dockerimage: demisto/python3:3.10.10.51930
   feed: false
   isfetch: false
   isremotesyncin: true

--- a/Packs/QRadar/ReleaseNotes/2_4_14.md
+++ b/Packs/QRadar/ReleaseNotes/2_4_14.md
@@ -4,3 +4,4 @@
 ##### IBM QRadar v3
 
 - The command ***qradar-reference-set-value-delete*** will not fail when the value is missing from the reference set. 
+- Updated the Docker image to: *demisto/python3:3.10.10.51930*.

--- a/Packs/QRadar/ReleaseNotes/2_4_14.md
+++ b/Packs/QRadar/ReleaseNotes/2_4_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### IBM QRadar v3
+
+- The command ***qradar-reference-set-value-delete*** will not fail when the value is missing from the reference set. 

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.4.13",
+    "currentVersion": "2.4.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-22822

## Description
The command ***qradar-reference-set-value-delete*** will not fail when the value is missing from the reference set.