### PR TITLE
Add logs to EDL

### DIFF
--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -105,7 +105,6 @@ class RequestArguments:
     CTX_URL_TRUNCATE_KEY = 'url_truncate'
     CTX_MAXIMUM_CIDR = 'maximum_cidr_size'
     CTX_NO_TLD = 'no_wildcard_tld'
-    raw = "raw"
 
     FILTER_FIELDS_ON_FORMAT_TEXT = "name,type"
     FILTER_FIELDS_ON_FORMAT_MWG = "name,type,sourceBrands"
@@ -131,6 +130,7 @@ class RequestArguments:
                  url_truncate: bool = False,
                  maximum_cidr_size: int = MAXIMUM_CIDR_SIZE_DEFAULT,
                  no_wildcard_tld: bool = False,
+                 raw: bool = False,
                  ):
 
         self.query = query
@@ -150,7 +150,7 @@ class RequestArguments:
         self.url_truncate = url_truncate
         self.maximum_cidr_size = maximum_cidr_size
         self.no_wildcard_tld = no_wildcard_tld
-
+        self.raw = raw
         if category_attribute is not None:
             category_attribute_list = argToList(category_attribute)
 
@@ -1007,7 +1007,7 @@ def get_request_args(request_args: dict, params: dict) -> RequestArguments:
     maximum_cidr_size = try_parse_integer(request_args.get('mc', params.get(
         'maximum_cidr_size', MAXIMUM_CIDR_SIZE_DEFAULT)), EDL_CIDR_SIZR_MSG)
     no_wildcard_tld = argToBoolean(request_args.get('nt', params.get('no_wildcard_tld')))
-
+    raw = argToBoolean(request_args.get("raw", False))
     # handle flags
     if drop_invalids == '':
         drop_invalids = True
@@ -1070,7 +1070,8 @@ def get_request_args(request_args: dict, params: dict) -> RequestArguments:
                             strip_protocol,
                             url_truncate,
                             maximum_cidr_size,
-                            no_wildcard_tld
+                            no_wildcard_tld,
+                            raw=raw
                             )
 
 

--- a/Packs/EDL/Integrations/EDL/EDL.py
+++ b/Packs/EDL/Integrations/EDL/EDL.py
@@ -105,14 +105,13 @@ class RequestArguments:
     CTX_URL_TRUNCATE_KEY = 'url_truncate'
     CTX_MAXIMUM_CIDR = 'maximum_cidr_size'
     CTX_NO_TLD = 'no_wildcard_tld'
+    raw = "raw"
 
     FILTER_FIELDS_ON_FORMAT_TEXT = "name,type"
     FILTER_FIELDS_ON_FORMAT_MWG = "name,type,sourceBrands"
     FILTER_FIELDS_ON_FORMAT_PROXYSG = "name,type,proxysgcategory"
     FILTER_FIELDS_ON_FORMAT_CSV = "name,type"
     FILTER_FIELDS_ON_FORMAT_JSON = "name,type"
