### PR TITLE
Fixed an issue in upload where a variable is referenced before assignment

### DIFF
--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -931,7 +931,7 @@ def get_images_data(packs_list: list, readme_images_dict: dict):
     pack_image_data: dict = {}
 
     for pack in packs_list:
-        pack_image_data: dict = {pack.name: {}}
+        pack_image_data[pack.name] = {}
         if pack.uploaded_author_image:
             pack_image_data[pack.name][BucketUploadFlow.AUTHOR] = True
         if pack.uploaded_integration_images:

--- a/Tests/Marketplace/upload_packs.py
+++ b/Tests/Marketplace/upload_packs.py
@@ -928,6 +928,7 @@ def get_images_data(packs_list: list, readme_images_dict: dict):
         The images data structure
     """
     images_data = {}
+    pack_image_data: dict = {}
 
     for pack in packs_list:
         pack_image_data: dict = {pack.name: {}}


### PR DESCRIPTION
## Description
Fixed an issue where `UnboundLocalError: local variable 'pack_image_data' referenced before assignment` in https://code.pan.run/xsoar/content/-/jobs/25799984.