### PR TITLE
Fixes for 'Detonate_URL_-_ThreatStream_copy' playbook

### DIFF
--- a/Packs/Anomali_ThreatStream/Playbooks/playbook-Detonate_URL_-_ThreatStream.yml
+++ b/Packs/Anomali_ThreatStream/Playbooks/playbook-Detonate_URL_-_ThreatStream.yml
@@ -32,12 +32,17 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: ebd0e978-215d-43e5-8ceb-54384a2f99ba
+    taskid: b2dc8b93-caec-4473-8a3b-d68fe32e41d6
     type: regular
     task:
-      id: ebd0e978-215d-43e5-8ceb-54384a2f99ba
+      id: b2dc8b93-caec-4473-8a3b-d68fe32e41d6
       version: -1
       name: ThreatStream Submit URL for Analysis
       description: Submits a file or URL to the ThreatStream-hosted Sandbox for detonation.
@@ -50,7 +55,8 @@ tasks:
       - "2"
     scriptarguments:
       detail:
-        simple: ${inputs.Tags}
+        complex:
+          root: inputs.Tags
       premium_sandbox:
         simple: ${inputs.PremiumSandbox}
       report_platform:
@@ -60,7 +66,8 @@ tasks:
       submission_type:
         simple: url
       submission_value:
