### PR TITLE
Prisma cloud playbook fix azure fqdn

### DIFF
--- a/Packs/PrismaCloud/Playbooks/playbook-Prisma_Cloud_-_Find_Azure_Resource_by_FQDN_v2.yml
+++ b/Packs/PrismaCloud/Playbooks/playbook-Prisma_Cloud_-_Find_Azure_Resource_by_FQDN_v2.yml
@@ -520,7 +520,7 @@ tasks:
             iscontext: true
             value:
               complex:
-                root: AzureFQDN
+                root: NONAzureFQDN
           operator: isNotEmpty
       label: "yes"
     id: "26"

--- a/Packs/PrismaCloud/ReleaseNotes/4_1_4.md
+++ b/Packs/PrismaCloud/ReleaseNotes/4_1_4.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Prisma Cloud - Find Azure Resource by FQDN v2
+
+The condition in task #26, `Are there NON Azure FQDNs?`, has been revised to validate that the variable **NONAzureFQDN** is not empty, instead of checking **AzureFQDN**.

--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud by Palo Alto Networks",
     "description": "Automate and unify security incident response across your cloud environments, while still giving a degree of control to dedicated cloud teams.",
     "support": "xsoar",
-    "currentVersion": "4.1.3",
+    "currentVersion": "4.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6861

## Description
A logic fail was fixed in the playbook: Prisma Cloud - Find Azure Resource by FQDN v2.
The condition in task #26, `Are there NON Azure FQDNs?`, has been revised to validate that the variable **NONAzureFQDN** is not empty, instead of checking **AzureFQDN**.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No


