### PR TITLE
Fix default argument values in Generate Password

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_17.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_17.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### GeneratePassword
+
+- Fixed an issue where no correct default values were given for max_* arguments.
+- Updated the Docker image to: *demisto/python3:3.10.12.68714*.

--- a/Packs/CommonScripts/ReleaseNotes/1_12_17.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_17.md
@@ -3,5 +3,5 @@
 
 ##### GeneratePassword
 
-- Fixed an issue where no correct default values were given for max_* arguments.
+- Fixed an issue where the *min_* and *max_* arguments were not correctly assigned to the value *0* when provided.
 - Updated the Docker image to: *demisto/python3:3.10.12.68714*.

--- a/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.py
+++ b/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.py
@@ -28,14 +28,14 @@ def print_char_values(pw):
 
 def generate_password(args: Dict[str, Any]) -> CommandResults:
     is_debug = argToBoolean(args.get('debug'))
-    min_lowercase = arg_to_number(args.get('min_lcase')) or DEFAULT_MIN
-    max_lowercase = arg_to_number(args.get('max_lcase')) or DEFAULT_MAX
-    min_uppercase = arg_to_number(args.get('min_ucase')) or DEFAULT_MIN
-    max_uppercase = arg_to_number(args.get('max_ucase')) or DEFAULT_MAX
-    min_digits = arg_to_number(args.get('min_digits')) or DEFAULT_MIN
-    max_digits = arg_to_number(args.get('max_digits')) or DEFAULT_MAX
-    min_symbols = arg_to_number(args.get('min_symbols')) or DEFAULT_MIN
-    max_symbols = arg_to_number(args.get('max_symbols')) or DEFAULT_MAX
+    min_lowercase = arg_to_number(args.get('min_lcase', DEFAULT_MIN))
+    max_lowercase = arg_to_number(args.get('max_lcase', DEFAULT_MAX))
+    min_uppercase = arg_to_number(args.get('min_ucase', DEFAULT_MIN))
+    max_uppercase = arg_to_number(args.get('max_ucase', DEFAULT_MAX))
+    min_digits = arg_to_number(args.get('min_digits', DEFAULT_MIN))
+    max_digits = arg_to_number(args.get('max_digits', DEFAULT_MAX))
+    min_symbols = arg_to_number(args.get('min_symbols', DEFAULT_MIN))
+    max_symbols = arg_to_number(args.get('max_symbols', DEFAULT_MAX))
 
     if min(min_uppercase, min_lowercase, min_digits, min_symbols) < 0:
         raise DemistoException("All numeral arguments must be positive.")

--- a/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.py
+++ b/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.py
@@ -37,18 +37,18 @@ def generate_password(args: Dict[str, Any]) -> CommandResults:
     min_symbols = arg_to_number(args.get('min_symbols', DEFAULT_MIN))
     max_symbols = arg_to_number(args.get('max_symbols', DEFAULT_MAX))
 
-    if min(min_uppercase, min_lowercase, min_digits, min_symbols) < 0:
+    if min(min_uppercase, min_lowercase, min_digits, min_symbols) < 0:  # type:ignore[type-var,operator]
         raise DemistoException("All numeral arguments must be positive.")
 
-    if sum((min_uppercase, min_lowercase, min_digits, min_symbols)) == 0:
+    if sum((min_uppercase, min_lowercase, min_digits, min_symbols)) == 0:  # type:ignore[arg-type]
         raise DemistoException("error: At least one of the following arguments should be above 0: "
                                "min_uppercase, min_lowercase, min_digits, min_symbols")
 
     # randomize the amount of characters we get as per parameters
-    num_upper = randomize_number_in_range(min_uppercase, max_uppercase)
-    num_lower = randomize_number_in_range(min_lowercase, max_lowercase)
-    num_digits = randomize_number_in_range(min_digits, max_digits)
-    num_symbols = randomize_number_in_range(min_symbols, max_symbols)
+    num_upper = randomize_number_in_range(min_uppercase, max_uppercase)  # type:ignore[arg-type]
+    num_lower = randomize_number_in_range(min_lowercase, max_lowercase)  # type:ignore[arg-type]
+    num_digits = randomize_number_in_range(min_digits, max_digits)  # type:ignore[arg-type]
+    num_symbols = randomize_number_in_range(min_symbols, max_symbols)  # type:ignore[arg-type]
 
     if num_upper + num_lower + num_digits + num_symbols == 0:
         raise DemistoException("error: insane password. No character length.")

--- a/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.yml
+++ b/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword.yml
@@ -5,7 +5,7 @@ name: GeneratePassword
 script: ''
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.12.66339
+dockerimage: demisto/python3:3.10.12.68714
 tags:
 - Utility
 comment: "This function generates a password and allows various parameters to customize the properties of the password depending on the use case (e.g. password complexity requirements).  The default behavior is to generate a password of  *random length* including all four character classes (upper, lower, digits, symbols) with at least five and at most ten characters per class. \n\nThe min_* values all default to 0. This means that if the command is executed in this way:\n!GeneratePassword max_lcase=10\nIt is possible that a password of length zero could be generated. It is therefore recommended to always include a min_* parameter that matches. \n\nThe debug parameter will print certain properties of the command into the WarRoom for easy diagnostics."

--- a/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword_test.py
+++ b/Packs/CommonScripts/Scripts/GeneratePassword/GeneratePassword_test.py
@@ -32,6 +32,7 @@ def does_password_meet_requirement(
     [
         (1, 2, 1, 2, 1, 2, 1, 2),  # Test case with all ranges set to 1-2
         (2, 5, 3, 5, 4, 6, 1, 3),  # Test case with various ranges
+        (2, 5, 3, 5, 4, 10, 0, 0),  # Test case with no symbols
     ]
 )
 def test_generate_password(

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.16",
+    "currentVersion": "1.12.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-8069)

## Description
Fixed an issue where no correct default values were given for max_* arguments.

## Screenshot
Before and after the fix:
![Screenshot 2023-08-24 at 15 36 34](https://github.com/demisto/content/assets/59408745/7c4e2ce9-78af-47af-a831-b7b82a8e58c8)

## Must have
- [x] Tests
- [ ] Documentation 
