### PR TITLE
Phishing playbooks small performance improvements

### DIFF
--- a/Packs/Phishing/Playbooks/Phishing_-_Generic_v3_6_8.yml
+++ b/Packs/Phishing/Playbooks/Phishing_-_Generic_v3_6_8.yml
@@ -1133,10 +1133,10 @@ tasks:
       version: -1
       name: Authenticate email
       description: Checks the authenticity of an email based on the email's SPF, DMARC, and DKIM.
-      script: CheckEmailAuthenticity
       type: regular
       iscommand: false
       brand: ""
+      scriptName: CheckEmailAuthenticity
     nexttasks:
       '#none#':
       - "83"
@@ -1244,17 +1244,26 @@ tasks:
     isautoswitchedtoquietmode: false
   "84":
     id: "84"
-    taskid: 987110a5-1108-468d-85bb-7dcbd9baad15
+    taskid: 5bb34c10-a58e-480a-8c9a-af220dac1b71
     type: playbook
     task:
-      id: 987110a5-1108-468d-85bb-7dcbd9baad15
+      id: 5bb34c10-a58e-480a-8c9a-af220dac1b71
       version: -1
       name: Calculate Severity - Generic v2
       playbookName: Calculate Severity - Generic v2
       type: playbook
       iscommand: false
       brand: ""
-      description: ''
+      description: |-
+        Calculate and assign the incident severity based on the highest returned severity level from the following calculations:
+
+        - DBotScores of indicators
+        - Critical assets
+        - Email authenticity
+        - Current incident severity
+        - Microsoft Headers
+        - Risky users (XDR)
+        - Risky hosts (XDR).
     nexttasks:
       '#none#':
       - "2"
@@ -1274,6 +1283,66 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    scriptarguments:
+      Account:
+        complex:
+          root: Account
+          transformers:
+          - operator: uniq
+      CriticalEndpoints:
+        simple: admin
+      CriticalGroups:
+        simple: admins,administrators
+      CriticalUsers:
+        simple: admin,administrator
+      DBotScoreIndicators:
+        complex:
+          root: DBotScore
+          accessor: Indicator
+          transformers:
+          - operator: uniq
+      DBotScoreMaxScore:
+        complex:
+          root: DBotScore
+          accessor: Score
+          transformers:
+          - operator: sort
+            args:
+              descending:
+                value:
+                  simple: "true"
+          - operator: uniq
+          - operator: FirstArrayElement
+      EmailAuthenticityCheck:
+        complex:
+          root: Email
+          accessor: AuthenticityCheck
+          transformers:
+          - operator: uniq
+      Endpoint:
+        complex:
+          root: Endpoint
+          transformers:
+          - operator: uniq
+      MicrosoftHeadersSeverityCheck:
+        simple: ${Email.MicrosoftHeadersSeverityCheck}
+      XDRRiskyHosts:
+        complex:
+          root: PaloAltoNetworksXDR
+          accessor: RiskyHost
+          transformers:
+          - operator: uniq
+      XDRRiskyUsers:
+        complex:
+          root: PaloAltoNetworksXDR
+          accessor: RiskyUser
+          transformers:
+          - operator: uniq
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+      max: 100
   "85":
     id: "85"
     taskid: 2eecb8e9-8b1d-4ba5-87d3-dbfbb10baf6e
@@ -2930,17 +2999,23 @@ tasks:
     isautoswitchedtoquietmode: false
   "217":
     id: "217"
-    taskid: 2339bed3-a001-409f-8a65-a2b59923fa51
+    taskid: f36a1fb4-aab4-4a3d-8203-138e42b0c453
     type: playbook
     task:
-      id: 2339bed3-a001-409f-8a65-a2b59923fa51
+      id: f36a1fb4-aab4-4a3d-8203-138e42b0c453
       version: -1
       name: TIM - Indicator Relationships Analysis
       playbookName: TIM - Indicator Relationships Analysis
       type: playbook
       iscommand: false
       brand: ""
-      description: ''
+      description: |-
+        This playbook is designed to assist with a security investigation by providing an analysis of indicator relationships. The following information is included:
+        - Indicators of compromise (IOCs) related to the investigation.
+        - Attack patterns related to the investigation.
+        - Campaigns related to the investigation.
+        - IOCs associated with the identified campaigns.
+        - Reports containing details on the identified campaigns.
     nexttasks:
       '#none#':
       - "218"
@@ -2962,8 +3037,9 @@ tasks:
                 value:
                   simple: Domain.Name
                 iscontext: true
+          - operator: uniq
       LimitResults:
-        simple: "300"
+        simple: "150"
     separatecontext: true
     continueonerrortype: ""
     loop:
@@ -3431,17 +3507,37 @@ tasks:
     isautoswitchedtoquietmode: false
   "227":
     id: "227"
-    taskid: 109a066f-22b3-479e-8779-5e8f6fe4a080
+    taskid: b7d56405-d0e0-4421-8d2a-54bdb5104285
     type: playbook
     task:
