### PR TITLE
Add list_target to f5-silverline-ip-object-delete

### DIFF
--- a/Packs/F5Silverline/Integrations/F5Silverline/F5Silverline.yml
+++ b/Packs/F5Silverline/Integrations/F5Silverline/F5Silverline.yml
@@ -98,7 +98,7 @@ script:
       - denylist
       required: true
     - auto: PREDEFINED
-      description: 'This argument can be supplied to target either the proxy or routed denylist. If list_target is not specifiedm it will assume both proxy and routed are requested (i.e., proxy-routed). Possible values are: "proxy", "routed", or "proxy-routed". This argument limits the denylist type but is ignored for allowlist.'
+      description: 'This argument can be supplied to target either the proxy or routed denylist. If list_target is not specified it will assume both proxy and routed are requested (i.e., proxy-routed). Possible values are: "proxy", "routed", or "proxy-routed". This argument limits the denylist type but is ignored for allowlist.'
       name: list_target
       predefined:
       - proxy
@@ -129,6 +129,13 @@ script:
       name: object_id
     - description: The IP address of an existing threatening IP address object that should be deleted.
       name: object_ip
+    - auto: PREDEFINED
+      description: 'This argument can be supplied to target either the proxy or routed denylist (or both). If list_target is not specified it will assume proxy is requested. Possible values are: "proxy", "routed", or "proxy-routed". This argument limits the denylist type but is ignored for allowlist.'
+      name: list_target
+      predefined:
+      - proxy
+      - routed
+      - proxy-routed
     description: Delete an existing particular threatening IP address object by its object ID or by its IP address. If both id and ip are given, delete operation will be done by the given object_id.
     name: f5-silverline-ip-object-delete
   dockerimage: demisto/python3:3.10.12.63474


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-29244](https://jira-hq.paloaltonetworks.local/browse/XSUP-29244)

## Description
Add `list_target` arguemnt to `f5-silverline-ip-object-delete` command for more versatile IP deletion.

## Must have
- [ ] Tests
- [ ] Documentation 
