### PR TITLE
add fetch-depth - handle external pr workflow

### DIFF
--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## PR Description
Fixes an issue where the `changed-files` in the `handle-new-external-pr.yml` workflow failed on the following error:

```
  Error: Similar commit hashes detected: previous sha: d547ae0268b99a344c9f9d19032f98f80493bc67 is equivalent to the current sha: d547ae0268b99a344c9f9d19032f98f80493bc67.
  Error: Please verify that both commits are valid, and increase the fetch_depth to a number higher than 50.
  Error: Process completed with exit code 1.
```

the fetch-depth = 2 will retrieve the previous commit.
for more info see: https://github.com/tj-actions/changed-files#usage

 
![image](https://github.com/demisto/content/assets/53861351/12a7db29-28c1-4490-903f-bfcc1d176f46)
