### PR TITLE
[Launch And Fetch Scheduled Report - Qualys] added outputs to the playbook

### DIFF
--- a/Packs/qualys/Playbooks/playbook-Launch_And_Fetch_Scheduled_Report_-_Qualys.yml
+++ b/Packs/qualys/Playbooks/playbook-Launch_And_Fetch_Scheduled_Report_-_Qualys.yml
@@ -1,8 +1,7 @@
 id: Launch And Fetch Scheduled Report - Qualys
 version: -1
 name: Launch And Fetch Scheduled Report - Qualys
-description: Launches a scheduled report and fetches the report when it's
-  ready.
+description: Launches a scheduled report and fetches the report when it's ready.
 starttaskid: "0"
 tasks:
   "0":
@@ -201,7 +200,11 @@ inputs:
   required: true
   description: Scheduled report ID. Can be found by running the command qualys-scheduled-report-list.
   playbookInputQuery:
-outputs: []
+outputs:
+- contextPath: Qualys.Report.VM.Launched.KEY
+  description: Key name of launched VM scan, either ID or a REFERENCE.
+- contextPath: Qualys.Report.VM.Launched.VALUE
+  description: Value of the key.
 tests:
 - QualysVulnerabilityManagement-Test
 fromversion: 5.5.0

--- a/Packs/qualys/Playbooks/playbook-Launch_And_Fetch_Scheduled_Report_-_Qualys_README.md
+++ b/Packs/qualys/Playbooks/playbook-Launch_And_Fetch_Scheduled_Report_-_Qualys_README.md
@@ -1,23 +1,29 @@
 Launches a scheduled report and fetches the report when it's ready.
 
 ## Dependencies
+
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
-GenericPolling
+
+* GenericPolling
 
 ### Integrations
-QualysV2
+
+* QualysV2
 
 ### Scripts
+
 This playbook does not use any scripts.
 
 ### Commands
+
 * qualys-scheduled-report-launch
 * qualys-report-fetch
 * qualys-scheduled-report-list
 
 ## Playbook Inputs
+
 ---
 
 | **Name** | **Description** | **Default Value** | **Required** |
@@ -25,9 +31,16 @@ This playbook does not use any scripts.
 | id | Scheduled report ID. Can be found by running the command qualys-scheduled-report-list. |  | Required |
 
 ## Playbook Outputs
+
 ---
-There are no outputs for this playbook.
+
+| **Path** | **Description** | **Type** |
+| --- | --- | --- |
+| Qualys.Report.VM.Launched.KEY | Key name of launched VM scan, either ID or a REFERENCE. | unknown |
+| Qualys.Report.VM.Launched.VALUE | Value of the key. | unknown |
 
 ## Playbook Image
+
 ---
+
 ![Launch And Fetch Scheduled Report - Qualys](../doc_files/Launch_And_Fetch_Scheduled_Report_-_Qualys.png)


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6245)

## Description
Added "Qualys.Report.VM.Launched.KEY" and "Qualys.Report.VM.Launched.VALUE" to the outputs of the playbook

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
