### PR TITLE
Fix small grammar typos in documentation

### DIFF
--- a/Packs/AWS_WAF/Integrations/AWSWAF/AWSWAF.py
+++ b/Packs/AWS_WAF/Integrations/AWSWAF/AWSWAF.py
@@ -133,7 +133,7 @@ def build_visibility_config_object(metric_name: str,
 
 def get_tags_dict_from_args(tag_keys: list, tag_values: list) -> list:
     """
-    Creates a list of dictionaries containing the tag key, and it's corresponding value
+    Creates a list of dictionaries containing the tag key, and its corresponding value
     Args:
         tag_keys: tag keys list
         tag_values: tag values list

--- a/Packs/AWS_WAF/Integrations/AWSWAF/AWSWAF.yml
+++ b/Packs/AWS_WAF/Integrations/AWSWAF/AWSWAF.yml
@@ -1463,7 +1463,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/boto3py3:1.0.0.50693
+  dockerimage: demisto/boto3py3:1.0.0.63655
 fromversion: 6.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/AWS_WAF/ReleaseNotes/1_0_1.md
+++ b/Packs/AWS_WAF/ReleaseNotes/1_0_1.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### AWS-WAF
+
+- Fixed grammar in a comment.
+- Updated the Docker image to: *demisto/boto3py3:1.0.0.63655*.

--- a/Packs/AWS_WAF/pack_metadata.json
+++ b/Packs/AWS_WAF/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS WAF",
     "description": "Amazon Web Services Web Application Firewall (WAF)",
     "support": "xsoar",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.py
+++ b/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.py
@@ -172,7 +172,7 @@ def _extract_analysis_info(res: dict, dbot_score_type: str,
 
 def _check_returned_results(res: dict) -> List[str]:
     """
-    Checks which indicator value founded on iDefense database.
+    Checks which indicator values were found on iDefense database.
     Args:
         res: api response
     Returns: list of indicator values that returned from api request

--- a/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.py
+++ b/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.py
@@ -172,7 +172,7 @@ def _extract_analysis_info(res: dict, dbot_score_type: str,
 
 def _check_returned_results(res: dict) -> List[str]:
     """
-    Checks which indicator values were found on iDefense database.
+    Checks which indicator values were found in the iDefense database.
     Args:
         res: api response
     Returns: list of indicator values that returned from api request

--- a/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.yml
+++ b/Packs/AccentureCTI/Integrations/ACTIIndicatorQuery/ACTIIndicatorQuery.yml
@@ -404,7 +404,7 @@ script:
       description: The actual score.
       type: String
 
-  dockerimage: demisto/python3:3.10.11.61265
+  dockerimage: demisto/python3:3.10.12.63474
   feed: false
   isfetch: false
   longRunning: false

--- a/Packs/AccentureCTI/ReleaseNotes/2_2_16.md
+++ b/Packs/AccentureCTI/ReleaseNotes/2_2_16.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ACTI Indicator Query
+
+- Fixed grammar in a comment.
+- Updated the Docker image to: *demisto/python3:3.10.12.63474*.

--- a/Packs/AccentureCTI/pack_metadata.json
+++ b/Packs/AccentureCTI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Accenture CTI v2",
     "description": "Accenture CTI provides intelligence regarding security threats and vulnerabilities.",
     "support": "partner",
-    "currentVersion": "2.2.15",
+    "currentVersion": "2.2.16",
     "author": "Accenture",
     "url": "https://www.accenture.com/us-en/services/security/cyber-defense",
     "email": "CTI.AcctManagement@accenture.com",


### PR DESCRIPTION
This fix addresses a couple of small grammar mistakes in docstrings.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)
