### PR TITLE
[DevSecOps] MinIO Bug fix and add new commands

### DIFF
--- a/Packs/DevSecOps/Integrations/MinIO/MinIO.yml
+++ b/Packs/DevSecOps/Integrations/MinIO/MinIO.yml
@@ -24,42 +24,42 @@ configuration:
   name: ssl
   type: 8
   required: false
-description: An Integration with MinIO Object Storage
+description: An Integration with MinIO Object Storage.
 display: MinIO
 name: MinIO
 script:
   commands:
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: name
       required: true
     description: Create a new bucket.
     name: minio-make-bucket
     outputs:
     - contextPath: MinIO.Buckets.bucket
-      description: MinIO Bucket Name
+      description: MinIO Bucket Name.
       type: Unknown
     - contextPath: MinIO.Buckets.status
-      description: MinIO Bucket Status
+      description: MinIO Bucket Status.
       type: Unknown
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: name
       required: true
     description: Remove an existing bucket.
     name: minio-remove-bucket
     outputs:
     - contextPath: MinIO.Buckets.bucket
-      description: MinIO Bucket Name
+      description: MinIO Bucket Name.
       type: Unknown
     - contextPath: MinIO.Buckets.status
-      description: MinIO Bucket Status
+      description: MinIO Bucket Status.
       type: Unknown
-  - description: List All MinIO Buckets
+  - description: List All MinIO Buckets.
     name: minio-list-buckets
     outputs:
     - contextPath: MinIO.Buckets
-      description: MinIO Buckets
+      description: MinIO Buckets.
       type: Unknown
   - arguments:
     - description: Name of the bucket.
@@ -79,21 +79,19 @@ script:
     name: minio-list-objects
     outputs:
     - contextPath: MinIO.Objects
-      description: MinIO Objects
+      description: MinIO Objects.
       type: Unknown
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: bucket_name
       required: true
-    - description: Object Name
+    - description: Object Name.
       name: name
       required: true
     - description: Start byte position of object data.
       name: offset
     - description: Number of bytes of object data from offset.
       name: length
-      predefined:
-      - ''
     - description: Any additional headers to be added with GET request.
       name: request_headers
     - description: Extra query parameters for advanced usage.
@@ -101,10 +99,10 @@ script:
     description: Gets data from offset to length of an object.
     name: minio-get-object
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: bucket_name
       required: true
-    - description: Object Name
+    - description: Object Name.
       name: name
       required: true
     - description: Extra query parameters for advanced usage.
@@ -112,55 +110,113 @@ script:
     description: Get object information and metadata of an object.
     name: minio-stat-object
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: bucket_name
       required: true
-    - description: Object Name
+    - description: Object Name.
       name: name
       required: true
     description: Remove an object.
     name: minio-remove-object
     outputs:
     - contextPath: MinIO.Objects.name
-      description: Object Name
+      description: Object Name.
       type: Unknown
     - contextPath: MinIO.Objects.status
-      description: Object Status
+      description: Object Status.
       type: Unknown
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: bucket_name
-      predefined:
-      - ''
       required: true
-    - description: File Entry ID
+    - description: File Entry ID.
       name: entry_id
       required: true
-    - description: File Type
+    - description: File Type.
       name: content_type
     - description: Any additional metadata to be uploaded along with your PUT request.
       name: metadata
     description: Uploads data from a file to an object in a bucket.
     name: minio-fput-object
   - arguments:
-    - description: Bucket Name
+    - description: Bucket Name.
       name: bucket_name
-      predefined:
-      - ''
       required: true
-    - description: Contains object data
+    - description: Contains object data.
       name: data
       required: true
-    - description: Object name in the bucket
+    - description: Object name in the bucket.
       name: name
       required: true
-    - description: File Type
+    - description: File Type.
       name: content_type
     - description: Any additional metadata to be uploaded along with your PUT request.
       name: metadata
     description: Uploads data from a stream to an object in a bucket.
     name: minio-put-object
