### PR TITLE
Additional argument for servicenow-generic-api-call command

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
@@ -2464,11 +2464,11 @@ Generic call to ServiceNow api
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| method | action to be performed on path. Possible values are: GET, POST, PATCH, DELETE. Default is 0. | Required | 
-| path | the API path starting with forward slash (/). | Required | 
-| json_body | whether or not the request body is json. Possible values are: true, false. Default is false. | Optional |
-| body | json to send in body. | Optional | 
-| headers | json of headers to add. | Optional | 
+| method | Action to be performed on path. Possible values are: GET, POST, PATCH, DELETE. Default is 0. | Required | 
+| path | The API path (without a leading forward slash '/'). | Required | 
+| json_body | Whether or not the request body is json. Possible values are: true, false. Default is false. | Optional |
+| body | JSON to send in body. | Optional | 
+| headers | JSON of headers to add. | Optional | 
 | sc_api | Service Catalog Call. Possible values are: true, false. Default is false. | Optional | 
 | cr_api | Change Request Call. Possible values are: true, false. Default is false. | Optional | 
 | custom_api_root | Define a custom API root (like /api/tasks/). | Optional | 

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
@@ -2471,6 +2471,7 @@ Generic call to ServiceNow api
 | headers | json of headers to add. | Optional | 
 | sc_api | Service Catalog Call. Possible values are: true, false. Default is false. | Optional | 
 | cr_api | Change Request Call. Possible values are: true, false. Default is false. | Optional | 
+| custom_api_root | Define a custom API root (like /api/tasks/). | Optional | 
 
 
 #### Context Output

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/README.md
@@ -2464,14 +2464,14 @@ Generic call to ServiceNow api
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| method | Action to be performed on path. Possible values are: GET, POST, PATCH, DELETE. Default is 0. | Required | 
-| path | The API path (without a leading forward slash '/'). | Required | 
-| json_body | Whether or not the request body is json. Possible values are: true, false. Default is false. | Optional |
-| body | JSON to send in body. | Optional | 
-| headers | JSON of headers to add. | Optional | 
+| method | action to be performed on path. Possible values are: GET, POST, PATCH, DELETE. Default is 0. | Required | 
+| path | the API path starting with forward slash (/). | Required | 
+| json_body | whether or not the request body is json. Possible values are: true, false. Default is false. | Optional |
+| body | json to send in body. | Optional | 
+| headers | json of headers to add. | Optional | 
 | sc_api | Service Catalog Call. Possible values are: true, false. Default is false. | Optional | 
 | cr_api | Change Request Call. Possible values are: true, false. Default is false. | Optional | 
-| custom_api_root | Define a custom API root (like /api/tasks/). | Optional | 
+| custom_api | Define a custom API root (like /api/custom/tasks). | Optional | 
 
 
 #### Context Output

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -648,9 +648,10 @@ class Client(BaseClient):
             header (dict): requests headers. Default is None.
             sc_api: Whether to send the request to the Service Catalog API
             cr_api: Whether to send the request to the Change Request REST API
+            custom_api: the custom api root to use
 
         Returns:
-            Resposne object or Exception
+            Response object or Exception
         """
         return self.send_request(path, method, body, headers=headers, sc_api=sc_api, cr_api=cr_api, custom_api=custom_api)
 
@@ -669,6 +670,7 @@ class Client(BaseClient):
             sc_api: Whether to send the request to the Service Catalog API
             cr_api: Whether to send the request to the Change Request REST API
             get_attachments: if to get attachments or not.
+            custom_api: the custom api root to use
 
         Returns:
             response from API

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2,7 +2,7 @@ import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 import re
 import shutil
-from typing import Callable, Dict, Iterable, List, Tuple
+from collections.abc import Callable, Iterable
 
 
 import mimetypes
@@ -171,9 +171,8 @@ def arg_to_timestamp(arg: Any, arg_name: str, required: bool = False) -> int:
         returns ``None`` if arg is ``None`` and required is set to ``False``
         otherwise throws an Exception
     """
