### PR TITLE
[Common Scripts] Make MITRE ATT&CK optional dependency

### DIFF
--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -20,6 +20,10 @@
             "mandatory": true,
             "display_name": "Demisto REST API"
         },
+        "FeedMitreAttackv2": {
+            "mandatory": false,
+            "display_name": "MITRE ATT&CK v2"
+        },
         "Gmail": {
             "mandatory": false,
             "display_name": "Gmail"


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9446)

## Description
Now the ExtractAttackPattern script is in the Common Scripts pack, and since it uses an integration command from the MITER ATT&CK pack, it creates a circular dependency between the two packs.
That's why we make MITER ATT&CK optional in Common Scripts dependency.

## Must have
- [ ] Tests
- [ ] Documentation 
