### PR TITLE
Malware Investigation and Response -  Added specification for integration brand for the  !endpoint command.

### DIFF
--- a/Packs/CrowdStrikeFalcon/Playbooks/playbook-CrowdStrike_Falcon_Malware_-_Incident_Enrichment.yml
+++ b/Packs/CrowdStrikeFalcon/Playbooks/playbook-CrowdStrike_Falcon_Malware_-_Incident_Enrichment.yml
@@ -90,7 +90,7 @@ tasks:
       version: -1
       name: Enrich endpoint details
       description: Returns information about an endpoint.
-      script: '|||endpoint'
+      script: 'CrowdstrikeFalcon|||endpoint'
       type: regular
       iscommand: true
       brand: ''

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_12_7.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_12_7.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### CrowdStrike Falcon Malware - Incident Enrichment
+
+Added a command brand specification for !endpoint.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.12.6",
+    "currentVersion": "1.12.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Playbooks/playbook-MDE_Malware_-_Incident_Enrichment.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Playbooks/playbook-MDE_Malware_-_Incident_Enrichment.yml
@@ -88,7 +88,7 @@ tasks:
       id: aaf8082e-fe44-455d-8ca0-f9243218db51
       iscommand: true
       name: Enrich endpoint details
-      script: '|||endpoint'
+      script: 'Microsoft Defender Advanced Threat Protection|||endpoint'
       type: regular
       version: -1
     taskid: aaf8082e-fe44-455d-8ca0-f9243218db51

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_16_20.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_16_20.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### MDE Malware - Incident Enrichment
+
+Added a command brand specification for !endpoint.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.16.19",
+    "currentVersion": "1.16.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: N.A.

## Description
I specified an integration brand for MDE and CS Falcon (as shown on Cortex XDR PB).
The main reason is to avoid PB failing in case another integration implements `!endpoint` and keeps on failing as we are checking for an endpoint ID (which only appears in the same EDR that we are using).

## Must have
- [ ] Tests
- [ ] Documentation 
