### PR TITLE
[OpsGenie] Context Path Type Confusion

### DIFF
--- a/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.py
+++ b/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.py
@@ -828,7 +828,7 @@ def get_request_command(client: Client, args: Dict[str, Any]) -> CommandResults:
         return CommandResults(
             raw_response=results,
             readable_output=None if args.get('polled_once') else f"Waiting for request_id={request_id}",
-            outputs_prefix=args.get("output_prefix", "OpsGenie.Request"),
+            outputs_prefix="OpsGenie.Request",
             outputs=None if args.get('polled_once') else {"requestId": request_id},
             scheduled_command=ScheduledCommand(command='opsgenie-get-request',
                                                next_run_in_seconds=int(

--- a/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.py
+++ b/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.py
@@ -829,7 +829,7 @@ def get_request_command(client: Client, args: Dict[str, Any]) -> CommandResults:
             raw_response=results,
             readable_output=None if args.get('polled_once') else f"Waiting for request_id={request_id}",
             outputs_prefix="OpsGenie.Request",
-            outputs=None if args.get('polled_once') else {"requestId": request_id},
+            outputs=None if args.get('polled_once') else [{"requestId": request_id}],
             scheduled_command=ScheduledCommand(command='opsgenie-get-request',
                                                next_run_in_seconds=int(
                                                    args.get('interval_in_seconds', DEFAULT_POLL_INTERVAL)),

--- a/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.yml
+++ b/Packs/OpsGenie/Integrations/OpsGenieV3/OpsGenieV3.yml
@@ -1591,7 +1591,7 @@ script:
       description: Whether the request was successful.
       type: Boolean
 
-  dockerimage: demisto/python3:3.10.10.47713
+  dockerimage: demisto/python3:3.10.11.56857
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/OpsGenie/Integrations/OpsGenieV3/README.md
+++ b/Packs/OpsGenie/Integrations/OpsGenieV3/README.md
@@ -12,7 +12,7 @@ If you are upgrading from a previous of this integration, see [Breaking Changes]
 
     | **Parameter** | **Description** | **Required** |
     | --- | --- | --- |
-    | Server URL (e.g., https://api.opsgenie.com) |  | True |
+    | Server URL (e.g., <https://api.opsgenie.com>) |  | True |
     | API Token |  | False |
     | Fetch incidents |  | False |
     | First fetch timestamp (&lt;number&gt; &lt;time unit&gt;, e.g., 12 hours, 7 days) |  | False |
@@ -27,10 +27,14 @@ If you are upgrading from a previous of this integration, see [Breaking Changes]
     | Use system proxy settings |  | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
+
 ## Commands
+
 You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
+
 ### opsgenie-create-alert
+
 ***
 Create an alert in Opsgenie.
 
@@ -38,6 +42,7 @@ Create an alert in Opsgenie.
 #### Base Command
 
 `opsgenie-create-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -68,9 +73,11 @@ Create an alert in Opsgenie.
 
 
 #### Command Example
+
 ```!opsgenie-create-alert message="Example Message"```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -91,12 +98,14 @@ Create an alert in Opsgenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Create | 4c4623e3-0b3f-47b7-becd-907d3e51d129-1638366498716 | 4c4623e3-0b3f-47b7-becd-907d3e51d129-1638366498716 | 3cc69931-167f-411c-a331-768997c29d2e | true | 2021-12-01T13:48:18.757Z | Created alert | true |
 
 
 ### opsgenie-get-alerts
+
 ***
 List the current alerts from OpsGenie.
 
@@ -104,6 +113,7 @@ List the current alerts from OpsGenie.
 #### Base Command
 
 `opsgenie-get-alerts`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -155,9 +165,11 @@ List the current alerts from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-get-alerts limit=1```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -198,12 +210,14 @@ List the current alerts from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|id|createdAt|acknowledged|count|status|
 >|---|---|---|---|---|
 >| 4c4623e3-0b3f-47b7-becd-907d3e51d129-1638366498716 | 2021-12-01T13:48:18.716Z | false | 1 | open |
 
 
 ### opsgenie-delete-alert
+
 ***
 Delete an alert from OpsGenie.
 
@@ -211,6 +225,7 @@ Delete an alert from OpsGenie.
 #### Base Command
 
 `opsgenie-delete-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -234,9 +249,11 @@ Delete an alert from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-delete-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -257,12 +274,14 @@ Delete an alert from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Delete |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:40.911Z | Alert does not exist | false |
 
 
 ### opsgenie-ack-alert
+
 ***
 Acknowledge an alert in OpsGenie.
 
@@ -270,6 +289,7 @@ Acknowledge an alert in OpsGenie.
 #### Base Command
 
 `opsgenie-ack-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -294,9 +314,11 @@ Acknowledge an alert in OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-ack-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -317,12 +339,14 @@ Acknowledge an alert in OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Acknowledge |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:23.374Z | Alert does not exist | false |
 
 
 ### opsgenie-close-alert
+
 ***
 Close an alert in OpsGenie.
 
@@ -330,6 +354,7 @@ Close an alert in OpsGenie.
 #### Base Command
 
 `opsgenie-close-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -354,9 +379,11 @@ Close an alert in OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-close-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -377,12 +404,14 @@ Close an alert in OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Close |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:38.491Z | Alert does not exist | false |
 
 
 ### opsgenie-assign-alert
+
 ***
 Assign an OpsGenie alert.
 
@@ -390,6 +419,7 @@ Assign an OpsGenie alert.
 #### Base Command
 
 `opsgenie-assign-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -416,9 +446,11 @@ Assign an OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-assign-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286 owner_username=b@g.com```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -439,12 +471,14 @@ Assign an OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Assign |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:24.942Z | Alert does not exist | false |
 
 
 ### opsgenie-add-responder-alert
+
 ***
 Add a responder to an OpsGenie alert.
 
@@ -452,6 +486,7 @@ Add a responder to an OpsGenie alert.
 #### Base Command
 
 `opsgenie-add-responder-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -478,9 +513,11 @@ Add a responder to an OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-add-responder-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286 responders=schedule,name,test_schedule```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -501,12 +538,14 @@ Add a responder to an OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Add Responder |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:26.82Z | Alert does not exist | false |
 
 
 ### opsgenie-get-escalations
+
 ***
 Get escalations from OpsGenie.
 
@@ -514,6 +553,7 @@ Get escalations from OpsGenie.
 #### Base Command
 
 `opsgenie-get-escalations`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -541,9 +581,11 @@ Get escalations from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-get-escalations```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -669,6 +711,7 @@ Get escalations from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie Escalations
+
 >|description|id|name|ownerTeam|rules|
 >|---|---|---|---|---|
 >|  | 9a441a8d-2410-43f4-9ef2-f7a265e12b74 | Engineering_escalation | id: 51d69df8-c40b-439e-9808-e1a78e54f91b<br/>name: Engineering | {'condition': 'if-not-acked', 'notifyType': 'default', 'delay': {'timeAmount': 0, 'timeUnit': 'minutes'}, 'recipient': {'type': 'schedule', 'id': '7835aa84-7440-41d5-90bf-92e0045714d5', 'name': 'Engineering_schedule'}},<br/>{'condition': 'if-not-acked', 'notifyType': 'next', 'delay': {'timeAmount': 5, 'timeUnit': 'minutes'}, 'recipient': {'type': 'schedule', 'id': '7835aa84-7440-41d5-90bf-92e0045714d5', 'name': 'Engineering_schedule'}},<br/>{'condition': 'if-not-acked', 'notifyType': 'all', 'delay': {'timeAmount': 10, 'timeUnit': 'minutes'}, 'recipient': {'type': 'team', 'id': '51d69df8-c40b-439e-9808-e1a78e54f91b', 'name': 'Engineering'}} |
@@ -676,6 +719,7 @@ Get escalations from OpsGenie.
 
 
 ### opsgenie-escalate-alert
+
 ***
 Escalate an OpsGenie alert.
 
@@ -683,6 +727,7 @@ Escalate an OpsGenie alert.
 #### Base Command
 
 `opsgenie-escalate-alert`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -710,9 +755,11 @@ Escalate an OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-escalate-alert alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286 escalation_id=9a441a8d-2410-43f4-9ef2-f7a265e12b74```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -733,12 +780,14 @@ Escalate an OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Escalate |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:31.549Z | Alert does not exist | false |
 
 
 ### opsgenie-add-alert-tag
+
 ***
 Add tag to the OpsGenie alert.
 
@@ -746,6 +795,7 @@ Add tag to the OpsGenie alert.
 #### Base Command
 
 `opsgenie-add-alert-tag`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -771,9 +821,11 @@ Add tag to the OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-add-alert-tag alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286 tags=1,2,3```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -794,12 +846,14 @@ Add tag to the OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Add Tags |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:33.376Z | Alert does not exist | false |
 
 
 ### opsgenie-remove-alert-tag
+
 ***
 Remove a tag from the OpsGenie alert.
 
@@ -807,6 +861,7 @@ Remove a tag from the OpsGenie alert.
 #### Base Command
 
 `opsgenie-remove-alert-tag`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -832,9 +887,11 @@ Remove a tag from the OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-remove-alert-tag alert-id=69df59c2-41c6-4866-8c03-65c1ecf5417d-1636973048286 tags=1,2,3```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -855,12 +912,14 @@ Remove a tag from the OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Remove Tags |  |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:35.606Z | Alert does not exist | false |
 
 
 ### opsgenie-get-alert-attachments
+
 ***
 Get the attachments of the alert.
 
@@ -868,6 +927,7 @@ Get the attachments of the alert.
 #### Base Command
 
 `opsgenie-get-alert-attachments`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -892,6 +952,7 @@ Get the attachments of the alert.
 
 
 #### Command Example
+
 ``` ```
 
 #### Human Readable Output
@@ -899,6 +960,7 @@ Get the attachments of the alert.
 
 
 ### opsgenie-get-schedules
+
 ***
 Get a schedule from OpsGenie.
 
@@ -906,6 +968,7 @@ Get a schedule from OpsGenie.
 #### Base Command
 
 `opsgenie-get-schedules`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -928,9 +991,11 @@ Get a schedule from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-get-schedules```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -979,6 +1044,7 @@ Get a schedule from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie Schedule
+
 >|description|enabled|id|name|ownerTeam|rotations|timezone|
 >|---|---|---|---|---|---|---|
 >| Schedule when escalation was activated | true | 5892636c-6183-4788-99d6-6d93b9095194 | Escalation Schedule | id: fbbc3f9a-12f4-4794-9938-7e0a85a06f8b<br/>name: Integration Team |  | Asia/Jerusalem |
@@ -987,6 +1053,7 @@ Get a schedule from OpsGenie.
 
 
 ### opsgenie-get-schedule-overrides
+
 ***
 Get schedule overrides.
 
@@ -994,6 +1061,7 @@ Get schedule overrides.
 #### Base Command
 
 `opsgenie-get-schedule-overrides`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1019,15 +1087,18 @@ Get schedule overrides.
 
 
 #### Command Example
+
 ```!opsgenie-get-schedule-overrides schedule_id=5892636c-6183-4788-99d6-6d93b9095194```
 
 #### Human Readable Output
 
 >### OpsGenie Schedule
+
 >**No entries.**
 
 
 ### opsgenie-get-on-call
+
 ***
 Get the on-call users for the provided schedule.
 
@@ -1035,6 +1106,7 @@ Get the on-call users for the provided schedule.
 #### Base Command
 
 `opsgenie-get-on-call`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1057,9 +1129,11 @@ Get the on-call users for the provided schedule.
 
 
 #### Command Example
+
 ```!opsgenie-get-on-call schedule_id=5892636c-6183-4788-99d6-6d93b9095194```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1090,12 +1164,14 @@ Get the on-call users for the provided schedule.
 #### Human Readable Output
 
 >### OpsGenie Schedule OnCall
+
 >|_parent|onCallParticipants|
 >|---|---|
 >| id: 5892636c-6183-4788-99d6-6d93b9095194<br/>name: Escalation Schedule<br/>enabled: true | {'id': '154d6425-c120-4beb-a3e6-a66c8c44f61d', 'name': 'dvilenchik@paloaltonetworks.com', 'type': 'user'} |
 
 
 ### opsgenie-create-incident
+
 ***
 Create an incident in Opsgenie.
 
@@ -1103,6 +1179,7 @@ Create an incident in Opsgenie.
 #### Base Command
 
 `opsgenie-create-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1130,9 +1207,11 @@ Create an incident in Opsgenie.
 
 
 #### Command Example
+
 ```!opsgenie-create-incident message="test" responders=team,name,test_team,team,name,test_team_1```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1152,12 +1231,14 @@ Create an incident in Opsgenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Create | 4ba53100-30dc-47a6-992a-a96df4d1ba20 | 3cc69931-167f-411c-a331-768997c29d2e | true | 2021-12-01T13:48:49.133Z | Incident created successfully | true |
 
 
 ### opsgenie-delete-incident
+
 ***
 Delete an incident from OpsGenie.
 
@@ -1165,6 +1246,7 @@ Delete an incident from OpsGenie.
 #### Base Command
 
 `opsgenie-delete-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1187,9 +1269,11 @@ Delete an incident from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-delete-incident incident_id=c59086e0-bf2c-44e2-bdfb-ed7747cc126b```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1209,12 +1293,14 @@ Delete an incident from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Delete |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:52.534Z |  | false |
 
 
 ### opsgenie-get-incidents
+
 ***
 List the current incidents from OpsGenie.
 
@@ -1222,6 +1308,7 @@ List the current incidents from OpsGenie.
 #### Base Command
 
 `opsgenie-get-incidents`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1259,9 +1346,11 @@ List the current incidents from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-get-incidents limit=1```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1296,12 +1385,14 @@ List the current incidents from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|id|createdAt|status|
 >|---|---|---|
 >| 4ba53100-30dc-47a6-992a-a96df4d1ba20 | 2021-12-01T13:48:49.006Z | open |
 
 
 ### opsgenie-close-incident
+
 ***
 Close an incident from OpsGenie.
 
@@ -1309,6 +1400,7 @@ Close an incident from OpsGenie.
 #### Base Command
 
 `opsgenie-close-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1332,9 +1424,11 @@ Close an incident from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-close-incident incident_id=c59086e0-bf2c-44e2-bdfb-ed7747cc126b```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1354,12 +1448,14 @@ Close an incident from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Close |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:50.974Z |  | false |
 
 
 ### opsgenie-resolve-incident
+
 ***
 Resolve an incident from OpsGenie.
 
@@ -1367,6 +1463,7 @@ Resolve an incident from OpsGenie.
 #### Base Command
 
 `opsgenie-resolve-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1390,9 +1487,11 @@ Resolve an incident from OpsGenie.
 
 
 #### Command Example
+
 ```!opsgenie-resolve-incident incident_id=b15c7555-d685-4a96-8798-46320618004e```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1412,12 +1511,14 @@ Resolve an incident from OpsGenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Resolve |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:57.042Z |  | false |
 
 
 ### opsgenie-add-responder-incident
+
 ***
 Add a responder to an OpsGenie incident.
 
@@ -1425,6 +1526,7 @@ Add a responder to an OpsGenie incident.
 #### Base Command
 
 `opsgenie-add-responder-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1449,9 +1551,11 @@ Add a responder to an OpsGenie incident.
 
 
 #### Command Example
+
 ```!opsgenie-add-responder-incident incident_id=577424c1-b03c-4d23-9871-da0d395fea17 responders="team,name,Integration Team"```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1471,12 +1575,14 @@ Add a responder to an OpsGenie incident.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Add Responder |  | 3cc69931-167f-411c-a331-768997c29d2e | false | 2021-12-01T13:48:59.193Z | Given teams/users already added as responders. | false |
 
 
 ### opsgenie-add-tag-incident
+
 ***
 Add a tag to the OpsGenie incident.
 
@@ -1484,6 +1590,7 @@ Add a tag to the OpsGenie incident.
 #### Base Command
 
 `opsgenie-add-tag-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1508,9 +1615,11 @@ Add a tag to the OpsGenie incident.
 
 
 #### Command Example
+
 ```!opsgenie-add-tag-incident incident_id=b15c7555-d685-4a96-8798-46320618004e tags=1,2,3```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1530,12 +1639,14 @@ Add a tag to the OpsGenie incident.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Add Tags | b15c7555-d685-4a96-8798-46320618004e | 3cc69931-167f-411c-a331-768997c29d2e | true | 2021-12-01T13:49:00.839Z | Added tags | true |
 
 
 ### opsgenie-remove-tag-incident
+
 ***
 Remove a tag from the OpsGenie alert.
 
@@ -1543,6 +1654,7 @@ Remove a tag from the OpsGenie alert.
 #### Base Command
 
 `opsgenie-remove-tag-incident`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1567,9 +1679,11 @@ Remove a tag from the OpsGenie alert.
 
 
 #### Command Example
+
 ```!opsgenie-remove-tag-incident incident_id=b15c7555-d685-4a96-8798-46320618004e tags=1,2```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1589,17 +1703,20 @@ Remove a tag from the OpsGenie alert.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|incidentId|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|
 >| Remove Tags | b15c7555-d685-4a96-8798-46320618004e | 3cc69931-167f-411c-a331-768997c29d2e | true | 2021-12-01T13:49:02.53Z | Removed tags | true |
 
 ### opsgenie-invite-user
+
 ***
 Invite a user to OpsGenie
 
 #### Base Command
 
 `opsgenie-invite-user`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1618,9 +1735,11 @@ Invite a user to OpsGenie
 
 
 #### Command Example
+
 ```!opsgenie-invite-user username=test@example.com fullName="Test XSOAR" role=user```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1635,11 +1754,13 @@ Invite a user to OpsGenie
 #### Human Readable Output
 
 >### OpsGenie
+
 >|Id|name|
 >|---|---|
 >| 3cc69931-167f-411c-a331-768997c29d2e | test@example.com |
 
 ### opsgenie-get-teams
+
 ***
 Get teams
 
@@ -1647,6 +1768,7 @@ Get teams
 #### Base Command
 
 `opsgenie-get-teams`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1666,9 +1788,11 @@ Get teams
 
 
 #### Command Example
+
 ```!opsgenie-get-teams```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1699,6 +1823,7 @@ Get teams
 #### Human Readable Output
 
 >### OpsGenie Team
+
 >|description|id|links|name|
 >|---|---|---|---|
 >| Engineering | 51d69df8-c40b-439e-9808-e1a78e54f91b | web: https:<span>//</span>demisto1.app.opsgenie.com/teams/dashboard/51d69df8-c40b-439e-9808-e1a78e54f91b/main<br/>api: https:<span>//</span>api.opsgenie.com/v2/teams/51d69df8-c40b-439e-9808-e1a78e54f91b | Engineering |
@@ -1706,12 +1831,14 @@ Get teams
 
 
 ### opsgenie-get-request
+
 ***
 Get a request in Opsgenie.
 
 #### Base Command
 
 `opsgenie-get-request`
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -1745,9 +1872,11 @@ Get a request in Opsgenie.
 
 
 #### Command Example
+
 ```opsgenie-get-request request_id=b79800b2-4378-4249-8677-0bf2332b8a1f request_type=alerts"```
 
 #### Context Example
+
 ```json
 {
     "OpsGenie": {
@@ -1768,6 +1897,7 @@ Get a request in Opsgenie.
 #### Human Readable Output
 
 >### OpsGenie
+
 >|action|alertId|alias|integrationId|isSuccess|processedAt|status|success|
 >|---|---|---|---|---|---|---|---|
 >| Create | 4c4623e3-0b3f-47b7-becd-907d3e51d129-1638366498716 | 4c4623e3-0b3f-47b7-becd-907d3e51d129-1638366498716 | 3cc69931-167f-411c-a331-768997c29d2e | true | 2021-12-01T13:48:18.757Z | Created alert | true |
@@ -1776,18 +1906,20 @@ Get a request in Opsgenie.
 ## Breaking changes from the previous version of this integration - OpsGenie v3
 
 ### Commands
+
 Removed the following commands in this version:
+
 * ***opsgenie-list-alerts*** - this command was replaced by *opsgenie-get-alerts*.
 * ***opsgenie-get-alert*** - this command was replaced by *opsgenie-get-alerts*.
 * ***opsgenie-get-schedule*** - this command was replaced by *opsgenie-get-schedules*.
 * ***opsgenie-list-schedules*** - this command was replaced by *opsgenie-get-schedules*.
 
 ### Arguments
-- In the ***opsgenie-get-on-call*** command, the *schedule-id* argument was replaced by the *schedule_id* and *schedule_name* arguments.
-- In the ***opsgenie-create-alert*** command, the default value of the *priority* argument was changed to 'P3'.
+* In the ***opsgenie-get-on-call*** command, the *schedule-id* argument was replaced by the *schedule_id* and *schedule_name* arguments.
+* In the ***opsgenie-create-alert*** command, the default value of the *priority* argument was changed to 'P3'.
 
 ### Outputs
-- In the ***opsgenie-create-alert*** command the following outputs were replaced:
+* In the ***opsgenie-create-alert*** command the following outputs were replaced:
   * *OpsGenieV2.CreatedAlert.action* - replaced by *OpsGenie.Alert.action*.
   * *OpsGenieV2.CreatedAlert.alertId* - replaced by *OpsGenie.Alert.alertId*.
   * *OpsGenieV2.CreatedAlert.alias* - replaced by *OpsGenie.Alert.alias*.
@@ -1798,7 +1930,7 @@ Removed the following commands in this version:
   * *OpsGenieV2.CreatedAlert.status* - replaced by *OpsGenie.Alert.status*.
   * *OpsGenieV2.CreatedAlert.success* - replaced by *OpsGenie.Alert.success*.
 
-- In the ***opsgenie-delete-alert*** command the following outputs were replaced:
+* In the ***opsgenie-delete-alert*** command the following outputs were replaced:
   * *OpsGenieV2.DeletedAlert.action* - replaced by *OpsGenie.DeletedAlert.action*.
   * *OpsGenieV2.DeletedAlert.alertId* - replaced by *OpsGenie.DeletedAlert.alertId*.
   * *OpsGenieV2.DeletedAlert.alias* - replaced by *OpsGenie.DeletedAlert.alias*.
@@ -1809,7 +1941,7 @@ Removed the following commands in this version:
   * *OpsGenieV2.DeletedAlert.status* - replaced by *OpsGenie.DeletedAlert.status*.
   * *OpsGenieV2.DeletedAlert.success* - replaced by *OpsGenie.DeletedAlert.success*.
 
-- In the ***opsgenie-ack-alert*** command the following outputs were replaced:
+* In the ***opsgenie-ack-alert*** command the following outputs were replaced:
   * *OpsGenieV2.AckedAlert.action* - replaced by *OpsGenie.AckedAlert.action*.
   * *OpsGenieV2.AckedAlert.alertId* -replaced by *OpsGenie.AckedAlert.alertId*.
   * *OpsGenieV2.AckedAlert.alias* -replaced by *OpsGenie.AckedAlert.alias*.
@@ -1820,7 +1952,7 @@ Removed the following commands in this version:
   * *OpsGenieV2.AckedAlert.status* - replaced by *OpsGenie.AckedAlert.status*.
   * *OpsGenieV2.AckedAlert.success* - replaced by *OpsGenie.AckedAlert.success*.
 
-- In the ***opsgenie-get-on-call*** command the following outputs were replaced:
+* In the ***opsgenie-get-on-call*** command the following outputs were replaced:
   * *OpsGenieV2.OnCall._parent.enabled* - replaced by *OpsGenie.Schedule.OnCall._parent.enabled*.
   * *OpsGenieV2.OnCall._parent.id* - replaced by *OpsGenie.Schedule.OnCall._parent.id*.
   * *OpsGenieV2.OnCall._parent.name* - replaced by *OpsGenie.Schedule.OnCall._parent.name*.
@@ -1828,7 +1960,7 @@ Removed the following commands in this version:
   * *OpsGenieV2.OnCall.onCallParticipants.name* - replaced by *OpsGenie.Schedule.OnCall.onCallParticipants.name*.
   * *OpsGenieV2.OnCall.onCallParticipants.type* - replaced by *OpsGenie.Schedule.OnCall.onCallParticipants.type*.
 
-- In the ***opsgenie-close-alert*** command the following outputs were replaced:
+* In the ***opsgenie-close-alert*** command the following outputs were replaced:
   * *OpsGenieV2.CloseAlert.action* - replaced by *OpsGenie.ClosedAlert.action*.
   * *OpsGenieV2.CloseAlert.alertId* - replaced by *OpsGenie.ClosedAlert.alertId*.
   * *OpsGenieV2.CloseAlert.alias* - replaced by *OpsGenie.ClosedAlert.alias*.

--- a/Packs/OpsGenie/ReleaseNotes/2_0_14.md
+++ b/Packs/OpsGenie/ReleaseNotes/2_0_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### OpsGenie v3
+
+- Fixed an issue where opsgenie-create-alert occationally returned polling results which resulted in context path type changes.

--- a/Packs/OpsGenie/ReleaseNotes/2_0_14.md
+++ b/Packs/OpsGenie/ReleaseNotes/2_0_14.md
@@ -3,4 +3,4 @@
 
 ##### OpsGenie v3
 
-- Fixed an issue where opsgenie-create-alert occationally returned polling results which resulted in context path type changes.
+- Fixed an issue where opsgenie-create-alert occasionally returned polling results which resulted in context path type changes.

--- a/Packs/OpsGenie/pack_metadata.json
+++ b/Packs/OpsGenie/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "OpsGenie",
     "description": "Get current on-call assignments, schedules, and users info",
     "support": "xsoar",
-    "currentVersion": "2.0.13",
+    "currentVersion": "2.0.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description

!opsgenie-create-alert occasionally returns polling result and here is OpsGenie.Alert as a dict.

![image](https://user-images.githubusercontent.com/49711791/236151147-9ffbaad4-4273-4dd0-86c6-17a6c07e0351.png)

After polling, a proper response found and this behavior resulted in a type change. OpsGenie.Alert turned into a list below

![image](https://user-images.githubusercontent.com/49711791/236151058-dbe4a861-c85f-44ee-9c72-368200324a63.png)

This PR resolves the issue by writing to OpsGenie.Request rather than OpsGenie.Alert when the integration has to poll for the alert status.


## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
