### PR TITLE
solve too many arguments with correct bash syntax

### DIFF
--- a/Tests/scripts/wait_in_line_for_cloud_env.sh
+++ b/Tests/scripts/wait_in_line_for_cloud_env.sh
@@ -8,6 +8,7 @@
 #=================================
 #   Main Execution Point
 #==================================
+set -e
 
 touch CloudEnvVariables
 
@@ -17,7 +18,7 @@ export NUM_OF_TEST_MACHINES=`sed -n '$=' $TEST_MACHINES_LIST`	# reads num of lin
 TEST_MACHINES_LIST_STRING=`cat $TEST_MACHINES_LIST`
 echo "All existing machines: $TEST_MACHINES_LIST_STRING"
 
-if [ -z $TEST_MACHINES_LIST_STRING ];
+if [[ -z $TEST_MACHINES_LIST_STRING ]];
 then
   echo "No machines in Test Machines List."
   exit 1


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Solve 'too many arguments' with correct bash syntax, and set -e for failing the script when one line fails.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
