### PR TITLE
Add skip:true to skip sourcery

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -83,6 +83,7 @@ repos:
   hooks:
   - id: sourcery
     args: [--no-summary, --fix, --diff, "git diff HEAD"]
+    skip: true
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.982


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7670

## Description
Sourcery is configured to run once pre-commit is ran, and since Sourcery requires users to log in in order for it to run, [reference](https://github.com/sourcery-ai/sourcery#cli), we should disable it so users won't need to do that when they run pre-commit.

## Must have
- [ ] Tests
- [ ] Documentation 
