### PR TITLE
Fix gtihub workflow for partner-approved label flow

### DIFF
--- a/.github/workflows/check-partner-approved-label.yml
+++ b/.github/workflows/check-partner-approved-label.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   check_label_job:
     runs-on: ubuntu-latest
-    if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
+    if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

The initial [PR](https://github.com/demisto/content/pull/28279)
had a condition that made the partner-approved flow to run only when PR is opened and not when something changes in the PR.
Fixed it.

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
