### PR TITLE
Dou collector missing events

### DIFF
--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
@@ -207,7 +207,7 @@ def main():  # pragma: no cover
                     raw_response=events,
                 )
                 return_results(command_results)
-                if demisto_params.get('push_events'):
+                if argToBoolean(demisto_params.get('push_events', 'false')):
                     demisto.debug(f'Sending {len(events)} events to XSIAM')
                     send_events_to_xsiam(events, vendor=VENDOR, product=PRODUCT)
             else:

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
@@ -207,12 +207,15 @@ def main():  # pragma: no cover
                     raw_response=events,
                 )
                 return_results(command_results)
+                if demisto_params.get('push_events'):
+                    demisto.debug(f'Sending {len(events)} events to XSIAM')
+                    send_events_to_xsiam(events, vendor=VENDOR, product=PRODUCT)
             else:
-                demisto.setLastRun(get_events.get_last_run())
-                demisto_params['push_events'] = True
-            if demisto_params.get('push_events'):
+                # fetch-events
                 demisto.debug(f'Sending {len(events)} events to XSIAM')
                 send_events_to_xsiam(events, vendor=VENDOR, product=PRODUCT)
+                demisto.setLastRun(get_events.get_last_run())
+
     except Exception as e:
         return_error(f'Failed to execute {demisto.command()} command. Error: {str(e)}')
 

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
@@ -68,7 +68,7 @@ script:
     description: Manual command to fetch events and display them.
     execution: false
     name: duo-get-events
-  dockerimage: demisto/duoadmin3:1.0.0.51401
+  dockerimage: demisto/duoadmin3:1.0.0.54426
   runonce: false
   isfetchevents: true
   subtype: python3

--- a/Packs/DuoAdminApi/ReleaseNotes/3_2_10.md
+++ b/Packs/DuoAdminApi/ReleaseNotes/3_2_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Duo Event Collector
+
+- Fixed an issue caused by updating the last_run before sending events to XSIAM. This may lead to loss of events upon a failuer. 

--- a/Packs/DuoAdminApi/ReleaseNotes/3_2_10.md
+++ b/Packs/DuoAdminApi/ReleaseNotes/3_2_10.md
@@ -3,4 +3,5 @@
 
 ##### Duo Event Collector
 
-- Fixed an issue caused by updating the last_run before sending events to XSIAM. This may lead to loss of events upon a failuer. 
+- Fixed an issue caused by updating the last_run before sending events to XSIAM. This may lead to loss of events upon a failuer.
+- Upgraded the Docker image to: *demisto/duoadmin3:1.0.0.54426*

--- a/Packs/DuoAdminApi/pack_metadata.json
+++ b/Packs/DuoAdminApi/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DUO Admin",
     "description": "DUO for admins.\nMust have access to the admin api in order to use this",
     "support": "xsoar",
-    "currentVersion": "3.2.9",
+    "currentVersion": "3.2.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-23092

## Description
Bug in Duo collector that might be related to loss of events.
demisto.setLastRun is called before the sending of the events to XSIAM.
That means that if the send-events-to-xsaim will fail the last_run already changed and the events will be lost.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
