### PR TITLE
ParseEmailsV2: update docker image

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_15.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_15.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+Updated the Docker image to: *demisto/parse-emails:1.0.0.69980*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.py
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.py
@@ -60,7 +60,7 @@ def save_file(file_name, file_content) -> str:
     created_file = fileResult(file_name, file_content)
     file_id = created_file.get('FileID')
     attachment_internal_path = demisto.investigation().get('id') + '_' + file_id
-    demisto.results(created_file)
+    return_results(created_file)
 
     return attachment_internal_path
 

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -113,4 +113,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.67069
+dockerimage: demisto/parse-emails:1.0.0.69980

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.14",
+    "currentVersion": "1.12.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26948
https://jira-hq.paloaltonetworks.local/browse/XSUP-27106

## Description
update the docker image to the new one with the `parse-emails` module version 0.1.16