### PR TITLE
fix JSX error in OSQueryOpenSocket

### DIFF
--- a/Packs/OSQuery/ReleaseNotes/1_0_8.md
+++ b/Packs/OSQuery/ReleaseNotes/1_0_8.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### OSQueryOpenSockets
+Maintenance and stability enhancements.

--- a/Packs/OSQuery/Scripts/OSQueryOpenSockets/OSQueryOpenSockets.yml
+++ b/Packs/OSQuery/Scripts/OSQueryOpenSockets/OSQueryOpenSockets.yml
@@ -8,7 +8,7 @@ subtype: python2
 tags:
 - OSQuery
 deprecated: true
-comment: "Deprecated. Use OSQueryBasicQuery with query='select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path <> '' or remote_address <> '';' instead."
+comment: "Deprecated. Use OSQueryBasicQuery with query='select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path `<>` '' or remote_address `<>` '';' instead."
 system: true
 args:
 - name: system

--- a/Packs/OSQuery/pack_metadata.json
+++ b/Packs/OSQuery/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "OS Query",
     "description": "Run OS query on a linux system.",
     "support": "xsoar",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
The <> tags are not allowed in YML files when being rendered into HTML at xsoar.pan.dev.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
