### PR TITLE
[Microsoft Defender for Endpoint] Add new commands

### DIFF
--- a/Packs/ApiModules/ReleaseNotes/2_2_20.md
+++ b/Packs/ApiModules/ReleaseNotes/2_2_20.md
@@ -1,0 +1,4 @@
+
+#### Scripts
+##### MicrosoftApiModule
+- Remove the value of the Content-Type from the default headers.

--- a/Packs/ApiModules/Scripts/MicrosoftApiModule/MicrosoftApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftApiModule/MicrosoftApiModule.py
@@ -776,7 +776,6 @@ class MicrosoftClient(BaseClient):
         token = self.get_access_token(resource=resource, scope=scope)
         default_headers = {
             'Authorization': f'Bearer {token}',
-            'Content-Type': 'application/json',
             'Accept': 'application/json'
         }
 

--- a/Packs/ApiModules/pack_metadata.json
+++ b/Packs/ApiModules/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ApiModules",
     "description": "API Modules",
     "support": "xsoar",
-    "currentVersion": "2.2.19",
+    "currentVersion": "2.2.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -5489,6 +5489,7 @@ def put_file_get_successful_action_results(client, res):
 def upload_library_file(client, args):
     entry_ids = argToList(args['entry_id'])
     description = args['description']
+    parameters_description = args.get("parameters_description", "")
     HasParameters = args.get("has_parameters", "false")
     OverrideIfExists = args.get("override_if_exists", "true")
     outputs = []
@@ -5496,22 +5497,23 @@ def upload_library_file(client, args):
         info_file = demisto.getFilePath(entry_id)
         file_path = info_file['path']
         file_name = info_file['name']
-
-        f = open(file_path, 'rb')
         file_name = urllib.parse.quote(file_name)
-        files = {
-            "file": (file_name, f)
-        }
-        data = {
-            "fileName": file_name,
-            "HasParameters": HasParameters.lower(),
-            "OverrideIfExists": OverrideIfExists.lower(),
-            "Description": description
-        }
 
