### PR TITLE
Fix BA125 Validation Failure

### DIFF
--- a/Packs/HarfangLabEDR/.pack-ignore
+++ b/Packs/HarfangLabEDR/.pack-ignore
@@ -1,5 +1,5 @@
 [file:Hurukai.yml]
-ignore=IN126,BA124
+ignore=IN126,BA124,BA125
 
 [known_words]
 harfanglab

--- a/Packs/Zabbix/.pack-ignore
+++ b/Packs/Zabbix/.pack-ignore
@@ -2,4 +2,4 @@
 ignore=IM111
 
 [file:Zabbix.yml]
-ignore=IN153
+ignore=IN153,BA125

--- a/Packs/Zabbix/Integrations/Zabbix/README.md
+++ b/Packs/Zabbix/Integrations/Zabbix/README.md
@@ -545,6 +545,24 @@ Get events
 | 0 | 0 | 1585589664 | 0 | 15 | Zabbix task manager processes more than 75% busy | 596351852 | 0 | 13560 | 0 | 0 | 0 | 0 | 0 | 0 |
 
 
+### test-module
+
+***
+Test if module is working
+
+#### Base Command
+
+`test-module`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+
+#### Context Output
+
+There is no context output for this command.
+
 ## Additional Information
 Using execute_command you can do anything available on Zabbix API.
 

--- a/Packs/Zabbix/Integrations/Zabbix/README.md
+++ b/Packs/Zabbix/Integrations/Zabbix/README.md
@@ -545,24 +545,6 @@ Get events
 | 0 | 0 | 1585589664 | 0 | 15 | Zabbix task manager processes more than 75% busy | 596351852 | 0 | 13560 | 0 | 0 | 0 | 0 | 0 | 0 |
 
 
-### test-module
-
-***
-Test if module is working
-
-#### Base Command
-
-`test-module`
-
-#### Input
-
-| **Argument Name** | **Description** | **Required** |
-| --- | --- | --- |
-
-#### Context Output
-
-There is no context output for this command.
-
 ## Additional Information
 Using execute_command you can do anything available on Zabbix API.
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
`BA125` validation assures that terms like `test-module` aren't in use in customer-facing documentation.
The 2 integrations that are being ignored from this validation on this PR are integrations that have `test-module` as a command in their YAML file, meaning that when we run format on them (which is what happened that failed the build), a section with `test-module` command's description (from the YAML) is automatically added.