### PR TITLE
fix Test_XDR_Playbook_general_commands TPB

### DIFF
--- a/Packs/CortexXDR/TestPlaybooks/Test_XDR_Playbook_general_commands.yml
+++ b/Packs/CortexXDR/TestPlaybooks/Test_XDR_Playbook_general_commands.yml
@@ -5,15 +5,14 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 0977a659-4924-43ce-8f26-ff7d4176473e
+    taskid: 32c3a3fe-28c5-4d2c-88bd-92e35c4805eb
     type: start
     task:
-      id: 0977a659-4924-43ce-8f26-ff7d4176473e
+      id: 32c3a3fe-28c5-4d2c-88bd-92e35c4805eb
       version: -1
       name: ""
       iscommand: false
       brand: ""
-      description: ''
     nexttasks:
       '#none#':
       - "59"
@@ -23,7 +22,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 50
+          "y": -100
         }
       }
     note: false
@@ -35,10 +34,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: bf6e7f34-6f28-4938-813f-f4d659706300
+    taskid: 341eae2b-a9df-4ac8-82e2-d09c65df852f
     type: regular
     task:
-      id: bf6e7f34-6f28-4938-813f-f4d659706300
+      id: 341eae2b-a9df-4ac8-82e2-d09c65df852f
       version: -1
       name: DeleteContext
       description: DeleteContext
@@ -70,10 +69,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: aaa05243-1790-4cb8-8d38-0184582a2e1f
+    taskid: 157df404-614f-47f4-87cd-0371a630446d
     type: regular
     task:
-      id: aaa05243-1790-4cb8-8d38-0184582a2e1f
+      id: 157df404-614f-47f4-87cd-0371a630446d
       version: -1
       name: xdr-get-incidents
       description: xdr-get-incidents
@@ -109,10 +108,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: fb600597-4798-49fa-87a3-2d748772388b
+    taskid: 4a527b96-da71-45ff-849b-80b84c897915
     type: condition
     task:
-      id: fb600597-4798-49fa-87a3-2d748772388b
+      id: 4a527b96-da71-45ff-849b-80b84c897915
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -163,10 +162,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: 74012e5a-fca8-4b35-8df3-3cc4f8c8886a
+    taskid: 0b3a4fe4-f134-4ace-8ee9-723597ce8aa6
     type: regular
     task:
-      id: 74012e5a-fca8-4b35-8df3-3cc4f8c8886a
+      id: 0b3a4fe4-f134-4ace-8ee9-723597ce8aa6
       version: -1
       name: xdr-get-incident-extra-data
       description: xdr-get-incident-extra-data
@@ -198,10 +197,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: 483a2f56-f952-4086-812d-57a787e505d2
+    taskid: 49c37fa5-9f5f-44e0-87db-2ed6c13c9501
     type: condition
     task:
-      id: 483a2f56-f952-4086-812d-57a787e505d2
+      id: 49c37fa5-9f5f-44e0-87db-2ed6c13c9501
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -277,10 +276,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: 0244e580-4af9-4825-85ed-2e0d6e435e93
+    taskid: 638390de-ae89-4c00-8a87-af8a179c117a
     type: regular
     task:
-      id: 0244e580-4af9-4825-85ed-2e0d6e435e93
+      id: 638390de-ae89-4c00-8a87-af8a179c117a
       version: -1
       name: xdr-update-incident
       description: xdr-update-incident
@@ -320,10 +319,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 1297a2f5-3047-409f-8845-611d98ef43ad
+    taskid: 5c9a57b5-fc03-495f-8f4d-330f2fa52079
     type: regular
     task:
-      id: 1297a2f5-3047-409f-8845-611d98ef43ad
+      id: 5c9a57b5-fc03-495f-8f4d-330f2fa52079
       version: -1
       name: Save incident id
       description: Save incident id
@@ -361,10 +360,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: 81aa0d8a-9fcc-4eb5-8eca-caf37d540700
+    taskid: b54cda42-9c17-410e-8cef-2bf1c89066ad
     type: regular
     task:
-      id: 81aa0d8a-9fcc-4eb5-8eca-caf37d540700
+      id: b54cda42-9c17-410e-8cef-2bf1c89066ad
       version: -1
       name: DeleteContext
       description: DeleteContext
@@ -398,10 +397,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "9":
     id: "9"
-    taskid: 92453a3b-4940-40d2-8b21-364ed356882f
+    taskid: 98ef82f9-82db-4505-8fcb-8f55cb1184f4
     type: regular
     task:
-      id: 92453a3b-4940-40d2-8b21-364ed356882f
+      id: 98ef82f9-82db-4505-8fcb-8f55cb1184f4
       version: -1
       name: xdr-get-incidents
       description: xdr-get-incidents
@@ -435,10 +434,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "10":
     id: "10"
-    taskid: b3d920f8-00fb-4a94-8a24-08e6168e06dd
+    taskid: 2924d5e4-cf5a-4503-8c88-63596b739236
     type: condition
     task:
