### PR TITLE
[SMBv2] Add Windows Support

### DIFF
--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.py
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.py
@@ -52,7 +52,7 @@ def smb_upload(client: SMBClient, args: dict):
     entry_id = args.get('entryID')
     content = args.get('content')  # The input is text.
     path_input = args['file_path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     if not entry_id and not content:
         raise DemistoException(
@@ -83,7 +83,7 @@ def smb_download(client: SMBClient, args: dict):
     username = args.get('username')
     password = args.get('password')
     path_input = args['file_path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     client.create_session(hostname, username, password)
 
@@ -101,7 +101,7 @@ def smb_remove_file(client: SMBClient, args: dict):
     username = args.get('username')
     password = args.get('password')
     path_input = args['file_path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     client.create_session(hostname, username, password)
 
@@ -117,7 +117,7 @@ def list_dir(client: SMBClient, args: dict):
     username = args.get('username')
     password = args.get('password')
     path_input = args['path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     client.create_session(hostname, username, password)
 
@@ -153,7 +153,7 @@ def smb_mkdir(client: SMBClient, args: dict):
     username = args.get('username')
     password = args.get('password')
     path_input = args['path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     client.create_session(hostname, username, password)
 
@@ -168,7 +168,7 @@ def smb_rmdir(client: SMBClient, args: dict):
     username = args.get('username')
     password = args.get('password')
     path_input = args['path']
-    path = generate_pathlib_object(hostname, path_input, os_type)
+    path = generate_pathlib_object(hostname or client.hostname, path_input, os_type)
 
     client.create_session(hostname, username, password)
 

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.py
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.py
@@ -190,29 +190,29 @@ def main():
     verify = params.get('require_secure_negotiate', True)
     client_guid = params.get('client_guid', None)
 
-    # Temporary workaround to an issue in the smbprotocol package.
-    # GitHub issue: https://github.com/jborean93/smbprotocol/issues/109
-    config = smbclient.ClientConfig(username=user, password=password, require_secure_negotiate=verify)
-    config.domain_controller = dc
-
-    if client_guid:
-        try:
-            client_guid = uuid.UUID(client_guid)
-            config.client_guid = client_guid
-        except ValueError:
-            demisto.info(
-                f'Failed to convert {client_guid} to a valid UUID string. Using a random generated UUID instead')
-
-    client = SMBClient(hostname=hostname,
-                       os_type=os_type,
-                       user=user,
-                       password=password,
-                       encrypt=encrypt,
-                       port=port)
-
-    demisto.info(f'Command used: {demisto.command()}')
-
     try:
+        # Temporary workaround to an issue in the smbprotocol package.
+        # GitHub issue: https://github.com/jborean93/smbprotocol/issues/109
+        config = smbclient.ClientConfig(username=user, password=password, require_secure_negotiate=verify)
+        config.domain_controller = dc
+
+        if client_guid:
+            try:
+                client_guid = uuid.UUID(client_guid)
+                config.client_guid = client_guid
+            except ValueError:
+                demisto.info(
+                    f'Failed to convert {client_guid} to a valid UUID string. Using a random generated UUID instead')
+
+        client = SMBClient(hostname=hostname,
+                           os_type=os_type,
+                           user=user,
+                           password=password,
+                           encrypt=encrypt,
+                           port=port)
+
+        demisto.info(f'Command used: {demisto.command()}')
+
         if demisto.command() == 'test-module':
             return_results(test_module(client))
         elif demisto.command() == 'smb-download':

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
@@ -171,7 +171,7 @@ script:
       description: The password to use for authentication. If empty, the password
         from the instance configuration is used.
     description: Removes a directory from the given path.
-  dockerimage: demisto/smbprotocol:1.0.0.46456
+  dockerimage: demisto/smbprotocol:1.0.0.53206
   isfetch: false
   runonce: false
   script: '-'

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
@@ -9,18 +9,25 @@ configuration:
 - display: Server IP / Hostname (e.g. 1.2.3.4)
   name: hostname
   type: 0
-  required: false
+  required: true
 - display: Port
   name: port
   defaultvalue: "445"
   type: 0
   required: false
+- display: OS Type
+  name: os_type
+  type: 15
+  required: false
+  options:
+  - Unix
+  - Windows
+  defaultvalue: Unix
 - display: Domain Controller
   name: dc
   type: 0
   required: false
-  additionalinfo: The domain controller hostname. This is useful for environments
-    with DFS servers as it is used to identify the DFS domain information automatically.
+  additionalinfo: The domain controller hostname. This is useful for environments with DFS servers as it is used to identify the DFS domain information automatically.
 - display: Username
   name: credentials
   type: 9
@@ -51,6 +58,13 @@ script:
       description: 'The path to the file, starting from the share, for example: Share/Folder/File. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname.  If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
       description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
@@ -92,6 +106,13 @@ script:
       description: 'The path to the file, starting from the share, for example: Share/Folder/File. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname.  If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
       description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
@@ -111,21 +132,28 @@ script:
       description: 'The path to the directory, starting from the share, for example: Share/Folder. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname.  If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
       description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
       description: The password to use for authentication. If empty, the password from the instance configuration is used.
     description: Returns a list containing the names of the entries in the directory given by path.
     outputs:
-      - contextPath: SMB.Path.SharedFolder
-        description: The full path of the shared folder.
-        type: String
-      - contextPath: SMB.Path.Files
-        description: List of files under the shared folder.
-        type: Unknown
-      - contextPath: SMB.Path.Directories
-        description: List of directories under the shared folder.
-        type: Unknown
+    - contextPath: SMB.Path.SharedFolder
+      description: The full path of the shared folder.
+      type: String
+    - contextPath: SMB.Path.Files
+      description: List of files under the shared folder.
+      type: Unknown
+    - contextPath: SMB.Path.Directories
+      description: List of directories under the shared folder.
+      type: Unknown
   - name: smb-file-remove
     arguments:
     - name: file_path
@@ -134,12 +162,17 @@ script:
       description: 'The path to the file, starting from the share, for example: Share/Folder/File. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname. If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
-      description: The username to use when creating a new SMB session. If empty,
-        the username from the instance configuration is used.
+      description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
-      description: The password to use for authentication. If empty, the password
-        from the instance configuration is used.
+      description: The password to use for authentication. If empty, the password from the instance configuration is used.
     description: Removes a file from the server.
   - name: smb-directory-create
     arguments:
@@ -149,12 +182,17 @@ script:
       description: 'The path to the directory, starting from the share, for example: Share/NewFolder. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname. If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
-      description: The username to use when creating a new SMB session. If empty,
-        the username from the instance configuration is used.
+      description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
-      description: The password to use for authentication. If empty, the password
-        from the instance configuration is used.
+      description: The password to use for authentication. If empty, the password from the instance configuration is used.
     description: Creates a new directory under the given path.
   - name: smb-directory-remove
     arguments:
@@ -164,12 +202,17 @@ script:
       description: 'The path to the directory, starting from the share, for example: Share/NewFolder. This field is case-insensitive'
     - name: hostname
       description: Server IP address / hostname. If empty, the hostname from the instance configuration is used.
+    - name: os_type
+      description: The OS type of the server. If empty, the OS type from the instance configuration is used.
+      auto: PREDEFINED
+      predefined:
+      - Unix
+      - Windows
+      defaultValue: Unix
     - name: username
-      description: The username to use when creating a new SMB session. If empty,
-        the username from the instance configuration is used.
+      description: The username to use when creating a new SMB session. If empty, the username from the instance configuration is used.
     - name: password
-      description: The password to use for authentication. If empty, the password
-        from the instance configuration is used.
+      description: The password to use for authentication. If empty, the password from the instance configuration is used.
     description: Removes a directory from the given path.
   dockerimage: demisto/smbprotocol:1.0.0.53206
   isfetch: false

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
@@ -221,5 +221,5 @@ script:
   type: python
   subtype: python3
 tests:
-- No tests
+- SMB_v2-Test
 fromversion: 5.0.0

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
@@ -178,5 +178,5 @@ script:
   type: python
   subtype: python3
 tests:
-- SMB_v2-Test
+- No tests
 fromversion: 5.0.0

--- a/Packs/SMB/TestPlaybooks/playbook-SMB_v2-test.yml
+++ b/Packs/SMB/TestPlaybooks/playbook-SMB_v2-test.yml
@@ -184,10 +184,10 @@ tasks:
     task:
       id: 2ac733bf-0659-4141-8133-75af29cfb6a2
       version: -1
-      name: FileCreateAndUpload
+      name: FileCreateAndUploadV2
       description: |
-        Will create a file (using the given data input or entry ID) and upload it to current investigation war room.
-      scriptName: FileCreateAndUpload
+        Creates a file (using the given data input or entry ID) and uploads it to the current investigation War Room.
+      scriptName: FileCreateAndUploadV2
       type: regular
       iscommand: false
       brand: ""
@@ -197,7 +197,6 @@ tasks:
     scriptarguments:
       data:
         simple: Test file for TPB
-      entryId: {}
       filename:
         simple: test.txt
     separatecontext: false


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-23107)

## Description
Add support for Windows servers by making paths OS-agnostic.