### PR TITLE
Draft - Adding A New Version corepacks.json File Example

### DIFF
--- a/Tests/Marketplace/versions-metadata.json
+++ b/Tests/Marketplace/versions-metadata.json
@@ -2,6 +2,11 @@
   "version_map": {
     "8.3.0": {
       "core_packs_file": "corepacks-8.3.0.json",
+      "core_packs_file_is_locked": true,
+      "file_version": "1"
+    },
+    "8.4.0": {
+      "core_packs_file": "corepacks-8.4.0.json",
       "core_packs_file_is_locked": false,
       "file_version": "1"
     }


### PR DESCRIPTION
Confluence: https://confluence-dc.paloaltonetworks.com/display/DemistoContent/Versioned+corepacks+files

## Related Issues
related: https://jira-hq.paloaltonetworks.local/browse/CIAC-5745

## Description
An example of a PR that should be opened to create a new versioned corepacks file. In this example:
1. Server version 8.3.0 should be locked, i.e. the corepacks list for this version shouldn't be updated anymore.
2. A new versioned corepacks file is created for server version 8.4.0,
