### PR TITLE
[TAXII2ApiModule] Fix kwargs argument in function call

### DIFF
--- a/Packs/ApiModules/Scripts/TAXII2ApiModule/TAXII2ApiModule.py
+++ b/Packs/ApiModules/Scripts/TAXII2ApiModule/TAXII2ApiModule.py
@@ -1211,8 +1211,8 @@ class Taxii2FeedClient:
             self.objects_to_fetch.append('relationship')
         kwargs['type'] = self.objects_to_fetch
         if isinstance(self.collection_to_fetch, v20.Collection):
-            return v20.as_pages(get_objects, per_request=page_size, **kwargs)
-        return v21.as_pages(get_objects, per_request=page_size, **kwargs)
+            return v20.as_pages(get_objects, per_request=page_size, kwargs=kwargs)
+        return v21.as_pages(get_objects, per_request=page_size, kwargs=kwargs)
 
     def get_page_size(self, max_limit: int, cur_limit: int) -> int:
         """

--- a/Packs/FeedDHS/ReleaseNotes/2_0_10.md
+++ b/Packs/FeedDHS/ReleaseNotes/2_0_10.md
@@ -3,4 +3,4 @@
 
 ##### DHS Feed v2
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack.
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** script.

--- a/Packs/FeedDHS/ReleaseNotes/2_0_10.md
+++ b/Packs/FeedDHS/ReleaseNotes/2_0_10.md
@@ -3,4 +3,4 @@
 
 ##### DHS Feed v2
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** script.
+Fixed an issue with an invalid function call in the **TAXII2ApiModule** script.

--- a/Packs/FeedDHS/ReleaseNotes/2_0_10.md
+++ b/Packs/FeedDHS/ReleaseNotes/2_0_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### DHS Feed v2
+
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack.

--- a/Packs/FeedDHS/pack_metadata.json
+++ b/Packs/FeedDHS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DHS Feed",
     "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency’s (CISA’s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
     "support": "xsoar",
-    "currentVersion": "2.0.9",
+    "currentVersion": "2.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### MITRE ATT&CK
+
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack.

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
@@ -3,4 +3,4 @@
 
 ##### MITRE ATT&CK
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** script.
+Fixed an issue with an invalid function call in the **TAXII2ApiModule** script.

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_13.md
@@ -3,4 +3,4 @@
 
 ##### MITRE ATT&CK
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack.
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** script.

--- a/Packs/FeedMitreAttackv2/pack_metadata.json
+++ b/Packs/FeedMitreAttackv2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MITRE ATT&CK",
     "description": "Fetches indicators from MITRE ATT&CK.",
     "support": "xsoar",
-    "currentVersion": "1.1.12",
+    "currentVersion": "1.1.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
@@ -3,4 +3,4 @@
 
 ##### TAXII 2 Feed
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack which caused ***taxii2-get-indicators*** to fail.
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** script which caused ***taxii2-get-indicators*** to fail.

--- a/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
@@ -3,4 +3,4 @@
 
 ##### TAXII 2 Feed
 
-- Fixed an issue with an invalid function call in **TAXII2ApiModule** script which caused ***taxii2-get-indicators*** to fail.
+Fixed an issue with an invalid function call in the **TAXII2ApiModule** script which caused ***taxii2-get-indicators*** to fail.

--- a/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_1_26.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TAXII 2 Feed
+
+- Fixed an issue with an invalid function call in **TAXII2ApiModule** pack which caused ***taxii2-get-indicators*** to fail.

--- a/Packs/FeedTAXII/pack_metadata.json
+++ b/Packs/FeedTAXII/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Feed",
     "description": "Ingest indicator feeds from TAXII 1 and TAXII 2 servers.",
     "support": "xsoar",
-    "currentVersion": "1.1.25",
+    "currentVersion": "1.1.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-24851](https://jira-hq.paloaltonetworks.local/browse/XSUP-24851)
## Description
This PR will fix a function call error in `TAXII2ApiModule.py` where kwargs are being called as defined (`**kwargs`) instead of as an argument (`kwargs=kwargs`).

## Screenshots
Results of `TAXII 2 Feed Test` playbook with original pack:
![image](https://github.com/demisto/content/assets/65926551/f144caaf-0142-4978-ad76-bb2152122aa5)

Results of `TAXII 2 Feed Test` playbook after changes:
![image](https://github.com/demisto/content/assets/65926551/b38a9899-b66e-4ae4-863f-f0e36426605b)


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
