### PR TITLE
Kill long running container when the connection is lost

### DIFF
--- a/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule.py
+++ b/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule.py
@@ -87,7 +87,7 @@ def create_nginx_server_conf(file_path: str, port: int, params: Dict):
     Raises:
         DemistoException: raised if there is a detected config error
     """
-    params = demisto.params() if not params else params
+    params = params if params else demisto.params()
     template_str = params.get('nginx_server_conf') or NGINX_SERVER_CONF
     certificate: str = params.get('certificate', '')
     private_key: str = params.get('key', '')
@@ -125,7 +125,7 @@ def create_nginx_server_conf(file_path: str, port: int, params: Dict):
 
 
 def start_nginx_server(port: int, params: Dict = {}) -> subprocess.Popen:
-    params = demisto.params() if not params else params
+    params = params if params else demisto.params()
     create_nginx_server_conf(NGINX_SERVER_CONF_FILE, port, params)
     nginx_global_directives = 'daemon off;'
     global_directives_conf = params.get('nginx_global_directives')
@@ -149,53 +149,50 @@ def start_nginx_server(port: int, params: Dict = {}) -> subprocess.Popen:
 
 
 def nginx_log_process(nginx_process: subprocess.Popen):
-    try:
-        old_access = NGINX_SERVER_ACCESS_LOG + '.old'
-        old_error = NGINX_SERVER_ERROR_LOG + '.old'
-        log_access = False
-        log_error = False
-        # first check if one of the logs are missing. This may happen on rare ocations that we renamed and deleted the file
-        # before nginx completed the role over of the logs
-        missing_log = False
-        if not os.path.isfile(NGINX_SERVER_ACCESS_LOG):
-            missing_log = True
-            demisto.info(f'Missing access log: {NGINX_SERVER_ACCESS_LOG}. Will send roll signal to nginx.')
-        if not os.path.isfile(NGINX_SERVER_ERROR_LOG):
-            missing_log = True
-            demisto.info(f'Missing error log: {NGINX_SERVER_ERROR_LOG}. Will send roll signal to nginx.')
-        if missing_log:
-            nginx_process.send_signal(int(SIGUSR1))
-            demisto.info(f'Done sending roll signal to nginx (pid: {nginx_process.pid}) after detecting missing log file.'
-                         ' Will skip this iteration.')
-            return
-        if os.path.getsize(NGINX_SERVER_ACCESS_LOG):
-            log_access = True
-            Path(NGINX_SERVER_ACCESS_LOG).rename(old_access)
-        if os.path.getsize(NGINX_SERVER_ERROR_LOG):
-            log_error = True
-            Path(NGINX_SERVER_ERROR_LOG).rename(old_error)
-        if log_access or log_error:
-            # nginx rolls the logs when getting sigusr1
-            nginx_process.send_signal(int(SIGUSR1))
-            gevent.sleep(0.5)  # sleep 0.5 to let nginx complete the roll
-        if log_access:
-            with open(old_access, 'rt') as f:
-                start = 1
-                for lines in batch(f.readlines(), 100):
-                    end = start + len(lines)
-                    demisto.info(f'nginx access log ({start}-{end-1}): ' + ''.join(lines))
-                    start = end
-            Path(old_access).unlink()
-        if log_error:
-            with open(old_error, 'rt') as f:
-                start = 1
-                for lines in batch(f.readlines(), 100):
-                    end = start + len(lines)
-                    demisto.error(f'nginx error log ({start}-{end-1}): ' + ''.join(lines))
-                    start = end
-            Path(old_error).unlink()
-    except Exception as e:
-        demisto.error(f'Failed nginx log processing: {e}. Exception: {traceback.format_exc()}')
+    old_access = NGINX_SERVER_ACCESS_LOG + '.old'
+    old_error = NGINX_SERVER_ERROR_LOG + '.old'
+    log_access = False
+    log_error = False
+    # first check if one of the logs are missing. This may happen on rare ocations that we renamed and deleted the file
+    # before nginx completed the role over of the logs
+    missing_log = False
+    if not os.path.isfile(NGINX_SERVER_ACCESS_LOG):
+        missing_log = True
+        demisto.info(f'Missing access log: {NGINX_SERVER_ACCESS_LOG}. Will send roll signal to nginx.')
+    if not os.path.isfile(NGINX_SERVER_ERROR_LOG):
+        missing_log = True
+        demisto.info(f'Missing error log: {NGINX_SERVER_ERROR_LOG}. Will send roll signal to nginx.')
+    if missing_log:
+        nginx_process.send_signal(int(SIGUSR1))
+        demisto.info(f'Done sending roll signal to nginx (pid: {nginx_process.pid}) after detecting missing log file.'
+                     ' Will skip this iteration.')
+        return
+    if os.path.getsize(NGINX_SERVER_ACCESS_LOG):
+        log_access = True
+        Path(NGINX_SERVER_ACCESS_LOG).rename(old_access)
+    if os.path.getsize(NGINX_SERVER_ERROR_LOG):
+        log_error = True
+        Path(NGINX_SERVER_ERROR_LOG).rename(old_error)
+    if log_access or log_error:
+        # nginx rolls the logs when getting sigusr1
+        nginx_process.send_signal(int(SIGUSR1))
+        gevent.sleep(0.5)  # sleep 0.5 to let nginx complete the roll
+    if log_access:
+        with open(old_access, 'rt') as f:
+            start = 1
+            for lines in batch(f.readlines(), 100):
+                end = start + len(lines)
+                demisto.info(f'nginx access log ({start}-{end-1}): ' + ''.join(lines))
+                start = end
+        Path(old_access).unlink()
+    if log_error:
+        with open(old_error, 'rt') as f:
+            start = 1
+            for lines in batch(f.readlines(), 100):
+                end = start + len(lines)
+                demisto.error(f'nginx error log ({start}-{end-1}): ' + ''.join(lines))
+                start = end
+        Path(old_error).unlink()
 
 
 def nginx_log_monitor_loop(nginx_process: subprocess.Popen):
@@ -263,7 +260,7 @@ def get_params_port(params: Dict = None) -> int:
     """
     Gets port from the integration parameters
     """
-    params = demisto.params() if not params else params
+    params = params if params else demisto.params()
     port_mapping: str = params.get('longRunningPort', '')
     err_msg: str
     port: int
@@ -285,7 +282,7 @@ def run_long_running(params: Dict = None, is_test: bool = False):
     :param is_test: Indicates whether it's test-module run or regular run
     :return: None
     """
