### PR TITLE
XDR classifier fix

### DIFF
--- a/Packs/CortexXDR/Classifiers/classifier-PaloAltoNetworks_Cortex_XDR_Incident_Handler.json
+++ b/Packs/CortexXDR/Classifiers/classifier-PaloAltoNetworks_Cortex_XDR_Incident_Handler.json
@@ -1,4 +1,5 @@
 {
+    "defaultIncidentType": "Cortex XDR Incident",
     "description": "Classifies Cortex XDR incidents.",
     "feed": false,
     "id": "Cortex XDR Incident Handler - Classifier",

--- a/Packs/CortexXDR/Classifiers/classifier-PaloAltoNetworks_Cortex_XDR_Incident_Handler.json
+++ b/Packs/CortexXDR/Classifiers/classifier-PaloAltoNetworks_Cortex_XDR_Incident_Handler.json
@@ -22,7 +22,7 @@
                     "args": {
                         "dt": {
                             "value": {
-                                "simple": ".=val \u0026\u0026 val.description.toLowerCase().indexOf(\"port scan\") \u003e -1 ? \"PortScan\" : (val.description.toLowerCase().indexOf(\"rdp brute-force\") \u003e -1 ? \"RDPBruteForce\" : (val.description.toLowerCase().indexOf(\"first successful sso connection from a country in organization\") \u003e -1 ? \"FirstSSOAccess\" : (val.description.toLowerCase().indexOf(\"first sso access from asn in organization\") \u003e -1 ? \"FirstSSOAccess\" : (val.file_artifacts != \"\" ? \"Malware\" : \"XDR Incident\"))))"
+                                "simple": ".=val \u0026\u0026 val.description.toLowerCase().indexOf(\"port scan\") \u003e -1 ? \"PortScan\" : (val.description.toLowerCase().indexOf(\"rdp brute-force\") \u003e -1 ? \"RDPBruteForce\" : (val.description.toLowerCase().indexOf(\"first successful sso connection from a country in organization\") \u003e -1 ? \"FirstSSOAccess\" : (val.description.toLowerCase().indexOf(\"first sso access from asn in organization\") \u003e -1 ? \"FirstSSOAccess\" : (!val.file_artifacts || val.file_artifacts.length === 0 ? \"XDR Incident\" : \"Malware\"))))"
                             }
                         }
                     },

--- a/Packs/CortexXDR/ReleaseNotes/5_0_6.md
+++ b/Packs/CortexXDR/ReleaseNotes/5_0_6.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Cortex XDR Incident Handler - Classifier
+
+- Fixed an issue where incoming incidents classified as "Malware" instead of "XDR incident" incident type.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "5.0.5",
+    "currentVersion": "5.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26713

## Description
Fixed an issue where incoming incidents classified to the wrong incident type (malware instead of XDR incident).

