### PR TITLE
CIRCL CVE Search parse CVSS version

### DIFF
--- a/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch.py
+++ b/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch.py
@@ -64,6 +64,16 @@ def test_module(client: Client):
     return 'ok'
 
 
+def get_cvss_verion(cvss_vector: str) -> float:
+    # Checks for the CVSS score version according to its vector
+    if not cvss_vector:
+        return 0
+    elif cvss_version_regex := re.match('CVSS:(?P<version>.+?)/', cvss_vector):
+        return float(cvss_version_regex.group("version"))
+    else:
+        return 2.0
+
+
 def cve_latest_command(client: Client, limit) -> list[CommandResults]:
     """
     Returns the 30 latest updated CVEs.
@@ -224,6 +234,7 @@ def generate_indicator(data: dict) -> Common.CVE:
         id=cve_id,
         cvss=data.get('cvss'),
         cvss_vector=data.get('cvss-vector'),
+        cvss_version=get_cvss_verion(data.get('cvss-vector', '')),
         cvss_table=cvss_table,
         published=data.get('Published'),
         modified=data.get('Modified'),

--- a/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch.py
+++ b/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch.py
@@ -65,7 +65,16 @@ def test_module(client: Client):
 
 
 def get_cvss_verion(cvss_vector: str) -> float:
-    # Checks for the CVSS score version according to its vector
+    """
+    Extracts the CVSS score version according to its vector.
+
+    Args:
+        cvss_vector: The CVSS of the CVE.
+
+    Returns:
+        The CVSS version as a float.
+
+    """
     if not cvss_vector:
         return 0
     elif cvss_version_regex := re.match('CVSS:(?P<version>.+?)/', cvss_vector):

--- a/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch_test.py
+++ b/Packs/CIRCL/Integrations/CirclCVESearch/CirclCVESearch_test.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 import pytest
-from CirclCVESearch import Client, cve_command, generate_indicator, parse_cpe, valid_cve_id_format
+from CirclCVESearch import Client, cve_command, generate_indicator, parse_cpe, valid_cve_id_format, get_cvss_verion
 
 from CommonServerPython import DemistoException, EntityRelationship, argToList
 
@@ -72,6 +72,16 @@ def test_indicator_creation():
     indicator = generate_indicator(response).to_context()
     assert set(indicator["CVE(val.ID && val.ID == obj.ID)"]["Tags"]) == set(
         correct_indicator["CVE(val.ID && val.ID == obj.ID)"]["Tags"])
+
+
+@pytest.mark.parametrize("cvss_vector, expected_output", [
+    ("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 3.0),
+    ("", 0),
+    ("AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 2.0)
+])
+def test_parse_cvss_version(cvss_vector, expected_output):
+    version = get_cvss_verion(cvss_vector)
+    assert version == expected_output
 
 
 @pytest.mark.parametrize("cpe, expected_output, expected_relationships", [

--- a/Packs/CIRCL/ReleaseNotes/1_0_13.md
+++ b/Packs/CIRCL/ReleaseNotes/1_0_13.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CIRCL CVE Search
+
+- Updated the integration to parse the CVE CVSS Version according to the vector.

--- a/Packs/CIRCL/ReleaseNotes/1_0_14.md
+++ b/Packs/CIRCL/ReleaseNotes/1_0_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CIRCL CVE Search
+
+- Updated the integration to parse the CVE CVSS Version according to the vector.

--- a/Packs/CIRCL/pack_metadata.json
+++ b/Packs/CIRCL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CIRCL",
     "description": "The Computer Incident Response Center Luxembourg (CIRCL) is a government-driven initiative designed to provide a systematic response facility to computer security threats and incidents.\nThis pack includes:\n# CIRCL Passive DNS which is a database storing historical DNS records from various resources.\n# CIRCL Passive SSL is a database storing historical X.509 certificates seen per IP address. The Passive SSL historical data is indexed per IP address.\n# CIRCL CVE Search, interface to search publicly known information from security vulnerabilities in software and hardware along with their corresponding exposures.",
     "support": "xsoar",
-    "currentVersion": "1.0.13",
+    "currentVersion": "1.0.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CIRCL/pack_metadata.json
+++ b/Packs/CIRCL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CIRCL",
     "description": "The Computer Incident Response Center Luxembourg (CIRCL) is a government-driven initiative designed to provide a systematic response facility to computer security threats and incidents.\nThis pack includes:\n# CIRCL Passive DNS which is a database storing historical DNS records from various resources.\n# CIRCL Passive SSL is a database storing historical X.509 certificates seen per IP address. The Passive SSL historical data is indexed per IP address.\n# CIRCL CVE Search, interface to search publicly known information from security vulnerabilities in software and hardware along with their corresponding exposures.",
     "support": "xsoar",
-    "currentVersion": "1.0.12",
+    "currentVersion": "1.0.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Updated the integration to extract the correct CVSS version from its vector.

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No
