### PR TITLE
Ignore any Python update in ApiModules, until we can properly determine their desired version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -457,6 +457,8 @@ src = [
 
 [tool.ruff.per-file-ignores]
 "**/*_test.py" = []
+# Ignore any Python update in ApiModules, until we can proprtly determine their desired version.
+"**/*ApiModule.py"  = [ "UP" ]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Ignore any Python update in ApiModules, until we can properly determine their desired version.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7313

## Description
Ignore any Python update in ApiModules, until we can properly determine their desired version.
