### PR TITLE
Mitre indicators by open incidents bug fix

### DIFF
--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_19.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_19.md
@@ -2,5 +2,5 @@
 #### Scripts
 
 ##### MITREIndicatorsByOpenIncidentsV2
-
+- Updated the Docker image to: *demisto/python3:3.10.12.66339*.
 - Fixed an issue where the script did not handle properly empty iocs.

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_19.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_19.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### MITREIndicatorsByOpenIncidentsV2
+
+- Fixed an issue where the script did not handle properly empty iocs.

--- a/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2.py
+++ b/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2.py
@@ -13,7 +13,8 @@ def main():
         res = search_indicators.search_indicators_by_version(query=query, from_date=from_date, to_date=to_date)
 
         indicators = []
-        for ind in res.get('iocs', []):
+        iocs = res.get('iocs') if res.get('iocs') is not None else []
+        for ind in iocs:
             indicators.append({
                 'Value': dict_safe_get(ind, ['value']),
                 'Name': dict_safe_get(ind, ['CustomFields', 'mitreid']),

--- a/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2.yml
+++ b/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2.yml
@@ -15,7 +15,7 @@ tags:
 - widget
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.10.12.63474
+dockerimage: demisto/python3:3.10.12.66339
 runas: DBotWeakRole
 tests:
 - No test.

--- a/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2_test.py
+++ b/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2_test.py
@@ -1,6 +1,6 @@
-import pytest
 import MITREIndicatorsByOpenIncidentsv2
 from CommonServerPython import *
+
 
 def test_mitre_indicators_by_open_incidents_v2(mocker):
     """
@@ -11,13 +11,17 @@ def test_mitre_indicators_by_open_incidents_v2(mocker):
     Then:
         - Ensure that the iocs values appear in the Human Readable result.
     """
-    mocker.patch.object(IndicatorsSearcher, 'search_indicators_by_version', return_value=
-                        {'total': 0, 'iocs': [{'value': '1'}, {'value': '2'}, {'value': '3'}], 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
+
+    mocker.patch.object(IndicatorsSearcher,
+                        'search_indicators_by_version',
+                        return_value={'total': 0, 'iocs': [{'value': '1'}, {'value': '2'}, {'value': '3'}],
+                                      'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
     mocker.patch.object(demisto, 'args', return_value={'from': '2023-07-25', 'to': '2023-07-26'})
     mocker.patch.object(demisto, 'results')
     MITREIndicatorsByOpenIncidentsv2.main()
 
     assert "\n| 1 |  |  |  |\n| 2 |  |  |  |\n| 3 |  |  |  |\n" in demisto.results.call_args_list[0].args[0]["HumanReadable"]
+
 
 def test_mitre_indicators_by_open_incidents_v2_empty_iocs(mocker):
     """
@@ -28,10 +32,12 @@ def test_mitre_indicators_by_open_incidents_v2_empty_iocs(mocker):
     Then:
         - Ensure that the scripts completed the run with no errors.
     """
-    mocker.patch.object(IndicatorsSearcher, 'search_indicators_by_version', return_value=
-                        {'total': 0, 'iocs': None, 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
+    mocker.patch.object(IndicatorsSearcher,
+                        'search_indicators_by_version',
+                        return_value={'total': 0, 'iocs': None, 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
     mocker.patch.object(demisto, 'args', return_value={'from': '2023-07-25', 'to': '2023-07-26'})
     mocker.patch.object(demisto, 'results')
     MITREIndicatorsByOpenIncidentsv2.main()
 
-    assert "### MITRE ATT&CK techniques by related Incidents\n**No entries.**\n" in demisto.results.call_args_list[0].args[0]["HumanReadable"]
+    assert "### MITRE ATT&CK techniques by related Incidents\n**No entries.**\n" in \
+           demisto.results.call_args_list[0].args[0]["HumanReadable"]

--- a/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2_test.py
+++ b/Packs/FeedMitreAttackv2/Scripts/MITREIndicatorsByOpenIncidentsv2/MITREIndicatorsByOpenIncidentsv2_test.py
@@ -1,0 +1,37 @@
+import pytest
+import MITREIndicatorsByOpenIncidentsv2
+from CommonServerPython import *
+
+def test_mitre_indicators_by_open_incidents_v2(mocker):
+    """
+    Given:
+        - A search_indicators_by_version result with iocs.
+    When:
+        - Running the MITREIndicatorsByOpenIncidentsv2 script.
+    Then:
+        - Ensure that the iocs values appear in the Human Readable result.
+    """
+    mocker.patch.object(IndicatorsSearcher, 'search_indicators_by_version', return_value=
+                        {'total': 0, 'iocs': [{'value': '1'}, {'value': '2'}, {'value': '3'}], 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
+    mocker.patch.object(demisto, 'args', return_value={'from': '2023-07-25', 'to': '2023-07-26'})
+    mocker.patch.object(demisto, 'results')
+    MITREIndicatorsByOpenIncidentsv2.main()
+
+    assert "\n| 1 |  |  |  |\n| 2 |  |  |  |\n| 3 |  |  |  |\n" in demisto.results.call_args_list[0].args[0]["HumanReadable"]
+
+def test_mitre_indicators_by_open_incidents_v2_empty_iocs(mocker):
+    """
+    Given:
+        - A search_indicators_by_version result with empty iocs (iocs: None which is a valid response from the server).
+    When:
+        - Running the MITREIndicatorsByOpenIncidentsv2 script.
+    Then:
+        - Ensure that the scripts completed the run with no errors.
+    """
+    mocker.patch.object(IndicatorsSearcher, 'search_indicators_by_version', return_value=
+                        {'total': 0, 'iocs': None, 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0})
+    mocker.patch.object(demisto, 'args', return_value={'from': '2023-07-25', 'to': '2023-07-26'})
+    mocker.patch.object(demisto, 'results')
+    MITREIndicatorsByOpenIncidentsv2.main()
+
+    assert "### MITRE ATT&CK techniques by related Incidents\n**No entries.**\n" in demisto.results.call_args_list[0].args[0]["HumanReadable"]

--- a/Packs/FeedMitreAttackv2/pack_metadata.json
+++ b/Packs/FeedMitreAttackv2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MITRE ATT&CK",
     "description": "Fetches indicators from MITRE ATT&CK.",
     "support": "xsoar",
-    "currentVersion": "1.1.18",
+    "currentVersion": "1.1.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Managed to reproduce. When the server http response was as follows:
res = {'total': 0, 'iocs': None, 'searchAfter': None, 'accountErrors': None, 'totalAccounts': 0}

res.get('iocs', []) will return [] only if iocs key does not exist in the dict. if the iocs is None in the dict it will return None and fail afterwords in the for loop.

Added UT to cover this case.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-26443)

## Must have
- [x] Tests
- [x] Documentation 