-    if arg is None:
-        if required is True:
-            raise ValueError(f'Missing "{arg_name}"')
+    if arg is None and required is True:
+        raise ValueError(f'Missing "{arg_name}"')
 
     if isinstance(arg, str) and arg.isdigit():
         # timestamp is a str containing digits - we just convert it to int
@@ -188,7 +187,7 @@ def arg_to_timestamp(arg: Any, arg_name: str, required: bool = False) -> int:
             raise ValueError(f'Invalid date: {arg_name}')
 
         return int(date.timestamp())
-    if isinstance(arg, (int, float)):
+    if isinstance(arg, int | float):
         # Convert to int if the input is a float
         return int(arg)
     raise ValueError(f'Invalid date: "{arg_name}"')
@@ -424,7 +423,7 @@ def get_ticket_fields(args: dict, template_name: dict = {}, ticket_type: str = '
         args.get('clear_fields', []))  # This argument will contain fields to allow their value empty
 
     # This is for updating null fields for update_remote_system function for example: assigned_to.
-    for arg in args.keys():
+    for arg in args:
         if not args[arg]:
             fields_to_clear.append(arg)
     demisto.debug(f'Fields to clear {fields_to_clear}')
@@ -512,11 +511,11 @@ def split_fields(fields: str = '', delimiter: str = ';') -> dict:
 
 
 def split_notes(raw_notes, note_type, time_info):
-    notes: List = []
+    notes: list = []
     # The notes should be in this form:
     # '16/05/2023 15:49:56 - John Doe (Additional comments)\nsecond note first line\n\nsecond line\n\nthird
     # line\n\n2023-05-10 15:41:38 - פלוני אלמוני (Additional comments)\nfirst note first line\n\nsecond line\n\n
-    delimiter = '([0-9]{1,4}(?:\/|-)[0-9]{1,2}(?:\/|-)[0-9]{1,4}.*\((?:Additional comments|Work notes)\))'
+    delimiter = r'([0-9]{1,4}(?:\/|-)[0-9]{1,2}(?:\/|-)[0-9]{1,4}.*\((?:Additional comments|Work notes)\))'
     notes_split = list(filter(None, re.split(delimiter, raw_notes)))
     for note_info, note_value in zip(notes_split[::2], notes_split[1::2]):
         created_on, _, created_by = note_info.partition(" - ")
@@ -608,7 +607,7 @@ class Client(BaseClient):
         self._username = username
         self._password = password
         self._proxies = handle_proxy(proxy_param_name='proxy', checkbox_default_value=False)
-        self.use_oauth = True if oauth_params else False
+        self.use_oauth = bool(oauth_params)
         self.fetch_time = fetch_time
         self.timestamp_field = timestamp_field
         self.ticket_type = ticket_type
@@ -636,8 +635,8 @@ class Client(BaseClient):
         else:
             self._auth = (self._username, self._password)
 
-    def generic_request(self, method: str, path: str, body: Optional[Dict] = None, headers: Optional[Dict] = None,
-                        sc_api: bool = False, cr_api: bool = False):
+    def generic_request(self, method: str, path: str, body: Optional[dict] = None, headers: Optional[dict] = None,
+                        sc_api: bool = False, cr_api: bool = False, custom_api: str = ""):
         """Generic request to ServiceNow api.
 
         Args:
@@ -657,7 +656,7 @@ class Client(BaseClient):
 
     def send_request(self, path: str, method: str = 'GET', body: dict | None = None, params: dict | None = None,
                      headers: dict | None = None, file=None, sc_api: bool = False, cr_api: bool = False,
-                     get_attachments: bool = False, no_record_found_res: dict = {'result': []}):
+                     get_attachments: bool = False, no_record_found_res: dict = {'result': []}, custom_api: str | None = None):
         """Generic request to ServiceNow.
 
         Args:
