### PR TITLE
Azure Sentinel: send the original owner in mirror

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -674,6 +674,7 @@ def update_incident_request(client: AzureSentinelClient, incident_id: str, data:
     Returns:
         Dict[str, Any]: the response of the update incident request
     """
+    fetched_incident_data = get_incident_by_id_command(client, {'incident_id': incident_id}).raw_response
     required_fields = ('severity', 'status', 'title')
     if any(field not in data for field in required_fields):
         raise DemistoException(f'Update incident request is missing one of the required fields for the '
@@ -686,7 +687,8 @@ def update_incident_request(client: AzureSentinelClient, incident_id: str, data:
         'status': 'Active',
         'labels': [{'labelName': label, 'type': 'User'} for label in delta.get('tags', [])],
         'firstActivityTimeUtc': delta.get('firstActivityTimeUtc'),
-        'lastActivityTimeUtc': delta.get('lastActivityTimeUtc')
+        'lastActivityTimeUtc': delta.get('lastActivityTimeUtc'),
+        'owner': demisto.get(fetched_incident_data, 'properties.owner', {})
     }
     if close_ticket:
         properties |= {

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.yml
@@ -2351,7 +2351,7 @@ script:
     execution: false
     name: azure-sentinel-auth-reset
     arguments: []
-  dockerimage: demisto/crypto:1.0.0.66562
+  dockerimage: demisto/crypto:1.0.0.68914
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_16.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_16.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Microsoft Sentinel
+
+- Fixed an issue where the Owner in Azure incident was changed to Unassigned in mirror out.
+- Updated the Docker image to: *demisto/crypto:1.0.0.68914*.

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_16.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_16.md
@@ -3,5 +3,5 @@
 
 ##### Microsoft Sentinel
 
-- Fixed an issue where the Owner in Azure incident was changed to Unassigned in mirror out.
+- Fixed an issue where the Owner in an Azure incident was changed to Unassigned when mirroring out.
 - Updated the Docker image to: *demisto/crypto:1.0.0.68914*.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Sentinel",
     "description": "Microsoft Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.5.15",
+    "currentVersion": "1.5.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26514

## Description
Currently, in mirror out we send only few fields if they are changed
but the `owner` field is missed and this lead to Azure to set the owner to Unassigned.

fix: get the original owner from azure and send it when we update the other fields

