### PR TITLE
Use "alert" instead of "incident" for XSIAM content

### DIFF
--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -14,26 +14,27 @@ from typing import Any, List, Dict, Union
 warnings.simplefilter("ignore")
 warnings.filterwarnings('ignore', category=UserWarning)
 
+INCIDENT_ALIAS = 'incident' if (demisto.demistoVersion()['platform'] == 'xsoar') else 'alert'
 MESSAGE_NO_FIELDS_USED = "- No field are used to find similarity. Possible reasons: 1) No field selected  " \
-                         " 2) Selected field are empty for this incident  3) Fields are misspelled"
+                         f" 2) Selected field are empty for this {INCIDENT_ALIAS}  3) Fields are misspelled"
 
-MESSAGE_NO_INCIDENT_FETCHED = "- 0 incidents fetched with these exact match for the given dates."
+MESSAGE_NO_INCIDENT_FETCHED = f"- 0 {INCIDENT_ALIAS}s fetched with these exact match for the given dates."
 
-MESSAGE_WARNING_TRUNCATED = "- Incidents fetched have been truncated to %s, please either add incident fields in " \
+MESSAGE_WARNING_TRUNCATED = f"- Incidents fetched have been truncated to %s, please either add {INCIDENT_ALIAS} fields in " \
                             "fieldExactMatch, enlarge the time period or increase the limit argument " \
                             "to more than %s."
 
 MESSAGE_NO_CURRENT_INCIDENT = "- Incident %s does not exist within the given time range. " \
-                              "Please check incidentId value or that you are running the command within an incident."
-MESSAGE_NO_FIELD = "- %s field(s) does not exist in the current incident."
-MESSAGE_INCORRECT_FIELD = "- %s field(s) don't/doesn't exist within the fetched incidents."
+                              f"Please check incidentId value or that you are running the command within an {INCIDENT_ALIAS}."  # What todo about
+MESSAGE_NO_FIELD = f"- %s field(s) does not exist in the current {INCIDENT_ALIAS}."
+MESSAGE_INCORRECT_FIELD = "- %s field(s) don't/doesn't exist within the fetched {INCIDENT_ALIAS}s."
 
-SIMILARITY_COLUNM_NAME = 'similarity incident'
+SIMILARITY_COLUNM_NAME = f'similarity {INCIDENT_ALIAS}'
 SIMILARITY_COLUNM_NAME_INDICATOR = 'similarity indicators'
 IDENTICAL_INDICATOR = 'Identical indicators'
 ORDER_SCORE_WITH_INDICATORS = [SIMILARITY_COLUNM_NAME, SIMILARITY_COLUNM_NAME_INDICATOR]
 ORDER_SCORE_NO_INDICATORS = [SIMILARITY_COLUNM_NAME]
-COLUMN_ID = 'incident ID'
+COLUMN_ID = f'{INCIDENT_ALIAS} ID'
 FIRST_COLUMNS_INCIDENTS_DISPLAY = [COLUMN_ID, 'created', 'name', SIMILARITY_COLUNM_NAME,
                                    SIMILARITY_COLUNM_NAME_INDICATOR,
                                    IDENTICAL_INDICATOR]
