### PR TITLE
[QualysV2] Add asset-tag related documentation

### DIFF
--- a/Packs/qualys/.secrets-ignore
+++ b/Packs/qualys/.secrets-ignore
@@ -63,3 +63,4 @@ https://www.qualys.com
 5.2.8.9
 https://qualysapi.<tenant>.apps.qualys.com/<end-point>
 https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf
+https://qualysapi..apps.qualys.com

--- a/Packs/qualys/.secrets-ignore
+++ b/Packs/qualys/.secrets-ignore
@@ -61,3 +61,5 @@ https://www.qualys.com
 1.4.3.6
 1.4.3.9
 5.2.8.9
+https://qualysapi.<tenant>.apps.qualys.com/<end-point>
+https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -7,8 +7,8 @@ configuration:
   display: Server URL
   name: url
   required: true
-  additionalinfo: "When using asset-tag commands, the official documentation recommends that the SERVER URL parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`. For more details see the integration documentation."
   type: 0
+  additionalinfo: "When using asset-tag commands, the official documentation recommends that the SERVER URL parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`. For more details see the integration documentation."
 - display: Username
   name: credentials
   required: true
@@ -2670,7 +2670,7 @@ script:
     description: Delete an existing asset tag.
     name: qualys-asset-tag-delete
 
-  dockerimage: demisto/python3:3.10.11.54132
+  dockerimage: demisto/python3:3.10.11.58677
   runonce: false
   script: ''
   subtype: python3

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -7,6 +7,7 @@ configuration:
   display: Server URL
   name: url
   required: true
+  additionalinfo: "When using asset-tag commands, the official documentation recommends that the SERVER URL parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`. For more details see the integration documentation."
   type: 0
 - display: Username
   name: credentials

--- a/Packs/qualys/Integrations/Qualysv2/README.md
+++ b/Packs/qualys/Integrations/Qualysv2/README.md
@@ -68,7 +68,7 @@ This integration was integrated and tested with version 2.0 of QualysVulnerabili
 
 4. Click **Test** to validate the URLs, token, and connection.
 
-## Asset Tags Commands
+## Asset Tag Commands
 When using `asset-tag` commands, the [official documentation](https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf) recommends that the `SERVER URL` parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`.
 
 ## Commands

--- a/Packs/qualys/Integrations/Qualysv2/README.md
+++ b/Packs/qualys/Integrations/Qualysv2/README.md
@@ -69,6 +69,7 @@ This integration was integrated and tested with version 2.0 of QualysVulnerabili
 4. Click **Test** to validate the URLs, token, and connection.
 
 ## Asset Tag Commands
+There are several API endpoints on the Qualys API that can be used in the QualysV2 integration configurations as the `SERVER URL` parameter.
 When using `asset-tag` commands, the [official documentation](https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf) recommends that the `SERVER URL` parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`.
 
 ## Commands

--- a/Packs/qualys/Integrations/Qualysv2/README.md
+++ b/Packs/qualys/Integrations/Qualysv2/README.md
@@ -67,6 +67,10 @@ This integration was integrated and tested with version 2.0 of QualysVulnerabili
     | Use system proxy settings | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
+
+## Asset Tags Commands
+When using `asset-tag` commands, the [official documentation](https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf) recommends that the `SERVER URL` parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`.
+
 ## Commands
 You can execute these commands from the Cortex XSOAR CLI, as part of an automation, or in a playbook.
 After you successfully execute a command, a DBot message appears in the War Room with the command details.

--- a/Packs/qualys/Integrations/Qualysv2/README.md
+++ b/Packs/qualys/Integrations/Qualysv2/README.md
@@ -69,7 +69,7 @@ This integration was integrated and tested with version 2.0 of QualysVulnerabili
 4. Click **Test** to validate the URLs, token, and connection.
 
 ## Asset Tag Commands
-There are several API endpoints on the Qualys API that can be used in the QualysV2 integration configurations as the `SERVER URL` parameter.
+There are several API endpoints on the Qualys API that can be used in the QualysV2 integration configuration as the `SERVER URL` parameter.
 When using `asset-tag` commands, the [official documentation](https://www.qualys.com/docs/qualys-asset-management-tagging-api-v2-user-guide.pdf) recommends that the `SERVER URL` parameter should be in the following format: `https://qualysapi.<tenant>.apps.qualys.com/<end-point>`.
 
 ## Commands

--- a/Packs/qualys/ReleaseNotes/1_2_7.md
+++ b/Packs/qualys/ReleaseNotes/1_2_7.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Qualys v2
+
+- Updated the documentation on the SERVER URL parameter when using asset-tag commands.
+- Updated the Docker image to: *demisto/python3:3.10.11.58677*.

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Qualys",
     "description": "Qualys Vulnerability Management let's you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance",
     "support": "xsoar",
-    "currentVersion": "1.2.6",
+    "currentVersion": "1.2.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
There are several API endpoints on the Qualys API that can be used in the QualysV2 integration configurations as the `SERVER URL` parameter.
Due to a recent [issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-23644), this PR adds relevant info about making use of the right `SERVER URL` parameter when using asset-tags commands.

## Screenshots
![image](https://github.com/demisto/content/assets/65926551/3d9a8431-63d3-4132-851d-20ad33fa5d4c)
![image](https://github.com/demisto/content/assets/65926551/1c9dcf12-3a39-40f5-911a-792b1e7af217)

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