-        simple: ${inputs.URL}
+        complex:
+          root: inputs.URL
     separatecontext: false
     view: |-
       {
@@ -72,17 +79,22 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: 8449fa75-aa65-469c-849d-89c02cb850f4
+    taskid: 40f7fd76-4554-43f3-8517-7ddb79b601d8
     type: playbook
     task:
-      id: 8449fa75-aa65-469c-849d-89c02cb850f4
+      id: 40f7fd76-4554-43f3-8517-7ddb79b601d8
       version: -1
       name: GenericPolling
       description: |-
-        Use as a sub-playbook to block execution of the master playbook until a remote action is complete.
-        This playbook implements polling by continually running the command in Step #2 until the operation completes.
+        Use this playbook as a sub-playbook to block execution of the master playbook until a remote action is complete.
+        This playbook implements polling by continuously running the command in Step \#2 until the operation completes.
         The remote action should have the following structure:
 
         1. Initiate the operation.
@@ -96,8 +108,6 @@ tasks:
       '#none#':
       - "8"
     scriptarguments:
-      AdditionalPollingCommandArgNames: {}
-      AdditionalPollingCommandArgValues: {}
       Ids:
         complex:
           root: ThreatStream
@@ -119,6 +129,7 @@ tasks:
       iscommand: false
       exitCondition: ""
       wait: 1
+      max: 0
     view: |-
       {
         "position": {
@@ -129,6 +140,11 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "5":
     id: "5"
     taskid: 4cd6fbcd-1b55-40ed-8dfd-c54be310bccf
@@ -152,6 +168,11 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "6":
     id: "6"
     taskid: 6788a219-1746-44bf-8dfe-6b5c0ef9f311
@@ -182,13 +203,18 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 162.5,
+          "x": 160,
           "y": 370
         }
       }
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "7":
     id: "7"
     taskid: 569601dc-c5d2-430b-8fe7-df84b0d9c3a9
@@ -244,12 +270,17 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
   "8":
     id: "8"
-    taskid: a9f1b51f-cb92-456b-8597-ed0f6816bc9d
+    taskid: 7f0c228f-a0db-4763-8b00-2bb406f56c91
     type: regular
     task:
-      id: a9f1b51f-cb92-456b-8597-ed0f6816bc9d
+      id: 7f0c228f-a0db-4763-8b00-2bb406f56c91
       version: -1
       name: ThreatStream Get Report
       description: Returns a report of the file or URL that was submitted to the sandbox.
@@ -262,7 +293,9 @@ tasks:
       - "5"
     scriptarguments:
       report_id:
-        simple: ${ThreatStream.Analysis.ReportID}
+        complex:
+          root: ThreatStream.Analysis
+          accessor: ReportID
     separatecontext: false
     view: |-
       {
@@ -274,6 +307,11 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
+    continueonerrortype: ""
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {},
@@ -293,212 +331,119 @@ inputs:
       root: URL
   required: false
   description: URL to detonate.
+  playbookInputQuery:
 - key: Interval
   value:
     simple: "5"
   required: false
   description: How often to execute polling (in minutes).
+  playbookInputQuery:
 - key: Timeout
   value:
     simple: "120"
   required: false
   description: The duration after which to stop polling and to resume the playbook (in minutes).
+  playbookInputQuery:
 - key: VM
   value: {}
   required: false
   description: The VM to use (string)
+  playbookInputQuery:
 - key: SubmissionClassification
   value: {}
   required: false
   description: Classification of the sandbox submission.
+  playbookInputQuery:
 - key: PremiumSandbox
   value: {}
   required: false
   description: Specifies if the premium sandbox should be used for detonation.
+  playbookInputQuery:
 - key: Tags
   value: {}
   required: false
   description: A CSV list of tags applied to this sample.
+  playbookInputQuery:
 outputs:
-- contextPath: ANYRUN.Task.AnalysisDate
-  description: Date and time the analysis was executed.
-  type: String
-- contextPath: ANYRUN.Task.Behavior.Category
-  description: Category of a process behavior.
-  type: String
-- contextPath: ANYRUN.Task.Behavior.Action
-  description: Actions performed by a process.
-  type: String
-- contextPath: ANYRUN.Task.Behavior.ThreatLevel
-  description: Threat score associated with a process behavior.
-  type: Number
-- contextPath: ANYRUN.Task.Behavior.ProcessUUID
-  description: Unique ID of the process whose behaviors are being profiled.
-  type: String
-- contextPath: ANYRUN.Task.Connection.Reputation
-  description: Connection reputation.
-  type: String
-- contextPath: ANYRUN.Task.Connection.ProcessUUID
-  description: ID of the process that created the connection.
-  type: String
-- contextPath: ANYRUN.Task.Connection.ASN
-  description: Connection autonomous system network.
-  type: String
-- contextPath: ANYRUN.Task.Connection.Country
-  description: Connection country.
-  type: String
-- contextPath: ANYRUN.Task.Connection.Protocol
-  description: Connection protocol.
-  type: String
-- contextPath: ANYRUN.Task.Connection.Port
-  description: Connection port number.
-  type: Number
-- contextPath: ANYRUN.Task.Connection.IP
-  description: Connection IP number.
-  type: String
-- contextPath: ANYRUN.Task.DnsRequest.Reputation
-  description: Reputation of the DNS request.
-  type: String
-- contextPath: ANYRUN.Task.DnsRequest.IP
-  description: IP addresses associated with a DNS request.
-  type: Unknown
-- contextPath: ANYRUN.Task.DnsRequest.Domain
-  description: Domain resolution of a DNS request.
-  type: String
-- contextPath: ANYRUN.Task.Threat.ProcessUUID
-  description: Unique process ID from where the threat originated.
-  type: String
-- contextPath: ANYRUN.Task.Threat.Msg
-  description: Threat message.
-  type: String
-- contextPath: ANYRUN.Task.Threat.Class
-  description: Class of the threat.
-  type: String
-- contextPath: ANYRUN.Task.Threat.SrcPort
-  description: Port on which the threat originated.
-  type: Number
-- contextPath: ANYRUN.Task.Threat.DstPort
-  description: Destination port of the threat.
-  type: Number
-- contextPath: ANYRUN.Task.Threat.SrcIP
-  description: Source IP address where the threat originated.
-  type: String
-- contextPath: ANYRUN.Task.Threat.DstIP
-  description: Destination IP address of the threat.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.Reputation
-  description: Reputation of the HTTP request.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.Country
-  description: HTTP request country.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.ProcessUUID
-  description: ID of the process making the HTTP request.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.Body
-  description: HTTP request body parameters and details.
-  type: Unknown
-- contextPath: ANYRUN.Task.HttpRequest.HttpCode
-  description: HTTP request response code.
-  type: Number
-- contextPath: ANYRUN.Task.HttpRequest.Status
-  description: Status of the HTTP request.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.ProxyDetected
-  description: Whether the HTTP request was made through a proxy.
-  type: Boolean
-- contextPath: ANYRUN.Task.HttpRequest.Port
-  description: HTTP request port.
-  type: Number
-- contextPath: ANYRUN.Task.HttpRequest.IP
-  description: HTTP request IP address.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.URL
-  description: HTTP request URL.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.Host
-  description: HTTP request host.
-  type: String
-- contextPath: ANYRUN.Task.HttpRequest.Method
-  description: HTTP request method type.
-  type: String
-- contextPath: ANYRUN.Task.FileInfo
-  description: Details of the submitted file.
-  type: String
-- contextPath: ANYRUN.Task.OS
-  description: OS of the sandbox in which the file was analyzed.
-  type: String
-- contextPath: ANYRUN.Task.ID
-  description: The unique ID of the task.
-  type: String
-- contextPath: ANYRUN.Task.MIME
-  description: The MIME of the file submitted for analysis.
-  type: String
-- contextPath: ANYRUN.Task.Verdict
-  description: ANY.RUN verdict for the maliciousness of the submitted file or URL.
-  type: String
-- contextPath: ANYRUN.Task.Process.FileName
-  description: File name of the process.
-  type: String
-- contextPath: ANYRUN.Task.Process.PID
-  description: Process identification number.
-  type: Number
-- contextPath: ANYRUN.Task.Process.PPID
-  description: Parent process identification number.
-  type: Number
-- contextPath: ANYRUN.Task.Process.ProcessUUID
-  description: Unique process ID (used by ANY.RUN).
-  type: String
-- contextPath: ANYRUN.Task.Process.CMD
-  description: Process command.
-  type: String
-- contextPath: ANYRUN.Task.Process.Path
-  description: Path of the executed command.
-  type: String
-- contextPath: ANYRUN.Task.Process.User
-  description: User who executed the command.
-  type: String
-- contextPath: ANYRUN.Task.Process.IntegrityLevel
-  description: The process integrity level.
-  type: String
-- contextPath: ANYRUN.Task.Process.ExitCode
-  description: Process exit code.
-  type: Number
-- contextPath: ANYRUN.Task.Process.MainProcess
-  description: Whether the process is the main process.
-  type: Boolean
-- contextPath: ANYRUN.Task.Process.Version.Company
-  description: Company responsible for the program executed.
-  type: String
-- contextPath: ANYRUN.Task.Process.Version.Description
-  description: Description of the type of program.
-  type: String
-- contextPath: ANYRUN.Task.Process.Version.Version
-  description: Version of the program executed.
-  type: String
-- contextPath: DBotScore.Indicator
-  description: The indicator that was tested.
-  type: String
-- contextPath: DBotScore.Score
-  description: The actual score.
-  type: Number
-- contextPath: DBotScore.Type
-  description: The indicator type.
-  type: String
-- contextPath: DBotScore.Vendor
-  description: Vendor used to calculate the score.
-  type: String
-- contextPath: URL.Data
-  description: URL data.
-  type: String
-- contextPath: URL.Malicious.Vendor
-  description: For malicious URLs, the vendor that made the decision.
-  type: String
-- contextPath: URL.Malicious.Description
-  description: For malicious URLs, the reason that the vendor made the decision.
-  type: String
-- contextPath: ANYRUN.Task.Status
-  description: Task analysis status.
-  type: String
+- contextPath: ThreatStream.Analysis.ReportID
+  description: The report ID submitted to the sandbox.
+  type: string
+- contextPath: ThreatStream.Analysis.Status
+  description: The analysis status.
+  type: string
+- contextPath: ThreatStream.Analysis.Platform
+  description: The platform of the submission submitted to the sandbox.
+  type: string
+- contextPath: ThreatStream.Analysis.Category
+  description: The report category.
+  type: string
+- contextPath: ThreatStream.Analysis.Started
+  description: The detonation start time.
+  type: string
+- contextPath: ThreatStream.Analysis.Completed
+  description: The detonation completion time.
+  type: string
+- contextPath: ThreatStream.Analysis.Duration
+  description: The duration of the detonation (in seconds).
+  type: string
+- contextPath: ThreatStream.Analysis.VmName
+  description: The VM name.
+  type: string
+- contextPath: ThreatStream.Analysis.VmID
+  description: The VM ID.
+  type: string
+- contextPath: ThreatStream.Analysis.Verdict
+  description: The verdict of the sandbox detonation.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.UdpSource
+  description: The UDP source.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.UdpDestination
+  description: The UDP destination.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.UdpPort
+  description: The UDP port.
+  type: number
+- contextPath: ThreatStream.Analysis.Network.IcmpSource
+  description: The ICMP source.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.IcmpDestination
+  description: The ICMP destination.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.IcmpPort
+  description: The ICMP port.
+  type: number
+- contextPath: ThreatStream.Analysis.Network.TcpSource
+  description: The TCP source.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.TcpDestination
+  description: The TCP destination.
+  type: number
+- contextPath: ThreatStream.Analysis.Network.TcpPort
+  description: The TCP port.
+  type: number
+- contextPath: ThreatStream.Analysis.Network.HttpSource
+  description: The source of the HTTP address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.HttpDestinaton
+  description: The destination of the HTTP address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.HttpPort
+  description: The port of the HTTP address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.HttpsSource
+  description: The source of the HTTPS address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.HttpsDestinaton
+  description: The destination of the HTTPS address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.HttpsPort
+  description: The port of the HTTPS address.
+  type: string
+- contextPath: ThreatStream.Analysis.Network.Hosts
+  description: The network analysis hosts.
+  type: string
 tests:
-- No test
+- No tests (auto formatted)
+contentitemexportablefields:
+  contentitemfields: {}

--- a/Packs/Anomali_ThreatStream/Playbooks/playbook-Detonate_URL_-_ThreatStream_README.md
+++ b/Packs/Anomali_ThreatStream/Playbooks/playbook-Detonate_URL_-_ThreatStream_README.md
@@ -2,100 +2,76 @@ Detonates one or more URLs using the Anomali ThreatStream v2 sandbox integration
 Returns relevant reports to the War Room and URL reputations to the context data.
 
 ## Dependencies
+
 This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
+
 * GenericPolling
 
 ### Integrations
-This playbook does not use any integrations.
+
+* Anomali_ThreatStream_v2
+* AnomaliThreatStreamv3
 
 ### Scripts
+
 This playbook does not use any scripts.
 
 ### Commands
+
 * threatstream-submit-to-sandbox
 * threatstream-analysis-report
 
 ## Playbook Inputs
+
 ---
 
-| **Name** | **Description** | **Default Value** | **Source** | **Required** |
-| --- | --- | --- | --- | --- |
-| URL | The URL to detonate. | None | URL | Optional |
-| Interval | How often to execute polling (in minutes). | 5 | - | Optional |
-| Timeout | The duration after which to stop polling and to resume the playbook (in minutes). | 120 | - | Optional |
-| VM | The VM to use (string). | - | - | Optional |
-| SubmissionClassification | The classification of the sandbox submission. | - | - | Optional |
-| PremiumSandbox | The specifies if the premium sandbox should be used for detonation. | - | - | Optional |
-| Tags | The CSV list of tags applied to this sample. | - | - | Optional |
+| **Name** | **Description** | **Default Value** | **Required** |
+| --- | --- | --- | --- |
+| URL | URL to detonate. | URL | Optional |
+| Interval | How often to execute polling \(in minutes\). | 5 | Optional |
+| Timeout | The duration after which to stop polling and to resume the playbook \(in minutes\). | 120 | Optional |
+| VM | The VM to use \(string\) |  | Optional |
+| SubmissionClassification | Classification of the sandbox submission. |  | Optional |
+| PremiumSandbox | Specifies if the premium sandbox should be used for detonation. |  | Optional |
+| Tags | A CSV list of tags applied to this sample. |  | Optional |
 
 ## Playbook Outputs
+
 ---
 
 | **Path** | **Description** | **Type** |
 | --- | --- | --- |
-| ANYRUN.Task.AnalysisDate | The date and time the analysis was executed. | String |
-| ANYRUN.Task.Behavior.Category | The category of a process behavior. | String |
-| ANYRUN.Task.Behavior.Action | The actions performed by a process. | String |
-| ANYRUN.Task.Behavior.ThreatLevel | The threat score associated with a process behavior. | Number |
-| ANYRUN.Task.Behavior.ProcessUUID | The unique ID of the process whose behaviors are being profiled. | String |
-| ANYRUN.Task.Connection.Reputation | The connection reputation. | String |
-| ANYRUN.Task.Connection.ProcessUUID | The ID of the process that created the connection. | String |
-| ANYRUN.Task.Connection.ASN | The connection autonomous system network. | String |
-| ANYRUN.Task.Connection.Country | The connection country. | String |
-| ANYRUN.Task.Connection.Protocol | The connection protocol. | String |
-| ANYRUN.Task.Connection.Port | The connection port number. | Number |
-| ANYRUN.Task.Connection.IP | The connection IP address number. | String |
-| ANYRUN.Task.DnsRequest.Reputation | The reputation of the DNS request. | String |
-| ANYRUN.Task.DnsRequest.IP | The IP addresses associated with a DNS request. | Unknown |
-| ANYRUN.Task.DnsRequest.Domain | The domain resolution of a DNS request. | String |
-| ANYRUN.Task.Threat.ProcessUUID | The unique process ID from where the threat originated. | String |
-| ANYRUN.Task.Threat.Msg | The threat message. | String |
-| ANYRUN.Task.Threat.Class | The class of the threat. | String |
-| ANYRUN.Task.Threat.SrcPort | The port on which the threat originated. | Number |
-| ANYRUN.Task.Threat.DstPort | The destination port of the threat. | Number |
-| ANYRUN.Task.Threat.SrcIP | The source IP address where the threat originated. | String |
-| ANYRUN.Task.Threat.DstIP | The destination IP address of the threat. | String |
-| ANYRUN.Task.HttpRequest.Reputation | The reputation of the HTTP request. | String |
-| ANYRUN.Task.HttpRequest.Country | The HTTP request country. | String |
-| ANYRUN.Task.HttpRequest.ProcessUUID | The ID of the process making the HTTP request. | String |
-| ANYRUN.Task.HttpRequest.Body | The HTTP request body parameters and details. | Unknown |
-| ANYRUN.Task.HttpRequest.HttpCode | The HTTP request response code. | Number |
-| ANYRUN.Task.HttpRequest.Status | The Status of the HTTP request. | String |
-| ANYRUN.Task.HttpRequest.ProxyDetected | Whether the HTTP request was made through a proxy. | Boolean |
-| ANYRUN.Task.HttpRequest.Port | The HTTP request port. | Number |
-| ANYRUN.Task.HttpRequest.IP | The HTTP request IP address. | String |
-| ANYRUN.Task.HttpRequest.URL | The HTTP request URL. | String |
-| ANYRUN.Task.HttpRequest.Host | The HTTP request host. | String |
-| ANYRUN.Task.HttpRequest.Method | The HTTP request method type. | String |
-| ANYRUN.Task.FileInfo | The details of the submitted file. | String |
-| ANYRUN.Task.OS | The OS of the sandbox in which the file was analyzed. | String |
-| ANYRUN.Task.ID | The unique ID of the task. | String |
-| ANYRUN.Task.MIME | The MIME of the file submitted for analysis. | String |
-| ANYRUN.Task.Verdict | The `ANY.RUN` verdict for the maliciousness of the submitted file or URL. | String |
-| ANYRUN.Task.Process.FileName | The file name of the process. | String |
-| ANYRUN.Task.Process.PID | The process identification number. | Number |
-| ANYRUN.Task.Process.PPID | The parent process identification number. | Number |
-| ANYRUN.Task.Process.ProcessUUID | The unique process ID (used by `ANY.RUN`). | String |
-| ANYRUN.Task.Process.CMD | The process command. | String |
-| ANYRUN.Task.Process.Path | The path of the executed command. | String |
-| ANYRUN.Task.Process.User | The user who executed the command. | String |
-| ANYRUN.Task.Process.IntegrityLevel | The process integrity level. | String |
-| ANYRUN.Task.Process.ExitCode | The process exit code. | Number |
-| ANYRUN.Task.Process.MainProcess | Whether the process is the main process. | Boolean |
-| ANYRUN.Task.Process.Version.Company | The company responsible for the program executed. | String |
-| ANYRUN.Task.Process.Version.Description | The description of the type of program. | String |
-| ANYRUN.Task.Process.Version.Version | The version of the program executed. | String |
-| DBotScore.Indicator | The indicator that was tested. | String |
-| DBotScore.Score | The actual score. | Number |
-| DBotScore.Type | The indicator type. | String |
-| DBotScore.Vendor | The vendor used to calculate the score. | String |
-| URL.Data | The URL data. | String |
-| URL.Malicious.Vendor | The vendor that made the decision that the URL is malicious. | String |
-| URL.Malicious.Description | The reason that the vendor made the decision that the URL was malicious. | String |
-| ANYRUN.Task.Status | The task analysis status. | String |
+| ThreatStream.Analysis.ReportID | The report ID submitted to the sandbox. | string |
+| ThreatStream.Analysis.Status | The analysis status. | string |
+| ThreatStream.Analysis.Platform | The platform of the submission submitted to the sandbox. | string |
+| ThreatStream.Analysis.Category | The report category. | string |
+| ThreatStream.Analysis.Started | The detonation start time. | string |
+| ThreatStream.Analysis.Completed | The detonation completion time. | string |
+| ThreatStream.Analysis.Duration | The duration of the detonation \(in seconds\). | string |
+| ThreatStream.Analysis.VmName | The VM name. | string |
+| ThreatStream.Analysis.VmID | The VM ID. | string |
+| ThreatStream.Analysis.Verdict | The verdict of the sandbox detonation. | string |
+| ThreatStream.Analysis.Network.UdpSource | The UDP source. | string |
+| ThreatStream.Analysis.Network.UdpDestination | The UDP destination. | string |
+| ThreatStream.Analysis.Network.UdpPort | The UDP port. | number |
+| ThreatStream.Analysis.Network.IcmpSource | The ICMP source. | string |
+| ThreatStream.Analysis.Network.IcmpDestination | The ICMP destination. | string |
+| ThreatStream.Analysis.Network.IcmpPort | The ICMP port. | number |
+| ThreatStream.Analysis.Network.TcpSource | The TCP source. | string |
+| ThreatStream.Analysis.Network.TcpDestination | The TCP destination. | number |
+| ThreatStream.Analysis.Network.TcpPort | The TCP port. | number |
+| ThreatStream.Analysis.Network.HttpSource | The source of the HTTP address. | string |
+| ThreatStream.Analysis.Network.HttpDestinaton | The destination of the HTTP address. | string |
+| ThreatStream.Analysis.Network.HttpPort | The port of the HTTP address. | string |
+| ThreatStream.Analysis.Network.HttpsSource | The source of the HTTPS address. | string |
+| ThreatStream.Analysis.Network.HttpsDestinaton | The destination of the HTTPS address. | string |
+| ThreatStream.Analysis.Network.HttpsPort | The port of the HTTPS address. | string |
+| ThreatStream.Analysis.Network.Hosts | The network analysis hosts. | string |
 
 ## Playbook Image
+
 ---
-![Detonate_URL_ThreatStream](https://raw.githubusercontent.com/demisto/content/1bdd5229392bd86f0cc58265a24df23ee3f7e662/docs/images/playbooks/Detonate_URL_ThreatStream.png)
+
+![Detonate URL - ThreatStream](../doc_files/Detonate_URL_-_ThreatStream.png)


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-8853

## Description
Upon reviewing the 'Detonate URL - Generic v1.5' playbook, I noticed that all the 'Detonate URL - ThreatStream' sub-playbook outputs refer to 'ANYRUN' integrations instead of 'ThreatStream'.
