### PR TITLE
Fixed empty installation 

### DIFF
--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -340,7 +340,7 @@ def install_packs(client: demisto_client,
     """
     global SUCCESS_FLAG
     if not packs_to_install:
-        logging.info("There is not packs to install on servers. Consolidating installation as success")
+        logging.info("There are no packs to install on servers. Consolidating installation as success")
         return SUCCESS_FLAG
     try:
         for attempt in range(attempts_count - 1, -1, -1):

--- a/Tests/Marketplace/search_and_install_packs.py
+++ b/Tests/Marketplace/search_and_install_packs.py
@@ -339,6 +339,9 @@ def install_packs(client: demisto_client,
         sleep_interval (int): The sleep interval, in seconds, between install attempts.
     """
     global SUCCESS_FLAG
+    if not packs_to_install:
+        logging.info("There is not packs to install on servers. Consolidating installation as success")
+        return SUCCESS_FLAG
     try:
         for attempt in range(attempts_count - 1, -1, -1):
             try:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
We always try to install packs on the servers, even if the packs list is empty. Added a check on that list and considered the installation as a success in case there are no packs to install.