-      id: b3d920f8-00fb-4a94-8a24-08e6168e06dd
+      id: 2924d5e4-cf5a-4503-8c88-63596b739236
       version: -1
       name: Verify updated values
       description: Verify updated values
@@ -485,10 +484,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "11":
     id: "11"
-    taskid: f601bd58-5359-48e5-836f-60cb6453000e
+    taskid: 914f893a-0a88-4f85-8f86-edf10ee6b3ab
     type: regular
     task:
-      id: f601bd58-5359-48e5-836f-60cb6453000e
+      id: 914f893a-0a88-4f85-8f86-edf10ee6b3ab
       version: -1
       name: xdr-update-incident
       description: xdr-update-incident
@@ -524,10 +523,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "12":
     id: "12"
-    taskid: b8280320-7007-4599-8c1e-503fbfddbc5c
+    taskid: 9e4fbdec-bfb8-4f66-8dcc-2d66d5bc2f17
     type: regular
     task:
-      id: b8280320-7007-4599-8c1e-503fbfddbc5c
+      id: 9e4fbdec-bfb8-4f66-8dcc-2d66d5bc2f17
       version: -1
       name: xdr-insert-parsed-alert
       description: xdr-insert-parsed-alert
@@ -575,10 +574,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "13":
     id: "13"
-    taskid: b57ed06b-57b0-441e-8b01-3104f5a0c7e3
+    taskid: 88adf053-0271-421a-871d-23d4e45ce70d
     type: regular
     task:
-      id: b57ed06b-57b0-441e-8b01-3104f5a0c7e3
+      id: 88adf053-0271-421a-871d-23d4e45ce70d
       version: -1
       name: Set 2 CEF alerts to context
       description: Set 2 CEF alerts to context
@@ -618,10 +617,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "14":
     id: "14"
-    taskid: 6e38c135-0ef4-412d-8b4c-7e4747b62521
+    taskid: a9c7d974-0c5b-4fd8-8ef1-3bb2028ea924
     type: regular
     task:
-      id: 6e38c135-0ef4-412d-8b4c-7e4747b62521
+      id: a9c7d974-0c5b-4fd8-8ef1-3bb2028ea924
       version: -1
       name: xdr-insert-cef-alerts
       description: xdr-insert-cef-alerts
@@ -653,10 +652,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "15":
     id: "15"
-    taskid: 1866aa4b-2db0-4aae-8b38-b2e8a0cb691a
+    taskid: 18a22975-3344-4e18-869d-9e3cdbb81921
     type: regular
     task:
-      id: 1866aa4b-2db0-4aae-8b38-b2e8a0cb691a
+      id: 18a22975-3344-4e18-869d-9e3cdbb81921
       version: -1
       name: Get Endpoint aeec6a2cc92e46fab3b6f621722e9916
       description: Gets a list of endpoints, according to the passed filters. Filtering by multiple fields will be concatenated using AND condition (OR is not supported). Maximum result set size is 100. Offset is the zero-based number of endpoint from the start of the result set (start by counting from 0).
@@ -688,10 +687,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "16":
     id: "16"
-    taskid: 11520fc0-dc05-41d2-8d5f-528d2658c979
+    taskid: 96d5efde-a448-4667-8612-812fc0947194
     type: condition
     task:
-      id: 11520fc0-dc05-41d2-8d5f-528d2658c979
+      id: 96d5efde-a448-4667-8612-812fc0947194
       version: -1
       name: To isolate ?
       description: To isolate
@@ -732,10 +731,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "17":
     id: "17"
-    taskid: a80d0fc5-af26-40b2-8068-0d893f20b691
+    taskid: d654baeb-b9cd-4e3c-8e0f-e90d7218b9ec
     type: condition
     task:
-      id: a80d0fc5-af26-40b2-8068-0d893f20b691
+      id: d654baeb-b9cd-4e3c-8e0f-e90d7218b9ec
       version: -1
       name: To unisolate?
       description: To unisolate
@@ -776,10 +775,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "18":
     id: "18"
-    taskid: 15c6ce5d-e7c5-4148-80df-83a41b8757e4
+    taskid: 95807320-56e8-4a69-8be5-3baf127a07a3
     type: regular
     task:
-      id: 15c6ce5d-e7c5-4148-80df-83a41b8757e4
+      id: 95807320-56e8-4a69-8be5-3baf127a07a3
       version: -1
       name: xdr-unisolate-endpoint
       description: xdr-unisolate-endpoint
@@ -811,10 +810,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "19":
     id: "19"
-    taskid: e34e13b4-612d-4d92-8167-54498d36116b
+    taskid: c9a44025-c78c-471d-8efa-9dade67f86f3
     type: regular
     task:
-      id: e34e13b4-612d-4d92-8167-54498d36116b
+      id: c9a44025-c78c-471d-8efa-9dade67f86f3
       version: -1
       name: xdr-isolate-endpoint
       description: xdr-isolate-endpoint
@@ -846,10 +845,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "20":
     id: "20"
