### PR TITLE
MicrosoftGraphUser: msgraph-user-change-password 403 error

### DIFF
--- a/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/README.md
+++ b/Packs/MicrosoftGraphUser/Integrations/MicrosoftGraphUser/README.md
@@ -599,7 +599,7 @@ There is no context output for this command.
 ***
 Changes the user password.
 Supported only in a self deployed app flow with the Permission: Directory.AccessAsUser.All(Delegated)
-
+Note: In order to change the password, you need additional permissions: Auth Admin, Privileged Auth Admin or Global Admin, depending on the target user's role.
 
 #### Base Command
 


### PR DESCRIPTION
**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-25386)

## Description
Currently the **msgraph-user-change-password** command is implemented like **msgraph-user-update**.
That means same endpoint, and the admin needs to give the user who wants to change his password additional permissions: Auth Admin, Privileged Auth Admin or Global Admin, depending on the target user's role.
A user changing his own password is a different scenario, use the /changePassword endpoint for it:
https://learn.microsoft.com/en-us/graph/api/user-changepassword?view=graph-rest-beta&tabs=http 

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
