### PR TITLE
Fixing an error of Bcc values was processed as an array of values

### DIFF
--- a/Packs/MicrosoftGraphMail/Classifiers/classifier-Microsoft_Graph_Mail_Mapper.json
+++ b/Packs/MicrosoftGraphMail/Classifiers/classifier-Microsoft_Graph_Mail_Mapper.json
@@ -197,8 +197,19 @@
                             ]
                         ],
                         "root": "Headers",
-                        "transformers": []
-                    },
+						"transformers": [
+                            {
+                                "args": {
+                                    "separator": {
+                                        "isContext": false,
+                                        "value": {
+                                            "simple": ","
+                                        }
+                                    }
+                                },
+                                "operator": "join"
+                            }
+                        ]                    },
                     "simple": ""
                 },
                 "Email Return Path": {
@@ -304,6 +315,27 @@
                     },
                     "simple": ""
                 },
+                "Email BCC": {
+					"complex": {
+						"accessor": "",
+						"filters": [],
+						"root": "Bcc",
+						"transformers": [
+                            {
+                                "args": {
+                                    "separator": {
+                                        "isContext": false,
+                                        "value": {
+                                            "simple": ","
+                                        }
+                                    }
+                                },
+                                "operator": "join"
+                            }
+                        ]
+					},
+					"simple": ""
+				},
                 "Email To Count": {
                     "complex": {
                         "accessor": "",

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_2.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_2.md
@@ -1,0 +1,5 @@
+
+#### Mappers
+
+##### Microsoft Graph Mail Mapper
+- Fixed an issue where in some cases multiple **Email BCC** values was processed as an array of values.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.6.1",
+    "currentVersion": "1.6.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-30182

## Description
Fixed an issue where in some cases multiple **Email BCC** value was processed as an array of values.
