### PR TITLE
Validate content-test-conf failed when brachname is substring of the branchname

### DIFF
--- a/.gitlab/ci/on-push.yml
+++ b/.gitlab/ci/on-push.yml
@@ -103,7 +103,8 @@ validate-content-conf:
         # replace slashes ('/') in the branch name, if exist, with underscores ('_')
         UNDERSCORE_CI_BRANCH=${CI_COMMIT_BRANCH//\//_}
         RESP=$(curl --location --request GET "https://code.pan.run/api/v4/projects/3734/repository/branches?search=$UNDERSCORE_CI_BRANCH" --header "PRIVATE-TOKEN: $GITLAB_API_READ_TOKEN") # disable-secrets-detection
-        if [ "$RESP" != "[]" ]; then
+        EXIST=$(echo $RESP | jq --arg branch $UNDERSCORE_CI_BRANCH -c '.[] | select(.name==$branch)')
+        if [ -n "$EXIST" ]; then
             echo "Found a branch with the same name in contest-test-conf- $UNDERSCORE_CI_BRANCH."
             echo "Merge it in order to merge the current branch into content repo."
             job-done


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6359

## Description
validate-test-conf build step validates that there is no branch in content-test-conf repo with the same name as the content branch, but contains the name. For example: 
My content branch name is: test
Content-Test-Cont repo has branches: test_darya, test_new etc.. 
Before my fix the step will fail. 
