### PR TITLE
handling in case no indicator found in get-ip command

### DIFF
--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
@@ -72,6 +72,8 @@ RPZ_RULES_DICT = {
     }
 }
 
+NO_INDICATORS_FOUND = "A network was not found for this address"
+
 
 class Client(BaseClient):
     def __init__(self, base_url, verify=True, proxy=False, ok_codes=tuple(), headers=None, auth=None, params=None):
@@ -346,7 +348,13 @@ def get_ip_command(client: Client, args: Dict[str, str]) -> Tuple[str, Dict, Dic
         Outputs
     """
     ip = args.get('ip')
-    raw_response = client.get_ip(ip)
+    try:
+        raw_response = client.get_ip(ip)
+    except DemistoException as e:
+        if e.message and NO_INDICATORS_FOUND in e.message:
+            return "No indicators found", {},  {}
+        else:
+            raise
     ip_list = raw_response.get('result')
 
     # If no IP object was returned

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox_test.py
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox_test.py
@@ -1,4 +1,5 @@
-from Infoblox import Client
+import pytest
+from Infoblox import NO_INDICATORS_FOUND, Client, get_ip_command
 import demistomock as demisto
 import json
 
@@ -118,3 +119,40 @@ class TestZonesOperations:
             }}
 
     # def test_delete_response_policy_zone_command(self, mocker, requests_mock):
+
+
+def test_get_ip_command_no_indicator_found(mocker):
+    """
+    Given:
+        - IP address to get
+    When:
+        - Get IP command is called
+    Then:
+        - Ensure that no raises an error when the IP address is not found
+    """
+    mocker.patch.object(client, "get_ip", side_effect=DemistoException(NO_INDICATORS_FOUND))
+
+    readable_output, _, _ = get_ip_command(client, {'ip': '1.1.1.1'})
+    assert readable_output == "No indicators found"
+
+
+@pytest.mark.parametrize(
+    "mock_exception",
+    [
+        DemistoException,
+        Exception
+    ]
+)
+def test_get_ip_command_raise_error(mocker, mock_exception):
+    """
+    Given:
+        - IP address to get
+    When:
+        - Get IP command is called
+    Then:
+        - Ensure that an error is raised
+    """
+    mocker.patch.object(client, "get_ip", side_effect=mock_exception("test"))
+
+    with pytest.raises(mock_exception, match="test"):
+        get_ip_command(client, {'ip': '1.1.1.1'})

--- a/Packs/Infoblox/ReleaseNotes/1_0_20.md
+++ b/Packs/Infoblox/ReleaseNotes/1_0_20.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Infoblox
+
+- Fixed an issue where the ***infoblox-get-ip*** command failed when the IP address was not found in Infoblox.

--- a/Packs/Infoblox/pack_metadata.json
+++ b/Packs/Infoblox/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Infoblox NIOS",
     "description": "Infoblox enables you to receive metadata about IPs in your network and manages the DNS Firewall by configuring RPZs. It defines RPZ rules to block DNS resolution for malicious or unauthorized hostnames, or redirect clients to a walled garden by substituting responses.",
     "support": "xsoar",
-    "currentVersion": "1.0.19",
+    "currentVersion": "1.0.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32268


## Must have
- [ ] Tests
- [ ] Documentation 
