### PR TITLE
Fixing url in 'core-get-script-execution-result-files'  XSIAM command

### DIFF
--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
@@ -1083,12 +1083,13 @@ class CoreClient(BaseClient):
             timeout=self.timeout,
         )
         link = response.get('reply', {}).get('DATA')
+        demisto.debug(f"From the previous API call, this link was returned {link=}")
         # If the link is None, the API call will result in a 'Connection Timeout Error', so we raise an exception
         if not link:
             raise DemistoException(f'Failed getting response files for {action_id=}, {endpoint_id=}')
         return self._http_request(
             method='GET',
-            full_url=link,
+            url_suffix=re.findall('download.*', link)[0],
             resp_type='response',
         )
 

--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
@@ -3207,3 +3207,22 @@ def test_generate_files_dict(mocker):
                                           file_path_list=['fake\\path1', 'fake\\path2', 'fake\\path3'])
 
     assert res == {"macos": ['fake\\path1'], "linux": ['fake\\path2'], "windows": ['fake\\path3']}
+
+
+def test_get_script_execution_result_files(mocker):
+    """
+    Given:
+    - no arguments
+    When:
+    - executing the get_script_execution_result_files command
+    Then:
+    - Validate that the url_suffix generated correctly
+    """
+    http_request = mocker.patch.object(test_client, '_http_request',
+                                       return_value={
+                                           "reply": {
+                                               "DATA": "https://test_api/public_api/v1/download/test"
+                                           }
+                                       })
+    test_client.get_script_execution_result_files(action_id="1", endpoint_id="1")
+    http_request.assert_called_with(method='GET', url_suffix="download/test", resp_type="response")

--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
@@ -1819,14 +1819,14 @@ def test_get_script_execution_files_command(requests_mock, mocker, request):
             pass
 
     request.addfinalizer(cleanup)
-    zip_link = 'https://example-link'
+    zip_link = 'https://download/example-link'
     zip_filename = 'file.zip'
     requests_mock.post(
         f'{Core_URL}/public_api/v1/scripts/get_script_execution_results_files',
         json={'reply': {'DATA': zip_link}}
     )
     requests_mock.get(
-        zip_link,
+        f"{Core_URL}/public_api/v1/download/example-link",
         content=b'PK\x03\x04\x14\x00\x00\x00\x00\x00%\x98>R\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\r\x00\x00'
                 b'\x00your_file.txtPK\x01\x02\x14\x00\x14\x00\x00\x00\x00\x00%\x98>R\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xb6\x81\x00\x00\x00\x00your_file'

--- a/Packs/Core/ReleaseNotes/1_3_50.md
+++ b/Packs/Core/ReleaseNotes/1_3_50.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Investigation & Response
+
+- Added support for ***core-get-script-execution-result-files*** command to work with XSIAM.

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "1.3.49",
+    "currentVersion": "1.3.50",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CortexXDR/ReleaseNotes/4_10_39.md
+++ b/Packs/CortexXDR/ReleaseNotes/4_10_39.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+
+- Added support for ***core-get-script-execution-result-files*** command to work with XSIAM.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "4.10.38",
+    "currentVersion": "4.10.39",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-21419)

## Description
Fixed the url in the get request. 
In XSOAR, the base URL is the same as in XDR, but in XSIAM we must add "/api/webapp/" before the "public_api/v1/download/" (as we are doing in the main function in the Core integration).