### PR TITLE
DBotFindSimilarIncidentsByIndicators - fix fromDate filter

### DIFF
--- a/Packs/Base/ReleaseNotes/1_31_95.md
+++ b/Packs/Base/ReleaseNotes/1_31_95.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotFindSimilarIncidentsByIndicators
+
+- Fixed an issue where the script ignore the *fromDate* argument.

--- a/Packs/Base/ReleaseNotes/1_31_95.md
+++ b/Packs/Base/ReleaseNotes/1_31_95.md
@@ -4,3 +4,4 @@
 ##### DBotFindSimilarIncidentsByIndicators
 
 - Fixed an issue where the script ignore the *fromDate* argument.
+- Updated the Docker image to: *demisto/ml:1.0.0.57750*.

--- a/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.py
@@ -263,7 +263,7 @@ def enriched_incidents(df, fields_incident_to_display, from_date: str):
     if is_error(res):
         return_error(res)
     if not json.loads(res[0]['Contents']):
-        return df
+        return []
     else:
         incidents = json.loads(res[0]['Contents'])
         incidents_dict = {incident['id']: incident for incident in incidents}

--- a/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.yml
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.yml
@@ -83,7 +83,7 @@ subtype: python3
 system: false
 timeout: '0'
 type: python
-dockerimage: demisto/ml:1.0.0.55262
+dockerimage: demisto/ml:1.0.0.57750
 runas: DBotWeakRole
 runonce: false
 tests:

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.31.94",
+    "currentVersion": "1.31.95",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-24078

## Description
The method **enriched_incidents**  call **GetIncidentsByQuery**  with the **from_date**  filter
in case the result from this command is empty :
`if not json.loads(res[0]['Contents']):`
we expected to get empty array and not the `dt` (Incidents dataFrame) value.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
