### PR TITLE
TaegisXDR - Investigations v2

### DIFF
--- a/Packs/SecureWorks/.pack-ignore
+++ b/Packs/SecureWorks/.pack-ignore
@@ -4,7 +4,6 @@ ignore=IN126
 [file:README.md]
 ignore=RM104
 
-
 [file:SecureWorks_image.png]
 ignore=IM111
 
@@ -12,8 +11,10 @@ ignore=IM111
 ignore=IM111
 
 [known_words]
-CQL
-Taegis
 assignee
-taegis-xdr
+CQL
+MSPs
 namespace
+sharelink
+Taegis
+XDR

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -762,12 +762,11 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | id | Investigation ID to update | True |
-| key_findings | | False |
+| title | The title of the investigation | False |
+| keyFindings | The investigation Key Findings | False |
 | prioirity | The priority of the Investigation (1-5) | False |
-| service_desk_id | An ID or ticket # to relate to an Investigation | False |
-| service_desk_type | The type of id related to an investigation (e.g. Jira) | False |
 | status | The current status of the Investigation | False |
-| assignee_id | The id of a user to assign, in `auth0|12345` format | False |
+| assigneeId | The id of a user to assign, in `auth0|12345` format | False |
 
 Note: At least 1 of the above inputs (in addition to id) must be defined
 
@@ -788,7 +787,7 @@ Note: At least 1 of the above inputs (in addition to id) must be defined
 #### Command Example
 
 ```
-!taegis-update-investigation id="936c1cc1-db8f-430c-837c-1c914fcca35a" priority=3 status="Open" service_desk_id="XDR-1234" service_desk_type="Jira"
+!taegis-update-investigation id="936c1cc1-db8f-430c-837c-1c914fcca35a" priority=3 status="OPEN"
 ```
 
 #### Context Example

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -129,13 +129,18 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| description | The subject or description of the investigation | True |
+| title | The subject or description of the investigation | True |
 | priority | The priority for the investigiation [Default: 3] | False |
+| status | The status for the investigation [Default: OPEN] | False |
+| alerts | A list of alert IDs to add to the investigation [Default: []] | False |
+| keyFindings | The Key Findings for the investigation | False |
+| type | The investigation type [Default: SECURITY_INVESTIGATION] | False |
+| assigneeId | The assignee for the investigation [Default: @secureworks] | False |
 
 #### Command Example
 
 ```
-!taegis-create-investigation priority=1 description="XSOAR Created Investigation"
+!taegis-create-investigation priority=1 title="XSOAR Created Investigation"
 ```
 
 #### Context Example

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -486,7 +486,12 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| id | Investigation ID to lookup | True |
+| id | Investigation ID to lookup | False |
+| query | If not using ID, the query to utilize when searching investigations [Default: deleted_at is null] | False |
+| page | Search page number [Default: 0] | False |
+| page_size | Number of results per page [Default: 10] | False |
+| order_by | The field to order results by [Default: created_at] | False |
+| order_direction | The order direction [Default: DESCENDING] | False |
 
 #### Command Example
 
@@ -547,46 +552,6 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
                 "description": "Test Alert",
                 "message": "This is a test alert",
                 "severity": 0.5,
-            }
-        ]
-    }
-}
-```
-
-
-
-### taegis-fetch-investigations
-
-#### Base Command
-`!taegis-fetch-investigations`
-
-#### Inputs
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-| page |  | False |
-| page_size | | False |
-
-#### Command Example
-
-```
-!taegis-fetch-investigations
-```
-
-#### Context Example
-
-```
-{
-    "TaegisXDR": {
-        "Investigations": [
-            {
-                "description": "Test Investigation",
-                "id": "c2e09554-833e-41a1-bc9d-8160aec0d70d",
-                "key_findings": "",
-                "priority": 2,
-                "service_desk_id": "",
-                "service_desk_type": "",
-                "status": "Open"
             }
         ]
     }

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -252,7 +252,8 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
                     "title": "Test Alert",
                     "description": "This is a test alert",
                     "severity": 0.5,
-                }
+                },
+                "url": "https://ctpx.secureworks.com/alerts/c4f33b53-eaba-47ac-8272-199af0f7935b"
             }
         ]
     }
@@ -536,6 +537,8 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | id | Investigation ID to lookup | True |
+| page | Search page number [Default: 0] | False |
+| page_size | Number of results per page [Default: 10] | False |
 
 #### Command Example
 
@@ -700,6 +703,7 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 * OPEN
 * TRUE_POSITIVE_BENIGN
 * TRUE_POSITIVE_MALICIOUS
+* OTHER
 
 
 #### Command Examples

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -151,6 +151,39 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 ```
 
 
+### taegis-create-sharelink
+
+#### Base Command
+
+`!taegis-create-sharelink`
+
+#### Inputs
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| id | The ID of the Taegis element to create a sharelink to | True |
+| type | The type of Taegis element to create a sharelink with | True |
+
+#### Command Example
+
+```
+!taegis-create-sharelink type=investigationId id=219da0ee-8642-4363-827c-8a6fbd479082
+```
+
+#### Context Example
+
+```
+{
+    "TaegisXDR": {
+        "ShareLink": {
+            "id": "593fa115-abad-4a52-9fc4-2ec403a8a1e4",
+            "url": "https://ctpx.secureworks.com/share/593fa115-abad-4a52-9fc4-2ec403a8a1e4"
+        }
+    }
+}
+```
+
+
 ### taegis-execute-playbook
 
 #### Base Command

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -98,12 +98,12 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | comment | The comment string to add to the investigation | True |
-| parent_id | The investigation ID to add the comment to | True |
+| id | The investigation ID to add the comment to | True |
 
 #### Command Example
 
 ```
-!taegis-create-comment comment="This is a test comment" parent_id="219da0ee-8642-4363-827c-8a6fbd479082"
+!taegis-create-comment comment="This is a test comment" id="219da0ee-8642-4363-827c-8a6fbd479082"
 ```
 
 #### Context Example

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -381,12 +381,15 @@ At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| parent_id | The investigation ID to fetch comments for | True |
+| id | The investigation ID to fetch comments for | True |
+| page | Search page number [Default: 0] | False |
+| page_size | Number of results per page [Default: 10] | False |
+| order_direction | The order direction [Default: DESCENDING] | False |
 
 #### Command Example
 
 ```
