### PR TITLE
MicrosoftGraphListener: remove the "from" arg in "send-mail" and "reply-mail"

### DIFF
--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
@@ -324,8 +324,6 @@ script:
     - description: A CSV list of CIDs to embed attachments within the email itself.
       isArray: true
       name: attachCIDs
-    - description: Email address of the sender.
-      name: from
     - deprecated: true
       description: flag for rate limit retry
       isArray: false
@@ -415,8 +413,6 @@ script:
     - description: A comma-separated list of CIDs to embed attachments within the actual email.
       name: attach_cids
       isArray: true
-    - description: The email address from which to reply.
-      name: from
     - description: Email addresses that need to be used to reply to the message. Supports comma-separated values.
       isArray: true
       name: replyTo
@@ -759,7 +755,7 @@ script:
     execution: false
     name: msgraph-mail-generate-login-url
     arguments: []
-  dockerimage: demisto/crypto:1.0.0.57063
+  dockerimage: demisto/crypto:1.0.0.58768
   isfetch: true
   runonce: false
   script: ''

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/README.md
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/README.md
@@ -144,7 +144,6 @@ Replies to an email using Graph Mail Single User.
 | htmlBody | HTML formatted content (body) of the email to be sent. This argument overrides the "body" argument. | Optional | 
 | attachNames | A comma-separated list of names of attachments to send. Should be the same number of elements as attachIDs. | Optional | 
 | attachCIDs | A comma-separated list of CIDs to embed attachments within the email itself. | Optional | 
-| from | Email address of the sender. | Optional | 
 
 
 #### Context Output
@@ -190,7 +189,6 @@ Sends an email using Microsoft Graph.
 | attach_ids | A comma-separated list of War Room entry IDs that contain files, which are used to attach files for the email to send. For example, attachIDs=15@8,19@8. | Optional | 
 | attach_names | A comma-separated list of names of attachments to display in the email to send. Must be the same number of elements as attachIDs. | Optional | 
 | attach_cids | A comma-separated list of CIDs to embed attachments within the actual email. | Optional | 
-| from | The email address from which to reply. | Optional | 
 | replyTo | Email addresses that need to be used to reply to the message. Supports comma-separated values. | Optional | 
 
 

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_2.json
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_2.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"Removed the *from* argument from the **send-mail***, **reply-mail***  commands as they are not allowed in Single User."}

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_2.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_2.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### Microsoft Graph Mail Single User
+
+- Removed the *from* argument from the **send-mail***, **reply-mail***  commands as they are not allowed in Single User. 
+
+- Updated the Docker image to: *demisto/crypto:1.0.0.58768*.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.5.1",
+    "currentVersion": "1.5.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-24185

## Description
As `Single User` integration comes to provide mail functionalities for a single user, the `from`
arg is not supported in the `send-mail` and `reply-mail`, the sender will be the email configured in the `Email address from which to fetch incidents` integration param

