### PR TITLE
Deprecate opsgenieV2

### DIFF
--- a/Packs/Opsgeniev2/Integrations/Opsgeniev2/Opsgeniev2.yml
+++ b/Packs/Opsgeniev2/Integrations/Opsgeniev2/Opsgeniev2.yml
@@ -2,7 +2,6 @@ category: Messaging and Conferencing
 commonfields:
   id: Opsgeniev2
   version: -1
-deprecated: true
 configuration:
 - defaultvalue: https://api.opsgenie.com
   display: Server URL (e.g. https://example.net)
@@ -24,7 +23,8 @@ configuration:
   required: false
   type: 4
 description: Deprecated. Use the OpsGenieV3 integration instead.
-display: Opsgenie v2
+display: Opsgenie v2 (Deprecated)
+deprecated: true
 name: Opsgeniev2
 fromversion: 6.0.0
 tests:

--- a/Packs/Opsgeniev2/Integrations/Opsgeniev2/Opsgeniev2.yml
+++ b/Packs/Opsgeniev2/Integrations/Opsgeniev2/Opsgeniev2.yml
@@ -2,6 +2,7 @@ category: Messaging and Conferencing
 commonfields:
   id: Opsgeniev2
   version: -1
+deprecated: true
 configuration:
 - defaultvalue: https://api.opsgenie.com
   display: Server URL (e.g. https://example.net)
@@ -22,7 +23,7 @@ configuration:
   name: token
   required: false
   type: 4
-description: Integration with Atlassian OpsGenie V2
+description: Deprecated. Use the OpsGenieV3 integration instead.
 display: Opsgenie v2
 name: Opsgeniev2
 fromversion: 6.0.0

--- a/Packs/Opsgeniev2/ReleaseNotes/1_0_6.md
+++ b/Packs/Opsgeniev2/ReleaseNotes/1_0_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Opsgenie v2
+
+- Deprecated. Use the OpsGenieV3 integration instead.

--- a/Packs/Opsgeniev2/ReleaseNotes/1_0_6.md
+++ b/Packs/Opsgeniev2/ReleaseNotes/1_0_6.md
@@ -1,6 +1,7 @@
 
 #### Integrations
 
-##### Opsgenie v2
+##### Opsgenie v2 (Deprecated)
 
 - Deprecated. Use the OpsGenieV3 integration instead.
+

--- a/Packs/Opsgeniev2/pack_metadata.json
+++ b/Packs/Opsgeniev2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Opsgenie v2",
     "description": "Create and read alerts, schedules and on-call information from OpsGenie.",
     "support": "community",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Adam Baumeister",
     "url": "",
     "email": "",

--- a/Packs/Opsgeniev2/pack_metadata.json
+++ b/Packs/Opsgeniev2/pack_metadata.json
@@ -1,6 +1,6 @@
 {
-    "name": "Opsgenie v2",
-    "description": "Create and read alerts, schedules and on-call information from OpsGenie.",
+    "name": "Opsgenie v2 (Deprecated)",
+    "description": "Deprecated. Use OpsGenie instead.",
     "support": "community",
     "currentVersion": "1.0.6",
     "author": "Adam Baumeister",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/CIAC-6615

## Description
Deprecate the **opsgeniev2** integration

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