-!taegis-fetch-comments parent_id=c2e09554-833e-41a1-bc9d-8160aec0d70d
+!taegis-fetch-comments id=c2e09554-833e-41a1-bc9d-8160aec0d70d
 ```
 
 #### Context Example

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -20,6 +20,42 @@ You can execute these commands from the Cortex XSOAR CLI, as part of an automati
 After you successfully execute a command, a DBot message appears in the War Room with the command details.
 
 
+### taegis-add-evidence-to-investigation
+
+#### Base Command
+
+`!taegis-add-evidence-to-investigation`
+
+#### Inputs
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| id | The investigation id to update | True |
+| alerts | A list of alert IDs to add to an investigation | False |
+| events | A list of event IDs to add to an investigation | False |
+| alert_query | A Taegis CQL query for alerts to add to the investigation | False |
+
+At least one of the inputs `alerts`, `events`, or `alert_query` MUST be defined
+
+#### Command Example
+
+```
+`!taegis-add-evidence-to-investigation` id=c207ca4c-8a78-4408-a056-49f05d6eb77d alerts="alert://priv:crowdstrike:11772:1677742145475:07e2d9cc-0a04-55ec-890a-97f39d63698e"
+```
+
+#### Context Example
+
+```
+{
+    "TaegisXDR": {
+        "InvestigationEvidenceUpdate": {
+            "investigationId": "c207ca4c-8a78-4408-a056-49f05d6eb77d"
+        }
+    }
+}
+```
+
+
 ### taegis-archive-investigation
 
 #### Base Command

--- a/Packs/SecureWorks/Integrations/TaegisXDR/README.md
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/README.md
@@ -11,6 +11,8 @@
     | Client ID | Client ID as described in the [Taegis Documentation](https://docs.ctpx.secureworks.com/apis/api_authenticate/) | True |
     | Client Secret | Client Secret as described in the [Taegis Documentation](https://docs.ctpx.secureworks.com/apis/api_authenticate/) | True |
     | Use system proxy settings | Defines whether the system proxy is used or not | False |
+    | Fetch Incident Type | The type of incident to fetch from Taegis (Alerts or Investigations) | True |
+    | Include Assets in Fetch | When using the Investigations fetch type, should assets be included? This can cause API failures or latency and should only be enabled if necessary | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
 

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -440,10 +440,10 @@ def fetch_alerts_command(client: Client, env: str, args=None):
     Fetch a specific alert or a list of alerts based on a CQL Taegis query
     """
     variables: dict = {
-        "cql_query": args.get("cql_query", "from alert severity >= 0.6 and status='OPEN'"),
+        "cql_query": args.get("cql_query", "from alert severity >= 0.4 and status='OPEN'"),
         "limit": args.get("limit", 10),
         "offset": args.get("offset", 0),
-        "ids": args.get("ids", []),  # ["alerts://id1", "alerts://id2"]
+        "ids": args.get("ids", []),  # ["alert://id1", "alert://id2"]
     }
     fields: str = args.get("fields") or """
         status
@@ -922,8 +922,8 @@ def fetch_incidents(client: Client, max_fetch: int = 15, include_assets: bool = 
 
 def fetch_investigation_alerts_command(client: Client, env: str, args=None):
     investigation_id = args.get("id")
-    page = args.get("page", 0)
-    page_size = args.get("page_size", 10)
+    page = arg_to_number(args.get("page")) or 0
+    page_size = arg_to_number(args.get("page_size")) or 10
     if not investigation_id:
         raise ValueError("Cannot fetch investigation, missing investigation_id")
 
@@ -1146,8 +1146,8 @@ def fetch_playbook_execution_command(client: Client, env: str, args=None):
 
 
 def fetch_users_command(client: Client, env: str, args=None):
-    page = int(args.get("page", 0))
-    page_size = int(args.get("page_size", 10))
+    page = arg_to_number(args.get("page")) or 0
+    page_size = arg_to_number(args.get("page_size")) or 10
 
     variables: Dict[str, Any] = {
         "filters": {
@@ -1530,7 +1530,7 @@ def generate_id_url(env: str, endpoint: str, element_id: str):
 
 def main():
     command = demisto.command()
-    demisto.info(f'Command being called is {command}')
+    demisto.debug(f'Running Taegis Command: {command}')
 
     commands: Dict[str, Any] = {
         "fetch-incidents": fetch_incidents,

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -1359,24 +1359,26 @@ def update_comment_command(client: Client, env: str, args=None):
     if not args.get("comment"):
         raise ValueError("Cannot update comment, comment cannot be empty")
 
+    fields: str = args.get("fields") or "id"
+
     query = """
-    mutation updateComment ($comment_id: ID!, $comment: CommentUpdate!) {
-        updateComment(comment_id: $comment_id, comment: $comment) {
-            id
+    mutation updateInvestigationComment($input: UpdateInvestigationCommentInput!) {
+        updateInvestigationComment(input: $input) {
+            %s
         }
     }
-    """
+    """ % (fields)
     variables = {
-        "comment_id": args.get("id"),
-        "comment": {
-            "comment": args.get("comment")
-        },
+        "input": {
+            "commentId": args.get("id"),
+            "comment": args.get("comment"),
+        }
     }
 
     result = client.graphql_run(query=query, variables=variables)
 
     try:
-        comment = result["data"]["updateComment"]
+        comment = result["data"]["updateInvestigationComment"]
     except (KeyError, TypeError):
         raise ValueError(f"Failed to locate/update comment: {result['errors'][0]['message']}")
 

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -208,38 +208,30 @@ def create_comment_command(client: Client, env: str, args=None):
     if not args.get("comment"):
         raise ValueError("Cannot create comment, comment cannot be empty")
 
-    if not args.get("parent_id"):
-        raise ValueError("Cannot create comment, parent_id cannot be empty")
+    if not args.get("id"):
+        raise ValueError("Cannot create comment, id cannot be empty")
 
-    parent_type = args.get("parent_type", "investigation").lower()
-    if parent_type not in COMMENT_TYPES:
-        raise ValueError(
-            f"The provided comment parent type, {parent_type}, is not valid. "
-            f"Supported Parent Types Values: {COMMENT_TYPES}"
-        )
+    fields: str = args.get("fields") or "id"
 
     query = """
-    mutation createComment ($comment: CommentInput!) {
-        createComment(comment: $comment) {
-            id
+    mutation addCommentToInvestigation($input: AddCommentToInvestigationInput!) {
+        addCommentToInvestigation(input: $input) {
+            %s
         }
     }
-    """
+    """ % (fields)
 
     variables = {
-        "comment": {
+        "input": {
             "comment": args.get("comment"),
-            "parent_id": args.get("parent_id"),
-            "parent_type": parent_type,
-            "section_id": args.get("section_id", ""),
-            "section_type": args.get("section_type", ""),
+            "id": args.get("id"),
         }
     }
 
     result = client.graphql_run(query=query, variables=variables)
 
     try:
-        comment = result["data"]["createComment"]
+        comment = result["data"]["addCommentToInvestigation"]
     except (KeyError, TypeError):
         raise ValueError(f"Failed to create comment: {result['errors'][0]['message']}")
 

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -12,6 +12,7 @@ GRAPHQL_ENDPOINT = "/graphql"
 ENV_URLS = {
     "us1": {"api": "https://api.ctpx.secureworks.com", "xdr": "https://ctpx.secureworks.com"},
     "us2": {"api": "https://api.delta.taegis.secureworks.com", "xdr": "https://delta.taegis.secureworks.com"},
+    "us3": {"api": "https://api.foxtrot.taegis.secureworks.com", "xdr": "https://foxtrot.taegis.secureworks.com"},
     "eu": {"api": "https://api.echo.taegis.secureworks.com", "xdr": "https://echo.taegis.secureworks.com"},
 }
 

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -21,6 +21,8 @@ ALERT_STATUSES = set((
     "OPEN",
     "TRUE_POSITIVE_BENIGN",
     "TRUE_POSITIVE_MALICIOUS",
+    "OTHER",
+    "SUPPRESSED",
 ))
 ASSET_SEARCH_FIELDS = ((
     "endpoint_type",

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -517,9 +517,7 @@ def fetch_alerts_command(client: Client, env: str, args=None):
         }
         """ % (fields)
 
-        if type(variables["ids"]) == str:
-            variables["ids"] = variables["ids"].split(",")  # alerts://id1,alerts://id2
-        variables["ids"] = [x.strip() for x in variables["ids"]]  # Ensure no whitespace
+        variables["ids"] = split_and_trim(variables["ids"])
     else:
         field = "alertsServiceSearch"
         query = """

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.py
@@ -1203,8 +1203,8 @@ def fetch_investigation_command(client: Client, env: str, args=None):
         }
         """ % (fields)
         variables = {
-            "page": arg_to_number(args.get("page")) or 0,
-            "perPage": arg_to_number(args.get("page_size")) or 10,
+            "page": args.get("page", 0),
+            "perPage": args.get("page_size", 10),
             "query": args.get("query", "deleted_at is null"),
             "orderByField": args.get("order_by", "created_at"),
             "orderDirection": args.get("order_direction", "desc")
@@ -1521,7 +1521,7 @@ def update_investigation_command(client: Client, env: str, args=None):
         if field == "assigneeId":
             if not args["assigneeId"].startswith("auth0") and args["assigneeId"] != "@secureworks":
                 raise ValueError("assigneeId MUST be in 'auth0|12345' format or '@secureworks'")
-        if field == "priority" and not 0 < arg_to_number(args.get("priority")) < 5:
+        if field == "priority" and not 0 < int(args.get("priority", 0)) < 5:
             raise ValueError("Priority must be between 1-4")
         if field == "status" and args.get("status") not in INVESTIGATION_STATUSES:
             raise ValueError((

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -60,10 +60,18 @@ configuration:
   required: false
 - display: Include Assets in Fetch
   name: include_assets
-  defaultvalue: "true"
+  defaultvalue: "false"
   type: 8
   required: false
   additionalinfo: An error can occur when the API is slow or there are a large numbers of assets being added to a new incident/investigation. Disabling this will fetch incidents without including asset information, allowing time for the investigation creation to be completed.
+- display: Fetch Incident Type
+  name: fetch_type
+  type: 15
+  required: false
+  options:
+  - alerts
+  - investigations
+  additionalinfo: The type of Taegis asset to fetch when using fetch-incidents
 script:
   script: ''
   type: python

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -386,6 +386,22 @@ script:
     - contextPath: TaegisXDR.Endpoint
       description: Results from fetching the endpoint information
     description: Fetch endpoint information
+  - name: taegis-add-evidence-to-investigation
+    arguments:
+    - name: id
+      required: true
+      description: The investigation ID to update
+    - name: alerts
+      description: A list of alert IDs or string of comma-separated alert IDs to add
+      isArray: true
+    - name: events
+      description: A list of alert IDs or string of comma-separated event IDs to add
+    - name: alert_query
+      description: A CQL query to find alerts to add to the investigation
+    outputs:
+    - contextPath: TaegisXDR.InvestigationEvidenceUpdate
+      description: The investigation that received the update
+    description: Add alerts and events to an existing investigation
   dockerimage: demisto/python3:3.10.12.63474
   runonce: false
   subtype: python3

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -81,6 +81,8 @@ script:
     - name: offset
       description: The results to start with
       defaultValue: "0"
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Alerts
       description: List of Taegis alerts
@@ -119,6 +121,8 @@ script:
       - "5"
       description: The priority of the investigation (1-5)
       defaultValue: "2"
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Investigation
       description: The investigation ID that was created
@@ -153,6 +157,8 @@ script:
       description: The type of service desk id (e.g. XSOAR)
     - name: assignee_id
       description: The auth0 ID of a user, in 'auth0|12345' format
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.InvestigationUpdate
       description: ID of the updated Taegis investigation
@@ -168,6 +174,8 @@ script:
     - name: page_size
       description: Number of alerts per investigation query
       defaultValue: "10"
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.InvestigationAlerts
       description: List of alerts related to a Taegis investigation
@@ -179,6 +187,8 @@ script:
       description: The ID of the playbook instance to execute
     - name: inputs
       description: JSON Object of optional playbook inputs
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Execution
       description: The playbook execution ID
@@ -190,6 +200,8 @@ script:
     - name: id
       required: true
       description: Playbook execution ID
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.PlaybookExecution
       description: Returns related execution information
@@ -199,6 +211,8 @@ script:
     - name: id
       required: true
       description: The ID of the comment to fetch
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Comment
       description: Return the comment
@@ -211,6 +225,8 @@ script:
     - name: parent_type
       description: The parent type that the comments belong to
       defaultValue: investigation
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Comments
       description: A list of comments to return
@@ -226,6 +242,8 @@ script:
     - name: parent_type
       description: The parent type that the comment is being added to
       defaultValue: investigation
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.CommentCreate
       description: The created comment information
@@ -238,6 +256,8 @@ script:
     - name: comment
       required: true
       description: String to update/replace the comment with
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.CommentUpdate
       description: The comment update results
@@ -256,6 +276,8 @@ script:
     - name: page_size
       description: Results to return per page
       defaultValue: "10"
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Users
       description: The located user(s)
@@ -265,6 +287,8 @@ script:
     - name: id
       required: true
       description: ID of investigation to update
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.ArchivedInvestigation
       description: The results from archiving an investigation
@@ -274,6 +298,8 @@ script:
     - name: id
       required: true
       description: ID of investigation to update
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.UnarchivedInvestigation
       description: The results from unarchiving an investigation
@@ -296,6 +322,8 @@ script:
       description: The status to update the alert with
     - name: reason
       description: A simple comment/reason for the status change
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.AlertStatusUpdate
       description: The result of the alert status update
@@ -328,6 +356,8 @@ script:
       description: Filter assets by sensor version
     - name: username
       description: Filter assets by username
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.Assets
       description: A list of located assets
@@ -340,6 +370,8 @@ script:
     - name: reason
       required: true
       description: A reason for the isolation
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     outputs:
     - contextPath: TaegisXDR.AssetIsolation
       description: Results from the asset isolation

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -100,9 +100,19 @@ script:
     - name: page_size
       description: Number of investigations to return
       defaultValue: "10"
-    - name: status
-      description: A list of statuses to use when searching for investigations
-      isArray: true
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: query
+      description: The Taegis query string to utilize for searching investigations
+      defaultValue: deleted_at is null
+    - name: order_by
+      description: The field to order by when performing a search
+      defaultValue: created_at
+    - name: order_direction
+      description: The order direction when performing a search
+      defaultValue: desc
+    - name: fields
+      description: The fields to return in the results
     outputs:
     - contextPath: TaegisXDR.Investigations
       description: Dictionary of the located Taegis investigation

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -488,6 +488,8 @@ script:
     - name: id
       required: true
       description: The endpoint ID to fetch
+    - name: tenant_id
+      description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
     - name: fields
       description: The fields to return from the query
     outputs:

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -84,6 +84,8 @@ script:
       defaultValue: "0"
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Alerts
       description: List of Taegis alerts
@@ -214,6 +216,8 @@ script:
       defaultValue: "10"
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.InvestigationAlerts
       description: List of alerts related to a Taegis investigation
@@ -227,6 +231,8 @@ script:
       description: JSON Object of optional playbook inputs
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Execution
       description: The playbook execution ID
@@ -240,6 +246,8 @@ script:
       description: Playbook execution ID
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.PlaybookExecution
       description: Returns related execution information
@@ -308,6 +316,8 @@ script:
       description: String to update/replace the comment with
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.CommentUpdate
       description: The comment update results
@@ -328,6 +338,8 @@ script:
       defaultValue: "10"
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Users
       description: The located user(s)
@@ -339,6 +351,8 @@ script:
       description: ID of investigation to update
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.ArchivedInvestigation
       description: The results from archiving an investigation
@@ -350,6 +364,8 @@ script:
       description: ID of investigation to update
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.UnarchivedInvestigation
       description: The results from unarchiving an investigation
@@ -374,6 +390,8 @@ script:
       description: A simple comment/reason for the status change
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.AlertStatusUpdate
       description: The result of the alert status update
@@ -408,6 +426,8 @@ script:
       description: Filter assets by username
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Assets
       description: A list of located assets
@@ -422,6 +442,8 @@ script:
       description: A reason for the isolation
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.AssetIsolation
       description: Results from the asset isolation
@@ -431,6 +453,8 @@ script:
     - name: id
       required: true
       description: The endpoint ID to fetch
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Endpoint
       description: Results from fetching the endpoint information

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -214,37 +214,49 @@ script:
       description: The ID of the comment to fetch
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Comment
       description: Return the comment
     description: Fetch comment by comment ID
   - name: taegis-fetch-comments
     arguments:
-    - name: parent_id
+    - name: id
       required: true
-      description: The ID of the parent related to the comments
-    - name: parent_type
-      description: The parent type that the comments belong to
-      defaultValue: investigation
+      description: The ID of the investigation related to the comments
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: page
+      description: The page number for fetching comments
+      defaultValue: "0"
+    - name: page_size
+      description: Number of comments to return
+      defaultValue: "10"
+    - name: order_direction
+      auto: PREDEFINED
+      predefined:
+      - ASCENDING
+      - DESCENDING
+      description: The order direction when performing a search
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.Comments
       description: A list of comments to return
-    description: Fetch comments by Parent Type and ID
+    description: Fetch comments by Investigation ID
   - name: taegis-create-comment
     arguments:
     - name: comment
       required: true
       description: The comment string to add to the parent
-    - name: parent_id
+    - name: id
       required: true
-      description: The parent that the comment is being added to
-    - name: parent_type
-      description: The parent type that the comment is being added to
-      defaultValue: investigation
+      description: The investigation that the comment is being added to
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
     outputs:
     - contextPath: TaegisXDR.CommentCreate
       description: The created comment information

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -183,32 +183,49 @@ script:
       required: true
       description: The investigation ID to update
     - name: priority
-      description: The priority of the investigation (1-5)
-    - name: key_findings
+      auto: PREDEFINED
+      predefined:
+      - "1"
+      - "2"
+      - "3"
+      - "4"
+      description: The priority of the investigation
+    - name: keyFindings
       description: The Key Findings field of the investigation
     - name: status
       auto: PREDEFINED
       predefined:
-      - Open
-      - Active
-      - Awaiting Action
-      - Suspended
-      - 'Closed: Authorized Activity'
-      - 'Closed: Confirmed Security Incident'
-      - 'Closed: False Positive Alert'
-      - 'Closed: Inconclusive'
-      - 'Closed: Informational'
-      - 'Closed: Not Vulnerable'
-      - 'Closed: Threat Mitigated'
+      - OPEN
+      - ACTIVE
+      - AWAITING_ACTION
+      - SUSPENDED
+      - CLOSED_AUTHORIZED_ACTIVITY
+      - CLOSED_CONFIRMED_SECURITY_INCIDENT
+      - CLOSED_FALSE_POSITIVE_ALERT
+      - CLOSED_INCONCLUSIVE
+      - CLOSED_INFORMATIONAL
+      - CLOSED_NOT_VULNERABLE
+      - CLOSED_THREAT_MITIGATED
       description: New status for the investigation
-    - name: service_desk_id
-      description: An ticket or ID for to an external system for reference
-    - name: service_desk_type
-      description: The type of service desk id (e.g. XSOAR)
-    - name: assignee_id
+    - name: assigneeId
       description: The auth0 ID of a user, in 'auth0|12345' format
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
+    - name: type
+      auto: PREDEFINED
+      predefined:
+      - SECURITY_INVESTIGATION
+      - INCIDENT_RESPONSE
+      - THREAT_HUNT
+      - MANAGED_XDR_THREAT_HUNT
+      - CTU_THREAT_HUNT
+      - MANAGED_XDR_ELITE_THREAT_HUNT
+      - SECUREWORKS_INCIDENT_RESPONSE
+      description: The type of investigation
+    - name: title
+      description: The title of the investigation
     outputs:
     - contextPath: TaegisXDR.InvestigationUpdate
       description: ID of the updated Taegis investigation

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -107,9 +107,9 @@ script:
     description: Fetch all investigations or a specific investigation
   - name: taegis-create-investigation
     arguments:
-    - name: description
+    - name: title
       required: true
-      description: The description of the investigation
+      description: The title of the investigation
     - name: priority
       required: true
       default: true
@@ -119,11 +119,48 @@ script:
       - "2"
       - "3"
       - "4"
-      - "5"
-      description: The priority of the investigation (1-5)
+      description: The priority of the investigation
       defaultValue: "2"
     - name: tenant_id
       description: The tenant to run against if an MSP. If no tenant  provided, the tenant of the generated credentials is used.
+    - name: fields
+      description: The fields to return from the query
+    - name: alerts
+      description: A list of alert IDs or string of comma-separated alert IDs to add to the investigation during creation
+      isArray: true
+    - name: keyFindings
+      description: The key findings to utilize within the Investigation
+    - name: type
+      auto: PREDEFINED
+      predefined:
+      - SECURITY_INVESTIGATION
+      - INCIDENT_RESPONSE
+      - THREAT_HUNT
+      - MANAGED_XDR_THREAT_HUNT
+      - CTU_THREAT_HUNT
+      - MANAGED_XDR_ELITE_THREAT_HUNT
+      - SECUREWORKS_INCIDENT_RESPONSE
+      description: The investigation type to create
+      defaultValue: SECURITY_INVESTIGATION
+    - name: assigneeId
+      description: The assignee for the investigation
+      defaultValue: '@secureworks'
+    - name: status
+      auto: PREDEFINED
+      predefined:
+      - OPEN
+      - ACTIVE
+      - AWAITING_ACTION
+      - SUSPENDED
+      - CLOSED_AUTHORIZED_ACTIVITY
+      - CLOSED_CONFIRMED_SECURITY_INCIDENT
+      - CLOSED_FALSE_POSITIVE_ALERT
+      - CLOSED_INCONCLUSIVE
+      - CLOSED_INFORMATIONAL
+      - CLOSED_NOT_VULNERABLE
+      - CLOSED_THREAT_MITIGATED
+      description: The investigation status
+      defaultValue: OPEN
     outputs:
     - contextPath: TaegisXDR.Investigation
       description: The investigation ID that was created

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -386,6 +386,32 @@ script:
     - contextPath: TaegisXDR.Endpoint
       description: Results from fetching the endpoint information
     description: Fetch endpoint information
+  - name: taegis-create-sharelink
+    arguments:
+    - name: id
+      required: true
+      description: The ID of the alert, investigation, etc
+    - name: type
+      required: true
+      auto: PREDEFINED
+      predefined:
+      - alertId
+      - investigationId
+      - queryId
+      - endpointDetails
+      - playbookTemplateId
+      - playbookInstanceId
+      - playbookExecutionId
+      - connectorId
+      - connectionId
+      - eventId
+      description: The type of Taegis element to create the ShareLink against
+    - name: fields
+      description: The fields to return from the query
+    outputs:
+    - contextPath: TaegisXDR.ShareLink
+      description: Results from creating the ShareLink
+    description: Create a ShareLink to a Taegis element, such as an alert or investigation
   - name: taegis-add-evidence-to-investigation
     arguments:
     - name: id

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR.yml
@@ -13,6 +13,7 @@ configuration:
   options:
   - US1
   - US2
+  - US3
   - EU
   additionalinfo: Used to determine the URL and API endpoint to utilize for your tenant
 - display: Trust any certificate (not secure)

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
@@ -185,33 +185,27 @@ def test_fetch_comment_by_id(requests_mock):
         assert fetch_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
 
 
-def test_fetch_comments_by_parent(requests_mock):
+def test_fetch_comments(requests_mock):
     """Tests taegis-fetch-comments command function
     """
     client = mock_client(requests_mock, FETCH_COMMENTS_RESPONSE)
 
     # comment_id not set
-    with pytest.raises(ValueError, match="Cannot fetch comments, missing parent_id"):
+    with pytest.raises(ValueError, match="Cannot fetch comments, missing id"):
         assert fetch_comments_command(client=client, env=TAEGIS_ENVIRONMENT, args={})
 
     args = {
-        "parent_id": "c2e09554-833e-41a1-bc9d-8160aec0d70d",
-        "parent_type": "bad_parent_type",
+        "id": "c2e09554-833e-41a1-bc9d-8160aec0d70d",
     }
 
-    # Invalid parent type
-    with pytest.raises(ValueError, match="The provided comment parent type, bad_parent_type, is not valid."):
-        assert fetch_comments_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
-
     # Successful fetch
-    args["parent_type"] = "investigation"
     response = fetch_comments_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
-    assert response.outputs == FETCH_COMMENTS_RESPONSE["data"]["commentsByParent"]
+    assert response.outputs == FETCH_COMMENTS_RESPONSE["data"]["commentsV2"]["comments"]
 
     # Comment not found, bad response
     client = mock_client(requests_mock, FETCH_COMMENTS_BAD_RESPONSE)
-    with pytest.raises(ValueError, match="Failed to fetch comments:"):
-        assert fetch_comments_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
+    response = fetch_comments_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
+    assert response.outputs == []
 
 
 def test_update_comment(requests_mock):

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
@@ -228,7 +228,7 @@ def test_update_comment(requests_mock):
 
     #  # Successful fetch - Comment created
     response = update_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
-    assert response.outputs == UPDATE_COMMENT_RESPONSE["data"]["updateComment"]
+    assert response.outputs == UPDATE_COMMENT_RESPONSE["data"]["updateInvestigationComment"]
 
     # Comment creation failed
     client = mock_client(requests_mock, CREATE_UPDATE_COMMENT_BAD_RESPONSE)
@@ -306,7 +306,7 @@ def test_fetch_incidents_investigations(requests_mock):
     assert len(response) == 0
 
 
-def test_fetch_investigaton(requests_mock):
+def test_fetch_investigation(requests_mock):
     """Tests taegis-fetch-investigation command function
 
     Test fetching of a single incident
@@ -320,6 +320,7 @@ def test_fetch_investigaton(requests_mock):
 
     response = fetch_investigation_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
     assert response.outputs[0] == TAEGIS_INVESTIGATION
+    assert response.outputs[0]["url"] == f"{TAEGIS_URL}/investigations/{args['id']}"
 
     # Investigation not found
     client = mock_client(requests_mock, {})
@@ -327,13 +328,13 @@ def test_fetch_investigaton(requests_mock):
     assert len(response.outputs) == 0
 
 
-def test_fetch_investigatons(requests_mock):
+def test_fetch_investigations(requests_mock):
     """Tests taegis-fetch-investigations command function
 
     Test fetching of all incidents
     """
 
-    client = mock_client(requests_mock, FETCH_INVESTIGATIONS)
+    client = mock_client(requests_mock, FETCH_INVESTIGATIONS_RESPONSE)
     args = {
         "page": 0,
         "page_size": 1,

--- a/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/TaegisXDR_test.py
@@ -144,25 +144,19 @@ def test_create_comment(requests_mock):
     with pytest.raises(ValueError, match="Cannot create comment, comment cannot be empty"):
         assert create_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args={})
 
-    # parent_id not set
-    with pytest.raises(ValueError, match="Cannot create comment, parent_id cannot be empty"):
-        assert create_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args={"comment": "test"})
+    # id not set
+    with pytest.raises(ValueError, match="Cannot create comment, id cannot be empty"):
+        assert create_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args={"comment": "Test comment"})
 
     args = {
-        "comment": FETCH_COMMENT_RESPONSE["data"]["comment"]["comment"],
-        "parent_id": FETCH_COMMENT_RESPONSE["data"]["comment"]["parent_id"],
-        "parent_type": "bad_parent_type",
+        "comment": "Test Comment",
+        "id": "12345-12345-12345",
+        "fields": "id",
     }
 
-    # Invalid parent type
-    with pytest.raises(ValueError, match="The provided comment parent type, bad_parent_type, is not valid."):
-        assert create_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
-
-    args["parent_type"] = "investigation"
-
-    #  # Successful fetch - Comment created
+    # Successful fetch - Comment created
     response = create_comment_command(client=client, env=TAEGIS_ENVIRONMENT, args=args)
-    assert response.outputs == CREATE_COMMENT_RESPONSE["data"]["createComment"]
+    assert response.outputs == CREATE_COMMENT_RESPONSE["data"]["addCommentToInvestigation"]
 
     # Comment creation failed
     client = mock_client(requests_mock, CREATE_UPDATE_COMMENT_BAD_RESPONSE)

--- a/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
@@ -1,5 +1,6 @@
 !taegis-create-comment comment="This is a test comment" parent_id="c2e09554-833e-41a1-bc9d-8160aec0d70d"
 !taegis-create-investigation priority=1 description="XSOAR Created Investigation"
+!taegis-add-evidence-to-investigation id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f alerts="alert://priv:crowdstrike:11772:1677742145475:07e2d9cc-0a04-55ec-890a-97f39d63698e"
 !taegis-execute-playbook id=UGxheWJvb2tJbnN0YW5jZTphZDNmNzBlZi1mN2U0LTQ0OWYtODJiMi1hYWQwMjQzZTA2NTg= inputs=`{'myvar': 'myval'}`
 !taegis-fetch-alerts
 !taegis-fetch-alerts offset=5 limit=5 cql_query="from alert status='OPEN' and severity >= 0.6"

--- a/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
@@ -1,6 +1,7 @@
 !taegis-create-comment comment="This is a test comment" parent_id="c2e09554-833e-41a1-bc9d-8160aec0d70d"
 !taegis-create-investigation priority=1 description="XSOAR Created Investigation"
 !taegis-add-evidence-to-investigation id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f alerts="alert://priv:crowdstrike:11772:1677742145475:07e2d9cc-0a04-55ec-890a-97f39d63698e"
+!taegis-create-sharelink id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f type=investigationId
 !taegis-execute-playbook id=UGxheWJvb2tJbnN0YW5jZTphZDNmNzBlZi1mN2U0LTQ0OWYtODJiMi1hYWQwMjQzZTA2NTg= inputs=`{'myvar': 'myval'}`
 !taegis-fetch-alerts
 !taegis-fetch-alerts offset=5 limit=5 cql_query="from alert status='OPEN' and severity >= 0.6"

--- a/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
@@ -1,6 +1,6 @@
-!taegis-create-comment comment="This is a test comment" parent_id="c2e09554-833e-41a1-bc9d-8160aec0d70d"
 !taegis-create-investigation priority=1 description="XSOAR Created Investigation"
 !taegis-add-evidence-to-investigation id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f alerts="alert://priv:crowdstrike:11772:1677742145475:07e2d9cc-0a04-55ec-890a-97f39d63698e"
+!taegis-create-comment comment="This is a test comment" id="c2e09554-833e-41a1-bc9d-8160aec0d70d"
 !taegis-create-sharelink id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f type=investigationId
 !taegis-execute-playbook id=UGxheWJvb2tJbnN0YW5jZTphZDNmNzBlZi1mN2U0LTQ0OWYtODJiMi1hYWQwMjQzZTA2NTg= inputs=`{'myvar': 'myval'}`
 !taegis-fetch-alerts

--- a/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
@@ -1,6 +1,6 @@
-!taegis-create-investigation priority=1 description="XSOAR Created Investigation"
 !taegis-add-evidence-to-investigation id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f alerts="alert://priv:crowdstrike:11772:1677742145475:07e2d9cc-0a04-55ec-890a-97f39d63698e"
 !taegis-create-comment comment="This is a test comment" id="c2e09554-833e-41a1-bc9d-8160aec0d70d"
+!taegis-create-investigation priority=1 title="XSOAR Created Investigation"
 !taegis-create-sharelink id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f type=investigationId
 !taegis-execute-playbook id=UGxheWJvb2tJbnN0YW5jZTphZDNmNzBlZi1mN2U0LTQ0OWYtODJiMi1hYWQwMjQzZTA2NTg= inputs=`{'myvar': 'myval'}`
 !taegis-fetch-alerts

--- a/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/command_examples
@@ -10,7 +10,7 @@
 !taegis-fetch-assets page=1 page_size=5
 !taegis-fetch-assets hostname=MyHostname01
 !taegis-fetch-comment id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f
-!taegis-fetch-comments parent_id=c2e09554-833e-41a1-bc9d-8160aec0d70d
+!taegis-fetch-comments id=c2e09554-833e-41a1-bc9d-8160aec0d70d
 !taegis-fetch-endpoint id=ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f
 !taegis-fetch-investigation
 !taegis-fetch-investigation id="936c1cc1-db8f-430c-837c-1c914fcca35a"

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -330,8 +330,9 @@ CREATE_INVESTIGATION_RESPONSE = {
 
 UPDATE_INVESTIGATION_RESPONSE = {
     "data": {
-        "updateInvestigation": {
+        "updateInvestigationV2": {
             "id": "593fa115-abad-4a52-9fc4-2ec403a8a1e4",
+            "shortId": "INV00248",
         }
     }
 }

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -6,6 +6,9 @@ TAEGIS_ALERT = {
         "title": "Test Alert",
         "description": "This is a test alert",
         "severity": 0.5,
+        "created_at": {
+            "seconds": 1686083555
+        }
     },
     "url": f"{TAEGIS_URL}/alerts/alert:%2F%2Fpriv:crowdstrike:11772:1666247222095:4e41ec02-ca53-5ff7-95cc-eda434221ba6",
 }
@@ -55,13 +58,11 @@ TAEGIS_COMMENT = {
         "family_name": "Smith",
         "id": "auth0|000000000000000000000001",
     },
+    "athorId": "auth0|000000000000000000000001",
     "id": "ff9ca818-4749-4ccb-883a-2ccc6f6c9e0f",
     "comment": "This is a comment in an investigation",
-    "created_at": "2022-01-01T13:04:57.17234Z",
-    "deleted_at": None,
-    "modified_at": None,
-    "parent_id": "c2e09554-833e-41a1-bc9d-8160aec0d70d",
-    "parent_type": "investigation",
+    "createdAt": "2022-01-01T13:04:57.17234Z",
+    "updatedAt": "2022-01-01T14:04:57.17234Z",
 }
 
 TAEGIS_ENDPOINT = {

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -319,8 +319,9 @@ FETCH_PLAYBOOK_EXECUTION_BAD_RESPONSE = {
 
 CREATE_INVESTIGATION_RESPONSE = {
     "data": {
-        "createInvestigation": {
+        "createInvestigationV2": {
             "id": "593fa115-abad-4a52-9fc4-2ec403a8a1e4",
+            "shortId": "INV00248",
         }
     }
 }

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -431,3 +431,14 @@ UPDATE_ALERT_STATUS_BAD_RESPONSE = {
         }
     ]
 }
+
+CREATE_SHARELINK_RESPONSE = {
+    "data": {
+        "createShareLink": {
+            "createdTime": "2023-06-12T15:59:45.526512Z",
+            "id": "73a223f4-76d5-448a-8281-a361a2c2ce74",
+            "linkRef": "7a021411-01b6-4101-843e-c14218063c02",
+            "linkTarget": ""
+        }
+    }
+}

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -269,7 +269,9 @@ FETCH_ENDPOINT_BAD_RESPONSE = {
 
 FETCH_INCIDENTS_RESPONSE = {
     "data": {
-        "allInvestigations": [TAEGIS_INVESTIGATION]
+        "investigationsSearch": {
+            "investigations": [TAEGIS_INVESTIGATION]
+        }
     }
 }
 
@@ -285,13 +287,15 @@ FETCH_INCIDENTS_BAD_RESPONSE = {
 
 FETCH_INVESTIGATION_RESPONSE = {
     "data": {
-        "investigation": TAEGIS_INVESTIGATION
+        "investigationV2": TAEGIS_INVESTIGATION
     }
 }
 
-FETCH_INVESTIGATIONS = {
+FETCH_INVESTIGATIONS_RESPONSE = {
     "data": {
-        "allInvestigations": [TAEGIS_INVESTIGATION]
+        "investigationsSearch": {
+            "investigations": [TAEGIS_INVESTIGATION]
+        }
     }
 }
 

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -199,7 +199,7 @@ FETCH_ASSETS_BAD_RESPONSE = {
 
 CREATE_COMMENT_RESPONSE = {
     "data": {
-        "createComment": {
+        "addCommentToInvestigation": {
             "id": TAEGIS_COMMENT["id"],
         }
     }

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -432,6 +432,14 @@ UPDATE_ALERT_STATUS_BAD_RESPONSE = {
     ]
 }
 
+TAEGIS_ADD_EVIDENCE_TO_INVESTIGATION_RESPONSE = {
+    "data": {
+        "addEvidenceToInvestigation": {
+            "investigationId": UPDATE_INVESTIGATION_RESPONSE["data"]["updateInvestigationV2"]["id"]
+        },
+    }
+}
+
 CREATE_SHARELINK_RESPONSE = {
     "data": {
         "createShareLink": {

--- a/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDR/test_data/data.py
@@ -225,7 +225,9 @@ FETCH_COMMENT_RESPONSE = {
 
 FETCH_COMMENTS_RESPONSE = {
     "data": {
-        "commentsByParent": [TAEGIS_COMMENT]
+        "commentsV2": {
+            "comments": [TAEGIS_COMMENT]
+        },
     }
 }
 
@@ -243,7 +245,7 @@ FETCH_COMMENTS_BAD_RESPONSE = {
 
 UPDATE_COMMENT_RESPONSE = {
     "data": {
-        "updateComment": {
+        "updateInvestigationComment": {
             "id": TAEGIS_COMMENT["id"],
         }
     }

--- a/Packs/SecureWorks/ReleaseNotes/5_0_0.json
+++ b/Packs/SecureWorks/ReleaseNotes/5_0_0.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"Any command interacting with the Taegis Investigations or Comments APIs have been migrated to the V2 API. Most of these commands saw changes to their inputs and outputs. See Release Notes for a list of updated commands."}

--- a/Packs/SecureWorks/ReleaseNotes/5_0_0.md
+++ b/Packs/SecureWorks/ReleaseNotes/5_0_0.md
@@ -1,0 +1,22 @@
+
+#### Integrations
+
+##### TaegisXDR
+
+- Added support for defining which type of "incident" to fetch from Taegis when using **taegis-fetch-incidents**. The following are supported:
+  - **alerts**
+  - **investigations (default)**
+- Added support for overriding the fields returned from Taegis in most commands with the `fields` argument.
+- Added support for defining the `tenant_id` when running most commands. This is most useful for MSPs and tenants that contain child tenants.
+- Added support for the `OTHER` alert status.
+- Added support for the new US3 (Foxtrot) environment.
+- Added 2 new commands:
+  - **taegis-add-evidence-to-investigation** - Add alerts or events to an existing investigation
+  - **taegis-create-sharelink** - Allow creating a sharelink directly to an element within Taegis. For instance, a **ShareLink** to a specific **Alert** or **Investigation**
+- Updated the following commands to utilize the InvestigationsV2 API. Inputs and outputs may have changed during this change.
+  - **taegis-fetch-comments**
+  - **taegis-fetch-comments**
+  - **taegis-fetch-incidents**
+  - **taegis-fetch-investigation**
+  - **taegis-update-comment**
+  - **taegis-update-investigation**

--- a/Packs/SecureWorks/pack_metadata.json
+++ b/Packs/SecureWorks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Secureworks",
     "description": "Provides access to the Secureworks CTP and Taegis XDR systems",
     "support": "partner",
-    "currentVersion": "4.3.3",
+    "currentVersion": "5.0.0",
     "author": "Secureworks",
     "url": "https://ctpx.secureworks.com",
     "email": "support@secureworks.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This change primarily moves from the old Taegis Investigations v1 API to v2. The v1 API calls are being turned down in the near future and should not be used. Due to inconsistencies between the v1 and v2 APIs and pulling of data, users must move to the new API. For instance, some incidents will not be found in the v1 API but will in the v2 API.

The following changes were made during this PR:
- Updated the following commands to utilize the InvestigationsV2 API:
  - **taegis-fetch-comment**
  - **taegis-fetch-comments**
  - **taegis-fetch-incidents**
  - **taegis-fetch-investigation**
  - **taegis-update-comment**
  - **taegis-update-investigation**
- Added support for defining which type of "incident" to fetch from Taegis when using **taegis-fetch-incidents**. The following are supported:
  - **alerts**
  - **investigations (default)**
- Added support for overriding the fields returned from Taegis in most commands with the `fields` argument.
- Added support for defining the `tenant_id` when running most commands. This is most useful for MSPs and tenants that contain child tenants.
- Added support for the new US3 (Foxtrot) environment.
- Added 2 new commands:
  - **taegis-add-evidence-to-investigation** - Add alerts or events to an existing investigation
  - **taegis-create-sharelink**


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [x] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [x] Yes
       - Further details: The newer Investigations v2 API has different inputs and outputs. Additionally, some data is only available in the v2 API, such as newer investigations (incidents).
   - [ ] No

## Must have
- [x] Tests
- [x] Documentation 
