### PR TITLE
CoreRestAPI URL suffix fix

### DIFF
--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -1,9 +1,23 @@
+
+const MIN_HOSTED_XSOAR_VERSION = '8.0.0';
+
 var serverURL = params.url;
 if (serverURL.slice(-1) === '/') {
     serverURL = serverURL.slice(0,-1);
 }
 
-if (params.auth_id || (params.creds_apikey && params.creds_apikey.identifier)) {
+// returns true if the current platform is XSIAM or XSOAR 8.0 and above.
+isHosted = function () {
+    res = getDemistoVersion();
+    platform = res.platform;
+    if  (((platform === "xsoar") && (isDemistoVersionGE(MIN_HOSTED_XSOAR_VERSION))) || platform === "x2") {
+        return true
+    }
+    return false
+}
+
+// only when using XSIAM or XSOAR >= 8.0 we will add the /xsoar suffix
+if  (isHosted()) {
     if (!serverURL.endsWith('/xsoar')){
         serverURL = serverURL + '/xsoar'
     }

--- a/Packs/DemistoRESTAPI/ReleaseNotes/1_3_26.md
+++ b/Packs/DemistoRESTAPI/ReleaseNotes/1_3_26.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Core REST API
+
+- Fixed an issue where (in XSOAR 6.x) the integration added a "/xsoar" suffix to the URL when API Key ID was provided.

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex REST API",
     "description": "Use Demisto REST APIs",
     "support": "xsoar",
-    "currentVersion": "1.3.25",
+    "currentVersion": "1.3.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6864)

Force merge is needed:

[ERROR][INFO] : Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.yml: [RM110] - The following commands appear in CoreRESTAPI.yml but not in the README file:
demisto-api-post
demisto-api-get
demisto-api-put
demisto-api-delete
demisto-api-download
demisto-api-multipart
demisto-delete-incidents
demisto-api-install-packs
