### PR TITLE
fixed display for type 9 parameters in workday

### DIFF
--- a/Packs/Workday/Integrations/Workday/Workday.yml
+++ b/Packs/Workday/Integrations/Workday/Workday.yml
@@ -259,7 +259,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.12.63474
+  dockerimage: demisto/python3:3.10.12.66339
 fromversion: 5.0.0
 tests:
 - Workday - Test

--- a/Packs/Workday/Integrations/Workday/Workday.yml
+++ b/Packs/Workday/Integrations/Workday/Workday.yml
@@ -17,7 +17,7 @@ configuration:
   type: 4
   hidden: true
   required: false
-- display: Tenant name
+- displaypassword: Tenant name
   name: cred_tenant_name
   type: 9
   hiddenusername: true
@@ -27,7 +27,7 @@ configuration:
   type: 4
   hidden: true
   required: false
-- display: Token
+- displaypassword: Token
   name: cred_token
   type: 9
   hiddenusername: true

--- a/Packs/Workday/ReleaseNotes/1_3_8.md
+++ b/Packs/Workday/ReleaseNotes/1_3_8.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+##### Workday
+- Fixed an issue where ***Tenant name*** and ***Token*** parameters were displayed incorrectly. 
+- Updated the Docker image to: *demisto/python3:3.10.12.66339*.

--- a/Packs/Workday/pack_metadata.json
+++ b/Packs/Workday/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Workday",
     "description": "Workday offers enterprise-level software solutions for financial management, human resources, and planning.",
     "support": "xsoar",
-    "currentVersion": "1.3.7",
+    "currentVersion": "1.3.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26766

## Description
Fixed the credentials type parameters display names (they were all password)

<img width="448" alt="image" src="https://github.com/demisto/content/assets/86777474/c112e64d-16d9-450b-abfb-98a47e6f6956">