-  dockerimage: demisto/minio:1.0.0.19143
+  - name: minio-copy-object
+    arguments:
+    - name: bucket_name_src
+      description: Bucket Name Source.
+      required: true
+    - name: name_src
+      description: Object Name Source.
+      required: true
+    - name: bucket_name_dst
+      description: Bucket Name Destination.
+      required: true
+    - name: name_dst
+      description: Object Name Destination.
+      required: true
+    - name: metadata
+      description: Any additional metadata to be copied.
+    outputs:
+    - contextPath: MinIO.Objects.bucket
+      description: MinIO Destination Bucket Name.
+    - contextPath: MinIO.Objects.object
+      description: MinIO Destination Object Name.
+    - contextPath: MinIO.Objects.status
+      description: MinIO Object status.
+    description: Create an object by server-side copying data from another object.
+  - name: minio-get-tags
+    arguments:
+    - name: bucket_name
+      description: Bucket Name.
+      required: true
+    - name: name
+      description: Object Name.
+      required: true
+    outputs:
+    - contextPath: MinIO.Objects.bucket
+      description: MinIO Bucket Name.
+    - contextPath: MinIO.Objects.object
+      description: MinIO Object Name.
+    - contextPath: MinIO.Objects.tags
+      description: MinIO Object Tags.
+    description: Get tags configuration of an object.
+  - name: minio-set-tag
+    arguments:
+    - name: bucket_name
+      description: Bucket Name.
+      required: true
+    - name: name
+      description: Object Name.
+      required: true
+    - name: tag_key
+      description: Key for the tag.
+      required: true
+    - name: tag_value
+      description: Value for the tag.
+      required: true
+    outputs:
+    - contextPath: MinIO.Objects.bucket
+      description: MinIO Bucket Name.
+    - contextPath: MinIO.Objects.object
+      description: MinIO Object Name.
+    - contextPath: MinIO.Objects.tags
+      description: MinIO Object Tags.
+    description: Set tags configuration to an object.
+  dockerimage: demisto/py3-tools:1.0.0.77497
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/DevSecOps/Integrations/MinIO/README.md
+++ b/Packs/DevSecOps/Integrations/MinIO/README.md
@@ -473,3 +473,138 @@ There is no context output for this command.
 >|---|---|---|
 >| test10 | test.txt | uploaded |
 
+
+### minio-get-tags
+***
+Get tags configuration of an object.
+
+
+#### Base Command
+
+`minio-get-tags`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| bucket_name | Bucket Name. | Required | 
+| name | Object name in the bucket. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MinIO.Objects.bucket | Unknown | Bucket Name. | 
+| MinIO.Objects.object | Unknown | Object Name. | 
+| MinIO.Objects.tags | Unknown | Object Tags. | 
+
+#### Command Example
+```!minio-get-tags bucket_name="test11" name="test.txt"```
+
+#### Context Example
+```json
+{
+    "MinIO": {
+        "Objects": {
+            "bucket": "test11",
+            "object": "test.txt",
+            "status": "completed",
+            "tags": {
+                "test": "test"
+            }
+        }
+    }
+}
+```
+
+### minio-set-tag
+***
+Set tags configuration to an object.
+
+
+#### Base Command
+
+`minio-set-tag`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| bucket_name | Bucket Name. | Required | 
+| name | Object name in the bucket. | Required | 
+| tag_key | Key for the tag to add on the object. | Required | 
+| tag_value | Value for the tag to add on the object. | Required | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MinIO.Objects.bucket | Unknown | Bucket Name. | 
+| MinIO.Objects.object | Unknown | Object Name. | 
+| MinIO.Objects.tags | Unknown | Object Tags. | 
+
+#### Command Example
+```!minio-set-tag bucket_name="test11" name="test.txt" tag_key="status" tag_value="in_progress"```
+
+#### Context Example
+```json
+{
+    "MinIO": {
+        "Objects": {
+            "bucket": "test11",
+            "object": "test.txt",
+            "status": "completed",
+            "tags": {
+                "test": "test",
+                "status": "in_progress"
+            }
+        }
+    }
+}
+```
+
+### minio-copy-object
+***
+Create an object by server-side copying data from another object.
+
+
+#### Base Command
+
+`minio-copy-object`
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| bucket_name_src | Bucket Name to copy object from. | Required | 
+| name_src | Object name to copy. | Required | 
+| bucket_name_dst | Bucket Name to copy object to. | Required | 
+| name_dst | Object name copied. | Required | 
+| metadata | Any user-defined metadata to be copied along with destination object. | Optional | 
+
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MinIO.Objects.bucket | Unknown | Bucket Name. | 
+| MinIO.Objects.object | Unknown | Object Name | 
+| MinIO.Objects.status | Unknown | Object Status | 
+
+
+#### Command Example
+```!minio-copy-object bucket_name_src="test12" name_src="test_source.txt" bucket_name_dst="test12" name_dst="test_destination.txt"```
+
+```!minio-copy-object bucket_name_src="test12" name_src="test_source.txt" bucket_name_dst="test12" name_dst="myFolder/test_destination.txt"``` (It will create the folder *myFolder*)
+
+#### Context Example
+```json
+{
+    "MinIO": {
+        "Objects": {
+            "bucket": "test12",
+            "object": "test_destination.txt",
+            "status": "copied"
+        }
+    }
+}
+```

