### PR TITLE
[SetGridField] Handle XSOAR SAAS correctly

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_13_25.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_13_25.md
@@ -2,5 +2,6 @@
 #### Scripts
 
 ##### SetGridField
+- Updated the Docker image to: *demisto/pandas:1.0.0.86039*.
 
 - Fixed an issue where the script fails on XSOAR 8.0 and above.

--- a/Packs/CommonScripts/ReleaseNotes/1_13_25.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_13_25.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### SetGridField
+
+- Fixed an issue where the script fails on XSOAR 8.0 and above.

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField.yml
@@ -43,7 +43,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/pandas:1.0.0.83429
+dockerimage: demisto/pandas:1.0.0.86039
 fromversion: 5.0.0
 tests:
 - No tests

--- a/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
+++ b/Packs/CommonScripts/Scripts/SetGridField/SetGridField_test.py
@@ -215,7 +215,7 @@ def test_main_does_not_raises_error_in_xsoar(mocker):
                                                        "overwrite": "True",
                                                        "unpack_nested_elements": "False"})
     mocker.patch.object(demisto, 'incident', return_value={"CustomFields": None})
-    mocker.patch.object(SetGridField, 'is_xsiam', return_value=False)
+    mocker.patch.object(SetGridField, 'is_xsiam_or_xsoar_saas', return_value=False)
     mocker.patch.object(SetGridField, 'get_current_table', return_value=[])
     mocker.patch.object(SetGridField, 'build_grid_command', return_value=[{"name": "name", "readable_name": "readable_name"}])
     mocker.patch.object(demisto, 'executeCommand', side_effect=side_effect_for_execute_command)
@@ -238,7 +238,7 @@ def test_main_raises_error_in_xsiam(mocker):
                                                        'columns': "col1,col2", "sort_by": "col1",
                                                        "overwrite": "True",
                                                        "unpack_nested_elements": "False"})
-    mocker.patch.object(SetGridField, 'is_xsiam', return_value=True)
+    mocker.patch.object(SetGridField, 'is_xsiam_or_xsoar_saas', return_value=True)
     mocker.patch.object(demisto, 'incident', return_value={"CustomFields": None})
     mocker.patch.object(SetGridField, 'get_current_table', return_value=[])
     mocker.patch.object(SetGridField, 'build_grid_command', return_value=[{"name": "name", "readable_name": "readable_name"}])
@@ -259,7 +259,7 @@ def test_get_current_table_exception(mocker):
     """
 
     import SetGridField
-    mocker.patch.object(SetGridField, 'is_xsiam', return_value=False)
+    mocker.patch.object(SetGridField, 'is_xsiam_or_xsoar_saas', return_value=False)
     mocker.patch.object(demisto, 'incident', return_value={"CustomFields": None, "isPlayground": True})
     with pytest.raises(Exception):
         SetGridField.get_current_table("grid_id")

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.13.24",
+    "currentVersion": "1.13.25",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
As XSOAR SAAS ommits from the context keys with empty values as XSIAM, we need to handle XSOAR SAAS the same we do as XSIAM

fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32518