### PR TITLE
AzureSentinel - keywords argument from 'comma separate' to 'str' in azure-sentinel-threat-indicator-query

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -1391,7 +1391,7 @@ def build_query_filter(args):
         'minValidUntil': format_date(args.get('min_valid_from', '')),
         'maxValidUntil': format_date(args.get('max_valid_from', '')),
         'sources': argToList(args.get('sources')),
-        'keywords': args.get('keywords', ''),
+        'keywords': ' '.join(argToList(args.get('keywords', ''))),
         'threatTypes': argToList(args.get('threat_types')),
         'patternTypes': []
     }

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -1388,10 +1388,10 @@ def build_query_filter(args):
     filtering_args = {
         'minConfidence': args.get('min_confidence', ''),
         'maxConfidence': args.get('max_confidence', ''),
+        'keywords': args.get('keywords', ''),
         'minValidUntil': format_date(args.get('min_valid_from', '')),
         'maxValidUntil': format_date(args.get('max_valid_from', '')),
         'sources': argToList(args.get('sources')),
-        'keywords': argToList(args.get('keywords')),
         'threatTypes': argToList(args.get('threat_types')),
         'patternTypes': []
     }

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -1388,10 +1388,10 @@ def build_query_filter(args):
     filtering_args = {
         'minConfidence': args.get('min_confidence', ''),
         'maxConfidence': args.get('max_confidence', ''),
-        'keywords': args.get('keywords', ''),
         'minValidUntil': format_date(args.get('min_valid_from', '')),
         'maxValidUntil': format_date(args.get('max_valid_from', '')),
         'sources': argToList(args.get('sources')),
+        'keywords': args.get('keywords', ''),
         'threatTypes': argToList(args.get('threat_types')),
         'patternTypes': []
     }

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -3005,7 +3005,7 @@ script:
     - contextPath: AzureSentinel.AlertRule.properties.incidentConfiguration
       description: The settings of the incidents that were created from alerts triggered by this analytics rule.
       type: Unknown
-  dockerimage: demisto/crypto:1.0.0.61689
+  dockerimage: demisto/crypto:1.0.0.62834
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -1423,7 +1423,6 @@ script:
       name: keywords
       required: false
       secret: false
-      additionalinfo: It is possible to pass several keywords in one string with spaces between them.
     - default: false
       description: The subscription ID.
       isArray: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -1418,8 +1418,8 @@ script:
       required: false
       secret: false
     - default: false
-      description: Phrases used to filter threat indicators.
-      isArray: false
+      description: A comma-separated list of keywords.
+      isArray: true
       name: keywords
       required: false
       secret: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -1418,8 +1418,8 @@ script:
       required: false
       secret: false
     - default: false
-      description: A comma-separated list of keywords.
-      isArray: true
+      description: Filtering the Threat Indicators by keywords.
+      isArray: false
       name: keywords
       required: false
       secret: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -1423,7 +1423,6 @@ script:
       name: keywords
       required: false
       secret: false
-      additionalinfo: To use multiple keywords, separate them with spaces.
     - default: false
       description: The subscription ID.
       isArray: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -1423,6 +1423,7 @@ script:
       name: keywords
       required: false
       secret: false
+      additionalinfo: It is possible to pass several keywords in one string with spaces between them.
     - default: false
       description: The subscription ID.
       isArray: false

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/README.md
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/README.md
@@ -1430,7 +1430,7 @@ Returns a list of threat indicators with specific entities.
 | sources | The sources of the threat indicator. | Optional | 
 | indicator_types | The indicator types of the threat indicator. Possible values are: ipv4, ipv6, file, url, domain. | Optional | 
 | threat_types | A comma-separated list of threat types of the threat indicator. Possible values are: anomalous-activity, attribution, anonymization, benign, malicious-activity, compromised, unknown. | Optional | 
-| keywords | Phrases used to filter threat indicators. | Optional | 
+| keywords | A comma-separated list of keywords. | Optional | 
 | subscription_id | The subscription ID. | Optional |
 | resource_group_name | The resource group name. | Optional |
 

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/README.md
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/README.md
@@ -1430,7 +1430,7 @@ Returns a list of threat indicators with specific entities.
 | sources | The sources of the threat indicator. | Optional | 
 | indicator_types | The indicator types of the threat indicator. Possible values are: ipv4, ipv6, file, url, domain. | Optional | 
 | threat_types | A comma-separated list of threat types of the threat indicator. Possible values are: anomalous-activity, attribution, anonymization, benign, malicious-activity, compromised, unknown. | Optional | 
-| keywords | A comma-separated list of keywords. | Optional | 
+| keywords | Filtering the Threat Indicators by keywords. | Optional | 
 | subscription_id | The subscription ID. | Optional |
 | resource_group_name | The resource group name. | Optional |
 

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_8.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_8.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Sentinel
+
+- Fixed an issue where ***azure-sentinel-threat-indicator-query*** command failed due to incorrect *keywords* argument..

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_8.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_8.md
@@ -4,3 +4,4 @@
 ##### Microsoft Sentinel
 
 - Fixed an issue where ***azure-sentinel-threat-indicator-query*** command failed due to incorrect *keywords* argument..
+- Updated the Docker image to: *demisto/crypto:1.0.0.62834*.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Sentinel",
     "description": "Microsoft Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.5.7",
+    "currentVersion": "1.5.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4971,7 +4971,8 @@
             "integrations": "Azure Sentinel",
             "fromversion": "5.5.0",
             "is_mockable": false,
-            "playbookID": "TestAzureSentinelPlaybookV2"
+            "playbookID": "TestAzureSentinelPlaybookV2",
+            "instance_names": "azure_sentinel_dev"
         },
         {
             "integrations": "AnsibleAlibabaCloud",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25098

## Description
Despite the documentation stating that the argument is comma separated, calling the API throws an error. When passing a string, it works as expected.
