### PR TITLE
ParseEmailFilesV2: update docker image

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_27.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_27.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+- Updated the Docker image to: *demisto/parse-emails:1.0.0.75644*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -113,4 +113,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.72707
+dockerimage: demisto/parse-emails:1.0.0.75644

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.26",
+    "currentVersion": "1.12.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26948

[PR in dockerfiles ](https://github.com/demisto/dockerfiles/pull/20516)

## Description
Use the updated `parse-emails` image with the version `0.1.18` of `parse-emails` module 
