### PR TITLE
Fix incorrect parsing of severity level

### DIFF
--- a/Packs/Claroty/Integrations/Claroty/Claroty.py
+++ b/Packs/Claroty/Integrations/Claroty/Claroty.py
@@ -324,9 +324,9 @@ def query_alerts_command(client: Client, args: dict) -> Tuple:
     if alert_time:
         filters.append(Filter("timestamp", alert_time, "gte"))
 
-    alert_severity = args.get("severity", None)
+    alert_severity = args.get("minimal_severity", None)
     if alert_severity:
-        Filter("severity", get_severity_filter(alert_severity), "gte")
+        filters.append(Filter("severity", get_severity_filter(alert_severity), "gte"))
 
     if strtobool(args.get("exclude_resolved_alerts", "False")):
         filters = _add_exclude_resolved_alerts_filters(filters)
@@ -532,11 +532,11 @@ def transform_filters_labels_to_values(table_filters, filter_name: str, filter_v
 
 
 def get_severity_filter(severity: str) -> str:
-    severity_filter = ""
-    for severity_key in CTD_TO_DEMISTO_SEVERITY:
-        if CTD_TO_DEMISTO_SEVERITY.get(severity_key, 0) >= CTD_TO_DEMISTO_SEVERITY.get(severity, 0):
-            severity_filter += f"{severity_key},;$"
-    return severity_filter
+    severity_values = []
+    for severity_key, severity_value in CTD_TO_DEMISTO_SEVERITY.items():
+        if severity_value >= CTD_TO_DEMISTO_SEVERITY.get(severity, 0):
+            severity_values.append(str(severity_value))
+    return ",;$".join(severity_values)
 
 
 def get_list_incidents(client: Client, latest_created_time: str, page_number: int):

--- a/Packs/Claroty/Integrations/Claroty/Claroty.yml
+++ b/Packs/Claroty/Integrations/Claroty/Claroty.yml
@@ -488,7 +488,7 @@ script:
     - contextPath: Claroty.Alert.Severity
       description: The alert severity.
       type: String
-  dockerimage: demisto/python3:3.10.11.54132
+  dockerimage: demisto/python3:3.10.12.63474
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Claroty/ReleaseNotes/1_0_25.md
+++ b/Packs/Claroty/ReleaseNotes/1_0_25.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Claroty
+
+- Updated the Docker image to: *demisto/python3:3.10.12.63474*.
+- Fix severity level incorrect parsing

--- a/Packs/Claroty/pack_metadata.json
+++ b/Packs/Claroty/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Claroty",
     "description": "Use the Claroty CTD to manage assets and alerts.",
     "support": "partner",
-    "currentVersion": "1.0.24",
+    "currentVersion": "1.0.25",
     "author": "Claroty",
     "url": "",
     "email": "support@claroty.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling out the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

## Description
The severity mapping was not working correctly, and were sent key instead of a value. Also, there was an additional separator in query params that was braking filters

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [x] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
