### PR TITLE
GetListRow: fix tab separated values issue

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_5.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_5.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### GetListRow
+
+- Fixed an issue where using a tab character as separator didn't parsed correctly.
+- Updated the docker image to: *demisto/python3:3.10.12.65389*.

--- a/Packs/CommonScripts/ReleaseNotes/1_12_5.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_5.md
@@ -3,5 +3,5 @@
 
 ##### GetListRow
 
-- Fixed an issue where using a tab character as separator didn't parsed correctly.
+- Fixed an issue when using *\t* as a separator didn't parse tabs as expected.
 - Updated the docker image to: *demisto/python3:3.10.12.65389*.

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.py
@@ -80,7 +80,7 @@ def main():
     header = args.get('header', '')
     value = args.get('value', '')
     list_separator = args.get('list_separator', ',') or ','
-    list_separator = list_separator.replace('\\t', '	').replace('\t', '	')
+    list_separator = list_separator.replace('\\t', '\t')
 
     return_results(parse_list(parse_all, header, value, list_name, list_separator))
 

--- a/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
+++ b/Packs/CommonScripts/Scripts/GetlistRow/GetListRow.yml
@@ -42,7 +42,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.10.12.63474
+dockerimage: demisto/python3:3.10.12.65389
 runas: DBotWeakRole
 tests:
 - No tests (auto formatted)

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.4",
+    "currentVersion": "1.12.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
related: 
https://jira-hq.paloaltonetworks.local/browse/XSUP-25540
https://github.com/demisto/content/pull/28066

## Description
Server side issue that replace the tab character `	` to 4 space cause the `GetListRow` script to not work as expected when the delimator of the list are tab

fix : replace `\\t' with '\t' as now the tab separated values saved in server  as `\t` separated values


**the list**
<img width="136" alt="image" src="https://github.com/demisto/content/assets/79846863/dbb244fb-391a-42b7-9cc7-86ec9fc22fe8">


**call from Playbook**
<img width="512" alt="image" src="https://github.com/demisto/content/assets/79846863/9f3de04f-23d2-4ca1-bb00-c8d058a427c6">


**call from CLI**
<img width="918" alt="image" src="https://github.com/demisto/content/assets/79846863/9db49b8a-7172-4427-84b7-fc85354e91fe">
