### PR TITLE
Add IN145 To Failing Integrations

### DIFF
--- a/Packs/AnsibleCiscoIOS/.pack-ignore
+++ b/Packs/AnsibleCiscoIOS/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AnsibleCiscoIOS.yml]
-ignore=BA124
+ignore=BA124,IN145
 
 [file:README.md]
 ignore=RM113

--- a/Packs/AnsibleKubernetes/.pack-ignore
+++ b/Packs/AnsibleKubernetes/.pack-ignore
@@ -1,5 +1,5 @@
 [file:AnsibleKubernetes.yml]
-ignore=BA124
+ignore=BA124,IN145
 
 [known_words]
 ansii

--- a/Packs/AnsibleLinux/.pack-ignore
+++ b/Packs/AnsibleLinux/.pack-ignore
@@ -2,13 +2,13 @@
 ignore=RM100,RM113
 
 [file:AnsibleLinux.yml]
-ignore=BA124
+ignore=BA124,IN145
 
 [file:AnsibleOpenSSL.yml]
-ignore=BA124
+ignore=BA124,IN145
 
 [file:AnsibleACME.yml]
-ignore=BA124
+ignore=BA124,IN145
 
 [known_words]
 ansii

--- a/Packs/AzureKeyVault/.pack-ignore
+++ b/Packs/AzureKeyVault/.pack-ignore
@@ -77,3 +77,6 @@ x
 gcc
 n
 
+[file:AzureKeyVault.yml]
+ignore=IN145
+

--- a/Packs/CloudConvert/.pack-ignore
+++ b/Packs/CloudConvert/.pack-ignore
@@ -1,3 +1,6 @@
 [file:README.md]
 ignore=RM104
 
+[file:CloudConvert.yml]
+ignore=IN145
+

--- a/Packs/FreshDesk/.pack-ignore
+++ b/Packs/FreshDesk/.pack-ignore
@@ -1,5 +1,5 @@
 [file:FreshDesk.yml]
-ignore=IN126
+ignore=IN126,IN145
 
 [file:README.md]
 ignore=RM106

--- a/Packs/GoogleKubernetesEngine/.pack-ignore
+++ b/Packs/GoogleKubernetesEngine/.pack-ignore
@@ -1,3 +1,6 @@
 [file:README.md]
 ignore=RM104
 
+[file:GoogleKubernetesEngine.yml]
+ignore=IN145
+

--- a/Packs/GoogleSafeBrowsing/.pack-ignore
+++ b/Packs/GoogleSafeBrowsing/.pack-ignore
@@ -1,3 +1,6 @@
 [file:GoogleSafeBrowsing_image.png]
 ignore=IM111
 
+[file:GoogleSafeBrowsingV2.yml]
+ignore=IN145
+

--- a/Packs/GoogleVault/.pack-ignore
+++ b/Packs/GoogleVault/.pack-ignore
@@ -14,5 +14,5 @@ ignore=BA101
 ignore=RM104
 
 [file:GoogleVault.yml]
-ignore=BA124
+ignore=BA124,IN145
 

--- a/Packs/Jira/.pack-ignore
+++ b/Packs/Jira/.pack-ignore
@@ -1,5 +1,5 @@
 [file:JiraV2.yml]
-ignore=IN126
+ignore=IN126,IN145
 
 [file:README.md]
 ignore=RM106

--- a/Packs/Perch/.pack-ignore
+++ b/Packs/Perch/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Perch.yml]
-ignore=IN126
+ignore=IN126,IN145
 
 [file:README.md]
 ignore=RM106

--- a/Packs/SalesforceFusion/.pack-ignore
+++ b/Packs/SalesforceFusion/.pack-ignore
@@ -1,3 +1,6 @@
 [file:SalesforceFusionIAM_image.png]
 ignore=IM111
 
+[file:SalesforceFusionIAM.yml]
+ignore=IN145
+

--- a/Packs/SplunkPyPreRelease/.pack-ignore
+++ b/Packs/SplunkPyPreRelease/.pack-ignore
@@ -1,5 +1,5 @@
 [file:SplunkPyPreRelease.yml]
-ignore=IN126,IN135
+ignore=IN126,IN135,IN145
 
 [file:README.md]
 ignore=RM106

--- a/Packs/TrendMicroCAS/.pack-ignore
+++ b/Packs/TrendMicroCAS/.pack-ignore
@@ -10,3 +10,6 @@ ignore=BA101
 [file:classifier-TrendMicroCAS.json]
 ignore=BA101
 
+[file:TrendMicroCAS.yml]
+ignore=IN145
+

--- a/Packs/TrendMicroDDA/.pack-ignore
+++ b/Packs/TrendMicroDDA/.pack-ignore
@@ -1,5 +1,5 @@
 [file:TrendMicroDDA.yml]
-ignore=IN110,IN109,BA124
+ignore=IN110,IN109,BA124,IN145
 
 [file:README.md]
 ignore=RM104

--- a/Packs/VMwareWorkspaceONEUEM/.pack-ignore
+++ b/Packs/VMwareWorkspaceONEUEM/.pack-ignore
@@ -1,0 +1,3 @@
+[file:VMwareWorkspaceONEUEM.yml]
+ignore=IN145
+

--- a/Packs/VersaDirector/.pack-ignore
+++ b/Packs/VersaDirector/.pack-ignore
@@ -1,0 +1,3 @@
+[file:VersaDirector.yml]
+ignore=IN145
+

--- a/Packs/cyberark_AIM/.pack-ignore
+++ b/Packs/cyberark_AIM/.pack-ignore
@@ -1,5 +1,5 @@
 [file:CyberArkAIM_v2.yml]
-ignore=BA108,BA109
+ignore=BA108,BA109,IN145
 
 [file:CyberArkAIM_v2_image.png]
 ignore=IM111


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Add IN145 To Failing Integrations

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ ] No

## Must have
- [ ] Tests
- [ ] Documentation 
