### PR TITLE
Generalize the mode option in pre-commit

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -36,6 +36,8 @@ repos:
   rev: "v0.0.272"
   hooks:
   - id: ruff
+    args: ["--fix"]
+    args:nightly: ["--config=nightly_ruff.toml"]
 
 - repo: https://github.com/pre-commit/mirrors-autopep8
   rev: "v2.0.4"
@@ -84,7 +86,8 @@ repos:
   rev: "v1.6.0"
   hooks:
   - id: sourcery
-    args: [--no-summary, --diff, "git diff HEAD"]
+    args: [--no-summary, --diff, "git diff HEAD", "--fix"]
+    args:nightly: [--no-summary, --diff, "git diff HEAD"]
     skip: true
 
 - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-8764)

## Description
In this [PR](https://github.com/demisto/demisto-sdk/pull/3765), I removed PreCommitModes() in order to allow the usage of other modes except Nightly. 
In order to support this option, I updated some of the arguments in pre-commit-config_template.yaml.  

## Must have
- [ ] Tests
- [ ] Documentation 
