### PR TITLE
[Autofocus Query Samples, Sessions and Tags Test Playbook] Adding timeout

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -760,7 +760,7 @@
             "integrations": "AutoFocus V2",
             "playbookID": "Autofocus Query Samples, Sessions and Tags Test Playbook",
             "fromversion": "4.5.0",
-            "timeout": 1500
+            "timeout": 1800
         },
         {
             "integrations": "HelloWorld",


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-8614)

## Description
Added timeout = 1800 to "Autofocus Query Samples, Sessions and Tags Test Playbook"
