### PR TITLE
added the transform creation command

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -1048,6 +1048,27 @@ Returns the Splunk's username matching the given Cortex XSOAR's username.
 >| admin | unassigned |
 
 
+
+### splunk-kv-store-collection-create-transform
+
+***
+Creates the KV store collection transform.
+
+#### Base Command
+
+`splunk-kv-store-collection-create-transform`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| kv_store_collection_name | The name of the KV store collection. | Required | 
+| supported_fields | A comma-delimited list of the fields supported by the collection, e.g. _key,id,name,address.<br/>. | Required | 
+| app_name | The name of the Splunk application that contains the KV store collection. The default is "search". Default is search. | Required | 
+
+#### Context Output
+
+There is no context output for this command.
 ## Additional Information
 To get the HEC token
 1. Go to the Splunk UI.

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -2441,6 +2441,23 @@ def kv_store_collection_config(service: client.Service, args: dict) -> CommandRe
     )
 
 
+def kv_store_collection_create_transform(service: client.Service, args: dict) -> CommandResults:
+    # app = service.namespace['app']
+    collection_name = args['kv_store_collection_name']
+    fields = args['supported_fields']
+    transforms = service.confs["transforms"]
+    params = {
+        "external_type": "kvstore",
+        "collection": collection_name,
+        "namespace": service.namespace,
+        "fields_list": fields
+    }
+    transforms.create(name=collection_name, **params)
+    return CommandResults(
+        readable_output=f"KV store collection transforms {collection_name} created successfully"
+    )
+
+
 def batch_kv_upload(kv_data_service_client: client.KVStoreCollectionData, json_data: str) -> dict:
     if json_data.startswith('[') and json_data.endswith(']'):
         record: Record = kv_data_service_client._post(
@@ -2718,6 +2735,8 @@ def main():  # pragma: no cover
             return_results(kv_store_collection_create(service, args))
         elif command == 'splunk-kv-store-collection-config':
             return_results(kv_store_collection_config(service, args))
+        elif command == 'splunk-kv-store-collection-create-transform':
+            return_results(kv_store_collection_create_transform(service, args))
         elif command == 'splunk-kv-store-collection-delete':
             return_results(kv_store_collection_delete(service, args))
         elif command == 'splunk-kv-store-collections-list':

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -479,6 +479,21 @@ script:
     description: Configures the KV store fields.
     name: splunk-kv-store-collection-config
   - arguments:
+    - description: The name of the KV store collection.
+      name: kv_store_collection_name
+      required: true
+    - description: |
+        A comma-delimited list of the fields supported by the collection, e.g., _key,id,name,address.
+      name: supported_fields
+      required: true
+    - default: true
+      defaultValue: search
+      description: The name of the Splunk application that contains the KV store collection. The default is "search".
+      name: app_name
+      required: true
+    description: Creates the KV store collection transform.
+    name: splunk-kv-store-collection-create-transform
+  - arguments:
     - description: 'The data to add to the KV store collection, according to the collection JSON format, e.g., [{"name": "Splunk HQ", "id": 456, "address": { "street": "340 Brannan Street", "city": "San Francisco", "state": "CA", "zip": "121212"}}, {"name": "Splunk HQ", "id": 123, "address": { "street": "250 Brannan Street", "city": "San Francisco", "state": "CA", "zip": "94107"}}]'
       name: kv_store_data
       required: true
@@ -626,7 +641,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: Splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk-py3:1.0.0.66897
+  dockerimage: demisto/splunksdk-py3:1.0.0.68083
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/SplunkPy/Integrations/SplunkPy/commands.txt
+++ b/Packs/SplunkPy/Integrations/SplunkPy/commands.txt
@@ -7,4 +7,5 @@
 !splunk-kv-store-collection-delete-entry app_name=search kv_store_collection_name=demisto_store key=addr value=0.0.0.0 indicator_path=addr
 !splunk-kv-store-collection-data-delete app_name=search kv_store_collection_name=demisto_store
 !splunk-kv-store-collection-delete app_name=search kv_store_name=demisto_store
+!splunk-kv-store-collection-create-transform app_name=search kv_store_collection_name=demisto_store supported_fields=name,id,address
 !splunk-get-username-by-xsoar-user xsoar_username=admin

--- a/Packs/SplunkPy/ReleaseNotes/3_1_3.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_3.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### SplunkPy
+
+- Added the command **splunk-kv-store-collection-create-transform** providing the ability to create KVStore transform.
+- Updated the Docker image to: *demisto/splunksdk-py3:1.0.0.68083*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "3.1.2",
+    "currentVersion": "3.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26908

## Description
- Added the command **splunk-kv-store-collection-create-transform** providing the ability to create KVStore transform.

[Splunk documentation](https://community.splunk.com/t5/Building-for-the-Splunk-Platform/How-to-create-a-KVStore-using-Python-SDK-w-SPL-commands/m-p/461461)
