### PR TITLE
Fixing coverage report file

### DIFF
--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -267,7 +267,7 @@
         if [[ -n $BUCKET_UPLOAD ]]; then
           demisto-sdk lint -vvv -p 8 -g --no-mypy --prev-ver $LAST_UPLOAD_COMMIT -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
         else
-          if [[ "$CI_COMMIT_BRANCH" =! "master" ]]
+          if [[ "$CI_COMMIT_BRANCH" != "master" ]]
             # skip running `lint -g` on master
             demisto-sdk lint -p 8 -g -vvv --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
           fi

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -267,7 +267,7 @@
         if [[ -n $BUCKET_UPLOAD ]]; then
           demisto-sdk lint -vvv -p 8 -g --no-mypy --prev-ver $LAST_UPLOAD_COMMIT -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
         else
-          if [[ "$CI_COMMIT_BRANCH" != "master" ]]
+          if [[ "$CI_COMMIT_BRANCH" != "master" ]]; then
             # skip running `lint -g` on master
             demisto-sdk lint -p 8 -g -vvv --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
           fi

--- a/.gitlab/ci/global.yml
+++ b/.gitlab/ci/global.yml
@@ -267,7 +267,10 @@
         if [[ -n $BUCKET_UPLOAD ]]; then
           demisto-sdk lint -vvv -p 8 -g --no-mypy --prev-ver $LAST_UPLOAD_COMMIT -v --test-xml ./unit-tests --log-path $ARTIFACTS_FOLDER --failure-report $ARTIFACTS_FOLDER --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
         else
-          demisto-sdk lint -p 8 -g -vvv --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
+          if [[ "$CI_COMMIT_BRANCH" =! "master" ]]
+            # skip running `lint -g` on master
+            demisto-sdk lint -p 8 -g -vvv --test-xml ./unit-tests --log-path ./artifacts --failure-report ./artifacts --coverage-report $ARTIFACTS_FOLDER/coverage_report -cdam --docker-image ${DOCKER}
+          fi
         fi
       
         if [[ -f $ARTIFACTS_FOLDER/coverage_report/.coverage ]]; then


### PR DESCRIPTION
Do not run lint -g on master since it breaks the coverage report

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6250)

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