-    taskid: 266737b4-727f-4cf4-8f23-7432037a6881
+    taskid: f8f050ee-c241-488e-84c9-27dce0c5fd51
     type: regular
     task:
-      id: 266737b4-727f-4cf4-8f23-7432037a6881
+      id: f8f050ee-c241-488e-84c9-27dce0c5fd51
       version: -1
       name: xdr-get-endpoints
       description: xdr-get-endpoints
@@ -881,10 +880,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "21":
     id: "21"
-    taskid: 6a494f10-9ea7-461e-85e3-502bd861d8b4
+    taskid: e694b028-ae06-4b83-83fc-7b48a91a0375
     type: condition
     task:
-      id: 6a494f10-9ea7-461e-85e3-502bd861d8b4
+      id: e694b028-ae06-4b83-83fc-7b48a91a0375
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -933,10 +932,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "22":
     id: "22"
-    taskid: 39d74a0d-e0c8-498d-8b59-12868c0b6b4c
+    taskid: 7ea4bed4-4fdc-4c91-8377-ef69a86ea15c
     type: title
     task:
-      id: 39d74a0d-e0c8-498d-8b59-12868c0b6b4c
+      id: 7ea4bed4-4fdc-4c91-8377-ef69a86ea15c
       version: -1
       name: Isolation done
       description: Isolation done
@@ -964,16 +963,15 @@ tasks:
     isautoswitchedtoquietmode: false
   "24":
     id: "24"
-    taskid: b4aaaae6-b780-4527-82d3-898ef7ffd3c5
+    taskid: f93cc330-e3e4-48eb-84a2-998541fb91dd
     type: title
     task:
-      id: b4aaaae6-b780-4527-82d3-898ef7ffd3c5
+      id: f93cc330-e3e4-48eb-84a2-998541fb91dd
       version: -1
       name: Success!
       type: title
       iscommand: false
       brand: ""
-      description: ''
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -992,10 +990,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "30":
     id: "30"
-    taskid: 50078983-9370-4e57-80d4-c4f2fe7bb8cf
+    taskid: cc23793b-a8e5-4e2a-8773-fcfa42ebb38e
     type: condition
     task:
-      id: 50078983-9370-4e57-80d4-c4f2fe7bb8cf
+      id: cc23793b-a8e5-4e2a-8773-fcfa42ebb38e
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1031,10 +1029,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "31":
     id: "31"
-    taskid: c9da8960-70b0-413f-89ee-b56ad082594c
+    taskid: 5e9302cd-8730-474e-89ef-9ad1710b6c73
     type: regular
     task:
-      id: c9da8960-70b0-413f-89ee-b56ad082594c
+      id: 5e9302cd-8730-474e-89ef-9ad1710b6c73
       version: -1
       name: xdr-get-script-code
       description: Gets the code of a specific script in the script library.
@@ -1070,10 +1068,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "32":
     id: "32"
-    taskid: 45409e33-4bb5-4141-8620-76de5747cefe
+    taskid: 62068161-c31b-41f3-8490-aaf97810cf7d
     type: condition
     task:
-      id: 45409e33-4bb5-4141-8620-76de5747cefe
+      id: 62068161-c31b-41f3-8490-aaf97810cf7d
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1109,10 +1107,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "33":
     id: "33"
-    taskid: 1da99354-1d6b-4148-829f-64758e84f35c
+    taskid: 2224bb2f-f913-4cf0-8a90-9fbe85c946c8
     type: regular
     task:
-      id: 1da99354-1d6b-4148-829f-64758e84f35c
+      id: 2224bb2f-f913-4cf0-8a90-9fbe85c946c8
       version: -1
       name: xdr-get-script-metadata
       description: Gets the full definition of a specific script in the scripts library.
@@ -1148,10 +1146,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "34":
     id: "34"
-    taskid: 0ae9a03e-3cea-4a52-840a-28030c03ca66
+    taskid: f67fe57e-5c39-4c3b-85c7-309190669668
     type: condition
     task:
-      id: 0ae9a03e-3cea-4a52-840a-28030c03ca66
+      id: f67fe57e-5c39-4c3b-85c7-309190669668
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1191,10 +1189,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "35":
     id: "35"
-    taskid: 856c9fe7-b8da-4d94-8f8f-ad0f865de6e3
+    taskid: 7d0a79fa-097e-433b-83b9-fcd5fe234823
     type: regular
     task:
-      id: 856c9fe7-b8da-4d94-8f8f-ad0f865de6e3
+      id: 7d0a79fa-097e-433b-83b9-fcd5fe234823
       version: -1
       name: xdr-get-scripts
       description: Gets a list of scripts available in the scripts library.
@@ -1223,10 +1221,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "36":
     id: "36"
-    taskid: 1e129ba3-4c0e-4c9c-8a40-b286c164b8b7
+    taskid: cb8ce739-192c-4b83-850d-bd182a7fd994
     type: condition
     task:
