### PR TITLE
[Pre-Commit] Run pre-commit in community PR

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,14 +10,5 @@ jobs:
       pull-requests: write
       contents: write
 
-    if: "!contains(github.event.pull_request.labels.*.name, 'Community Support Level')"
     uses: ./.github/workflows/pre-commit-reuse.yml
       
-  pre-commit-community-level:
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: write
-
-    if: contains(github.event.pull_request.labels.*.name, 'Community Support Level')
-    uses: ./.github/workflows/pre-commit-reuse.yml


### PR DESCRIPTION
We can now unite the pre-commit to one workflow since we can now can exclude hooks from running on community packs.