### PR TITLE
[XSUP 31458] Fix test-module in PANW Enterprise DLP

### DIFF
--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
@@ -56,6 +56,7 @@ class Client(BaseClient):
             self.refresh_token = credentials[PASSWORD]
         else:
             self.access_token = ''
+            self._refresh_token_with_client_credentials()
 
     def _refresh_token(self):
         """Refreshes Access Token"""
@@ -108,7 +109,7 @@ class Client(BaseClient):
 
         except Exception as e:
             print_debug_msg(str(e))
-            raise
+            raise e
 
     def _handle_403_errors(self, res):
         """
@@ -225,7 +226,7 @@ class Client(BaseClient):
         query_string = urllib.parse.urlencode(params)
         url = f"{url}?{query_string}"
         resp, status_code = self._get_dlp_api_call(url)
-        return resp
+        return resp, status_code
 
     def update_dlp_incident(self, incident_id: str, feedback: FeedbackStatus, user_id: str, region: str,
                             report_id: str, dlp_channel: str, error_details: str = None):
@@ -356,13 +357,19 @@ def parse_dlp_report(report_json) -> CommandResults:
     )
 
 
-def test(client):
+def test(client: Client, params: dict):
     """ Test Function to test validity of access and refresh tokens"""
-    report_json, status_code = client.get_dlp_report('1')
+    dlp_regions = params.get("dlp_regions")
+    report_json, status_code = client.get_dlp_incidents(regions=dlp_regions)
     if status_code in [200, 204]:
         return_results("ok")
     else:
-        raise DemistoException(f"Integration test failed: Unexpected status ({status_code})")
+        message = f"Integration test failed: Unexpected status ({status_code}) - "
+        if "error" in report_json:
+            message += f"Error message: \"{report_json.get('error')}\""
+        else:
+            message += f"The DLP Regions \"{dlp_regions}\" might be invalid, please check them again."
+        raise DemistoException(message)
 
 
 def print_debug_msg(msg: str):
@@ -447,7 +454,7 @@ def fetch_incidents(client: Client, regions: str, start_time: int = None, end_ti
     else:
         print_debug_msg('Start fetching most recent incidents')
 
-    notification_map = client.get_dlp_incidents(regions=regions, start_time=start_time, end_time=end_time)
+    notification_map, _ = client.get_dlp_incidents(regions=regions, start_time=start_time, end_time=end_time)
     incidents = []
     for region, notifications in notification_map.items():
         for notification in notifications:
@@ -620,7 +627,7 @@ def main():
         elif demisto.command() == 'pan-dlp-reset-last-run':
             return_results(reset_last_run_command())
         elif demisto.command() == "test-module":
-            test(client)
+            test(client, params)
 
     except Exception as e:
         return_error(f'Failed to execute {demisto.command()} command.\nError:\n{str(e)}')

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.yml
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.yml
@@ -29,7 +29,6 @@ configuration:
   - EU
   - AP
   - UK
-  defaultvalue: US,EU,AP,UK
   required: false
 - display: Data profiles to allow exemption
   name: dlp_exemptible_list

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_0_8.md
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_0_8.md
@@ -1,0 +1,3 @@
+#### Integrations
+##### Palo Alto Networks Enterprise DLP
+- Fixed an issue where running the ***test-module*** and authenticating with the credentials option.

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
@@ -5,7 +5,7 @@
     "support": "xsoar",
     "author": "Palo Alto Networks Enterprise DLP",
     "url": "https://www.paloaltonetworks.com/enterprise-data-loss-prevention",
-    "currentVersion": "2.0.7",
+    "currentVersion": "2.0.8",
     "categories": [
         "Network Security"
     ],


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-31458)

## Description
Fixed the test-module command where authenticating with credentials and the default report ID doesn't exist.