### PR TITLE
Fix as_pages kwargs argument in function call

### DIFF
--- a/Packs/ApiModules/Scripts/TAXII2ApiModule/TAXII2ApiModule.py
+++ b/Packs/ApiModules/Scripts/TAXII2ApiModule/TAXII2ApiModule.py
@@ -1259,8 +1259,8 @@ class Taxii2FeedClient:
             self.objects_to_fetch.append('relationship')
         kwargs['type'] = self.objects_to_fetch
         if isinstance(self.collection_to_fetch, v20.Collection):
-            return v20.as_pages(get_objects, per_request=page_size, kwargs=kwargs)
-        return v21.as_pages(get_objects, per_request=page_size, kwargs=kwargs)
+            return v20.as_pages(get_objects, per_request=page_size, **kwargs)
+        return v21.as_pages(get_objects, per_request=page_size, **kwargs)
 
     def get_page_size(self, max_limit: int, cur_limit: int) -> int:
         """

--- a/Packs/FeedDHS/ReleaseNotes/2_0_15.md
+++ b/Packs/FeedDHS/ReleaseNotes/2_0_15.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### DHS Feed v2
+
+Fixed an issue passing kargs taxii2client in the **TAXII2ApiModule** script.

--- a/Packs/FeedDHS/pack_metadata.json
+++ b/Packs/FeedDHS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DHS Feed",
     "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency’s (CISA’s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
     "support": "xsoar",
-    "currentVersion": "2.0.14",
+    "currentVersion": "2.0.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_17.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_17.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### MITRE ATT&CK
+
+Fixed an issue passing kargs taxii2client in the **TAXII2ApiModule** script.

--- a/Packs/FeedMitreAttackv2/pack_metadata.json
+++ b/Packs/FeedMitreAttackv2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MITRE ATT&CK",
     "description": "Fetches indicators from MITRE ATT&CK.",
     "support": "xsoar",
-    "currentVersion": "1.1.16",
+    "currentVersion": "1.1.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedTAXII/ReleaseNotes/1_1_30.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_1_30.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TAXII 2 Feed
+
+Fixed an issue passing kargs taxii2client in the **TAXII2ApiModule** script which caused ***taxii2-get-indicators*** to fail.

--- a/Packs/FeedTAXII/pack_metadata.json
+++ b/Packs/FeedTAXII/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Feed",
     "description": "Ingest indicator feeds from TAXII 1 and TAXII 2 servers.",
     "support": "xsoar",
-    "currentVersion": "1.1.29",
+    "currentVersion": "1.1.30",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: Reverse this change -> https://github.com/demisto/content/pull/27205

## Description
This PR #27205 break passing arguments to taxii client correctly.
If bad arguments are passed to the function, the PR #27205 make the code working by breaking passing arguments, but if every arguments are passed correctly, the PR broke passing arguments to the taxii-client.

`**kwargs` is the right way to pass python arguments since Python 2.0

So my PR is reverting it to make everything working as expected.

Last version of the integration TAXII Feed 1.1.29 5786478
![image](https://github.com/demisto/content/assets/363342/060a95f0-98aa-4c6b-a711-60c66c6d25c7)
We can see the kwargs passed in parameter to the Taxii server (`match%5Bkwargs%5D=added_after%2Ctype`) and it's not valid at all, it's why we are receiving a 400 Bad request.


With the version after reverting to pass parameters with `**kwargs`, everything is passed correctly
![image](https://github.com/demisto/content/assets/363342/c73bca5b-6b10-44cd-b673-5f0434a2009d)
We can see those log if ran in debug-mode
`GET /taxii2/api_root/collections/0e1d60d0-99bf-44e1-aaec-a172c40262cb/objects/?limit=10&match%5Btype%5D=attack-pattern%2Cautonomous-system%2Ccampaign%2Ccourse-of-action%2Cdomain-name%2Cemail-addr%2Cfile%2Cidentity%2Cindicator%2Cinfrastructure%2Cintrusion-set%2Cipv4-addr%2Cipv6-addr%2Clocation%2Cmalware%2Cmutex%2Creport%2Cthreat-actor%2Ctool%2Curl%2Cuser-account%2Cvulnerability%2Cwindows-registry-key%2Crelationship`
Now all parameters are passed correctly.

## Must have
- [ ] Tests
- [ ] Documentation 
