### PR TITLE
PAN-OS tag vs tags bug

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -3559,7 +3559,7 @@ def panorama_list_rules_command(args: dict):
         xpath = XPATH_SECURITY_RULES
 
     filters = assign_params(
-        tags=argToList(args.get('tag')),
+        tags=argToList(args.get('tags')),
         action=args.get('action')
     )
     name = args.get('rulename')

--- a/Packs/PAN-OS/ReleaseNotes/1_17_4.md
+++ b/Packs/PAN-OS/ReleaseNotes/1_17_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks PAN-OS
+
+- Fixed an issue where ***pan-os-list-rules*** command was filtering by *tag* instead of *tags* argument. 

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "1.17.3",
+    "currentVersion": "1.17.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-24853

## Description
Fixed an issue where ***pan-os-list-rules*** command was filtering by *tag* instead of *tags* argument.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
