### PR TITLE
updating cve command parameter cve to cve_id

### DIFF
--- a/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2.py
+++ b/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2.py
@@ -550,7 +550,7 @@ def file_command(client: Client, args: Dict) -> List[CommandResults]:
 
 def cve_command(client: Client, args: Dict) -> List[CommandResults]:
 
-    cves = argToList(args.get("cve"))
+    cves = argToList(args.get("cve_id"))
     command_results_list: List[CommandResults] = []
 
     for cve in cves:

--- a/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2.yml
+++ b/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2.yml
@@ -128,9 +128,9 @@ script:
       type: String
   - arguments:
     - default: true
-      description: A comma-separated list of CVE names.
+      description: A comma-separated list of CVE ID.
       isArray: true
-      name: cve
+      name: cve_id
       required: true
       secret: false
     deprecated: false
@@ -1245,7 +1245,7 @@ script:
     - contextPath: ThreatVault.ATP.PCAP.Name
       description: Threatvault ATP PCAP Name
       type: string
-  dockerimage: demisto/crypto:1.0.0.58095
+  dockerimage: demisto/crypto:1.0.0.59835
   isfetch: true
   runonce: false
   script: ''

--- a/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2_test.py
+++ b/Packs/PaloAltoNetworks_Threat_Vault/Integrations/ThreatVaultv2/ThreatVaultv2_test.py
@@ -114,7 +114,7 @@ def test_commands_failure(command, demisto_args, expected_results):
         ),
         (
             cve_command,
-            {"cve": "1234567890"},
+            {"cve_id": "1234567890"},
             "CVE 1234567890 vulnerability reputation is unknown to Threat Vault.",
             None,
         ),
@@ -684,7 +684,7 @@ def test_file_command(mocker, args, resp, expected_results):
 
 CVE_COMMAND_ARGS = [
     (
-        {"cve": "CVE-2011-1272"},
+        {"cve_id": "CVE-2011-1272"},
         [
             {
                 "data": {
@@ -718,7 +718,7 @@ CVE_COMMAND_ARGS = [
         },
     ),
     (
-        {"cve": "CVE-2011-1272,CVE-2011-1272"},
+        {"cve_id": "CVE-2011-1272,CVE-2011-1272"},
         [
             {
                 "data": {

--- a/Packs/PaloAltoNetworks_Threat_Vault/ReleaseNotes/2_0_7.md
+++ b/Packs/PaloAltoNetworks_Threat_Vault/ReleaseNotes/2_0_7.md
@@ -1,0 +1,11 @@
+#### Integrations
+
+##### Palo Alto Networks Threat Vault v2
+- Updated the Docker image to: *demisto/crypto:1.0.0.59835*.
+- Updated 1 command:
+  - ***cve***: Changed CVE command from *cve* to *cve_id* to align with other cve commands from integrations for Prisma Cloud and CVE Search.
+
+#### Scripts
+
+##### SetThreatVaultIncidentMarkdownRepresentation
+- Updated the Docker image to: *demisto/python3:3.10.11.59581*.

--- a/Packs/PaloAltoNetworks_Threat_Vault/Scripts/SetThreatVaultIncidentMarkdownRepresentation/SetThreatVaultIncidentMarkdownRepresentation.yml
+++ b/Packs/PaloAltoNetworks_Threat_Vault/Scripts/SetThreatVaultIncidentMarkdownRepresentation/SetThreatVaultIncidentMarkdownRepresentation.yml
@@ -11,7 +11,7 @@ enabled: true
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.11.57890
+dockerimage: demisto/python3:3.10.11.59581
 runas: DBotWeakRole
 fromversion: 6.2.0
 tests:

--- a/Packs/PaloAltoNetworks_Threat_Vault/TestPlaybooks/ThreatVaultv2_-_Test.yml
+++ b/Packs/PaloAltoNetworks_Threat_Vault/TestPlaybooks/ThreatVaultv2_-_Test.yml
@@ -166,7 +166,7 @@ tasks:
       '#none#':
       - "5"
     scriptarguments:
-      cve:
+      cve_id:
         simple: CVE-2020-2040
     separatecontext: false
     continueonerrortype: ""

--- a/Packs/PaloAltoNetworks_Threat_Vault/TestPlaybooks/Threat_Vault_-_Signature_Search-Test.yml
+++ b/Packs/PaloAltoNetworks_Threat_Vault/TestPlaybooks/Threat_Vault_-_Signature_Search-Test.yml
@@ -47,7 +47,7 @@ tasks:
       '#none#':
       - "3"
     scriptarguments:
-      cve:
+      cve_id:
         simple: CVE-2015-8650
       domain_name: {}
       from:

--- a/Packs/PaloAltoNetworks_Threat_Vault/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_Threat_Vault/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Threat Vault by Palo Alto Networks",
     "description": "Use the Palo Alto Networks Threat Vault to research the latest threats (vulnerabilities/exploits, viruses, and spyware) that Palo Alto Networks next-generation firewalls can detect and prevent.",
     "support": "xsoar",
-    "currentVersion": "2.0.6",
+    "currentVersion": "2.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
@@ -18,7 +18,8 @@
         "logs",
         "antispyware",
         "antivirus",
-        "pan-os"
+        "pan-os",
+        "CVE"
     ],
     "dependencies": {
         "CommonScripts": {


### PR DESCRIPTION
cve command used cve as parameter which was different than other commands that searched for CVE in XSOAR. aligning to the parameters from other cve search  including prisma cloud and cve search integrations. dropping cve
adding cve_id to align

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Change the CVE command parameter from cve to cve_id to align with other CVE search command parameters (CVE Search V2, Prisma Cloud Compute)

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details: parameter (required) cve change to cve_id
   - [ ] No

## Must have
- [x] Tests
- [ ] Documentation 
