### PR TITLE
Zscaler add reliability

### DIFF
--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
@@ -464,7 +464,8 @@ def url_lookup(args):
                 indicator_type=DBotScoreType.URL,
                 integration_name=INTEGRATION_NAME,
                 malicious_description=data.get('urlClassificationsWithSecurityAlert', None),
-                score=score
+                score=score,
+                reliability=demisto.params().get('reliability')
             )
         )
 
@@ -518,7 +519,8 @@ def ip_lookup(ip):
                 indicator_type=DBotScoreType.IP,
                 integration_name=INTEGRATION_NAME,
                 malicious_description=data.get('ipClassificationsWithSecurityAlert', None),
-                score=score
+                score=score,
+                reliability=demisto.params().get('reliability')
             )
         )
         results.append(CommandResults(
@@ -823,7 +825,8 @@ def sandbox_report_command():
         'Indicator': md5,
         'Type': 'file',
         'Vendor': 'Zscaler',
-        'Score': dbot_score
+        'Score': dbot_score,
+        'reliability': demisto.params().get('reliability')
     }}
 
     human_readable_report = ec['DBotScore'].copy()

--- a/Packs/Zscaler/ReleaseNotes/1_3_10.md
+++ b/Packs/Zscaler/ReleaseNotes/1_3_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Zscaler Internet Access
+
+- Fixed an issue where the *Reliability* integration parameter was not used correctly.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zscaler Internet Access",
     "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
     "support": "xsoar",
-    "currentVersion": "1.3.9",
+    "currentVersion": "1.3.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6827

## Description
Fixed an issue where the Reliability integration parameter was not used when setting the DBot score of an IOC.