### PR TITLE
Fixed typo in vmray-get-sample Command

### DIFF
--- a/Packs/VMRay/Integrations/VMRay/VMRay.py
+++ b/Packs/VMRay/Integrations/VMRay/VMRay.py
@@ -675,7 +675,7 @@ def get_sample_command():
     entry = create_sample_entry(data)
     scores = dbot_score_by_hash(entry)
     entry_context = {
-        'VMRay.Sample(var.SampleID === obj.SampleID)': entry,
+        'VMRay.Sample(val.SampleID === obj.SampleID)': entry,
         outputPaths.get('dbotscore'): scores,
     }
 

--- a/Packs/VMRay/Integrations/VMRay/VMRay.yml
+++ b/Packs/VMRay/Integrations/VMRay/VMRay.yml
@@ -1205,7 +1205,7 @@ script:
     description: Retrieves a sample using the sample ID. (Deprecated)
     execution: false
     name: upload_sample
-  dockerimage: demisto/python3:3.10.10.51930
+  dockerimage: demisto/python3:3.10.11.56082
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/VMRay/ReleaseNotes/1_1_9.md
+++ b/Packs/VMRay/ReleaseNotes/1_1_9.md
@@ -1,0 +1,3 @@
+##### VMRay
+
+- Fixed a typo in the **vmray-get-sample** command.

--- a/Packs/VMRay/ReleaseNotes/1_1_9.md
+++ b/Packs/VMRay/ReleaseNotes/1_1_9.md
@@ -1,3 +1,6 @@
+#### Integrations
+
 ##### VMRay
 
 - Fixed a typo in the **vmray-get-sample** command.
+

--- a/Packs/VMRay/pack_metadata.json
+++ b/Packs/VMRay/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VMRay Analyzer",
     "description": "Analyze files and URLs using the VMRay Platform for accurate threat intelligence and high-quality IOCs.",
     "support": "partner",
-    "currentVersion": "1.1.8",
+    "currentVersion": "1.1.9",
     "author": "VMRay",
     "url": "https://www.vmray.com/",
     "email": "support@vmray.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-23603

## Description
Fixed an issue in `vmray-get-sample` output where it fails to match on SampleID (produces redundant sample entries) as reported in https://github.com/demisto/content/issues/24533.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