-    params = demisto.params() if not params else params
+    params = params if params else demisto.params()
     nginx_process = None
     nginx_log_monitor = None
 

--- a/Packs/EDL/ReleaseNotes/3_2_3.md
+++ b/Packs/EDL/ReleaseNotes/3_2_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Generic Export Indicators Service
+
+- Kill long running container when the connection to the server is lost.

--- a/Packs/EDL/ReleaseNotes/3_2_3.md
+++ b/Packs/EDL/ReleaseNotes/3_2_3.md
@@ -3,4 +3,4 @@
 
 ##### Generic Export Indicators Service
 
-- Kill long running container when the connection to the server is lost.
+- Fixed an issue where the integration will not restart when the engine running it reconnects to the server.

--- a/Packs/EDL/ReleaseNotes/3_2_4.md
+++ b/Packs/EDL/ReleaseNotes/3_2_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Generic Export Indicators Service
+
+- Fixed an issue where the integration will not restart when the engine running it reconnects to the server.

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Export Indicators Service",
     "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to ANY other product in your network, such as your firewall, agent or SIEM. This pack is built for ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
-    "currentVersion": "3.2.3",
+    "currentVersion": "3.2.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Export Indicators Service",
     "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to ANY other product in your network, such as your firewall, agent or SIEM. This pack is built for ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
-    "currentVersion": "3.2.2",
+    "currentVersion": "3.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_19.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_19.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Export Indicators Service (Deprecated)
+
+- Kill long running container when the connection to the server is lost.

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_19.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_19.md
@@ -3,4 +3,4 @@
 
 ##### Export Indicators Service (Deprecated)
 
-- Kill long running container when the connection to the server is lost.
+- Fixed an issue where the integration will not restart when the engine running it reconnects to the server.

--- a/Packs/ExportIndicators/pack_metadata.json
+++ b/Packs/ExportIndicators/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Deprecated. Use Generic Export Indicators Service instead.",
     "support": "xsoar",
     "hidden": true,
-    "currentVersion": "1.0.18",
+    "currentVersion": "1.0.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_41.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_41.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TAXII2 Server
+
+- Kill long running container when the connection to the server is lost.

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_41.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_41.md
@@ -3,4 +3,4 @@
 
 ##### TAXII2 Server
 
-- Kill long running container when the connection to the server is lost.
+- Fixed an issue where the integration will not restart when the engine running it reconnects to the server.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "2.0.40",
+    "currentVersion": "2.0.41",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://jira-hq.paloaltonetworks.local/browse/XSUP-24435?filter=-1
## Description
This fixes an issue when the exception was supressed in internal function.
