### PR TITLE
[CrowdStrikeFalcon] Update the last run object out of unflitered result

### DIFF
--- a/Packs/Base/ReleaseNotes/1_32_41.md
+++ b/Packs/Base/ReleaseNotes/1_32_41.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CommonServerPython
+
+- Lookback: Maintenance and stability enhancements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -10855,8 +10855,7 @@ def create_updated_last_run_object(last_run, incidents, fetch_limit, look_back, 
 
 
 def update_last_run_object(last_run, incidents, fetch_limit, start_fetch_time, end_fetch_time, look_back,
-                           created_time_field, id_field, date_format='%Y-%m-%dT%H:%M:%S', increase_last_run_time=False,
-                           incidents_before_filter=None, new_offset=None):
+                           created_time_field, id_field, date_format='%Y-%m-%dT%H:%M:%S', increase_last_run_time=False, new_offset=None):
     """
     Updates the LastRun object with the next fetch time and limit and with the new fetched incident IDs.
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -10773,7 +10773,8 @@ def get_found_incident_ids(last_run, incidents, look_back, id_field, remove_inci
     current_time = int(time.time())
 
     for incident in incidents:
-        found_incidents[incident[id_field]] = current_time
+        if incident[id_field] not in found_incidents:
+            found_incidents[incident[id_field]] = current_time
     if remove_incident_ids:
         found_incidents = remove_old_incidents_ids(found_incidents, current_time, look_back)
 
@@ -10854,7 +10855,8 @@ def create_updated_last_run_object(last_run, incidents, fetch_limit, look_back, 
 
 
 def update_last_run_object(last_run, incidents, fetch_limit, start_fetch_time, end_fetch_time, look_back,
-                           created_time_field, id_field, date_format='%Y-%m-%dT%H:%M:%S', increase_last_run_time=False, new_offset=None):
+                           created_time_field, id_field, date_format='%Y-%m-%dT%H:%M:%S', increase_last_run_time=False,
+                           incidents_before_filter=None, new_offset=None):
     """
     Updates the LastRun object with the next fetch time and limit and with the new fetched incident IDs.
 

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.32.40",
+    "currentVersion": "1.32.41",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -2553,7 +2553,7 @@ def fetch_incidents():
         if detections_offset:
             demisto.debug(f"CrowdStrikeFalconMsg: The new detections offset is {detections_offset}")
         raw_res = get_detections_entities(detections_ids)
-
+        detections_before_filtering = []
         if raw_res is not None and "resources" in raw_res:
             full_detections = demisto.get(raw_res, "resources")
 
@@ -2563,8 +2563,7 @@ def fetch_incidents():
                     f"CrowdStrikeFalconMsg: Detection {detection['detection_id']} "
                     f"was fetched which was created in {detection['created_timestamp']}")
                 incident = detection_to_incident(detection)
