### PR TITLE
Armis fix url suffix

### DIFF
--- a/Packs/Armis/Integrations/Armis/Armis.py
+++ b/Packs/Armis/Integrations/Armis/Armis.py
@@ -644,6 +644,8 @@ def main():
 
     # get the service API url
     base_url = params.get('url')
+    if 'api/v1' not in base_url:
+        base_url = urljoin(params.get('url'), '/api/v1/')
     verify = not params.get('insecure', False)
 
     # How much time before the first fetch to retrieve incidents

--- a/Packs/Armis/Integrations/Armis/Armis.py
+++ b/Packs/Armis/Integrations/Armis/Armis.py
@@ -645,7 +645,7 @@ def main():
     # get the service API url
     base_url = params.get('url')
     if 'api/v1' not in base_url:
-        base_url = urljoin(params.get('url'), '/api/v1/')
+        base_url = urljoin(base_url, '/api/v1/')
     verify = not params.get('insecure', False)
 
     # How much time before the first fetch to retrieve incidents

--- a/Packs/Armis/Integrations/Armis/Armis.yml
+++ b/Packs/Armis/Integrations/Armis/Armis.yml
@@ -385,7 +385,7 @@ script:
     - contextPath: Armis.Device.visibility
       description: The visibility of the device.
       type: String
-  dockerimage: demisto/python3:3.10.13.78960
+  dockerimage: demisto/python3:3.10.13.83255
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/Armis/Integrations/Armis/Armis_test.py
+++ b/Packs/Armis/Integrations/Armis/Armis_test.py
@@ -7,6 +7,7 @@ import pytest
 import time
 
 import CommonServerPython
+import demistomock as demisto
 
 
 def test_untag_device_success(requests_mock):
@@ -429,3 +430,30 @@ def test_fetch_incidents_no_duplicates(mocker):
     assert incidents[0]['rawJSON'] == json.dumps(armis_incident)
     _, incidents = fetch_incidents(client, next_run, '', 'Low', [], [], '', 1)
     assert not incidents
+
+
+class MockClient:
+    def __init__(self, secret: str, base_url: str, verify: bool, proxy):
+        pass
+
+
+def test_url_parameter(mocker):
+    """
+    Given:
+    - Instance parameters with a base URL without `api/v1` prefix.
+
+    When:
+    - Running the main function and configured the client class.
+
+    Then:
+    - Ensure that hte base URL in the client class is with teh `api/v1` prefix.
+
+    """
+    from Armis import main
+
+    mocker.patch.object(demisto, 'params', return_value={'url': 'test.com'})
+    mock_client = mocker.patch('Armis.Client', side_effect=MockClient)
+
+    main()
+
+    assert mock_client.call_args.kwargs['base_url'] == 'test.com/api/v1/'

--- a/Packs/Armis/ReleaseNotes/1_1_10.md
+++ b/Packs/Armis/ReleaseNotes/1_1_10.md
@@ -3,4 +3,5 @@
 
 ##### Armis
 
-Fixed an issue in the **Server URL** parameter without `api/v1` suffix.
+- Fixed an issue in the **Server URL** parameter without `api/v1` suffix.
+- Updated the Docker image to: *demisto/python3:3.10.13.83255*.

--- a/Packs/Armis/ReleaseNotes/1_1_10.md
+++ b/Packs/Armis/ReleaseNotes/1_1_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Armis
+
+- Fixed an issue in the **Server URL** parameter without `api/v1` suffix.

--- a/Packs/Armis/ReleaseNotes/1_1_10.md
+++ b/Packs/Armis/ReleaseNotes/1_1_10.md
@@ -3,4 +3,4 @@
 
 ##### Armis
 
-- Fixed an issue in the **Server URL** parameter without `api/v1` suffix.
+Fixed an issue in the **Server URL** parameter without `api/v1` suffix.

--- a/Packs/Armis/pack_metadata.json
+++ b/Packs/Armis/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Armis",
     "description": "Agentless and passive security platform that sees, identifies, and classifies every device, tracks behavior, identifies threats, and takes action automatically to protect critical information and systems",
     "support": "partner",
-    "currentVersion": "1.1.9",
+    "currentVersion": "1.1.10",
     "author": "Armis Corporation",
     "url": "https://support.armis.com/",
     "email": "support@armis.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9187
reported https://github.com/demisto/content-docs/issues/1439

## Description
Added support for base URL without `api/v1` suffix.

## Must have
- [ ] Tests
- [ ] Documentation 
