### PR TITLE
handle external pr workflow: downgrade the changed-files version

### DIFF
--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35.9.0  # disable-secrets-detection
+        uses: tj-actions/changed-files@v35.1.0
         with:
           separator: ${{ env.CHANGED_FILES_DELIMITER }}
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Downgrade the changed-files because the newest version causes issues.

example:
https://github.com/demisto/content/actions/runs/5038409895/jobs/9035879956?pr=26669

we will use in the external pr workflow the same version as we have in update_release_notes.
