### PR TITLE
fix issue with note .split()

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -520,7 +520,7 @@ def split_notes(raw_notes, note_type, time_info):
             if retrieved_last_note:  # add to last note only in case the note was not filtered by the time filter
                 notes[-1]['value'] += '\n\n Mirrored from Cortex XSOAR'
             continue
-        note_info, note_value = note.split('\n')
+        note_info, note_value = note.split('\n', 1)
         created_on, created_by = note_info.split(' - ')
         created_by = created_by.split(' (')[0]
         if not created_on or not created_by:

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -177,7 +177,7 @@ configuration:
   - closed
   - resolved
   hidden:
-    - marketplacev2
+  - marketplacev2
 - additionalinfo: 'Define how to close the mirrored tickets in Cortex XSOAR with a custom state. Enter here a comma-separated list of custom closure state codes and their labels (acceptable format example: “10=Design,11=Development,12=Testing”) to override the default closure method. Note that a matching user-defined list of custom close reasons must be configured as a "Server configuration" in Cortex XSOAR. Not following this format will result in closing the incident with a default close reason.'
   defaultvalue: ''
   display: Mirrored XSOAR Ticket custom close state code
@@ -1595,7 +1595,7 @@ script:
     - contextPath: ServiceNow.Generic.Response
       description: Generic response to servicenow api
       type: string
-  dockerimage: demisto/python3:3.10.10.51930
+  dockerimage: demisto/python3:3.10.10.52956
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/ServiceNow/ReleaseNotes/2_5_17.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_17.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### ServiceNow v2
+- Fixed an issue where ticket work notes and comments containing newlines were not retrieved successfully with use_display_value=true

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.5.16",
+    "currentVersion": "2.5.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
n/a – Customer-reported issue but the customer is unable to open a support case.

## Description
Small change to fix an issue with running `servicenow-get-ticket-notes` with `use_display_value=true` when any of the ticket work notes or comments contain any newline characters. Previously, the script would throw the error below due to the notes being split on the newline (`\n`) character.

## Screenshots
<img width="1076" alt="Screenshot 2023-04-06 at 11 30 06 PM" src="https://user-images.githubusercontent.com/91506078/230547252-1a4eaaea-023e-4b27-8ba2-97991d809df9.png">

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
