### PR TITLE
ThreatZone: fix README

### DIFF
--- a/Packs/ThreatZone/README.md
+++ b/Packs/ThreatZone/README.md
@@ -1,4 +1,4 @@
-# ThreatZone Cortex XSOAR Integration Pack
+# ThreatZone Cortex XSOAR Integration Pack
 Threat.Zone enrichments are adaptable and can seamlessly integrate into various playbooks, such as sandbox, static-scan, and CDR playbooks, along with incidents and related files marked as indicators for threat intelligence.
 
 ## Supported commands


### PR DESCRIPTION


## Description
wrong character in the README cause it to not rendered well
<img width="424" alt="image" src="https://github.com/demisto/content/assets/79846863/93121bca-254c-46af-95d4-b24d45a3202e">

