### PR TITLE
fix regex of getting the version of the server

### DIFF
--- a/Tests/test_content.py
+++ b/Tests/test_content.py
@@ -347,7 +347,7 @@ def get_server_numeric_version(ami_env, is_local_run=False):
 
 def extract_server_numeric_version(instances_ami_name, default_version):
     try:
-        server_numeric_version = re.match(
+        server_numeric_version = re.search(
             r'server-image-(?:ga-)?(?P<version>[a-z0-9\-]+)-(?P<build_number>\d+)-(?P<creation_date>\d{4}-\d{2}-\d{2})',
             instances_ami_name
         ).group('version')


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
fix the regex of getting the version of the server. During the upload version, we need to get the version of the server to determine which packs to install. We had a bug in the regex as we searched using match and not search.
This bug caused us to return the default version
