### PR TITLE
MicrosoftGraphMailApiModule: ignore BA124

### DIFF
--- a/Packs/ApiModules/.pack-ignore
+++ b/Packs/ApiModules/.pack-ignore
@@ -13,5 +13,8 @@ ignore=BA124
 [file:DemistoClassApiModule.yml]
 ignore=BA124
 
+[file:MicrosoftGraphMailApiModule.yml]
+ignore=BA124
+
 [tests_require_network]
 NGINXApiModule


### PR DESCRIPTION


## Description
As all the functionality of MicrosoftGraphMailApiModule are tested in the sub classes (MSGraphMail & MSGraphListener)
there is no need to test it 
add ignore to the .pack_ignoe
prevent [build fails ](https://app.circleci.com/pipelines/github/demisto/demisto-sdk/23529/workflows/eec8edff-cecb-45bf-a093-3d35a0e24bf9)