-      id: 1e129ba3-4c0e-4c9c-8a40-b286c164b8b7
+      id: cb8ce739-192c-4b83-850d-bd182a7fd994
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1262,10 +1260,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "37":
     id: "37"
-    taskid: 5c5fc708-3384-42d0-823f-2edae6942bc2
+    taskid: e291fb21-3769-4f59-849c-88f724ce1be7
     type: regular
     task:
-      id: 5c5fc708-3384-42d0-823f-2edae6942bc2
+      id: e291fb21-3769-4f59-849c-88f724ce1be7
       version: -1
       name: xdr-get-endpoint-device-control-violations
       description: Gets a list of device control violations filtered by selected fields. You can retrieve up to 100 violations.
@@ -1294,10 +1292,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "38":
     id: "38"
-    taskid: b02aa156-ab2d-4466-83d1-47f21f9e4fc5
+    taskid: 2ef3fa01-4fa1-4ad3-877f-4bcd14d00b45
     type: condition
     task:
-      id: b02aa156-ab2d-4466-83d1-47f21f9e4fc5
+      id: 2ef3fa01-4fa1-4ad3-877f-4bcd14d00b45
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1333,10 +1331,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "39":
     id: "39"
-    taskid: e98aaaff-32c2-4fcd-8251-3c5804e882b1
+    taskid: 951f029d-975d-4625-88e7-6f4a0e00c65d
     type: regular
     task:
-      id: e98aaaff-32c2-4fcd-8251-3c5804e882b1
+      id: 951f029d-975d-4625-88e7-6f4a0e00c65d
       version: -1
       name: xdr-get-policy
       description: Gets the policy name for a specific endpoint.
@@ -1368,10 +1366,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "41":
     id: "41"
-    taskid: 13482abf-f80e-4aff-8c73-ea1892e89cca
+    taskid: 831a0609-dd5d-4a0c-8c80-21e4416c247d
     type: condition
     task:
-      id: 13482abf-f80e-4aff-8c73-ea1892e89cca
+      id: 831a0609-dd5d-4a0c-8c80-21e4416c247d
       version: -1
       name: Check the number of endpoints in context
       description: Check the number of endpoints in context
@@ -1414,10 +1412,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "42":
     id: "42"
-    taskid: 50c4c90d-3a33-4fa0-829c-8998ec068637
+    taskid: f12d8c07-a71f-4fe7-8f69-0cc9326364b2
     type: regular
     task:
-      id: 50c4c90d-3a33-4fa0-829c-8998ec068637
+      id: f12d8c07-a71f-4fe7-8f69-0cc9326364b2
       version: -1
       name: xdr-get-endpoints
       description: Gets a list of endpoints, according to the passed filters. If there are no filters, all endpoints are returned. Filtering by multiple fields will be concatenated using AND condition (OR is not supported). Maximum result set size is 100. Offset is the zero-based number of endpoint from the start of the result set (start by counting from 0).
@@ -1446,10 +1444,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "43":
     id: "43"
-    taskid: d023e674-a215-4bf2-8882-e7c247f3a8b1
+    taskid: a1da1fa8-1531-48ce-8f0e-debeddbac2f4
     type: condition
     task:
-      id: d023e674-a215-4bf2-8882-e7c247f3a8b1
+      id: a1da1fa8-1531-48ce-8f0e-debeddbac2f4
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1498,10 +1496,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "44":
     id: "44"
-    taskid: 21a109a6-4e40-4735-811d-0db09f8897d1
+    taskid: 85d56b77-4b86-4f37-8560-865c5defbea1
     type: regular
     task:
-      id: 21a109a6-4e40-4735-811d-0db09f8897d1
+      id: 85d56b77-4b86-4f37-8560-865c5defbea1
       version: -1
       name: xdr-get-audit-agent-reports
       description: xdr-get-audit-agent-reports
@@ -1547,10 +1545,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "45":
     id: "45"
-    taskid: b6461e9d-6a85-4041-81b3-9be0e0450624
+    taskid: 98f9ddfc-5df1-4ea6-81a3-3d2d6c345a86
     type: condition
     task:
-      id: b6461e9d-6a85-4041-81b3-9be0e0450624
+      id: 98f9ddfc-5df1-4ea6-81a3-3d2d6c345a86
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1594,10 +1592,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "46":
     id: "46"
-    taskid: fc674481-cdd0-41bb-8dce-fb48427bb270
+    taskid: b86fcd0f-cf55-40d6-8388-4e42eca51c63
     type: regular
     task:
-      id: fc674481-cdd0-41bb-8dce-fb48427bb270
+      id: b86fcd0f-cf55-40d6-8388-4e42eca51c63
       version: -1
       name: xdr-get-audit-management-logs
       description: xdr-get-audit-management-logs
@@ -1637,10 +1635,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "47":
     id: "47"
-    taskid: 68bb4e81-3967-4acd-80c0-fe602e3bf619
+    taskid: 41d66d95-87a4-4d47-8792-b5488064ce20
     type: condition
     task:
