### PR TITLE
NetskopeAPIv2 `alert_query` argument

### DIFF
--- a/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2.py
+++ b/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2.py
@@ -749,7 +749,7 @@ def fetch_incidents(client: Client, params: dict[str, Any]):
     last_run: dict[str, Any] = {}
 
     event_types = argToList(params.get("event_types"))
-    alert_query = params.get("alert_query")
+    alert_query = params.get("alerts_query")
     alert_max_fetch = arg_to_number(params["max_fetch"]) or MAX_LIMIT
 
     if (

--- a/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2.yml
+++ b/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2.yml
@@ -1026,7 +1026,7 @@ script:
     - contextPath: Netskope.Client.emails
       description: Netskope client emails.
       type: String
-  dockerimage: demisto/python3:3.10.13.75921
+  dockerimage: demisto/python3:3.10.13.83255
   feed: false
   isfetch: true
   longRunning: false

--- a/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2_test.py
+++ b/Packs/Netskope/Integrations/NetskopeAPIv2/NetskopeAPIv2_test.py
@@ -12,7 +12,7 @@ API_TOKEN = "api_token"
 
 def util_load_json(file_name):
     with open(
-        os.path.join("test_data", f"{file_name}.json"), mode="r", encoding="utf-8"
+        os.path.join("test_data", f"{file_name}.json"), encoding="utf-8"
     ) as mock_file:
         return json.loads(mock_file.read())
 

--- a/Packs/Netskope/ReleaseNotes/3_3_2.md
+++ b/Packs/Netskope/ReleaseNotes/3_3_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Netskope (API v2)
+
+- Fixed an issue where the `alert_query` argument value was not used when provided.

--- a/Packs/Netskope/ReleaseNotes/3_3_2.md
+++ b/Packs/Netskope/ReleaseNotes/3_3_2.md
@@ -4,3 +4,4 @@
 ##### Netskope (API v2)
 
 - Fixed an issue where the `alert_query` argument value was not used when provided.
+- Updated the docker image to: *demisto/python3:3.10.13.83255*.

--- a/Packs/Netskope/pack_metadata.json
+++ b/Packs/Netskope/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Netskope",
     "description": "Cloud access security broker that enables to find, understand, and secure cloud apps.",
     "support": "xsoar",
-    "currentVersion": "3.3.1",
+    "currentVersion": "3.3.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixed an issue where due to a typo, the `alert_query` argument value was not used when provided. 

fixes: [XSUP-31727](https://jira-dc.paloaltonetworks.com/browse/XSUP-31727)