### PR TITLE
[Armis Event Collector] Update initial fetch handling

### DIFF
--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
@@ -403,13 +403,13 @@ def events_to_command_results(events: list[dict[str, Any]]) -> CommandResults:
                                         removeNull=True))
 
 
-def init_last_run(last_run: dict, event_types_to_fetch) -> None:
-    """ Initialize last fetch time values for all selected event types to current time.
-        This will set a fetch starting point until events are fetched for each event type.
+def set_last_run_with_current_time(last_run: dict, event_types_to_fetch) -> None:
+    """ Set last fetch time values for all selected event types to current time.
+        This will set a fetch starting time until events are fetched for each event type.
 
     Args:
-        last_run (dict): _description_
-        event_types_to_fetch (_type_): _description_
+        last_run (dict): Last run dictionary.
+        event_types_to_fetch (list): List of event types to fetch.
     """
     now: datetime = datetime.now()
     now_str: str = now.strftime(DATE_FORMAT)
@@ -453,8 +453,8 @@ def main():  # pragma: no cover
         elif command in ('fetch-events', 'armis-get-events'):
             should_return_results = False
 
-            if not last_run:  # only happens on initial fetch
-                init_last_run(last_run, event_types_to_fetch)
+            if not last_run:  # in initial fetch - update last fetch time values to current time
+                set_last_run_with_current_time(last_run, event_types_to_fetch)
 
             if command == 'armis-get-events':
                 last_run = {}

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
@@ -65,7 +65,7 @@ class Client(BaseClient):
             list[dict]: List of events objects represented as dictionaries.
         """
         params: dict[str, Any] = {'aql': aql_query, 'includeTotal': 'true', 'length': max_fetch, 'orderBy': 'time'}
-        if not after:  # this should only happen when get-event command is used without from_date argument
+        if not after:  # this should only happen when get-events command is used without from_date argument
             after = datetime.now()
         params['aql'] += f' after:{after.strftime(DATE_FORMAT)}'  # add 'after' date filter to AQL query in the desired format
         raw_response = self._http_request(url_suffix='/search/', method='GET', params=params, headers=self._headers)

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
@@ -455,6 +455,7 @@ def main():  # pragma: no cover
             if not last_run:  # initial fetch - update last fetch time values to current time
                 set_last_run_with_current_time(last_run, event_types_to_fetch)
                 demisto.setLastRun(last_run)
