### PR TITLE
Fix last run date TAXII2Feed Integration

### DIFF
--- a/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.py
+++ b/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.py
@@ -70,6 +70,7 @@ def fetch_indicators_command(
             initial_interval, date_format=TAXII_TIME_FORMAT
         )
 
+    now = f"{datetime.utcnow().isoformat()}Z"
     last_fetch_time = (
         last_run_ctx.get(client.collection_to_fetch.id)
         if client.collection_to_fetch
@@ -88,9 +89,7 @@ def fetch_indicators_command(
             )
             fetched_iocs = client.build_iterator(limit, added_after=added_after)
             indicators.extend(fetched_iocs)
-            last_run_ctx[collection.id] = client.last_fetched_indicator__modified \
-                if client.last_fetched_indicator__modified \
-                else added_after
+            last_run_ctx[collection.id] = now
             if limit >= 0:
                 limit -= len(fetched_iocs)
                 if limit <= 0:
@@ -99,11 +98,7 @@ def fetch_indicators_command(
         # fetch from a single collection
         added_after = get_added_after(fetch_full_feed, initial_interval, last_fetch_time)
         indicators = client.build_iterator(limit, added_after=added_after)
-        last_run_ctx[client.collection_to_fetch.id] = (
-            client.last_fetched_indicator__modified
-            if client.last_fetched_indicator__modified
-            else added_after
-        )
+        last_run_ctx[client.collection_to_fetch.id] = now
     demisto.debug(f'{indicators=}')
     return indicators, last_run_ctx
 

--- a/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.yml
+++ b/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.yml
@@ -227,7 +227,7 @@ script:
   - deprecated: true
     description: 'WARNING: This command will reset your fetch history.'
     name: taxii2-reset-fetch-indicators
-  dockerimage: demisto/taxii2:1.0.0.80190
+  dockerimage: demisto/taxii2:1.0.0.83423
   feed: true
   runonce: false
   script: '-'

--- a/Packs/FeedTAXII/ReleaseNotes/1_2_3.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_2_3.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### TAXII 2 Feed
+
+- Fixed an issue where Taxii2Feed incorrectly set the Last Run date. This date is now based on the last run time.
+- Updated the Docker image to: *demisto/taxii2:1.0.0.83423*.

--- a/Packs/FeedTAXII/pack_metadata.json
+++ b/Packs/FeedTAXII/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Feed",
     "description": "Ingest indicator feeds from TAXII 1 and TAXII 2 servers.",
     "support": "xsoar",
-    "currentVersion": "1.2.2",
+    "currentVersion": "1.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
There is an issue with the Last Run date of the TAXII 2 Feed Integration, which is not based on the last run time.
Currently it is based on the "modified" date of the fetched indicators, which makes no sense as the last run date is then passed to the query parameter "added_after", which filters on the indicators ingestion date into the Taxii feed, and not on their last "modified" date.
So even if no new indicators are added to the Taxii feed, if their last "modified" date is before the time they were added to the feed, then the instance keeps pulling the same indicators at every fetch over and over again. 

## Must have
- [ ] Tests
- [ ] Documentation 
