### PR TITLE
fix `AssignAnalystToAlert` to `AssignAnalystToIncident`

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_12.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_12.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### AssignAnalystToIncident
+
+Fixed an issue where this script was shown as `AssignAnalystToAlert` in XSIAM. Script functionality is unchanged (Assigns analyst to an incident. XSIAM alerts cannot be assigned.)

--- a/Packs/CommonScripts/Scripts/AssignAnalystToIncident/AssignAnalystToIncident.yml
+++ b/Packs/CommonScripts/Scripts/AssignAnalystToIncident/AssignAnalystToIncident.yml
@@ -43,3 +43,5 @@ args:
   defaultValue: "false"
 scripttarget: 0
 fromversion: 5.0.0
+skipprepare:
+- script-name-incident-to-alert

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.11",
+    "currentVersion": "1.12.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixed an issue where this script was shown as `AssignAnalystToAlert` in XSIAM. Script functionality is unchanged (Assigns analyst to an incident. XSIAM alerts cannot be assigned.)

fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-7748