-
-    DEBUG_SEARCH_INDICATORS = "debug_search_indicators"
 
     def __init__(self,
                  query: str = '',
@@ -292,7 +291,7 @@ def create_new_edl(request_args: RequestArguments, extensive_logging: bool = Fal
             # Because there may be illegal indicators or they may turn into cider, the limit is increased
             indicator_searcher.limit = int(limit * INCREASE_LIMIT)
         new_iocs_file, original_indicators_count = get_indicators_to_format(indicator_searcher, request_args, extensive_logging)
-        if request_args.DEBUG_SEARCH_INDICATORS:
+        if request_args.raw:
             return new_iocs_file.read(), original_indicators_count
 
         # we collect first all indicators because we need all ips to collapse_ips
@@ -310,7 +309,9 @@ def create_new_edl(request_args: RequestArguments, extensive_logging: bool = Fal
                 formatted_indicators += line
 
     else:
-        new_iocs_file, original_indicators_count = get_indicators_to_format(indicator_searcher, request_args)
+        new_iocs_file, original_indicators_count = get_indicators_to_format(indicator_searcher, request_args, extensive_logging)
+        if request_args.raw:
+            return new_iocs_file.read(), original_indicators_count
         new_iocs_file.seek(0)
         formatted_indicators = new_iocs_file.read()
     new_iocs_file.close()

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -263,6 +263,7 @@ configuration:
   advanced: true
   required: false
 - name: extensive_logging
+  display: 'Advanced: Enable Extensive Logging'
   type: 8
   additionalinfo: This parameter will write additional data to the logs and should only be used when you are directed to by XSOAR support.
   section: Connect

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -262,6 +262,14 @@ configuration:
   section: Collect
   advanced: true
   required: false
+- name: extensive_logging
+  type: 8
+  additionalinfo: This parameter will write additional data to the logs and should only be used when you are directed to by XSOAR support.
+  section: Connect
+  advanced: true
+  required: false
+  defaultvalue: 'false'
+
 description: Use the Generic Export Indicators Service integration to provide an endpoint with a list of indicators as a service for the system indicators.
 display: Generic Export Indicators Service
 name: EDL

--- a/Packs/EDL/Integrations/EDL/EDL_test.py
+++ b/Packs/EDL/Integrations/EDL/EDL_test.py
@@ -102,11 +102,11 @@ class TestHelperFunctions:
         mocker.patch.object(edl, 'get_integration_context', return_value={})
         actual_edl, original_indicators_count = edl.get_edl_on_demand()
 
-        with open(edl.EDL_ON_DEMAND_CACHE_PATH, 'r') as f:
+        with open(edl.EDL_ON_DEMAND_CACHE_PATH) as f:
             expected_edl = f.read()
 
         assert actual_edl == expected_edl
-        assert edl.EDL_ON_DEMAND_CACHE_ORIGINAL_SIZE == original_indicators_count
+        assert original_indicators_count == edl.EDL_ON_DEMAND_CACHE_ORIGINAL_SIZE
 
     def test_get_edl_on_demand__with_refresh_signal(self, mocker):
         """
@@ -127,7 +127,7 @@ class TestHelperFunctions:
         mocker.patch.object(edl, 'create_new_edl', return_value=(expected_edl, 1))
         actual_edl, _ = edl.get_edl_on_demand()
 
-        with open(edl.EDL_ON_DEMAND_CACHE_PATH, 'r') as f:
+        with open(edl.EDL_ON_DEMAND_CACHE_PATH) as f:
             cached_edl = f.read()
             assert actual_edl == expected_edl == cached_edl
 
@@ -228,7 +228,7 @@ class TestHelperFunctions:
                       {"value": "*.co.uk", "indicator_type": "Domain"},  # tld
                       {"value": "*.google.com", "indicator_type": "Domain"},  # no tld
                       {"value": "aא.com", "indicator_type": "URL"}]  # no ascii
-        f = '\n'.join((json.dumps(indicator) for indicator in indicators))
+        f = '\n'.join(json.dumps(indicator) for indicator in indicators)
         request_args = edl.RequestArguments(collapse_ips=DONT_COLLAPSE, maximum_cidr_size=2)
         mocker.patch.object(edl, 'get_indicators_to_format', return_value=(io.StringIO(f), 6))
         edl_v, _ = edl.create_new_edl(request_args)
@@ -272,7 +272,7 @@ class TestHelperFunctions:
                       {"value": "*.co.uk", "indicator_type": "Domain"},  # tld
                       {"value": "*.google.com", "indicator_type": "Domain"},  # no tld
                       {"value": "aא.com", "indicator_type": "URL"}]  # no ascii
-        f = '\n'.join((json.dumps(indicator) for indicator in indicators))
+        f = '\n'.join(json.dumps(indicator) for indicator in indicators)
 
         # create_new_edl with no offset
         request_args = edl.RequestArguments(collapse_ips=DONT_COLLAPSE, maximum_cidr_size=8)
@@ -299,7 +299,7 @@ class TestHelperFunctions:
         """
         from EDL import create_json_out_format, RequestArguments
         returned_output = []
-        with open('test_data/demisto_url_iocs.json', 'r') as iocs_json_f:
+        with open('test_data/demisto_url_iocs.json') as iocs_json_f:
             iocs_json = json.loads(iocs_json_f.read())
 
             # strips port numbers
@@ -328,7 +328,7 @@ class TestHelperFunctions:
           - assert the result
         """
         from EDL import create_csv_out_format, RequestArguments
-        with open('test_data/demisto_url_iocs.json', 'r') as iocs_json_f:
+        with open('test_data/demisto_url_iocs.json') as iocs_json_f:
             iocs_json = json.loads(iocs_json_f.read())
             request_args = RequestArguments(query='', drop_invalids=True, url_port_stripping=True,
                                             url_protocol_stripping=True)
@@ -353,7 +353,7 @@ class TestHelperFunctions:
           - assert the result
         """
         from EDL import create_mwg_out_format, RequestArguments
-        with open('test_data/demisto_url_iocs.json', 'r') as iocs_json_f:
+        with open('test_data/demisto_url_iocs.json') as iocs_json_f:
             iocs_json = json.loads(iocs_json_f.read())
             request_args = RequestArguments(query='', drop_invalids=True, url_port_stripping=True,
                                             url_protocol_stripping=True)
@@ -381,7 +381,7 @@ class TestHelperFunctions:
         """
         from EDL import create_proxysg_out_format, RequestArguments, create_proxysg_all_category_out_format
         files_by_category = {}
-        with open('test_data/demisto_url_iocs.json', 'r') as iocs_json_f:
+        with open('test_data/demisto_url_iocs.json') as iocs_json_f:
             iocs_json = json.loads(iocs_json_f.read())
 
         request_args = RequestArguments(query='', drop_invalids=True, url_port_stripping=True,


### PR DESCRIPTION
This adds extensive logging to the configuration, and adds new request parameter for the indicators after the search and before the format.

related: https://jira-dc.paloaltonetworks.com/browse/XSUP-32470
related: https://jira-dc.paloaltonetworks.com/browse/XSUP-31635