@@ -677,7 +676,12 @@ class Client(BaseClient):
         body = body if body is not None else {}
         params = params if params is not None else {}
 
-        if sc_api:
+        if custom_api:
+            server_url = demisto.params().get('url')
+            api = '/' + custom_api.strip(' /') + '/'
+            path = path.strip(' /')
+            url = f'{get_server_url(server_url)}{api}{path}'
+        elif sc_api:
             url = f'{self._sc_server_url}{path}'
         elif cr_api:
             url = f'{self._cr_server_url}{path}'
@@ -851,7 +855,7 @@ class Client(BaseClient):
             Array of attachments entries.
         """
         entries = []
-        links = []  # type: List[Tuple[str, str]]
+        links = []  # type: List[tuple[str, str]]
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
@@ -1175,7 +1179,7 @@ def get_ticket_command(client: Client, args: dict):
     return entries
 
 
-def update_ticket_command(client: Client, args: dict) -> Tuple[Any, Dict, Dict, bool]:
+def update_ticket_command(client: Client, args: dict) -> tuple[Any, dict, dict, bool]:
     """Update a ticket.
 
     Args:
@@ -1215,7 +1219,7 @@ def update_ticket_command(client: Client, args: dict) -> Tuple[Any, Dict, Dict, 
     return human_readable, entry_context, result, True
 
 
-def create_ticket_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def create_ticket_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Create a ticket.
 
     Args:
@@ -1271,7 +1275,7 @@ def create_ticket_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, 
     return human_readable, entry_context, result, True
 
 
-def delete_ticket_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def delete_ticket_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Delete a ticket.
 
     Args:
@@ -1289,7 +1293,7 @@ def delete_ticket_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, 
     return f'Ticket with ID {ticket_id} was successfully deleted.', {}, result, True
 
 
-def query_tickets_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def query_tickets_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Query tickets.
 
     Args:
@@ -1329,7 +1333,7 @@ def query_tickets_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, 
     return human_readable, entry_context, result, True
 
 
-def add_link_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def add_link_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Add a link.
 
     Args:
@@ -1361,7 +1365,7 @@ def add_link_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]
     return human_readable, {}, result, True
 
 
-def add_comment_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def add_comment_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Add a comment.
 
     Args:
@@ -1392,7 +1396,7 @@ def add_comment_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bo
     return human_readable, {}, result, True
 
 
-def upload_file_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def upload_file_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Upload a file.
 
     Args:
@@ -1439,7 +1443,7 @@ def upload_file_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bo
     return human_readable, entry_context, result, True
 
 
-def add_tag_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def add_tag_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Add tag to a ticket.
 
     Args:
@@ -1476,7 +1480,7 @@ def add_tag_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
     return human_readable, entry_context, result, True
 
 
-def get_ticket_notes_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def get_ticket_notes_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Get the ticket's note.
 
     Args:
@@ -1531,7 +1535,7 @@ def get_ticket_notes_command(client: Client, args: dict) -> Tuple[str, Dict, Dic
     return human_readable, entry_context, result, True
 
 
-def get_record_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def get_record_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Get a record.
 
     Args:
@@ -1579,7 +1583,7 @@ def get_record_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, boo
     return human_readable, entry_context, result, True
 
 
-def create_record_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Any, bool]:
+def create_record_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], Any, bool]:
     """Create a record.
 
     Args:
@@ -1616,7 +1620,7 @@ def create_record_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, An
     return human_readable, entry_context, result, True
 
 
-def update_record_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def update_record_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Update a record.
 
     Args:
@@ -1655,7 +1659,7 @@ def update_record_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, An
     return human_readable, entry_context, result, True
 
 
-def delete_record_command(client: Client, args: dict) -> Tuple[str, Dict[Any, Any], Dict, bool]:
+def delete_record_command(client: Client, args: dict) -> tuple[str, dict[Any, Any], dict, bool]:
     """Delete a record.
 
     Args:
