### PR TITLE
fixing "operation is already in progress" string search

### DIFF
--- a/Tests/Marketplace/common.py
+++ b/Tests/Marketplace/common.py
@@ -9,7 +9,7 @@ from urllib3.exceptions import HTTPError, HTTPWarning
 
 from Tests.scripts.utils import logging_wrapper as logging
 
-ALREADY_IN_PROGRESS = "create / update / delete operation is already in progress (10102)"
+ALREADY_IN_PROGRESS = "operation is already in progress"
 
 
 def generic_request_with_retries(client: demisto_client,


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fixing "operation is already in progress" string search
related to [CRTX-93506](https://jira-hq.paloaltonetworks.local/browse/CRTX-93506)