### PR TITLE
Filter non-hidden packs by server_min_version

### DIFF
--- a/Tests/configure_and_test_integration_instances.py
+++ b/Tests/configure_and_test_integration_instances.py
@@ -1800,7 +1800,7 @@ def get_packs_to_install(build: Build) -> Tuple[Set[str], Set[str]]:
 
     non_hidden_packs = get_turned_non_hidden_packs(modified_packs_names, build)
 
-    packs_with_higher_min_version = get_packs_with_higher_min_version(set(build.pack_ids_to_install) - non_hidden_packs,
+    packs_with_higher_min_version = get_packs_with_higher_min_version(set(build.pack_ids_to_install),
                                                                       build.server_numeric_version)
     # packs to install used in post update
     build.pack_ids_to_install = list(set(build.pack_ids_to_install) - packs_with_higher_min_version)


### PR DESCRIPTION
## Description
A [PR](https://github.com/demisto/content/pull/26247) that un-hides a pack that has server_min_version=6.6.0 and the [build fails](https://code.pan.run/xsoar/content/-/jobs/25202665) to install it on 6.5.0 because it didn't filter out the pack for the post update.
This PR fixes it by filtering also the turned non-hidden packs by the server_min_version as well as for all modified packs.