### PR TITLE
handle external pr workflow: checkout to the triggered branch

### DIFF
--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-          ref: ${{ github.ref }}  # check out to the branch that triggered the workflow, by default actions/checkout checks out to the master for the 'pull_request_target' event.
+          ref: ${{ github.event.pull_request.head.ref }}  # check out to the branch that triggered the workflow, by default actions/checkout checks out to the master for the 'pull_request_target' event.
 
       - name: Setup Python
         uses: actions/setup-python@v3

--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
+          ref: ${{ github.ref }}  # check out to the branch that triggered the workflow, by default actions/checkout checks out to the master for the 'pull_request_target' event.
 
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
Fixed an issue where the `handle-new-external-pr.yml` workflow checks out to the master by default causing the following failure:

```
  Error: Similar commit hashes detected: previous sha: d547ae0268b99a344c9f9d19032f98f80493bc67 is equivalent to the current sha: d547ae0268b99a344c9f9d19032f98f80493bc67.
  Error: Please verify that both commits are valid, and increase the fetch_depth to a number higher than 50.
  Error: Process completed with exit code 1.
```

that happens because the checkout step checks out to the master branch instead of the branch that triggered the workflow.

see [https://github.com/actions/checkout/issues/20](https://github.com/actions/checkout/issues/20#issuecomment-524521113) as a solution

see also the two workflows for the test branch:
1. review-release-notes which checks out to the triggered branch: https://github.com/demisto/content/actions/runs/5039367295/jobs/9037462417?pr=26678

see that the github ref for it is: `GITHUB_REF: refs/pull/26678/merge` which is the current pull request.

2. handle external pr which checks out to the master branch causing the error: https://github.com/demisto/content/actions/runs/5039367206/jobs/9037510926?pr=26678

see that the github ref for it is: `GITHUB_REF: refs/heads/master` which causes the issue


references: https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git