### PR TITLE
moving the pack to on_prem support only

### DIFF
--- a/Packs/ElasticsearchMonitoring/pack_metadata.json
+++ b/Packs/ElasticsearchMonitoring/pack_metadata.json
@@ -17,6 +17,6 @@
         "OpenSearch"
     ],
     "marketplaces": [
-        "xsoar"
+        "xsoar_on_prem"
     ]
 }


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:[ link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9242)

## Description
Move the elasticsearch monitoring to xsoar on prem only 

## Must have
- [ ] Tests
- [ ] Documentation 
