### PR TITLE
Support label feature fixes

### DIFF
--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -1,5 +1,7 @@
 name: Handle New External PRs
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened]
 
 permissions:
   contents: read
@@ -7,7 +9,7 @@ permissions:
 jobs:
   handle_new_external_pr:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content'
+    if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
   handle_new_external_pr:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
+    if: github.repository == 'demisto/content'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -1,13 +1,8 @@
 name: Handle New External PRs
-on:
-  pull_request_target:
-    types: [opened]
+on: pull_request
 
 permissions:
   contents: read
-
-env:
-  CHANGED_FILES_DELIMITER: ";"
 
 jobs:
   handle_new_external_pr:
@@ -35,12 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install pipenv==2021.5.29
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v35.1.0
-        with:
-          separator: ${{ env.CHANGED_FILES_DELIMITER }}
-
       - name: Update External PR
         env:
           CONTENTBOT_GH_ADMIN_TOKEN: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}
@@ -50,7 +39,7 @@ jobs:
           cd Utils/github_workflow_scripts
           pipenv sync
           
-          pipenv run ./handle_external_pr.py --changed_files "${{ steps.changed-files.outputs.all_changed_files }}" --delimiter "${{ env.CHANGED_FILES_DELIMITER }}"
+          pipenv run ./handle_external_pr.py
           echo "Finished Handling External PR"
       - name: Send Notification
         env:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -13125,7 +13125,7 @@ def get_query_entries(log_type: str, query: str, max_fetch: int) -> List[Dict[An
             entries.append(result)
         else:
             raise DemistoException(f'Could not parse fetch results: {result}')
-    demisto.info('test')
+
     entries_log_info = {entry.get('seqno',''):entry.get('time_generated') for entry in entries}
     demisto.debug(f'{log_type} log type: {len(entries)} raw incidents (entries) found.')
     demisto.debug(f'fetched raw incidents (entries) are (ID:time_generated): {entries_log_info}')

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -13125,7 +13125,7 @@ def get_query_entries(log_type: str, query: str, max_fetch: int) -> List[Dict[An
             entries.append(result)
         else:
             raise DemistoException(f'Could not parse fetch results: {result}')
-
+    demisto.info('test')
     entries_log_info = {entry.get('seqno',''):entry.get('time_generated') for entry in entries}
     demisto.debug(f'{log_type} log type: {len(entries)} raw incidents (entries) found.')
     demisto.debug(f'fetched raw incidents (entries) are (ID:time_generated): {entries_log_info}')

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -151,6 +151,10 @@ def main():
     pr_number = payload.get('pull_request', {}).get('number')
     pr = content_repo.get_pull(pr_number)
     print(f'{pr.get_files()=}')
+    for file in pr.get_files():
+        print(f'{file=}')
+
+    print(f'{list(pr.get_files())=}')
 
     labels_to_add = [CONTRIBUTION_LABEL]
 

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -152,9 +152,10 @@ def main():
     pr = content_repo.get_pull(pr_number)
     print(f'{pr.get_files()=}')
     for file in pr.get_files():
-        print(f'{file=}')
+        print(f'{file.filename=}')
 
-    print(f'{list(pr.get_files())=}')
+    file_names = [file.filename for file in pr.get_files()]
+    print(f'{file_names=}')
 
     labels_to_add = [CONTRIBUTION_LABEL]
 

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -151,11 +151,11 @@ def main():
     pr_number = payload.get('pull_request', {}).get('number')
     pr = content_repo.get_pull(pr_number)
 
-    changed_file_paths = [file.filename for file in pr.get_files()]
-    print(f'{changed_file_paths=} for {pr_number=}')
+    changed_files_paths = [file.filename for file in pr.get_files()]
+    print(f'{changed_files_paths=} for {pr_number=}')
 
     labels_to_add = [CONTRIBUTION_LABEL]
-    if support_label := get_packs_support_level_label(changed_file_paths):
+    if support_label := get_packs_support_level_label(changed_files_paths):
         labels_to_add.append(support_label)
 
     # Add 'Contribution' + support Label to the external PR

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -30,6 +30,7 @@ PARTNER_SUPPORT_LEVEL_LABEL = 'Partner Support Level'
 COMMUNITY_SUPPORT_LEVEL_LABEL = 'Community Support Level'
 CONTRIBUTION_LABEL = 'Contribution'
 
+
 def determine_reviewer(potential_reviewers: List[str], repo: Repository) -> str:
     """Checks the number of open 'Contribution' PRs that have either been assigned to a user or a review
     was requested from the user for each potential reviewer and returns the user with the smallest amount

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import json
 
 from typing import List, Set

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -150,16 +150,15 @@ def main():
     content_repo = gh.get_repo(f'{org_name}/{repo_name}')
     pr_number = payload.get('pull_request', {}).get('number')
     pr = content_repo.get_pull(pr_number)
-    print(f'{pr.get_files()=}')
-    for file in pr.get_files():
-        print(f'{file.filename=}')
 
-    file_names = [file.filename for file in pr.get_files()]
-    print(f'{file_names=}')
+    changed_file_names = [file.filename for file in pr.get_files()]
+    print(f'{changed_file_names=} for {pr_number=}')
 
     labels_to_add = [CONTRIBUTION_LABEL]
+    if support_label := get_packs_support_level_label(changed_file_names):
+        labels_to_add.append(support_label)
 
-    # Add 'Contribution' label
+    # Add 'Contribution' label + support label
     for label in labels_to_add:
         pr.add_to_labels(label)
         print(f'{t.cyan}Added "{label}" label to the PR{t.normal}')

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -164,40 +164,40 @@ def main():
         print(f'{t.cyan}Added "{label}" label to the PR{t.normal}')
 
     # check base branch is master
-    # if pr.base.ref == 'master':
-    #     print(f'{t.cyan}Determining name for new base branch{t.normal}')
-    #     branch_prefix = 'contrib/'
-    #     new_branch_name = f'{branch_prefix}{pr.head.label.replace(":", "_")}'
-    #     existant_branches = content_repo.get_git_matching_refs(f'heads/{branch_prefix}')
-    #     potential_conflicting_branch_names = [branch.ref.lstrip('refs/heads/') for branch in existant_branches]
-    #     # make sure new branch name does not conflict with existing branch name
-    #     while new_branch_name in potential_conflicting_branch_names:
-    #         # append or increment digit
-    #         if not new_branch_name[-1].isdigit():
-    #             new_branch_name += '-1'
-    #         else:
-    #             digit = str(int(new_branch_name[-1]) + 1)
-    #             new_branch_name = f'{new_branch_name[:-1]}{digit}'
-    #     master_branch_commit_sha = content_repo.get_branch('master').commit.sha
-    #     # create new branch
-    #     print(f'{t.cyan}Creating new branch "{new_branch_name}"{t.normal}')
-    #     content_repo.create_git_ref(f'refs/heads/{new_branch_name}', master_branch_commit_sha)
-    #     # update base branch of the PR
-    #     pr.edit(base=new_branch_name)
-    #     print(f'{t.cyan}Updated base branch of PR "{pr_number}" to "{new_branch_name}"{t.normal}')
-    #
-    # # assign reviewers / request review from
-    # reviewer_to_assign = determine_reviewer(REVIEWERS, content_repo)
-    # pr.add_to_assignees(reviewer_to_assign)
-    # pr.create_review_request(reviewers=[reviewer_to_assign])
-    # print(f'{t.cyan}Assigned user "{reviewer_to_assign}" to the PR{t.normal}')
-    # print(f'{t.cyan}Requested review from user "{reviewer_to_assign}"{t.normal}')
-    #
-    # # create welcome comment (only users who contributed through Github need to have that contribution form filled)
-    # message_to_send = WELCOME_MSG if pr.user.login == MARKETPLACE_CONTRIBUTION_PR_AUTHOR else WELCOME_MSG_WITH_GFORM
-    # body = message_to_send.format(selected_reviewer=reviewer_to_assign)
-    # pr.create_issue_comment(body)
-    # print(f'{t.cyan}Created welcome comment{t.normal}')
+    if pr.base.ref == 'master':
+        print(f'{t.cyan}Determining name for new base branch{t.normal}')
+        branch_prefix = 'contrib/'
+        new_branch_name = f'{branch_prefix}{pr.head.label.replace(":", "_")}'
+        existant_branches = content_repo.get_git_matching_refs(f'heads/{branch_prefix}')
+        potential_conflicting_branch_names = [branch.ref.lstrip('refs/heads/') for branch in existant_branches]
+        # make sure new branch name does not conflict with existing branch name
+        while new_branch_name in potential_conflicting_branch_names:
+            # append or increment digit
+            if not new_branch_name[-1].isdigit():
+                new_branch_name += '-1'
+            else:
+                digit = str(int(new_branch_name[-1]) + 1)
+                new_branch_name = f'{new_branch_name[:-1]}{digit}'
+        master_branch_commit_sha = content_repo.get_branch('master').commit.sha
+        # create new branch
+        print(f'{t.cyan}Creating new branch "{new_branch_name}"{t.normal}')
+        content_repo.create_git_ref(f'refs/heads/{new_branch_name}', master_branch_commit_sha)
+        # update base branch of the PR
+        pr.edit(base=new_branch_name)
+        print(f'{t.cyan}Updated base branch of PR "{pr_number}" to "{new_branch_name}"{t.normal}')
+
+    # assign reviewers / request review from
+    reviewer_to_assign = determine_reviewer(REVIEWERS, content_repo)
+    pr.add_to_assignees(reviewer_to_assign)
+    pr.create_review_request(reviewers=[reviewer_to_assign])
+    print(f'{t.cyan}Assigned user "{reviewer_to_assign}" to the PR{t.normal}')
+    print(f'{t.cyan}Requested review from user "{reviewer_to_assign}"{t.normal}')
+
+    # create welcome comment (only users who contributed through Github need to have that contribution form filled)
+    message_to_send = WELCOME_MSG if pr.user.login == MARKETPLACE_CONTRIBUTION_PR_AUTHOR else WELCOME_MSG_WITH_GFORM
+    body = message_to_send.format(selected_reviewer=reviewer_to_assign)
+    pr.create_issue_comment(body)
+    print(f'{t.cyan}Created welcome comment{t.normal}')
 
 
 if __name__ == "__main__":

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -151,14 +151,14 @@ def main():
     pr_number = payload.get('pull_request', {}).get('number')
     pr = content_repo.get_pull(pr_number)
 
-    changed_file_names = [file.filename for file in pr.get_files()]
-    print(f'{changed_file_names=} for {pr_number=}')
+    changed_file_paths = [file.filename for file in pr.get_files()]
+    print(f'{changed_file_paths=} for {pr_number=}')
 
     labels_to_add = [CONTRIBUTION_LABEL]
-    if support_label := get_packs_support_level_label(changed_file_names):
+    if support_label := get_packs_support_level_label(changed_file_paths):
         labels_to_add.append(support_label)
 
-    # Add 'Contribution' label + support label
+    # Add 'Contribution' + support Label to the external PR
     for label in labels_to_add:
         pr.add_to_labels(label)
         print(f'{t.cyan}Added "{label}" label to the PR{t.normal}')


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
we cannot use the `changed-files` for the `handle-external-pr` workflow because the `pull_request_target` event operates on the base branch and not on the branch that triggered the workflow, because of that we got the following error:

```
  Error: Similar commit hashes detected: previous sha: d547ae0268b99a344c9f9d19032f98f80493bc67 is equivalent to the current sha: d547ae0268b99a344c9f9d19032f98f80493bc67.
  Error: Please verify that both commits are valid, and increase the fetch_depth to a number higher than 50.
  Error: Process completed with exit code 1.
```

this commit is a commit of merging to the master branch which is not what we want in this case, we want the commits of the branch that triggered the workflow.

that happens because the checkout step checks out to the master branch instead of the branch that triggered the workflow.

so now instead of using `changed-files` we can simply use the `Github` module to request all the changed files from the pull request which is easier and more concise and we do not depend on the github workflow's ref branches.

see also the two workflows for the test branch:
1. review-release-notes which checks out to the triggered branch: https://github.com/demisto/content/actions/runs/5039367295/jobs/9037462417?pr=26678

see that the github ref for it is: `GITHUB_REF: refs/pull/26678/merge` which is the current pull request.

2. handle external pr which checks out to the master branch causing the error: https://github.com/demisto/content/actions/runs/5039367206/jobs/9037510926?pr=26678

see that the github ref for it is: `GITHUB_REF: refs/heads/master` which causes the issue


references: https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git