### PR TITLE
remove traps from native image config

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -162,16 +162,6 @@
          ]
       },
       {
-         "id":"Traps",
-         "reason":"Integration is Deprecated.",
-         "ignored_native_images": [
-            "native:8.1",
-            "native:8.2",
-            "native:dev",
-            "native:candidate"
-         ]
-      },
-      {
          "id": "Rasterize",
          "reason": "Issue: CRTX-72338.",
          "ignored_native_images": [


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Remove traps from native image config as `lint -a` does not run on deprecated integrations anymore.

