### PR TITLE
fix demisto-sdk -vvv in content management pack

### DIFF
--- a/Packs/ContentManagement/doc_files/ci-cd.yml
+++ b/Packs/ContentManagement/doc_files/ci-cd.yml
@@ -106,7 +106,7 @@ jobs:
           cp $GITHUB_WORKSPACE/content/Tests/scripts/dev_envs/pytest/conftest.py ./dev_envs/pytest/
 
           # Run lint on all changed files
-          demisto-sdk lint -g -vvv
+          demisto-sdk lint -g
       - name: Create Packs Artifacts
         run: |
           if [ $PACKS_CHANGED ]; then


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixing call to demisto-sdk lint with -vvv, this flag is deprecated