### PR TITLE
wrong filter for pdf files in playbook extract indicators from file generic v2

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -1,7 +1,5 @@
 id: Extract Indicators From File - Generic v2
 version: -1
-contentitemexportablefields:
-  contentitemfields: {}
 name: Extract Indicators From File - Generic v2
 description: |-
   This playbook extracts indicators from a file.
@@ -28,10 +26,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 66ff4520-efa0-4c28-81d4-6d933e7ac182
+    taskid: bcdc9d1b-25b8-4f8e-8718-043218ed8977
     type: start
     task:
-      id: 66ff4520-efa0-4c28-81d4-6d933e7ac182
+      id: bcdc9d1b-25b8-4f8e-8718-043218ed8977
       version: -1
       name: ""
       iscommand: false
@@ -58,10 +56,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: 01e70914-25f3-495d-81f4-5864bd04340a
+    taskid: 9c37cfa4-5bd3-4994-80df-33bd4b58728f
     type: condition
     task:
-      id: 01e70914-25f3-495d-81f4-5864bd04340a
+      id: 9c37cfa4-5bd3-4994-80df-33bd4b58728f
       version: -1
       name: Is there a file?
       description: |
@@ -102,10 +100,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: 5ba31bc7-84ab-4d1b-8c1a-501b04cfe9c6
+    taskid: b287e371-7f7f-43cf-8f07-ea42b1ab70b6
     type: regular
     task:
-      id: 5ba31bc7-84ab-4d1b-8c1a-501b04cfe9c6
+      id: b287e371-7f7f-43cf-8f07-ea42b1ab70b6
       version: -1
       name: Set file to local context
       description: Sets the input file into local context.
@@ -143,10 +141,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: cd4f63cd-d080-4574-86f2-73b6dd9854d9
+    taskid: 9f01ab9b-8991-4705-83a8-2bc3f0e902b2
     type: title
     task:
-      id: cd4f63cd-d080-4574-86f2-73b6dd9854d9
+      id: 9f01ab9b-8991-4705-83a8-2bc3f0e902b2
       version: -1
       name: Done
       type: title
@@ -171,10 +169,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: 3745ecc5-a6c8-4c53-83ff-25d3dbef7eb1
+    taskid: ccedd221-520c-4c64-8ec8-fc07d1b107fc
     type: title
     task:
-      id: 3745ecc5-a6c8-4c53-83ff-25d3dbef7eb1
+      id: ccedd221-520c-4c64-8ec8-fc07d1b107fc
       version: -1
       name: Extract Indicators From Files
       type: title
@@ -206,10 +204,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: 816708c1-620e-495b-8102-081c06a0146f
+    taskid: 6b1ca925-a7ee-46d9-8f41-bc1ca5ee1f28
     type: condition
     task:
-      id: 816708c1-620e-495b-8102-081c06a0146f
+      id: 6b1ca925-a7ee-46d9-8f41-bc1ca5ee1f28
       version: -1
       name: Is there a text-based file?
       description: Checks if there is a text-based file in context. Skips MSG and EML files.
@@ -361,10 +359,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: baa0320d-9647-44bb-8110-99b6d1c618df
+    taskid: 25e595b9-5c08-4247-8888-ad17fecd9703
     type: regular
     task:
-      id: baa0320d-9647-44bb-8110-99b6d1c618df
+      id: 25e595b9-5c08-4247-8888-ad17fecd9703
       version: -1
       name: Extract indicators from text-based file
       description: Extracts indicators from text-based files.
@@ -503,10 +501,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 60ecb284-7af0-463e-80d7-8f7e36dce929
+    taskid: 6456e51c-3165-435e-8fd4-9b3143f4b011
     type: condition
     task:
-      id: 60ecb284-7af0-463e-80d7-8f7e36dce929
+      id: 6456e51c-3165-435e-8fd4-9b3143f4b011
       version: -1
       name: Is there a PDF file?
       description: Checks if there is a PDF file in context.
