### PR TITLE
Wildfire Reports - Reverted the content patch

### DIFF
--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.py
@@ -20,13 +20,7 @@ class Client(BaseClient):
         Auto API expect the agent header to be 'xdr' when running from within XSIAM and 'xsoartim' when running from
         within XSOAR (both on-prem and cloud).
         """
-        # This block is a patch - need to remove it once the server side fix of the following issue is merged:
-        # https://jira-hq.paloaltonetworks.local/browse/CRTX-77146
-        if version := get_demisto_version().get('version'):
-            if version == '8.1.0':
-                return 'xsoartim'
-
-        platform = get_demisto_version().get('platform')
+        platform = get_demisto_version().get('platform')  # Platform = xsoar_hosted / xsoar / x2 depends on the machine
         return 'xdr' if platform == 'x2' else 'xsoartim'
 
     def get_file_report(self, file_hash: str):

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.py
@@ -7,7 +7,7 @@ urllib3.disable_warnings()
 
 
 class Client(BaseClient):
-    def __init__(self, base_url: str, verify: bool = True, proxy: bool = False, ok_codes=tuple(), headers: dict = None,
+    def __init__(self, base_url: str, verify: bool = True, proxy: bool = False, ok_codes=(), headers: dict = None,
                  token: str = None):
         super().__init__(base_url, verify, proxy, ok_codes, headers)
         self.token = token

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.yml
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/WildFireReports/WildFireReports.yml
@@ -53,7 +53,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.12.63474
+  dockerimage: demisto/python3:3.10.12.68714
 fromversion: 6.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_33.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_33.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Palo Alto Networks WildFire Reports
+
+- Updated the way we distinguish between running on *XSOAR* or *XSIAM* machines.
+- Updated the Docker image to: *demisto/python3:3.10.12.68714*.

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "WildFire by Palo Alto Networks",
     "description": "Perform malware dynamic analysis",
     "support": "xsoar",
-    "currentVersion": "2.1.32",
+    "currentVersion": "2.1.33",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [CRTX-77146](https://jira-hq.paloaltonetworks.local/browse/CRTX-77146).

## Description
While working on the above-mentioned issue, I opened this PR - [pull/25002](https://github.com/demisto/content/pull/25002) which includes a content patch for handling xsoar ng version 8.1.0. 
As described in the issue, the server team fixed their issue and we can now classify XSAOR NG machines as XSOAR machines, by using the `get_demisto_version().get('platform')` only. 
![BA5DB4CD-C659-44FA-AAAB-744E355B30EF](https://github.com/demisto/content/assets/82749224/aa16c195-df1f-4838-a5aa-04a32afb4ec9)

In this PR I'm reverting the content patch. 

## Must have
- [ ] Tests
- [ ] Documentation 
