### PR TITLE
[CortexCoreIR] change the "email" argument of core-report-incorrect-wildfire

### DIFF
--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
@@ -1697,6 +1697,7 @@ script:
       required: true
     - description: User’s email address.
       name: email
+      required: true
     description: Reports to WildFire about incorrect hash verdict through Cortex.
     execution: true
     name: core-report-incorrect-wildfire

--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
@@ -2850,7 +2850,7 @@ script:
   script: '-'
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.10.12.63474
+  dockerimage: demisto/python3:3.10.12.68300
 tests:
 - No tests
 fromversion: 6.2.0

--- a/Packs/Core/ReleaseNotes/2_0_5.json
+++ b/Packs/Core/ReleaseNotes/2_0_5.json
@@ -1,0 +1,4 @@
+{
+    "breakingChanges": true,
+    "breakingChangesNotes": "The *email* argument is now required when using the command ***core-report-incorrect-wildfire***"
+}

--- a/Packs/Core/ReleaseNotes/2_0_5.json
+++ b/Packs/Core/ReleaseNotes/2_0_5.json
@@ -1,4 +1,0 @@
-{
-    "breakingChanges": true,
-    "breakingChangesNotes": "The *email* argument is now required when using the command ***core-report-incorrect-wildfire***"
-}

--- a/Packs/Core/ReleaseNotes/2_0_5.md
+++ b/Packs/Core/ReleaseNotes/2_0_5.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### Investigation & Response
+- Updated the Docker image to: *demisto/python3:3.10.12.68300*.
 
 - Fixed an issue where the *email* argument was not required in the command ***core-report-incorrect-wildfire***.

--- a/Packs/Core/ReleaseNotes/2_0_5.md
+++ b/Packs/Core/ReleaseNotes/2_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Investigation & Response
+
+- Fixed an issue where the *email* argument was not required in the command ***core-report-incorrect-wildfire***.

--- a/Packs/Core/ReleaseNotes/2_0_5.md
+++ b/Packs/Core/ReleaseNotes/2_0_5.md
@@ -2,6 +2,5 @@
 #### Integrations
 
 ##### Investigation & Response
-- Updated the Docker image to: *demisto/python3:3.10.12.68300*.
-
-- Fixed an issue where the *email* argument was not required in the command ***core-report-incorrect-wildfire***.
+- Changed the *email* argument of the command ***core-report-incorrect-wildfire*** to be required as the command wouldn't return any results without it.
+- - Updated the Docker image to: *demisto/python3:3.10.12.68300*.

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "2.0.4",
+    "currentVersion": "2.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:[ link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-26537)

## Description
Changed the *email* argument of the command ***core-report-incorrect-wildfire*** to be required as the command wouldn't return any results without it.