### PR TITLE
[Hatching Triage] - remove usage of get pack version

### DIFF
--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -66,6 +66,7 @@ def map_scores_to_dbot(score):
         return 2
     elif 8 <= score <= 10:
         return 3
+    return None
 
 
 def query_samples(client, **args) -> CommandResults:
@@ -195,9 +196,8 @@ def get_static_report(client: Client, **args) -> CommandResults:
     r = client._http_request("GET", f"samples/{sample_id}/reports/static")
 
     score = 0
-    if 'analysis' in r:
-        if 'score' in r['analysis']:
-            score = map_scores_to_dbot(r['analysis']['score'])
+    if 'analysis' in r and 'score' in r['analysis']:
+        score = map_scores_to_dbot(r['analysis']['score'])
 
     indicator: Any
     if 'sample' in r:
@@ -258,9 +258,8 @@ def get_report_triage(client: Client, **args) -> CommandResults:
     )
     score = 0
     indicator: Any
-    if 'sample' in r:
-        if 'score' in r['sample']:
-            score = map_scores_to_dbot(r['sample']['score'])
+    if 'sample' in r and 'score' in r['sample']:
+        score = map_scores_to_dbot(r['sample']['score'])
 
     target = r['sample']['target']
     if "sha256" not in r['sample']:

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.py
@@ -14,7 +14,7 @@ def _version_header():
     demisto_version = get_demisto_version()
     return f"Palo Alto XSOAR/{demisto_version.get('version')}." \
            f"{demisto_version.get('buildNumber')} " \
-           f"Hatching Triage Pack/{get_pack_version()}"
+           f"Hatching Triage Pack/1.0.16"
 
 
 class Client(BaseClient):

--- a/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
+++ b/Packs/HatchingTriage/Integrations/HatchingTriage/HatchingTriage.yml
@@ -594,7 +594,7 @@ script:
       required: true
     name: triage-delete-profile
     description: Update the profile with the specified ID or name. The stored profile is overwritten, so it is important that the submitted profile has all fields, with the exception of the ID.
-  dockerimage: demisto/python3:3.10.13.80014
+  dockerimage: demisto/python3:3.10.13.84405
   runonce: false
   script: ''
   subtype: python3

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_16.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_16.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Hatching Triage
+
+- Fixed an issue where using the integration could potentially cause xsoar to be overloaded.

--- a/Packs/HatchingTriage/ReleaseNotes/1_0_16.md
+++ b/Packs/HatchingTriage/ReleaseNotes/1_0_16.md
@@ -4,3 +4,4 @@
 ##### Hatching Triage
 
 - Fixed an issue where using the integration could potentially cause xsoar to be overloaded.
+- Updated the Docker image to: *demisto/python3:3.10.13.84405*.

--- a/Packs/HatchingTriage/pack_metadata.json
+++ b/Packs/HatchingTriage/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Scalable malware sandbox",
     "support": "partner",
     "certification": "certified",
-    "currentVersion": "1.0.15",
+    "currentVersion": "1.0.16",
     "author": "Hatching",
     "url": "https://hatching.io/",
     "email": "support@hatching.io",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-31229)

## Description
- Fixed an issue where using the integration could potentially cause xsoar to be overloaded. That happens because the `get_pack_version` pulls all the integration/script metadata which can be quite large.


