### PR TITLE
Ignore Modeling Rules test conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,9 @@ Packs/**/Scripts/**/.pytest.ini
 pytest_report.json
 test_runner.sh
 
-
 # log files
 demisto_sdk_debug.log
 demisto_sdk_debug.log.*
+
+# Ignore Modeling Rules test conf
+Packs/**/ModelingRules/**/**/*_testdata.json


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6696

## Description
Since we don't want to add Modeling Rules test configuration to `content` repository, we can add it to `gitignore`. 
The PR adds a `glob` pattern to match the expected directory and files of Modeling Rules test configuration.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