-
-                detections.append(incident)
+                detections_before_filtering.append(incident)
 
         detections = filter_incidents_by_duplicates_and_limit(incidents_res=detections,
                                                               last_run=current_fetch_info_detections,
@@ -2576,7 +2575,7 @@ def fetch_incidents():
                 detection["occurred"] = occurred.strftime(DATE_FORMAT)
                 demisto.debug(f"CrowdStrikeFalconMsg: Detection {detection['name']} occurred at {detection['occurred']}")
         current_fetch_info_detections = update_last_run_object(last_run=current_fetch_info_detections,
-                                                               incidents=detections,
+                                                               incidents=detections_before_filtering,
                                                                fetch_limit=INCIDENTS_PER_FETCH,
                                                                start_fetch_time=start_fetch_time,
                                                                end_fetch_time=end_fetch_time,
@@ -2611,7 +2610,7 @@ def fetch_incidents():
         incidents_offset = calculate_new_offset(incidents_offset, len(incidents_ids), total_incidents)
         if incidents_offset:
             demisto.debug(f"CrowdStrikeFalconMsg: The new incidents offset is {incidents_offset}")
-
+        incidents_before_filtering = []
         if incidents_ids:
             raw_res = get_incidents_entities(incidents_ids)
             if raw_res is not None and "resources" in raw_res:
@@ -2619,9 +2618,10 @@ def fetch_incidents():
                 for incident in full_incidents:
                     incident['incident_type'] = incident_type
                     incident_to_context = incident_to_incident_context(incident)
-                    incidents.append(incident_to_context)
+                    incidents_before_filtering.append(incident_to_context)
 
-        incidents = filter_incidents_by_duplicates_and_limit(incidents_res=incidents, last_run=current_fetch_info_incidents,
+        incidents = filter_incidents_by_duplicates_and_limit(incidents_res=incidents_before_filtering,
+                                                             last_run=current_fetch_info_incidents,
                                                              fetch_limit=INCIDENTS_PER_FETCH, id_field='name')
         for incident in incidents:
             occurred = dateparser.parse(incident["occurred"])
@@ -2629,7 +2629,8 @@ def fetch_incidents():
                 incident["occurred"] = occurred.strftime(DATE_FORMAT)
                 demisto.debug(f"CrowdStrikeFalconMsg: Incident {incident['name']} occurred at {incident['occurred']}")
 
-        current_fetch_info_incidents = update_last_run_object(last_run=current_fetch_info_incidents, incidents=incidents,
+        current_fetch_info_incidents = update_last_run_object(last_run=current_fetch_info_incidents,
+                                                              incidents=incidents_before_filtering,
                                                               fetch_limit=INCIDENTS_PER_FETCH,
                                                               start_fetch_time=start_fetch_time, end_fetch_time=end_fetch_time,
                                                               look_back=look_back,
@@ -2657,7 +2658,7 @@ def fetch_incidents():
         idp_detections_offset = calculate_new_offset(idp_detections_offset, len(idp_detections_ids), total_idp_detections)
         if idp_detections_offset:
             demisto.debug(f"CrowdStrikeFalconMsg: The new idp detections offset is {idp_detections_offset}")
-
+        idp_detections_before_filtering = []
         if idp_detections_ids:
             raw_res = get_idp_detection_entities(idp_detections_ids)
             if "resources" in raw_res:
@@ -2665,14 +2666,14 @@ def fetch_incidents():
                 for idp_detection in full_detections:
                     idp_detection['incident_type'] = IDP_DETECTION
                     idp_detection_to_context = idp_detection_to_incident_context(idp_detection)
-                    idp_detections.append(idp_detection_to_context)
+                    idp_detections_before_filtering.append(idp_detection_to_context)
 
-            idp_detections = filter_incidents_by_duplicates_and_limit(incidents_res=idp_detections,
+            idp_detections = filter_incidents_by_duplicates_and_limit(incidents_res=idp_detections_before_filtering,
                                                                       last_run=current_fetch_info_idp_detections,
                                                                       fetch_limit=INCIDENTS_PER_FETCH, id_field='name')
 
         current_fetch_info_idp_detections = update_last_run_object(last_run=current_fetch_info_idp_detections,
-                                                                   incidents=idp_detections,
+                                                                   incidents=idp_detections_before_filtering,
                                                                    fetch_limit=fetch_limit,
                                                                    start_fetch_time=start_fetch_time,
                                                                    end_fetch_time=end_fetch_time,

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_12_4.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_12_4.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Fixed an issue where the `last_run` was not set correctly in some cases for the **fetch-incidents** command.
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.79743*.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.12.3",
+    "currentVersion": "1.12.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
The last run in the lookback is updated according to the list that filtered by the duplicates.
However, as the CrowdStrike detections are not sorted, we have to provide the unfiltered list to the look back to take care of it.

Inside the lookback, we will add to the found incidents list only if it's not there already, because now the list may contain duplicates.