### PR TITLE
Re-lock corepacks-8.3.0.json file

### DIFF
--- a/Tests/Marketplace/versions-metadata.json
+++ b/Tests/Marketplace/versions-metadata.json
@@ -2,7 +2,7 @@
   "version_map": {
     "8.3.0": {
       "core_packs_file": "corepacks-8.3.0.json",
-      "core_packs_file_is_locked": false,
+      "core_packs_file_is_locked": true,
       "file_version": "1"
     },
     "8.4.0": {


### PR DESCRIPTION
## Description
Lock corepacks-8.3.0.json file back after unlocking it for fixing the issue below.

## Related Issues
relates: https://jira-hq.paloaltonetworks.local/browse/CRTX-89375.