### PR TITLE
XSIAM Dropbox Correlation-Rule Refactoring - DO NOT MERGE!!!!

### DIFF
--- a/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Alterations.yml
+++ b/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Alterations.yml
@@ -18,9 +18,9 @@ description: This rule detects more than 100 edited files during an hour by the 
 drilldown_query_timeframe: QUERY
 execution_mode: SCHEDULED
 global_rule_id: 6de99f56-dfbf-40e0-bffd-bffe0a543cf5
-investigation_query_link: 'datamodel
+investigation_query_link: 'datamodel dataset = "dropbox_dropbox_raw"
 
-  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit" and xdm.observer.product = "dropbox" and xdm.observer.vendor = "dropbox"
+  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit"
 
   | alter user = coalesce(xdm.source.user.username, xdm.target.user.username)
 
@@ -39,9 +39,9 @@ suppression_enabled: true
 suppression_fields:
 user_defined_category:
 user_defined_severity:
-xql_query: 'datamodel
+xql_query: 'datamodel dataset = "dropbox_dropbox_raw"
 
-  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit" and xdm.observer.product = "dropbox" and xdm.observer.vendor = "dropbox"
+  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit"
 
   | alter user = coalesce(xdm.source.user.username, xdm.target.user.username)
 

--- a/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Alterations.yml
+++ b/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Alterations.yml
@@ -18,7 +18,7 @@ description: This rule detects more than 100 edited files during an hour by the 
 drilldown_query_timeframe: QUERY
 execution_mode: SCHEDULED
 global_rule_id: 6de99f56-dfbf-40e0-bffd-bffe0a543cf5
-investigation_query_link: 'datamodel dataset = "dropbox_dropbox_raw"
+investigation_query_link: 'datamodel dataset = dropbox_dropbox_raw
 
   | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit"
 
@@ -39,7 +39,7 @@ suppression_enabled: true
 suppression_fields:
 user_defined_category:
 user_defined_severity:
-xql_query: 'datamodel dataset = "dropbox_dropbox_raw"
+xql_query: 'datamodel dataset = dropbox_dropbox_raw
 
   | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_edit"
 

--- a/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Downloads.yml
+++ b/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Downloads.yml
@@ -18,9 +18,9 @@ description: This rule detects more than 100 downloaded files during an hour by 
 drilldown_query_timeframe: ALERT
 execution_mode: SCHEDULED
 global_rule_id: 205317b6-c494-4836-ac31-f80c8204cf4e
-investigation_query_link: 'datamodel
+investigation_query_link: 'datamodel dataset = "dropbox_dropbox_raw"
 
-  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download" and xdm.observer.product = "dropbox" and xdm.observer.vendor = "dropbox"
+  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download"
 
   | alter user = coalesce(xdm.source.user.username, xdm.target.user.username)
 
@@ -37,9 +37,9 @@ suppression_enabled: true
 suppression_fields:
 user_defined_category:
 user_defined_severity:
-xql_query: 'datamodel
+xql_query: 'datamodel dataset = "dropbox_dropbox_raw"
 
-  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download" and xdm.observer.product = "dropbox" and xdm.observer.vendor = "dropbox"
+  | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download"
 
   | alter user = coalesce(xdm.source.user.username, xdm.target.user.username)
 

--- a/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Downloads.yml
+++ b/Packs/Dropbox/CorrelationRules/Dropbox_-_Massive_File_Downloads.yml
@@ -18,7 +18,7 @@ description: This rule detects more than 100 downloaded files during an hour by 
 drilldown_query_timeframe: ALERT
 execution_mode: SCHEDULED
 global_rule_id: 205317b6-c494-4836-ac31-f80c8204cf4e
-investigation_query_link: 'datamodel dataset = "dropbox_dropbox_raw"
+investigation_query_link: 'datamodel dataset = dropbox_dropbox_raw
 
   | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download"
 
@@ -37,7 +37,7 @@ suppression_enabled: true
 suppression_fields:
 user_defined_category:
 user_defined_severity:
-xql_query: 'datamodel dataset = "dropbox_dropbox_raw"
+xql_query: 'datamodel dataset = dropbox_dropbox_raw
 
   | filter xdm.event.type = "file_operations" and xdm.event.operation_sub_type = "file_download"
 

--- a/Packs/Dropbox/ReleaseNotes/1_0_27.md
+++ b/Packs/Dropbox/ReleaseNotes/1_0_27.md
@@ -1,0 +1,6 @@
+#### Correlation Rules
+##### DropBox - Massive File Alterations
+Improved implementation of the Rule's XQL query for improved runtime performance. 
+
+##### DropBox - Massive File Downloads
+Improved implementation of the Rule's XQL query for improved runtime performance.

--- a/Packs/Dropbox/pack_metadata.json
+++ b/Packs/Dropbox/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Dropbox",
     "description": "Use the Dropbox integration to fetch events",
     "support": "xsoar",
-    "currentVersion": "1.0.26",
+    "currentVersion": "1.0.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This PR is for testing a new feature which enables correlation rule XQL queries that uses XDM to be used with a specific dataset even if the dataset does not yet exist on the tenant. On previous versions this was not possible. 

## Must have
- [ ] Tests
- [ ] Documentation 
