### PR TITLE
PreproccessEmail: correct the if condition

### DIFF
--- a/Packs/EmailCommunication/ReleaseNotes/2_0_7.md
+++ b/Packs/EmailCommunication/ReleaseNotes/2_0_7.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### PreprocessEmail
+
+- Fixed an issue where script failed when there is no *emailsubject* in the incident.
+- Updated the Docker image to: *demisto/python3:3.10.11.57293*.

--- a/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail.py
+++ b/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail.py
@@ -267,7 +267,8 @@ def get_email_related_incident_id(email_related_incident_code, email_original_su
     incidents_details = get_incident_by_query(query)
 
     for incident in incidents_details:
-        if email_original_subject in incident.get('emailsubject', ''):
+        email_subject = incident.get('emailsubject', '')
+        if email_subject and email_original_subject in email_subject:
             return str(incident.get('id'))
         else:
             # If 'emailsubject' doesn't match, check 'EmailThreads' context entries

--- a/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail.yml
+++ b/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail.yml
@@ -23,7 +23,7 @@ tags:
 - email
 - preProcessing
 type: python
-dockerimage: demisto/python3:3.10.9.45313
+dockerimage: demisto/python3:3.10.11.57293
 runas: DBotRole
 tests:
 - No tests (auto formatted)

--- a/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail_test.py
+++ b/Packs/EmailCommunication/Scripts/PreprocessEmail/PreprocessEmail_test.py
@@ -503,7 +503,7 @@ def test_get_email_related_incident_id_email_in_context(mocker):
     """
     import PreprocessEmail
     from PreprocessEmail import get_email_related_incident_id
-    mocker.patch.object(PreprocessEmail, 'get_incident_by_query', return_value=[{'emailsubject': '', 'id': '3'}])
+    mocker.patch.object(PreprocessEmail, 'get_incident_by_query', return_value=[{'emailsubject': None, 'id': '3'}])
     mocker.patch.object(demisto, 'executeCommand', return_value=EMAIL_THREADS)
     id = get_email_related_incident_id('69433507', 'Test Email 2')
     assert id == '3'

--- a/Packs/EmailCommunication/pack_metadata.json
+++ b/Packs/EmailCommunication/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Email Communication",
     "description": "Do you have to send multiple emails to end users? This content pack helps you streamline the process and automate updates, notifications and more.\n",
     "support": "xsoar",
-    "currentVersion": "2.0.6",
+    "currentVersion": "2.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "videos": [


### PR DESCRIPTION

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-24033)

## Description
when the emailsubject field of the incident are `None` the script fail due to incorrect if condition

## Screenshots
**updated unit test failed before the fix**
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/79846863/236677823-df68b89d-e6a6-4458-9993-1a3883b4cb5d.png">


**updated unit test pass after the fix**
<img width="572" alt="image" src="https://user-images.githubusercontent.com/79846863/236677839-250c69b3-8793-4acc-9f8c-2fdae985d266.png">

