### PR TITLE
Core rest api add xsoar hosted

### DIFF
--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -10,7 +10,7 @@ if (serverURL.slice(-1) === '/') {
 isHosted = function () {
     res = getDemistoVersion();
     platform = res.platform;
-    if  (((platform === "xsoar") && (isDemistoVersionGE(MIN_HOSTED_XSOAR_VERSION))) || platform === "x2") {
+    if  (((platform === "xsoar" || platform === "xsoar_hosted") && (isDemistoVersionGE(MIN_HOSTED_XSOAR_VERSION))) || platform === "x2") {
         return true
     }
     return false

--- a/Packs/DemistoRESTAPI/ReleaseNotes/1_3_27.md
+++ b/Packs/DemistoRESTAPI/ReleaseNotes/1_3_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Core REST API
+
+- Fixed an issue where the '/xsoar' suffix was not added to the URL parameter in some of the XSOAR 8.x machines. 

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex REST API",
     "description": "Use Demisto REST APIs",
     "support": "xsoar",
-    "currentVersion": "1.3.26",
+    "currentVersion": "1.3.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6915

## Description
A "xsoar_hosted" option as a possible platform name of XSOAR 8.x.

tested on XSOAR 6.x, XSAIM and XSOAR 8.x