### PR TITLE
Fixing `limit` argument for `mati-feed-get-indicators`

### DIFF
--- a/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
+++ b/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
@@ -1112,7 +1112,7 @@ def fetch_indicators(client: MandiantClient, args: dict = None) -> tuple[List, d
     if not args:
         args = {}
 
-    limit = arg_to_number(args.get("limit", client.limit), None, False)
+    limit = arg_to_number(args.get("limit", client.limit), None, True)
 
     # Cap maximum number of indicators to 1000
     if limit > 1000:

--- a/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
+++ b/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
@@ -1112,7 +1112,8 @@ def fetch_indicators(client: MandiantClient, args: dict = None) -> tuple[List, d
     if not args:
         args = {}
 
-    limit = int(args.get("limit", client.limit))
+    limit = arg_to_number(args.get("limit", client.limit), None, False)
+
     # Cap maximum number of indicators to 1000
     if limit > 1000:
         limit = 1000

--- a/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
+++ b/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
@@ -1112,7 +1112,7 @@ def fetch_indicators(client: MandiantClient, args: dict = None) -> tuple[List, d
     if not args:
         args = {}
 
-    limit = args.get("limit", client.limit)
+    limit = int(args.get("limit", client.limit))
     # Cap maximum number of indicators to 1000
     if limit > 1000:
         limit = 1000

--- a/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
+++ b/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.py
@@ -1112,7 +1112,7 @@ def fetch_indicators(client: MandiantClient, args: dict = None) -> tuple[List, d
     if not args:
         args = {}
 
-    limit = arg_to_number(args.get("limit", client.limit), None, True)
+    limit = int(args.get("limit", client.limit))
 
     # Cap maximum number of indicators to 1000
     if limit > 1000:

--- a/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.yml
+++ b/Packs/MandiantAdvantageThreatIntelligence/Integrations/MandiantAdvantageThreatIntelligence/MandiantAdvantageThreatIntelligence.yml
@@ -485,7 +485,7 @@ script:
       - Actors
       required: true
     description: Get Mandiant Indicators.
-  dockerimage: demisto/python3:3.10.13.74666
+  dockerimage: demisto/python3:3.10.13.75921
   feed: true
   runonce: false
   script: '-'

--- a/Packs/MandiantAdvantageThreatIntelligence/ReleaseNotes/1_0_9.md
+++ b/Packs/MandiantAdvantageThreatIntelligence/ReleaseNotes/1_0_9.md
@@ -3,4 +3,4 @@
 
 ##### Mandiant Advantage Threat Intelligence
 
-- Fixing `limit` argument for `mati-feed-get-indicators`
+- Fixed an issue where *limit* argument from ***mati-feed-get-indicators*** command was not parse properly.

--- a/Packs/MandiantAdvantageThreatIntelligence/ReleaseNotes/1_0_9.md
+++ b/Packs/MandiantAdvantageThreatIntelligence/ReleaseNotes/1_0_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Mandiant Advantage Threat Intelligence
+
+- Fixing `limit` argument for `mati-feed-get-indicators`

--- a/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
+++ b/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mandiant Advantage Threat Intelligence",
     "description": "Integrate your Mandiant Advantage Threat Intelligence data with Cortex XSOAR",
     "support": "partner",
-    "currentVersion": "1.0.8",
+    "currentVersion": "1.0.9",
     "author": "Mandiant",
     "hidden": false,
     "url": "https://www.mandiant.com/support",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Resolves an issue where a limit is manually passed to the `mati-feed-get-indicators` command results in an error saying '>' not supported between instances of 'str' and 'int'
