### PR TITLE
Remove generic-sql-oracle from skipped_tests

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5557,7 +5557,6 @@
     ],
     "skipped_tests": {
         "generic-sql-mssql-encrypted-connection": "Instance issues",
-        "generic-sql-oracle": "Instance issues",
         "RSANetWitnessv115-Test": "mocking error CIAC-7576",
         "CiscoWSAv2": "No instance - developed by Qmasters",
         "DatadogCloudSIEM": "No instance - developed by Login soft",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
`generic-sql-oracle` TPB was added to "skipped_tests" due to instance issues as a part of the following Jira issue: https://jira-hq.paloaltonetworks.local/browse/XSUP-24414.

Now that the instance is valid, we are removing the `generic-sql-oracle` TPB from skipped_tests so it can run in Nightly again.
