### PR TITLE
[IsEmailAddressInternal] Fix an issue with **domain** argument

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_12_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_54.md
@@ -3,4 +3,4 @@
 
 ##### IsEmailAddressInternal
 
-- Fixed an issue where when the **domain** argument received a single value (rather than a list) it did not work as expected (issue was introduced in 1.12.53).
+- Fixed an issue where the **domain** argument did not work as expected when run with a single value rather than a list. The issue was introduced in 1.12.53.

--- a/Packs/CommonScripts/ReleaseNotes/1_12_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_12_54.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### IsEmailAddressInternal
+
+- Fixed an issue where when the **domain** argument received a single value (rather than a list) it did not work as expected (issue was introduced in 1.12.53).

--- a/Packs/CommonScripts/Scripts/IsEmailAddressInternal/IsEmailAddressInternal.js
+++ b/Packs/CommonScripts/Scripts/IsEmailAddressInternal/IsEmailAddressInternal.js
@@ -18,7 +18,7 @@ function escapeRegex(string) {
 
 function main() {
     const emails = argToList(args.email);
-    const domains = argToList(JSON.stringify(args.domain)).map(x => x.toLowerCase());
+    const domains = argToList(args.domain).map(x => x.toLowerCase());
     const includeSubdomains = toBoolean(args.include_subdomains);
 
     let results = [];

--- a/Packs/CommonScripts/Scripts/IsEmailAddressInternal/IsEmailAddressInternal.yml
+++ b/Packs/CommonScripts/Scripts/IsEmailAddressInternal/IsEmailAddressInternal.yml
@@ -41,3 +41,4 @@ scripttarget: 0
 fromversion: 5.0.0
 tests:
 - IsEmailAddressInternal_Test
+- TestIsEmailAddressInternal

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.12.53",
+    "currentVersion": "1.12.54",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9069)

## Description
Fixed an issue where when the **domain** argument received a single value (rather than a list) it did not work as expected (issue was introduced in 1.12.53).