### PR TITLE
LogRhythm: correct the drilldown data endpoint & the headers

### DIFF
--- a/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.py
+++ b/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.py
@@ -1107,9 +1107,10 @@ class Client(BaseClient):
         return alarm_details, response
 
     def alarm_drilldown_request(self, alarm_id):  # pragma: no cover
-        response = self._http_request('GET', f'drilldown/{alarm_id}')
+        headers = self._headers | {'content-type': 'application/json'}
+        response = self._http_request('GET', f'lr-drilldown-cache-api/drilldown/{alarm_id}', headers=headers)
 
-        drilldown_results = response.get('DrillDownResults')
+        drilldown_results = response.get('Data', {}).get('DrillDownResults')
         return drilldown_results, response
 
     def cases_list_request(self, case_id=None, timestamp_filter_type=None, timestamp=None, priority=None, status=None,

--- a/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.yml
+++ b/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.yml
@@ -114,7 +114,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.10.51930
+  dockerimage: demisto/python3:3.10.11.56082
   isfetch: true
   commands:
   - name: lr-alarms-list

--- a/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.yml
+++ b/Packs/LogRhythmRest/Integrations/LogRhythmRestV2/LogRhythmRestV2.yml
@@ -114,7 +114,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.11.56082
+  dockerimage: demisto/python3:3.10.11.56857
   isfetch: true
   commands:
   - name: lr-alarms-list

--- a/Packs/LogRhythmRest/ReleaseNotes/2_0_18.md
+++ b/Packs/LogRhythmRest/ReleaseNotes/2_0_18.md
@@ -4,4 +4,4 @@
 ##### LogRhythmRest v2
 
 - Fixed an issue where **lr-alarm-drilldown** command didn't work properly.
-- Updated the Docker image to: *demisto/python3:3.10.11.56082*.
+- Updated the Docker image to: *demisto/python3:3.10.11.56857*.

--- a/Packs/LogRhythmRest/ReleaseNotes/2_0_18.md
+++ b/Packs/LogRhythmRest/ReleaseNotes/2_0_18.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### LogRhythmRest v2
+
+- Fixed an issue where **lr-alarm-drilldown** command didn't work properly.
+- Updated the Docker image to: *demisto/python3:3.10.11.56082*.

--- a/Packs/LogRhythmRest/TestPlaybooks/playbook-LogRhythmRestV2-test.yml
+++ b/Packs/LogRhythmRest/TestPlaybooks/playbook-LogRhythmRestV2-test.yml
@@ -2445,7 +2445,7 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isNotEmpty
+      - - operator: isExists
           left:
             value:
               simple: LogRhythm.AlarmSummary.additionalDetails

--- a/Packs/LogRhythmRest/TestPlaybooks/playbook-LogRhythmRestV2-test.yml
+++ b/Packs/LogRhythmRest/TestPlaybooks/playbook-LogRhythmRestV2-test.yml
@@ -3151,11 +3151,6 @@ tasks:
             value:
               simple: LogRhythm.Search.TaskId
             iscontext: true
-      - - operator: isExists
-          left:
-            value:
-              simple: LogRhythm.Search.Results
-            iscontext: true
     view: |-
       {
         "position": {

--- a/Packs/LogRhythmRest/pack_metadata.json
+++ b/Packs/LogRhythmRest/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "LogRhythm",
     "description": "LogRhythm security intelligence.",
     "support": "xsoar",
-    "currentVersion": "2.0.17",
+    "currentVersion": "2.0.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-22838

## Description
currently, the command to get the drilldown data of an alarm points to incorrect path
fixing this and add the required header

according to [LogRhythm community doc](https://community.logrhythm.com/t5/AIE-Rules/AIE-Drilldown-API/m-p/44276#M1295%C2%A0)
