### PR TITLE
Catch and ignore error on pack version retrieval

### DIFF
--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -775,7 +775,7 @@ script:
     execution: false
     name: triage-delete-profile
     description: Update the profile with the specified ID or name. The stored profile is overwritten, so it is important that the submitted profile has all fields, with the exception of the ID
-  dockerimage: demisto/python3:3.10.10.51930
+  dockerimage: demisto/python3:3.10.11.54132
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### Hatching Triage
 - Fixed an issue where the integration would crash due to connection errors when trying to retrieve XSOAR version.
-- Update docker image tag to demisto/python3:3.10.11.54132
+- Updated the docker image tag to *demisto/python3:3.10.11.54132*

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Hatching Triage
+- Resolve crash when version header creation fails
+- Update docker image tag to demisto/python3:3.10.11.54132

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_10.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### Hatching Triage
-- Resolve crash when version header creation fails
+- Fixed an issue where the integration would crash due to connection errors when trying to retrieve XSOAR version.
 - Update docker image tag to demisto/python3:3.10.11.54132

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_9.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_9.md
@@ -2,4 +2,4 @@
 ##### Hatching Triage
 - Added *user_tags* argument to the ***triage-submit-sample*** command, which makes it possible to specify an array of user tags
 - Update user-agent string to include the integration version
-- Update docker image tag to demisto/python3:3.10.10.51930
+- Update docker image tag to demisto/python3:3.10.11.54132

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_9.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_9.md
@@ -2,4 +2,4 @@
 ##### Hatching Triage
 - Added *user_tags* argument to the ***triage-submit-sample*** command, which makes it possible to specify an array of user tags
 - Update user-agent string to include the integration version
-- Update docker image tag to demisto/python3:3.10.11.54132
+- Update docker image tag to demisto/python3:3.10.10.51930

--- a/Packs/HatchingTriage/pack_metadata.json
+++ b/Packs/HatchingTriage/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Scalable malware sandbox",
     "support": "partner",
     "certification": "certified",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Hatching",
     "url": "https://hatching.io/",
     "email": "support@hatching.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Some users experienced get_pack_version throwing connection errors, which causes commands to fail.
This commit should stop that from happening.

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Tests
- [x] Documentation 
