### PR TITLE
Added Cortex XDR to be mandatory dependency for Capture the flag 01 pack

### DIFF
--- a/Packs/ctf01/pack_metadata.json
+++ b/Packs/ctf01/pack_metadata.json
@@ -18,6 +18,10 @@
         "CTF02": {
             "mandatory": false,
             "display_name": "Capture The Flag - 02"
+        },
+        "CortexXDR": {
+            "mandatory": true,
+            "display_name": "Cortex XDR by Palo Alto Networks"
         }
     },
     "marketplaces": [


### PR DESCRIPTION

## Status
- [X] Ready

## Related Issues
fixes: N.A.

## Description
Added Cortex XDR to be a mandatory dependency for Capture the Flag 01 pack

