### PR TITLE
Ews header deduplication bug

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
@@ -2023,7 +2023,11 @@ def get_item_as_eml(client: EWSClient, item_id, target_mailbox=None):      # pra
                         header.name.lower(),
                         header.value,
                 ) not in attached_email_headers and header.name.lower() != "content-type":
-                    email_content.add_header(header.name, header.value)
+                    try:
+                        email_content.add_header(header.name, header.value)
+                    except ValueError as err:
+                        if "There may be at most" not in str(err):
+                            raise err
 
         eml_name = item.subject if item.subject else "demisto_untitled_eml"
         file_result = fileResult(eml_name + ".eml", email_content.as_string())
@@ -2160,7 +2164,12 @@ def parse_incident_from_item(item):     # pragma: no cover
                                     not in attached_email_headers
                                     and header.name.lower() != "content-type"
                             ):
-                                attached_email.add_header(header.name, header.value)
+                                try:
+                                    attached_email.add_header(header.name, header.value)
+                                except ValueError as err:
+                                    if "There may be at most" not in str(err):
+                                        raise err
+
                     attached_email_bytes = attached_email.as_bytes()
                     chardet_detection = chardet.detect(attached_email_bytes)
                     encoding = chardet_detection.get('encoding', 'utf-8') or 'utf-8'

--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
@@ -607,6 +607,7 @@ def test_parse_incident_from_item_with_eml_attachment_header_integrity(mocker):
               b'Content-Type: text/plain; charset="us-ascii"\r\n' \
               b'X-FAKE-Header: HVALue\r\n' \
               b'X-Who-header: whovALUE\r\n' \
+              b'DATE: 2023-12-16T12:04:45\r\n' \
               b'\r\nHello'
     # headers set in the Item
     item_headers = [
@@ -615,17 +616,19 @@ def test_parse_incident_from_item_with_eml_attachment_header_integrity(mocker):
         MessageHeader(name="Content-Type", value="text/plain; charset=\"us-ascii\""),
         MessageHeader(name="X-Fake-Header", value="HVALue"),
         MessageHeader(name="X-WHO-header", value="whovALUE"),
+        # this is a header whose value is different. The field is limited to 1 by RFC
+        MessageHeader(name="Date", value="2023-12-16 12:04:45"),
         # This is an extra header logged by exchange in the item -> add to the output
         MessageHeader(name="X-EXTRA-Missed-Header", value="EXTRA")
     ]
 
     # sent to "fileResult", original headers from content with matched casing, with additional header
     expected_data = 'MIME-Version: 1.0\r\n' \
-                    'Message-ID:  <message-test-idRANDOMVALUES@testing.com>' \
-                    '\r\nX-FAKE-Header: HVALue\r\n' \
+                    'Message-ID:  <message-test-idRANDOMVALUES@testing.com>\r\n' \
+                    'X-FAKE-Header: HVALue\r\n' \
                     'X-Who-header: whovALUE\r\n' \
-                    'X-EXTRA-Missed-Header: EXTRA' \
-                    '\r\n' \
+                    'DATE: 2023-12-16T12:04:45\r\n' \
+                    'X-EXTRA-Missed-Header: EXTRA\r\n' \
                     '\r\nHello'
 
     message = Message(
@@ -744,15 +747,18 @@ def test_get_item_as_eml(subject, expected_file_name, mocker):
               b'Content-Type: text/plain; charset="us-ascii"\r\n' \
               b'X-FAKE-Header: HVALue\r\n' \
               b'X-Who-header: whovALUE\r\n' \
+              b'DATE: 2023-12-16T12:04:45\r\n' \
               b'\r\nHello'
 
     # headers set in the Item
     item_headers = [
-        # these headers may have different casing than what exists in the raw content
+        # these header keys may have different casing than what exists in the raw content
         MessageHeader(name="Mime-Version", value="1.0"),
         MessageHeader(name="Content-Type", value="text/plain; charset=\"us-ascii\""),
         MessageHeader(name="X-Fake-Header", value="HVALue"),
         MessageHeader(name="X-WHO-header", value="whovALUE"),
+        # this is a header whose value is different. The field is limited to 1 by RFC
+        MessageHeader(name="Date", value="2023-12-16 12:04:45"),
         # This is an extra header logged by exchange in the item -> add to the output
         MessageHeader(name="X-EXTRA-Missed-Header", value="EXTRA")
     ]
@@ -760,8 +766,8 @@ def test_get_item_as_eml(subject, expected_file_name, mocker):
                     'Message-ID:  <message-test-idRANDOMVALUES@testing.com>\r\n' \
                     'X-FAKE-Header: HVALue\r\n' \
                     'X-Who-header: whovALUE\r\n' \
-                    'X-EXTRA-Missed-Header: EXTRA' \
-                    '\r\n' \
+                    'DATE: 2023-12-16T12:04:45\r\n' \
+                    'X-EXTRA-Missed-Header: EXTRA\r\n' \
                     '\r\nHello'
 
     class MockEWSClient:

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_34.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_34.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS O365
+
+- allow **get_item_as_eml** and **parse_incident_from_item** to continue when adding limited header which already exists in the eml bytes

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_34.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_2_34.md
@@ -3,4 +3,4 @@
 
 ##### EWS O365
 
-- allow **get_item_as_eml** and **parse_incident_from_item** to continue when adding limited header which already exists in the eml bytes
+- Fixed a bug **get_item_as_eml** and **parse_incident_from_item**, so they continue when adding limited header which already exists in the eml bytes.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.2.33",
+    "currentVersion": "1.2.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This is a quick bug fix for the recent additions to the EWS_0365 which added the rfc compliant specifications along with the header deduplication prevention.

We just had one email come through where the DATE header value stored in the O365 object was different than the value stored in the EML bytes. 

When parsing using the python email library, since when using the SMTP and SMTPUTF8 policies, some  headers have specific restrictions on how many can be included. DATE has a restriction of 1, and since the header deduplication works off key/value pair, as some headers can and should appear more than once, the DATE header was attempted to be added again with the altered value from the microsoft api data, which threw this uncaught exception. 

This change adds a simple try/except around the add_header call to catch this specific error:

```
 ValueError: There may be at most <n> <header name> headers in a message
```

where <n> is the limit and <header name> is the name of the header. 

the exception logic is this:

```python
...
try:
    email_content.add_header(header.name, header.value)
except ValueError as err:
    if "There may be at most" not in str(err):
        raise err
```

Which will catch a value error and check if it matches the error message for this problem. If it does, the function will continue as normal. If it does not, the error is raised. 

## Must have
- [x] Tests
- [x] Documentation 
