### PR TITLE
Update dockerimage in DBotUpdateLogoURLPhishing.yml

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_13_20.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_13_20.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### DBotUpdateLogoURLPhishing
+
+- Fixed an issue where the script failed to run.
+- Updated the Docker image to: *demisto/mlurlphishing:1.0.0.85127*.

--- a/Packs/CommonScripts/Scripts/DBotUpdateLogoURLPhishing/DBotUpdateLogoURLPhishing.py
+++ b/Packs/CommonScripts/Scripts/DBotUpdateLogoURLPhishing/DBotUpdateLogoURLPhishing.py
@@ -177,10 +177,10 @@ def display_all_logos(model):
     logo_list = []
     for name, logo in model.logos_dict.items():
         custom_associated_logo = model.custom_logo_associated_domain.get(name, '')
-        if name in model.custom_logo_associated_domain.keys():
-            description = description + ", %s (%s, %s)" % (name, 'Custom Logo', ','.join(custom_associated_logo))
+        if name in model.custom_logo_associated_domain:
+            description = description + ", {} ({}, {})".format(name, 'Custom Logo', ','.join(custom_associated_logo))
         else:
-            description = description + ", %s (%s)" % (name, 'Default Logo')
+            description = description + ", {} ({})".format(name, 'Default Logo')
         logo_list.append(logo)
     description = description[1:]
     merged_logos = get_concat_logo_single_image([image_from_base64_to_bytes(logo) for logo in logo_list])
@@ -214,7 +214,7 @@ def main():
             else:
                 model = load_model_from_docker()
             display_all_logos(model)
-            return
+            return None
 
         if (action == KEY_ADD_LOGO) and (not logo_image_id or not logo_name):
             return_error(MSG_EMPTY_NAME_OR_URL)

--- a/Packs/CommonScripts/Scripts/DBotUpdateLogoURLPhishing/DBotUpdateLogoURLPhishing.yml
+++ b/Packs/CommonScripts/Scripts/DBotUpdateLogoURLPhishing/DBotUpdateLogoURLPhishing.yml
@@ -27,7 +27,7 @@ tags:
 - ml
 timeout: '0'
 type: python
-dockerimage: demisto/mlurlphishing:1.0.0.61412
+dockerimage: demisto/mlurlphishing:1.0.0.85127
 runas: DBotRole
 tests:
 - DBotUpdateLogoURLPhishing_test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.13.19",
+    "currentVersion": "1.13.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Change docker image to an image of python 3.9 since the model was trained on python 3.9 so we can't use python3.10.

fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32123?filter=-1