### PR TITLE
[Demisto-SDK] Fix BA125 Validation Failure (part 2)

### DIFF
--- a/Packs/HarfangLabEDR/.pack-ignore
+++ b/Packs/HarfangLabEDR/.pack-ignore
@@ -1,6 +1,9 @@
 [file:Hurukai.yml]
 ignore=IN126,BA124,BA125
 
+[file:README.md]
+BA125
+
 [known_words]
 harfanglab
 filesize

--- a/Packs/Zabbix/.pack-ignore
+++ b/Packs/Zabbix/.pack-ignore
@@ -2,4 +2,7 @@
 ignore=IM111
 
 [file:Zabbix.yml]
-ignore=IN153,BA125
+ignore=IN153
+
+[file:README.md]
+BA125


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The fix on https://github.com/demisto/content/pull/28403 added the ignore to the wrong file (YAML instead of README).
This PR fixes it.
