### PR TITLE
remove intezer v2 from docker native image config

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -161,13 +161,6 @@
             ]
         },
         {
-            "id":"Intezer v2",
-            "reason":"Lint and UT depend on intezer-sdk package",
-            "ignored_native_images":[
-                "native:8.3"
-            ]
-        },
-        {
             "id":"SlackV3",
             "reason":"Issue: CIAC-7854",
             "ignored_native_images":[


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description
remove intezer v2 as it contains two entries under the `ignored_content_items`

