### PR TITLE
Ignore Intezer from Running on Native Docker Images

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -1,7 +1,7 @@
 {
-   "native_images":{
-      "native:8.3":{
-         "supported_docker_images":[
+   "native_images": {
+      "native:8.3": {
+         "supported_docker_images": [
             "python3",
             "python3-deb",
             "python3-ubi",
@@ -31,8 +31,8 @@
          ],
          "docker_ref": "demisto/py3-native:8.3.0.62286"
       },
-      "native:dev":{
-         "supported_docker_images":[
+      "native:dev": {
+         "supported_docker_images": [
             "python3",
             "python3-deb",
             "python3-ubi",
@@ -61,8 +61,8 @@
             "tesseract"
          ]
       },
-      "native:candidate":{
-         "supported_docker_images":[
+      "native:candidate": {
+         "supported_docker_images": [
             "python3",
             "python3-deb",
             "python3-ubi",
@@ -93,11 +93,11 @@
          "docker_ref": "demisto/py3-native:8.3.0.65288"
       }
    },
-   "ignored_content_items":[
+   "ignored_content_items": [
       {
-         "id":"FetchIndicatorsFromFile",
-         "reason":"issue: CIAC-5243 - ElementTree object (xml) in python3.9 has getiterator attribute while in python 3.10 this attribute does not exist - causing unit tests failures.",
-         "ignored_native_images":[
+         "id": "FetchIndicatorsFromFile",
+         "reason": "issue: CIAC-5243 - ElementTree object (xml) in python3.9 has getiterator attribute while in python 3.10 this attribute does not exist - causing unit tests failures.",
+         "ignored_native_images": [
             "native:8.3",
             "native:dev",
             "native:candidate"
@@ -143,12 +143,21 @@
             "native:dev",
             "native:candidate"
          ]
+      },
+      {
+         "id": "Intezer v2",
+         "reason": "This script is supposed to run inside a container, does not support podman",
+         "ignored_native_images": [
+            "native:dev",
+            "native:ga",
+            "native:maintenance"
+         ]
       }
    ],
    "flags_versions_mapping": {
-      "native:dev" : "native:dev",
-      "native:ga" : "native:8.3",
-      "native:maintenance" : "",
+      "native:dev": "native:dev",
+      "native:ga": "native:8.3",
+      "native:maintenance": "",
       "native:candidate": "native:candidate"
    }
 }

--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -146,7 +146,7 @@
       },
       {
          "id": "Intezer v2",
-         "reason": "This script is supposed to run inside a container, does not support podman",
+         "reason": "Lint and UT depend on intezer-sdk package",
          "ignored_native_images": [
             "native:dev",
             "native:ga",

--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -148,9 +148,7 @@
          "id": "Intezer v2",
          "reason": "Lint and UT depend on intezer-sdk package",
          "ignored_native_images": [
-            "native:dev",
-            "native:ga",
-            "native:maintenance"
+            "native:8.3"
          ]
       }
    ],


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7655

## Description
Add Intezer to the list of ignored content items to run UT and lints on `native` Docker image. This is for https://github.com/demisto/content/pull/28630.

## Must have
- [ ] Tests
- [ ] Documentation 
