### PR TITLE
SanePDFReport: Change port number in test and Increase timeout

### DIFF
--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
@@ -39,7 +39,7 @@ def test_sane_pdf_report(mocker):
         'ZmlsdGVyIjp7InF1ZXJ5IjoiIiwicGVyaW9kIjp7ImJ5RnJvbSI6ImRheXMiLCJmcm9tVmFsdWUiOjd9fX0sImF1dG9tYXRpb24iOnsibmFt'
         'ZSI6IiIsImlkIjoiIiwiYXJncyI6bnVsbCwibm9FdmVudCI6ZmFsc2V9LCJmcm9tRGF0ZSI6IjIwMjAtMTAtMThUMTE6MTY6MzcrMDM6MDAi'
         'LCJ0aXRsZSI6IlRleHQgV2lkZ2V0IiwiZW1wdHlOb3RpZmljYXRpb24iOiJObyByZXN1bHRzIGZvdW5kIiwidGl0bGVTdHlsZSI6bnVsbH1d',
-        'resourceTimeout': "4000"
+        'resourceTimeout': "10000"
     })
     mocker.patch.object(demisto, 'results')
 

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
@@ -29,7 +29,7 @@ def test_find_zombie_processes(mocker):
 
 def test_sane_pdf_report(mocker):
     import SanePdfReport
-    mocker.patch.object(SanePdfReport, 'MD_HTTP_PORT', 10889)
+    # mocker.patch.object(SanePdfReport, 'MD_HTTP_PORT', 10889)
     mocker.patch.object(demisto, 'args', return_value={
         'sane_pdf_report_base64':
         'W3sidHlwZSI6Im1hcmtkb3duIiwiZGF0YSI6eyJ0ZXh0IjoiaGVsbG8gd29ybGQiLCJncm91cHMiOlt7Im5hbWUiOiIiLCJkYXRhIjpbMl0s'

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
@@ -29,7 +29,8 @@ def test_find_zombie_processes(mocker):
 
 def test_sane_pdf_report(mocker):
     import SanePdfReport
-    # mocker.patch.object(SanePdfReport, 'MD_HTTP_PORT', 10889)
+    # changing the port number just to make sure it has no conflicts with other integrations/scripts
+    mocker.patch.object(SanePdfReport, 'MD_HTTP_PORT', 10889)
     mocker.patch.object(demisto, 'args', return_value={
         'sane_pdf_report_base64':
         'W3sidHlwZSI6Im1hcmtkb3duIiwiZGF0YSI6eyJ0ZXh0IjoiaGVsbG8gd29ybGQiLCJncm91cHMiOlt7Im5hbWUiOiIiLCJkYXRhIjpbMl0s'

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
@@ -35,7 +35,8 @@ def test_sane_pdf_report(mocker):
         'YzAzYTAtMTZhMi0xMWViLWFhNmUtOTMzMWU5NjVhYjA2Iiwicm93UG9zIjowLCJ3Ijo2fSwicXVlcnkiOnsidHlwZSI6ImluY2lkZW50Iiwi'
         'ZmlsdGVyIjp7InF1ZXJ5IjoiIiwicGVyaW9kIjp7ImJ5RnJvbSI6ImRheXMiLCJmcm9tVmFsdWUiOjd9fX0sImF1dG9tYXRpb24iOnsibmFt'
         'ZSI6IiIsImlkIjoiIiwiYXJncyI6bnVsbCwibm9FdmVudCI6ZmFsc2V9LCJmcm9tRGF0ZSI6IjIwMjAtMTAtMThUMTE6MTY6MzcrMDM6MDAi'
-        'LCJ0aXRsZSI6IlRleHQgV2lkZ2V0IiwiZW1wdHlOb3RpZmljYXRpb24iOiJObyByZXN1bHRzIGZvdW5kIiwidGl0bGVTdHlsZSI6bnVsbH1d'
+        'LCJ0aXRsZSI6IlRleHQgV2lkZ2V0IiwiZW1wdHlOb3RpZmljYXRpb24iOiJObyByZXN1bHRzIGZvdW5kIiwidGl0bGVTdHlsZSI6bnVsbH1d',
+        'resourceTimeout': "4000"
     })
     mocker.patch.object(demisto, 'results')
 

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport_test.py
@@ -28,6 +28,8 @@ def test_find_zombie_processes(mocker):
 
 
 def test_sane_pdf_report(mocker):
+    import SanePdfReport
+    mocker.patch.object(SanePdfReport, 'MD_HTTP_PORT', 10889)
     mocker.patch.object(demisto, 'args', return_value={
         'sane_pdf_report_base64':
         'W3sidHlwZSI6Im1hcmtkb3duIiwiZGF0YSI6eyJ0ZXh0IjoiaGVsbG8gd29ybGQiLCJncm91cHMiOlt7Im5hbWUiOiIiLCJkYXRhIjpbMl0s'

--- a/Packs/rasterize/Integrations/rasterize/rasterize_test.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize_test.py
@@ -163,7 +163,6 @@ def http_wait_server():
         server_thread.join()
 
 
-
 # Some web servers can block the connection after the http is sent
 # In this case chromium will hang. An example for this is:
 # curl -v -H 'user-agent: HeadlessChrome' --max-time 10  "http://www.grainger.com/"  # disable-secrets-detection

--- a/Packs/rasterize/Integrations/rasterize/rasterize_test.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize_test.py
@@ -163,6 +163,7 @@ def http_wait_server():
         server_thread.join()
 
 
+
 # Some web servers can block the connection after the http is sent
 # In this case chromium will hang. An example for this is:
 # curl -v -H 'user-agent: HeadlessChrome' --max-time 10  "http://www.grainger.com/"  # disable-secrets-detection


### PR DESCRIPTION

* Increase timeout sanepdf report test
* Change port in the test

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
