### PR TITLE
sync from marketplace-saas-dist instead of marketplace-dist to qa-dev bucket

### DIFF
--- a/.gitlab/ci/.gitlab-ci.bucket-upload.yml
+++ b/.gitlab/ci/.gitlab-ci.bucket-upload.yml
@@ -718,7 +718,7 @@ sync-buckets-between-projects:
         gcloud auth activate-service-account --key-file="$GCS_XSOAR_CONTENT_DEV_KEY"
 
         echo "Syncing gs://marketplace-xsoar-dev"
-        gsutil -m rsync -r gs://marketplace-dist gs://marketplace-xsoar-dev
+        gsutil -m rsync -r gs://marketplace-saas-dist gs://marketplace-xsoar-dev
         echo "Syncing gs://marketplace-xsiam-dev"
         gsutil -m rsync -r gs://marketplace-v2-dist gs://marketplace-xsiam-dev
         echo "Syncing gs://marketplace-xpanse-dev"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:[ link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6807)

## Description
Sync at first stage marketplace-saas-dist instead of marketplace-dist to marketplace-xsoar-dev

## Must have
- [ ] Tests
- [ ] Documentation 
