### PR TITLE
Sixgill Darkfeed - update pack-ignore

### DIFF
--- a/Packs/Sixgill-Darkfeed/.pack-ignore
+++ b/Packs/Sixgill-Darkfeed/.pack-ignore
@@ -10,9 +10,6 @@ ignore=BA108,BA109,IN145
 [file:Darkfeed_IOC_detonation_and_proactive_blocking.yml]
 ignore=PB115
 
-[file:Darkfeed_Threat_hunting_research.yml]
-ignore=PB118,PB119
-
 [file:SixgillDVEFeed.yml]
 ignore=IN145
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/CIAC-5940

## Description
Now after fixing the bug with the PB validation for inputs (PB118, PB119) in this [PR](https://github.com/demisto/demisto-sdk/pull/2866) we remove these ignored errors from pack-ignore file

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
