### PR TITLE
Fix GeneratePassword-Test TPB

### DIFF
--- a/Packs/CommonScripts/TestPlaybooks/playbook-GeneratePassword-Test.yml
+++ b/Packs/CommonScripts/TestPlaybooks/playbook-GeneratePassword-Test.yml
@@ -54,7 +54,8 @@ tasks:
       min_digits: {}
       min_lcase: {}
       min_symbols: {}
-      min_ucase: {}
+      min_ucase:
+        simple: "1"
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-7732](https://jira-hq.paloaltonetworks.local/browse/CIAC-7732)

## Description
Fix `GeneratePassword-Test` TPB as a part of the following effort: [CIAC-7201](https://jira-hq.paloaltonetworks.local/browse/CIAC-7201).

This TPB failed because none of the following GeneratePassword script arguments were sent to the GeneratePassword-Test TPB:  min_uppercase, min_lowercase, min_digits, min_symbols.
As a result, all of the arguments defaulted to 0 and a corresponding exception was raised (further details in the Jira issue).

Changes made:
- [x] Update min_ucase command argument in task 1 of the playbook.
