### PR TITLE
EWS O365 Fix for attachment XML error

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
@@ -2,6 +2,7 @@ import random
 import string
 import subprocess
 from typing import Dict
+from xml.sax import SAXParseException
 
 import dateparser
 import chardet
@@ -2127,6 +2128,13 @@ def parse_incident_from_item(item):     # pragma: no cover
                 except TypeError as e:
                     if str(e) != "must be string or buffer, not None":
                         raise
+                    continue
+                except SAXParseException as e:
+                    # TODO: When a fix is released, we will need to bump the library version.
+                    #  https://github.com/ecederstrand/exchangelib/issues/1200
+                    demisto.debug(f'An XML error occurred while loading an attachments content.'
+                                  f'\nMessage ID is {item.id}'
+                                  f'\nError: {e.getMessage()}')
                     continue
             else:
                 # other item attachment

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_5.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS O365
+
+- Fixed an issue where attachments with names containing a non-XML supported character would cause fetch to fail.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.2.4",
+    "currentVersion": "1.2.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-24410

## Description
When an attachment's name contains a control character, the XML is no longer valid when parsing the attachment's information from Microsoft via exchangelib.

Please note, when a new version of exchangelib is available, we will need to bump the docker image (should happen automatically, but we can revert this fix when it happens).

Details of the XML parsing issue can be found here - https://github.com/ecederstrand/exchangelib/issues/1200

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
