### PR TITLE
Update CommonServerPython.py

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -1808,7 +1808,7 @@ def flattenCell(data, is_pretty=True):
 
         return ',\n'.join(string_list)
     else:
-        return json.dumps(data, indent=indent, ensure_ascii=False)
+        return json.dumps(data, indent=indent, ensure_ascii=False, default=str)
 
 
 def FormatIso8601(t):


### PR DESCRIPTION
Cast python object to string instead of throwing an error in flattenCell

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
No related issues.

## Description
The proposed change will make it easier to add python objects to dictionaries without casting them to string.
Additionally, it is impossible now to get a database table that has a datetime column in it because of this issue.

## Must have
- [ ] Tests
- [ ] Documentation 
