### PR TITLE
Add marketplaces to pack metadata

### DIFF
--- a/Packs/AWS-SNS/pack_metadata.json
+++ b/Packs/AWS-SNS/pack_metadata.json
@@ -15,5 +15,9 @@
     "keywords": [],
     "githubUser": [
         "jieliau"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/CIRCLHashlookup/pack_metadata.json
+++ b/Packs/CIRCLHashlookup/pack_metadata.json
@@ -20,5 +20,9 @@
     "keywords": [],
     "githubUser": [
         "Hruuttila"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/CadoResponse/pack_metadata.json
+++ b/Packs/CadoResponse/pack_metadata.json
@@ -20,5 +20,9 @@
     ],
     "githubUser": [
         "cado-joshua"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/CheckPointSandBlast/pack_metadata.json
+++ b/Packs/CheckPointSandBlast/pack_metadata.json
@@ -14,5 +14,9 @@
     "useCases": [],
     "keywords": [],
     "githubUser": [],
-    "certification": "certified"
+    "certification": "certified",
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/CimTrak-SystemIntegrityAssurance/pack_metadata.json
+++ b/Packs/CimTrak-SystemIntegrityAssurance/pack_metadata.json
@@ -15,5 +15,9 @@
     "keywords": [],
     "githubUser": [
         "kigerjoel"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/CiscoAMP/pack_metadata.json
+++ b/Packs/CiscoAMP/pack_metadata.json
@@ -16,5 +16,9 @@
     "githubUser": [],
     "certification": "certified",
     "hidden": true,
-    "deprecated": true
+    "deprecated": true,
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/FeedCognyteLuminar/pack_metadata.json
+++ b/Packs/FeedCognyteLuminar/pack_metadata.json
@@ -12,5 +12,9 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
-    "githubUser": []
+    "githubUser": [],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
+++ b/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
@@ -24,5 +24,9 @@
         "Feed",
         "Ransomware",
         "Indicators"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/FortinetFortiwebVM/pack_metadata.json
+++ b/Packs/FortinetFortiwebVM/pack_metadata.json
@@ -14,5 +14,9 @@
     "useCases": [],
     "keywords": [],
     "githubUser": [],
-    "certification": "certified"
+    "certification": "certified",
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/Hackuity/pack_metadata.json
+++ b/Packs/Hackuity/pack_metadata.json
@@ -11,5 +11,9 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": []
+    "keywords": [],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/HarfangLabEDR/pack_metadata.json
+++ b/Packs/HarfangLabEDR/pack_metadata.json
@@ -15,5 +15,9 @@
     "keywords": [],
     "githubUser": [
         "Pierre-HarfangLab"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/Inventa/pack_metadata.json
+++ b/Packs/Inventa/pack_metadata.json
@@ -18,5 +18,9 @@
     ],
     "githubUser": [
         "andriidomasov"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/Jq/pack_metadata.json
+++ b/Packs/Jq/pack_metadata.json
@@ -16,5 +16,9 @@
     "githubUser": [
         "68zuhKQfKPk"
     ],
-    "hidden": true
+    "hidden": true,
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/MITRECoA/pack_metadata.json
+++ b/Packs/MITRECoA/pack_metadata.json
@@ -63,5 +63,9 @@
             "display_name": "Malware",
             "mandatory": false
         }
-    }
+    },
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/ManageEngine_PAM360/pack_metadata.json
+++ b/Packs/ManageEngine_PAM360/pack_metadata.json
@@ -15,5 +15,9 @@
     "devEmail": [
         "pam360-support@manageengine.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/Ncurion/pack_metadata.json
+++ b/Packs/Ncurion/pack_metadata.json
@@ -15,5 +15,9 @@
     "keywords": [],
     "githubUser": [
         "shleeNc"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/PhishUp/pack_metadata.json
+++ b/Packs/PhishUp/pack_metadata.json
@@ -37,5 +37,9 @@
         "CommonScripts",
         "Phishing",
         "Gmail"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/RemoveEmptyEvidence/pack_metadata.json
+++ b/Packs/RemoveEmptyEvidence/pack_metadata.json
@@ -16,5 +16,9 @@
     "githubUser": [
         "GavrielFilippov"
     ],
-    "hidden": true
+    "hidden": true,
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/SimpleAPIProxy/pack_metadata.json
+++ b/Packs/SimpleAPIProxy/pack_metadata.json
@@ -13,5 +13,9 @@
     "keywords": [],
     "githubUser": [
         "thimanshu474"
+    ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
     ]
 }

--- a/Packs/TrustwaveFusion/pack_metadata.json
+++ b/Packs/TrustwaveFusion/pack_metadata.json
@@ -12,5 +12,9 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
-    "githubUser": [ "cforbes-tw" ]
+    "githubUser": [ "cforbes-tw" ],
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -23,5 +23,9 @@
             "name": "Generic Webhook"
         }
     },
-    "githubUser": "ariel-wiz"
+    "githubUser": "ariel-wiz",
+    "marketplaces": [
+        "xsoar",
+        "marketplacev2"
+    ]
 }

--- a/Tests/scripts/collect_tests/constants.py
+++ b/Tests/scripts/collect_tests/constants.py
@@ -32,7 +32,11 @@ ALWAYS_INSTALLED_PACKS_MAPPING = {
     MarketplaceVersions.XPANSE: ALWAYS_INSTALLED_PACKS_XPANSE,
 }
 
-DEFAULT_MARKETPLACE_WHEN_MISSING: MarketplaceVersions = MarketplaceVersions.XSOAR
+DEFAULT_MARKETPLACE_WHEN_MISSING: MarketplaceVersions = [
+    MarketplaceVersions.XSOAR,
+    MarketplaceVersions.MarketplaceV2,
+    MarketplaceVersions.XPANSE
+]
 
 SKIPPED_CONTENT_ITEMS__NOT_UNDER_PACK: set[str] = {
     # these are not under packs, and are not supported anymore.


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-92099
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-92921
fixes: https://jira-hq.paloaltonetworks.local/browse/CRTX-92914

## Description
- Adds the `marketplaces` key to pack metadata files that are missing this.
- Align default marketplaces between collect-tests and create-graph.