-      id: 68bb4e81-3967-4acd-80c0-fe602e3bf619
+      id: 41d66d95-87a4-4d47-8792-b5488064ce20
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1676,10 +1674,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "48":
     id: "48"
-    taskid: 36752207-6f4f-47b9-8130-8c20dcceb03d
+    taskid: 881c45ee-fe01-4e6a-8a34-cba49d12c5eb
     type: regular
     task:
-      id: 36752207-6f4f-47b9-8130-8c20dcceb03d
+      id: 881c45ee-fe01-4e6a-8a34-cba49d12c5eb
       version: -1
       name: xdr-get-distribution-url
       description: xdr-get-distribution-url
@@ -1713,10 +1711,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "49":
     id: "49"
-    taskid: 200b688e-b366-4fee-8a9f-b9066927fff2
+    taskid: 18d86a1c-020e-4a89-8041-57b7df5bbe4a
     type: condition
     task:
-      id: 200b688e-b366-4fee-8a9f-b9066927fff2
+      id: 18d86a1c-020e-4a89-8041-57b7df5bbe4a
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1763,10 +1761,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "50":
     id: "50"
-    taskid: 82d28c49-247a-4ec0-8221-3f9c2e9240c2
+    taskid: 56069267-4c4c-4d63-8d5a-c57d2928db16
     type: regular
     task:
-      id: 82d28c49-247a-4ec0-8221-3f9c2e9240c2
+      id: 56069267-4c4c-4d63-8d5a-c57d2928db16
       version: -1
       name: xdr-get-create-distribution-status
       description: xdr-get-create-distribution-status
@@ -1798,10 +1796,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "51":
     id: "51"
-    taskid: 6a5cffd3-8566-456e-896d-10ce83c57bc4
+    taskid: 549d3eaf-3f5a-4ba4-8a9e-dbeb24fd2700
     type: condition
     task:
-      id: 6a5cffd3-8566-456e-896d-10ce83c57bc4
+      id: 549d3eaf-3f5a-4ba4-8a9e-dbeb24fd2700
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1842,10 +1840,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "52":
     id: "52"
-    taskid: 07600676-2d21-4f78-83cc-0fca19829a2f
+    taskid: 3386d7c3-e532-47f2-8526-7427f52e2b3c
     type: regular
     task:
-      id: 07600676-2d21-4f78-83cc-0fca19829a2f
+      id: 3386d7c3-e532-47f2-8526-7427f52e2b3c
       version: -1
       name: xdr-create-distribution
       description: xdr-create-distribution
@@ -1889,10 +1887,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "53":
     id: "53"
-    taskid: 88d6bf1d-1425-41db-88de-551fd8061d01
+    taskid: e4bab8aa-3021-41ad-89ad-6cbc4002bf2e
     type: condition
     task:
-      id: 88d6bf1d-1425-41db-88de-551fd8061d01
+      id: e4bab8aa-3021-41ad-89ad-6cbc4002bf2e
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -1933,10 +1931,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "54":
     id: "54"
-    taskid: b8f14494-700a-46fa-864e-bdc1840c3528
+    taskid: 33de01f8-7db0-4cff-8ee6-dc39008e9a0a
     type: regular
     task:
-      id: b8f14494-700a-46fa-864e-bdc1840c3528
+      id: 33de01f8-7db0-4cff-8ee6-dc39008e9a0a
       version: -1
       name: xdr-get-distribution-versions
       description: xdr-get-distribution-versions
@@ -1965,10 +1963,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "55":
     id: "55"
-    taskid: 8a5a09c2-499c-4405-8abe-70416f176508
+    taskid: 7a97cba3-a9f7-42b5-8677-b67fa58fea19
     type: regular
     task:
-      id: 8a5a09c2-499c-4405-8abe-70416f176508
+      id: 7a97cba3-a9f7-42b5-8677-b67fa58fea19
       version: -1
       name: xdr-get-contributing-event
       description: Retrieves contributing events for a specific alert.
@@ -1981,7 +1979,11 @@ tasks:
       - "56"
     scriptarguments:
       alert_ids:
-        simple: "34159"
+        complex:
+          root: PaloAltoNetworksXDR.Alert
+          accessor: internal_id
+          transformers:
+          - operator: FirstArrayElement
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -2000,10 +2002,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "56":
     id: "56"
-    taskid: 7abc7119-4016-4140-895c-e83ee85786f5
+    taskid: ceeef896-569c-4f73-8004-459a682e2d17
     type: condition
     task:
-      id: 7abc7119-4016-4140-895c-e83ee85786f5
+      id: ceeef896-569c-4f73-8004-459a682e2d17
       version: -1
       name: Verify Outputs
       type: condition
@@ -2016,26 +2018,20 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isEqualString
+      - - operator: isNotEmpty
           left:
             value:
               complex:
                 root: PaloAltoNetworksXDR.ContributingEvent
                 accessor: alertID
             iscontext: true
-          right:
-            value:
-              simple: "34159"
-      - - operator: hasLength
+      - - operator: isNotEmpty
           left:
             value:
               complex:
                 root: PaloAltoNetworksXDR.ContributingEvent
                 accessor: events
             iscontext: true
