### PR TITLE
XSIAM | Remove dependencies from Windows Packs & Fix for Windows Events Modeling (EventType)

### DIFF
--- a/Packs/MicrosoftADFS/pack_metadata.json
+++ b/Packs/MicrosoftADFS/pack_metadata.json
@@ -12,16 +12,6 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
-    "dependencies": {
-        "MicrosoftCore": {
-            "mandatory": true,
-            "display_name": "Microsoft Logs Base"
-        },
-        "MicrosoftWindowsEvents": {
-            "mandatory": false,
-            "display_name": "Microsoft Windows Event Logs"
-        }
-    },
     "marketplaces": [
         "marketplacev2"
     ]

--- a/Packs/MicrosoftCore/pack_metadata.json
+++ b/Packs/MicrosoftCore/pack_metadata.json
@@ -12,16 +12,6 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
-    "dependencies": {
-        "MicrosoftADFS": {
-            "mandatory": false,
-            "display_name": "Microsoft AD FS Collection"
-        },
-        "MicrosoftWindowsEvents": {
-            "mandatory": false,
-            "display_name": "Microsoft Windows Event Logs"
-        }
-    },
     "marketplaces": [
         "marketplacev2"
     ]

--- a/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
+++ b/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
@@ -2,7 +2,7 @@
 filter provider_name contains "Microsoft-Windows-Security-"
 |alter IpPort=json_extract_scalar(event_data ,"$.IpPort"),
 LogLevel=lowercase(log_level),
-xdm.event.original_event_type=coalesce(event_action,task,"")
+EventType=coalesce(event_action,task,"")
 |alter 
 xdm.source.ipv4=if(json_extract_scalar(event_data ,"$.IpAddress") contains "." and json_extract_scalar(event_data ,"$.IpAddress") not contains ":",json_extract_scalar(event_data ,"$.IpAddress"),json_extract_scalar(event_data ,"$.IpAddress") contains ":" and json_extract_scalar(event_data ,"$.IpAddress") contains ".", arrayindex(regextract(json_extract_scalar(event_data ,"$.IpAddress"),"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"),0),null),
 xdm.source.ipv6=if(json_extract_scalar(event_data ,"$.IpAddress") contains ":" and json_extract_scalar(event_data ,"$.IpAddress") not contains ".",json_extract_scalar(event_data ,"$.IpAddress"),json_extract_scalar(event_data ,"$.IpAddress") contains ":" and json_extract_scalar(event_data ,"$.IpAddress") contains ".", arrayindex(regextract(json_extract_scalar(event_data ,"$.IpAddress"),"(.*?)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"),0),null),
@@ -14,8 +14,8 @@ xdm.source.user.identifier=coalesce(json_extract_scalar(event_data ,"$.SubjectUs
 xdm.target.user.identifier=json_extract_scalar(event_data ,"$.TargetUserSid"),
 xdm.source.user.domain=coalesce(json_extract_scalar(event_data ,"$.SubjectDomainName"),json_extract_scalar(user,"$.domain"),json_extract_scalar(user_data,"$.SubjectDomainName")),
 xdm.target.user.domain=json_extract_scalar(event_data ,"$.TargetDomainName"),
-xdm.target.user.username=if(json_extract_scalar(event_data ,"$.TargetUserName") not contains "*$" AND xdm.event.original_event_type!="Security Group Management",json_extract_scalar(event_data ,"$.TargetUserName")),
-xdm.target.user.groups=if(json_extract_scalar(event_data ,"$.TargetUserName") not contains "*$" AND xdm.event.original_event_type="Security Group Management",arraycreate(json_extract_scalar(event_data ,"$.TargetUserName"))),
+xdm.target.user.username=if(json_extract_scalar(event_data ,"$.TargetUserName") not contains "*$" AND EventType!="Security Group Management",json_extract_scalar(event_data ,"$.TargetUserName")),
+xdm.target.user.groups=if(json_extract_scalar(event_data ,"$.TargetUserName") not contains "*$" AND EventType="Security Group Management",arraycreate(json_extract_scalar(event_data ,"$.TargetUserName"))),
 xdm.source.host.hostname=coalesce(host_name,computer_name,if(json_extract_scalar(event_data ,"$.SubjectUserName") contains "*$",json_extract_scalar(event_data ,"$.SubjectUserName") ),if(json_extract_scalar(user, "$.name") contains "*$",json_extract_scalar(user, "$.name")),if(json_extract_scalar(user_data,"$.SubjectUserName") contains "*$",json_extract_scalar(user_data,"$.SubjectUserName"))),
 xdm.source.host.fqdn=json_extract_scalar(event_data ,"$.WorkstationName"),
 xdm.event.type=channel,
@@ -34,6 +34,7 @@ userType=json_extract_scalar(user,"$.type"),
 xdm.source.host.os_family=XDM_CONST.OS_FAMILY_WINDOWS,
 xdm.event.operation_sub_type=arrayindex(regextract(message,"(^.*?)\."),0),
 xdm.source.host.os=os_subtype,
+xdm.event.original_event_type=EventType,
 xdm.source.process.command_line=process_cmd,
 xdm.source.process.executable.md5=process_md5,
 xdm.source.process.executable.sha256=process_sha256,

--- a/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_0_5.md
+++ b/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_0_5.md
@@ -1,0 +1,5 @@
+#### Modeling Rules
+
+##### MicrosoftWindowsEvents
+
+- Updated the Modeling Rule with a new event type field.

--- a/Packs/MicrosoftWindowsEvents/pack_metadata.json
+++ b/Packs/MicrosoftWindowsEvents/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Windows Event Logs",
     "description": "The Windows event log is a detailed record of system, security and application notifications stored by the Windows operating system.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
@@ -12,16 +12,6 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
-    "dependencies": {
-        "MicrosoftCore": {
-            "mandatory": true,
-            "display_name": "Microsoft Logs Base"
-        },
-        "MicrosoftADFS": {
-            "mandatory": false,
-            "display_name": "Microsoft AD FS Collection"
-        }
-    },
     "marketplaces": [
         "marketplacev2"
     ]


### PR DESCRIPTION
## Contributing to Cortex XSIAM Content

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
This PR is created in order of removing the dependecies between the packs - Microsoft Core, ADFS and Windows Event Logs

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0
- [x] 8.2.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No