### PR TITLE
F5 APM Remove XSIAM tags

### DIFF
--- a/Packs/F5APM/README.md
+++ b/Packs/F5APM/README.md
@@ -1,4 +1,3 @@
-<~XSIAM>
 # F5 APM
 This pack includes Cortex XSIAM content.
 
@@ -85,5 +84,3 @@ You can configure the specific vendor and product for this instance.
 4. When configuring the Syslog Collector, set the following values:
    - vendor as f5 
    - product as apm
-
-</~XSIAM>


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9078

## Description
Removed the XSIAM tags in the README file since it brokes the marketplace build and it's redundant because the entire pack is XSIAM only.

## Must have
- [ ] Tests
- [ ] Documentation 
