### PR TITLE
S&c timeout issue

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/SecurityAndComplianceV2/SecurityAndComplianceV2.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/SecurityAndComplianceV2/SecurityAndComplianceV2.ps1
@@ -913,6 +913,7 @@ class SecurityAndComplianceClient {
         }
         if ($action -eq "Preview") {
             $cmd_params.Preview = $true
+            $cmd_params.Confirm = $false
         } elseif ($action -eq "Purge") {
             $cmd_params.Purge = $true
             $cmd_params.PurgeType = $purge_type

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_22.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_22.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### O365 - Security And Compliance - Content Search v2
+Fixed an issue where the ***o365-sc-new-search-action*** command failed on timeout because of a missing command parameter.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.2.21",
+    "currentVersion": "1.2.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-27369)

## Description
Fixed an issue where the ***o365-sc-new-search-action*** command failed on timeout because of a missing command parameter.