-          right:
-            value:
-              simple: "1"
     continueonerrortype: ""
     view: |-
       {
@@ -2053,10 +2049,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "57":
     id: "57"
-    taskid: 955404fe-3e42-48e4-8826-91418157e1e5
+    taskid: 1ea61c4d-031e-4380-8dff-39358f0b7658
     type: regular
     task:
-      id: 955404fe-3e42-48e4-8826-91418157e1e5
+      id: 1ea61c4d-031e-4380-8dff-39358f0b7658
       version: -1
       name: xdr-replace-featured-field
       description: Replace the featured hosts\users\ips\active-directory_groups listed in your environment.
@@ -2092,10 +2088,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "58":
     id: "58"
-    taskid: 2f5c5864-63dc-4a83-8f28-b80029edcb87
+    taskid: f4f304a0-fad3-4d8c-8304-c87113225df2
     type: condition
     task:
-      id: 2f5c5864-63dc-4a83-8f28-b80029edcb87
+      id: f4f304a0-fad3-4d8c-8304-c87113225df2
       version: -1
       name: Verify Outputs
       type: condition
@@ -2145,10 +2141,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "59":
     id: "59"
-    taskid: 55aff88b-08c7-43f8-892f-4ad2fd811560
+    taskid: df55a9c0-283c-425c-854e-0b3e724e6bab
     type: regular
     task:
-      id: 55aff88b-08c7-43f8-892f-4ad2fd811560
+      id: df55a9c0-283c-425c-854e-0b3e724e6bab
       version: -1
       name: DeleteContext
       description: DeleteContext
@@ -2158,7 +2154,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "55"
+      - "81"
     scriptarguments:
       all:
         simple: "yes"
@@ -2168,7 +2164,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 195
+          "y": 45
         }
       }
     note: false
@@ -2180,10 +2176,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "60":
     id: "60"
-    taskid: 30f977d2-6caa-446c-8bd3-b35bbf9e76b0
+    taskid: 816090ca-43ff-486e-88d2-6c5361a24097
     type: regular
     task:
-      id: 30f977d2-6caa-446c-8bd3-b35bbf9e76b0
+      id: 816090ca-43ff-486e-88d2-6c5361a24097
       version: -1
       name: Get endpoint
       description: Gets a list of endpoints, according to the passed filters. If there are no filters, all endpoints are returned. Filtering by multiple fields will be concatenated using AND condition (OR is not supported). Maximum result set size is 100. Offset is the zero-based number of endpoint from the start of the result set (start by counting from 0).
@@ -2215,10 +2211,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "61":
     id: "61"
-    taskid: 9b262711-051b-4706-803a-08e19d172c23
+    taskid: ca6d2ce8-dcab-43cf-8b0b-16a89c5be6af
     type: regular
     task:
-      id: 9b262711-051b-4706-803a-08e19d172c23
+      id: ca6d2ce8-dcab-43cf-8b0b-16a89c5be6af
       version: -1
       name: Save original alias name
       description: Set a value in context under the key you entered.
@@ -2263,10 +2259,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "62":
     id: "62"
-    taskid: 4ec5cdf1-0795-4894-8619-fe938dca4012
+    taskid: eea9b039-c0e4-4d48-88f3-524730c40d8f
     type: regular
     task:
-      id: 4ec5cdf1-0795-4894-8619-fe938dca4012
+      id: eea9b039-c0e4-4d48-88f3-524730c40d8f
       version: -1
       name: Delete context
       description: |-
@@ -2303,10 +2299,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "63":
     id: "63"
-    taskid: 4441a38d-b405-4ae3-8d59-1278eb51bc4b
+    taskid: 4ae5c7f3-765c-493b-875e-625c1f8cc11e
     type: regular
     task:
-      id: 4441a38d-b405-4ae3-8d59-1278eb51bc4b
+      id: 4ae5c7f3-765c-493b-875e-625c1f8cc11e
       version: -1
       name: Change alias name
       description: Gets a list of endpoints according to the passed filters, and changes their alias name. Filtering by multiple fields will be concatenated using the AND condition (OR is not supported).
@@ -2340,10 +2336,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "64":
     id: "64"
-    taskid: 6ff1ed98-0f53-4771-83e8-9a3508393889
+    taskid: 56a6c868-66c9-4ccf-8b8e-322930493f04
     type: condition
     task:
-      id: 6ff1ed98-0f53-4771-83e8-9a3508393889
+      id: 56a6c868-66c9-4ccf-8b8e-322930493f04
       version: -1
       name: Verify the name was changed
       description: Gets a list of endpoints, according to the passed filters. If there are no filters, all endpoints are returned. Filtering by multiple fields will be concatenated using AND condition (OR is not supported). Maximum result set size is 100. Offset is the zero-based number of endpoint from the start of the result set (start by counting from 0).
@@ -2393,10 +2389,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "65":
     id: "65"
