### PR TITLE
Update Jira V3 OAuth 2.0 documentation

### DIFF
--- a/Packs/Jira/Integrations/JiraV3/JiraV3_description.md
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3_description.md
@@ -5,6 +5,11 @@ Please configure only one of the following fields:
 
 For both instances, it is advised to use the `https://oproxy.demisto.ninja/authcode` **Callback URL**. The oproxy url is a client side only web page which provides an easy interface to copy the obtained auth code from the authorization response to the integration configuration in the authorization flow steps. Optionally: if you don't want to use the oproxy url, you may use a localhost url on a port which is not used locally on your machine. For example: <http://localhost:9004>. You will then need to copy the code from the url address bar in the response.
 
+**Notes**:
+
+1. Authentication is done using OAuth 2.0.
+2. OAuth 2.0 works for Jira OnPrem 8.22 and above.
+
 ### Cloud authentication
 
 Go to your [Developer console](https://developer.atlassian.com/console/myapps/) page, and choose the App you want to integrate with your instance. It must be of type OAuth 2.0. For creating a new app with type OAuth 2.0, click **Create** and choose **OAuth 2.0 integration** and follow the steps.

--- a/Packs/Jira/Integrations/JiraV3/README.md
+++ b/Packs/Jira/Integrations/JiraV3/README.md
@@ -42,6 +42,11 @@ If you are upgrading from a previous version of this integration, see [Breaking 
 
 For both instances, it is advised to use the `https://oproxy.demisto.ninja/authcode` **Callback URL**. The oproxy url is a client side only web page which provides an easy interface to copy the obtained auth code from the authorization response to the integration configuration in the authorization flow steps. Optionally: if you don't want to use the oproxy url, you may use a localhost url on a port which is not used locally on your machine. For example: <http://localhost:9004>. You will then need to copy the code from the url address bar in the response (see [Authorization Flow In Cortex XSOAR](#authorization-flow-in-cortex-xsoar)).
 
+**Notes**:
+
+1. Authentication is done using OAuth 2.0.
+2. OAuth 2.0 works for Jira OnPrem 8.22 and above.
+
 ### Cloud authentication
 
 Go to your [Developer console](https://developer.atlassian.com/console/myapps/) page, and choose the App you want to integrate with your instance. It must be of type OAuth 2.0. For creating a new app with type OAuth 2.0, click **Create** and choose **OAuth 2.0 integration** and follow the steps.


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Add description stating that Jira OnPrem version 8.22 and above is required to use OAuth 2.0

## Must have
- [ ] Tests
- [ ] Documentation 
