### PR TITLE
Add urlscan res page to content output

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -47,7 +47,8 @@ RELATIONSHIP_TYPE = {
 class Client:
     def __init__(self, api_key='', user_agent='', scan_visibility=None, threshold=None, use_ssl=False,
                  reliability=DBotScoreReliability.C):
-        self.base_url = 'https://urlscan.io/api/v1/'
+        self.base_url = 'https://urlscan.io/'
+        self.base_api_url = 'https://urlscan.io/api/v1/'
         self.api_key = api_key
         self.user_agent = user_agent
         self.threshold = threshold
@@ -103,11 +104,11 @@ def http_request(client, method, url_suffix, json=None, retries=0):
     if method == 'POST':
         headers.update({'Content-Type': 'application/json'})
     demisto.debug(
-        'requesting https request with method: {}, url: {}, data: {}'.format(method, client.base_url + url_suffix,
+        'requesting https request with method: {}, url: {}, data: {}'.format(method, client.base_api_url + url_suffix,
                                                                              json))
     r = requests.request(
         method,
-        client.base_url + url_suffix,
+        client.base_api_url + url_suffix,
         data=json,
         headers=headers,
         verify=client.use_ssl
@@ -172,13 +173,13 @@ def schedule_and_report(command_results, items_to_schedule, execution_metrics, r
 
 def get_result_page(client):
     uuid = demisto.args().get('uuid')
-    uri = client.base_url + 'result/{}'.format(uuid)
+    uri = client.base_api_url + 'result/{}'.format(uuid)
     return uri
 
 
 def polling(client, uuid):
     TIMEOUT = int(demisto.args().get('timeout', 60))
-    uri = client.base_url + 'result/{}'.format(uuid)
+    uri = client.base_api_url + 'result/{}'.format(uuid)
 
     headers = {'API-Key': client.api_key}
     if client.user_agent:
@@ -671,6 +672,8 @@ def urlscan_search_command(client):
             continue
 
         human_readable = makehash()
+
+        cont['ResultPage'] = client.base_url + 'result/{}'.format(uuid)
 
         if 'url' in res_tasks:
             url = res_tasks['url']

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -343,6 +343,8 @@ def format_results(client, uuid, use_url_as_name):
 
     feed_related_indicators = []
 
+    cont['ResultPage'] = client.base_url + 'result/{}'.format(uuid)
+
     LIMIT = int(demisto.args().get('limit', 20))
     if 'certificates' in scan_lists:
         cert_md = []
@@ -672,8 +674,6 @@ def urlscan_search_command(client):
             continue
 
         human_readable = makehash()
-
-        cont['ResultPage'] = client.base_url + 'result/{}'.format(uuid)
 
         if 'url' in res_tasks:
             url = res_tasks['url']

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -413,6 +413,9 @@ script:
     - contextPath: URL.Tags
       description: Tags that are associated with the URL.
       type: String
+    - contextPath: URL.ResultPage
+      description: Page in the URLScan UI displaying the scan result.
+      type: String
     polling: true
   - arguments:
     - description: The UUID of the URL for which to search the transaction list.

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -464,7 +464,7 @@ script:
   script: ''
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.9.42476
+  dockerimage: demisto/python3:3.10.10.51930
 fromversion: 5.0.0
 tests:
 - urlscan_malicious_Test

--- a/Packs/UrlScan/ReleaseNotes/1_2_7.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_7.md
@@ -1,4 +1,4 @@
 
 #### Integrations
 ##### urlscan.io
-- Added Result page link to content output
+- Added the *ResultPage* link as an output of the ***url*** and ***urlscan-submit*** commands.

--- a/Packs/UrlScan/ReleaseNotes/1_2_7.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_7.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Added Result page link to content output

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.2.6",
+    "currentVersion": "1.2.7",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
To make it easier for analysts to refer to the scan result as shown by URLScans own UI, I added a link to the scan result page to the output that gets written to the context.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [x] Documentation 