-    taskid: 6b838130-6c58-4b7f-8615-76493fca566d
+    taskid: 4dbc9cc3-0685-4e0c-83ca-3f0f262af935
     type: regular
     task:
-      id: 6b838130-6c58-4b7f-8615-76493fca566d
+      id: 4dbc9cc3-0685-4e0c-83ca-3f0f262af935
       version: -1
       name: Get endpoint
       description: Gets a list of endpoints, according to the passed filters. If there are no filters, all endpoints are returned. Filtering by multiple fields will be concatenated using AND condition (OR is not supported). Maximum result set size is 100. Offset is the zero-based number of endpoint from the start of the result set (start by counting from 0).
@@ -2428,10 +2424,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "66":
     id: "66"
-    taskid: 85c4ea4f-82ab-4877-8be5-69699a3cc0c3
+    taskid: 86098caa-d146-44c8-8a9d-746cfb4bc3f2
     type: regular
     task:
-      id: 85c4ea4f-82ab-4877-8be5-69699a3cc0c3
+      id: 86098caa-d146-44c8-8a9d-746cfb4bc3f2
       version: -1
       name: Change alias name to the original name
       description: Gets a list of endpoints according to the passed filters, and changes their alias name. Filtering by multiple fields will be concatenated using the AND condition (OR is not supported).
@@ -2468,10 +2464,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "67":
     id: "67"
-    taskid: 94779237-00f3-4bc6-8801-470490cac3b5
+    taskid: b2497abd-049f-429d-8cec-b7b879769957
     type: regular
     task:
-      id: 94779237-00f3-4bc6-8801-470490cac3b5
+      id: b2497abd-049f-429d-8cec-b7b879769957
       version: -1
       name: xdr-list-users
       description: Retrieve a list of the current users in your environment.
@@ -2500,10 +2496,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "68":
     id: "68"
-    taskid: 2b7d5a49-e2de-41bb-898e-70656fa9be1f
+    taskid: 710bc3a3-51b7-4669-83bd-8c00c74761f5
     type: condition
     task:
-      id: 2b7d5a49-e2de-41bb-898e-70656fa9be1f
+      id: 710bc3a3-51b7-4669-83bd-8c00c74761f5
       version: -1
       name: Verify Outputs
       type: condition
@@ -2541,10 +2537,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "72":
     id: "72"
-    taskid: ecd13a4a-c773-4705-8366-3a93f0c587e7
+    taskid: c6c51606-70b0-439d-84f3-4547d748059d
     type: regular
     task:
-      id: ecd13a4a-c773-4705-8366-3a93f0c587e7
+      id: c6c51606-70b0-439d-84f3-4547d748059d
       version: -1
       name: xdr-list-risky-users
       description: Retrieve the risk score of a specific user or list of users with the highest risk score in your environment along with the reason affecting each score.
@@ -2576,10 +2572,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "73":
     id: "73"
-    taskid: b82a9db8-b169-4a60-8b47-f1be458f45d4
+    taskid: 1d136452-a2cf-43ef-8615-9d51f80b1caf
     type: condition
     task:
-      id: b82a9db8-b169-4a60-8b47-f1be458f45d4
+      id: 1d136452-a2cf-43ef-8615-9d51f80b1caf
       version: -1
       name: Verify Outputs
       type: condition
@@ -2617,10 +2613,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "76":
     id: "76"
-    taskid: 9731d6f6-3efa-48e1-8efe-4e00114c40ac
+    taskid: a02bdc7e-d4d6-412f-81bd-6268c7e48c61
     type: regular
     task:
-      id: 9731d6f6-3efa-48e1-8efe-4e00114c40ac
+      id: a02bdc7e-d4d6-412f-81bd-6268c7e48c61
       version: -1
       name: xdr-list-risky-hosts
       description: Retrieve the risk score of a specific host or list of hosts with the highest risk score in your environment along with the reason affecting each score.
@@ -2652,10 +2648,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "77":
     id: "77"
-    taskid: 09f53c2f-9d88-4c8f-8f64-cbb1d7d0b6c7
+    taskid: dda888db-59bb-4ae2-8e68-6ad42db7f387
     type: condition
     task:
-      id: 09f53c2f-9d88-4c8f-8f64-cbb1d7d0b6c7
+      id: dda888db-59bb-4ae2-8e68-6ad42db7f387
       version: -1
       name: Verify Outputs
       type: condition
@@ -2693,10 +2689,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "78":
     id: "78"
-    taskid: 2af31dfc-0851-4c10-86c2-cdfec87b0765
+    taskid: 986cd567-b783-43bb-8a53-d1b905773c36
     type: regular
     task:
-      id: 2af31dfc-0851-4c10-86c2-cdfec87b0765
+      id: 986cd567-b783-43bb-8a53-d1b905773c36
       version: -1
       name: xdr-list-roles
       description: Retrieve information about one or more roles created in your environment.
@@ -2728,10 +2724,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "79":
     id: "79"
