### PR TITLE
Fix js get incident tasks by state

### DIFF
--- a/Packs/DemistoRESTAPI/ReleaseNotes/1_3_41.md
+++ b/Packs/DemistoRESTAPI/ReleaseNotes/1_3_41.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetIncidentTasksByState
+
+Fixed an issue where the script failed in XSOAR version 6.9.0

--- a/Packs/DemistoRESTAPI/Scripts/GetIncidentTasksByState/GetIncidentTasksByState.js
+++ b/Packs/DemistoRESTAPI/Scripts/GetIncidentTasksByState/GetIncidentTasksByState.js
@@ -39,7 +39,7 @@ function getAllPlaybookTasks(tasks) {
 
 function getStates(states) {
     var input_states = states.split(",");
-    if (input_states.includes('error')) {
+    if (input_states.indexOf('error') > -1) {
         input_states = input_states.concat('loopError')
     }
     var readyStates = {};

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex REST API",
     "description": "Use Demisto REST APIs",
     "support": "xsoar",
-    "currentVersion": "1.3.40",
+    "currentVersion": "1.3.41",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9172

## Description
Changed `includes` to `indexOf` as it is not supported in ecma 5 which means it will not work in xsoar 6.9