### PR TITLE
Add playbook videos to DNS Sinkhole and Password Reset via Chatbot use-cases

### DIFF
--- a/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
+++ b/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
@@ -59,3 +59,10 @@ There are no outputs for this playbook.
 ---
 
 ![Default](../doc_files/Default_8_2.png)
+
+## Playbook Demo Video
+<video controls>
+    <source src="https://github.com/demisto/content-assets/raw/master/Assets/Default/Default%20Pack%20-%20Playbook%20and%20Layout.mp4"
+            type="video/mp4"/>
+    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/blob/7982404664dc68c2035b7c701d093ec026628802/Assets/GDPR/GDPR_Data_Breach_Notification.mp4
+</video>

--- a/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
+++ b/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
@@ -58,11 +58,8 @@ There are no outputs for this playbook.
 
 ---
 
-![Default](../doc_files/Default_8_2.png)
+## Playbook Image
 
-## Playbook Demo Video
-<video controls>
-    <source src="https://github.com/demisto/content-assets/raw/master/Assets/Default/Default%20Pack%20-%20Playbook%20and%20Layout.mp4"
-            type="video/mp4"/>
-    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/blob/7982404664dc68c2035b7c701d093ec026628802/Assets/GDPR/GDPR_Data_Breach_Notification.mp4
-</video>
+---
+
+![Default](../doc_files/Default_8_2.png)

--- a/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
+++ b/Packs/DefaultPlaybook/Playbooks/Default_8_2_README.md
@@ -58,8 +58,4 @@ There are no outputs for this playbook.
 
 ---
 
-## Playbook Image
-
----
-
 ![Default](../doc_files/Default_8_2.png)

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole_README.md
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole_README.md
@@ -81,3 +81,10 @@ There are no outputs for this playbook.
 ---
 
 ![PAN-OS - Configure DNS Sinkhole](../doc_files/PAN-OS_-_Configure_DNS_Sinkhole.png)
+
+## Playbook Demo Video
+<video controls>
+    <source src="https://github.com/demisto/content-assets/raw/master/Assets/DNSSinkhole/DNS%20Sinkhole.mp4"
+            type="video/mp4"/>
+    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/blob/7982404664dc68c2035b7c701d093ec026628802/Assets/GDPR/GDPR_Data_Breach_Notification.mp4
+</video>

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole_README.md
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole_README.md
@@ -86,5 +86,5 @@ There are no outputs for this playbook.
 <video controls>
     <source src="https://github.com/demisto/content-assets/raw/master/Assets/DNSSinkhole/DNS%20Sinkhole.mp4"
             type="video/mp4"/>
-    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/blob/7982404664dc68c2035b7c701d093ec026628802/Assets/GDPR/GDPR_Data_Breach_Notification.mp4
+    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/raw/master/Assets/DNSSinkhole/DNS%20Sinkhole.mp4
 </video>

--- a/Packs/PasswordResetViaChatbot/Playbooks/Reset_User_Password_via_Chatbot_README.md
+++ b/Packs/PasswordResetViaChatbot/Playbooks/Reset_User_Password_via_Chatbot_README.md
@@ -77,3 +77,10 @@ There are no outputs for this playbook.
 ---
 
 ![Reset User Password via Chatbot](../doc_files/Reset_User_Password_via_Chatbot.png)
+
+## Playbook Demo Video
+<video controls>
+    <source src="https://github.com/demisto/content-assets/raw/master/Assets/PasswordResetViaChatbot/Password%20Reset%20via%20Chatbot.mp4"
+            type="video/mp4"/>
+    Sorry, your browser doesn't support embedded videos. You can download the video at: https://github.com/demisto/content-assets/raw/master/Assets/PasswordResetViaChatbot/Password%20Reset%20via%20Chatbot.mp4
+</video>


### PR DESCRIPTION
## Status
Ready

## Related Issues
Related: https://jira-hq.paloaltonetworks.local/browse/CIAC-2793
Related: https://jira-hq.paloaltonetworks.local/browse/CIAC-4697

## Description
Adds videos to the playbook READMEs of the DNS Sinkhole and Password Reset via Chatbot use-cases.

