### PR TITLE
fix WildFire v2 file command for files array

### DIFF
--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.py
@@ -1499,7 +1499,7 @@ def wildfire_file_command(args: dict):
         else:
             command_results = wildfire_get_file_report(element, args)[0]
             command_results_list.append(command_results)
-            return command_results
+    return command_results_list
 
 
 def wildfire_get_sample(file_hash):

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
@@ -4,11 +4,26 @@ from requests import Response
 import pytest
 
 import demistomock as demisto
-from Palo_Alto_Networks_WildFire_v2 import prettify_upload, prettify_report_entry, prettify_verdict, \
-    create_dbot_score_from_verdict, prettify_verdicts, create_dbot_score_from_verdicts, hash_args_handler, \
-    file_args_handler, wildfire_get_sample_command, wildfire_get_report_command, run_polling_command, \
-    wildfire_upload_url_command, prettify_url_verdict, create_dbot_score_from_url_verdict, parse_file_report, \
-    parse_wildfire_object, wildfire_get_file_report
+from Palo_Alto_Networks_WildFire_v2 import (
+    prettify_upload,
+    prettify_report_entry,
+    prettify_verdict,
+    create_dbot_score_from_verdict,
+    prettify_verdicts,
+    create_dbot_score_from_verdicts,
+    hash_args_handler,
+    file_args_handler,
+    wildfire_get_sample_command,
+    wildfire_get_report_command,
+    run_polling_command,
+    wildfire_upload_url_command,
+    prettify_url_verdict,
+    create_dbot_score_from_url_verdict,
+    parse_file_report,
+    parse_wildfire_object,
+    wildfire_get_file_report,
+    wildfire_file_command,
+)
 
 
 def test_will_return_ok():
@@ -220,6 +235,52 @@ def test_report_chunked_response(mocker):
 
     assert command_results[0].outputs == context
     assert command_results[0].readable_output == hr
+
+
+def test_file_command_with_array(mocker):
+    """
+    Given:
+     - hash of file.
+
+    When:
+     - Running report command.
+
+    Then:
+     - outputs is valid.
+    """
+    mocker.patch.object(demisto, "results")
+    get_sample_response = Response()
+    get_sample_response.status_code = 200
+    get_sample_response.headers = {
+        "Server": "nginx",
+        "Date": "Thu, 28 May 2020 15:03:35 GMT",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "x-envoy-upstream-service-time": "258",
+    }
+    get_sample_response._content = (
+        b'<?xml version="1.0" encoding="UTF-8"?><wildfire><version>2.0</version><file_info>'
+        b"<file_signer>None</file_signer><malware>no</malware><sha1></sha1><filetype>PDF"
+        b"</filetype><sha256>"
+        b"8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51</sha256><md5>"
+        b"4b41a3475132bd861b30a878e30aa56a</md5><size>3028</size></file_info><task_info>"
+        b"<report><version>2.0</version><platform>100</platform><software>"
+        b"PDF Static Analyzer</software><sha256>"
+        b"8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51</sha256>"
+        b"<md5>4b41a3475132bd861b30a878e30aa56a</md5><malware>no</malware><summary/>"
+        b"</report></task_info></wildfire>"
+    )
+    mocker.patch("requests.request", return_value=get_sample_response)
+    mocker.patch(
+        "Palo_Alto_Networks_WildFire_v2.URL",
+        "https://wildfire.paloaltonetworks.com/publicapi",
+    )
+    command_outputs = wildfire_file_command(
+        {
+            "file": "8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51,8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51"
+        }
+    )
+    assert len(command_outputs) == 2
 
 
 def util_load_json(path):

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
@@ -277,7 +277,8 @@ def test_file_command_with_array(mocker):
     )
     command_outputs = wildfire_file_command(
         {
-            "file": "8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51,8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51"
+            "file": "8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51"
+            ",8decc8571946d4cd70a024949e033a2a2a54377fe9f1c1b944c20f9ee11a9e51"
         }
     )
     assert len(command_outputs) == 2

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_29.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_29.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks WildFire v2
+
+- Fixed an issue that caused the **file** command to return data only for a single file.

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_29.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_29.md
@@ -3,4 +3,4 @@
 
 ##### Palo Alto Networks WildFire v2
 
-- Fixed an issue that caused the **file** command to return data only for a single file.
+- Fixed an issue that caused the ***file*** command to return data only for a single file.

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "WildFire by Palo Alto Networks",
     "description": "Perform malware dynamic analysis",
     "support": "xsoar",
-    "currentVersion": "2.1.28",
+    "currentVersion": "2.1.29",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-25973

## Description
fixed an issue that caused the `file` command to return data for only one file.

## Does it break backward compatibility?
- [x] No

## Must have
- [x] Tests