### PR TITLE
Test upload: use the SDK_REF in the test upload job

### DIFF
--- a/Utils/trigger_test_upload_flow.sh
+++ b/Utils/trigger_test_upload_flow.sh
@@ -16,6 +16,8 @@ if [ "$#" -lt "1" ]; then
   [-sbp, --storage-base-path] A path to copy from in this current upload, and to be used as a target destination. This path should look like upload-flow/builds/branch_name/build_number/content.
   [-dz, --create_dependencies_zip] Upload packs with dependencies zip
   [-o, --override_all_packs]  Whether to override all packs, and not just modified packs.
+  [-sr, --sdk-ref]            The demisto-sdk repo branch to run this build with.
+
   "
   exit 1
 fi
@@ -28,7 +30,7 @@ _bucket_xsoar_saas="marketplace-saas-dist-dev"
 _bucket_upload="true"
 _slack_channel="dmst-bucket-upload"
 _storage_base_path=""
-
+_sdk_ref=$SDK_REF
 # Parsing the user inputs.
 
 while [[ "$#" -gt 0 ]]; do
@@ -91,6 +93,10 @@ while [[ "$#" -gt 0 ]]; do
     shift;;
 
   -sbp|--storage-base-path) _storage_base_path="$2"
+    shift
+    shift;;
+
+  -sr|--sdk-ref) _sdk_ref="$2"
     shift
     shift;;
 
@@ -164,5 +170,5 @@ curl --request POST \
   --form "variables[OVERRIDE_ALL_PACKS]=${_override_all_packs}" \
   --form "variables[CREATE_DEPENDENCIES_ZIP]=${_create_dependencies_zip}" \
   --form "variables[OVERRIDE_SDK_REF]=${DEMISTO_SDK_NIGHTLY}" \
-  --form "variables[SDK_REF]=${SDK_REF}" \
+  --form "variables[SDK_REF]=${_sdk_ref}" \
   "$BUILD_TRIGGER_URL"

--- a/Utils/trigger_test_upload_flow.sh
+++ b/Utils/trigger_test_upload_flow.sh
@@ -164,4 +164,5 @@ curl --request POST \
   --form "variables[OVERRIDE_ALL_PACKS]=${_override_all_packs}" \
   --form "variables[CREATE_DEPENDENCIES_ZIP]=${_create_dependencies_zip}" \
   --form "variables[OVERRIDE_SDK_REF]=${DEMISTO_SDK_NIGHTLY}" \
+  --form "variables[SDK_REF]=${SDK_REF}" \
   "$BUILD_TRIGGER_URL"

--- a/Utils/trigger_test_upload_flow.sh
+++ b/Utils/trigger_test_upload_flow.sh
@@ -30,7 +30,7 @@ _bucket_xsoar_saas="marketplace-saas-dist-dev"
 _bucket_upload="true"
 _slack_channel="dmst-bucket-upload"
 _storage_base_path=""
-_sdk_ref=$SDK_REF
+_sdk_ref=${SDK_REF:-master}
 # Parsing the user inputs.
 
 while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
This will provide the SDK_REF variable to the trigger of test upload so the test upload flow will be triggered with the custom sdk branch if necessary.

fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8375