@@ -545,11 +543,14 @@ tasks:
                     right:
                       value:
                         simple: pdf
+                    ignorecase: true
                 accessor: EntryID
                 transformers:
                 - operator: uniq
             iscontext: true
           ignorecase: true
+          right:
+            value: {}
     continueonerrortype: ""
     view: |-
       {
@@ -567,10 +568,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: fa0e5d0b-c66c-4837-8b73-bacf7e890d12
+    taskid: 413768ed-dc27-441e-8395-9878777549e5
     type: regular
     task:
-      id: fa0e5d0b-c66c-4837-8b73-bacf7e890d12
+      id: 413768ed-dc27-441e-8395-9878777549e5
       version: -1
       name: Extract indicators from PDF file
       description: Load a PDF file's content and metadata into context.
@@ -586,14 +587,15 @@ tasks:
         complex:
           root: File
           filters:
-          - - operator: isEqualString
+          - - operator: containsString
               left:
                 value:
                   simple: File.Type
                 iscontext: true
               right:
                 value:
-                  simple: application/pdf
+                  simple: pdf
+              ignorecase: true
             - operator: containsString
               left:
                 value:
@@ -601,7 +603,7 @@ tasks:
                 iscontext: true
               right:
                 value:
-                  simple: application/pdf
+                  simple: pdf
               ignorecase: true
           accessor: EntryID
           transformers:
@@ -625,10 +627,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "9":
     id: "9"
-    taskid: a43c6497-ba16-4f6e-8432-04b149d9810c
+    taskid: 56597c25-22cd-42b4-8c2f-f08c31fd1dd4
     type: condition
     task:
-      id: a43c6497-ba16-4f6e-8432-04b149d9810c
+      id: 56597c25-22cd-42b4-8c2f-f08c31fd1dd4
       version: -1
       name: Is there a Word file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
@@ -821,10 +823,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "10":
     id: "10"
-    taskid: c0b4f86a-6063-455f-8bc7-92d09cd519fa
+    taskid: 68b22c92-c5b7-4e98-8b45-cadb678c6da8
     type: title
     task:
-      id: c0b4f86a-6063-455f-8bc7-92d09cd519fa
+      id: 68b22c92-c5b7-4e98-8b45-cadb678c6da8
       version: -1
       name: No File To Parse
       type: title
@@ -852,10 +854,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "11":
     id: "11"
-    taskid: a7b3afc7-61ea-41b9-8b87-2b7026f8c1db
+    taskid: 94620d34-671a-4869-81f1-dcf67071a9ee
     type: regular
     task:
-      id: a7b3afc7-61ea-41b9-8b87-2b7026f8c1db
+      id: 94620d34-671a-4869-81f1-dcf67071a9ee
       version: -1
       name: Extract indicators from Word file
       description: Extracts indicators from word files (DOC, DOCX).
@@ -1008,10 +1010,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "12":
     id: "12"
-    taskid: 1572cbb3-ceff-4d00-8f8a-468ad338953b
+    taskid: 53f7a7dd-1720-451f-892d-28bdc2938d12
     type: condition
     task:
-      id: 1572cbb3-ceff-4d00-8f8a-468ad338953b
+      id: 53f7a7dd-1720-451f-892d-28bdc2938d12
       version: -1
       name: Were images extracted?
       description: Checks whether images were extracted from PDF files.
@@ -1089,10 +1091,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "13":
     id: "13"
-    taskid: 92e92794-63db-4875-88c3-89bd5a4ec179
+    taskid: 016dfd29-eb0c-4638-8f9c-b47a21dbf83e
     type: condition
     task:
-      id: 92e92794-63db-4875-88c3-89bd5a4ec179
+      id: 016dfd29-eb0c-4638-8f9c-b47a21dbf83e
       version: -1
       name: Is Image OCR enabled?
       description: Checks whether there is an active instance of the Image OCR integration. enabled.
@@ -1140,10 +1142,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "14":
     id: "14"
-    taskid: c6d841e4-812f-40e0-8ef4-9203859c9781
+    taskid: 9e63e4dc-c072-46b9-876d-6862cf429573
     type: regular
     task:
-      id: c6d841e4-812f-40e0-8ef4-9203859c9781
+      id: 9e63e4dc-c072-46b9-876d-6862cf429573
       version: -1
       name: Extract text from images
       description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
@@ -1217,10 +1219,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "15":
     id: "15"
-    taskid: 32dd3613-cac8-4ac6-8b2a-59fd9c2e4233
+    taskid: ffb93222-0298-4fc1-8087-6e2e66eecda4
     type: condition
     task:
-      id: 32dd3613-cac8-4ac6-8b2a-59fd9c2e4233
+      id: ffb93222-0298-4fc1-8087-6e2e66eecda4
       version: -1
       name: Is there another supported document type?
       description: |-
@@ -1368,10 +1370,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "16":
     id: "16"
-    taskid: 430b4252-4478-4150-8641-2444119a6005
+    taskid: 9a754389-5cc2-4638-84b4-2877b55a649a
     type: regular
     task:
-      id: 430b4252-4478-4150-8641-2444119a6005
+      id: 9a754389-5cc2-4638-84b4-2877b55a649a
       version: -1
       name: Convert a document to PDF
       description: |-
@@ -1507,10 +1509,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "17":
     id: "17"
-    taskid: 68c81da0-f91d-4ea4-8616-82a0e333eb6f
+    taskid: 0fa1cea9-9c2e-4512-81d1-37058f817ea2
     type: regular
     task:
-      id: 68c81da0-f91d-4ea4-8616-82a0e333eb6f
+      id: 0fa1cea9-9c2e-4512-81d1-37058f817ea2
       version: -1
       name: Preview PDF files
       description: Gets a preview (image) of the PDF files.
@@ -1569,10 +1571,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "18":
     id: "18"
-    taskid: d3466327-cfe5-4364-8b19-187f67320432
+    taskid: f7e70aea-197a-48b0-8e5b-1a0e4e813a15
     type: condition
     task:
-      id: d3466327-cfe5-4364-8b19-187f67320432
+      id: f7e70aea-197a-48b0-8e5b-1a0e4e813a15
       version: -1
       name: Is Rasterize enabled?
       description: Checks if the Rasterize integration is enabled.
@@ -1632,10 +1634,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "19":
     id: "19"
-    taskid: 78c502fd-f7dd-4fa5-8cac-14a11bf176f7
+    taskid: dff24f87-3133-4c5b-85f0-3e8cfb5910f6
     type: regular
     task:
-      id: 78c502fd-f7dd-4fa5-8cac-14a11bf176f7
+      id: dff24f87-3133-4c5b-85f0-3e8cfb5910f6
       version: -1
       name: Set ExtractedURLsFromFiles
       description: |-
@@ -1673,10 +1675,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "20":
     id: "20"
-    taskid: 60347e57-061c-46ec-87bf-dff0684adc13
+    taskid: 0ca91cf6-8403-4e3e-84fd-a5076cb1e172
     type: playbook
     task:
-      id: 60347e57-061c-46ec-87bf-dff0684adc13
+      id: 0ca91cf6-8403-4e3e-84fd-a5076cb1e172
       version: -1
       name: Microsoft Office File Enrichment - Oletools
       description: |-
@@ -1726,7 +1728,6 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
-system: true
 view: |-
   {
     "linkLabelsPosition": {
@@ -1985,7 +1986,6 @@ outputs:
 - contextPath: DBotScore.Score
   description: The actual score.
   type: number
-quiet: true
 tests:
 - Extract Indicators From File - Generic v2 - Test
 fromversion: 5.0.0

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5_README.md
@@ -20,36 +20,43 @@ Supported file types:
 - PPSM
 
 ## Dependencies
+
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
-Microsoft Office File Enrichment - Oletools
+
+* Microsoft Office File Enrichment - Oletools
 
 ### Integrations
+
 This playbook does not use any integrations.
 
 ### Scripts
-* ConvertFile
-* Set
-* ExtractIndicatorsFromTextFile
-* SetAndHandleEmpty
-* ReadPDFFileV2
+
 * ExtractIndicatorsFromWordFile
+* ConvertFile
+* ExtractIndicatorsFromTextFile
+* ReadPDFFileV2
+* Set
+* SetAndHandleEmpty
 
 ### Commands
+
 * rasterize-pdf
 * image-ocr-extract-text
 
 ## Playbook Inputs
+
 ---
 
 | **Name** | **Description** | **Default Value** | **Required** |
 | --- | --- | --- | --- |
 | File | The file to extract indicators from. | File | Optional |
-| Indicator Query | Indicators matching the indicator query will be used as playbook input. |  | Optional |
-| Decode | Possible values: "True" or "False". Default is "False".<br/>When this is set to "True", in case a macro was found within the file \(using oletools\), it will output all the obfuscated strings with their decoded content \(Hex, Base64, StrReverse, Dridex, VBA\). | False | Optional |
+| Indicator Query | Indicators matching the indicator query will be used as playbook input |  | Optional |
+| Decode | Available values: "True" or "False". Default is "False"<br/>When this is set to "True", in case a macro was found within the file \(using oletools\), it will output all the obfuscated strings with their decoded content \(Hex, Base64, StrReverse, Dridex, VBA\). | False | Optional |
 
 ## Playbook Outputs
+
 ---
 
 | **Path** | **Description** | **Type** |
@@ -77,7 +84,7 @@ This playbook does not use any integrations.
 | Oletools.Oleid.sha256 | SHA256 hash. | string |
 | Oletools.Oleid.ole_command_result.File_format | Indicator file format. | string |
 | Oletools.Oleid.ole_command_result.Container_format | Indicator container format. | string |
-| Oletools.Oleid.ole_command_result.Encrypted | Encrypted indicator. | string |
+| Oletools.Oleid.ole_command_result.Encrypted | Indicator encrypted. | string |
 | Oletools.Oleid.ole_command_result.VBA_Macros | Indicator VBA macros. | string |
 | Oletools.Oleid.ole_command_result.XLM_Macros | Indicator XLM macros. | string |
 | Oletools.Oleid.ole_command_result.External_Relationships | Indicator external relationships. | string |
@@ -121,5 +128,7 @@ This playbook does not use any integrations.
 | DBotScore.Score | The actual score. | number |
 
 ## Playbook Image
+
 ---
+
 ![Extract Indicators From File - Generic v2](../doc_files/Extract_Indicators_From_File_-_Generic_v2.png)

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_59.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_59.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Extract Indicators From File - Generic v2
+
+- Fixed an issue with wrong filter for pdf files in the task "Extract indicators from PDF file"

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_59.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_59.md
@@ -3,4 +3,4 @@
 
 ##### Extract Indicators From File - Generic v2
 
-- Fixed an issue with wrong filter for pdf files in the task "Extract indicators from PDF file"
+- Fixed an issue with wrong filter for pdf files in the task "Extract indicators from PDF file".

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.58",
+    "currentVersion": "2.3.59",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA 

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**-->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-23485)

## Description
Fix a bug with the filter for pdf files in the task "Extract indicators from PDF file" of the playbook "Extract Indicators From File - Generic v2". the filter tried to match equals to `application/pdf` which was sometimes shown as other text including `pdf`, introduced a fix which changes the filter to match when includes `pdf`.

## Screenshots
![image](https://user-images.githubusercontent.com/102903097/232909948-1b2ed932-242d-471c-81d8-9506e394cace.png)

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.8.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [x] Documentation 
