### PR TITLE
Infoblox-NIOS-Modeling-Refactor-CIAC-9444

### DIFF
--- a/Packs/Infoblox/.secrets-ignore
+++ b/Packs/Infoblox/.secrets-ignore
@@ -1,0 +1,1 @@
+https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.4

--- a/Packs/Infoblox/ModelingRules/Infoblox_1_3/Infoblox_1_3.xif
+++ b/Packs/Infoblox/ModelingRules/Infoblox_1_3/Infoblox_1_3.xif
@@ -1,44 +1,71 @@
 [MODEL: dataset="infoblox_infoblox_raw"]
-filter
-    _raw_log ~= "client" and _raw_log ~="infoblox-responses" and _raw_log ~="named"
+filter _raw_log ~= "(?:UDP|TCP):\s*query:\s*(?:\S+\s+){3}response:"  // DNS Response Events 
 | alter 
-    process_pid = arrayindex(regextract(_raw_log, "\s\w+\[(\d+)\]"),0),
-    Source_ipv4 = arrayindex(regextract(_raw_log, "\s(\d{1,3}(?:\.\d{1,3}){3})\#"),0),
-    Source_ports = arrayindex(regextract(_raw_log, "#(\d+)"),0),
-    protocol_layers = regextract(_raw_log, "#(?:\d+):\s([A-Z]+)"),
-    dns_question_name = arrayindex(regextract(_raw_log, "query:\s+(\S*)?\s"), 0),
-    dns_question_type = arrayindex(regextract(_raw_log, "query:\s+\S*?\sIN\s(\S*?)\s"), 0),
-    dns_response_code = arrayindex(regextract(_raw_log, "response\:\s(.*?)\s"), 0),
-    dns_resource_record_name = arrayindex(regextract(_raw_log, "(\S*?)\s\d*?\sIN\s\w*?\s\S*?[;]$"), 0),
-    dns_resource_record_type = arrayindex(regextract(_raw_log, "response:\s+.*?\s+(A\s|AAAA\s)"), 0),
-    dns_resource_record_value = arrayindex(regextract(_raw_log, "response:.*?A\s(\S*)[;]$"), 0)
-| alter
-    xdm.source.process.pid = to_number(process_pid),
-    xdm.source.ipv4 = Source_ipv4,
-    xdm.source.port = to_number(Source_ports),
-    xdm.network.protocol_layers = protocol_layers,
-    xdm.network.dns.dns_question.name = dns_question_name,
-    xdm.network.dns.dns_question.type = dns_question_type,
-    xdm.network.dns.response_code = dns_response_code,
-    xdm.network.dns.dns_resource_record.name = dns_resource_record_name,
-    xdm.network.dns.dns_resource_record.type = dns_resource_record_type,
-    xdm.network.dns.dns_resource_record.value = dns_resource_record_value;
-
-filter
-    _raw_log ~= "httpd"
-| alter
-    Client_user_username = arrayindex(regextract(_raw_log, "\s\[(.*?)\]\:"), 0),
-    original_event_type = arrayindex(regextract(_raw_log, ":\s.*?:\s(.*?)\s-\s-"), 0),
-    Server_process_name = arrayindex(regextract(_raw_log, "to=(.*?)\s"), 0),
-    Client_ipv4 = arrayindex(regextract(_raw_log, "ip=(.*?)\s"), 0),
-    auth_methods = arrayindex(regextract(_raw_log, "auth=(.*?)\s"), 0),
-    Client_user_groups = arrayindex(regextract(_raw_log, "group=(.*?)\s"), 0),
-    application_protocols = arrayindex(regextract(_raw_log, "apparently_via=(.*?)$"), 0)
-| alter
-    xdm.source.user.username = Client_user_username,
-    xdm.event.type = original_event_type,
-    xdm.intermediate.process.name = Server_process_name,
-    xdm.source.ipv4 = Client_ipv4,
-    xdm.auth.auth_method = auth_methods,
-    xdm.source.user.groups = arraycreate(coalesce(Client_user_groups, "")),
-    xdm.network.application_protocol = application_protocols;
+    syslog_process_id = arrayindex(regextract(_raw_log, "\s\w+\[(\d+)\]"), 0),
+    syslog_process_name = arrayindex(regextract(_raw_log, "\s(\w+)\[\d+\]"), 0),
+    syslog_priority = to_integer(arrayindex(regextract(_raw_log, "^\<(\d{1,3})\>\s*\w+"), 0)),
+    syslog_msg = coalesce( 
+        arrayindex(regextract(_raw_log, "\w+\[\d+\]:\s*(.+)"), 0), // messages that are sent directly from infoblox 
+        arrayindex(regextract(_raw_log, "^\<\d+\>\w?\s+(?:\S+\s+){6}(.+)"), 0)) // messages that are downloaded to file and sent via an intermediate syslog client 
+| alter syslog_facility_code = floor(divide(syslog_priority, 8))
+| alter syslog_severity = to_string(subtract(syslog_priority, multiply(syslog_facility_code, 8)))
+| alter // Extract query & response data 
+    client_ip = arrayindex(regextract(syslog_msg, "client\s+([\da-fA-F\.\:]+)\#\d{1,5}"), 0),
+    client_port = arrayindex(regextract(syslog_msg, "client\s+[\da-fA-F\.\:]+\#(\d{1,5})"), 0),
+    ip_protocol = arrayindex(regextract(syslog_msg, "client\s+[\da-fA-F\.\:]+\#\d{1,5}:\s+(TCP|UDP)"), 0),
+    query_domain_name = arrayindex(regextract(syslog_msg, "query\:\s+(\S+)"), 0),
+    query_class = arrayindex(regextract(syslog_msg, "query\:\s+\S+\s+(?:\@0x[\da-fA-F]+\s+)?(\w+)"), 0),
+    query_record_type = arrayindex(regextract(syslog_msg, "query\:\s+\S+\s+(?:\@0x[\da-fA-F]+\s+)?\w+\s+(\w+)"), 0),
+    response_rcode = arrayindex(regextract(syslog_msg, "response\:\s+(\S+)"), 0),
+    response_flags = arrayindex(regextract(syslog_msg, "response\:\s+\S+\s+((?:\+|\-)*[ATEDVL]{0,6})"), 0),
+    response_rr = arrayfilter(split(arrayindex(regextract(syslog_msg, "response\:\s+(?:\S+\s+){2}(.+)"), 0), ";"), len("@element") > 0) // response resource records (RR)
+| alter // Extract ipv4 & ipv6 resolved addresses (A & AAAA record types, respectively)
+    response_resolved_ipv4_addresses = arraymap(response_rr, arrayindex(regextract("@element", "(?:\S+\s+){3}A\s+(\S+)"), 0)), // A records 
+    response_resolved_ipv6_addresses = arraymap(response_rr, arrayindex(regextract("@element", "(?:\S+\s+){3}A{4}\s+(\S+)"), 0)) // AAAA records
+| alter // Isolate only the requested records types from the entire response 
+    response_requested_records = if(query_record_type = "ANY", response_rr, arrayfilter(response_rr,  arrayindex(regextract("@element", "(?:\S+\s+){3}(\S+)"), 0) = query_record_type))
+| alter // Extract the domain names and their associated record values from the response  
+    response_domain_names = arraymap(response_requested_records, rtrim(arrayindex(regextract("@element", "(\S+)"), 0), ".")),
+    response_values = arraymap(response_requested_records, arrayindex(regextract("@element", "(?:\S+\s+){4}(.+)"), 0))
+| alter // reformat the domain names & values from array to semicolon separated strings
+    response_distinct_domain_names = arraydistinct(response_domain_names),
+    response_distinct_values = arraydistinct(response_values)
+| alter 
+    response_domain_names = if(array_length(response_distinct_domain_names) = 1, arraystring(response_distinct_domain_names, ";"), arraystring(response_domain_names, ";")),
+    response_values = if(array_length(response_distinct_values) = 1, arraystring(response_distinct_values, ";"), arraystring(response_values, ";"))
+| alter // additional processing 
+    application_protocol = "DNS",
+	client_ipv4 = if(client_ip ~= "(?:\d{1,3}\.){3}\d{1,3}", client_ip),
+	client_ipv6 = if(client_ip ~= ":", client_ip),
+    query_class_enum = if(query_class = "IN", 1, query_class = "CS", 2, query_class = "CH", 3, query_class = "HS", 4), // see https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.4
+    query_record_type_enum = if(query_record_type = "A", XDM_CONST.DNS_RECORD_TYPE_A, query_record_type = "AAAA", XDM_CONST.DNS_RECORD_TYPE_AAAA, query_record_type = "AFSDB", XDM_CONST.DNS_RECORD_TYPE_AFSDB, query_record_type = "APL", XDM_CONST.DNS_RECORD_TYPE_APL, query_record_type = "CAA", XDM_CONST.DNS_RECORD_TYPE_CAA, query_record_type = "CDNSKEY", XDM_CONST.DNS_RECORD_TYPE_CDNSKEY, query_record_type = "CDS", XDM_CONST.DNS_RECORD_TYPE_CDS, query_record_type = "CERT", XDM_CONST.DNS_RECORD_TYPE_CERT, query_record_type = "CNAME", XDM_CONST.DNS_RECORD_TYPE_CNAME, query_record_type = "CSYNC", XDM_CONST.DNS_RECORD_TYPE_CSYNC, query_record_type = "DHCID", XDM_CONST.DNS_RECORD_TYPE_DHCID, query_record_type = "DLV", XDM_CONST.DNS_RECORD_TYPE_DLV, query_record_type = "DNAME", XDM_CONST.DNS_RECORD_TYPE_DNAME, query_record_type = "DNSKEY", XDM_CONST.DNS_RECORD_TYPE_DNSKEY, query_record_type = "DS", XDM_CONST.DNS_RECORD_TYPE_DS, query_record_type = "EUI48", XDM_CONST.DNS_RECORD_TYPE_EUI48, query_record_type = "EUI64", XDM_CONST.DNS_RECORD_TYPE_EUI64, query_record_type = "HINFO", XDM_CONST.DNS_RECORD_TYPE_HINFO, query_record_type = "HIP", XDM_CONST.DNS_RECORD_TYPE_HIP, query_record_type = "HTTPS", XDM_CONST.DNS_RECORD_TYPE_HTTPS, query_record_type = "IPSECKEY", XDM_CONST.DNS_RECORD_TYPE_IPSECKEY, query_record_type = "KEY", XDM_CONST.DNS_RECORD_TYPE_KEY, query_record_type = "KX", XDM_CONST.DNS_RECORD_TYPE_KX, query_record_type = "LOC", XDM_CONST.DNS_RECORD_TYPE_LOC, query_record_type = "MX", XDM_CONST.DNS_RECORD_TYPE_MX, query_record_type = "NAPTR", XDM_CONST.DNS_RECORD_TYPE_NAPTR, query_record_type = "NS", XDM_CONST.DNS_RECORD_TYPE_NS, query_record_type = "NSEC", XDM_CONST.DNS_RECORD_TYPE_NSEC, query_record_type = "NSEC3", XDM_CONST.DNS_RECORD_TYPE_NSEC3, query_record_type = "NSEC3PARAM", XDM_CONST.DNS_RECORD_TYPE_NSEC3PARAM, query_record_type = "OPENPGPKEY", XDM_CONST.DNS_RECORD_TYPE_OPENPGPKEY, query_record_type = "PTR", XDM_CONST.DNS_RECORD_TYPE_PTR, query_record_type = "RRSIG", XDM_CONST.DNS_RECORD_TYPE_RRSIG, query_record_type = "RP", XDM_CONST.DNS_RECORD_TYPE_RP, query_record_type = "SIG", XDM_CONST.DNS_RECORD_TYPE_SIG, query_record_type = "SMIMEA", XDM_CONST.DNS_RECORD_TYPE_SMIMEA, query_record_type = "SOA", XDM_CONST.DNS_RECORD_TYPE_SOA, query_record_type = "SRV", XDM_CONST.DNS_RECORD_TYPE_SRV, query_record_type = "SSHFP", XDM_CONST.DNS_RECORD_TYPE_SSHFP, query_record_type = "SVCB", XDM_CONST.DNS_RECORD_TYPE_SVCB, query_record_type = "TA", XDM_CONST.DNS_RECORD_TYPE_TA, query_record_type = "TKEY", XDM_CONST.DNS_RECORD_TYPE_TKEY, query_record_type = "TLSA", XDM_CONST.DNS_RECORD_TYPE_TLSA, query_record_type = "TSIG", XDM_CONST.DNS_RECORD_TYPE_TSIG, query_record_type = "TXT", XDM_CONST.DNS_RECORD_TYPE_TXT, query_record_type = "URI", XDM_CONST.DNS_RECORD_TYPE_URI, query_record_type = "ZONEMD", XDM_CONST.DNS_RECORD_TYPE_ZONEMD, query_record_type)
+| alter // XDM Mapping 
+    xdm.alert.severity = syslog_severity,
+    xdm.event.type = "DNS Response",
+    xdm.event.description = syslog_msg,
+    xdm.event.log_level = if(syslog_severity = "0", XDM_CONST.LOG_LEVEL_EMERGENCY, syslog_severity = "1", XDM_CONST.LOG_LEVEL_ALERT, syslog_severity = "2", XDM_CONST.LOG_LEVEL_CRITICAL, syslog_severity = "3", XDM_CONST.LOG_LEVEL_ERROR, syslog_severity = "4", XDM_CONST.LOG_LEVEL_WARNING, syslog_severity = "5", XDM_CONST.LOG_LEVEL_NOTICE, syslog_severity = "6", XDM_CONST.LOG_LEVEL_INFORMATIONAL, syslog_severity = "7", XDM_CONST.LOG_LEVEL_DEBUG, syslog_severity),
+    xdm.event.outcome = if(response_rcode = "NOERROR", XDM_CONST.OUTCOME_SUCCESS, response_rcode != null, XDM_CONST.OUTCOME_FAILED),
+    xdm.event.outcome_reason = response_rcode,
+    xdm.network.application_protocol = application_protocol,
+    xdm.network.dns.authoritative = if(response_flags contains "A", to_boolean("TRUE"), to_boolean("FALSE")),
+    xdm.network.dns.dns_question.class = query_class_enum,
+    xdm.network.dns.dns_question.name = query_domain_name,
+    xdm.network.dns.dns_question.type = query_record_type_enum,
+    xdm.network.dns.dns_resource_record.class = query_class_enum,
+    xdm.network.dns.dns_resource_record.name = response_domain_names,
+    xdm.network.dns.dns_resource_record.type = query_record_type_enum,
+    xdm.network.dns.dns_resource_record.value = response_values,
+    xdm.network.dns.is_response = to_boolean("TRUE"),
+    xdm.network.dns.is_truncated = if(response_flags contains "t", to_boolean("TRUE"), to_boolean("FALSE")),
+    xdm.network.dns.response_code = if(response_rcode = "NOERROR", XDM_CONST.DNS_RESPONSE_CODE_NO_ERROR, response_rcode = "FORMERR", XDM_CONST.DNS_RESPONSE_CODE_FORMAT_ERROR, response_rcode = "SERVFAIL", XDM_CONST.DNS_RESPONSE_CODE_SERVER_FAILURE, response_rcode = "NXDOMAIN", XDM_CONST.DNS_RESPONSE_CODE_NON_EXISTENT_DOMAIN, response_rcode = "NOTIMP", XDM_CONST.DNS_RESPONSE_CODE_NOT_IMPLEMENTED, response_rcode ~= "REFUSED", XDM_CONST.DNS_RESPONSE_CODE_QUERY_REFUSED, response_rcode ~= "YXDOMAIN", XDM_CONST.DNS_RESPONSE_CODE_NAME_EXISTS_WHEN_IT_SHOULD_NOT, response_rcode = "YXRRSET", XDM_CONST.DNS_RESPONSE_CODE_RR_SET_EXISTS_WHEN_IT_SHOULD_NOT, response_rcode = "NXRRSET", XDM_CONST.DNS_RESPONSE_CODE_RR_SET_THAT_SHOULD_EXIST_DOES_NOT, response_rcode = "NOTAUTH", XDM_CONST.DNS_RESPONSE_CODE_SERVER_NOT_AUTHORITATIVE_FOR_ZONE, response_rcode = "NOTZONE", XDM_CONST.DNS_RESPONSE_CODE_NAME_NOT_CONTAINED_IN_ZONE, response_rcode = "BADVERS", XDM_CONST.DNS_RESPONSE_CODE_BAD_OPT_VERSION, response_rcode = "BADSIG", XDM_CONST.DNS_RESPONSE_CODE_TSIG_SIGNATURE_FAILURE, response_rcode = "BADKEY", XDM_CONST.DNS_RESPONSE_CODE_KEY_NOT_RECOGNIZED, response_rcode = "BADTIME", XDM_CONST.DNS_RESPONSE_CODE_SIGNATURE_OUT_OF_TIME_WINDOW, response_rcode = "BADMODE", XDM_CONST.DNS_RESPONSE_CODE_BAD_TKEY_MODE, response_rcode = "BADNAME", XDM_CONST.DNS_RESPONSE_CODE_DUPLICATE_KEY_NAME, response_rcode = "BADALG", XDM_CONST.DNS_RESPONSE_CODE_ALGORITHM_NOT_SUPPORTED, response_rcode = "BADTRUNC", XDM_CONST.DNS_RESPONSE_CODE_BAD_TRUNCATION, response_rcode),
+    xdm.network.ip_protocol = if(ip_protocol = "TCP", XDM_CONST.IP_PROTOCOL_TCP, ip_protocol = "UDP", XDM_CONST.IP_PROTOCOL_UDP),
+    xdm.network.protocol_layers = arraycreate(application_protocol, ip_protocol),
+    xdm.source.ipv4 = client_ipv4,
+    xdm.source.ipv6 = client_ipv6,
+    xdm.source.port = to_number(client_port),
+    xdm.source.process.name = syslog_process_name,
+    xdm.source.process.pid = to_number(syslog_process_id),
+    xdm.target.host.ipv4_addresses = response_resolved_ipv4_addresses,
+    xdm.target.host.ipv6_addresses = response_resolved_ipv6_addresses,
+    xdm.target.ipv4 = arrayindex(response_resolved_ipv4_addresses, 0),
+    xdm.target.ipv6 = arrayindex(response_resolved_ipv6_addresses, 0);


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-9444](https://jira-dc.paloaltonetworks.com/browse/CIAC-9444)

## Description
This PR reimplements the modeling and parsing for the Infoblox NIOS pack. 
It takes care of incomplete filters which were introduced on the initial implementation, improves and extends the existing extractions, and adds support for DHCP logs in addition to the existing support for DNS & Audit logs. 
In addition it extends support for additional log formats which might be ingested by an intermediate syslog process (for example if the logs were downloaded to a local file rather than sent to XSIAM via syslog directly from Infoblox). 

## Must have
- [x] Tests
- [x] Documentation 
