### PR TITLE
Google BigQuery: fix wrong param validation in fetch incident

### DIFF
--- a/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery.py
+++ b/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery.py
@@ -209,7 +209,7 @@ def get_last_run_date():
     demisto.debug('[BigQuery Debug] last_date is: {}'.format(last_date))
 
     if last_date is None:
-        first_fetch_time = demisto.params().get('first_fetch_time', '1 days')
+        first_fetch_time = demisto.params().get('first_fetch', '1 days')
         first_fetch, _ = parse_date_range(first_fetch_time, date_format='%Y-%m-%d %H:%M:%S.%f')
         last_date = first_fetch
         demisto.debug('[BigQuery Debug] FIRST RUN - last_date is: {}'.format(last_date))
@@ -305,7 +305,7 @@ def remove_outdated_incident_ids(found_incidents_ids, latest_incident_time_str):
 
 def verify_params():
     params = demisto.params()
-    if not params.get('first_fetch_time'):
+    if not params.get('first_fetch'):
         return_error('Error: fetch start time must be supplied.')
     if not params.get('fetch_query'):
         return_error('Error: fetch query must be supplied.')

--- a/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery.yml
+++ b/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery.yml
@@ -103,7 +103,7 @@ script:
       description: The table rows the given query returned.
       type: Unknown
     description: Performs a query on BigQuery.
-  dockerimage: demisto/bigquery:1.0.0.42718
+  dockerimage: demisto/bigquery:1.0.0.52173
   subtype: python3
   isfetch: true
   runonce: false

--- a/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery_test.py
+++ b/Packs/GoogleBigQuery/Integrations/GoogleBigQuery/GoogleBigQuery_test.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import pytest
 
 import demistomock as demisto
 
@@ -89,10 +90,12 @@ def test_remove_outdated_incident_ids_keep_equal_no_incidents():
     assert 'aaa' not in res and 'bbb' not in res
 
 
-def test_verify_params_all_existing(mocker):
+@pytest.mark.parametrize('first_fetch_key, expected_error_call',
+                         [('first_fetch', 0), ('first_fetch_time', 1)])
+def test_verify_params_all_existing(mocker, first_fetch_key, expected_error_call):
     """
     Given:
-    - Demisto params that include the first_fetch_time, fetch_query and fetch_time_field params.
+    - Demisto params that include the first_fetch, fetch_query and fetch_time_field params.
 
     When:
     - Activating the verify_params function.
@@ -102,7 +105,7 @@ def test_verify_params_all_existing(mocker):
     """
     from GoogleBigQuery import verify_params
     mock_params = {
-        'first_fetch_time': "1 days",
+        first_fetch_key: "1 days",
         'fetch_query': "test",
         'fetch_time_field': "test"
     }
@@ -112,13 +115,13 @@ def test_verify_params_all_existing(mocker):
     return_error_target = 'GoogleBigQuery.return_error'
     return_error_mock = mocker.patch(return_error_target)
     verify_params()
-    assert return_error_mock.call_count == 0
+    assert return_error_mock.call_count == expected_error_call
 
 
-def test_verify_params_first_fetch_time_missing(mocker):
+def test_verify_params_first_fetch_missing(mocker):
     """
     Given:
-    - Demisto params that don't include the first_fetch_time param.
+    - Demisto params that don't include the first_fetch param.
 
     When:
     - Activating the verify_params function.
@@ -141,7 +144,7 @@ def test_verify_params_first_fetch_time_missing(mocker):
     assert return_error_mock.call_count == 1
 
     mock_params = {
-        'first_fetch_time': '',
+        'first_fetch': '',
         'fetch_query': "test",
         'fetch_time_field': "test"
     }
@@ -165,7 +168,7 @@ def test_verify_params_fetch_query_missing(mocker):
     from GoogleBigQuery import verify_params
 
     mock_params = {
-        'first_fetch_time': "1 days",
+        'first_fetch': "1 days",
         'fetch_time_field': "test"
     }
     mocker.patch.object(demisto, 'params', return_value=mock_params)
@@ -177,7 +180,7 @@ def test_verify_params_fetch_query_missing(mocker):
     assert return_error_mock.call_count == 1
 
     mock_params = {
-        'first_fetch_time': "1 days",
+        'first_fetch': "1 days",
         'fetch_query': "",
         'fetch_time_field': "test"
     }
@@ -201,7 +204,7 @@ def test_verify_params_fetch_time_field_missing(mocker):
     from GoogleBigQuery import verify_params
 
     mock_params = {
-        'first_fetch_time': "1 days",
+        'first_fetch': "1 days",
         'fetch_query': "test",
     }
     mocker.patch.object(demisto, 'params', return_value=mock_params)
@@ -213,7 +216,7 @@ def test_verify_params_fetch_time_field_missing(mocker):
     assert return_error_mock.call_count == 1
 
     mock_params = {
-        'first_fetch_time': "1 days",
+        'first_fetch': "1 days",
         'fetch_query': "test",
         'fetch_time_field': ""
     }

--- a/Packs/GoogleBigQuery/ReleaseNotes/1_1_6.md
+++ b/Packs/GoogleBigQuery/ReleaseNotes/1_1_6.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Google BigQuery
+
+- Fixed an issue in the **fetch-incident** command where there was an wrong params verification.
+- Updated the Docker image to: *demisto/bigquery:1.0.0.52173*.

--- a/Packs/GoogleBigQuery/ReleaseNotes/1_1_6.md
+++ b/Packs/GoogleBigQuery/ReleaseNotes/1_1_6.md
@@ -3,5 +3,5 @@
 
 ##### Google BigQuery
 
-- Fixed an issue in the **fetch-incident** command where there was an wrong params verification.
+- Fixed an issue in the **fetch-incident** command where the **First fetch timestamp** parameter was ignored.
 - Updated the Docker image to: *demisto/bigquery:1.0.0.52173*.

--- a/Packs/GoogleBigQuery/pack_metadata.json
+++ b/Packs/GoogleBigQuery/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google BigQuery",
     "description": "Integration for Google BigQuery, a data warehouse for querying and analyzing large databases. In all commands, for any argument not specified, the BigQuery default value for that argument will be applied.",
     "support": "xsoar",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-22923

## Description
there fas typo in the param name when validate the fetch params

