### PR TITLE
Set feed fetch interval default for unit42 intel objects feed

### DIFF
--- a/Packs/Unit42Intel/Integrations/FeedUnit42IntelObjects/FeedUnit42IntelObjects.yml
+++ b/Packs/Unit42Intel/Integrations/FeedUnit42IntelObjects/FeedUnit42IntelObjects.yml
@@ -60,7 +60,7 @@ configuration:
   - WHITE
   required: false
   type: 15
-- defaultvalue: '10'
+- defaultvalue: '300'
   display: Feed Fetch Interval
   name: feedFetchInterval
   required: false

--- a/Packs/Unit42Intel/ReleaseNotes/1_0_9.md
+++ b/Packs/Unit42Intel/ReleaseNotes/1_0_9.md
@@ -3,4 +3,4 @@
 
 ##### Unit 42 Intel Objects Feed
 
-- Updated the *Feed Fetch Interval* parameter as default to 5 hours.
+- Updated the default value of the *Feed Fetch Interval* parameter to 5 hours.

--- a/Packs/Unit42Intel/ReleaseNotes/1_0_9.md
+++ b/Packs/Unit42Intel/ReleaseNotes/1_0_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Unit 42 Intel Objects Feed
+
+- Updated the *Feed Fetch Interval* parameter as default to 5 hours.

--- a/Packs/Unit42Intel/pack_metadata.json
+++ b/Packs/Unit42Intel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Unit 42 Intel",
     "description": "Use the Unit 42 Intel pack to enrich your Threat Intel Library with Palo Alto Networks threat intelligence.",
     "support": "xsoar",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.5.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-24889

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
