### PR TITLE
Calculate Severity By Highest DBotScore - performance improvement

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Calculate_Severity_By_Highest_DBotScore_6_0.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Calculate_Severity_By_Highest_DBotScore_6_0.yml
@@ -181,10 +181,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "25":
     id: "25"
-    taskid: 7082757c-758b-4cda-803e-526f85f26a68
+    taskid: 8ad27555-7d81-4dd4-86e5-598b2c445def
     type: condition
     task:
-      id: 7082757c-758b-4cda-803e-526f85f26a68
+      id: 8ad27555-7d81-4dd4-86e5-598b2c445def
       version: -1
       name: Evaluate severity based on DBotScore of indicators
       description: |-
@@ -475,10 +475,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "31":
     id: "31"
-    taskid: b894e09e-1a9a-4c62-80df-f1b53961c7c9
+    taskid: 5acf56ba-5b7b-4472-86e2-637756c34822
     type: regular
     task:
-      id: b894e09e-1a9a-4c62-80df-f1b53961c7c9
+      id: 5acf56ba-5b7b-4472-86e2-637756c34822
       version: -1
       name: Get DBotScore from XSOAR
       description: Get the overall score for the indicator as calculated by DBot.
@@ -494,6 +494,8 @@ tasks:
         complex:
           root: DBotScore
           accessor: Indicator
+          transformers:
+          - operator: uniq
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -544,3 +546,4 @@ outputs:
 tests:
 - Calculate Severity - Standard - Test
 fromversion: 6.0.0
+system: true

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_4_17.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_4_17.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Calculate Severity By Highest DBotScore
+
+Improved the performance of the playbook by ensuring that only unique indicators are retrieved from the cache.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.4.16",
+    "currentVersion": "2.4.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-8883

## Description
Improved the performance of the `Calculate Severity By Highest DBotScore` playbook by ensuring that only unique items from `DBotScore.Indicator` are passed to the `GetIndicatorDBotScoreFromCache` script.

