### PR TITLE
Add `qutoe_params_via` in `http_request` base client

### DIFF
--- a/Packs/Base/ReleaseNotes/1_32_28.md
+++ b/Packs/Base/ReleaseNotes/1_32_28.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### CommonServerPython
+Added the ability to custom the http requests query params encoding.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8697,7 +8697,7 @@ if 'requests' in sys.modules:
                           params=None, data=None, files=None, timeout=None, resp_type='json', ok_codes=None,
                           return_empty_response=False, retries=0, status_list_to_retry=None,
                           backoff_factor=5, raise_on_redirect=False, raise_on_status=False,
-                          error_handler=None, empty_valid_codes=None, **kwargs):
+                          error_handler=None, empty_valid_codes=None, quote_params_via=None, **kwargs):
             """A wrapper for requests lib to send our requests and handle requests and responses better.
 
             :type method: ``str``
@@ -8790,6 +8790,10 @@ if 'requests' in sys.modules:
             :param empty_valid_codes: A list of all valid status codes of empty responses (usually only 204, but
                 can vary)
 
+            :type quote_params_via: ``callable``
+            :param quote_params_via: How to quote the params. By default, spaces are replaced with '+' and ‘/’ to '%2F'.
+            see here for more info: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode
+
             :return: Depends on the resp_type parameter
             :rtype: ``dict`` or ``str`` or ``bytes`` or ``xml.etree.ElementTree.Element`` or ``requests.Response``
             """
@@ -8802,6 +8806,8 @@ if 'requests' in sys.modules:
                     self._implement_retry(retries, status_list_to_retry, backoff_factor, raise_on_redirect, raise_on_status)
                 if not timeout:
                     timeout = self.timeout
+                if quote_params_via:
+                    params = urllib.parse.urlencode(params, quote_via=quote_params_via)
 
                 # Execute
                 res = self._session.request(

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.32.27",
+    "currentVersion": "1.32.28",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-hq.paloaltonetworks.local/browse/XSUP-26505

## Description
Added the quote_params_via parameter in the _http_request function in CommionServerPython in order to allow specific decoding for query params. by default, spaces are replaced with + using the new quote_params_via parameters we can choose to replace them with %20.

For more info see: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode.

## Must have
- [ ] Tests
- [ ] Documentation 
