### PR TITLE
Update elastic search & cyjax docker images

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -379,7 +379,7 @@ script:
       description: The result of the index operation.
       type: string
     description: Indexes a document into an Elasticsearch index.
-  dockerimage: demisto/py3-tools:1.0.0.76737
+  dockerimage: demisto/elasticsearch:1.0.0.77444
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/Elasticsearch/ReleaseNotes/1_3_18.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_3_18.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Elasticsearch v2
+
+- Updated the Docker image to: *demisto/elasticsearch:1.0.0.77444*.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.3.17",
+    "currentVersion": "1.3.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedCyjax/Integrations/FeedCyjax/FeedCyjax.yml
+++ b/Packs/FeedCyjax/Integrations/FeedCyjax/FeedCyjax.yml
@@ -145,7 +145,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/py3-tools:1.0.0.77054
+  dockerimage: demisto/cyjax:1.0.0.77444
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/FeedCyjax/ReleaseNotes/1_0_24.md
+++ b/Packs/FeedCyjax/ReleaseNotes/1_0_24.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cyjax Feed
+
+- Updated the Docker image to: *demisto/cyjax:1.0.0.77444*.

--- a/Packs/FeedCyjax/pack_metadata.json
+++ b/Packs/FeedCyjax/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cyjax Feed",
     "description": "This pack is used to pull indicators of compromise from the Cyjax Threat Intelligence Platform.",
     "support": "partner",
-    "currentVersion": "1.0.23",
+    "currentVersion": "1.0.24",
     "author": "Cyjax",
     "url": "https://cyjax.com",
     "email": "devs@cyjax.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Update cyjax and elastic search images as the python modules that they use cannot support urlib3 > 2
see docker PR: https://github.com/demisto/dockerfiles/pull/20988
