### PR TITLE
Email regex revert to allow slash at start of email

### DIFF
--- a/Packs/CommonTypes/IndicatorTypes/reputation-email.json
+++ b/Packs/CommonTypes/IndicatorTypes/reputation-email.json
@@ -7,7 +7,7 @@
   "commitMessage": "",
   "shouldPublish": false,
   "shouldCommit": false,
-  "regex": "(?:(?:\\|\\^{3})u[a-f\\d]{4})?(?P<localpart>[\\p{L}\\d.!#$%&'*+/=?^_\\xe60{|}~-]{1,64})\\[?@]?(?P<domain>[\\p{L}\\d-]{1,255}(?:\\[?\\.]?(?:[\\p{L}\\d]{2,}))*(?:\\[?\\.]?(?P<tld>[\\p{L}]{2,})))",
+  "regex": "(?:(?:\\\\|\\^{3})u[a-f\\d]{4})?(?P<localpart>[\\p{L}\\d.!#$%&'*+/=?^_\\xe60{|}~-]{1,64})\\[?@]?(?P<domain>[\\p{L}\\d-]{1,255}(?:\\[?\\.]?(?:[\\p{L}\\d]{2,}))*(?:\\[?\\.]?(?P<tld>[\\p{L}]{2,})))",
   "details": "Email",
   "prevDetails": "Email",
   "reputationScriptName": "",

--- a/Packs/CommonTypes/ReleaseNotes/3_3_63.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_3_63.md
@@ -1,0 +1,5 @@
+
+#### Indicator Types
+
+- **emailRep**
+- Restored regex to handle unicode properly.

--- a/Packs/CommonTypes/ReleaseNotes/3_3_63.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_3_63.md
@@ -1,5 +1,4 @@
 
 #### Indicator Types
 
-- **emailRep**
-- Restored regex to handle unicode properly.
+- **emailRep** - Fixed an issue in the regular expression to address improper handling of Unicode.

--- a/Packs/CommonTypes/ReleaseNotes/3_3_63.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_3_63.md
@@ -1,4 +1,5 @@
 
 #### Indicator Types
 
-- **emailRep** - Fixed an issue in the regular expression to address improper handling of Unicode.
+- **emailRep** 
+- Fixed an issue in the regular expression to address improper handling of Unicode.

--- a/Packs/CommonTypes/ReleaseNotes/3_3_63.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_3_63.md
@@ -1,5 +1,5 @@
 
 #### Indicator Types
 
-- **emailRep** 
-- Fixed an issue in the regular expression to address improper handling of Unicode.
+- **emailRep**
+Fixed an issue in the regular expression to address improper handling of Unicode.

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "3.3.62",
+    "currentVersion": "3.3.63",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6253

## Description
Some of the regex got changed by mistake from `\\\\` to `\\` changing its meaning.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No