### PR TITLE
Skip non-relevant steps in test upload-flow build

### DIFF
--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -512,15 +512,13 @@ upload-id-set-bucket:
   extends:
     - .bucket-upload-rule
     - .default-job-settings
-  rules:
-    - if: '$TEST_UPLOAD == "false"'
   script:
     # This is needed because we still use id_set.json in other repos
-    # - |
-    #   if [[ $TEST_UPLOAD == "true" ]]; then
-    #     echo "Skipping uploading id-set to the bucket in test upload-flow"
-    #     exit 0
-    #   fi
+    - |
+      if [[ $TEST_UPLOAD == "true" ]]; then
+        echo "Skipping uploading id-set to the bucket in test upload-flow"
+        exit 0
+      fi
 
     - !reference [.create-id-set-xsoar]
     - gcloud auth activate-service-account --key-file="$GCS_MARKET_KEY"
@@ -537,14 +535,12 @@ sync-buckets-between-projects:
   stage: upload-to-marketplace
   needs: ["upload-packs-to-marketplace", "upload-packs-to-marketplace-v2", "upload-packs-to-xpanse-marketplace"]
   when: always
-  rules:
-    - if: '$TEST_UPLOAD == "false"'
   script:
-    # - |
-    #   if [[ $TEST_UPLOAD == "true" ]]; then
-    #     echo "Skipping syncing buckets in test upload-flow"
-    #     exit 0
-    #   fi
+    - |
+      if [[ $TEST_UPLOAD == "true" ]]; then
+        echo "Skipping syncing buckets in test upload-flow"
+        exit 0
+      fi
 
     - |
       if [[ -z "$GCS_XSOAR_CONTENT_DEV_KEY" ]] || [[ -z "$GCS_XSOAR_CONTENT_PROD_KEY" ]]; then

--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -514,6 +514,10 @@ upload-id-set-bucket:
     - .default-job-settings
   script:
     # This is needed because we still use id_set.json in other repos
+    - if [[ $TEST_UPLOAD == "false" ]]; then
+        echo "Skipping uploading id-set to the bucket in test upload-flow"
+        exit 0
+      fi
     - !reference [.create-id-set-xsoar]
     - gcloud auth activate-service-account --key-file="$GCS_MARKET_KEY"
     - gsutil cp $ARTIFACTS_FOLDER/id_set.json "gs://$GCS_MARKET_BUCKET/content/id_set.json"
@@ -531,6 +535,10 @@ sync-buckets-between-projects:
   when: always
   script:
     - |
+      if [[ $TEST_UPLOAD == "false" ]]; then
+        echo "Skipping syncing buckets in test upload-flow"
+        exit 0
+      fi
       if [[ -z "$GCS_XSOAR_CONTENT_DEV_KEY" ]] || [[ -z "$GCS_XSOAR_CONTENT_PROD_KEY" ]]; then
         echo "GCS_XSOAR_CONTENT_DEV_KEY or GCS_XSOAR_CONTENT_PROD_KEY not set, cannot perform sync"
         job-done

--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -512,12 +512,16 @@ upload-id-set-bucket:
   extends:
     - .bucket-upload-rule
     - .default-job-settings
+  rules:
+    - if: '$TEST_UPLOAD == "false"'
   script:
     # This is needed because we still use id_set.json in other repos
-    - if [[ $TEST_UPLOAD == "false" ]]; then
-        echo "Skipping uploading id-set to the bucket in test upload-flow"
-        exit 0
-      fi
+    # - |
+    #   if [[ $TEST_UPLOAD == "true" ]]; then
+    #     echo "Skipping uploading id-set to the bucket in test upload-flow"
+    #     exit 0
+    #   fi
+
     - !reference [.create-id-set-xsoar]
     - gcloud auth activate-service-account --key-file="$GCS_MARKET_KEY"
     - gsutil cp $ARTIFACTS_FOLDER/id_set.json "gs://$GCS_MARKET_BUCKET/content/id_set.json"
@@ -533,12 +537,16 @@ sync-buckets-between-projects:
   stage: upload-to-marketplace
   needs: ["upload-packs-to-marketplace", "upload-packs-to-marketplace-v2", "upload-packs-to-xpanse-marketplace"]
   when: always
+  rules:
+    - if: '$TEST_UPLOAD == "false"'
   script:
+    # - |
+    #   if [[ $TEST_UPLOAD == "true" ]]; then
+    #     echo "Skipping syncing buckets in test upload-flow"
+    #     exit 0
+    #   fi
+
     - |
-      if [[ $TEST_UPLOAD == "false" ]]; then
-        echo "Skipping syncing buckets in test upload-flow"
-        exit 0
-      fi
       if [[ -z "$GCS_XSOAR_CONTENT_DEV_KEY" ]] || [[ -z "$GCS_XSOAR_CONTENT_PROD_KEY" ]]; then
         echo "GCS_XSOAR_CONTENT_DEV_KEY or GCS_XSOAR_CONTENT_PROD_KEY not set, cannot perform sync"
         job-done

--- a/.gitlab/ci/bucket-upload.yml
+++ b/.gitlab/ci/bucket-upload.yml
@@ -517,6 +517,7 @@ upload-id-set-bucket:
     - |
       if [[ $TEST_UPLOAD == "true" ]]; then
         echo "Skipping uploading id-set to the bucket in test upload-flow"
+        job-done
         exit 0
       fi
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Skip non-relevant steps (upload-id-set-bucket and sync-buckets) in test upload-flow build.
Example test upload-flow build: https://code.pan.run/xsoar/content/-/pipelines/5178715