### PR TITLE
Phishing add subject to layout

### DIFF
--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing_v_3.json
@@ -137,10 +137,19 @@
                             },
                             {
                                 "endCol": 2,
+                                "fieldId": "reportedemailsubject",
+                                "height": 22,
+                                "id": "02f6f6c0-111c-11ee-a4d9-8dbe5c55933f",
+                                "index": 9,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
                                 "fieldId": "attachmentcount",
                                 "height": 22,
                                 "id": "86ae8b10-a901-11ec-8585-0dac7af6e9b0",
-                                "index": 9,
+                                "index": 10,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -149,7 +158,7 @@
                                 "fieldId": "emailrecipientscount",
                                 "height": 22,
                                 "id": "77a63970-6279-11ec-8fa2-217b8b611613",
-                                "index": 10,
+                                "index": 11,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -158,7 +167,7 @@
                                 "fieldId": "categories",
                                 "height": 22,
                                 "id": "5e2287d0-e502-11ed-ba0f-99a713ead7dc",
-                                "index": 11,
+                                "index": 12,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             }

--- a/Packs/Phishing/ReleaseNotes/3_5_22.md
+++ b/Packs/Phishing/ReleaseNotes/3_5_22.md
@@ -1,0 +1,6 @@
+
+#### Layouts
+
+##### Phishing Incident v3
+
+- "Reported Email Subject" field has been added to the basic details section of the layout.

--- a/Packs/Phishing/ReleaseNotes/3_5_22.md
+++ b/Packs/Phishing/ReleaseNotes/3_5_22.md
@@ -3,4 +3,4 @@
 
 ##### Phishing Incident v3
 
-- "Reported Email Subject" field has been added to the basic details section of the layout.
+The "Reported Email Subject" field has been added to the layout's "Basic Details" section.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.5.21",
+    "currentVersion": "3.5.22",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6884

## Description
"Reported Email Subject" field has been added to the basic details section of the layout.


## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

