### PR TITLE
[Zscaler] improved test module command

### DIFF
--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler.py
@@ -1008,8 +1008,12 @@ def activate_command():
 
 
 def test_module():
-    http_request("GET", "/status", None, DEFAULT_HEADERS)
-    return "ok"
+
+    response = http_request("GET", "/status", None, DEFAULT_HEADERS).json()
+    if 'status' in response:
+        return "ok"
+    else:
+        raise ValueError('Test failed, please check if URL is valid')
 
 
 def get_category_by_id(category_id):

--- a/Packs/Zscaler/Integrations/Zscaler/Zscaler_test.py
+++ b/Packs/Zscaler/Integrations/Zscaler/Zscaler_test.py
@@ -674,3 +674,17 @@ def test_delete_ip_destination_groups(mocker):
                      response_path='test_data/responses/delete_ip_destination_group.json',
                      expected_result_path='test_data/results/delete_ip_destination_group.json',
                      mocker=mocker)
+
+
+def test_test_module_command(mocker):
+    from Zscaler import test_module
+    mocker.patch('Zscaler.http_request', return_value={'status': 'ACTIVE'})
+    assert test_module() == 'ok'
+
+
+def test_test_module_command_failure(mocker):
+    from Zscaler import test_module
+    mocker.patch('Zscaler.http_request', return_value={})
+    msg = 'Test failed, please check if URL is valid'
+    with pytest.raises(ValueError, match=msg):
+        test_module()

--- a/Packs/Zscaler/ReleaseNotes/1_3_12.md
+++ b/Packs/Zscaler/ReleaseNotes/1_3_12.md
@@ -1,0 +1,4 @@
+#### Integrations
+
+##### Zscaler Internet Access
+- Fixed an issue where the ***test-module*** command passed with *Cloud Name* parameter incorrect.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zscaler Internet Access",
     "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
     "support": "xsoar",
-    "currentVersion": "1.3.11",
+    "currentVersion": "1.3.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25099
## Description
fix an issue where the test-module command pass even when the cloud name parameter is incorrect

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
