### PR TITLE
ParseEmailFilesV2: update the docker image to stop embed the base64

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_11_82.json
+++ b/Packs/CommonScripts/ReleaseNotes/1_11_82.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"ParseEmailFilesV2 automation will no longer embed the base64 of an image in the returned HTML"}

--- a/Packs/CommonScripts/ReleaseNotes/1_11_82.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_11_82.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+- Updated the Docker image to: *demisto/parse-emails:1.0.0.62142*.

--- a/Packs/CommonScripts/ReleaseNotes/1_11_82.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_11_82.md
@@ -2,5 +2,5 @@
 #### Scripts
 
 ##### ParseEmailFilesV2
-
+- The automation will no longer embed the base64 of an image in the returned HTML.
 - Updated the Docker image to: *demisto/parse-emails:1.0.0.62142*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -116,4 +116,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.60423
+dockerimage: demisto/parse-emails:1.0.0.62142

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.11.81",
+    "currentVersion": "1.11.82",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-81822

## Screenshots
**Before:**
<img width="530" alt="image" src="https://github.com/demisto/content/assets/79846863/9f3b1fa7-fa8f-463d-af03-67723e024b7d">


**After:**
<img width="476" alt="image" src="https://github.com/demisto/content/assets/79846863/78eab37a-f6b9-4d3d-80ab-2a6496d257ee">


## Does it break backward compatibility?
   - [x] Yes
       - Further details: `ParseEmailFilesV2` automation will no longer embed the base64 of an image in the returned HTML


## Must have
- [ ] Tests
- [ ] Documentation 