-      id: 109a066f-22b3-479e-8779-5e8f6fe4a080
+      id: b7d56405-d0e0-4421-8d2a-54bdb5104285
       version: -1
       name: Detonate URL - Generic v1.5
       playbookName: Detonate URL - Generic v1.5
       type: playbook
       iscommand: false
       brand: ""
-      description: ''
+      description: |-
+        Detonate URL through one or more active integrations that support URL detonation.
+        Supported integrations:
+        - SecneurX Analysis
+        - ANY.RUN
+        - McAfee Advanced Threat Defense
+        - WildFire
+        - Lastline
+        - Cuckoo Sandbox
+        - Cisco Secure Malware Analytics (ThreatGrid)
+        - JoeSecurity
+        - CrowdStrike Falcon Sandbox
+        - FireEye AX
+        - VMRay Analyzer
+        - Polygon
+        - CrowdStrike Falcon Intelligence Sandbox
+        - OPSWAT Filescan
+        - ANYRUN
+        -  VirusTotal
+        - Anomali ThreatStream
+        - Hatching Triage.
     nexttasks:
       '#none#':
       - "52"
@@ -3461,6 +3557,18 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    scriptarguments:
+      URL:
+        complex:
+          root: URL
+          accessor: Data
+          transformers:
+          - operator: uniq
+    loop:
+      iscommand: false
+      exitCondition: ""
+      wait: 1
+      max: 100
 view: |-
   {
     "linkLabelsPosition": {
@@ -3696,50 +3804,10 @@ inputs:
     For example: name of the organization finance app that the attacker might impersonate.
     This input is used in the "Spear Phishing Investigation" sub-playbook.
   playbookInputQuery:
-inputSections:
-- name: Role and Assignment
-  description:  Parameters defining user responsibilities and task allocations.
-  inputs: 
-  - Role
-  - OnCall
-- name: Search and Delete Functionality
-  description: Input criteria to locate specific entries and actions to remove them.
-  inputs:
-  - SearchAndDelete
-  - SearchAndDeleteIntegration
-  - O365DeleteType
-  - O365ExchangeLocation
-  - O365AllowNotFoundSearchLocations
-  - O365ExchangeLocationExclusion
-- name: Email Verification and Classification
-  description: Criteria and actions for authenticating email sources and categorizing by content.
-  inputs:
-  - AuthenticateEmail
-  - CheckMicrosoftHeaders
-  - InternalDomains
-  - GetOriginalEmail
-  - OriginalAuthenticationHeader
-- name: Analysis and Threat Detection
-  description: Parameters for examining data, identifying, and assessing security threats.
-  inputs:
-  - BlockIndicators
-  - DetonateURL
-  - InternalRange
-  - PhishingModelName
-  - DBotPredictURLPhishingURLsNumber
-  - EmailFileToExtract
-  - HuntEmailIndicators
-- name: Incident Management and User Engagement
-  description: Input settings for handling security events and involving end-users in the resolution process.
-  inputs:
-  - EmailHuntingCreateNewIncidents
-  - ListenerMailbox
-  - SendMailInstance
-  - UserEngagement
-  - TakeManualActions
-  - KeyWordsToSearch
 outputs: []
 tests:
 - Phishing v3 - DomainSquatting+EML+MaliciousIndicators - Test
 - Phishing v3 - Get Original Email + Search & Delete - Test
 fromversion: 6.8.0
+contentitemexportablefields:
+  contentitemfields: {}

--- a/Packs/Phishing/Playbooks/Phishing_-_Machine_Learning_Analysis.yml
+++ b/Packs/Phishing/Playbooks/Phishing_-_Machine_Learning_Analysis.yml
@@ -34,6 +34,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "1":
     id: "1"
     taskid: 5e4e4a8f-7beb-4747-83ad-e5cb91005f28
@@ -88,6 +89,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "2":
     id: "2"
     taskid: 5345d43a-b025-4330-8e87-98526f3d5741
@@ -139,6 +141,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "3":
     id: "3"
     taskid: 303ac6fb-f6e4-420f-8c61-4ce748ff84de
@@ -195,6 +198,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "4":
     id: "4"
     taskid: cdddceeb-fc75-4a43-8cce-e0d6eb1fde3b
@@ -241,6 +245,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "5":
     id: "5"
     taskid: 72983272-0f84-40fc-847a-9eb6276f724a
@@ -271,6 +276,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "6":
     id: "6"
     taskid: 31000bcf-f2bf-4cc0-8764-f40671c8aa6f
@@ -301,6 +307,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "7":
     id: "7"
     taskid: fed90362-cf65-406c-8c9a-0c7f95b96e0e
@@ -322,8 +329,6 @@ tasks:
     scriptarguments:
       brandname:
         simple: Rasterize
-    results:
-    - brandInstances
     separatecontext: false
     view: |-
       {
@@ -339,6 +344,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "8":
     id: "8"
     taskid: 87380172-9f96-4da1-8aad-9422659e770c
@@ -380,6 +386,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "9":
     id: "9"
     taskid: 948d42a3-3fd5-4592-8da5-3c02768ca950
@@ -431,6 +438,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "10":
     id: "10"
     taskid: 8ee3c6f5-93b4-4477-8f18-f76a1e55f0eb
@@ -458,6 +466,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
 view: |-
   {
     "linkLabelsPosition": {
@@ -516,3 +525,6 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.1.0
+contentitemexportablefields:
+  contentitemfields: {}
+system: true

--- a/Packs/Phishing/Playbooks/playbook-Phishing_-_Indicators_Hunting.yml
+++ b/Packs/Phishing/Playbooks/playbook-Phishing_-_Indicators_Hunting.yml
@@ -41,14 +41,14 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: f0a7a0b1-156d-4f73-8a68-e0c06661cb54
+    taskid: 2f9c6950-28fb-4994-8d79-5dfe301cd2e2
     type: playbook
     task:
-      id: f0a7a0b1-156d-4f73-8a68-e0c06661cb54
+      id: 2f9c6950-28fb-4994-8d79-5dfe301cd2e2
       version: -1
       name: Microsoft 365 Defender - Threat Hunting Generic
       description: |
-        This playbook retrieves email data based on the `URLDomain`, `SHA256`, `IPAddress`, and `MessageID` inputs. The output will be a unified object with all of the retrieved emails based on the sub-playbooks outputs:
+        This playbook retrieves email data based on the `URLDomain`, `SHA256`, `IPAddress`. and `MessageID` inputs. The output is a unified object with all of the retrieved emails based on the following sub-playbooks outputs:
 
         - **Microsoft 365 Defender - Get Email URL clicks**:
                 Retrieves data based on URL click events.
@@ -57,7 +57,7 @@ tasks:
         - **Microsoft 365 Defender - Emails Indicators Hunt**:
                 Retrieves data based on several different email events.
 
-        Read the playbooks' descriptions in order to get the full details.
+        Read the playbook's descriptions in order to get the full details.
       playbookName: Microsoft 365 Defender - Threat Hunting Generic
       type: playbook
       iscommand: false
@@ -88,6 +88,8 @@ tasks:
                 value:
                   simple: "3"
           accessor: Indicator
+          transformers:
+          - operator: uniq
       ListenerMailbox:
         complex:
           root: inputs.ListenerMailbox
@@ -129,6 +131,8 @@ tasks:
               right:
                 value:
                   simple: "64"
+          transformers:
+          - operator: uniq
       URLDomain:
         complex:
           root: inputs.DBotScore
@@ -160,6 +164,14 @@ tasks:
                 value:
                   simple: "3"
           accessor: Indicator
+          transformers:
+          - operator: uniq
+      ResultsLimit:
+        simple: "50"
+      SearchTimeframe:
+        simple: "7"
+      Timeout:
+        simple: "180"
     separatecontext: true
     continueonerrortype: ""
     loop:
@@ -349,3 +361,6 @@ quiet: true
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+contentitemexportablefields:
+  contentitemfields: {}
+system: true

--- a/Packs/Phishing/ReleaseNotes/3_6_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_6_6.md
@@ -1,0 +1,13 @@
+
+#### Playbooks
+
+##### Phishing - Machine Learning Analysis
+
+- Added the Unique for URLs in Phishing URL prediction to ensure only unique URLs are analyzed in the machine-learning subplaybook.
+##### Phishing - Generic v3
+
+- Added the Unique transformer to the URLs sent for detonation.
+- Added the Unique transformer to ensure that the IPs, URLs and Domains are unique when getting their relationships.
+##### Phishing - Indicators Hunting
+
+- Added the Unique transformer to the DBotScore indicators, which should improve performance when multiple enrichers are enabled.

--- a/Packs/Phishing/ReleaseNotes/3_6_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_6_6.md
@@ -7,7 +7,7 @@
 ##### Phishing - Generic v3
 
 - Added the Unique transformer to the URLs sent for detonation.
-- Added the Unique transformer to ensure that the IPs, URLs and Domains are unique when getting their relationships.
+- Added the Unique transformer to ensure that only unique relationships are retrieved for the IP, URL and Domain indicators.
 ##### Phishing - Indicators Hunting
 
 - Added the Unique transformer to the DBotScore indicators, which should improve performance when multiple enrichers are enabled.

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.6.5",
+    "currentVersion": "3.6.6",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9493

## Description
##### Phishing - Machine Learning Analysis

- Added the Unique for URLs in Phishing URL prediction to ensure only unique URLs are analyzed in the machine-learning subplaybook.
##### Phishing - Generic v3

- Added the Unique transformer to the URLs sent for detonation.
- Added the Unique transformer to ensure that only unique relationships are retrieved for the IP, URL and Domain indicators.
##### Phishing - Indicators Hunting

- Added the Unique transformer to the DBotScore indicators, which should improve performance when multiple enrichers are enabled.