@@ -724,8 +725,8 @@ def return_outputs_summary(confidence: float, number_incident_fetched: int, numb
     """
     summary = {
         'Confidence': str(confidence),
-        'Number of incidents fetched with exact match ': number_incident_fetched,
-        'Number of similar incidents found ': number_incidents_found,
+        f'Number of {INCIDENT_ALIAS}s fetched with exact match ': number_incident_fetched,
+        f'Number of similar {INCIDENT_ALIAS}s found ': number_incidents_found,
         'Valid fields used for similarity': ', '.join(fields_used),
     }
     return_outputs(readable_output=global_msg + tableToMarkdown("Summary", summary))
@@ -833,8 +834,8 @@ def return_outputs_similar_incidents_empty():
     Return entry and context for similar incidents if no similar incidents were found
     :return:
     """
-    hr = '### Similar Incident' + '\n'
-    hr += 'No Similar incident were found.'
+    hr = f'### Similar {INCIDENT_ALIAS.capitalize()}' + '\n'
+    hr += f'No Similar {INCIDENT_ALIAS}s were found.'
     return_outputs(readable_output=hr,
                    outputs={'DBotFindSimilarIncidents': create_context_for_incidents()})
 
@@ -924,9 +925,9 @@ def main():
     global_msg += "%s \n" % msg
 
     if incidents:
-        demisto.debug(f'Found {len(incidents)} incidents for {incident_id=}')
+        demisto.debug(f'Found {len(incidents)} {INCIDENT_ALIAS} for {incident_id=}')
     else:
-        demisto.debug(f'No incidents found for {incident_id=}')
+        demisto.debug(f'No {INCIDENT_ALIAS} found for {incident_id=}')
         return_outputs_summary(confidence, 0, 0, [], global_msg)
         return_outputs_similar_incidents_empty()
         return None, global_msg

--- a/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.py
+++ b/Packs/CommonScripts/Scripts/FindSimilarIncidentsV2/FindSimilarIncidentsV2.py
@@ -21,6 +21,7 @@ STATUS_MAP = {
     '2': 'Closed',
     '3': 'Closed'
 }
+INCIDENT_ALIAS = 'incident' if (demisto.demistoVersion()['platform'] == 'xsoar') else 'alert'
 
 
 def parse_input(csv):
@@ -76,7 +77,7 @@ def get_map_from_nested_dict(nested_dict, keys, raise_error=False):
             elif key in nested_dict:
                 result[key] = nested_dict[key]
             else:
-                message = "Missing key\label\custom\context field for incident: %s" % key
+                message = f"Missing key\label\custom\context field for {INCIDENT_ALIAS}: %s" % key
                 if raise_error:
                     return_error(message)
                 else:
@@ -154,7 +155,7 @@ def get_incidents_by_keys(similar_incident_keys, time_field, incident_time, inci
     min_date = incident_time - timedelta(hours=hours_back)
     query = build_incident_query(similar_keys_query, ignore_closed, incident_id, extra_query)
 
-    demisto.debug("Find similar incidents based on initial query: %s" % query)
+    demisto.debug(f"Find similar {INCIDENT_ALIAS}s based on initial query: %s" % query)
 
     get_incidents_argument = {'query': query, 'size': max_number_of_results, 'sort': '%s.desc' % time_field}
 
@@ -256,7 +257,7 @@ def did_not_found_duplicates():
     }
     demisto.results({'ContentsFormat': formats['markdown'],
                      'Type': entryTypes['note'],
-                     'Contents': 'No duplicate incidents has been found.',
+                     'Contents': f'No duplicate {INCIDENT_ALIAS}s has been found.',
                      'EntryContext': context})
     sys.exit(0)
 
@@ -333,14 +334,14 @@ def main():
             response = demisto.dt(incident_similar_context, key)
             original_context_map[key] = response
             if not response and RAISE_ERROR_MISSING_VALUES:
-                raise ValueError("Error: Missing context key for incident: %s" % key)
+                raise ValueError(f"Error: Missing context key for {INCIDENT_ALIAS}: %s" % key)
 
     log_message = 'Incident fields with exact match: %s' % exact_match_incident_fields
     if len(exact_match_incident_fields) > 1:
         log_message += ', applied with %s condition' % INCIDENT_FIELDS_APPLIED_CONDITION
     demisto.debug(log_message)
     if len(similar_incident_fields) > 0:
-        demisto.debug('Similar incident fields (not exact match): %s' % similar_incident_fields)
+        demisto.debug(f'Similar {INCIDENT_ALIAS} fields (not exact match): %s' % similar_incident_fields)
     if len(incident_similar_labels) > 0:
         demisto.debug('Similar labels: %s' % incident_similar_labels)
     if len(incident_similar_context) > 0:
@@ -348,7 +349,7 @@ def main():
 
     if len(exact_match_incident_fields) == 0 and len(similar_incident_fields) == 0 and len(
             incident_similar_labels) == 0 and len(original_context_map) == 0:
-        return_error("Does not have any field to compare in the current incident")
+        return_error(f"Does not have any field to compare in the current {INCIDENT_ALIAS}")
 
     duplicate_incidents = get_incidents_by_keys(exact_match_incident_fields, TIME_FIELD, incident[TIME_FIELD],
                                                 incident['id'],
@@ -408,7 +409,7 @@ def main():
         duplicate_incidents_rows = duplicate_incidents_rows[:MAX_CANDIDATES_IN_LIST]
         hr_result = [dict((camel_case_to_space(k), v) for k, v in list(row.items())) for row in
                      duplicate_incidents_rows]
-        markdown_result = tableToMarkdown("Duplicate incidents",
+        markdown_result = tableToMarkdown(f"Duplicate {INCIDENT_ALIAS}s",
                                           hr_result,
                                           headers=['Id', 'Name', 'Closed time', 'Time'])
         return {'ContentsFormat': formats['markdown'],


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9022)

## Description
Switches the use of the word "Incidents" to "alerts" for the XSIAM scripts **FindSimilarAlerts** and **DBotFindSimilarAlerts**.

## Must have
- [ ] Tests
- [ ] Documentation 
