### PR TITLE
Remove Poetry Installation During `add_pr_link_to_related_jira_issue` Job

### DIFF
--- a/.github/workflows/link_edited_pr_to_jira_issue.yml
+++ b/.github/workflows/link_edited_pr_to_jira_issue.yml
@@ -17,15 +17,9 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.10'
-      - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v7
-      - uses: actions/cache@v2
-        with:
-          path: .venv
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install Python Dependencies
         run: |
-          poetry install --with ci
+          pip install -r 'Utils/github_workflow_scripts/jira_integration_scripts/requirements.txt'
       - name: Run Linking pr to Jira Script
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6715)

## Description
Remove unnecessary Poetry installation during the `add_pr_link_to_related_jira_issue` job.