### PR TITLE
[pre-commit-config_template] Fix validate

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -63,15 +63,15 @@ repos:
   - id: update-additional-dependencies
     args: [--pre_commit_config, .pre-commit-config_template.yaml]
 
-          # enable with --test
-  - id: run-unit-tests
-
   - id: format
           # update docker image to the latest version, assume no
     args: ["-ud", "-n", "--no-validate"]
 
   - id: validate
     args: ["--skip-pack-dependencies"]
+
+          # enable with --test
+  - id: run-unit-tests
 
   - id: secrets
     args: ["--ignore-entropy"]


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Because `run-unit-tests` hook sometimes generates temporary files, and currently they are not deleted, then `validate` hook fails because it does not recognize these files, so `validate` needs to run before `run-unit-tests`.
**This will only take effect after https://github.com/demisto/demisto-sdk/pull/3719 is merged.**