### PR TITLE
added functionallity to download index by marketplace

### DIFF
--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -30,6 +30,7 @@ from Tests.Marketplace.marketplace_constants import PackFolders, Metadata, GCPCo
     PackTags, PackIgnored, Changelog, BASE_PACK_DEPENDENCY_DICT, SIEM_RULES_OBJECTS, PackStatus, PACK_FOLDERS_TO_ID_SET_KEYS, \
     CONTENT_ROOT_PATH, XSOAR_MP, XSIAM_MP, XPANSE_MP, TAGS_BY_MP, CONTENT_ITEM_NAME_MAPPING, \
     ITEMS_NAMES_TO_DISPLAY_MAPPING, RN_HEADER_TO_ID_SET_KEYS
+from demisto_sdk.commands.common.constants import MarketplaceVersions, MarketplaceVersionToMarketplaceName
 from Utils.release_notes_generator import aggregate_release_notes_for_marketplace, merge_version_blocks, construct_entities_block
 from Tests.scripts.utils import logging_wrapper as logging
 
@@ -4279,7 +4280,7 @@ def underscore_file_name_to_dotted_version(file_name: str) -> str:
     return os.path.splitext(file_name)[0].replace('_', '.')
 
 
-def get_last_commit_from_index(service_account):
+def get_last_commit_from_index(service_account, marketplace=MarketplaceVersions.XSOAR):
     """ Downloading index.json from GCP and extract last upload commit.
 
     Args:
@@ -4288,8 +4289,9 @@ def get_last_commit_from_index(service_account):
     Returns: last upload commit.
 
     """
+    production_bucket_name = MarketplaceVersionToMarketplaceName(marketplace)
     storage_client = init_storage_client(service_account)
-    storage_bucket = storage_client.bucket(GCPConfig.PRODUCTION_BUCKET)
+    storage_bucket = storage_client.bucket(production_bucket_name)
     index_storage_path = os.path.join('content/packs/', f"{GCPConfig.INDEX_NAME}.json")
     index_blob = storage_bucket.blob(index_storage_path)
     index_string = index_blob.download_as_string()

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -4290,15 +4290,12 @@ def get_last_commit_from_index(service_account, marketplace=MarketplaceVersions.
 
     """
     production_bucket_name = MarketplaceVersionToMarketplaceName.get(marketplace)
-    logging.info(f'{production_bucket_name=}')
     storage_client = init_storage_client(service_account)
     storage_bucket = storage_client.bucket(production_bucket_name)
-    logging.info(f'{storage_bucket=}')
     index_storage_path = os.path.join('content/packs/', f"{GCPConfig.INDEX_NAME}.json")
     index_blob = storage_bucket.blob(index_storage_path)
     index_string = index_blob.download_as_string()
     index_json = json.loads(index_string)
-    logging.info(f'Commit from index.json {index_json.get("commit")}')
     return index_json.get('commit')
 
 

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -4289,7 +4289,8 @@ def get_last_commit_from_index(service_account, marketplace=MarketplaceVersions.
     Returns: last upload commit.
 
     """
-    production_bucket_name = MarketplaceVersionToMarketplaceName(marketplace)
+    production_bucket_name = MarketplaceVersionToMarketplaceName.get(marketplace)
+    logging.info(f'{production_bucket_name=}')
     storage_client = init_storage_client(service_account)
     storage_bucket = storage_client.bucket(production_bucket_name)
     logging.info(f'{storage_bucket=}')

--- a/Tests/Marketplace/marketplace_services.py
+++ b/Tests/Marketplace/marketplace_services.py
@@ -4292,10 +4292,12 @@ def get_last_commit_from_index(service_account, marketplace=MarketplaceVersions.
     production_bucket_name = MarketplaceVersionToMarketplaceName(marketplace)
     storage_client = init_storage_client(service_account)
     storage_bucket = storage_client.bucket(production_bucket_name)
+    logging.info(f'{storage_bucket=}')
     index_storage_path = os.path.join('content/packs/', f"{GCPConfig.INDEX_NAME}.json")
     index_blob = storage_bucket.blob(index_storage_path)
     index_string = index_blob.download_as_string()
     index_json = json.loads(index_string)
+    logging.info(f'Commit from index.json {index_json.get("commit")}')
     return index_json.get('commit')
 
 

--- a/Tests/scripts/collect_tests/collect_tests.py
+++ b/Tests/scripts/collect_tests/collect_tests.py
@@ -1074,7 +1074,7 @@ class BranchTestCollector(TestCollector):
 
         if os.getenv('IFRA_ENV_TYPE') == 'Bucket-Upload':
             logger.info('bucket upload: getting last commit from index')
-            previous_commit = get_last_commit_from_index(self.service_account)
+            previous_commit = get_last_commit_from_index(self.service_account, self.marketplace)
             if self.branch_name == 'master':
                 current_commit = 'origin/master'
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8285?

## Description
Fix a bug that collect_test.py would always work with the index file of marketplace-dist. instead of downloading the index file corresponding to the marketplace we are collecting test for. 
 
## Must have
- [ ] Tests
- [ ] Documentation 
