### PR TITLE
Switched the PB to use generic cve command as CVE Search is going to be derecated

### DIFF
--- a/Packs/ExtraHop/Playbooks/playbook-ExtraHop_-_CVE-2019-0708_BlueKeep.yml
+++ b/Packs/ExtraHop/Playbooks/playbook-ExtraHop_-_CVE-2019-0708_BlueKeep.yml
@@ -131,10 +131,10 @@ tasks:
       version: -1
       name: Run CVE search for BlueKeep vulnerability
       description: Returns CVE information by CVE ID.
-      script: CVE Search v2|||cve
+      script: '|||cve'
       type: regular
       iscommand: true
-      brand: CVE Search v2
+      brand: ""
     nexttasks:
       '#none#':
       - "17"

--- a/Packs/ExtraHop/ReleaseNotes/2_1_1.md
+++ b/Packs/ExtraHop/ReleaseNotes/2_1_1.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### ExtraHop - CVE-2019-0708 (BlueKeep)
+
+Updated the playbook to use the generic `cve` command instead of CVE Search V2 which will be deprecated.

--- a/Packs/ExtraHop/pack_metadata.json
+++ b/Packs/ExtraHop/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ExtraHop Reveal(x)",
     "description": "Network detection and response. Complete visibility of network communications at enterprise scale, real-time threat detections backed by machine learning, and guided investigation workflows that simplify response.",
     "support": "partner",
-    "currentVersion": "2.1.0",
+    "currentVersion": "2.1.1",
     "author": "ExtraHop",
     "url": "",
     "email": "support@extrahop.com",
@@ -34,10 +34,6 @@
             "mandatory": true,
             "display_name": "Common Types"
         },
-        "CVESearch": {
-            "mandatory": true,
-            "display_name": "CVE Search"
-        },
         "CommonPlaybooks": {
             "mandatory": true,
             "display_name": "Common Playbooks"
@@ -47,7 +43,6 @@
         "CommonScripts",
         "CoreAlertFields",
         "CommonTypes",
-        "CVESearch",
         "CommonPlaybooks"
     ]
 }


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This is a PR so we can merge the changes to the CVE layout and type that is blocked due to a bug. After merging this one we will merge the CVE one which will be able to pass the checks.

https://github.com/demisto/content/pull/26486


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No