### PR TITLE
[SetGridField] Fixed checking if customFields were set

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_32.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_32.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### SetGridField
+
+- Fixed an issue where the automation failed when setting empty grid fields on XSIAM.

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.py
@@ -367,8 +367,13 @@ def main():  # pragma: no cover
                 grid_id: table,
             },
         })
-        custom_fields = demisto.incident().get("CustomFields", {})
-        if grid_id not in custom_fields:
+        # we want to check if the incident was succefully updated
+        # we execute command and not using `demisto.incident()` because we want to get the updated incident and context
+        res = demisto.executeCommand("getIncidents", {"id": demisto.incident().get("id")})
+        data = res[0]["Contents"]["data"]
+        custom_fields = data[0].get("CustomFields")
+
+        if table and grid_id not in custom_fields:
             raise ValueError(f"The following grid id was not found: {grid_id}. Please make sure you entered the correct "
                              f"incident type with the \"Machine name\" as it appears in the incident field editor in "
                              f"Settings->Advanced ->Fields (Incident). Also make sure that this value appears in the "

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.31",
+    "currentVersion": "1.12.32",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
In the previous version, we check if the custom fields were set in the incident with calling `demisto.incident()` after changing the incident context and to see if it's changed. However, it returns the incident in the beginning of the command call.
Instead, now we run "getIncents" script which returns the up-to-date data of the incident, after it is set

fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8564