### PR TITLE
Fix TIM IP enrichment playbook - wrong value in task #134

### DIFF
--- a/Packs/TIM_Processing/.pack-ignore
+++ b/Packs/TIM_Processing/.pack-ignore
@@ -58,3 +58,5 @@ ignore=PB115
 [file:playbook-TIM_-_Run_Enrichment_For_All__Indicator_Types.yml]
 ignore=PB110
 
+[file:playbook-TIM_-_Run_Enrichment_For_IP_Indicators_6_0_0.yml]
+ignore=RM109

--- a/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Run_Enrichment_For_IP_Indicators_6_0_0.yml
+++ b/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Run_Enrichment_For_IP_Indicators_6_0_0.yml
@@ -409,7 +409,7 @@ tasks:
                       iscontext: true
                     right:
                       value:
-                        simple: "0"
+                        simple: "2"
                 accessor: value
             iscontext: true
     view: |-

--- a/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Run_Enrichment_For_IP_Indicators_6_0_0_README.md
+++ b/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Run_Enrichment_For_IP_Indicators_6_0_0_README.md
@@ -1,0 +1,48 @@
+This playbook processes indicators by enriching indicators
+based on the indicator feed's reputation, as specified in the playbook
+inputs. This playbook needs to be used with caution as it might use up the user
+enrichment integration's API license when running enrichment for large amounts of
+indicators.
+
+## Dependencies
+
+This playbook uses the following sub-playbooks, integrations, and scripts.
+
+### Sub-playbooks
+
+This playbook does not use any sub-playbooks.
+
+### Integrations
+
+This playbook does not use any integrations.
+
+### Scripts
+
+This playbook does not use any scripts.
+
+### Commands
+
+* enrichIndicators
+
+## Playbook Inputs
+
+---
+
+| **Name** | **Description** | **Default Value** | **Required** |
+| --- | --- | --- | --- |
+| Indicator Query | Indicators matching the indicator query will be used as playbook input |  | Optional |
+| EnrichBadIndicators | Enter a value of true to enrich indicators whose reputation from the feed is bad. |  | Optional |
+| EnrichGoodIndicators | Enter a value of true to enrich indicators whose reputation from the feed is good. |  | Optional |
+| EnrichSuspiciousIndicators | Enter a value of true to enrich indicators whose reputation from the feed is suspicious. |  | Optional |
+| EnrichUnknownIndicators | Enter a value of true to enrich indicators whose reputation from the feed is unknown. |  | Optional |
+
+## Playbook Outputs
+
+---
+There are no outputs for this playbook.
+
+## Playbook Image
+
+---
+
+![TIM - Run Enrichment For IP Indicators](../doc_files/TIM_-_Run_Enrichment_For_IP_Indicators.png)

--- a/Packs/TIM_Processing/ReleaseNotes/1_1_17.md
+++ b/Packs/TIM_Processing/ReleaseNotes/1_1_17.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### TIM - Run Enrichment For IP Indicators
+
+- Fixed an issue with task 134 in the playbook checking the wrong value (0 and not 2).

--- a/Packs/TIM_Processing/pack_metadata.json
+++ b/Packs/TIM_Processing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TIM - Indicator Auto-Processing",
     "description": "Too many threat feeds? This Content Pack automates the processing of indicators at scale, significantly reducing busywork for your analysts.",
     "support": "xsoar",
-    "currentVersion": "1.1.16",
+    "currentVersion": "1.1.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-23893

## Description
The task needs to check for suspicious IPs but checks for unknown as it is set to "0" and not "2".

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
