### PR TITLE
timeout for polling command (create file) was updated.

### DIFF
--- a/Packs/CommonPlaybooks/TestPlaybooks/playbook-Containment_Plan-Test.yml
+++ b/Packs/CommonPlaybooks/TestPlaybooks/playbook-Containment_Plan-Test.yml
@@ -399,6 +399,10 @@ tasks:
         complex:
           root: Core.Endpoint
           accessor: endpoint_id
+      timeout:
+        simple: "120"
+      timeout_in_seconds:
+        simple: "180"
     separatecontext: false
     continueonerrortype: ""
     view: |-

--- a/Packs/CommonPlaybooks/TestPlaybooks/playbook-Eradication_plan_-_Test.yml
+++ b/Packs/CommonPlaybooks/TestPlaybooks/playbook-Eradication_plan_-_Test.yml
@@ -643,6 +643,10 @@ tasks:
         complex:
           root: Core.Endpoint
           accessor: endpoint_id
+      timeout:
+        simple: "120"
+      timeout_in_seconds:
+        simple: "180"
     separatecontext: false
     continueonerrortype: ""
     view: |-


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The following test playbook failed during the nightly run with a timeout error when the playbook attempted to create a file using core-run-script-execute-commands. The timeout for the polling command (to create the file) was updated.

## Must have
- [ ] Tests
- [ ] Documentation 
