### PR TITLE
Fix "unexpected keyword argument" Error

### DIFF
--- a/Packs/FiltersAndTransformers/ReleaseNotes/1_2_45.md
+++ b/Packs/FiltersAndTransformers/ReleaseNotes/1_2_45.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### If-Elif
+
+- Fixed an issue where an error would be returned when *Common Arguments* were provided.

--- a/Packs/FiltersAndTransformers/ReleaseNotes/1_2_45.md
+++ b/Packs/FiltersAndTransformers/ReleaseNotes/1_2_45.md
@@ -4,3 +4,4 @@
 ##### If-Elif
 
 - Fixed an issue where an error would be returned when *Common Arguments* were provided.
+- Updated the docker image to *demisto/python3:3.10.13.83255*.

--- a/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.py
+++ b/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.py
@@ -47,7 +47,7 @@ class ConditionParser:
         ast.Add: return_none_on_error(lambda x, y: x + y),
     }
 
-    def __init__(self, context, conditions, flags=None, **kwargs):
+    def __init__(self, context, conditions, flags=None, **_):
         self.conditions: list
         self.functions: dict[str, Callable] = {
             'from_context': partial(demisto.dt, context)

--- a/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.py
+++ b/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.py
@@ -47,7 +47,7 @@ class ConditionParser:
         ast.Add: return_none_on_error(lambda x, y: x + y),
     }
 
-    def __init__(self, context, conditions, flags=None):
+    def __init__(self, context, conditions, flags=None, **kwargs):
         self.conditions: list
         self.functions: dict[str, Callable] = {
             'from_context': partial(demisto.dt, context)

--- a/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.yml
+++ b/Packs/FiltersAndTransformers/Scripts/IfElif/IfElif.yml
@@ -33,7 +33,7 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.13.74666
+dockerimage: demisto/python3:3.10.13.83255
 runas: DBotWeakRole
 fromversion: 6.9.0
 tests:

--- a/Packs/FiltersAndTransformers/pack_metadata.json
+++ b/Packs/FiltersAndTransformers/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Filters And Transformers",
     "description": "Frequently used filters and transformers pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.44",
+    "currentVersion": "1.2.45",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Currently, if more args than specified in the yml would be added to the If-Elif transformer, it would throw an error as the args are unpacked directly into the `ConditionParser` constructor and it has only the yml args a parameters.
To solve this, this PR adds the parameter `**_` to the constructor so that the unexpected args can be safely ignored.

## Must have
- [ ] Tests
- [ ] Documentation
