### PR TITLE
update the retry count to 0

### DIFF
--- a/Packs/Whois/Integrations/Whois/Whois.py
+++ b/Packs/Whois/Integrations/Whois/Whois.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Type
 import urllib
 
 
-RATE_LIMIT_RETRY_COUNT_DEFAULT: int = 3
+RATE_LIMIT_RETRY_COUNT_DEFAULT: int = 0
 RATE_LIMIT_WAIT_SECONDS_DEFAULT: int = 120
 RATE_LIMIT_ERRORS_SUPPRESSEDL_DEFAULT: bool = False
 

--- a/Packs/Whois/Integrations/Whois/Whois.yml
+++ b/Packs/Whois/Integrations/Whois/Whois.yml
@@ -44,7 +44,7 @@ configuration:
   type: 15
   section: Collect
 - additionalinfo: The number of times to try when getting a Rate Limit response.
-  defaultvalue: '3'
+  defaultvalue: '0'
   display: Rate Limit Retry Count
   name: rate_limit_retry_count
   type: 0
@@ -460,12 +460,12 @@ script:
       name: ip
       required: true
     - description: 'The number of times to try when getting a Rate Limit response.'
-      defaultValue: 3
+      defaultValue: 0
       name: rate_limit_retry_count
     - description: 'The number of seconds to wait each iteration when getting a Rate Limit response.'
       defaultValue: 120
       name: rate_limit_wait_seconds
-    - description: 'Whether Rate Limit errors should be supressed or not.'
+    - description: 'Whether Rate Limit errors should be suppressed or not.'
       defaultValue: 'false'
       name: rate_limit_errors_suppressed
     description: Provides data enrichment for ips.
@@ -582,7 +582,7 @@ script:
     - contextPath: DBotScore.Reliability
       description: Reliability of the source providing the intelligence data.
       type: String
-  dockerimage: demisto/ippysocks-py3:1.0.0.75529
+  dockerimage: demisto/ippysocks-py3:1.0.0.78777
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/Whois/ReleaseNotes/1_5_5.json
+++ b/Packs/Whois/ReleaseNotes/1_5_5.json
@@ -1,0 +1,4 @@
+{
+	"breakingChanges": true,
+	"breakingChangesNotes": "The default value of Rate Limit Retry Count parameter and rate_limit_retry_count argument of !ip command changed from 3 to 0."
+}

--- a/Packs/Whois/ReleaseNotes/1_5_5.md
+++ b/Packs/Whois/ReleaseNotes/1_5_5.md
@@ -3,5 +3,5 @@
 
 ##### Whois
 
-- Updated the default value of Rate Limit Retry Count parameter and rate_limit_retry_count argument of !ip command from 3 to 0. The change should fix performance issues that caused because of ip lookup retry.
+- Updated the default value of Rate Limit Retry Count parameter and *rate_limit_retry_count* argument of the ***ip*** command from 3 to 0. The change should fix performance issues that were caused because of ip lookup retry.
 - Updated the Docker image to: *demisto/ippysocks-py3:1.0.0.78777*.

--- a/Packs/Whois/ReleaseNotes/1_5_5.md
+++ b/Packs/Whois/ReleaseNotes/1_5_5.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Whois
+
+- Updated the default value of Rate Limit Retry Count parameter and rate_limit_retry_count argument of !ip command from 3 to 0. The change should fix performance issues that caused because of ip lookup retry.
+- Updated the Docker image to: *demisto/ippysocks-py3:1.0.0.78777*.

--- a/Packs/Whois/pack_metadata.json
+++ b/Packs/Whois/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Whois",
     "description": "This Content Pack helps you run Whois commands as playbook tasks or real-time actions within Cortex XSOAR to obtain valuable domain metadata.",
     "support": "xsoar",
-    "currentVersion": "1.5.4",
+    "currentVersion": "1.5.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5353,7 +5353,8 @@
                 "Whois",
                 "Rasterize"
             ],
-            "memory_threshold": 300
+            "memory_threshold": 300,
+            "toversion": "7.9.9"
         },
         {
             "playbookID": "DBotUpdateLogoURLPhishing_test"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-30171

## Description
Updated the default value of Rate Limit Retry Count parameter and rate_limit_retry_count argument of !ip command from 3 to 0.

## Must have
- [ ] Tests
- [ ] Documentation 
