### PR TITLE
PAN-OS new command: pan-os-remove-security-profile

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -6937,8 +6937,11 @@ def apply_security_profile(xpath: str, profile_name: str, profile_type: str) -> 
     profile_types = {'data-filtering', 'file-blocking', 'spyware', 'url-filtering',
                      'virus', 'vulnerability', 'wildfire-analysis'} - {profile_type}
 
-    # first we update the given profile type with the given profile name
-    rule_profiles = f"<{profile_type}><member>{profile_name}</member></{profile_type}>"
+    rule_profiles = ''
+
+    if profile_name:  # if not, we remove the given profile_type
+        # first we update the given profile type with the given profile name
+        rule_profiles += f"<{profile_type}><member>{profile_name}</member></{profile_type}>"
 
     # Keeping the existing profile types
     for p_type in profile_types:
@@ -6960,7 +6963,7 @@ def apply_security_profile(xpath: str, profile_name: str, profile_type: str) -> 
 
 
 def apply_security_profile_command(args):
-    profile_name = args.get('profile_name')
+    profile_name = args.get('profile_name', '')  # when removing a profile, no need to a pass a profile_name
     profile_type = args.get('profile_type')
     rule_name = args.get('rule_name')
     pre_post = args.get('pre_post')
@@ -6975,7 +6978,10 @@ def apply_security_profile_command(args):
         xpath = f"{XPATH_RULEBASE}rulebase/security/rules/entry[@name='{rule_name}']"
 
     apply_security_profile(xpath, profile_name, profile_type)
-    return_results(f'The profile {profile_name} has been applied to the rule {rule_name}')
+    if profile_name:
+        return_results(f'The profile {profile_type} = {profile_name} has been applied to the rule {rule_name}')
+    else:
+        return_results(f'The profile {profile_type} has been removed from the rule {rule_name}')
 
 
 @logger
@@ -14178,6 +14184,9 @@ def main():  # pragma: no cover
             get_security_profiles_command(args.get('security_profile'))
 
         elif command == 'panorama-apply-security-profile' or command == 'pan-os-apply-security-profile':
+            apply_security_profile_command(args)
+
+        elif command == 'pan-os-remove-security-profile':
             apply_security_profile_command(args)
 
         elif command == 'panorama-get-ssl-decryption-rules' or command == 'pan-os-get-ssl-decryption-rules':

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -3,7 +3,7 @@ sectionorder:
 - Connect
 - Collect
 commonfields:
-  id: Panorama
+  id: Panorama - dev
   version: -1
 configuration:
 - display: Server URL (e.g., https://192.168.0.1)
@@ -214,8 +214,8 @@ configuration:
   type: 13
   section: Connect
 description: Manage Palo Alto Networks Firewall and Panorama. Use this pack to manage Prisma Access through Panorama. For more information, see the Panorama documentation
-display: Palo Alto Networks PAN-OS
-name: Panorama
+display: Palo Alto Networks PAN-OS - dev
+name: Panorama - dev
 script:
   commands:
   - arguments:
@@ -6879,6 +6879,33 @@ script:
       required: false
     description: Applies a security profile to specific rules or rules with a specific tag.
     name: pan-os-apply-security-profile
+  - arguments:
+    - description: The security profile type.
+      name: profile_type
+      required: true
+      auto: PREDEFINED
+      predefined:
+      - data-filtering
+      - file-blocking
+      - spyware
+      - url-filtering
+      - virus
+      - vulnerability
+      - wildfire-analysis
+    - description: The rule name to apply.
+      name: rule_name
+      required: true
+    - auto: PREDEFINED
+      description: The location of the rules. Mandatory for Panorama instances.
+      name: pre_post
+      predefined:
+      - pre-rulebase
+      - post-rulebase
+    - description: The device group for which to apply security profiles.
+      name: device-group
+      required: false
+    description: Removes a security profile to specific rules or rules with a specific tag.
+    name: pan-os-remove-security-profile
   - arguments:
     - description: The location of the rules. Mandatory for Panorama instances.
       name: pre_post


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6985

## Description
This command was added since *pan-os-apply-security-profile* does not support for removing a profile (just adding or replacing an exists one).

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
