### PR TITLE
Changed AutoFocus Tags Feed to not be configured by default

### DIFF
--- a/Packs/AutoFocus/Integrations/AutoFocusTagsFeed/AutoFocusTagsFeed.yml
+++ b/Packs/AutoFocus/Integrations/AutoFocusTagsFeed/AutoFocusTagsFeed.yml
@@ -2,7 +2,7 @@ category: Data Enrichment & Threat Intelligence
 commonfields:
   id: AutoFocusTagsFeed
   version: -1
-defaultEnabled: true
+defaultEnabled: false
 configuration:
 - display: AutoFocus Endpoint URL
   name: url

--- a/Packs/AutoFocus/ReleaseNotes/2_1_8.md
+++ b/Packs/AutoFocus/ReleaseNotes/2_1_8.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### AutoFocus Tags Feed (Deprecated)
+
+As the feed is deprecated it will not be autoconfigured.

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AutoFocus by Palo Alto Networks",
     "description": "Use the Palo Alto Networks AutoFocus integration to distinguish the most\n  important threats from everyday commodity attacks.",
     "support": "xsoar",
-    "currentVersion": "2.1.7",
+    "currentVersion": "2.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-78763

## Description
As the AutoFocus Tags Feed is deprecated we are removing its auto install