-    taskid: 22022e46-6681-469d-8bc1-f901bc04ff81
+    taskid: 926deb2e-7e35-47da-819c-84afdd15c088
     type: condition
     task:
-      id: 22022e46-6681-469d-8bc1-f901bc04ff81
+      id: 926deb2e-7e35-47da-819c-84afdd15c088
       version: -1
       name: Verify Outputs
       type: condition
@@ -2769,15 +2765,50 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+  "81":
+    id: "81"
+    taskid: c17f9fd4-87cd-4582-84ab-a2ad7cb63f94
+    type: regular
+    task:
+      id: c17f9fd4-87cd-4582-84ab-a2ad7cb63f94
+      version: -1
+      name: get-correlation-alerts
+      description: "Returns a list of alerts and their metadata, which you can filter by built-in arguments or use the custom_filter to input a JSON filter object. \nMultiple filter arguments will be concatenated using the AND operator, while arguments that support a comma-separated list of values will use an OR operator between each value."
+      script: '|||xdr-get-alerts'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "55"
+    scriptarguments:
+      alert_source:
+        simple: correlation
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 205
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 11555,
+        "height": 11705,
         "width": 922.5,
         "x": 50,
-        "y": 50
+        "y": -100
       }
     }
   }

--- a/Packs/CortexXDR/TestPlaybooks/Test_XDR_Playbook_general_commands.yml
+++ b/Packs/CortexXDR/TestPlaybooks/Test_XDR_Playbook_general_commands.yml
@@ -22,7 +22,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": -100
+          "y": -270
         }
       }
     note: false
@@ -197,10 +197,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: 49c37fa5-9f5f-44e0-87db-2ed6c13c9501
+    taskid: 86a0e7eb-c183-4441-832f-7a814860a718
     type: condition
     task:
-      id: 49c37fa5-9f5f-44e0-87db-2ed6c13c9501
+      id: 86a0e7eb-c183-4441-832f-7a814860a718
       version: -1
       name: Verify Outputs
       description: Verify Outputs
@@ -219,11 +219,6 @@ tasks:
             value:
               simple: PaloAltoNetworksXDR.Incident.incident_id
             iscontext: true
-      - - operator: isExists
-          left:
-            value:
-              simple: PaloAltoNetworksXDR.Incident.manual_severity
-            iscontext: true
       - - operator: isNotEmpty
           left:
             value:
@@ -232,32 +227,7 @@ tasks:
       - - operator: isNotEmpty
           left:
             value:
-              simple: PaloAltoNetworksXDR.Incident.xdr_url
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
               simple: PaloAltoNetworksXDR.Incident.status
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: PaloAltoNetworksXDR.Incident.alerts.alert_id
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: PaloAltoNetworksXDR.Incident.alerts.source
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: PaloAltoNetworksXDR.Incident.network_artifacts.network_remote_ip
-            iscontext: true
-      - - operator: isNotEmpty
-          left:
-            value:
-              simple: File.SHA256
             iscontext: true
     continueonerrortype: ""
     view: |-
@@ -1990,7 +1960,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 370
+          "y": 360
         }
       }
     note: false
@@ -2164,7 +2134,7 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 45
+          "y": -135
         }
       }
     note: false
@@ -2780,7 +2750,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "55"
+      - "82"
     scriptarguments:
       alert_source:
         simple: correlation
@@ -2790,7 +2760,47 @@ tasks:
       {
         "position": {
           "x": 265,
-          "y": 205
+          "y": 25
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "82":
+    id: "82"
+    taskid: c8603613-0ee9-4615-8b2c-0cc37400e027
+    type: condition
+    task:
+      id: c8603613-0ee9-4615-8b2c-0cc37400e027
+      version: -1
+      name: check if have any correlation alerts
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "57"
+      "yes":
+      - "55"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: PaloAltoNetworksXDR.Alert.internal_id
+            iscontext: true
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 190
         }
       }
     note: false
@@ -2805,14 +2815,13 @@ view: |-
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 11705,
+        "height": 11875,
         "width": 922.5,
         "x": 50,
-        "y": -100
+        "y": -270
       }
     }
   }
 inputs: []
 outputs: []
 fromversion: 5.0.0
-description: ''


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6961)

## Description
Instead of sending arbitrary alert that might be removed by XDR, we query all the correlation alerts we have in the instance and then put the first one we find.

In that way its being done dynamically rather then giving specific `alert_id` as an input.


<img width="408" alt="image" src="https://github.com/demisto/content/assets/53861351/ce50a710-1a9a-4c05-a03c-890f5681277e">


<img width="941" alt="image" src="https://github.com/demisto/content/assets/53861351/32c29ff5-fa4d-4bfa-8e10-3bb4325bc48d">

<img width="608" alt="image" src="https://github.com/demisto/content/assets/53861351/9db5d724-b957-40a0-b702-c2bf9056afa0">

<img width="1755" alt="image" src="https://github.com/demisto/content/assets/53861351/d193c02e-87ec-4bda-8875-f2874cf4de0d">

