### PR TITLE
[TestIsMaliciousIndicatorFound] - add sleep for indexing indicators

### DIFF
--- a/Packs/CommonScripts/TestPlaybooks/playbook-TestIsMaliciousIndicatorFound.yml
+++ b/Packs/CommonScripts/TestPlaybooks/playbook-TestIsMaliciousIndicatorFound.yml
@@ -1345,7 +1345,7 @@ tasks:
       - "35"
     scriptarguments:
       seconds:
-        simple: "4"
+        simple: "8"
     separatecontext: false
     view: |-
       {
@@ -1413,7 +1413,7 @@ tasks:
       - "37"
     scriptarguments:
       seconds:
-        simple: "4"
+        simple: "8"
     separatecontext: false
     view: |-
       {
@@ -1480,7 +1480,7 @@ tasks:
       - "39"
     scriptarguments:
       seconds:
-        simple: "4"
+        simple: "8"
     separatecontext: false
     view: |-
       {
@@ -1547,7 +1547,7 @@ tasks:
       - "41"
     scriptarguments:
       seconds:
-        simple: "4"
+        simple: "8"
     separatecontext: false
     view: |-
       {
@@ -1842,7 +1842,7 @@ tasks:
       - "46"
     scriptarguments:
       seconds:
-        simple: "4"
+        simple: "8"
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6842)

## Description
add sleep in order to wait for indicators to be indexed

