### PR TITLE
Limit Hypothesis Examples

### DIFF
--- a/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector.yml
+++ b/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector.yml
@@ -58,7 +58,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.11.57890
+  dockerimage: demisto/python3:3.10.11.58677
 marketplaces:
 - marketplacev2
 fromversion: 6.10.0

--- a/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector_test.py
+++ b/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector_test.py
@@ -25,7 +25,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from CommonServerPython import *
-from hypothesis import given, strategies as st
+from hypothesis import given, strategies as st, settings
 from freezegun import freeze_time
 
 """ Constants """
@@ -45,9 +45,9 @@ DETECTIONS: Dict[str, Any] = load_json(Path("./test_data/search_detections.json"
 """ VectraClient Tests """
 
 
+@settings(max_examples=10)
 @given(st.text())
 def test_create_headers(token: str):
-
     """
     Given:
         - A Vectra client.
@@ -86,7 +86,6 @@ def test_test_module(mocker: MockerFixture):
 
 
 def test_test_module_exception(mocker: MockerFixture):
-
     """
     Given
     - A dictionary of endpoints
@@ -205,7 +204,6 @@ class TestCommands:
         detections: Dict[str, Any],
         audits: Dict[str, Any],
     ):
-
         """
         Given:
             - Fetching for the first time, first_fetch set to default (3 days)
@@ -384,7 +382,6 @@ def test_add_parsing_rules(event: Dict[str, Any], expected_time: str, format: st
     ],
 )
 def test_get_most_recent_detection(detections: List[Dict[str, Any]], expected: str):
-
     """
     Given: A list of detections
 

--- a/Packs/Vectra_AI/ReleaseNotes/1_2_3.md
+++ b/Packs/Vectra_AI/ReleaseNotes/1_2_3.md
@@ -1,0 +1,3 @@
+##### Vectra_AI
+
+- Fixed an issue with the unit test **test_create_headers** failing because of a met deadline.

--- a/Packs/Vectra_AI/ReleaseNotes/1_2_3.md
+++ b/Packs/Vectra_AI/ReleaseNotes/1_2_3.md
@@ -1,3 +1,7 @@
-##### Vectra_AI
+#### Integrations
+
+##### Vectra AI Event Collector
 
 - Fixed an issue with the unit test **test_create_headers** failing because of a met deadline.
+- Updated the Docker image to: *demisto/python3:3.10.11.58677*.
+

--- a/Packs/Vectra_AI/pack_metadata.json
+++ b/Packs/Vectra_AI/pack_metadata.json
@@ -4,7 +4,7 @@
         "Network Security"
     ],
     "created": "2022-06-27T10:00:00Z",
-    "currentVersion": "1.2.2",
+    "currentVersion": "1.2.3",
     "description": "This content pack allows to create incidents based on Vectra Accounts/Hosts/Detections objects.",
     "devEmail": [
         "tme@vectra.ai"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6639

## Description
Nightly job failed https://code.pan.run/xsoar/content/-/jobs/25812483.

Basically the `given` decorator is what is fed as input into the function `test_create_headers`. the argument that is fed into the given is `strategies.text()` which means that it generates a very large amount of `str`-type inputs into the function.

i looked further at the log out of curiosity and found why this test was considered flaky. looks like when the generated str that we use as input to the test function is “/X”, we see the following printed:

```python
message = "Hypothesis test_create_headers(token='X/') produces unreliable results:
                  Falsified on the first call but did not on a subsequent one"
```

I scrolled up a bit and saw the following:

```python
raise DeadlineExceeded(runtime, self.settings.deadline)
E           hypothesis.errors.DeadlineExceeded: Test took 298.09ms, which exceeds the deadline of 200.00ms
```

So it seems that because the hypothesis execution for this test timed out, the test was unreliable/flaky (since the result wasn’t consistent across different executions).
After discussion with @yucohen  we decided the best solution is to set `max_examples=10` (default is 100 comparisons made).

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
