### PR TITLE
Remove `BA125` from `.pack-ignore`

### DIFF
--- a/Packs/HarfangLabEDR/.pack-ignore
+++ b/Packs/HarfangLabEDR/.pack-ignore
@@ -1,8 +1,5 @@
 [file:Hurukai.yml]
-ignore=IN126,BA124,BA125
-
-[file:README.md]
-BA125
+ignore=IN126,BA124
 
 [known_words]
 harfanglab
@@ -28,4 +25,3 @@ evtx
 logs
 filesystem
 downloadfile
-

--- a/Packs/Zabbix/.pack-ignore
+++ b/Packs/Zabbix/.pack-ignore
@@ -3,6 +3,3 @@ ignore=IM111
 
 [file:Zabbix.yml]
 ignore=IN153
-
-[file:README.md]
-BA125


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
We originally added `BA125` to `.pack-ignore` of these packs because their integrations have `test-module` listed as a command in their YAML file, causing the validation to fail when people run `format` and don't remove the added`test-module` section in their README file.

Now that the SDK version has been updated on the `content` repository, we can restore the validation for these integrations and trust that people won't cause master's build to fail, since the validation will fail during the PR stage, blocking them from merging, and they'll have to remove the `test-module` section from the README file to merge.