### PR TITLE
Add argument include_resolved_param to sentinelone-get-threats

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/README.md
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/README.md
@@ -197,6 +197,7 @@ Returns threats according to the specified filters.
 | rank | Risk level threshold to retrieve (1-10). Relevant for API version 2.0 only. | Optional | 
 | site_ids | A comma-separated list of site IDs to search for threats, for example: "225494730938493804,225494730938493915". | Optional |
 | incident_statuses | Incident status. Example: "IN_PROGRESS, UNRESOLVED". | Optional |
+| include_resolved_param | Whether to include the resolved parameter in the query. Possible values are: false, true. Default is false. | Optional | 
 
 #### Context Output
 

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -280,7 +280,7 @@ class Client(BaseClient):
             createdAt__lte=created_until_parsed,
             createdAt__gte=created_from_parsed,
             updatedAt__gte=updated_from_parsed,
-            resolved=argToBoolean(resolved) if include_resolved_param else None,
+            resolved=argToBoolean(resolved) if argToBoolean(include_resolved_param) else None,
             displayName__like=display_name,
             displayName=display_name,
             query=query,

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -395,6 +395,13 @@ script:
       name: site_ids
     - description: 'Incident status. Example: "IN_PROGRESS, UNRESOLVED".'
       name: incident_statuses
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Whether to include the resolved parameter in the query.
+      name: include_resolved_param
+      predefined:
+      - "false"
+      - "true"
     description: Returns threats according to the specified filters.
     name: sentinelone-get-threats
     outputs:

--- a/Packs/SentinelOne/ReleaseNotes/3_2_14.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_14.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+
+##### SentinelOne v2
+- Added the *include_resolved_param* argument to the command ***sentinelone-get-threats*** which allows to ignore the *resolved* argument in order to get threats whatever their status.

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "Endpoint protection",
     "support": "partner",
-    "currentVersion": "3.2.13",
+    "currentVersion": "3.2.14",
     "author": "SentinelOne",
     "url": "https://www.sentinelone.com/support/",
     "email": "support@sentinelone.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Currently, it is not possible to retrieve threats regardless of their status (resolved/unresolved/in_progress) with the command ***sentinelone-get-threats***.
This PR adds the *include_resolved_param* argument to the command ***sentinelone-get-threats*** which allows to ignore the *resolved* argument in order to get threats regardless of their status.

## Must have
- [ ] Tests
- [ ] Documentation 
