### PR TITLE
FeedAzure: add missed header

### DIFF
--- a/Packs/FeedAzure/Integrations/FeedAzure/FeedAzure.py
+++ b/Packs/FeedAzure/Integrations/FeedAzure/FeedAzure.py
@@ -80,6 +80,7 @@ class Client(BaseClient):
             method='GET',
             full_url=self._base_url,
             url_suffix='',
+            headers={'User-Agent': 'PANW-XSOAR'},
             stream=False,
             timeout=self._polling_timeout,
             resp_type='text'

--- a/Packs/FeedAzure/ReleaseNotes/1_0_24.md
+++ b/Packs/FeedAzure/ReleaseNotes/1_0_24.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Azure Feed
+
+Fixed an issue where integration failed due to missing http header.

--- a/Packs/FeedAzure/pack_metadata.json
+++ b/Packs/FeedAzure/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Azure Feed",
     "description": "Indicators feed from Azure",
     "support": "xsoar",
-    "currentVersion": "1.0.23",
+    "currentVersion": "1.0.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-23493

## Description
in case there is no 'User-Agent' header - the response are 
`Your current User-Agent string appears to be from an automated process, if this is incorrect, please click this link`

added the User-Agent - solve the issue
@DeanArbel WDYT?

