### PR TITLE
[Symantec Data Loss Protection V2] fixed - 'ValueError: empty separator' when using the  incidentStatusId parameter

### DIFF
--- a/Packs/SymantecDLP/.pack-ignore
+++ b/Packs/SymantecDLP/.pack-ignore
@@ -6,3 +6,7 @@ ignore=RM104
 
 [tests_require_network]
 Symantec Data Loss Prevention
+
+[known_words]
+incidentStatusId
+Symantec

--- a/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.py
+++ b/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.py
@@ -799,7 +799,7 @@ def main() -> None:
         username = credentials.get('identifier', '')
         password = credentials.get('password', '')
         incident_type = argToList(params.get('fetchIncidentType'), 'Network,Discover,Endpoint')
-        incident_status_id = check_status_ids_type(argToList(params.get('incidentStatusId'), ''))
+        incident_status_id = check_status_ids_type(argToList(params.get('incidentStatusId', '')))
         incident_severity = argToList(params.get('incidentSeverity'), 'Medium,High')
         verify_certificate = not params.get('insecure', False)
         proxy = params.get('proxy', False)

--- a/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
+++ b/Packs/SymantecDLP/Integrations/SymantecDLPV2/SymantecDLPV2.yml
@@ -590,7 +590,7 @@ script:
     - contextPath: SymantecDLP.IncidentRemediationStatus.name
       description: The name of the remediation status.
       type: String
-  dockerimage: demisto/python3:3.10.10.48392
+  dockerimage: demisto/python3:3.10.11.55362
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_10.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_10.md
@@ -4,3 +4,4 @@
 ##### Symantec Data Loss Prevention v2
 
 - Fixed an issue where the **incidentStatusId** parameter was not parsed as expected.
+- Updated the Docker image to *demisto/python3:3.10.11.55362*.

--- a/Packs/SymantecDLP/ReleaseNotes/2_0_10.md
+++ b/Packs/SymantecDLP/ReleaseNotes/2_0_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Symantec Data Loss Prevention v2
+
+- Fixed an issue where the **incidentStatusId** parameter was not parsed as expected.

--- a/Packs/SymantecDLP/pack_metadata.json
+++ b/Packs/SymantecDLP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Symantec Data Loss Prevention",
     "description": "Symantec Data Loss Prevention enables you to discover, monitor and protect your sensitive corporate information.",
     "support": "xsoar",
-    "currentVersion": "2.0.9",
+    "currentVersion": "2.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6374)

## Description
Fixed incidentStatusId parameter handling.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