@@ -1673,7 +1677,7 @@ def delete_record_command(client: Client, args: dict) -> Tuple[str, Dict[Any, An
     return f'ServiceNow record with ID {record_id} was successfully deleted.', {}, result, True
 
 
-def query_table_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bool]:
+def query_table_command(client: Client, args: dict) -> tuple[str, dict, dict, bool]:
     """Query a table.
 
     Args:
@@ -1719,7 +1723,7 @@ def query_table_command(client: Client, args: dict) -> Tuple[str, Dict, Dict, bo
     return human_readable, entry_context, result, False
 
 
-def query_computers_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def query_computers_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Query computers.
 
     Args:
@@ -1791,7 +1795,7 @@ def query_computers_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, 
     return human_readable, entry_context, result, False
 
 
-def query_groups_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def query_groups_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Query groups.
 
     Args:
@@ -1844,7 +1848,7 @@ def query_groups_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any
     return human_readable, entry_context, result, False
 
 
-def query_users_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def query_users_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Query users.
 
     Args:
@@ -1895,7 +1899,7 @@ def query_users_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any]
     return human_readable, entry_context, result, False
 
 
-def list_table_fields_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def list_table_fields_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """List table fields.
 
     Args:
@@ -1923,7 +1927,7 @@ def list_table_fields_command(client: Client, args: dict) -> Tuple[Any, Dict[Any
     return human_readable, entry_context, result, False
 
 
-def get_table_name_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def get_table_name_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """List table fields.
 
     Args:
@@ -1961,7 +1965,7 @@ def get_table_name_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, A
     return human_readable, entry_context, result, False
 
 
-def query_items_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def query_items_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Query items.
 
     Args:
@@ -2000,7 +2004,7 @@ def query_items_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any]
     return human_readable, entry_context, result, True
 
 
-def get_item_details_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def get_item_details_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Get item details.
 
     Args:
@@ -2027,7 +2031,7 @@ def get_item_details_command(client: Client, args: dict) -> Tuple[Any, Dict[Any,
     return human_readable, entry_context, result, True
 
 
-def create_order_item_command(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def create_order_item_command(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Create item order.
 
     Args:
@@ -2057,7 +2061,7 @@ def create_order_item_command(client: Client, args: dict) -> Tuple[Any, Dict[Any
     return human_readable, entry_context, result, True
 
 
-def document_route_to_table(client: Client, args: dict) -> Tuple[Any, Dict[Any, Any], Dict[Any, Any], bool]:
+def document_route_to_table(client: Client, args: dict) -> tuple[Any, dict[Any, Any], dict[Any, Any], bool]:
     """Document routes to table.
 
     Args:
@@ -2249,7 +2253,7 @@ def test_instance(client: Client):
             raise ValueError(f"The field [{client.incident_name}] does not exist in the ticket.")
 
 
-def test_module(client: Client, *_) -> Tuple[str, Dict[Any, Any], Dict[Any, Any], bool]:
+def test_module(client: Client, *_) -> tuple[str, dict[Any, Any], dict[Any, Any], bool]:
     """
     Test the instance configurations when using basic authorization.
     """
@@ -2265,7 +2269,7 @@ def test_module(client: Client, *_) -> Tuple[str, Dict[Any, Any], Dict[Any, Any]
     return 'ok', {}, {}, True
 
 
-def oauth_test_module(client: Client, *_) -> Tuple[str, Dict[Any, Any], Dict[Any, Any], bool]:
+def oauth_test_module(client: Client, *_) -> tuple[str, dict[Any, Any], dict[Any, Any], bool]:
     """
     Test the instance configurations when using OAuth authentication.
     """
@@ -2279,7 +2283,7 @@ def oauth_test_module(client: Client, *_) -> Tuple[str, Dict[Any, Any], Dict[Any
     return hr, {}, {}, True
 
 
-def login_command(client: Client, args: Dict[str, Any]) -> Tuple[str, Dict[Any, Any], Dict[Any, Any], bool]:
+def login_command(client: Client, args: dict[str, Any]) -> tuple[str, dict[Any, Any], dict[Any, Any], bool]:
     """
     Login the user using OAuth authorization
     Args:
@@ -2366,7 +2370,7 @@ def get_timezone_offset(full_response, display_date_format):
     return offset
 
 
-def get_remote_data_command(client: Client, args: Dict[str, Any], params: Dict) -> Union[List[Dict[str, Any]], str]:
+def get_remote_data_command(client: Client, args: dict[str, Any], params: dict) -> Union[list[dict[str, Any]], str]:
     """
     get-remote-data command: Returns an updated incident and entries
     Args:
@@ -2531,10 +2535,10 @@ def converts_state_close_reason(ticket_state: Optional[str], server_close_custom
             received state code: {ticket_state}')
         # parse custom state parameter into a dictionary of custom state codes and their names (label)
         server_close_custom_state_dict = dict(item.split("=") for item in server_close_custom_state.split(","))
-        if ticket_state in server_close_custom_state_dict:
+        if ticket_state in server_close_custom_state_dict and (
+                custom_state_label := server_close_custom_state_dict.get(ticket_state)):
             # check if state code is in the parsed dictionary
-            if custom_state_label := server_close_custom_state_dict.get(ticket_state):
-                custom_label = custom_state_label
+            custom_label = custom_state_label
 
     if custom_label:
         demisto.debug(f'incident should be closed using custom state. State Code: {ticket_state}, Label: {custom_label}')
@@ -2546,7 +2550,7 @@ def converts_state_close_reason(ticket_state: Optional[str], server_close_custom
     return 'Other'
 
 
-def update_remote_system_command(client: Client, args: Dict[str, Any], params: Dict[str, Any]) -> str:
+def update_remote_system_command(client: Client, args: dict[str, Any], params: dict[str, Any]) -> str:
     """
     This command pushes local changes to the remote system.
     Args:
@@ -2639,7 +2643,7 @@ def update_remote_system_command(client: Client, args: Dict[str, Any], params: D
     return ticket_id
 
 
-def get_closure_case(params: Dict[str, Any]):
+def get_closure_case(params: dict[str, Any]):
     """
     return the right incident closing states according to old and new close_ticket integration param.
     Args:
@@ -2647,7 +2651,7 @@ def get_closure_case(params: Dict[str, Any]):
 
     Returns: None if no closure method is specified. otherwise returns (str) The right closure method.
     """
-    if not params.get('close_ticket_multiple_options') == 'None':
+    if params.get('close_ticket_multiple_options') != 'None':
         return params.get('close_ticket_multiple_options')
     elif params.get('close_ticket'):
         return 'closed'
@@ -2693,7 +2697,7 @@ def get_mapping_fields_command(client: Client) -> GetMappingFieldsResponse:
 
 def get_modified_remote_data_command(
         client: Client,
-        args: Dict[str, str],
+        args: dict[str, str],
         update_timestamp_field: str = 'sys_updated_on',
         mirror_limit: str = '100',
 ) -> GetModifiedRemoteDataResponse:
@@ -2842,7 +2846,7 @@ def create_co_from_template_command(client: Client, args: dict) -> CommandResult
     )
 
 
-def get_co_human_readable(ticket: dict, ticket_type: str, additional_fields: Iterable = tuple()) -> dict:
+def get_co_human_readable(ticket: dict, ticket_type: str, additional_fields: Iterable = ()) -> dict:
     """Get co human readable.
 
     Args:
@@ -2888,7 +2892,7 @@ def get_co_human_readable(ticket: dict, ticket_type: str, additional_fields: Ite
     return item
 
 
-def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandResults]:
+def generic_api_call_command(client: Client, args: dict) -> Union[str, CommandResults]:
     """make a call to ServiceNow api
     Args:
         (Required Arguments)
@@ -2897,6 +2901,7 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
         (Optional Arguments)
         body (dict): The body to send in a 'POST' request. Default is None.
         header (dict): requests headers. Default is None.
+        custom_api (str): custom API root. Default is None.
 
     Return:
         Generic Api Response.
@@ -2905,8 +2910,9 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
     method = str(args.get("method"))
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
+    custom_api = args.get('custom_api_root', '')
     try:
-        body: Dict = json.loads(str(args.get("body", {})))
+        body: dict = json.loads(str(args.get("body", {})))
     except ValueError:
         body = args.get("body", "")
     sc_api: bool = argToBoolean(args.get("sc_api", False))
@@ -2916,7 +2922,8 @@ def generic_api_call_command(client: Client, args: Dict) -> Union[str, CommandRe
         return f"{method} method not supported.\nTry something from {', '.join(methods)}"
 
     response = None
-    response = client.generic_request(method=method, path=path, body=body, headers=headers, sc_api=sc_api, cr_api=cr_api)
+    response = client.generic_request(method=method, path=path, body=body, headers=headers,
+                                      sc_api=sc_api, cr_api=cr_api, custom_api=custom_api)
 
     if response is not None:
         resp = response
@@ -3033,7 +3040,7 @@ def main():
                         timestamp_field=timestamp_field, ticket_type=ticket_type, get_attachments=get_attachments,
                         incident_name=incident_name, oauth_params=oauth_params, version=version, look_back=look_back,
                         use_display_value=use_display_value, display_date_format=display_date_format)
-        commands: Dict[str, Callable[[Client, Dict[str, str]], Tuple[str, Dict[Any, Any], Dict[Any, Any], bool]]] = {
+        commands: dict[str, Callable[[Client, dict[str, str]], tuple[str, dict[Any, Any], dict[Any, Any], bool]]] = {
             'test-module': test_module,
             'servicenow-oauth-test': oauth_test_module,
             'servicenow-oauth-login': login_command,

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -679,10 +679,10 @@ class Client(BaseClient):
         params = params if params is not None else {}
 
         if custom_api:
+            if not custom_api.startswith("/"):
+                return_error("Argument custom_api must start with a leading forward slash '/'")
             server_url = demisto.params().get('url')
-            api = '/' + custom_api.strip(' /') + '/'
-            path = path.strip(' /')
-            url = f'{get_server_url(server_url)}{api}{path}'
+            url = f'{get_server_url(server_url)}{custom_api}{path}'
         elif sc_api:
             url = f'{self._sc_server_url}{path}'
         elif cr_api:

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -652,7 +652,7 @@ class Client(BaseClient):
         Returns:
             Resposne object or Exception
         """
-        return self.send_request(path, method, body, headers=headers, sc_api=sc_api, cr_api=cr_api)
+        return self.send_request(path, method, body, headers=headers, sc_api=sc_api, cr_api=cr_api, custom_api=custom_api)
 
     def send_request(self, path: str, method: str = 'GET', body: dict | None = None, params: dict | None = None,
                      headers: dict | None = None, file=None, sc_api: bool = False, cr_api: bool = False,

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2912,7 +2912,7 @@ def generic_api_call_command(client: Client, args: dict) -> Union[str, CommandRe
     method = str(args.get("method"))
     path = str(args.get("path"))
     headers = json.loads(str(args.get("headers", {})))
-    custom_api = args.get('custom_api_root', '')
+    custom_api = args.get('custom_api', '')
     try:
         body: dict = json.loads(str(args.get("body", {})))
     except ValueError:

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1571,7 +1571,7 @@ script:
       - PATCH
       - DELETE
       required: true
-    - description: the API path starting with forward slash (/).
+    - description: the API path (without a leading forward slash '/').
       name: path
       required: true
     - description: data to send in body, can be json.

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1571,13 +1571,13 @@ script:
       - PATCH
       - DELETE
       required: true
-    - description: the API path (without a leading forward slash '/').
+    - description: the API path starting with forward slash (/).
       name: path
       required: true
     - description: data to send in body, can be json.
       name: body
-    - description: the custom API root (like /api/tasks/).
-      name: custom_api_root
+    - description: the custom API root (like /api/custom/tasks).
+      name: custom_api
     - description: json of headers to add.
       name: headers
     - auto: PREDEFINED

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1576,6 +1576,8 @@ script:
       required: true
     - description: data to send in body, can be json.
       name: body
+    - description: the custom API root (like /api/tasks/).
+      name: custom_api_root
     - description: json of headers to add.
       name: headers
     - auto: PREDEFINED
@@ -1598,7 +1600,7 @@ script:
     - contextPath: ServiceNow.Generic.Response
       description: Generic response to servicenow api.
       type: string
-  dockerimage: demisto/python3:3.10.13.74666
+  dockerimage: demisto/python3:3.10.13.75921
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
@@ -1815,10 +1815,10 @@ def test_get_ticket_attachment_entries_with_oauth_token(mocker):
          RESPONSE_GENERIC_TICKET),
         (generic_api_call_command,
          {"method": "GET",
-          "path": "table/sn_si_incident?sysparam_limit=1&sysparam_query=active=true^ORDERBYDESCnumber",
+          "path": "/table/sn_si_incident?sysparam_limit=1&sysparam_query=active=true^ORDERBYDESCnumber",
           "body": {},
           "headers": {},
-          "custom_api_root": "/api/custom/"
+          "custom_api": "/api/custom"
           },
          RESPONSE_GENERIC_TICKET)
     ])

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
@@ -2,7 +2,6 @@ import re
 
 import pytest
 import json
-import io
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 import ServiceNowv2
@@ -50,16 +49,16 @@ from urllib.parse import urlencode
 
 
 def util_load_json(path):
-    with io.open(path, mode='r', encoding='utf-8') as f:
+    with open(path, encoding='utf-8') as f:
         return json.loads(f.read())
 
 
 def test_get_server_url():
-    assert "http://www.demisto.com/" == get_server_url("http://www.demisto.com//")
+    assert get_server_url("http://www.demisto.com//") == "http://www.demisto.com/"
 
 
 def test_get_ticket_context():
-    assert EXPECTED_TICKET_CONTEXT == get_ticket_context(RESPONSE_TICKET)
+    assert get_ticket_context(RESPONSE_TICKET) == EXPECTED_TICKET_CONTEXT
 
     assert EXPECTED_MULTIPLE_TICKET_CONTEXT[0] in get_ticket_context(RESPONSE_MULTIPLE_TICKET)
     assert EXPECTED_MULTIPLE_TICKET_CONTEXT[1] in get_ticket_context(RESPONSE_MULTIPLE_TICKET)
@@ -75,8 +74,9 @@ def test_get_ticket_context_additional_fields():
         - validate that all the details of the ticket were updated, and all the updated keys are shown in
         the context with do duplicates.
     """
-    assert EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS == get_ticket_context(RESPONSE_TICKET,
-                                                                                ['Summary', 'sys_created_by'])
+    assert get_ticket_context(RESPONSE_TICKET,
+                              ['Summary', 'sys_created_by']) == \
+        EXPECTED_TICKET_CONTEXT_WITH_ADDITIONAL_FIELDS
 
 
 def test_get_ticket_context_nested_additional_fields():
@@ -89,12 +89,13 @@ def test_get_ticket_context_nested_additional_fields():
         - validate that all the details of the ticket were updated, and all the updated keys are shown in
         the context with do duplicates.
     """
-    assert EXPECTED_TICKET_CONTEXT_WITH_NESTED_ADDITIONAL_FIELDS == get_ticket_context(RESPONSE_TICKET,
-                                                                                       ['Summary', 'opened_by.link'])
+    assert get_ticket_context(RESPONSE_TICKET,
+                              ['Summary', 'opened_by.link']) == \
+        EXPECTED_TICKET_CONTEXT_WITH_NESTED_ADDITIONAL_FIELDS
 
 
 def test_get_ticket_human_readable():
-    assert EXPECTED_TICKET_HR == get_ticket_human_readable(RESPONSE_TICKET, 'incident')
+    assert get_ticket_human_readable(RESPONSE_TICKET, 'incident') == EXPECTED_TICKET_HR
 
     assert EXPECTED_MULTIPLE_TICKET_HR[0] in get_ticket_human_readable(RESPONSE_MULTIPLE_TICKET, 'incident')
     assert EXPECTED_MULTIPLE_TICKET_HR[1] in get_ticket_human_readable(RESPONSE_MULTIPLE_TICKET, 'incident')
@@ -1229,7 +1230,7 @@ def test_get_mapping_fields():
                     sysparm_query='sysparm_query', sysparm_limit=10, timestamp_field='opened_at',
                     ticket_type='incident', get_attachments=False, incident_name='description')
     res = get_mapping_fields_command(client)
-    assert EXPECTED_MAPPING == res.extract_mapping()
+    assert res.extract_mapping() == EXPECTED_MAPPING
 
 
 def test_get_remote_data(mocker):
@@ -1446,12 +1447,12 @@ def test_get_remote_data_no_entries(mocker):
 
 
 def upload_file_request(*args):
-    assert 'test_mirrored_from_xsoar.txt' == args[2]
+    assert args[2] == 'test_mirrored_from_xsoar.txt'
     return {'id': "sys_id", 'file_id': "entry_id", 'file_name': 'test.txt'}
 
 
 def add_comment_request(*args):
-    assert '(dbot): This is a comment\n\n Mirrored from Cortex XSOAR' == args[3]
+    assert args[3] == '(dbot): This is a comment\n\n Mirrored from Cortex XSOAR'
     return {'id': "1234", 'comment': "This is a comment"}
 
 
@@ -1810,6 +1811,14 @@ def test_get_ticket_attachment_entries_with_oauth_token(mocker):
           "path": "table/sn_si_incident?sysparam_limit=1&sysparam_query=active=true^ORDERBYDESCnumber",
           "body": {},
           "headers": {},
+          },
+         RESPONSE_GENERIC_TICKET),
+        (generic_api_call_command,
+         {"method": "GET",
+          "path": "table/sn_si_incident?sysparam_limit=1&sysparam_query=active=true^ORDERBYDESCnumber",
+          "body": {},
+          "headers": {},
+          "custom_api_root": "/api/custom/"
           },
          RESPONSE_GENERIC_TICKET)
     ])

--- a/Packs/ServiceNow/ReleaseNotes/2_5_43.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_43.md
@@ -3,4 +3,4 @@
 
 ##### ServiceNow v2
 - Updated the Docker image to: *demisto/python3:3.10.13.75921*.
-- Added the ability to pass a custom API root to the ***servicenow-generic-api-call*** command.
+- Added the argument *custom_api* to the ***servicenow-generic-api-call*** command. This makes it possible to send requests to ServiceNow Scripted REST APIs.

--- a/Packs/ServiceNow/ReleaseNotes/2_5_43.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_43.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ServiceNow v2
+- Updated the Docker image to: *demisto/python3:3.10.13.75921*.
+- Added the ability to pass a custom API root to the ***servicenow-generic-api-call*** command.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.5.42",
+    "currentVersion": "2.5.43",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: None

## Description
ServiceNow lets you define custom APIs. Added the possibility to send request to such custom APIs by adding an optional custom_api_root argument to the **servicenow-generic-api-call** command which lets you overwrite the hardcoded default api root. Additionally the changes from demisto-sdk validation have been applied and a unit test for the new argument has been added.

## Must have
- [ ] Tests
- [ ] Documentation 
