### PR TITLE
fixed dt condition in snow ticket state polling playbook

### DIFF
--- a/Packs/ServiceNow/Playbooks/playbook-ServiceNow_Ticket_State_Polling.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-ServiceNow_Ticket_State_Polling.yml
@@ -59,7 +59,7 @@ tasks:
         complex:
           root: inputs.InstanceName
       dt:
-        simple: ServiceNow.Ticket(val.State != '6' || val.State != '7').Number
+        simple: ServiceNow.Ticket(val.State != '6' && val.State != '7').Number
       ids:
         complex:
           root: inputs.TicketNumber
@@ -244,8 +244,7 @@ inputs:
 - key: Timeout
   value: {}
   required: true
-  description: Amount of time to poll before declaring a timeout and resuming the
-    playbook (in minutes).
+  description: Amount of time to poll before declaring a timeout and resuming the playbook (in minutes).
   playbookInputQuery:
 - key: InstanceName
   value: {}

--- a/Packs/ServiceNow/ReleaseNotes/2_5_35.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_35.md
@@ -1,0 +1,4 @@
+
+#### Playbooks
+##### ServiceNow Ticket State Polling
+- Fixed an issue in the dt input.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.5.34",
+    "currentVersion": "2.5.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-7409)

## Description
Changed the condition from `ServiceNow.Ticket(val.State != '6' || val.State != '7').Number` to `ServiceNow.Ticket(val.State != '6' && val.State != '7').Number`, as in the original situation the loop is always true

## Must have
- [ ] Tests
- [ ] Documentation 
