### PR TITLE
[QRadar] fix task_id argument in YAML

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -1108,8 +1108,6 @@ script:
     - name: fields
       description: 'Comma-separated list of fields to retrieve in the response. Fields that are not explicitly named are excluded. E.g., "id,name". Specify subfields in brackets and multiple fields in the same object separated by commas. For a full list of available fields, see:  https://ibmsecuritydocs.github.io/qradar_api_14.0/14.0--config-domain_management-domains-GET.html.'
       isArray: true
-    - name: task_id
-      description: The ID of the task that is created to add or update the element in the reference set. The task ID can be used to poll the status of the task by using the 'qradar-tasks-get' command.
   - name: qradar-indicators-upload
     description: Uploads indicators to QRadar.
     outputs:
@@ -1157,6 +1155,8 @@ script:
     - name: fields
       description: 'Comma-separated list of fields to retrieve in the response. Fields that are not explicitly named are excluded. E.g., "name,timeout_type". Specify subfields in brackets and multiple fields in the same object separated by commas. For a full list of available fields, see: https://ibmsecuritydocs.github.io/qradar_api_14.0/14.0--reference_data-maps-bulk_load-namespace-name-domain_id-POST.html.'
       isArray: true
+    - name: task_id
+      description: The ID of the task that is created to add or update the element in the reference set. The task ID can be used to poll the status of the task by using the 'qradar-tasks-get' command.
     polling: true
   - name: qradar-geolocations-for-ip
     description: Retrieves the MaxMind GeoIP data for the specified IP address.

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -2268,6 +2268,9 @@ script:
     - defaultValue: '0'
       description: The page from which to get the indicators.
       name: page
+    - name: task_id
+      description: The ID of the task that is created to add or update the element in the reference set. The task ID can be used to poll the status of the task by using the 'qradar-tasks-get' command.
+
     description: Uploads indicators from Demisto to QRadar.
     hidden: true
     name: qradar-upload-indicators
@@ -2281,6 +2284,7 @@ script:
       name: fields
     - description: 'Range of results to return. e.g.: 0-20.'
       name: range
+      
     description: Get Source IPs.
     name: qradar-ips-source-get
     outputs:

--- a/Packs/QRadar/ReleaseNotes/2_4_37.md
+++ b/Packs/QRadar/ReleaseNotes/2_4_37.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### IBM QRadar v3
+
+- Fixed an issue where polling did not work as expected ***qradar-indicators-upload***.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.4.36",
+    "currentVersion": "2.4.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
The `task_id` argument is a polling argument in `qradar-indicators-upload` and  in `qradar-reference-set-value-upsert`. It was misplaces in the YAML. Moved this to the correct place

fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-28968?filter=-1