### PR TITLE
Taxii2Server: typo in an output type

### DIFF
--- a/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
+++ b/Packs/TAXIIServer/Integrations/TAXII2Server/TAXII2Server.py
@@ -62,7 +62,7 @@ XSOAR_TYPES_TO_STIX_SDO = {
     ThreatIntel.ObjectsNames.CAMPAIGN: 'campaign',
     ThreatIntel.ObjectsNames.COURSE_OF_ACTION: 'course-of-action',
     ThreatIntel.ObjectsNames.INFRASTRUCTURE: 'infrastructure',
-    ThreatIntel.ObjectsNames.INTRUSION_SET: 'instruction-set',
+    ThreatIntel.ObjectsNames.INTRUSION_SET: 'intrusion-set',
     ThreatIntel.ObjectsNames.REPORT: 'report',
     ThreatIntel.ObjectsNames.THREAT_ACTOR: 'threat-actor',
     ThreatIntel.ObjectsNames.TOOL: 'tool',

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_33.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_33.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### TAXII2 Server
+- Fixed a typo in the *intrusion-set* type output.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "2.0.32",
+    "currentVersion": "2.0.33",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6358)

## Description
typo in an output type

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
