### PR TITLE
External severity -  change to be searchable 

### DIFF
--- a/Packs/CommonTypes/IncidentFields/incidentfield-External_Severity.json
+++ b/Packs/CommonTypes/IncidentFields/incidentfield-External_Severity.json
@@ -20,7 +20,7 @@
     "threshold": 72,
     "type": "multiSelect",
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "useAsKpi": false,
     "version": -1,
     "fromVersion": "6.2.0"

--- a/Packs/CommonTypes/ReleaseNotes/3_3_93.md
+++ b/Packs/CommonTypes/ReleaseNotes/3_3_93.md
@@ -1,0 +1,5 @@
+
+#### Incident Fields
+
+- **External Severity**
+Updated the field to be searchable in XSOAR.

--- a/Packs/CommonTypes/pack_metadata.json
+++ b/Packs/CommonTypes/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Types",
     "description": "This Content Pack will get you up and running in no-time and provide you with the most commonly used incident & indicator fields and types.",
     "support": "xsoar",
-    "currentVersion": "3.3.92",
+    "currentVersion": "3.3.93",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-30432)

## Description
Make the `External Severity` field to be searchable in XSOAR.