-        res = client.upload_to_library(data, files)
-        res.pop('@odata.context', None)
-        outputs.append(res)
+        with open(file_path, 'rb') as f:
+            files = {
+                "file": (file_name, f)
+            }
+            data = {
+                "fileName": file_name,
+                "HasParameters": HasParameters.lower(),
+                "OverrideIfExists": OverrideIfExists.lower(),
+                "ParametersDescription": parameters_description,
+                "Description": description
+            }
+
+            res = client.upload_to_library(data, files)
+            res.pop('@odata.context', None)
+            outputs.append(res)
 
     return CommandResults(
         outputs_prefix='MicrosoftATP.Library',

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -5367,7 +5367,7 @@ def get_successfull_action_results_as_info(client, res):
         script_result = None
     return [
         CommandResults(
-            outputs_prefix='MicrosoftATP.LiveResponseAction',
+            outputs_prefix=f'MicrosoftATP.LiveResponseAction(val.action_id === "{machine_action_id}")',
             outputs=script_result if script_result else res,
             readable_output=tableToMarkdown('Script Results:', script_result, is_auto_json_transform=True)
             if script_result else 'Could not retrieve script results.'
@@ -5427,7 +5427,7 @@ def get_file_get_successfull_action_results(client, res):
         'Commands': res.get('commands')
     }
     return [fileResult('Response Result.gz', f_data.content), CommandResults(
-        outputs_prefix='MicrosoftATP.LiveResponseAction',
+        outputs_prefix=f'MicrosoftATP.LiveResponseAction(val.action_id === "{machine_action_id}")',
         outputs=res,
         readable_output=tableToMarkdown('Machine Action:', md_results, is_auto_json_transform=True)
 

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -1488,7 +1488,7 @@ script:
       name: machine_id
       required: true
     - description: |-
-        The file SHA1 hash to stop and quarantine on the machine. 
+        The file SHA1 hash to stop and quarantine on the machine.
         When providing multiple values, each value is checked for the same machine_id.
       isArray: true
       name: file_hash
@@ -5509,6 +5509,34 @@ script:
     execution: false
     name: microsoft-atp-auth-reset
     arguments: []
+  - name: microsoft-atp-library-upload-file
+    arguments:
+    - name: entry_id
+      required: true
+    - name: description
+      required: true
+    - name: has_parameters
+      auto: PREDEFINED
+      predefined:
+      - "False"
+      - "True"
+      defaultValue: "False"
+    - name: override_if_exists
+      auto: PREDEFINED
+      predefined:
+      - "False"
+      - "True"
+      defaultValue: "True"
+    description: Upload file to live response library
+  - name: microsoft-atp-library-list-file
+    arguments: []
+    description: List live response library files
+  - name: microsoft-atp-library-delete-file
+    arguments:
+    - name: filename
+      required: true
+      description: the filename to delete
+    description: Delete a file from live response library.
   dockerimage: demisto/crypto:1.0.0.68914
   isfetch: true
   runonce: false

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -5512,8 +5512,9 @@ script:
   - name: microsoft-atp-library-upload-file
     arguments:
     - name: entry_id
-      description: EntryID for file to be upload
+      description: EntryID for file to be upload (can be a comma-separated list of entryID)
       required: true
+      isArray: true
     - name: description
       description: Description to be added when upload a file
       required: true
@@ -5531,6 +5532,9 @@ script:
       - "False"
       - "True"
       defaultValue: "True"
+    - name: parameters_description
+      description: Parameters required for the script to run. Default value is an
+        empty string
     description: Upload file to live response library
   - name: microsoft-atp-library-list-file
     arguments: []

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.yml
@@ -5512,16 +5512,20 @@ script:
   - name: microsoft-atp-library-upload-file
     arguments:
     - name: entry_id
+      description: EntryID for file to be upload
       required: true
     - name: description
+      description: Description to be added when upload a file
       required: true
     - name: has_parameters
+      description: Whether the file as parameter
       auto: PREDEFINED
       predefined:
       - "False"
       - "True"
       defaultValue: "False"
     - name: override_if_exists
+      description: Whether to override the file if it already exists
       auto: PREDEFINED
       predefined:
       - "False"

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/README.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/README.md
@@ -7169,3 +7169,97 @@ There are no input arguments for this command.
 #### Context Output
 
 There is no context output for this command.
+
+### microsoft-atp-library-upload-file
+
+---
+Upload file to live response library.
+
+#### Base Command
+
+`microsoft-atp-library-upload-file`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| entry_id | EntryID of the file to upload. | Required |
+| description | Description to be added when upload a file. | Required |
+| has_parameters  | Whether the file as parameter. (Default is False) |Optional |
+| override_if_exists  | Whether to override the file if it already exists. Default is True) | Optional |
+
+
+#### Context Example
+
+```json
+{
+  "MicrosoftATP": {
+    "Library": [
+      {
+        "createdBy": "2937973e-bc58-48c6-a2ef-7bc060c6b6b0",
+        "creationTime": "2023-08-29T14:24:01.16254Z",
+        "description": "Test description",
+        "fileName": "my_filename.py",
+        "hasParameters": false,
+        "lastUpdatedTime": "2023-08-29T14:24:01.16254Z",
+        "parametersDescription": null,
+        "sha256": "541bf7bca0a5b9f3962eb15bb8a35c119c6c16ea1c9f7d54c5787a81011046ff"
+      }
+    ]
+  }
+}
+```
+
+### microsoft-atp-library-list-file
+
+---
+List live response library files.
+
+#### Base Command
+
+`microsoft-atp-library-list-file`
+
+#### Input
+
+There are no input arguments for this command.
+
+
+#### Context Example
+
+```json
+{
+  "MicrosoftATP": {
+    "Library": [
+      {
+        "createdBy": "2937973e-bc58-48c6-a2ef-7bc060c6b6b0",
+        "creationTime": "2023-08-29T14:24:01.16254Z",
+        "description": "Test description",
+        "fileName": "my_filename.py",
+        "hasParameters": false,
+        "lastUpdatedTime": "2023-08-29T14:24:01.16254Z",
+        "parametersDescription": null,
+        "sha256": "541bf7bca0a5b9f3962eb15bb8a35c119c6c16ea1c9f7d54c5787a81011046ff"
+      }
+    ]
+  }
+}
+```
+
+### microsoft-atp-library-delete-file
+
+---
+Delete live response library files.
+
+#### Base Command
+
+`microsoft-atp-library-delete-file`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| filename | The filename to delete. | Required |
+
+#### Context Output
+
+There is no context output for this command.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/README.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/README.md
@@ -7183,10 +7183,11 @@ Upload file to live response library.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| entry_id | EntryID of the file to upload. | Required |
+| entry_id | EntryID of the file to upload (can be a comma-separated list of entryID). | Required |
 | description | Description to be added when upload a file. | Required |
 | has_parameters  | Whether the file as parameter. (Default is False) |Optional |
-| override_if_exists  | Whether to override the file if it already exists. Default is True) | Optional |
+| override_if_exists  | Whether to override the file if it already exists. (Default is True) | Optional |
+| parameters_description  | Parameters required for the script to run. (Default is an empty string) | Optional |
 
 
 #### Context Example

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_16_7.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_16_7.md
@@ -1,0 +1,8 @@
+#### Integrations
+
+##### Microsoft Defender for Endpoint
+
+- Added the ***microsoft-atp-library-list-file*** command to list live response library files.
+- Added the ***microsoft-atp-library-upload-file*** command to upload file to live response library.
+- Added the ***microsoft-atp-library-delete-file*** command to delete a file from live response library.
+- Fixed an issue where the live response result's action created a new node in the context

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.16.6",
+    "currentVersion": "1.16.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This PR Adds 3 commands to the integration `Microsoft Defender Advanced Threat Protection` to deal with the Live Response Library (List / Upload / Delete). It also fix an issue where the live response result's action created a new node in the context

This PR also remove from the `MicrosoftApiModule` the default Content-Type which was set to 'application/json' which was not needed due to request library setting it correctly, and this was causing an issue on the upload command where content-type should be kept handled by requests due to the use of data= and files= at the same time.

## Must have
- [ ] Tests
- [ ] Documentation 
