### PR TITLE
Playbook enhancment enrichment for verdicet and user investigation

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict.yml
@@ -415,6 +415,9 @@ tasks:
       ResolveIP:
         complex:
           root: inputs.ResolveIP
+      UseReputationCommand:
+        complex:
+          root: inputs.UseReputationCommand
     separatecontext: true
     loop:
       iscommand: false
@@ -578,6 +581,7 @@ tasks:
         * SSL verification for URLs
         * Threat information
         * Providing of URL screenshots
+        * URL Reputation using !url
       playbookName: URL Enrichment - Generic v2
       type: playbook
       iscommand: false
@@ -591,6 +595,9 @@ tasks:
       URL:
         complex:
           root: inputs.URL
+      UseReputationCommand:
+        complex:
+          root: inputs.UseReputationCommand
       VerifyURL:
         simple: "False"
     separatecontext: true
@@ -992,6 +999,7 @@ tasks:
         Enrich domains using one or more integrations.
         Domain enrichment includes:
         * Threat information
+        * Domain reputation using !domain command
       playbookName: Domain Enrichment - Generic v2
       type: playbook
       iscommand: false
@@ -1003,6 +1011,9 @@ tasks:
       Domain:
         complex:
           root: inputs.Domain
+      UseReputationCommand:
+        complex:
+          root: inputs.UseReputationCommand
     separatecontext: true
     loop:
       iscommand: false
@@ -1461,6 +1472,12 @@ inputs:
   value: {}
   required: false
   description: The registry value to run prevalence check. The input registry key must be provided as well.
+  playbookInputQuery:
+- key: UseReputationCommand
+  value:
+    simple: "True"
+  required: false
+  description: Set 'True' to use the reputation commands (!ip, !domain, !url) to enrich the IP, URL, and domain.
   playbookInputQuery:
 outputs:
 - contextPath: PreviousVerdict

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict_README.md
@@ -6,12 +6,12 @@ This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
 
+* IP Enrichment - Generic v2
+* Account Enrichment - Generic v2.1
 * Domain Enrichment - Generic v2
 * URL Enrichment - Generic v2
-* IP Enrichment - Generic v2
-* File Reputation
 * Get prevalence for IOCs
-* Account Enrichment - Generic v2.1
+* File Reputation
 
 ### Integrations
 
@@ -24,8 +24,8 @@ This playbook does not use any integrations.
 
 ### Commands
 
-* wildfire-report
 * wildfire-get-verdict
+* wildfire-report
 
 ## Playbook Inputs
 
@@ -47,6 +47,7 @@ This playbook does not use any integrations.
 | ProcessName | The process name to run the prevalence check. |  | Optional |
 | RegistryKey | The registry key to run the prevalence check. The input registry value must be provided as well. |  | Optional |
 | RegistryValue | The registry value to run prevalence check. The input registry key must be provided as well. |  | Optional |
+| UseReputationCommand | Set 'True' to use the reputation commands \(\!ip, \!domain, \!url\) to enrich the IP, URL, and domain. | True | Optional |
 
 ## Playbook Outputs
 

--- a/Packs/CommonPlaybooks/Playbooks/playbook-User_Investigation_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-User_Investigation_-_Generic.yml
@@ -981,9 +981,23 @@ tasks:
       lh:
         complex:
           root: NumOfOktaFailedLogon
+          transformers:
+          - operator: SetIfEmpty
+            args:
+              applyIfEmpty: {}
+              defaultValue:
+                value:
+                  simple: "0"
       rh:
         complex:
           root: NumOfSiemFailedLogon
+          transformers:
+          - operator: SetIfEmpty
+            args:
+              applyIfEmpty: {}
+              defaultValue:
+                value:
+                  simple: "0"
     separatecontext: false
     continueonerror: true
     continueonerrortype: ""

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_82.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_82.md
@@ -1,5 +1,8 @@
 
 #### Playbooks
 
+##### User Investigation - Generic
+Added transformer `set-if-empty` to MathUtil task for calculating the total number of failed logins.
+
 ##### Enrichment for Verdict
 Added input `UseReputationCommand` - This input determines if to use the reputation command (!IP, !Domain, !Url) to enrich the IP, URL, and domain.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_3_82.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_3_82.md
@@ -1,0 +1,5 @@
+
+#### Playbooks
+
+##### Enrichment for Verdict
+Added input `UseReputationCommand` - This input determines if to use the reputation command (!IP, !Domain, !Url) to enrich the IP, URL, and domain.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.3.81",
+    "currentVersion": "2.3.82",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-7530)

## Description
enhancement for the following playbooks:
**User Investigation - Generic:**
Added transformer `set-if-empty` to MathUtil task for calculating the total number of failed logins.
**Enrichment for Verdict:**
Added input `UseReputationCommand` - This input determines if to use the reputation command (!IP, !Domain, !Url) to enrich the IP, URL, and domain.

## Must have
- [ ] Tests
- [ ] Documentation 
