### PR TITLE
[pre-commit template file] Fix validate hook

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -69,7 +69,7 @@ repos:
     args: ["-ud", "-n", "--no-validate", "-g"]
 
   - id: validate
-    args: ["-g", "--skip-pack-dependencies"]
+    args: ["--skip-pack-dependencies", "-g"]
 
   - id: secrets
     args: ["--ignore-entropy"]


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Since there are situations where we delete the `-g` flag [here](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/pre_commit/hooks/validate_format.py#L11), therefore it must be last in the list.
After the changes I make in this [PR](https://github.com/demisto/demisto-sdk/pull/3514), this issue can no longer be recovered again