### PR TITLE
Move Slack Token/Channel to Local method

### DIFF
--- a/Tests/scripts/infrastructure_tests/lock_cloud_machines_test.py
+++ b/Tests/scripts/infrastructure_tests/lock_cloud_machines_test.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 import requests
@@ -88,6 +89,7 @@ def test_get_my_place_in_the_queue(mocker):
     then:   assert that returns the right place and the right previous_build_in_queue.
     """
     storage = MockResponse()
+    mocker.patch.dict(os.environ, {"SLACK_TOKEN": "myslacktoken"})
     mocker.patch('Tests.scripts.lock_cloud_machines.send_slack_notification')
     mocker.patch.object(storage, 'list_blobs', return_value=[MockResponse('test/queue/1234', '08/04/2000'),
                                                              MockResponse('test/queue/1235', '05/04/2000'),

--- a/Tests/scripts/lock_cloud_machines.py
+++ b/Tests/scripts/lock_cloud_machines.py
@@ -8,7 +8,7 @@ import requests
 from google.cloud import storage  # noqa
 import argparse
 from Utils.github_workflow_scripts.utils import get_env_var
-from slack_sdk import WebClient
+from slack_sdk import WebClient as SlackWebClient
 from datetime import datetime
 
 GITLAB_SERVER_URL = get_env_var('CI_SERVER_URL', 'https://gitlab.xdr.pan.local')  # disable-secrets-detection
@@ -19,10 +19,6 @@ JOB_STATUS_URL = '{}/api/v4/projects/{}/jobs/{}'  # disable-secrets-detection
 CONTENT_GITLAB_PROJECT_ID = get_env_var('CI_PROJECT_ID', '1061')
 
 
-SLACK_TOKEN = get_env_var('SLACK_TOKEN')
-SLACK_CHANNEL = get_env_var('WAIT_SLACK_CHANNEL', "dmst-test-wait-in-line")
-
-
 def send_slack_notification(text: list[str]):
     """
     Sends a Slack notification with a list of items.
@@ -31,10 +27,14 @@ def send_slack_notification(text: list[str]):
         text (List[str]): A list of items to be included in the Slack notification.
 
     """
+
+    slack_token = get_env_var('SLACK_TOKEN')
+    slack_channel = get_env_var('WAIT_SLACK_CHANNEL', "dmst-test-wait-in-line")
+
     text = "\n".join(text)
-    client = WebClient(token=SLACK_TOKEN)
+    client = SlackWebClient(token=slack_token)
     client.chat_postMessage(
-        channel=SLACK_CHANNEL,
+        channel=slack_channel,
         text=text
     )
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9477

## Description
As a result of changes in https://github.com/demisto/content/pull/32098, the _Infrastructure testing_ job is failing in the _Run Unit Testing And Lint_ flows. An example can be seen in [this job failure](https://app.circleci.com/pipelines/github/demisto/content/337496/workflows/aa59b79b-cf47-475a-b6f2-002627c40556/jobs/737300?invite=true#step-119-2376_99).

This PR is a fix for this issue by moving the Slack token env var retrieval from global to local method scope.

## Must have
- [ ] Tests
- [ ] Documentation 
