### PR TITLE
lock core packs

### DIFF
--- a/Tests/Marketplace/versions-metadata.json
+++ b/Tests/Marketplace/versions-metadata.json
@@ -12,6 +12,11 @@
     },
     "8.5.0": {
       "core_packs_file": "corepacks-8.5.0.json",
+      "core_packs_file_is_locked": true,
+      "file_version": "1"
+    },
+    "8.6.0": {
+      "core_packs_file": "corepacks-8.6.0.json",
       "core_packs_file_is_locked": false,
       "file_version": "1"
     }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Updated the versioned core packs
from the prepare-testing-bucket step
![image](https://github.com/demisto/content/assets/86777474/b481f748-ccc1-4925-9055-baf9c0ac5776)

