### PR TITLE
[DockerHardeningCheck] - remove ignore from native:dev

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -147,7 +147,6 @@
          "ignored_native_images":[
             "native:8.1",
             "native:8.2",
-            "native:dev",
             "native:candidate"
          ]
       },


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5248)

## Description
[DockerHardeningCheck] - remove ignore from native:dev


