### PR TITLE
[MicrosoftTeamsAsk] Add support for open-answer forms

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -2,6 +2,7 @@ import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 
 ''' IMPORTS '''
+from enum import Enum
 import re
 import time
 from distutils.util import strtobool
@@ -21,6 +22,12 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 # Disable insecure warnings
 requests.packages.urllib3.disable_warnings()  # type: ignore
+
+
+class FormType(Enum):  # Used for 'send-message', and by the MicrosoftTeamsAsk script
+    PREDEFINED_OPTIONS = 'predefined-options'
+    OPEN_ANSWER = 'open-answer'
+
 
 ''' GLOBAL VARIABLES'''
 EXTERNAL_FORM_URL_DEFAULT_HEADER = 'Microsoft Teams Form'
@@ -360,7 +367,7 @@ def get_team_member_id(requested_team_member: str, integration_context: dict) ->
     raise ValueError(f'Team member {requested_team_member} was not found')
 
 
-def create_adaptive_card(body: list, actions: list = None) -> dict:
+def create_adaptive_card(body: list, actions: list | None = None) -> dict:
     """
     Creates Microsoft Teams adaptive card object given body and actions
     :param body: Adaptive card data
@@ -485,27 +492,73 @@ def process_ask_user(message: str) -> dict:
     message_object: dict = json.loads(message)
     text: str = message_object.get('message_text', '')
     entitlement: str = message_object.get('entitlement', '')
+    form_type: FormType = FormType(message_object.get('form_type', FormType.PREDEFINED_OPTIONS.value))
     options: list = message_object.get('options', [])
     investigation_id: str = message_object.get('investigation_id', '')
     task_id: str = message_object.get('task_id', '')
-    body = [
-        {
+
+    body: list[dict] = []
+    actions: list[dict] = []
+
+    if form_type == FormType.PREDEFINED_OPTIONS:
+        body.append({
             'type': 'TextBlock',
-            'text': text
-        }
-    ]
-    actions = []
-    for option in options:
+            'text': text,
+        })
+
+        for option in options:
+            actions.append({
+                'type': 'Action.Submit',
+                'title': option,
+                'data': {
+                    'response': option,
+                    'entitlement': entitlement,
+                    'investigation_id': investigation_id,
+                    'task_id': task_id
+                }
+            })
+
+    elif form_type == FormType.OPEN_ANSWER:
+        body.extend([
+            {
+                'type': 'TextBlock',
+                'text': 'Form',
+                'id': 'Title',
+                'spacing': 'Medium',
+                'horizontalAlignment': 'Center',
+                'size': 'Medium',
+                'weight': 'Bolder',
+                'color': 'Accent'
+            },
+            {
+                'type': 'Container',
+                'items': [
+                    {
+                        'type': 'TextBlock',
+                        'text': text,
+                        'wrap': True,
+                        'spacing': 'Medium',
+                    },
+                    {
+                        'type': 'Input.Text',
+                        'placeholder': 'Enter an answer',
+                        'id': 'response',
+                        'isMultiline': True,
+                    }
+                ]
+            },
+        ])
+
         actions.append({
             'type': 'Action.Submit',
-            'title': option,
+            'title': 'Submit',
             'data': {
-                'response': option,
                 'entitlement': entitlement,
                 'investigation_id': investigation_id,
                 'task_id': task_id
             }
         })
+
     return create_adaptive_card(body, actions)
 
 
@@ -1994,6 +2047,7 @@ def send_message():
                 'type': 'message',
                 'attachments': [adaptive_card]
             }
+            demisto.debug(f"The following Adaptive Card will be used:\n{json.dumps(adaptive_card)}")
         else:
             # Sending regular message
             formatted_message: str = urlify_hyperlinks(message, external_form_url_header)
@@ -2714,10 +2768,11 @@ def main():   # pragma: no cover
     }
 
     ''' EXECUTION '''
+    command: str = demisto.command()
+
     try:
         support_multithreading()
         handle_proxy()
-        command: str = demisto.command()
         LOG(f'Command being called is {command}')
         if command in commands:
             commands[command]()
@@ -2731,5 +2786,5 @@ def main():   # pragma: no cover
         return_error(f'Failed to execute {command} command.\nError:\n{str(e)}')
 
 
-if __name__ == 'builtins':
+if __name__ in ('__main__', '__builtin__', 'builtins'):
     main()

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -711,7 +711,7 @@ script:
   - description: Generate the login url used for Authorization code flow.
     name: microsoft-teams-generate-login-url
     arguments: []
-  dockerimage: demisto/teams:1.0.0.73705
+  dockerimage: demisto/teams:1.0.0.79668
   longRunning: true
   longRunningPort: true
   script: ''

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_4_36.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_4_36.md
@@ -1,0 +1,14 @@
+
+#### Integrations
+
+##### Microsoft Teams
+
+- Backend changes to the ***send-message*** command, in order to support the new open-answer form format.
+- Updated the Docker image to: *demisto/teams:1.0.0.79668*.
+
+#### Scripts
+
+##### MicrosoftTeamsAsk
+
+- Added support for open-answer forms, where the user can reply with a free text answer, which can be selected using the new **form_type** argument.
+- Updated the Docker image to: *demisto/python3:3.10.13.78960*.

--- a/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.py
+++ b/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.py
@@ -1,6 +1,13 @@
+from enum import Enum
+
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
+
+
+class FormType(Enum):
+    PREDEFINED_OPTIONS = 'predefined-options'
+    OPEN_ANSWER = 'open-answer'
 
 
 def main():
@@ -27,19 +34,24 @@ def main():
     task_id: str = script_arguments.get('task_id', '')
     message_text: str = script_arguments.get('message', '')
 
+    form_type = FormType(script_arguments.get('form_type', FormType.PREDEFINED_OPTIONS.value))
     first_option: str = script_arguments.get('option1', '')
     second_option: str = script_arguments.get('option2', '')
     options: list = [first_option, second_option]
-    additional_options: list = argToList(script_arguments.get('additional_options'))
-    options.extend(additional_options)
 
     message: dict = {
         'message_text': message_text,
         'options': options,
         'entitlement': entitlement,
         'investigation_id': investigation_id,
-        'task_id': task_id
+        'task_id': task_id,
+        'form_type': form_type.value,
     }
+
+    if form_type == FormType.PREDEFINED_OPTIONS:
+        additional_options: list = argToList(script_arguments.get('additional_options'))
+        options.extend(additional_options)
+        message['options'] = options
 
     command_arguments: dict = {
         'message': json.dumps(message),
@@ -53,6 +65,7 @@ def main():
     elif team_member:
         command_arguments['team_member'] = team_member
 
+    demisto.debug(f"Calling command 'send-notification' with arguments:\n{command_arguments}")
     demisto.results(demisto.executeCommand('send-notification', command_arguments))
 
 

--- a/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.yml
+++ b/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.yml
@@ -1,4 +1,13 @@
 args:
+- auto: PREDEFINED
+  default: true
+  required: true
+  defaultValue: predefined-options
+  description: The mirroring type. Can be "all", which mirrors everything, "chat", which mirrors only chats (not commands), or "none", which stops all mirroring.
+  name: form_type
+  predefined:
+    - predefined-options
+    - open-answer
 - description: Question (message) to send to the specified team member or channel.
   name: message
   required: true
@@ -9,12 +18,12 @@ args:
   - 'true'
   - 'false'
 - defaultValue: 'yes'
-  description: First reply option.
+  description: First reply option (used only for if the form type is "predefined-options").
   name: option1
 - defaultValue: 'no'
-  description: Second reply option.
+  description: Second reply option  (used only for if the form type is "predefined-options").
   name: option2
-- description: A CSV list of additional options (in case more than 2 options are required).
+- description: A CSV list of additional options (in case more than 2 options are required. Used only for if the form type is "predefined-options").
   name: additional_options
 - default: true
   description: Team member to which to send the question.

--- a/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.yml
+++ b/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/MicrosoftTeamsAsk.yml
@@ -1,13 +1,13 @@
 args:
-- auto: PREDEFINED
-  default: true
-  required: true
-  defaultValue: predefined-options
-  description: The mirroring type. Can be "all", which mirrors everything, "chat", which mirrors only chats (not commands), or "none", which stops all mirroring.
+- description: The mirroring type. Can be "all", which mirrors everything, "chat", which mirrors only chats (not commands), or "none", which stops all mirroring.
   name: form_type
+  required: true
+  auto: PREDEFINED
+  default: true
+  defaultValue: predefined-options
   predefined:
-    - predefined-options
-    - open-answer
+  - predefined-options
+  - open-answer
 - description: Question (message) to send to the specified team member or channel.
   name: message
   required: true
@@ -44,7 +44,7 @@ tags:
 - microsoftteams
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.10.12.63474
+dockerimage: demisto/python3:3.10.13.78960
 tests:
 - No test
 dependson:

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.4.35",
+    "currentVersion": "1.4.36",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-5633)

## Description
Add support for sending open-answer forms.

Example for `!MicrosoftTeamsAsk form_type="open-answer" message="Test Question?" team_member="X"`:

<img width="713" alt="Screenshot 2023-10-29 at 16 35 00" src="https://github.com/demisto/content/assets/8832013/64af0737-0ba1-4ad4-b568-f109c6f46746">

After hitting "Submit":
<img width="421" alt="Screenshot 2023-10-29 at 16 53 16" src="https://github.com/demisto/content/assets/8832013/bd4c3ea2-4be3-4002-8dac-b9e941e0b9a6">