--- a/Packs/DevSecOps/Integrations/MinIO/command_examples
+++ b/Packs/DevSecOps/Integrations/MinIO/command_examples
@@ -7,3 +7,6 @@
 !minio-put-object bucket_name="test10" data="'test100'" name="test.txt"
 !minio-stat-object bucket_name="test10" name="test.txt"
 !minio-remove-object bucket_name="test10" name="test.txt"
+!minio-copy-object bucket_name_src="test12" name_src="test_source.txt" bucket_name_dst="test12" name_dst="test_destination.txt"
+!minio-set-tag bucket_name="test11" name="test.txt" tag_key="status" tag_value="in_progress"
+!minio-get-tags bucket_name="test11" name="test.txt"

--- a/Packs/DevSecOps/ReleaseNotes/1_1_7.md
+++ b/Packs/DevSecOps/ReleaseNotes/1_1_7.md
@@ -1,0 +1,7 @@
+#### Integrations
+##### MinIO
+- Fix an issue where the parameter `bucket_name` had an predefined value to empty string which show a dropdown menu for the `minio-put-object` and `minio-fput-object` commands. It fix the same issue on the parameter `length` for the `minio-get-object` command
+- New commands added: \
+*minio-copy-object*: Create an object by server-side copying data from another object. \
+*minio-set-tag*: Set tags configuration to an object. \
+*minio-get-tags*: Get tags configuration of an object.

--- a/Packs/DevSecOps/pack_metadata.json
+++ b/Packs/DevSecOps/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DevSecOps",
     "description": "DevSecOps CI/CD Orchestration Integration Pack.",
     "support": "community",
-    "currentVersion": "1.1.6",
+    "currentVersion": "1.1.7",
     "author": "Ayman Mahmoud",
     "githubUser": [
         "ayman-m"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue


## Description

This PR adds 3 commands to the integration `MinIO`:
- minio-copy-object: Create an object by server-side copying data from another object.
- minio-set-tag: Set tags configuration to an object.
- minio-get-tags: Get tags configuration of an object.

It also fix an issue where the parameter `bucket_name` had an predefined value to empty string which show a dropdown menu for the `minio-put-object` and `minio-fput-object` commands. It fix the same issue on the parameter `length` for the `minio-get-object` command.


Here is the visual picture:
![image](https://github.com/demisto/content/assets/143391737/d792fbfd-1170-45b1-85a2-31500138ffd4)
Here is the code: 
![image](https://github.com/demisto/content/assets/143391737/887ebc57-e451-47ab-922e-4aae4c3ce499)

## Must have
- [ ] Tests
- [ ] Documentation 
