### PR TITLE
deprecating the format argument

### DIFF
--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
@@ -1264,7 +1264,7 @@ script:
     - contextPath: InfoFile.Type
       description: The web artifacts file type.
       type: string
-  dockerimage: demisto/python3:3.10.13.80593
+  dockerimage: demisto/python3:3.10.13.83255
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.yml
@@ -446,6 +446,7 @@ script:
       predefined:
       - 'xml'
       - 'pdf'
+      deprecated: true
     - auto: PREDEFINED
       defaultValue: 'false'
       description: Whether to receive extended information from WildFire. Only relevant when polling=true.
@@ -1003,6 +1004,7 @@ script:
       predefined:
       - 'xml'
       - 'pdf'
+      deprecated: true
     - auto: PREDEFINED
       defaultValue: 'false'
       description: Whether to receive extended information from WildFire. Only relevant when polling=true.

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_39.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_39.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks WildFire v2
+- Updated the Docker image to: *demisto/python3:3.10.13.83255*.
+- Deprecated the *format* argument for ***wildfire-upload-url*** and ***wildfire-upload-file-url*** commands.

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "WildFire by Palo Alto Networks",
     "description": "Perform malware dynamic analysis",
     "support": "xsoar",
-    "currentVersion": "2.1.38",
+    "currentVersion": "2.1.39",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/XSUP-31533

## Description
Deprecating the "format" argument for  "wildfire-upload-url" and "wildfire-upload-file-url" commands, since it was added by us by mistake. 

## Must have
- [ ] Tests
- [x] Documentation 
