### PR TITLE
Cloned html functionality from mail integration

### DIFF
--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_13.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_5_13.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Graph Mail Single User
+
+Fixed an issue where HTML body of emails was not being retrieved by the integration.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.5.12",
+    "currentVersion": "1.5.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ x ] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This update clones functionality from the GraphMail integration for retrieving the HTML bodies of email into the Listener integration. The listener integration does not pull the HTML bodies of email and is hardcoded to only pull text based representations of emails. This change does not completely align the two integrations and there are still significant differences between them. 

## Must have
- [ x ] Tests
- [ x ] Documentation 
