### PR TITLE
[ProofPoint Tap v2] Fix '<' is not supported

### DIFF
--- a/Packs/ProofpointTAP/Integrations/ProofpointTAP_v2/ProofpointTAP_v2.py
+++ b/Packs/ProofpointTAP/Integrations/ProofpointTAP_v2/ProofpointTAP_v2.py
@@ -1220,7 +1220,7 @@ def main():
 
     raw_json_encoding = params.get('raw_json_encoding')
 
-    fetch_limit = min(params.get('limit', DEFAULT_LIMIT), DEFAULT_LIMIT)
+    fetch_limit = min(int(params.get('limit', DEFAULT_LIMIT)), DEFAULT_LIMIT)
     # Remove proxy if not set to true in params
     proxies = handle_proxy()
 

--- a/Packs/ProofpointTAP/ReleaseNotes/1_2_9.md
+++ b/Packs/ProofpointTAP/ReleaseNotes/1_2_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Proofpoint TAP v2
+
+- Fixed an issue where setting new instance of the integration result in an error "'<' is not supported".

--- a/Packs/ProofpointTAP/pack_metadata.json
+++ b/Packs/ProofpointTAP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint TAP",
     "description": "Use the Proofpoint Targeted Attack Protection (TAP) integration to protect against and provide additional visibility into phishing and other malicious email attacks.",
     "support": "xsoar",
-    "currentVersion": "1.2.8",
+    "currentVersion": "1.2.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26869

## Description
Fixed an issue where setting new instance of the integration result in an error "'<' is not supported".