### PR TITLE
AWS-CloudTrail new attributes

### DIFF
--- a/Packs/AWS-CloudTrail/Integrations/AWS-CloudTrail/AWS-CloudTrail.yml
+++ b/Packs/AWS-CloudTrail/Integrations/AWS-CloudTrail/AWS-CloudTrail.yml
@@ -503,12 +503,14 @@ script:
       isArray: false
       name: attributeKey
       predefined:
+      - AccessKeyId
       - EventId
       - EventName
       - Username
       - ResourceType
       - ResourceName
       - EventSource
+      - ReadOnly
       required: true
       secret: false
     - default: false
@@ -582,7 +584,7 @@ script:
     - contextPath: AWS.CloudTrail.Events.CloudTrailEvent
       description: A JSON string that contains a representation of the event returned.
       type: string
-  dockerimage: demisto/boto3:2.0.0.38883
+  dockerimage: demisto/boto3:2.0.0.52592
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/AWS-CloudTrail/ReleaseNotes/1_0_9.md
+++ b/Packs/AWS-CloudTrail/ReleaseNotes/1_0_9.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### AWS - CloudTrail
+
+- Added the *AccessKeyId* and *ReadOnly* attribute keys to the **aws-cloudtrail-lookup-events** command.
+- Updated the Docker image to: *demisto/boto3:2.0.0.52592*.

--- a/Packs/AWS-CloudTrail/ReleaseNotes/1_0_9.md
+++ b/Packs/AWS-CloudTrail/ReleaseNotes/1_0_9.md
@@ -3,5 +3,5 @@
 
 ##### AWS - CloudTrail
 
-- Added the *AccessKeyId* and *ReadOnly* attribute keys to the **aws-cloudtrail-lookup-events** command.
+- Added the *AccessKeyId* and *ReadOnly* options to the *attributeKey* argument in the ***aws-cloudtrail-lookup-events*** command.
 - Updated the Docker image to: *demisto/boto3:2.0.0.52592*.

--- a/Packs/AWS-CloudTrail/pack_metadata.json
+++ b/Packs/AWS-CloudTrail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - CloudTrail",
     "description": "Amazon Web Services CloudTrail.",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6163

## Description
Added the *AccessKeyId* and *ReadOnly* attribute keys to the **aws-cloudtrail-lookup-events** command. 

## Does it break backward compatibility?
   - [x] No
