### PR TITLE
Darktrace Event Collector - Added the marketplacev2 to the yml file

### DIFF
--- a/Packs/Darktrace/Integrations/DarktraceEventCollector/DarktraceEventCollector.yml
+++ b/Packs/Darktrace/Integrations/DarktraceEventCollector/DarktraceEventCollector.yml
@@ -100,3 +100,5 @@ script:
 fromversion: 6.9.0
 tests:
 - No tests (auto formatted)
+marketplaces:
+- marketplacev2


### PR DESCRIPTION
Fix for missing `marketplacev2` for the event collector.
