### PR TITLE
Fixed RSAArcher deprecation command

### DIFF
--- a/Packs/ArcherRSA/Playbooks/playbook-Archer_initiate_incident.yml
+++ b/Packs/ArcherRSA/Playbooks/playbook-Archer_initiate_incident.yml
@@ -36,7 +36,7 @@ tasks:
       version: -1
       name: archer-get-file
       description: Downloads file from Archer to Demisto's context
-      script: RSA Archer|||archer-get-file
+      script: RSA Archer v2|||archer-get-file
       type: regular
       iscommand: true
       brand: RSA Archer

--- a/Packs/ArcherRSA/ReleaseNotes/1_2_10.md
+++ b/Packs/ArcherRSA/ReleaseNotes/1_2_10.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Archer initiate incident
+
+- Fixed an issue where the command ***archer-get-file*** was called from the deprecated integration.

--- a/Packs/ArcherRSA/pack_metadata.json
+++ b/Packs/ArcherRSA/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "RSA Archer",
     "description": "The RSA Archer GRC Platform provides a common foundation for managing policies, controls, risks, assessments and deficiencies across lines of business.",
     "support": "xsoar",
-    "currentVersion": "1.2.9",
+    "currentVersion": "1.2.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6255

## Description
Fixed an issue where the command ***archer-get-file*** was called from the deprecated integration.

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