+                demisto.debug('debug-log: Initial fetch - updating last fetch time value to current time for each event type.')
 
             else:
                 if command == 'armis-get-events':

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
@@ -65,7 +65,7 @@ class Client(BaseClient):
             list[dict]: List of events objects represented as dictionaries.
         """
         params: dict[str, Any] = {'aql': aql_query, 'includeTotal': 'true', 'length': max_fetch, 'orderBy': 'time'}
-        if not after:  # if this is the first fetch run of the instance, use current datetime as starting point
+        if not after:  # this should only happen when get-event command is used without from_date argument
             after = datetime.now()
         params['aql'] += f' after:{after.strftime(DATE_FORMAT)}'  # add 'after' date filter to AQL query in the desired format
         raw_response = self._http_request(url_suffix='/search/', method='GET', params=params, headers=self._headers)
@@ -380,9 +380,11 @@ def handle_fetched_events(events: list[dict[str, Any]], next_run: dict[str, str 
         )
         demisto.setLastRun(next_run)
         demisto.debug(f'debug-log: {len(events)} events were sent to XSIAM.')
-        demisto.debug(f'debug-log: {next_run=}')
     else:
-        demisto.debug('debug-log: No new events fetched, Last run was not updated.')
+        demisto.setLastRun(next_run)
+        demisto.debug('debug-log: No new events fetched.')
+
+    demisto.debug(f'debug-log: {next_run=}')
 
 
 def events_to_command_results(events: list[dict[str, Any]]) -> CommandResults:
@@ -399,6 +401,21 @@ def events_to_command_results(events: list[dict[str, Any]]) -> CommandResults:
         readable_output=tableToMarkdown(name=f'{VENDOR} {PRODUCT} events',
                                         t=events,
                                         removeNull=True))
+
+
+def init_last_run(last_run: dict, event_types_to_fetch) -> None:
+    """ Initialize last fetch time values for all selected event types to current time.
+        This will set a fetch starting point until events are fetched for each event type.
+
+    Args:
+        last_run (dict): _description_
+        event_types_to_fetch (_type_): _description_
+    """
+    now: datetime = datetime.now()
+    now_str: str = now.strftime(DATE_FORMAT)
+    for event_type in event_types_to_fetch:
+        last_fetch_time = f'{EVENT_TYPES[event_type].type}_last_fetch_time'
+        last_run[last_fetch_time] = now_str
 
 
 ''' MAIN FUNCTION '''
@@ -435,6 +452,9 @@ def main():  # pragma: no cover
 
         elif command in ('fetch-events', 'armis-get-events'):
             should_return_results = False
+
+            if not last_run:  # only happens on initial fetch
+                init_last_run(last_run, event_types_to_fetch)
 
             if command == 'armis-get-events':
                 last_run = {}

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector.py
@@ -381,7 +381,6 @@ def handle_fetched_events(events: list[dict[str, Any]], next_run: dict[str, str 
         demisto.setLastRun(next_run)
         demisto.debug(f'debug-log: {len(events)} events were sent to XSIAM.')
     else:
-        demisto.setLastRun(next_run)
         demisto.debug('debug-log: No new events fetched.')
 
     demisto.debug(f'debug-log: {next_run=}')
@@ -453,30 +452,32 @@ def main():  # pragma: no cover
         elif command in ('fetch-events', 'armis-get-events'):
             should_return_results = False
 
-            if not last_run:  # in initial fetch - update last fetch time values to current time
+            if not last_run:  # initial fetch - update last fetch time values to current time
                 set_last_run_with_current_time(last_run, event_types_to_fetch)
+                demisto.setLastRun(last_run)
 
-            if command == 'armis-get-events':
-                last_run = {}
-                should_return_results = True
+            else:
+                if command == 'armis-get-events':
+                    last_run = {}
+                    should_return_results = True
 
-            should_push_events = (command == 'fetch-events' or should_push_events)
+                should_push_events = (command == 'fetch-events' or should_push_events)
 
-            events, next_run = fetch_events(
-                client=client,
-                max_fetch=max_fetch,
-                last_run=last_run,
-                fetch_start_time=fetch_start_time,
-                event_types_to_fetch=event_types_to_fetch,
-            )
+                events, next_run = fetch_events(
+                    client=client,
+                    max_fetch=max_fetch,
+                    last_run=last_run,
+                    fetch_start_time=fetch_start_time,
+                    event_types_to_fetch=event_types_to_fetch,
+                )
 
-            demisto.debug(f'debug-log: {len(events)} events fetched from armis api')
+                demisto.debug(f'debug-log: {len(events)} events fetched from armis api')
 
-            if should_push_events:
-                handle_fetched_events(events, next_run)
+                if should_push_events:
+                    handle_fetched_events(events, next_run)
 
-            if should_return_results:
-                return_results(events_to_command_results(events))
+                if should_return_results:
+                    return_results(events_to_command_results(events))
 
         else:
             raise NotImplementedError(f'Command {command} is not implemented')

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
@@ -1,4 +1,4 @@
-from ArmisEventCollector import Client, datetime, DemistoException, arg_to_datetime, EVENT_TYPE, EVENT_TYPES
+from ArmisEventCollector import Client, datetime, DemistoException, arg_to_datetime, EVENT_TYPE, EVENT_TYPES, Any
 import pytest
 from freezegun import freeze_time
 
@@ -311,6 +311,26 @@ class TestHelperFunction:
             raw_response=response_with_two_events,
             readable_output=tableToMarkdown(name=f'{VENDOR} {PRODUCT} events', t=response_with_two_events, removeNull=True))
         assert events_to_command_results(response_with_two_events).readable_output == expected_result.readable_output
+
+    @freeze_time("2023-01-01 01:00:00")
+    def test_set_last_run_with_current_time_initial(self, mocker):
+        """
+        Given:
+            - A valid list of fetched events.
+            - An empty last_run dictionary.
+        When:
+            - Initial fetch is running.
+        Then:
+            - Set the last_run dictionary with the current time for each event type key.
+        """
+        from ArmisEventCollector import set_last_run_with_current_time
+
+        last_run: dict[Any, Any] = {}
+        event_types: list[str] = ['Alerts', 'Threat activities']
+
+        set_last_run_with_current_time(last_run, event_types)
+
+        assert last_run['alerts_last_fetch_time'] == last_run['threat_activities_last_fetch_time'] == '2023-01-01T01:00:00'
 
 
 class TestFetchFlow:

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
@@ -398,18 +398,8 @@ class TestFetchFlow:
             'time': '2023-01-01T01:00:30.123456+00:00'
         }]
 
-    case_initial_fetch = (  # type: ignore
-        1000,
-        {},
-        fetch_start_time,
-        ['Events'],
-        events_with_different_time_1,
-        events_with_different_time_1,
-        {'events_last_fetch_ids': ['3'],
-            'events_last_fetch_time': '2023-01-01T01:00:30.123456+00:00', 'access_token': 'test_access_token'}
-    )
-
     case_first_fetch = (  # type: ignore
+        # this case test the actual first fetch that runs after the initial fetch (that only sets the last run)
         1000,
         {'alerts_last_fetch_time': '2023-01-01T01:00:00'},
         fetch_start_time,

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
@@ -465,7 +465,7 @@ class TestFetchFlow:
     )
 
     @ pytest.mark.parametrize('max_fetch, last_run, fetch_start_time, event_types_to_fetch, response, events, next_run', [
-        case_initial_fetch, case_first_fetch, case_second_fetch, case_second_fetch_with_duplicates,
+        case_first_fetch, case_second_fetch, case_second_fetch_with_duplicates,
         case_no_new_event_from_fetch, case_all_events_from_fetch_have_the_same_time
     ])
     def test_fetch_flow_cases(self, mocker, dummy_client, max_fetch, last_run,

--- a/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
+++ b/Packs/Armis/Integrations/ArmisEventCollector/ArmisEventCollector_test.py
@@ -398,7 +398,7 @@ class TestFetchFlow:
             'time': '2023-01-01T01:00:30.123456+00:00'
         }]
 
-    case_first_fetch = (  # type: ignore
+    case_initial_fetch = (  # type: ignore
         1000,
         {},
         fetch_start_time,
@@ -408,6 +408,18 @@ class TestFetchFlow:
         {'events_last_fetch_ids': ['3'],
             'events_last_fetch_time': '2023-01-01T01:00:30.123456+00:00', 'access_token': 'test_access_token'}
     )
+
+    case_first_fetch = (  # type: ignore
+        1000,
+        {'alerts_last_fetch_time': '2023-01-01T01:00:00'},
+        fetch_start_time,
+        ['Events'],
+        events_with_different_time_1,
+        events_with_different_time_1,
+        {'events_last_fetch_ids': ['3'],
+            'events_last_fetch_time': '2023-01-01T01:00:30.123456+00:00', 'access_token': 'test_access_token'}
+    )
+
     case_second_fetch = (  # type: ignore
         1000,
         {'events_last_fetch_ids': ['1', '2', '3'],
@@ -463,7 +475,7 @@ class TestFetchFlow:
     )
 
     @ pytest.mark.parametrize('max_fetch, last_run, fetch_start_time, event_types_to_fetch, response, events, next_run', [
-        case_first_fetch, case_second_fetch, case_second_fetch_with_duplicates,
+        case_initial_fetch, case_first_fetch, case_second_fetch, case_second_fetch_with_duplicates,
         case_no_new_event_from_fetch, case_all_events_from_fetch_have_the_same_time
     ])
     def test_fetch_flow_cases(self, mocker, dummy_client, max_fetch, last_run,

--- a/Packs/Armis/ReleaseNotes/1_1_3.md
+++ b/Packs/Armis/ReleaseNotes/1_1_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Armis Event Collector
+
+- Updated the initial fetch handling to ensure that the fetch start time remains constant until new events are fetched for each event type.

--- a/Packs/Armis/pack_metadata.json
+++ b/Packs/Armis/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Armis",
     "description": "Agentless and passive security platform that sees, identifies, and classifies every device, tracks behavior, identifies threats, and takes action automatically to protect critical information and systems",
     "support": "partner",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Armis Corporation",
     "url": "https://support.armis.com/",
     "email": "support@armis.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [XSUP-28767](https://jira-hq.paloaltonetworks.local/browse/XSUP-28767)

## Description
This PR sets the last run for the initial fetch, so that the original fetch time would remain constant until events are fetched (and not update the initial fetch time every fetch cycle).

Changes made:
- [x] Set last run to current time on initial fetch events run.
- [x] Add/Update UTs 

## Must have
- [x] Tests
- [x] Documentation 
