### PR TITLE
Taegisxdrv2 Investigations Hotfix

### DIFF
--- a/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.py
@@ -1095,7 +1095,7 @@ def fetch_investigation_command(client: Client, env: str, args=None):
             }
             priority
             type
-            processing_status {
+            processingStatus {
                 assets
                 events
                 alerts

--- a/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.py
+++ b/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.py
@@ -242,7 +242,7 @@ def create_comment_command(client: Client, env: str, args=None):
     variables = {
         "input": {
             "comment": args.get("comment"),
-            "id": args.get("id"),
+            "investigationId": args.get("id"),
         }
     }
 

--- a/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.yml
+++ b/Packs/SecureWorks/Integrations/TaegisXDRv2/TaegisXDRv2.yml
@@ -537,7 +537,7 @@ script:
     - contextPath: TaegisXDR.InvestigationEvidenceUpdate
       description: The investigation that received the update
     description: Add alerts and events to an existing investigation
-  dockerimage: demisto/python3:3.10.12.66339
+  dockerimage: demisto/python3:3.10.12.68714
   isfetch: true
   runonce: false
   subtype: python3

--- a/Packs/SecureWorks/ReleaseNotes/5_0_1.md
+++ b/Packs/SecureWorks/ReleaseNotes/5_0_1.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### TaegisXDR v2
+
+- Fixed an issue with `taegis-fetch-investigation` with an incorrect processingStatus field
+- Updated the Docker image to: *demisto/python3:3.10.12.68714*.

--- a/Packs/SecureWorks/pack_metadata.json
+++ b/Packs/SecureWorks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Secureworks",
     "description": "Provides access to the Secureworks CTP and Taegis XDR systems",
     "support": "partner",
-    "currentVersion": "5.0.0",
+    "currentVersion": "5.0.1",
     "author": "Secureworks",
     "url": "https://ctpx.secureworks.com",
     "email": "support@secureworks.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This provides a fix for 2 issues:
* `taegis-fetch-investigation` was using an old field called `processing_status`. Should be `processingStatus`
* `taegis-create-comment` was using an old field called `id`. Should be `investigationId`.

## Must have
- [x] Tests
- [x] Documentation 
