### PR TITLE
Crowdstrike OpenAPI `cs-update-rulesv1` fix

### DIFF
--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
@@ -3254,7 +3254,7 @@ class Client:
 
     def update_rulesv1_request(self, domain_updaterulerequestv1_filter, domain_updaterulerequestv1_id, domain_updaterulerequestv1_name, domain_updaterulerequestv1_permissions, domain_updaterulerequestv1_priority):
         data = [assign_params(filter=domain_updaterulerequestv1_filter, id=domain_updaterulerequestv1_id, name=domain_updaterulerequestv1_name,
-                             permissions=domain_updaterulerequestv1_permissions, priority=domain_updaterulerequestv1_priority)]
+                              permissions=domain_updaterulerequestv1_permissions, priority=domain_updaterulerequestv1_priority)]
 
         headers = self.cs_client._headers
 

--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.py
@@ -3253,8 +3253,8 @@ class Client:
         return response
 
     def update_rulesv1_request(self, domain_updaterulerequestv1_filter, domain_updaterulerequestv1_id, domain_updaterulerequestv1_name, domain_updaterulerequestv1_permissions, domain_updaterulerequestv1_priority):
-        data = assign_params(filter=domain_updaterulerequestv1_filter, id=domain_updaterulerequestv1_id, name=domain_updaterulerequestv1_name,
-                             permissions=domain_updaterulerequestv1_permissions, priority=domain_updaterulerequestv1_priority)
+        data = [assign_params(filter=domain_updaterulerequestv1_filter, id=domain_updaterulerequestv1_id, name=domain_updaterulerequestv1_name,
+                             permissions=domain_updaterulerequestv1_permissions, priority=domain_updaterulerequestv1_priority)]
 
         headers = self.cs_client._headers
 

--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.yml
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI.yml
@@ -148,7 +148,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate allowlist ticket values based on the matched filter
+    description: Retrieve aggregate allowlist ticket values based on the matched filter.
     name: cs-aggregate-allow-list
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -236,7 +236,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate block list ticket values based on the matched filter
+    description: Retrieve aggregate block list ticket values based on the matched filter.
     name: cs-aggregate-block-list
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -324,7 +324,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate detection values based on the matched filter
+    description: Retrieve aggregate detection values based on the matched filter.
     name: cs-aggregate-detections
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -412,7 +412,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate host/devices count based on the matched filter
+    description: Retrieve aggregate host/devices count based on the matched filter.
     name: cs-aggregate-device-count-collection
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -500,7 +500,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate escalation ticket values based on the matched filter
+    description: Retrieve aggregate escalation ticket values based on the matched filter.
     name: cs-aggregate-escalations
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -688,7 +688,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate remediation ticket values based on the matched filter
+    description: Retrieve aggregate remediation ticket values based on the matched filter.
     name: cs-aggregate-remediations
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -776,7 +776,7 @@ script:
     - description: ''
       name: fwmgr_msa_aggregatequeryrequest_type
       required: true
-    description: Aggregate events for customer
+    description: Aggregate events for customer.
     name: cs-aggregateevents
     outputs:
     - contextPath: CrowdStrike.fwmgrapiAggregatesResponse.errors.code
@@ -864,7 +864,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Retrieve aggregate incident values based on the matched filter
+    description: Retrieve aggregate incident values based on the matched filter.
     name: cs-aggregatefc-incidents
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -952,7 +952,7 @@ script:
     - description: ''
       name: fwmgr_msa_aggregatequeryrequest_type
       required: true
-    description: Aggregate rules within a policy for customer
+    description: Aggregate rules within a policy for customer.
     name: cs-aggregatepolicyrules
     outputs:
     - contextPath: CrowdStrike.fwmgrapiAggregatesResponse.errors.code
@@ -1040,7 +1040,7 @@ script:
     - description: ''
       name: fwmgr_msa_aggregatequeryrequest_type
       required: true
-    description: Aggregate rule groups for customer
+    description: Aggregate rule groups for customer.
     name: cs-aggregaterulegroups
     outputs:
     - contextPath: CrowdStrike.fwmgrapiAggregatesResponse.errors.code
@@ -1128,7 +1128,7 @@ script:
     - description: ''
       name: fwmgr_msa_aggregatequeryrequest_type
       required: true
-    description: Aggregate rules for customer
+    description: Aggregate rules for customer.
     name: cs-aggregaterules
     outputs:
     - contextPath: CrowdStrike.fwmgrapiAggregatesResponse.errors.code
@@ -1171,10 +1171,10 @@ script:
       description: ''
       type: Number
   - arguments:
-    - description: An FQL filter string
+    - description: An FQL filter string.
       name: filter_
       required: true
-    description: Get the total number of detections pushed across all customers
+    description: Get the total number of detections pushed across all customers.
     name: cs-aggregates-detections-global-counts
     outputs:
     - contextPath: CrowdStrike.msaFacetsResponse.errors.code
@@ -1244,7 +1244,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Get aggregate OverWatch detection event info by providing an aggregate query
+    description: Get aggregate OverWatch detection event info by providing an aggregate query.
     name: cs-aggregates-events
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -1332,7 +1332,7 @@ script:
     - description: ''
       name: msa_aggregatequeryrequest_type
       required: true
-    description: Get OverWatch detection event collection info by providing an aggregate query
+    description: Get OverWatch detection event collection info by providing an aggregate query.
     name: cs-aggregates-events-collections
     outputs:
     - contextPath: CrowdStrike.msaAggregatesResponse.errors.code
@@ -1375,10 +1375,10 @@ script:
       description: ''
       type: Number
   - arguments:
-    - description: An FQL filter string
+    - description: An FQL filter string.
       name: filter_
       required: true
-    description: Get the total number of incidents pushed across all customers
+    description: Get the total number of incidents pushed across all customers.
     name: cs-aggregates-incidents-global-counts
     outputs:
     - contextPath: CrowdStrike.msaFacetsResponse.errors.code
@@ -1403,10 +1403,10 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: An FQL filter string
+    - description: An FQL filter string.
       name: filter_
       required: true
-    description: Get the total number of OverWatch events across all customers
+    description: Get the total number of OverWatch events across all customers.
     name: cs-aggregatesow-events-global-counts
     outputs:
     - contextPath: CrowdStrike.msaFacetsResponse.errors.code
@@ -1431,7 +1431,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Authorization Header
+    - description: Authorization Header.
       name: Authorization
       required: true
     description: Identity Protection GraphQL API. Allows to retrieve entities, timeline activities, identity-based incidents and security assessment. Allows to perform actions on entities and identity-based incidents.
@@ -1458,7 +1458,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: IDs of audit events to retrieve details for
+    - description: IDs of audit events to retrieve details for.
       isArray: true
       name: ids
     description: Gets the details of one or more audit events by id.
@@ -1578,7 +1578,7 @@ script:
       name: timeout
     - description: 'Timeout duration for for how long to wait for the request in duration syntax. Example, `10s`. Valid units: `ns, us, ms, s, m, h`. Maximum is 10 minutes.'
       name: timeout_duration
-    - description: Batch Get Command Request ID received from `/real-time-response/combined/get-command/v1`
+    - description: Batch Get Command Request ID received from `/real-time-response/combined/get-command/v1`.
       name: batch_get_cmd_req_id
       required: true
     description: Retrieves the status of the specified batch get command.  Will return successful files when they are finished processing.
@@ -1683,85 +1683,85 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.cid
-      description: The ID of the customer who created the action
+      description: The ID of the customer who created the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.created_timestamp
-      description: The date when the action was created
+      description: The date when the action was created.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.frequency
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.id
-      description: The ID of the action
+      description: The ID of the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule on which this action is attached
+      description: The ID of the rule on which this action is attached.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.status
       description: The action status. It can be either 'enabled' or 'muted'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.type
-      description: The action type. The only type currently supported is 'email'
+      description: The action type. The only type currently supported is 'email'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.updated_timestamp
-      description: The date when the action was updated
+      description: The date when the action was updated.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user who created the action
+      description: The UUID of the user who created the action.
       type: String
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_createdevicecontrolpoliciesv1_resources
       required: true
-    description: Create Device Control Policies by specifying details about the policy to create
+    description: Create Device Control Policies by specifying details about the policy to create.
     name: cs-create-device-control-policies
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_createfirewallpoliciesv1_resources
       required: true
-    - description: The policy ID to be cloned from
+    - description: The policy ID to be cloned from.
       name: clone_id
-    description: Create Firewall Policies by specifying details about the policy to create
+    description: Create Firewall Policies by specifying details about the policy to create.
     name: cs-create-firewall-policies
   - arguments:
-    - description: A collection of device groups to create
+    - description: A collection of device groups to create.
       isArray: true
       name: requests_creategroupsv1_resources
       required: true
-    description: Create Host Groups by specifying details about the group to create
+    description: Create Host Groups by specifying details about the group to create.
     name: cs-create-host-groups
   - arguments:
     - description: ''
       isArray: true
       name: models_modifyawscustomersettingsv1_resources
       required: true
-    description: Create or update Global Settings which are applicable to all provisioned AWS accounts
+    description: Create or update Global Settings which are applicable to all provisioned AWS accounts.
     name: cs-create-or-updateaws-settings
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_createpreventionpoliciesv1_resources
       required: true
-    description: Create Prevention Policies by specifying details about the policy to create
+    description: Create Prevention Policies by specifying details about the policy to create.
     name: cs-create-prevention-policies
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
-    - description: The filter to be used for searching
+    - description: The filter to be used for searching.
       name: sadomain_createrulerequestv1_filter
       required: true
-    - description: The name of a particular rule
+    - description: The name of a particular rule.
       name: sadomain_createrulerequestv1_name
       required: true
-    - description: 'The permissions for a particular rule which specifies the rule''s access by other users. Possible values: [public private]'
+    - description: 'The permissions for a particular rule which specifies the rule''s access by other users. Possible values: [public private].'
       name: sadomain_createrulerequestv1_permissions
       required: true
-    - description: 'The priority for a particular rule. Possible values: [medium high low]'
+    - description: 'The priority for a particular rule. Possible values: [medium high low].'
       name: sadomain_createrulerequestv1_priority
       required: true
-    - description: 'The topic of a given rule. Possible values: [SA_THIRD_PARTY SA_CVE SA_ALIAS SA_AUTHOR SA_BRAND_PRODUCT SA_VIP SA_IP SA_BIN SA_DOMAIN SA_EMAIL SA_CUSTOM]'
+    - description: 'The topic of a given rule. Possible values: [SA_THIRD_PARTY SA_CVE SA_ALIAS SA_AUTHOR SA_BRAND_PRODUCT SA_VIP SA_IP SA_BIN SA_DOMAIN SA_EMAIL SA_CUSTOM].'
       name: sadomain_createrulerequestv1_topic
       required: true
     description: Create monitoring rules.
@@ -1792,57 +1792,57 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.created_timestamp
-      description: The creation time for a given rule
+      description: The creation time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.filter
-      description: The FQL filter contained in a rule and used for searching
+      description: The FQL filter contained in a rule and used for searching.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.id
-      description: The ID of a given rule
+      description: The ID of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.name
-      description: The name for a given rule
+      description: The name for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.permissions
-      description: The permissions of a given rule
+      description: The permissions of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.priority
-      description: The priority of a given rule
+      description: The priority of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status
-      description: The status of a rule
+      description: The status of a rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status_message
-      description: The detailed status message
+      description: The detailed status message.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.topic
-      description: The topic of a given rule
+      description: The topic of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.updated_timestamp
-      description: The last updated time for a given rule
+      description: The last updated time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_id
-      description: The user ID of the user that created a given rule
+      description: The user ID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_name
-      description: The user name of the user that created a given rule
+      description: The user name of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user that created a given rule
+      description: The UUID of the user that created a given rule.
       type: String
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_createsensorupdatepoliciesv1_resources
       required: true
-    description: Create Sensor Update Policies by specifying details about the policy to create
+    description: Create Sensor Update Policies by specifying details about the policy to create.
     name: cs-create-sensor-update-policies
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_createsensorupdatepoliciesv2_resources
       required: true
-    description: Create Sensor Update Policies by specifying details about the policy to create with additional support for uninstall protection
+    description: Create Sensor Update Policies by specifying details about the policy to create with additional support for uninstall protection.
     name: cs-create-sensor-update-policiesv2
   - arguments:
     - description: ''
@@ -1853,7 +1853,7 @@ script:
       name: domain_usercreaterequest_password
     - description: ''
       name: domain_usercreaterequest_uid
-    description: Create a new user. After creating a user, assign one or more roles with POST /user-roles/entities/user-roles/v1
+    description: Create a new user. After creating a user, assign one or more roles with POST /user-roles/entities/user-roles/v1.
     name: cs-create-user
   - arguments:
     - description: ''
@@ -1889,7 +1889,7 @@ script:
       isArray: true
       name: k8sreg_createawsaccreq_resources
       required: true
-    description: Creates a new AWS account in our system for a customer and generates the installation script
+    description: Creates a new AWS account in our system for a customer and generates the installation script.
     name: cs-createaws-account
   - arguments:
     - description: ''
@@ -1945,7 +1945,7 @@ script:
       name: requests_mlexclusioncreatereqv1_groups
     - description: ''
       name: requests_mlexclusioncreatereqv1_value
-    description: Create the ML exclusions
+    description: Create the ML exclusions.
     name: cs-createml-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.errors.code
@@ -1967,31 +1967,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -2012,11 +2012,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: A collection of policies to create
+    - description: A collection of policies to create.
       isArray: true
       name: requests_creatertresponsepoliciesv1_resources
       required: true
-    description: Create Response Policies by specifying details about the policy to create
+    description: Create Response Policies by specifying details about the policy to create.
     name: cs-creatert-response-policies
   - arguments:
     - description: ''
@@ -2047,14 +2047,14 @@ script:
     description: Create a rule within a rule group. Returns the rule.
     name: cs-createrule
   - arguments:
-    - description: The user id
+    - description: The user id.
       name: X_CS_USERNAME
       required: true
     - description: A rule group ID from which to copy rules. If this is provided then the 'rules' property of the body is ignored.
       name: clone_id
     - description: If this flag is set to true then the rules will be cloned from the clone_id from the CrowdStrike Firewal Rule Groups Li ary.
       name: li_ary
-    - description: Audit log comment for this action
+    - description: Audit log comment for this action.
       name: comment
     - description: ''
       name: fwmgr_api_rulegroupcreaterequestv1_description
@@ -2069,7 +2069,7 @@ script:
       isArray: true
       name: fwmgr_api_rulegroupcreaterequestv1_rules
       required: true
-    description: Create new rule group on a platform for a customer with a name and description, and return the ID
+    description: Create new rule group on a platform for a customer with a name and description, and return the ID.
     name: cs-createrulegroup
   - arguments:
     - description: ''
@@ -2094,7 +2094,7 @@ script:
       name: requests_svexclusioncreatereqv1_groups
     - description: ''
       name: requests_svexclusioncreatereqv1_value
-    description: Create the sensor visibility exclusions
+    description: Create the sensor visibility exclusions.
     name: cs-createsv-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.errors.code
@@ -2116,31 +2116,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -2165,7 +2165,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: The maximum records to return. [1-2500]
+    - description: The maximum records to return. [1-2500].
       name: limit
     - auto: PREDEFINED
       description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
@@ -2175,7 +2175,7 @@ script:
       - score.desc
       - timestamp.asc
       - timestamp.desc
-    description: Query environment wide CrowdScore and return the entity data
+    description: Query environment wide CrowdScore and return the entity data.
     name: cs-crowd-score
     outputs:
     - contextPath: CrowdStrike.apiMsaEnvironmentScoreResponse.errors.code
@@ -2243,11 +2243,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Device Control Policies to delete
+    - description: The IDs of the Device Control Policies to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Device Control Policies by specifying their IDs
+    description: Delete a set of Device Control Policies by specifying their IDs.
     name: cs-delete-device-control-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2260,11 +2260,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Firewall Policies to delete
+    - description: The IDs of the Firewall Policies to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Firewall Policies by specifying their IDs
+    description: Delete a set of Firewall Policies by specifying their IDs.
     name: cs-delete-firewall-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2277,11 +2277,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Host Groups to delete
+    - description: The IDs of the Host Groups to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Host Groups by specifying their IDs
+    description: Delete a set of Host Groups by specifying their IDs.
     name: cs-delete-host-groups
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2323,11 +2323,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Prevention Policies to delete
+    - description: The IDs of the Prevention Policies to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Prevention Policies by specifying their IDs
+    description: Delete a set of Prevention Policies by specifying their IDs.
     name: cs-delete-prevention-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2346,7 +2346,7 @@ script:
     description: Delete report based on the report ID. Operation can be checked for success by polling for the report ID on the report-summaries endpoint.
     name: cs-delete-report
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: IDs of rules.
       isArray: true
@@ -2377,12 +2377,12 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: The file SHA256.
       name: ids
       required: true
-    description: Removes a sample, including file, meta and submissions from the collection
+    description: Removes a sample, including file, meta and submissions from the collection.
     name: cs-delete-samplev2
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2395,12 +2395,12 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: The file SHA256.
       name: ids
       required: true
-    description: Removes a sample, including file, meta and submissions from the collection
+    description: Removes a sample, including file, meta and submissions from the collection.
     name: cs-delete-samplev3
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2413,11 +2413,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Sensor Update Policies to delete
+    - description: The IDs of the Sensor Update Policies to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Sensor Update Policies by specifying their IDs
+    description: Delete a set of Sensor Update Policies by specifying their IDs.
     name: cs-delete-sensor-update-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2430,13 +2430,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the exclusions to delete
+    - description: The ids of the exclusions to delete.
       isArray: true
       name: ids
       required: true
-    - description: Explains why this exclusions was deleted
+    - description: Explains why this exclusions was deleted.
       name: comment
-    description: Delete the sensor visibility exclusions by id
+    description: Delete the sensor visibility exclusions by id.
     name: cs-delete-sensor-visibility-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2452,7 +2452,7 @@ script:
     - description: ID of a user. Find a user's ID from `/users/entities/user/v1`.
       name: user_uuid
       required: true
-    description: Delete a user permanently
+    description: Delete a user permanently.
     name: cs-delete-user
     outputs:
     - contextPath: CrowdStrike.msaReplyMetaOnly.errors.code
@@ -2485,7 +2485,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User Group IDs
+    - description: User Group IDs.
       isArray: true
       name: user_group_ids
       required: true
@@ -2502,11 +2502,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: IDs of accounts to remove
+    - description: IDs of accounts to remove.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of AWS Accounts by specifying their IDs
+    description: Delete a set of AWS Accounts by specifying their IDs.
     name: cs-deleteaws-accounts
     outputs:
     - contextPath: CrowdStrike.modelsBaseResponseV1.errors.code
@@ -2519,7 +2519,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: AWS Account IDs
+    - description: AWS Account IDs.
       isArray: true
       name: ids
       required: true
@@ -2565,7 +2565,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: CID group ids to be deleted
+    - description: CID group ids to be deleted.
       isArray: true
       name: cid_group_ids
       required: true
@@ -2582,10 +2582,10 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: AWS account IDs to remove
+    - description: AWS account IDs to remove.
       isArray: true
       name: ids
-    - description: AWS organization IDs to remove
+    - description: AWS organization IDs to remove.
       isArray: true
       name: organization_ids
     description: Deletes an existing AWS account or organization in our system.
@@ -2601,7 +2601,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Azure subscription IDs to remove
+    - description: Azure subscription IDs to remove.
       isArray: true
       name: ids
       required: true
@@ -2644,13 +2644,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the exclusions to delete
+    - description: The ids of the exclusions to delete.
       isArray: true
       name: ids
       required: true
-    - description: Explains why this exclusions was deleted
+    - description: Explains why this exclusions was deleted.
       name: comment
-    description: Delete the IOA exclusions by id
+    description: Delete the IOA exclusions by id.
     name: cs-deleteioa-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2663,13 +2663,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the exclusions to delete
+    - description: The ids of the exclusions to delete.
       isArray: true
       name: ids
       required: true
-    - description: Explains why this exclusions was deleted
+    - description: Explains why this exclusions was deleted.
       name: comment
-    description: Delete the ML exclusions by id
+    description: Delete the ML exclusions by id.
     name: cs-deleteml-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.errors.code
@@ -2691,31 +2691,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -2736,11 +2736,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Response Policies to delete
+    - description: The IDs of the Response Policies to delete.
       isArray: true
       name: ids
       required: true
-    description: Delete a set of Response Policies by specifying their IDs
+    description: Delete a set of Response Policies by specifying their IDs.
     name: cs-deletert-response-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -2753,16 +2753,16 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The user id
+    - description: The user id.
       name: X_CS_USERNAME
       required: true
-    - description: The IDs of the rule groups to be deleted
+    - description: The IDs of the rule groups to be deleted.
       isArray: true
       name: ids
       required: true
-    - description: Audit log comment for this action
+    - description: Audit log comment for this action.
       name: comment
-    description: Delete rule group entities by ID
+    description: Delete rule group entities by ID.
     name: cs-deleterulegroups
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -2775,9 +2775,9 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Explains why the entity is being deleted
+    - description: Explains why the entity is being deleted.
       name: comment
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -2794,12 +2794,12 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The parent rule group
+    - description: The parent rule group.
       name: rule_group_id
       required: true
-    - description: Explains why the entity is being deleted
+    - description: Explains why the entity is being deleted.
       name: comment
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -2819,10 +2819,10 @@ script:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: type_
       required: true
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: value
       required: true
-    description: Number of hosts in your customer account that have observed a given custom IOC
+    description: Number of hosts in your customer account that have observed a given custom IOC.
     name: cs-devices-count
     outputs:
     - contextPath: CrowdStrike.apiMsaReplyIOCDevicesCount.errors.code
@@ -2853,14 +2853,14 @@ script:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: type_
       required: true
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: value
       required: true
     - description: The first process to return, where 0 is the latest offset. Use with the offset  meter to manage pagination of results.
       name: limit
     - description: The first process to return, where 0 is the latest offset. Use with the limit  meter to manage pagination of results.
       name: offset
-    description: Find hosts that have observed a given custom IOC. For details about those hosts, use GET /devices/entities/devices/v2
+    description: Find hosts that have observed a given custom IOC. For details about those hosts, use GET /devices/entities/devices/v2.
     name: cs-devices-ran-on
     outputs:
     - contextPath: CrowdStrike.apiMsaReplyDevicesRanOn.errors.code
@@ -2873,17 +2873,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: SHA256 of the installer to download
+    - description: SHA256 of the installer to download.
       name: id_
       required: true
-    description: Download sensor installer by SHA256 ID
+    description: Download sensor installer by SHA256 ID.
     name: cs-download-sensor-installer-by-id
   - arguments:
-    - description: ProcessID for the running process you want to lookup
+    - description: ProcessID for the running process you want to lookup.
       isArray: true
       name: ids
       required: true
-    description: For the provided ProcessID retrieve the process details
+    description: For the provided ProcessID retrieve the process details.
     name: cs-entitiesprocesses
     outputs:
     - contextPath: CrowdStrike.apiMsaProcessDetailResponse.errors.code
@@ -2952,31 +2952,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.cid
-      description: The ID of the customer who created the action
+      description: The ID of the customer who created the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.created_timestamp
-      description: The date when the action was created
+      description: The date when the action was created.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.frequency
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.id
-      description: The ID of the action
+      description: The ID of the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule on which this action is attached
+      description: The ID of the rule on which this action is attached.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.status
       description: The action status. It can be either 'enabled' or 'muted'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.type
-      description: The action type. The only type currently supported is 'email'
+      description: The action type. The only type currently supported is 'email'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.updated_timestamp
-      description: The date when the action was updated
+      description: The date when the action was updated.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user who created the action
+      description: The UUID of the user who created the action.
       type: String
   - arguments:
     - description: ''
@@ -3131,7 +3131,7 @@ script:
       isArray: true
       name: msa_idsrequest_ids
       required: true
-    description: Get details on behaviors by providing behavior IDs
+    description: Get details on behaviors by providing behavior IDs.
     name: cs-get-behaviors
     outputs:
     - contextPath: CrowdStrike.apiMsaExternalBehaviorResponse.errors.code
@@ -3207,11 +3207,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: CID of a child customer
+    - description: CID of a child customer.
       isArray: true
       name: ids
       required: true
-    description: Get link to child customer by child CID(s)
+    description: Get link to child customer by child CID(s).
     name: cs-get-children
     outputs:
     - contextPath: CrowdStrike.domainChildrenResponseV1.resources.checksum
@@ -3236,9 +3236,9 @@ script:
     - description: SubscriptionIDs of accounts to select for this status operation. If this is empty then all accounts are returned.
       isArray: true
       name: ids
-    - description: Type of scan, dry or full, to perform on selected accounts
+    - description: Type of scan, dry or full, to perform on selected accounts.
       name: scan_type
-    description: Return information about Azure account registration
+    description: Return information about Azure account registration.
     name: cs-get-cloudconnectazure-entities-account-v1
     outputs:
     - contextPath: CrowdStrike.registrationAzureAccountResponseV1.errors.code
@@ -3274,7 +3274,7 @@ script:
     - contextPath: CrowdStrike.registrationAzureAccountResponseV1.resources.tenant_id
       description: Azure Tenant ID to use.
       type: String
-  - description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment as a downloadable attachment
+  - description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment as a downloadable attachment.
     name: cs-get-cloudconnectazure-entities-userscriptsdownload-v1
     outputs:
     - contextPath: CrowdStrike.registrationAzureProvisionGetUserScriptResponseV1.errors.code
@@ -3293,15 +3293,15 @@ script:
     - description: SubscriptionIDs of accounts to select for this status operation. If this is empty then all accounts are returned.
       isArray: true
       name: ids
-    - description: Type of scan, dry or full, to perform on selected accounts
+    - description: Type of scan, dry or full, to perform on selected accounts.
       name: scan_type
     - description: Account status to filter results by.
       name: status
     - description: The maximum records to return. Defaults to 100.
       name: limit
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    description: Return information about Azure account registration
+    description: Return information about Azure account registration.
     name: cs-get-cloudconnectcspmazure-entities-account-v1
     outputs:
     - contextPath: CrowdStrike.registrationAzureAccountResponseV1.errors.code
@@ -3340,7 +3340,7 @@ script:
   - arguments:
     - description: Tenant ID to generate script for. Defaults to most recently registered tenant.
       name: tenant_id
-    description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment as a downloadable attachment
+    description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment as a downloadable attachment.
     name: cs-get-cloudconnectcspmazure-entities-userscriptsdownload-v1
     outputs:
     - contextPath: CrowdStrike.registrationAzureProvisionGetUserScriptResponseV1.errors.code
@@ -3362,19 +3362,19 @@ script:
     - description: Cluster Account id. For EKS it will be AWS account ID.
       isArray: true
       name: account_ids
-    - description: Cloud location
+    - description: Cloud location.
       isArray: true
       name: locations
     - auto: PREDEFINED
-      description: Cluster Service
+      description: Cluster Service.
       name: cluster_service
       predefined:
       - eks
-    - description: Limit returned accounts
+    - description: Limit returned accounts.
       name: limit
-    - description: Offset returned accounts
+    - description: Offset returned accounts.
       name: offset
-    description: Provides the clusters acknowledged by the Kubernetes Protection service
+    description: Provides the clusters acknowledged by the Kubernetes Protection service.
     name: cs-get-clusters
     outputs:
     - contextPath: CrowdStrike.k8sregGetClustersResp.errors.code
@@ -3421,11 +3421,11 @@ script:
       name: offset
     - description: 'The number of items to return in this response (default: 100, max: 500). Use with the offset  meter to manage pagination of results.'
       name: limit
-    - description: 'Sort items using their properties. Common sort options include:   ul  li version|asc /li  li release_date|desc /li  /ul '
+    - description: 'Sort items using their properties. Common sort options include:   ul  li version|asc /li  li release_date|desc /li  /ul.'
       name: sort
-    - description: 'Filter items using a query in Falcon Query Language (FQL). An asterisk wildcard   includes all results.  Common filter options include:  ul  li platform:"windows" /li  li version: "5.2" /li  /ul '
+    - description: 'Filter items using a query in Falcon Query Language (FQL). An asterisk wildcard   includes all results.  Common filter options include:  ul  li platform:"windows" /li  li version: "5.2" /li  /ul.'
       name: filter_
-    description: Get sensor installer details by provided query
+    description: Get sensor installer details by provided query.
     name: cs-get-combined-sensor-installers-by-query
     outputs:
     - contextPath: CrowdStrike.domainSensorInstallersV1.errors.code
@@ -3438,16 +3438,16 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.description
-      description: installer description
+      description: installer description.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_size
-      description: file size
+      description: file size.
       type: Number
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_type
-      description: file type
+      description: file type.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.name
-      description: installer file name
+      description: installer file name.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.os
       description: ''
@@ -3456,23 +3456,23 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.platform
-      description: supported platform
+      description: supported platform.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.release_date
-      description: release date
+      description: release date.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.sha256
-      description: sha256
+      description: sha256.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.version
-      description: version of the installer
+      description: version of the installer.
       type: String
   - arguments:
     - description: ''
       isArray: true
       name: msa_idsrequest_ids
       required: true
-    description: View information about detections
+    description: View information about detections.
     name: cs-get-detect-summaries
     outputs:
     - contextPath: CrowdStrike.domainMsaDetectSummariesResponse.errors.code
@@ -3641,11 +3641,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Device Control Policies to return
+    - description: The IDs of the Device Control Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Device Control Policies by specifying their IDs
+    description: Retrieve a set of Device Control Policies by specifying their IDs.
     name: cs-get-device-control-policies
     outputs:
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
@@ -3658,61 +3658,61 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -3720,7 +3720,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve device count collection Ids that match the provided FQL filter, criteria with scrolling enabled
+    description: Retrieve device count collection Ids that match the provided FQL filter, criteria with scrolling enabled.
     name: cs-get-device-count-collection-queries-by-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -3733,11 +3733,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The host agentIDs used to get details on
+    - description: The host agentIDs used to get details on.
       isArray: true
       name: ids
       required: true
-    description: Get details on one or more hosts by providing agent IDs (AID). You can get a host's agent IDs (AIDs) from the /devices/queries/devices/v1 endpoint, the Falcon console or the Streaming API
+    description: Get details on one or more hosts by providing agent IDs (AID). You can get a host's agent IDs (AIDs) from the /devices/queries/devices/v1 endpoint, the Falcon console or the Streaming API.
     name: cs-get-device-details
     outputs:
     - contextPath: CrowdStrike.domainDeviceDetailsResponseSwagger.errors.code
@@ -3948,11 +3948,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Firewall Policies to return
+    - description: The IDs of the Firewall Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Firewall Policies by specifying their IDs
+    description: Retrieve a set of Firewall Policies by specifying their IDs.
     name: cs-get-firewall-policies
     outputs:
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
@@ -3965,77 +3965,77 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
   - arguments:
     - description: Cluster name. For EKS it will be cluster ARN.
       name: cluster_name
       required: true
-    description: Provides a sample Helm values.yaml file for a customer to install alongside the agent Helm chart
+    description: Provides a sample Helm values.yaml file for a customer to install alongside the agent Helm chart.
     name: cs-get-helm-values-yaml
   - arguments:
-    - description: The IDs of the Host Groups to return
+    - description: The IDs of the Host Groups to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Host Groups by specifying their IDs
+    description: Retrieve a set of Host Groups by specifying their IDs.
     name: cs-get-host-groups
     outputs:
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
@@ -4048,38 +4048,38 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
   - arguments:
     - description: ''
       isArray: true
       name: msa_idsrequest_ids
       required: true
-    description: Get details on incidents by providing incident IDs
+    description: Get details on incidents by providing incident IDs.
     name: cs-get-incidents
     outputs:
     - contextPath: CrowdStrike.apiMsaExternalIncidentResponse.errors.code
@@ -4602,7 +4602,7 @@ script:
     - description: The ID of the report you want to download as a PDF.
       name: id_
       required: true
-    description: Return a Report PDF attachment
+    description: Return a Report PDF attachment.
     name: cs-get-intel-reportpdf
   - arguments:
     - description: The ids of rules to return.
@@ -4658,7 +4658,7 @@ script:
   - arguments:
     - description: Choose the format you want the rule set in.
       name: Accept
-    - description: 'The rule news report type. Accepted values:  snort-suricata-master  snort-suricata-update  snort-suricata-changelog  yara-master  yara-update  yara-changelog  common-event-format  netwitness'
+    - description: 'The rule news report type. Accepted values:  snort-suricata-master  snort-suricata-update  snort-suricata-changelog  yara-master  yara-update  yara-changelog  common-event-format  netwitness.'
       name: type_
       required: true
     - description: Choose the format you want the rule set in. Valid formats are zip and gzip. Defaults to zip.
@@ -4667,14 +4667,14 @@ script:
     name: cs-get-latest-intel-rule-file
   - arguments:
     - auto: PREDEFINED
-      description: Cloud Provider
+      description: Cloud Provider.
       isArray: true
       name: clouds
       predefined:
       - aws
       - azure
       - gcp
-    description: Provides the cloud locations acknowledged by the Kubernetes Protection service
+    description: Provides the cloud locations acknowledged by the Kubernetes Protection service.
     name: cs-get-locations
     outputs:
     - contextPath: CrowdStrike.k8sregGetLocationsResp.errors.code
@@ -4697,20 +4697,20 @@ script:
       isArray: true
       name: ids
       required: true
-    description: Download a file indexed by MalQuery. Specify the file using its SHA256. Only one file is supported at this time
+    description: Download a file indexed by MalQuery. Specify the file using its SHA256. Only one file is supported at this time.
     name: cs-get-mal-query-downloadv1
   - arguments:
-    - description: Multidownload job id
+    - description: Multidownload job id.
       name: ids
       required: true
-    description: Fetch a zip archive with password 'infected' containing the samples. Call this once the /entities/samples-multidownload request has finished processing
+    description: Fetch a zip archive with password 'infected' containing the samples. Call this once the /entities/samples-multidownload request has finished processing.
     name: cs-get-mal-query-entities-samples-fetchv1
   - arguments:
     - description: The file SHA256.
       isArray: true
       name: ids
       required: true
-    description: Retrieve indexed files metadata by their hash
+    description: Retrieve indexed files metadata by their hash.
     name: cs-get-mal-query-metadatav1
     outputs:
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.errors.code
@@ -4726,30 +4726,30 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malquerySampleMetadataResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
-  - description: Get information about search and download quotas in your environment
+  - description: Get information about search and download quotas in your environment.
     name: cs-get-mal-query-quotasv1
     outputs:
     - contextPath: CrowdStrike.malqueryRateLimitsResponse.errors.code
@@ -4762,7 +4762,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Identifier of a MalQuery request
+    - description: Identifier of a MalQuery request.
       isArray: true
       name: ids
       required: true
@@ -4782,74 +4782,74 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryRequestResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
   - arguments:
     - description: Notification IDs.
       isArray: true
       name: ids
       required: true
-    description: Get detailed notifications based on their IDs. These include the raw intelligence content that generated the match.This endpoint will return translated notification content. The only target language available is English. A single notification can be translated per request
+    description: Get detailed notifications based on their IDs. These include the raw intelligence content that generated the match.This endpoint will return translated notification content. The only target language available is English. A single notification can be translated per request.
     name: cs-get-notifications-detailed-translatedv1
     outputs:
     - contextPath: CrowdStrike.domainNotificationDetailsResponseV1.errors.code
@@ -4974,34 +4974,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -5013,7 +5013,7 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.errors.code
       description: ''
@@ -5037,34 +5037,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -5076,7 +5076,7 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
   - arguments:
     - description: Notification IDs.
@@ -5108,34 +5108,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -5147,7 +5147,7 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.errors.code
       description: ''
@@ -5171,34 +5171,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -5210,14 +5210,14 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
   - arguments:
-    - description: The IDs of the Prevention Policies to return
+    - description: The IDs of the Prevention Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Prevention Policies by specifying their IDs
+    description: Retrieve a set of Prevention Policies by specifying their IDs.
     name: cs-get-prevention-policies
     outputs:
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
@@ -5230,73 +5230,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
       description: ''
@@ -5308,73 +5308,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
     - description: ID of a report. Find a report ID from the response when submitting a malware sample or search with `/falconx/queries/reports/v1`.
@@ -6511,7 +6511,7 @@ script:
       isArray: true
       name: ids
       required: true
-    description: Get info about a role
+    description: Get info about a role.
     name: cs-get-roles
     outputs:
     - contextPath: CrowdStrike.domainUserRoleResponse.errors.code
@@ -6557,7 +6557,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: 'MSSP Role assignment is of the format  user_group_id : cid_group_id '
+    - description: 'MSSP Role assignment is of the format  user_group_id : cid_group_id.'
       isArray: true
       name: ids
       required: true
@@ -6601,7 +6601,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: IDs of rules.
       isArray: true
@@ -6635,43 +6635,43 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.created_timestamp
-      description: The creation time for a given rule
+      description: The creation time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.filter
-      description: The FQL filter contained in a rule and used for searching
+      description: The FQL filter contained in a rule and used for searching.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.id
-      description: The ID of a given rule
+      description: The ID of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.name
-      description: The name for a given rule
+      description: The name for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.permissions
-      description: The permissions of a given rule
+      description: The permissions of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.priority
-      description: The priority of a given rule
+      description: The priority of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status
-      description: The status of a rule
+      description: The status of a rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status_message
-      description: The detailed status message
+      description: The detailed status message.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.topic
-      description: The topic of a given rule
+      description: The topic of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.updated_timestamp
-      description: The last updated time for a given rule
+      description: The last updated time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_id
-      description: The user ID of the user that created a given rule
+      description: The user ID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_name
-      description: The user name of the user that created a given rule
+      description: The user name of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user that created a given rule
+      description: The UUID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.errors.code
       description: ''
@@ -6698,70 +6698,70 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.created_timestamp
-      description: The creation time for a given rule
+      description: The creation time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.filter
-      description: The FQL filter contained in a rule and used for searching
+      description: The FQL filter contained in a rule and used for searching.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.id
-      description: The ID of a given rule
+      description: The ID of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.name
-      description: The name for a given rule
+      description: The name for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.permissions
-      description: The permissions of a given rule
+      description: The permissions of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.priority
-      description: The priority of a given rule
+      description: The priority of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status
-      description: The status of a rule
+      description: The status of a rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status_message
-      description: The detailed status message
+      description: The detailed status message.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.topic
-      description: The topic of a given rule
+      description: The topic of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.updated_timestamp
-      description: The last updated time for a given rule
+      description: The last updated time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_id
-      description: The user ID of the user that created a given rule
+      description: The user ID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_name
-      description: The user name of the user that created a given rule
+      description: The user name of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user that created a given rule
+      description: The UUID of the user that created a given rule.
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: The file SHA256.
       name: ids
       required: true
-    - description: Flag whether the sample should be zipped and password protected with pass='infected'
+    - description: Flag whether the sample should be zipped and password protected with pass='infected'.
       name: password_protected
-    description: Retrieves the file associated with the given ID (SHA256)
+    description: Retrieves the file associated with the given ID (SHA256).
     name: cs-get-samplev2
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: The file SHA256.
       name: ids
       required: true
-    - description: Flag whether the sample should be zipped and password protected with pass='infected'
+    - description: Flag whether the sample should be zipped and password protected with pass='infected'.
       name: password_protected
-    description: Retrieves the file associated with the given ID (SHA256)
+    description: Retrieves the file associated with the given ID (SHA256).
     name: cs-get-samplev3
   - arguments:
-    - description: ID of a submitted scan
+    - description: ID of a submitted scan.
       isArray: true
       name: ids
       required: true
-    description: Check the status of a volume scan. Time required for analysis increases with the number of samples in a volume but usually it should take less than 1 minute
+    description: Check the status of a volume scan. Time required for analysis increases with the number of samples in a volume but usually it should take less than 1 minute.
     name: cs-get-scans
     outputs:
     - contextPath: CrowdStrike.mlscannerScanV1Response.errors.code
@@ -6877,11 +6877,11 @@ script:
       name: offset
     - description: 'The number of items to return in this response (default: 100, max: 500). Use with the offset  meter to manage pagination of results.'
       name: limit
-    - description: 'Sort items using their properties. Common sort options include:   ul  li version|asc /li  li release_date|desc /li  /ul '
+    - description: 'Sort items using their properties. Common sort options include:   ul  li version|asc /li  li release_date|desc /li  /ul.'
       name: sort
-    - description: 'Filter items using a query in Falcon Query Language (FQL). An asterisk wildcard   includes all results.  Common filter options include:  ul  li platform:"windows" /li  li version: "5.2" /li  /ul '
+    - description: 'Filter items using a query in Falcon Query Language (FQL). An asterisk wildcard   includes all results.  Common filter options include:  ul  li platform:"windows" /li  li version: "5.2" /li  /ul.'
       name: filter_
-    description: Get sensor installer IDs by provided query
+    description: Get sensor installer IDs by provided query.
     name: cs-get-sensor-installers-by-query
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -6903,11 +6903,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the installers
+    - description: The IDs of the installers.
       isArray: true
       name: ids
       required: true
-    description: Get sensor installer details by provided SHA256 IDs
+    description: Get sensor installer details by provided SHA256 IDs.
     name: cs-get-sensor-installers-entities
     outputs:
     - contextPath: CrowdStrike.domainSensorInstallersV1.errors.code
@@ -6920,16 +6920,16 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.description
-      description: installer description
+      description: installer description.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_size
-      description: file size
+      description: file size.
       type: Number
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_type
-      description: file type
+      description: file type.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.name
-      description: installer file name
+      description: installer file name.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.os
       description: ''
@@ -6938,16 +6938,16 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.platform
-      description: supported platform
+      description: supported platform.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.release_date
-      description: release date
+      description: release date.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.sha256
-      description: sha256
+      description: sha256.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.version
-      description: version of the installer
+      description: version of the installer.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.errors.code
       description: ''
@@ -6959,16 +6959,16 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.description
-      description: installer description
+      description: installer description.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_size
-      description: file size
+      description: file size.
       type: Number
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.file_type
-      description: file type
+      description: file type.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.name
-      description: installer file name
+      description: installer file name.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.os
       description: ''
@@ -6977,18 +6977,18 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.platform
-      description: supported platform
+      description: supported platform.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.release_date
-      description: release date
+      description: release date.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.sha256
-      description: sha256
+      description: sha256.
       type: String
     - contextPath: CrowdStrike.domainSensorInstallersV1.resources.version
-      description: version of the installer
+      description: version of the installer.
       type: String
-  - description: Get CCID to use with sensor installers
+  - description: Get CCID to use with sensor installers.
     name: cs-get-sensor-installersccid-by-query
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -7010,11 +7010,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the Sensor Update Policies to return
+    - description: The IDs of the Sensor Update Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Sensor Update Policies by specifying their IDs
+    description: Retrieve a set of Sensor Update Policies by specifying their IDs.
     name: cs-get-sensor-update-policies
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
@@ -7027,58 +7027,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
       description: ''
@@ -7090,65 +7090,65 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The IDs of the Sensor Update Policies to return
+    - description: The IDs of the Sensor Update Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Sensor Update Policies with additional support for uninstall protection by specifying their IDs
+    description: Retrieve a set of Sensor Update Policies with additional support for uninstall protection by specifying their IDs.
     name: cs-get-sensor-update-policiesv2
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
@@ -7161,58 +7161,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
       description: ''
@@ -7224,65 +7224,65 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The ids of the exclusions to retrieve
+    - description: The ids of the exclusions to retrieve.
       isArray: true
       name: ids
       required: true
-    description: Get a set of Sensor Visibility Exclusions by specifying their IDs
+    description: Get a set of Sensor Visibility Exclusions by specifying their IDs.
     name: cs-get-sensor-visibility-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.errors.code
@@ -7304,31 +7304,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.id
       description: ''
@@ -7367,31 +7367,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.id
       description: ''
@@ -7758,7 +7758,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User Group IDs to search for
+    - description: User Group IDs to search for.
       name: user_group_ids
       required: true
     description: Get User Group members by User Group ID(s).
@@ -7789,7 +7789,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User Group IDs to search for
+    - description: User Group IDs to search for.
       isArray: true
       name: user_group_ids
       required: true
@@ -7864,11 +7864,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: 'One or more vulnerability IDs (max: 400). Find vulnerability IDs with GET /spotlight/queries/vulnerabilities/v1'
+    - description: 'One or more vulnerability IDs (max: 400). Find vulnerability IDs with GET /spotlight/queries/vulnerabilities/v1.'
       isArray: true
       name: ids
       required: true
-    description: Get details on vulnerabilities by providing one or more IDs
+    description: Get details on vulnerabilities by providing one or more IDs.
     name: cs-get-vulnerabilities
     outputs:
     - contextPath: CrowdStrike.domainSPAPIVulnerabilitiesEntitiesResponseV2.errors.code
@@ -7932,11 +7932,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: IDs of accounts to retrieve details
+    - description: IDs of accounts to retrieve details.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of AWS Accounts by specifying their IDs
+    description: Retrieve a set of AWS Accounts by specifying their IDs.
     name: cs-getaws-accounts
     outputs:
     - contextPath: CrowdStrike.modelsAWSAccountsV1.errors.code
@@ -8060,14 +8060,14 @@ script:
       description: Current version of cloudformation template used to manage access.
       type: String
   - arguments:
-    - description: AWS Account IDs
+    - description: AWS Account IDs.
       isArray: true
       name: ids
-    - description: Filter by account status
+    - description: Filter by account status.
       name: status
-    - description: Limit returned accounts
+    - description: Limit returned accounts.
       name: limit
-    - description: Offset returned accounts
+    - description: Offset returned accounts.
       name: offset
     description: Provides a list of AWS accounts.
     name: cs-getaws-accounts-mixin0
@@ -8168,7 +8168,7 @@ script:
     - contextPath: CrowdStrike.k8sregGetAWSAccountsResp.resources.updated_at
       description: ''
       type: String
-  - description: Retrieve a set of Global Settings which are applicable to all provisioned AWS accounts
+  - description: Retrieve a set of Global Settings which are applicable to all provisioned AWS accounts.
     name: cs-getaws-settings
     outputs:
     - contextPath: CrowdStrike.modelsCustomerConfigurationsV1.errors.code
@@ -8214,7 +8214,7 @@ script:
       description: By setting this value, all subsequent accounts that are provisioned will default to using this value as the external ID.
       type: String
   - arguments:
-    - description: CID Group IDs to be searched on
+    - description: CID Group IDs to be searched on.
       isArray: true
       name: cid_group_ids
       required: true
@@ -8264,7 +8264,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: CID Group IDs to be searched on
+    - description: CID Group IDs to be searched on.
       isArray: true
       name: cid_group_ids
       required: true
@@ -8296,19 +8296,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Type of scan, dry or full, to perform on selected accounts
+    - description: Type of scan, dry or full, to perform on selected accounts.
       name: scan_type
-    - description: AWS account IDs
+    - description: AWS account IDs.
       isArray: true
       name: ids
-    - description: AWS organization IDs
+    - description: AWS organization IDs.
       isArray: true
       name: organization_ids
     - description: Account status to filter results by.
       name: status
     - description: The maximum records to return. Defaults to 100.
       name: limit
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
     - auto: PREDEFINED
       description: Field to group by.
@@ -8486,7 +8486,7 @@ script:
     - contextPath: CrowdStrike.registrationAWSAccountConsoleURL.url
       description: ''
       type: String
-  - description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment
+  - description: Return a script for customer to run in their cloud environment to grant us access to their Azure environment.
     name: cs-getcspm-azure-user-scripts
     outputs:
     - contextPath: CrowdStrike.registrationAzureProvisionGetUserScriptResponseV1.errors.code
@@ -8514,7 +8514,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Policy ID
+    - description: Policy ID.
       name: ids
       required: true
     description: Given a policy ID, returns detailed policy information.
@@ -8685,10 +8685,10 @@ script:
   - arguments:
     - description: Service type to filter policy settings by.
       name: service
-    - description: Policy ID
+    - description: Policy ID.
       name: policy_id
     - auto: PREDEFINED
-      description: 'Cloud Platform (e.g.: aws|azure|gcp)'
+      description: 'Cloud Platform (e.g.: aws|azure|gcp).'
       name: cloud_platform
       predefined:
       - aws
@@ -8848,7 +8848,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Cloud Platform
+    - description: Cloud Platform.
       isArray: true
       name: cloud_platform
     description: Returns scan schedule configuration for one or more cloud platforms.
@@ -8891,9 +8891,9 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Type of scan, dry or full, to perform on selected accounts
+    - description: Type of scan, dry or full, to perform on selected accounts.
       name: scan_type
-    - description: Parent IDs of accounts
+    - description: Parent IDs of accounts.
       isArray: true
       name: ids
     description: Returns information about the current status of an GCP account.
@@ -8935,7 +8935,7 @@ script:
     - contextPath: CrowdStrike.registrationGCPAccountResponseV1.resources.status
       description: Account registration status.
       type: String
-  - description: Return a script for customer to run in their cloud environment to grant us access to their GCP environment
+  - description: Return a script for customer to run in their cloud environment to grant us access to their GCP environment.
     name: cs-getcspmgcp-user-scripts
     outputs:
     - contextPath: CrowdStrike.registrationGCPProvisionGetUserScriptResponseV1.errors.code
@@ -8962,7 +8962,7 @@ script:
     - contextPath: CrowdStrike.registrationGCPProvisionGetUserScriptResponseV1.resources.bash
       description: ''
       type: String
-  - description: Return a script for customer to run in their cloud environment to grant us access to their GCP environment as a downloadable attachment
+  - description: Return a script for customer to run in their cloud environment to grant us access to their GCP environment as a downloadable attachment.
     name: cs-getcspmgcp-user-scripts-attachment
     outputs:
     - contextPath: CrowdStrike.registrationGCPProvisionGetUserScriptResponseV1.errors.code
@@ -8990,11 +8990,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The events to retrieve, identified by ID
+    - description: The events to retrieve, identified by ID.
       isArray: true
       name: ids
       required: true
-    description: Get events entities by ID and optionally version
+    description: Get events entities by ID and optionally version.
     name: cs-getevents
     outputs:
     - contextPath: CrowdStrike.fwmgrapiEventsResponse.errors.code
@@ -9208,11 +9208,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the rule types to retrieve
+    - description: The IDs of the rule types to retrieve.
       isArray: true
       name: ids
       required: true
-    description: Get the firewall field specifications by ID
+    description: Get the firewall field specifications by ID.
     name: cs-getfirewallfields
     outputs:
     - contextPath: CrowdStrike.fwmgrapiFirewallFieldsResponse.errors.code
@@ -9276,22 +9276,22 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Policy ID
+    - description: Policy ID.
       name: policy_id
       required: true
-    - description: 'Cloud Provider (e.g.: aws|azure|gcp)'
+    - description: 'Cloud Provider (e.g.: aws|azure|gcp).'
       name: cloud_provider
       required: true
-    - description: 'Cloud account ID (e.g.: AWS accountID, Azure subscriptionID)'
+    - description: 'Cloud account ID (e.g.: AWS accountID, Azure subscriptionID).'
       name: account_id
-    - description: Azure tenantID
+    - description: Azure tenantID.
       name: azure_tenant_id
-    - description: user IDs
+    - description: user IDs.
       isArray: true
       name: user_ids
     - description: Starting index of overall result set from which to return events.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     description: For CSPM IOA events, gets list of IOA events.
     name: cs-getioa-events
@@ -9315,11 +9315,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the exclusions to retrieve
+    - description: The ids of the exclusions to retrieve.
       isArray: true
       name: ids
       required: true
-    description: Get a set of IOA Exclusions by specifying their IDs
+    description: Get a set of IOA Exclusions by specifying their IDs.
     name: cs-getioa-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.errors.code
@@ -9350,31 +9350,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.id
       description: ''
@@ -9425,31 +9425,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.id
       description: ''
@@ -9473,15 +9473,15 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Policy ID
+    - description: Policy ID.
       name: policy_id
       required: true
-    - description: 'Cloud Provider (e.g.: aws|azure|gcp)'
+    - description: 'Cloud Provider (e.g.: aws|azure|gcp).'
       name: cloud_provider
       required: true
-    - description: 'Cloud account ID (e.g.: AWS accountID, Azure subscriptionID)'
+    - description: 'Cloud account ID (e.g.: AWS accountID, Azure subscriptionID).'
       name: account_id
-    - description: Azure tenantID
+    - description: Azure tenantID.
       name: azure_tenant_id
     description: For CSPM IOA users, gets list of IOA users.
     name: cs-getioa-users
@@ -9520,7 +9520,7 @@ script:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: type_
       required: true
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: value
       required: true
     description: '    DEPRECATED     Use the new IOC Management endpoint (GET /iocs/entities/indicators/v1).     Get an IOC by providing a type and value.'
@@ -9623,11 +9623,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the exclusions to retrieve
+    - description: The ids of the exclusions to retrieve.
       isArray: true
       name: ids
       required: true
-    description: Get a set of ML Exclusions by specifying their IDs
+    description: Get a set of ML Exclusions by specifying their IDs.
     name: cs-getml-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.errors.code
@@ -9649,31 +9649,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -9712,31 +9712,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -9757,7 +9757,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -9795,11 +9795,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the platforms to retrieve
+    - description: The IDs of the platforms to retrieve.
       isArray: true
       name: ids
       required: true
-    description: Get platforms by ID, e.g., windows or mac or droid
+    description: Get platforms by ID, e.g., windows or mac or droid.
     name: cs-getplatforms
     outputs:
     - contextPath: CrowdStrike.fwmgrapiPlatformsResponse.errors.code
@@ -9833,7 +9833,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -9871,11 +9871,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The policy container(s) to retrieve, identified by policy ID
+    - description: The policy container(s) to retrieve, identified by policy ID.
       isArray: true
       name: ids
       required: true
-    description: Get policy container entities by policy ID
+    description: Get policy container entities by policy ID.
     name: cs-getpolicycontainers
     outputs:
     - contextPath: CrowdStrike.fwmgrapiPolicyContainersResponse.errors.code
@@ -9975,11 +9975,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the RTR Policies to return
+    - description: The IDs of the RTR Policies to return.
       isArray: true
       name: ids
       required: true
-    description: Retrieve a set of Response Policies by specifying their IDs
+    description: Retrieve a set of Response Policies by specifying their IDs.
     name: cs-getrt-response-policies
     outputs:
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
@@ -9992,73 +9992,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
       description: ''
@@ -10070,76 +10070,76 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
-    - description: The IDs of the rule groups to retrieve
+    - description: The IDs of the rule groups to retrieve.
       isArray: true
       name: ids
       required: true
@@ -10231,7 +10231,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -10509,11 +10509,11 @@ script:
       description: ''
       type: Number
   - arguments:
-    - description: The rules to retrieve, identified by ID
+    - description: The rules to retrieve, identified by ID.
       isArray: true
       name: ids
       required: true
-    description: Get rule entities by ID (64-bit unsigned int as decimal string) or Family ID (32-character hexadecimal string)
+    description: Get rule entities by ID (64-bit unsigned int as decimal string) or Family ID (32-character hexadecimal string).
     name: cs-getrules
     outputs:
     - contextPath: CrowdStrike.fwmgrapiRulesResponse.errors.code
@@ -10709,7 +10709,7 @@ script:
       description: ''
       type: Number
   - arguments:
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -11097,7 +11097,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The IDs of the entities
+    - description: The IDs of the entities.
       isArray: true
       name: ids
       required: true
@@ -11190,7 +11190,7 @@ script:
       isArray: true
       name: domain_roleids_roleids
       required: true
-    description: Assign one or more roles to a user
+    description: Assign one or more roles to a user.
     name: cs-grant-user-role-ids
     outputs:
     - contextPath: CrowdStrike.domainUserRoleIDsResponse.errors.code
@@ -11358,11 +11358,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The username
+    - description: The username.
       name: X_CS_USERNAME
-    - description: Whether to submit to retrodetects
+    - description: Whether to submit to retrodetects.
       name: retrodetects
-    - description: Set to true to ignore warnings and add all IOCs
+    - description: Set to true to ignore warnings and add all IOCs.
       name: ignore_warnings
     - description: ''
       name: api_indicatorcreatereqsv1_comment
@@ -11375,10 +11375,10 @@ script:
   - arguments:
     - description: The FQL expression to delete Indicators in bulk. If both 'filter' and 'ids' are provided, then filter takes precedence and ignores ids.
       name: filter_
-    - description: The ids of the Indicators to delete. If both 'filter' and 'ids' are provided, then filter takes precedence and ignores ids
+    - description: The ids of the Indicators to delete. If both 'filter' and 'ids' are provided, then filter takes precedence and ignores ids.
       isArray: true
       name: ids
-    - description: The comment why these indicators were deleted
+    - description: The comment why these indicators were deleted.
       name: comment
     description: Delete Indicators by ids.
     name: cs-indicatordeletev1
@@ -11402,7 +11402,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of the Indicators to retrieve
+    - description: The ids of the Indicators to retrieve.
       isArray: true
       name: ids
       required: true
@@ -11574,33 +11574,33 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The username
+    - description: The username.
       name: X_CS_USERNAME
-    - description: Whether to submit to retrodetects
+    - description: Whether to submit to retrodetects.
       name: retrodetects
-    - description: Set to true to ignore warnings and add all IOCs
+    - description: Set to true to ignore warnings and add all IOCs.
       name: ignore_warnings
-    - description: api_indicatorupdatereqsv1_bulk_update action
+    - description: api_indicatorupdatereqsv1_bulk_update action.
       name: api_indicatorupdatereqsv1_bulk_update_action
-    - description: api_indicatorupdatereqsv1_bulk_update applied_globally
+    - description: api_indicatorupdatereqsv1_bulk_update applied_globally.
       name: api_indicatorupdatereqsv1_bulk_update_applied_globally
-    - description: api_indicatorupdatereqsv1_bulk_update description
+    - description: api_indicatorupdatereqsv1_bulk_update description.
       name: api_indicatorupdatereqsv1_bulk_update_description
-    - description: api_indicatorupdatereqsv1_bulk_update expiration
+    - description: api_indicatorupdatereqsv1_bulk_update expiration.
       name: api_indicatorupdatereqsv1_bulk_update_expiration
-    - description: api_indicatorupdatereqsv1_bulk_update filter
+    - description: api_indicatorupdatereqsv1_bulk_update filter.
       name: api_indicatorupdatereqsv1_bulk_update_filter
-    - description: api_indicatorupdatereqsv1_bulk_update host_groups
+    - description: api_indicatorupdatereqsv1_bulk_update host_groups.
       name: api_indicatorupdatereqsv1_bulk_update_host_groups
-    - description: api_indicatorupdatereqsv1_bulk_update mobile_action
+    - description: api_indicatorupdatereqsv1_bulk_update mobile_action.
       name: api_indicatorupdatereqsv1_bulk_update_mobile_action
-    - description: api_indicatorupdatereqsv1_bulk_update platforms
+    - description: api_indicatorupdatereqsv1_bulk_update platforms.
       name: api_indicatorupdatereqsv1_bulk_update_platforms
-    - description: api_indicatorupdatereqsv1_bulk_update severity
+    - description: api_indicatorupdatereqsv1_bulk_update severity.
       name: api_indicatorupdatereqsv1_bulk_update_severity
-    - description: api_indicatorupdatereqsv1_bulk_update source
+    - description: api_indicatorupdatereqsv1_bulk_update source.
       name: api_indicatorupdatereqsv1_bulk_update_source
-    - description: api_indicatorupdatereqsv1_bulk_update tags
+    - description: api_indicatorupdatereqsv1_bulk_update tags.
       name: api_indicatorupdatereqsv1_bulk_update_tags
     - description: ''
       name: api_indicatorupdatereqsv1_comment
@@ -11729,9 +11729,9 @@ script:
     - description: 'Label that identifies your connection. Max: 32 alphanumeric characters (a-z, A-Z, 0-9).'
       name: appId
       required: true
-    - description: 'Format for streaming events. Valid values: json, flatjson'
+    - description: 'Format for streaming events. Valid values: json, flatjson.'
       name: format
-    description: Discover all event streams in your environment
+    description: Discover all event streams in your environment.
     name: cs-list-available-streamso-auth2
     outputs:
     - contextPath: CrowdStrike.maindiscoveryResponseV2.errors.code
@@ -11777,9 +11777,9 @@ script:
     - description: The API client secret to authenticate your API requests. For information on generating API clients, see [API documentation inside Falcon](https://falcon.crowdstrike.com/support/documentation/1/crowdstrike-api-introduction-for-developers).
       name: client_secret
       required: true
-    - description: For MSSP Master CIDs, optionally lock the token to act on behalf of this member CID
+    - description: For MSSP Master CIDs, optionally lock the token to act on behalf of this member CID.
       name: member_cid
-    description: Generate an OAuth2 access token
+    description: Generate an OAuth2 access token.
     name: cs-oauth2-access-token
   - arguments:
     - description: 'The OAuth2 access token you want to revoke.  Include your API client ID and secret in basic auth format (`Authorization: basic  encoded API client ID and secret `) in your request header.'
@@ -11807,18 +11807,18 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: ClientID to use for the Service Principal associated with the customer's Azure account
+    - description: ClientID to use for the Service Principal associated with the customer's Azure account.
       name: id_
       required: true
-    description: Update an Azure service account in our system by with the user-created client_id created with the public key we've provided
+    description: Update an Azure service account in our system by with the user-created client_id created with the public key we've provided.
     name: cs-patch-cloudconnectazure-entities-clientid-v1
   - arguments:
-    - description: ClientID to use for the Service Principal associated with the customer's Azure account
+    - description: ClientID to use for the Service Principal associated with the customer's Azure account.
       name: id_
       required: true
     - description: Tenant ID to update client ID for. Required if multiple tenants are registered.
       name: tenant_id
-    description: Update an Azure service account in our system by with the user-created client_id created with the public key we've provided
+    description: Update an Azure service account in our system by with the user-created client_id created with the public key we've provided.
     name: cs-patch-cloudconnectcspmazure-entities-clientid-v1
   - arguments:
     - description: ''
@@ -11828,7 +11828,7 @@ script:
     description: Patches a existing account in our system for a customer.
     name: cs-patchcspm-aws-account
   - arguments:
-    - description: 'Specify one of these actions:  - `contain` - This action contains the host, which stops any network communications to locations other than the CrowdStrike cloud and IPs specified in your [containment policy](https://falcon.crowdstrike.com/support/documentation/11/getting-started-guide#containmentpolicy) - `lift_containment`: This action lifts containment on the host, which returns its network communications to normal - `hide_host`: This action will delete a host. After the host is deleted, no new detections for that host will be reported via UI or APIs - `unhide_host`: This action will restore a host. Detection reporting will resume after the host is restored'
+    - description: 'Specify one of these actions:  - `contain` - This action contains the host, which stops any network communications to locations other than the CrowdStrike cloud and IPs specified in your [containment policy](https://falcon.crowdstrike.com/support/documentation/11/getting-started-guide#containmentpolicy) - `lift_containment`: This action lifts containment on the host, which returns its network communications to normal - `hide_host`: This action will delete a host. After the host is deleted, no new detections for that host will be reported via UI or APIs - `unhide_host`: This action will restore a host. Detection reporting will resume after the host is restored.'
       name: action_name
       required: true
     - description: ''
@@ -11842,7 +11842,7 @@ script:
     name: cs-perform-actionv2
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-host-group
@@ -11857,7 +11857,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Device Control Policies specified in the request
+    description: Perform the specified action on the Device Control Policies specified in the request.
     name: cs-perform-device-control-policies-action
     outputs:
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
@@ -11870,58 +11870,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
       description: ''
@@ -11933,62 +11933,62 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-host-group
@@ -12003,7 +12003,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Firewall Policies specified in the request
+    description: Perform the specified action on the Firewall Policies specified in the request.
     name: cs-perform-firewall-policies-action
     outputs:
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
@@ -12016,64 +12016,64 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
       description: ''
@@ -12085,68 +12085,68 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-hosts
@@ -12159,7 +12159,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Host Groups specified in the request
+    description: Perform the specified action on the Host Groups specified in the request.
     name: cs-perform-group-action
     outputs:
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
@@ -12172,31 +12172,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
       description: ''
@@ -12208,31 +12208,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
   - arguments:
     - description: ''
@@ -12242,7 +12242,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform a set of actions on one or more incidents, such as adding tags or comments or updating the incident name or description
+    description: Perform a set of actions on one or more incidents, such as adding tags or comments or updating the incident name or description.
     name: cs-perform-incident-action
     outputs:
     - contextPath: CrowdStrike.msaReplyMetaOnly.errors.code
@@ -12265,7 +12265,7 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-host-group
@@ -12282,7 +12282,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Prevention Policies specified in the request
+    description: Perform the specified action on the Prevention Policies specified in the request.
     name: cs-perform-prevention-policies-action
     outputs:
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
@@ -12295,73 +12295,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
       description: ''
@@ -12373,77 +12373,77 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-host-group
@@ -12458,7 +12458,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Sensor Update Policies specified in the request
+    description: Perform the specified action on the Sensor Update Policies specified in the request.
     name: cs-perform-sensor-update-policies-action
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
@@ -12471,58 +12471,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
       description: ''
@@ -12534,62 +12534,62 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The action to perform
+      description: The action to perform.
       name: action_name
       predefined:
       - add-host-group
@@ -12606,7 +12606,7 @@ script:
       isArray: true
       name: msa_entityactionrequestv2_ids
       required: true
-    description: Perform the specified action on the Response Policies specified in the request
+    description: Perform the specified action on the Response Policies specified in the request.
     name: cs-performrt-response-policies-action
     outputs:
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
@@ -12619,73 +12619,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
       description: ''
@@ -12697,73 +12697,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
     - description: ''
@@ -12780,11 +12780,11 @@ script:
     description: Creates a new account in our system for a customer and generates a script for them to run in their cloud environment to grant us access.
     name: cs-post-cloudconnectcspmazure-entities-account-v1
   - arguments:
-    - description: List of sample sha256 ids
+    - description: List of sample sha256 ids.
       isArray: true
       name: malquery_multidownloadrequestv1_samples
       required: true
-    description: Schedule samples for download. Use the result id with the /request endpoint to check if the download is ready after which you can call the /entities/samples-fetch to get the zip
+    description: Schedule samples for download. Use the result id with the /request endpoint to check if the download is ready after which you can call the /entities/samples-fetch to get the zip.
     name: cs-post-mal-query-entities-samples-multidownloadv1
     outputs:
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
@@ -12800,67 +12800,67 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
       description: ''
@@ -12875,88 +12875,88 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
   - arguments:
-    - description: malquery_externalexactsearchparametersv1_options filter_filetypes
+    - description: malquery_externalexactsearchparametersv1_options filter_filetypes.
       name: malquery_externalexactsearchparametersv1_options_filter_filetypes
-    - description: malquery_externalexactsearchparametersv1_options filter_meta
+    - description: malquery_externalexactsearchparametersv1_options filter_meta.
       name: malquery_externalexactsearchparametersv1_options_filter_meta
-    - description: malquery_externalexactsearchparametersv1_options limit
+    - description: malquery_externalexactsearchparametersv1_options limit.
       name: malquery_externalexactsearchparametersv1_options_limit
-    - description: malquery_externalexactsearchparametersv1_options max_date
+    - description: malquery_externalexactsearchparametersv1_options max_date.
       name: malquery_externalexactsearchparametersv1_options_max_date
-    - description: malquery_externalexactsearchparametersv1_options max_size
+    - description: malquery_externalexactsearchparametersv1_options max_size.
       name: malquery_externalexactsearchparametersv1_options_max_size
-    - description: malquery_externalexactsearchparametersv1_options min_date
+    - description: malquery_externalexactsearchparametersv1_options min_date.
       name: malquery_externalexactsearchparametersv1_options_min_date
-    - description: malquery_externalexactsearchparametersv1_options min_size
+    - description: malquery_externalexactsearchparametersv1_options min_size.
       name: malquery_externalexactsearchparametersv1_options_min_size
-    - description: Patterns to search for
+    - description: Patterns to search for.
       isArray: true
       name: malquery_externalexactsearchparametersv1_patterns
       required: true
-    description: Search Falcon MalQuery for a combination of hex patterns and strings in order to identify samples based upon file content at byte level granularity. You can filter results on criteria such as file type, file size and first seen date. Returns a request id which can be used with the /request endpoint
+    description: Search Falcon MalQuery for a combination of hex patterns and strings in order to identify samples based upon file content at byte level granularity. You can filter results on criteria such as file type, file size and first seen date. Returns a request id which can be used with the /request endpoint.
     name: cs-post-mal-query-exact-searchv1
     outputs:
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
@@ -12972,67 +12972,67 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
       description: ''
@@ -13047,72 +13047,72 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
   - arguments:
-    - description: malquery_fuzzysearchparametersv1_options filter_meta
+    - description: malquery_fuzzysearchparametersv1_options filter_meta.
       name: malquery_fuzzysearchparametersv1_options_filter_meta
-    - description: malquery_fuzzysearchparametersv1_options limit
+    - description: malquery_fuzzysearchparametersv1_options limit.
       name: malquery_fuzzysearchparametersv1_options_limit
     - description: ''
       isArray: true
@@ -13134,28 +13134,28 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.errors.code
       description: ''
@@ -13170,48 +13170,48 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryFuzzySearchResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
   - arguments:
-    - description: malquery_externalhuntparametersv1_options filter_filetypes
+    - description: malquery_externalhuntparametersv1_options filter_filetypes.
       name: malquery_externalhuntparametersv1_options_filter_filetypes
-    - description: malquery_externalhuntparametersv1_options filter_meta
+    - description: malquery_externalhuntparametersv1_options filter_meta.
       name: malquery_externalhuntparametersv1_options_filter_meta
-    - description: malquery_externalhuntparametersv1_options limit
+    - description: malquery_externalhuntparametersv1_options limit.
       name: malquery_externalhuntparametersv1_options_limit
-    - description: malquery_externalhuntparametersv1_options max_date
+    - description: malquery_externalhuntparametersv1_options max_date.
       name: malquery_externalhuntparametersv1_options_max_date
-    - description: malquery_externalhuntparametersv1_options max_size
+    - description: malquery_externalhuntparametersv1_options max_size.
       name: malquery_externalhuntparametersv1_options_max_size
-    - description: malquery_externalhuntparametersv1_options min_date
+    - description: malquery_externalhuntparametersv1_options min_date.
       name: malquery_externalhuntparametersv1_options_min_date
-    - description: malquery_externalhuntparametersv1_options min_size
+    - description: malquery_externalhuntparametersv1_options min_size.
       name: malquery_externalhuntparametersv1_options_min_size
-    - description: A YARA rule that defines your search
+    - description: A YARA rule that defines your search.
       name: malquery_externalhuntparametersv1_yara_rule
       required: true
-    description: Schedule a YARA-based search for execution. Returns a request id which can be used with the /request endpoint
+    description: Schedule a YARA-based search for execution. Returns a request id which can be used with the /request endpoint.
     name: cs-post-mal-query-huntv1
     outputs:
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
@@ -13227,67 +13227,67 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.errors.code
       description: ''
@@ -13302,70 +13302,70 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.ignore_reason
-      description: Reason why the resource is ignored
+      description: Reason why the resource is ignored.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.label_confidence
-      description: Resource label confidence
+      description: Resource label confidence.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern
-      description: Search pattern
+      description: Search pattern.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.pattern_type
-      description: Search pattern type
+      description: Search pattern type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.family
-      description: Sample family
+      description: Sample family.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filesize
-      description: Sample size
+      description: Sample size.
       type: Number
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.filetype
-      description: Sample file type
+      description: Sample file type.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.first_seen
-      description: Date when it was first seen
+      description: Date when it was first seen.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.label
-      description: Sample label
+      description: Sample label.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.md5
-      description: Sample MD5
+      description: Sample MD5.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.samples.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha1
-      description: Sample SHA1
+      description: Sample SHA1.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.sha256
-      description: Sample SHA256
+      description: Sample SHA256.
       type: String
     - contextPath: CrowdStrike.malqueryExternalQueryResponse.resources.yara_rule
-      description: Search YARA rule
+      description: Search YARA rule.
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: ''
       name: domain_rulepreviewrequest_filter
@@ -13482,7 +13482,7 @@ script:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: type_
       required: true
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: value
       required: true
     - description: Specify a host's ID to return only processes from that host. Get a host's ID from GET /devices/queries/devices/v1, the Falcon console, or the Streaming API.
@@ -13492,7 +13492,7 @@ script:
       name: limit
     - description: The first process to return, where 0 is the latest offset. Use with the limit  meter to manage pagination of results.
       name: offset
-    description: Search for processes associated with a custom IOC
+    description: Search for processes associated with a custom IOC.
     name: cs-processes-ran-on
     outputs:
     - contextPath: CrowdStrike.apiMsaReplyProcessesRanOn.errors.code
@@ -13524,7 +13524,7 @@ script:
       isArray: true
       name: models_createawsaccountsv1_resources
       required: true
-    description: Provision AWS Accounts by specifying details about the accounts to provision
+    description: Provision AWS Accounts by specifying details about the accounts to provision.
     name: cs-provisionaws-accounts
   - arguments:
     - description: Starting index of overall result set from which to return IDs.
@@ -13533,9 +13533,9 @@ script:
       name: limit
     - description: 'Possible order by fields: created_timestamp, updated_timestamp. Ex: ''updated_timestamp|desc''.'
       name: sort
-    - description: 'FQL query to filter actions by. Possible filter properties are: [id cid user_uuid rule_id type frequency recipients status created_timestamp updated_timestamp]'
+    - description: 'FQL query to filter actions by. Possible filter properties are: [id cid user_uuid rule_id type frequency recipients status created_timestamp updated_timestamp].'
       name: filter_
-    - description: Free text search across all indexed fields
+    - description: Free text search across all indexed fields.
       name: q
     description: Query actions based on provided criteria. Use the IDs from this response to get the action entities on GET /entities/actions/v1.
     name: cs-query-actionsv1
@@ -13583,7 +13583,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -13591,7 +13591,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve allowlist tickets that match the provided filter criteria with scrolling enabled
+    description: Retrieve allowlist tickets that match the provided filter criteria with scrolling enabled.
     name: cs-query-allow-list-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -13617,7 +13617,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - auto: PREDEFINED
       description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
@@ -13625,7 +13625,7 @@ script:
       predefined:
       - timestamp.asc
       - timestamp.desc
-    description: Search for behaviors by providing an FQL filter, sorting, and paging details
+    description: Search for behaviors by providing an FQL filter, sorting, and paging details.
     name: cs-query-behaviors
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -13647,7 +13647,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -13655,7 +13655,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve block listtickets that match the provided filter criteria with scrolling enabled
+    description: Retrieve block listtickets that match the provided filter criteria with scrolling enabled.
     name: cs-query-block-list-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -13678,15 +13678,15 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
-    - description: Starting index of overall result set from which to return ids
+    - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
-    description: Query for customers linked as children
+    description: Query for customers linked as children.
     name: cs-query-children
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -13708,14 +13708,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -13734,7 +13734,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Device Control Policies in your environment by providing an FQL filter and paging details. Returns a set of Device Control Policies which match the filter criteria
+    description: Search for Device Control Policies in your environment by providing an FQL filter and paging details. Returns a set of Device Control Policies which match the filter criteria.
     name: cs-query-combined-device-control-policies
     outputs:
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
@@ -13747,58 +13747,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
       description: ''
@@ -13810,71 +13810,71 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The ID of the Device Control Policy to search for members of
+    - description: The ID of the Device Control Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Device Control Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Device Control Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combined-device-control-policy-members
     outputs:
     - contextPath: CrowdStrike.responsesPolicyMembersRespV1.errors.code
@@ -14304,14 +14304,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -14330,7 +14330,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Firewall Policies in your environment by providing an FQL filter and paging details. Returns a set of Firewall Policies which match the filter criteria
+    description: Search for Firewall Policies in your environment by providing an FQL filter and paging details. Returns a set of Firewall Policies which match the filter criteria.
     name: cs-query-combined-firewall-policies
     outputs:
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
@@ -14343,64 +14343,64 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
       description: ''
@@ -14412,77 +14412,77 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
   - arguments:
-    - description: The ID of the Firewall Policy to search for members of
+    - description: The ID of the Firewall Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Firewall Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Firewall Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combined-firewall-policy-members
     outputs:
     - contextPath: CrowdStrike.responsesPolicyMembersRespV1.errors.code
@@ -14912,17 +14912,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Host Group to search for members of
+    - description: The ID of the Host Group to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Host Group in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Host Group in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combined-group-members
     outputs:
     - contextPath: CrowdStrike.responsesHostGroupMembersV1.errors.code
@@ -15274,14 +15274,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -15296,7 +15296,7 @@ script:
       - modified_timestamp.desc
       - name.asc
       - name.desc
-    description: Search for Host Groups in your environment by providing an FQL filter and paging details. Returns a set of Host Groups which match the filter criteria
+    description: Search for Host Groups in your environment by providing an FQL filter and paging details. Returns a set of Host Groups which match the filter criteria.
     name: cs-query-combined-host-groups
     outputs:
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
@@ -15309,31 +15309,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
       description: ''
@@ -15345,41 +15345,41 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -15398,7 +15398,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Prevention Policies in your environment by providing an FQL filter and paging details. Returns a set of Prevention Policies which match the filter criteria
+    description: Search for Prevention Policies in your environment by providing an FQL filter and paging details. Returns a set of Prevention Policies which match the filter criteria.
     name: cs-query-combined-prevention-policies
     outputs:
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
@@ -15411,73 +15411,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
       description: ''
@@ -15489,86 +15489,86 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
-    - description: The ID of the Prevention Policy to search for members of
+    - description: The ID of the Prevention Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Prevention Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Prevention Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combined-prevention-policy-members
     outputs:
     - contextPath: CrowdStrike.responsesPolicyMembersRespV1.errors.code
@@ -15999,13 +15999,13 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: The platform to return builds for
+      description: The platform to return builds for.
       name: platform
       predefined:
       - linux
       - mac
       - windows
-    description: Retrieve available builds for use with Sensor Update Policies
+    description: Retrieve available builds for use with Sensor Update Policies.
     name: cs-query-combined-sensor-update-builds
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdateBuildsV1.errors.code
@@ -16039,14 +16039,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -16065,7 +16065,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Sensor Update Policies in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policies which match the filter criteria
+    description: Search for Sensor Update Policies in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policies which match the filter criteria.
     name: cs-query-combined-sensor-update-policies
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
@@ -16078,58 +16078,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
       description: ''
@@ -16141,68 +16141,68 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -16221,7 +16221,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Sensor Update Policies with additional support for uninstall protection in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policies which match the filter criteria
+    description: Search for Sensor Update Policies with additional support for uninstall protection in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policies which match the filter criteria.
     name: cs-query-combined-sensor-update-policiesv2
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
@@ -16234,58 +16234,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
       description: ''
@@ -16297,71 +16297,71 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: The ID of the Sensor Update Policy to search for members of
+    - description: The ID of the Sensor Update Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Sensor Update Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Sensor Update Policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combined-sensor-update-policy-members
     outputs:
     - contextPath: CrowdStrike.responsesPolicyMembersRespV1.errors.code
@@ -16791,14 +16791,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -16817,7 +16817,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Response Policies in your environment by providing an FQL filter and paging details. Returns a set of Response Policies which match the filter criteria
+    description: Search for Response Policies in your environment by providing an FQL filter and paging details. Returns a set of Response Policies which match the filter criteria.
     name: cs-query-combinedrt-response-policies
     outputs:
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
@@ -16830,73 +16830,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
       description: ''
@@ -16908,86 +16908,86 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
-    - description: The ID of the Response policy to search for members of
+    - description: The ID of the Response policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Response policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria
+    description: Search for members of a Response policy in your environment by providing an FQL filter and paging details. Returns a set of host details which match the filter criteria.
     name: cs-query-combinedrt-response-policy-members
     outputs:
     - contextPath: CrowdStrike.responsesPolicyMembersRespV1.errors.code
@@ -17417,7 +17417,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -17425,7 +17425,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve DetectionsIds that match the provided FQL filter, criteria with scrolling enabled
+    description: Retrieve DetectionsIds that match the provided FQL filter, criteria with scrolling enabled.
     name: cs-query-detection-ids-by-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17451,13 +17451,13 @@ script:
       name: offset
     - description: 'The maximum number of detections to return in this response (default: 9999; max: 9999). Use with the `offset`  meter to manage pagination of results.'
       name: limit
-    - description: 'Sort detections using these options:  - `first_behavior`: Timestamp of the first behavior associated with this detection - `last_behavior`: Timestamp of the last behavior associated with this detection - `max_severity`: Highest severity of the behaviors associated with this detection - `max_confidence`: Highest confidence of the behaviors associated with this detection - `adversary_id`: ID of the adversary associated with this detection, if any - `devices.hostname`: Hostname of the host where this detection was detected  Sort either `asc` (ascending) or `desc` (descending). For example: `last_behavior|asc`'
+    - description: 'Sort detections using these options:  - `first_behavior`: Timestamp of the first behavior associated with this detection - `last_behavior`: Timestamp of the last behavior associated with this detection - `max_severity`: Highest severity of the behaviors associated with this detection - `max_confidence`: Highest confidence of the behaviors associated with this detection - `adversary_id`: ID of the adversary associated with this detection, if any - `devices.hostname`: Hostname of the host where this detection was detected  Sort either `asc` (ascending) or `desc` (descending). For example: `last_behavior|asc`.'
       name: sort
     - description: 'Filter detections using a query in Falcon Query Language (FQL) An asterisk wildcard ` ` includes all results.   Common filter options include:  - `status` - `device.device_id` - `max_severity`  The full list of valid filter options is extensive. Review it in our [documentation inside the Falcon console](https://falcon.crowdstrike.com/support/documentation/2/query-api-reference#detections_fql).'
       name: filter_
-    - description: Search all detection metadata for the provided string
+    - description: Search all detection metadata for the provided string.
       name: q
-    description: Search for detection IDs that match a given query
+    description: Search for detection IDs that match a given query.
     name: cs-query-detects
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17479,14 +17479,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -17505,7 +17505,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Device Control Policies in your environment by providing an FQL filter and paging details. Returns a set of Device Control Policy IDs which match the filter criteria
+    description: Search for Device Control Policies in your environment by providing an FQL filter and paging details. Returns a set of Device Control Policy IDs which match the filter criteria.
     name: cs-query-device-control-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17527,17 +17527,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Device Control Policy to search for members of
+    - description: The ID of the Device Control Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Device Control Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Device Control Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-query-device-control-policy-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17559,13 +17559,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by (e.g. status.desc or hostname.asc)
+    - description: The property to sort by (e.g. status.desc or hostname.asc).
       name: sort
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
     description: Search for hosts in your environment by platform, hostname, IP, and other criteria.
     name: cs-query-devices-by-filter
@@ -17589,15 +17589,15 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The offset to page from, for the next result set
+    - description: The offset to page from, for the next result set.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by (e.g. status.desc or hostname.asc)
+    - description: The property to sort by (e.g. status.desc or hostname.asc).
       name: sort
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    description: Search for hosts in your environment by platform, hostname, IP, and other criteria with continuous pagination capability (based on offset pointer which expires after 2 minutes with no maximum limit)
+    description: Search for hosts in your environment by platform, hostname, IP, and other criteria with continuous pagination capability (based on offset pointer which expires after 2 minutes with no maximum limit).
     name: cs-query-devices-by-filter-scroll
     outputs:
     - contextPath: CrowdStrike.domainDeviceResponse.errors.code
@@ -17619,7 +17619,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -17627,7 +17627,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve escalation tickets that match the provided filter criteria with scrolling enabled
+    description: Retrieve escalation tickets that match the provided filter criteria with scrolling enabled.
     name: cs-query-escalations-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17649,14 +17649,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -17675,7 +17675,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Firewall Policies in your environment by providing an FQL filter and paging details. Returns a set of Firewall Policy IDs which match the filter criteria
+    description: Search for Firewall Policies in your environment by providing an FQL filter and paging details. Returns a set of Firewall Policy IDs which match the filter criteria.
     name: cs-query-firewall-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17697,17 +17697,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Firewall Policy to search for members of
+    - description: The ID of the Firewall Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Firewall Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Firewall Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-query-firewall-policy-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17729,17 +17729,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Host Group to search for members of
+    - description: The ID of the Host Group to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Host Group in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Host Group in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-query-group-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17761,13 +17761,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by (e.g. status.desc or hostname.asc)
+    - description: The property to sort by (e.g. status.desc or hostname.asc).
       name: sort
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
     description: Retrieve hidden hosts that match the provided filter criteria.
     name: cs-query-hidden-devices
@@ -17791,14 +17791,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -17813,7 +17813,7 @@ script:
       - modified_timestamp.desc
       - name.asc
       - name.desc
-    description: Search for Host Groups in your environment by providing an FQL filter and paging details. Returns a set of Host Group IDs which match the filter criteria
+    description: Search for Host Groups in your environment by providing an FQL filter and paging details. Returns a set of Host Group IDs which match the filter criteria.
     name: cs-query-host-groups
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17835,7 +17835,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -17843,7 +17843,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve incidents that match the provided filter criteria with scrolling enabled
+    description: Retrieve incidents that match the provided filter criteria with scrolling enabled.
     name: cs-query-incident-ids-by-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -17891,9 +17891,9 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
-    description: Search for incidents by providing an FQL filter, sorting, and paging details
+    description: Search for incidents by providing an FQL filter, sorting, and paging details.
     name: cs-query-incidents
     outputs:
     - contextPath: CrowdStrike.apiMsaIncidentQueryResponse.errors.code
@@ -18194,7 +18194,7 @@ script:
   - arguments:
     - description: Set the starting row number to return indicators from. Defaults to 0.
       name: offset
-    - description: Set the number of indicators to return. The number must be between 1 and 50000
+    - description: Set the number of indicators to return. The number must be between 1 and 50000.
       name: limit
     - description: 'Order fields in ascending or descending order.  Ex: published_date|asc.'
       name: sort
@@ -18324,7 +18324,7 @@ script:
   - arguments:
     - description: Set the starting row number to return indicator IDs from. Defaults to 0.
       name: offset
-    - description: Set the number of indicator IDs to return. The number must be between 1 and 50000
+    - description: Set the number of indicator IDs to return. The number must be between 1 and 50000.
       name: limit
     - description: 'Order fields in ascending or descending order.  Ex: published_date|asc.'
       name: sort
@@ -18654,7 +18654,7 @@ script:
     - description: Search by rule title.
       isArray: true
       name: name
-    - description: 'The rule news report type. Accepted values:  snort-suricata-master  snort-suricata-update  snort-suricata-changelog  yara-master  yara-update  yara-changelog  common-event-format  netwitness'
+    - description: 'The rule news report type. Accepted values:  snort-suricata-master  snort-suricata-update  snort-suricata-changelog  yara-master  yara-update  yara-changelog  common-event-format  netwitness.'
       name: type_
       required: true
     - description: Substring match on description field.
@@ -18697,7 +18697,7 @@ script:
       name: limit
     - description: 'Possible order by fields: created_date, updated_date. Ex: ''updated_date|desc''.'
       name: sort
-    - description: 'FQL query to filter notifications by. Possible filter properties are: [id cid user_uuid status rule_id rule_name rule_topic rule_priority item_type created_date updated_date]'
+    - description: 'FQL query to filter notifications by. Possible filter properties are: [id cid user_uuid status rule_id rule_name rule_topic rule_priority item_type created_date updated_date].'
       name: filter_
     - description: Free text search across all indexed fields.
       name: q
@@ -18747,14 +18747,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -18773,7 +18773,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Prevention Policies in your environment by providing an FQL filter and paging details. Returns a set of Prevention Policy IDs which match the filter criteria
+    description: Search for Prevention Policies in your environment by providing an FQL filter and paging details. Returns a set of Prevention Policy IDs which match the filter criteria.
     name: cs-query-prevention-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -18795,17 +18795,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Prevention Policy to search for members of
+    - description: The ID of the Prevention Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Prevention Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Prevention Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-query-prevention-policy-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -18827,7 +18827,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - description: The property to sort on, followed by a dot (.), followed by the sort direction, either "asc" or "desc".
       name: sort
@@ -18835,7 +18835,7 @@ script:
       name: filter_
     - description: Starting index of overall result set from which to return ids.
       name: offset
-    description: Retrieve remediation tickets that match the provided filter criteria with scrolling enabled
+    description: Retrieve remediation tickets that match the provided filter criteria with scrolling enabled.
     name: cs-query-remediations-filter
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -18887,20 +18887,20 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User Group ID to fetch MSSP role for
+    - description: User Group ID to fetch MSSP role for.
       name: user_group_id
-    - description: CID Group ID to fetch MSSP role for
+    - description: CID Group ID to fetch MSSP role for.
       name: cid_group_id
-    - description: Role ID to fetch MSSP role for
+    - description: Role ID to fetch MSSP role for.
       name: role_id
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
-    - description: Starting index of overall result set from which to return ids
+    - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
     description: Query MSSP Role assignment. At least one of CID Group ID or User Group ID should also be provided. Role ID is optional.
     name: cs-query-roles
@@ -18924,7 +18924,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: Starting index of overall result set from which to return ids.
       name: offset
@@ -18932,7 +18932,7 @@ script:
       name: limit
     - description: 'Possible order by fields: created_timestamp, last_updated_timestamp. Ex: ''last_updated_timestamp|desc''.'
       name: sort
-    - description: 'FQL query to filter rules by. Possible filter properties are: [id cid user_uuid topic priority permissions filter status created_timestamp last_updated_timestamp]'
+    - description: 'FQL query to filter rules by. Possible filter properties are: [id cid user_uuid topic priority permissions filter status created_timestamp last_updated_timestamp].'
       name: filter_
     - description: Free text search across all indexed fields.
       name: q
@@ -18982,12 +18982,12 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: ''
       isArray: true
       name: samplestore_querysamplesrequest_sha256s
-    description: Retrieves a list with sha256 of samples that exist and customer has rights to access them, maximum number of accepted items is 200
+    description: Retrieves a list with sha256 of samples that exist and customer has rights to access them, maximum number of accepted items is 200.
     name: cs-query-samplev1
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -19009,14 +19009,14 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort by
+      description: The property to sort by.
       name: sort
       predefined:
       - created_by.asc
@@ -19035,7 +19035,7 @@ script:
       - platform_name.desc
       - precedence.asc
       - precedence.desc
-    description: Search for Sensor Update Policies in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policy IDs which match the filter criteria
+    description: Search for Sensor Update Policies in your environment by providing an FQL filter and paging details. Returns a set of Sensor Update Policy IDs which match the filter criteria.
     name: cs-query-sensor-update-policies
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -19057,17 +19057,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Sensor Update Policy to search for members of
+    - description: The ID of the Sensor Update Policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Sensor Update Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Sensor Update Policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-query-sensor-update-policy-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -19091,9 +19091,9 @@ script:
   - arguments:
     - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - auto: PREDEFINED
       description: The sort expression that should be used to sort the results.
@@ -19193,17 +19193,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID to lookup associated user group ID
+    - description: User UUID to lookup associated user group ID.
       name: user_uuid
       required: true
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
-    - description: Starting index of overall result set from which to return ids
+    - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
     description: Query User Group member by User UUID.
     name: cs-query-user-group-members
@@ -19227,17 +19227,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Name to lookup groups for
+    - description: Name to lookup groups for.
       name: name
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
       - name
-    - description: Starting index of overall result set from which to return ids
+    - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
     description: Query User Groups.
     name: cs-query-user-groups
@@ -19265,12 +19265,12 @@ script:
       name: after
     - description: 'The number of items to return in this response (default: 100, max: 400). Use with the after  meter to manage pagination of results.'
       name: limit
-    - description: 'Sort vulnerabilities by their properties. Common sort options include:   ul  li created_timestamp|desc /li  li closed_timestamp|asc /li  /ul '
+    - description: 'Sort vulnerabilities by their properties. Common sort options include:   ul  li created_timestamp|desc /li  li closed_timestamp|asc /li  /ul.'
       name: sort
-    - description: 'Filter items using a query in Falcon Query Language (FQL). Wildcards   are unsupported.   Common filter options include:   ul  li created_timestamp: ''2019-11-25T22:36:12Z'' /li  li closed_timestamp: ''2019-11-25T22:36:12Z'' /li  li aid:''8e7656b27d8c49a34a1af416424d6231'' /li  /ul '
+    - description: 'Filter items using a query in Falcon Query Language (FQL). Wildcards   are unsupported.   Common filter options include:   ul  li created_timestamp: ''2019-11-25T22:36:12Z'' /li  li closed_timestamp: ''2019-11-25T22:36:12Z'' /li  li aid:''8e7656b27d8c49a34a1af416424d6231'' /li  /ul.'
       name: filter_
       required: true
-    description: Search for Vulnerabilities in your environment by providing an FQL filter and paging details. Returns a set of Vulnerability IDs which match the filter criteria
+    description: Search for Vulnerabilities in your environment by providing an FQL filter and paging details. Returns a set of Vulnerability IDs which match the filter criteria.
     name: cs-query-vulnerabilities
     outputs:
     - contextPath: CrowdStrike.domainSPAPIQueryVulnerabilitiesResponse.errors.code
@@ -19294,13 +19294,13 @@ script:
   - arguments:
     - description: The maximum records to return. [1-500]. Defaults to 100.
       name: limit
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The property to sort by (e.g. alias.desc or state.asc)
+    - description: The property to sort by (e.g. alias.desc or state.asc).
       name: sort
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    description: Search for provisioned AWS Accounts by providing an FQL filter and paging details. Returns a set of AWS accounts which match the filter criteria
+    description: Search for provisioned AWS Accounts by providing an FQL filter and paging details. Returns a set of AWS accounts which match the filter criteria.
     name: cs-queryaws-accounts
     outputs:
     - contextPath: CrowdStrike.modelsAWSAccountsV1.errors.code
@@ -19426,13 +19426,13 @@ script:
   - arguments:
     - description: The maximum records to return. [1-500]. Defaults to 100.
       name: limit
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The property to sort by (e.g. alias.desc or state.asc)
+    - description: The property to sort by (e.g. alias.desc or state.asc).
       name: sort
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    description: Search for provisioned AWS Accounts by providing an FQL filter and paging details. Returns a set of AWS account IDs which match the filter criteria
+    description: Search for provisioned AWS Accounts by providing an FQL filter and paging details. Returns a set of AWS account IDs which match the filter criteria.
     name: cs-queryaws-accounts-fori-ds
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -19454,17 +19454,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: CID to lookup associated CID group ID
+    - description: CID to lookup associated CID group ID.
       name: cid
       required: true
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
-    - description: Starting index of overall result set from which to return id
+    - description: Starting index of overall result set from which to return id.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
     description: Query a CID Groups members by associated CID.
     name: cs-querycid-group-members
@@ -19488,17 +19488,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Name to lookup groups for
+    - description: Name to lookup groups for.
       name: name
     - auto: PREDEFINED
-      description: The sort expression used to sort the results
+      description: The sort expression used to sort the results.
       name: sort
       predefined:
       - last_modified_timestamp
       - name
-    - description: Starting index of overall result set from which to return ids
+    - description: Starting index of overall result set from which to return ids.
       name: offset
-    - description: Number of ids to return
+    - description: Number of ids to return.
       name: limit
     description: Query CID Groups.
     name: cs-querycid-groups
@@ -19522,11 +19522,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: 'Possible order by fields: '
+    - description: 'Possible order by fields:.'
       name: sort
     - description: 'FQL query specifying the filter  meters. Filter term criteria: enabled, platform, name, description, etc TODO. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields, plus TODO
+    - description: Match query criteria, which includes all the filter string fields, plus TODO.
       name: q
     - description: Starting index of overall result set from which to return ids.
       name: offset
@@ -19534,7 +19534,7 @@ script:
       name: after
     - description: Number of ids to return.
       name: limit
-    description: Find all event IDs matching the query with filter
+    description: Find all event IDs matching the query with filter.
     name: cs-queryevents
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -19556,13 +19556,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Get fields configuration for this platform
+    - description: Get fields configuration for this platform.
       name: platform_id
     - description: Starting index of overall result set from which to return ids.
       name: offset
     - description: Number of ids to return.
       name: limit
-    description: Get the firewall field specification IDs for the provided platform
+    description: Get the firewall field specification IDs for the provided platform.
     name: cs-queryfirewallfields
     outputs:
     - contextPath: CrowdStrike.fwmgrmsaQueryResponse.errors.code
@@ -19586,11 +19586,11 @@ script:
   - arguments:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: types
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: values
-    - description: Find custom IOCs created after this time (RFC-3339 timestamp)
+    - description: Find custom IOCs created after this time (RFC-3339 timestamp).
       name: from_expiration_timestamp
-    - description: Find custom IOCs created before this time (RFC-3339 timestamp)
+    - description: Find custom IOCs created before this time (RFC-3339 timestamp).
       name: to_expiration_timestamp
     - description: '\ndetect: Find custom IOCs that produce notifications\n\nnone: Find custom IOCs the particular indicator has been detected on a host. This is equivalent to turning the indicator off. '
       name: policies
@@ -19598,11 +19598,11 @@ script:
       name: sources
     - description: The level at which the indicator will be shared. Currently only red share level (not shared) is supported, indicating that the IOC isn't shared with other FH customers.
       name: share_levels
-    - description: created_by
+    - description: created_by.
       name: created_by
-    - description: The user or API client who deleted the custom IOC
+    - description: The user or API client who deleted the custom IOC.
       name: deleted_by
-    - description: ' true: Include deleted IOCs  false: Don''t include deleted IOCs (default) '
+    - description: 'true: Include deleted IOCs  false: Don''t include deleted IOCs (default).'
       name: include_deleted
     description: '    DEPRECATED     Use the new IOC Management endpoint (GET /iocs/queries/indicators/v1).     Search the custom IOCs in your customer account.'
     name: cs-queryio-cs
@@ -19628,9 +19628,9 @@ script:
   - arguments:
     - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - auto: PREDEFINED
       description: The sort expression that should be used to sort the results.
@@ -19676,9 +19676,9 @@ script:
   - arguments:
     - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-500]
+    - description: The maximum records to return. [1-500].
       name: limit
     - auto: PREDEFINED
       description: The sort expression that should be used to sort the results.
@@ -19718,9 +19718,9 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Get all pattern severity IDs.
     name: cs-querypatterns
@@ -19748,7 +19748,7 @@ script:
       name: offset
     - description: Number of ids to return.
       name: limit
-    description: Get the list of platform names
+    description: Get the list of platform names.
     name: cs-queryplatforms
     outputs:
     - contextPath: CrowdStrike.fwmgrmsaQueryResponse.errors.code
@@ -19770,9 +19770,9 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Get all platform IDs.
     name: cs-queryplatforms-mixin0
@@ -19796,19 +19796,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the policy container within which to query
+    - description: The ID of the policy container within which to query.
       name: id_
-    - description: 'Possible order by fields: '
+    - description: 'Possible order by fields:.'
       name: sort
     - description: 'FQL query specifying the filter  meters. Filter term criteria: enabled, platform, name, description, etc TODO. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields, plus TODO
+    - description: Match query criteria, which includes all the filter string fields, plus TODO.
       name: q
     - description: Starting index of overall result set from which to return ids.
       name: offset
     - description: Number of ids to return.
       name: limit
-    description: Find all firewall rule IDs matching the query with filter, and return them in precedence order
+    description: Find all firewall rule IDs matching the query with filter, and return them in precedence order.
     name: cs-querypolicyrules
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -19832,12 +19832,12 @@ script:
   - arguments:
     - description: The filter expression that should be used to determine the results.
       name: filter_
-    - description: The offset of the first record to retrieve from
+    - description: The offset of the first record to retrieve from.
       name: offset
-    - description: The maximum number of records to return [1-5000]
+    - description: The maximum number of records to return [1-5000].
       name: limit
     - auto: PREDEFINED
-      description: The property to sort results by
+      description: The property to sort results by.
       name: sort
       predefined:
       - created_by.asc
@@ -19878,17 +19878,17 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ID of the Response policy to search for members of
+    - description: The ID of the Response policy to search for members of.
       name: id_
-    - description: The filter expression that should be used to limit the results
+    - description: The filter expression that should be used to limit the results.
       name: filter_
-    - description: The offset to start retrieving records from
+    - description: The offset to start retrieving records from.
       name: offset
-    - description: The maximum records to return. [1-5000]
+    - description: The maximum records to return. [1-5000].
       name: limit
-    - description: The property to sort by
+    - description: The property to sort by.
       name: sort
-    description: Search for members of a Response policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria
+    description: Search for members of a Response policy in your environment by providing an FQL filter and paging details. Returns a set of Agent IDs which match the filter criteria.
     name: cs-queryrt-response-policy-members
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -19910,11 +19910,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: 'Possible order by fields: '
+    - description: 'Possible order by fields:.'
       name: sort
     - description: 'FQL query specifying the filter  meters. Filter term criteria: enabled, platform, name, description, etc TODO. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields, plus TODO
+    - description: Match query criteria, which includes all the filter string fields, plus TODO.
       name: q
     - description: Starting index of overall result set from which to return ids.
       name: offset
@@ -19922,7 +19922,7 @@ script:
       name: after
     - description: Number of ids to return.
       name: limit
-    description: Find all rule group IDs matching the query with filter
+    description: Find all rule group IDs matching the query with filter.
     name: cs-queryrulegroups
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -19945,7 +19945,7 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: 'Possible order by fields: {created_by, created_on, modified_by, modified_on, enabled, name, description}'
+      description: 'Possible order by fields: {created_by, created_on, modified_by, modified_on, enabled, name, description}.'
       name: sort
       predefined:
       - created_by
@@ -19957,11 +19957,11 @@ script:
       - name
     - description: 'FQL query specifying the filter  meters. Filter term criteria: [enabled platform name description rules.action_label rules.name rules.description rules.pattern_severity rules.ruletype_name rules.enabled]. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields
+    - description: Match query criteria, which includes all the filter string fields.
       name: q
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Finds all rule group IDs matching the query with optional filter.
     name: cs-queryrulegroups-mixin0
@@ -19986,7 +19986,7 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: 'Possible order by fields: {created_by, created_on, modified_by, modified_on, enabled, name, description}'
+      description: 'Possible order by fields: {created_by, created_on, modified_by, modified_on, enabled, name, description}.'
       name: sort
       predefined:
       - created_by
@@ -19998,11 +19998,11 @@ script:
       - name
     - description: 'FQL query specifying the filter  meters. Filter term criteria: [enabled platform name description rules.action_label rules.name rules.description rules.pattern_severity rules.ruletype_name rules.enabled]. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields
+    - description: Match query criteria, which includes all the filter string fields.
       name: q
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Find all rule groups matching the query with optional filter.
     name: cs-queryrulegroupsfull
@@ -20026,11 +20026,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: 'Possible order by fields: '
+    - description: 'Possible order by fields:.'
       name: sort
     - description: 'FQL query specifying the filter  meters. Filter term criteria: enabled, platform, name, description, etc TODO. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields, plus TODO
+    - description: Match query criteria, which includes all the filter string fields, plus TODO.
       name: q
     - description: Starting index of overall result set from which to return ids.
       name: offset
@@ -20038,7 +20038,7 @@ script:
       name: after
     - description: Number of ids to return.
       name: limit
-    description: Find all rule IDs matching the query with filter
+    description: Find all rule IDs matching the query with filter.
     name: cs-queryrules
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -20061,7 +20061,7 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: 'Possible order by fields: {rules.ruletype_name, rules.enabled, rules.created_by, rules.current_version.name, rules.current_version.modified_by, rules.created_on, rules.current_version.description, rules.current_version.pattern_severity, rules.current_version.action_label, rules.current_version.modified_on}'
+      description: 'Possible order by fields: {rules.ruletype_name, rules.enabled, rules.created_by, rules.current_version.name, rules.current_version.modified_by, rules.created_on, rules.current_version.description, rules.current_version.pattern_severity, rules.current_version.action_label, rules.current_version.modified_on}.'
       name: sort
       predefined:
       - rules.created_by
@@ -20076,11 +20076,11 @@ script:
       - rules.ruletype_name
     - description: 'FQL query specifying the filter  meters. Filter term criteria: [enabled platform name description rules.action_label rules.name rules.description rules.pattern_severity rules.ruletype_name rules.enabled]. Filter range criteria: created_on, modified_on; use any common date format, such as ''2010-05-15T14:55:21.892315096Z''.'
       name: filter_
-    - description: Match query criteria, which includes all the filter string fields
+    - description: Match query criteria, which includes all the filter string fields.
       name: q
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Finds all rule IDs matching the query with optional filter.
     name: cs-queryrules-mixin0
@@ -20104,9 +20104,9 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Starting index of overall result set from which to return IDs
+    - description: Starting index of overall result set from which to return IDs.
       name: offset
-    - description: Number of IDs to return
+    - description: Number of IDs to return.
       name: limit
     description: Get all rule type IDs.
     name: cs-queryruletypes
@@ -20160,7 +20160,7 @@ script:
     - contextPath: CrowdStrike.msaReplyMetaOnly.errors.message
       description: ''
       type: String
-  - description: Regenerate API key for docker registry integrations
+  - description: Regenerate API key for docker registry integrations.
     name: cs-regenerateapi-key
     outputs:
     - contextPath: CrowdStrike.k8sregRegenAPIKeyResp.errors.code
@@ -20187,7 +20187,7 @@ script:
     - contextPath: CrowdStrike.k8sregRegenAPIKeyResp.resources.api_key
       description: ''
       type: String
-  - description: List the usernames (usually an email address) for all users in your customer account
+  - description: List the usernames (usually an email address) for all users in your customer account.
     name: cs-retrieve-emails-bycid
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -20213,7 +20213,7 @@ script:
       isArray: true
       name: ids
       required: true
-    description: Get info about a user
+    description: Get info about a user.
     name: cs-retrieve-user
     outputs:
     - contextPath: CrowdStrike.domainUserMetaDataResponse.errors.code
@@ -20290,7 +20290,7 @@ script:
       isArray: true
       name: uid
       required: true
-    description: Get a user's ID by providing a username (usually an email address)
+    description: Get a user's ID by providing a username (usually an email address).
     name: cs-retrieve-useruuid
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -20312,12 +20312,12 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: An optional message to append to the recorded audit log
+    - description: An optional message to append to the recorded audit log.
       name: requests_revealuninstalltokenv1_audit_message
-    - description: The id of the device to reveal the token for
+    - description: The id of the device to reveal the token for.
       name: requests_revealuninstalltokenv1_device_id
       required: true
-    description: Reveals an uninstall token for a specific device. To retrieve the bulk maintenance token pass the value 'MAINTENANCE' as the value for 'device_id'
+    description: Reveals an uninstall token for a specific device. To retrieve the bulk maintenance token pass the value 'MAINTENANCE' as the value for 'device_id'.
     name: cs-reveal-uninstall-token
     outputs:
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.errors.code
@@ -20330,13 +20330,13 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.device_id
-      description: The device the token belongs to
+      description: The device the token belongs to.
       type: String
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.seed_id
-      description: The seedID of the uninstall token
+      description: The seedID of the uninstall token.
       type: Number
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.uninstall_token
-      description: The uninstall token
+      description: The uninstall token.
       type: String
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.errors.code
       description: ''
@@ -20348,13 +20348,13 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.device_id
-      description: The device the token belongs to
+      description: The device the token belongs to.
       type: String
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.seed_id
-      description: The seedID of the uninstall token
+      description: The seedID of the uninstall token.
       type: Number
     - contextPath: CrowdStrike.responsesRevealUninstallTokenRespV1.resources.uninstall_token
-      description: The uninstall token
+      description: The uninstall token.
       type: String
   - arguments:
     - description: ID of a user. Find a user's ID from `/users/entities/user/v1`.
@@ -20364,7 +20364,7 @@ script:
       isArray: true
       name: ids
       required: true
-    description: Revoke one or more roles from a user
+    description: Revoke one or more roles from a user.
     name: cs-revoke-user-role-ids
     outputs:
     - contextPath: CrowdStrike.domainUserRoleIDsResponse.errors.code
@@ -20513,10 +20513,10 @@ script:
       description: ''
       type: Number
   - arguments:
-    - description: Cloud Request ID of the executed command to query
+    - description: Cloud Request ID of the executed command to query.
       name: cloud_request_id
       required: true
-    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences
+    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences.
       name: sequence_id
       required: true
     description: Get status of an executed active-responder command on a single host.
@@ -20583,10 +20583,10 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Cloud Request ID of the executed command to query
+    - description: Cloud Request ID of the executed command to query.
       name: cloud_request_id
       required: true
-    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences
+    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences.
       name: sequence_id
       required: true
     description: Get status of an executed RTR administrator command on a single host.
@@ -20653,10 +20653,10 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: Cloud Request ID of the executed command to query
+    - description: Cloud Request ID of the executed command to query.
       name: cloud_request_id
       required: true
-    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences
+    - description: Sequence ID that we want to retrieve. Command responses are chunked across sequences.
       name: sequence_id
       required: true
     description: Get status of an executed command on a single host.
@@ -20723,15 +20723,15 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: put-file to upload
+    - description: put-file to upload.
       name: file
       required: true
-    - description: File description
+    - description: File description.
       name: description
       required: true
-    - description: File name (if different than actual file name)
+    - description: File name (if different than actual file name).
       name: name
-    - description: The audit log comment
+    - description: The audit log comment.
       name: comments_for_audit_log
     description: Upload a new put-file to use for the RTR `put` command.
     name: cs-rtr-create-put-files
@@ -20757,19 +20757,19 @@ script:
   - arguments:
     - description: custom-script file to upload.  These should be powershell scripts.
       name: file
-    - description: File description
+    - description: File description.
       name: description
       required: true
-    - description: File name (if different than actual file name)
+    - description: File name (if different than actual file name).
       name: name
-    - description: The audit log comment
+    - description: The audit log comment.
       name: comments_for_audit_log
-    - description: 'Permission for the custom-script. Valid permission values:   - `private`, usable by only the user who uploaded it   - `group`, usable by all RTR Admins   - `public`, usable by all active-responders and RTR admins'
+    - description: 'Permission for the custom-script. Valid permission values:   - `private`, usable by only the user who uploaded it   - `group`, usable by all RTR Admins   - `public`, usable by all active-responders and RTR admins.'
       name: permission_type
       required: true
-    - description: The script text that you want to use to upload
+    - description: The script text that you want to use to upload.
       name: content
-    - description: 'Platforms for the file. Currently supports: windows, mac, linux, . If no platform is provided, it will default to ''windows'''
+    - description: 'Platforms for the file. Currently supports: windows, mac, linux, . If no platform is provided, it will default to ''windows''.'
       isArray: true
       name: platform
     description: Upload a new custom-script to use for the RTR `runscript` command.
@@ -20794,16 +20794,16 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: RTR Session file id
+    - description: RTR Session file id.
       name: ids
       required: true
-    - description: RTR Session id
+    - description: RTR Session id.
       name: session_id
       required: true
     description: Delete a RTR session file.
     name: cs-rtr-delete-file
   - arguments:
-    - description: File id
+    - description: File id.
       name: ids
       required: true
     description: Delete a put-file based on the ID given.  Can only delete one file at a time.
@@ -20828,16 +20828,16 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: RTR Session id
+    - description: RTR Session id.
       name: session_id
       required: true
-    - description: Cloud Request ID of the executed command to query
+    - description: Cloud Request ID of the executed command to query.
       name: cloud_request_id
       required: true
-    description: Delete a queued session command
+    description: Delete a queued session command.
     name: cs-rtr-delete-queued-session
   - arguments:
-    - description: File id
+    - description: File id.
       name: ids
       required: true
     description: Delete a custom-script based on the ID given.  Can only delete one script at a time.
@@ -20862,7 +20862,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: RTR Session id
+    - description: RTR Session id.
       name: session_id
       required: true
     description: Delete a session.
@@ -20931,10 +20931,10 @@ script:
     description: Execute a command on a single host.
     name: cs-rtr-execute-command
   - arguments:
-    - description: RTR Session id
+    - description: RTR Session id.
       name: session_id
       required: true
-    - description: Extracted SHA256 (e.g. 'efa256a96af3b556cd3fc9d8b1cf587d72807d7805ced441e8149fc279db422b')
+    - description: Extracted SHA256 (e.g. 'efa256a96af3b556cd3fc9d8b1cf587d72807d7805ced441e8149fc279db422b').
       name: sha256
       required: true
     - description: Filename to use for the archive name and the file within the archive.
@@ -20942,7 +20942,7 @@ script:
     description: Get RTR extracted file contents for specified session and sha256.
     name: cs-rtr-get-extracted-file-contents
   - arguments:
-    - description: File IDs
+    - description: File IDs.
       isArray: true
       name: ids
       required: true
@@ -21094,7 +21094,7 @@ script:
       description: ''
       type: Boolean
   - arguments:
-    - description: File IDs
+    - description: File IDs.
       isArray: true
       name: ids
       required: true
@@ -21288,7 +21288,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: RTR Session id
+    - description: RTR Session id.
       name: session_id
       required: true
     description: Get a list of files for the specified RTR session.
@@ -21731,22 +21731,22 @@ script:
     description: Refresh a session timeout on a single host.
     name: cs-rtr-pulse-session
   - arguments:
-    - description: ID to update
+    - description: ID to update.
       name: id_
       required: true
     - description: custom-script file to upload.  These should be powershell scripts.
       name: file
-    - description: File description
+    - description: File description.
       name: description
-    - description: File name (if different than actual file name)
+    - description: File name (if different than actual file name).
       name: name
-    - description: The audit log comment
+    - description: The audit log comment.
       name: comments_for_audit_log
-    - description: 'Permission for the custom-script. Valid permission values:   - `private`, usable by only the user who uploaded it   - `group`, usable by all RTR Admins   - `public`, usable by all active-responders and RTR admins'
+    - description: 'Permission for the custom-script. Valid permission values:   - `private`, usable by only the user who uploaded it   - `group`, usable by all RTR Admins   - `public`, usable by all active-responders and RTR admins.'
       name: permission_type
-    - description: The script text that you want to use to upload
+    - description: The script text that you want to use to upload.
       name: content
-    - description: 'Platforms for the file. Currently supports: windows, mac, '
+    - description: 'Platforms for the file. Currently supports: windows, mac,.'
       isArray: true
       name: platform
     description: Upload a new scripts to replace an existing one.
@@ -21775,7 +21775,7 @@ script:
       isArray: true
       name: mlscanner_samplesscanparameters_samples
       required: true
-    description: Submit a volume of files for ml scanning. Time required for analysis increases with the number of samples in a volume but usually it should take less than 1 minute
+    description: Submit a volume of files for ml scanning. Time required for analysis increases with the number of samples in a volume but usually it should take less than 1 minute.
     name: cs-scan-samples
     outputs:
     - contextPath: CrowdStrike.mlscannerQueryResponse.errors.code
@@ -21797,19 +21797,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified
+    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified.
       isArray: true
       name: requests_setpolicyprecedencereqv1_ids
       required: true
     - auto: PREDEFINED
-      description: The name of the platform for which to set precedence
+      description: The name of the platform for which to set precedence.
       name: requests_setpolicyprecedencereqv1_platform_name
       predefined:
       - Windows
       - Mac
       - Linux
       required: true
-    description: Sets the precedence of Device Control Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence
+    description: Sets the precedence of Device Control Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence.
     name: cs-set-device-control-policies-precedence
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -21831,19 +21831,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified
+    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified.
       isArray: true
       name: requests_setpolicyprecedencereqv1_ids
       required: true
     - auto: PREDEFINED
-      description: The name of the platform for which to set precedence
+      description: The name of the platform for which to set precedence.
       name: requests_setpolicyprecedencereqv1_platform_name
       predefined:
       - Windows
       - Mac
       - Linux
       required: true
-    description: Sets the precedence of Firewall Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence
+    description: Sets the precedence of Firewall Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence.
     name: cs-set-firewall-policies-precedence
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -21865,19 +21865,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified
+    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified.
       isArray: true
       name: requests_setpolicyprecedencereqv1_ids
       required: true
     - auto: PREDEFINED
-      description: The name of the platform for which to set precedence
+      description: The name of the platform for which to set precedence.
       name: requests_setpolicyprecedencereqv1_platform_name
       predefined:
       - Windows
       - Mac
       - Linux
       required: true
-    description: Sets the precedence of Prevention Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence
+    description: Sets the precedence of Prevention Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence.
     name: cs-set-prevention-policies-precedence
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -21899,19 +21899,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified
+    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified.
       isArray: true
       name: requests_setpolicyprecedencereqv1_ids
       required: true
     - auto: PREDEFINED
-      description: The name of the platform for which to set precedence
+      description: The name of the platform for which to set precedence.
       name: requests_setpolicyprecedencereqv1_platform_name
       predefined:
       - Windows
       - Mac
       - Linux
       required: true
-    description: Sets the precedence of Sensor Update Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence
+    description: Sets the precedence of Sensor Update Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence.
     name: cs-set-sensor-update-policies-precedence
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -21933,19 +21933,19 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified
+    - description: The ids of all current prevention policies for the platform specified. The precedence will be set in the order the ids are specified.
       isArray: true
       name: requests_setpolicyprecedencereqv1_ids
       required: true
     - auto: PREDEFINED
-      description: The name of the platform for which to set precedence
+      description: The name of the platform for which to set precedence.
       name: requests_setpolicyprecedencereqv1_platform_name
       predefined:
       - Windows
       - Mac
       - Linux
       required: true
-    description: Sets the precedence of Response Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence
+    description: Sets the precedence of Response Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence.
     name: cs-setrt-response-policies-precedence
     outputs:
     - contextPath: CrowdStrike.msaQueryResponse.errors.code
@@ -22168,7 +22168,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: IDs of tokens to retrieve details for
+    - description: IDs of tokens to retrieve details for.
       isArray: true
       name: ids
     description: Gets the details of one or more tokens by id.
@@ -22280,14 +22280,14 @@ script:
       type: String
   - arguments:
     - auto: PREDEFINED
-      description: Scan Type to do
+      description: Scan Type to do.
       name: scan_type
       predefined:
       - cluster-refresh
       - dry-run
       - full
       required: true
-    description: Triggers a dry run or a full scan of a customer's kubernetes footprint
+    description: Triggers a dry run or a full scan of a customer's kubernetes footprint.
     name: cs-trigger-scan
   - arguments:
     - description: ''
@@ -22328,31 +22328,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.cid
-      description: The ID of the customer who created the action
+      description: The ID of the customer who created the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.created_timestamp
-      description: The date when the action was created
+      description: The date when the action was created.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.frequency
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.id
-      description: The ID of the action
+      description: The ID of the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule on which this action is attached
+      description: The ID of the rule on which this action is attached.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.status
       description: The action status. It can be either 'enabled' or 'muted'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.type
-      description: The action type. The only type currently supported is 'email'
+      description: The action type. The only type currently supported is 'email'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.updated_timestamp
-      description: The date when the action was updated
+      description: The date when the action was updated.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user who created the action
+      description: The UUID of the user who created the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.errors.code
       description: ''
@@ -22376,31 +22376,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.cid
-      description: The ID of the customer who created the action
+      description: The ID of the customer who created the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.created_timestamp
-      description: The date when the action was created
+      description: The date when the action was created.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.frequency
       description: ''
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.id
-      description: The ID of the action
+      description: The ID of the action.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule on which this action is attached
+      description: The ID of the rule on which this action is attached.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.status
       description: The action status. It can be either 'enabled' or 'muted'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.type
-      description: The action type. The only type currently supported is 'email'
+      description: The action type. The only type currently supported is 'email'.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.updated_timestamp
-      description: The date when the action was updated
+      description: The date when the action was updated.
       type: String
     - contextPath: CrowdStrike.domainActionEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user who created the action
+      description: The UUID of the user who created the action.
       type: String
   - arguments:
     - description: ''
@@ -22414,7 +22414,7 @@ script:
       name: domain_detectsentitiespatchrequest_show_in_ui
     - description: ''
       name: domain_detectsentitiespatchrequest_status
-    description: Modify the state, assignee, and visibility of detections
+    description: Modify the state, assignee, and visibility of detections.
     name: cs-update-detects-by-idsv2
     outputs:
     - contextPath: CrowdStrike.msaReplyMetaOnly.errors.code
@@ -22436,11 +22436,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatedevicecontrolpoliciesv1_resources
       required: true
-    description: Update Device Control Policies by specifying the ID of the policy and details to update
+    description: Update Device Control Policies by specifying the ID of the policy and details to update.
     name: cs-update-device-control-policies
     outputs:
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
@@ -22453,58 +22453,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.errors.code
       description: ''
@@ -22516,58 +22516,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesDeviceControlPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
     - description: ''
@@ -22603,11 +22603,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatefirewallpoliciesv1_resources
       required: true
-    description: Update Firewall Policies by specifying the ID of the policy and details to update
+    description: Update Firewall Policies by specifying the ID of the policy and details to update.
     name: cs-update-firewall-policies
     outputs:
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
@@ -22620,64 +22620,64 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.errors.code
       description: ''
@@ -22689,71 +22689,71 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.channel_version
-      description: Channel file version for the policy
+      description: Channel file version for the policy.
       type: Number
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesFirewallPoliciesV1.resources.rule_set_id
-      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy
+      description: Firewall rule set id. This id combines several firewall rules and gets attached to the policy.
       type: String
   - arguments:
-    - description: A collection of groups to update
+    - description: A collection of groups to update.
       isArray: true
       name: requests_updategroupsv1_resources
       required: true
-    description: Update Host Groups by specifying the ID of the group and details to update
+    description: Update Host Groups by specifying the ID of the group and details to update.
     name: cs-update-host-groups
     outputs:
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
@@ -22766,31 +22766,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.errors.code
       description: ''
@@ -22802,43 +22802,43 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesHostGroupsV1.resources.name
-      description: The name of the group
+      description: The name of the group.
       type: String
   - arguments:
-    - description: The unique ID of the user who is assigned to this notification
+    - description: The unique ID of the user who is assigned to this notification.
       name: domain_updatenotificationrequestv1_assigned_to_uuid
       required: true
-    - description: The ID of the notifications
+    - description: The ID of the notifications.
       name: domain_updatenotificationrequestv1_id
       required: true
     - description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       name: domain_updatenotificationrequestv1_status
       required: true
-    description: Update notification status or assignee. Accepts bulk requests
+    description: Update notification status or assignee. Accepts bulk requests.
     name: cs-update-notificationsv1
     outputs:
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.errors.code
@@ -22863,34 +22863,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -22902,7 +22902,7 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.errors.code
       description: ''
@@ -22926,34 +22926,34 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uid
-      description: The email of the user who is assigned to this notification
+      description: The email of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_username
-      description: The name of the user who is assigned to this notification
+      description: The name of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.assigned_to_uuid
-      description: The unique ID of the user who is assigned to this notification
+      description: The unique ID of the user who is assigned to this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.created_date
-      description: The date when the notification was generated
+      description: The date when the notification was generated.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.id
-      description: The ID of the notification
+      description: The ID of the notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_date
-      description: Timestamp when the intelligence item is considered to have been posted
+      description: Timestamp when the intelligence item is considered to have been posted.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_id
-      description: ID of the intelligence item which generated the match
+      description: ID of the intelligence item which generated the match.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.item_type
-      description: Type of intelligence item based on format, e.g. post, reply, botnet_config
+      description: Type of intelligence item based on format, e.g. post, reply, botnet_config.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_id
-      description: The ID of the rule that generated this notification
+      description: The ID of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_name
-      description: The name of the rule that generated this notification
+      description: The name of the rule that generated this notification.
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.rule_priority
       description: ''
@@ -22965,14 +22965,14 @@ script:
       description: 'The notification status. This can be one of: new, in-progress, closed-false-positive, closed-true-positive.'
       type: String
     - contextPath: CrowdStrike.domainNotificationEntitiesResponseV1.resources.updated_date
-      description: The date when the notification was updated
+      description: The date when the notification was updated.
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatepreventionpoliciesv1_resources
       required: true
-    description: Update Prevention Policies by specifying the ID of the policy and details to update
+    description: Update Prevention Policies by specifying the ID of the policy and details to update.
     name: cs-update-prevention-policies
     outputs:
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
@@ -22985,73 +22985,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.errors.code
       description: ''
@@ -23063,90 +23063,90 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesPreventionPoliciesV1.resources.prevention_settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
-    - description: The filter to be used for searching
+    - description: The filter to be used for searching.
       name: domain_updaterulerequestv1_filter
       required: true
-    - description: The rule ID to be updated
+    - description: The rule ID to be updated.
       name: domain_updaterulerequestv1_id
       required: true
-    - description: The name of a particular rule
+    - description: The name of a particular rule.
       name: domain_updaterulerequestv1_name
       required: true
-    - description: 'The permissions for a particular rule which specifies the rule''s access by other users. Possible values: [private public]'
+    - description: 'The permissions for a particular rule which specifies the rule''s access by other users. Possible values: [private public].'
       name: domain_updaterulerequestv1_permissions
       required: true
-    - description: 'The priority for a particular rule. Possible values: [low medium high]'
+    - description: 'The priority for a particular rule. Possible values: [low medium high].'
       name: domain_updaterulerequestv1_priority
       required: true
     description: Update monitoring rules.
@@ -23177,43 +23177,43 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.created_timestamp
-      description: The creation time for a given rule
+      description: The creation time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.filter
-      description: The FQL filter contained in a rule and used for searching
+      description: The FQL filter contained in a rule and used for searching.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.id
-      description: The ID of a given rule
+      description: The ID of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.name
-      description: The name for a given rule
+      description: The name for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.permissions
-      description: The permissions of a given rule
+      description: The permissions of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.priority
-      description: The priority of a given rule
+      description: The priority of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status
-      description: The status of a rule
+      description: The status of a rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status_message
-      description: The detailed status message
+      description: The detailed status message.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.topic
-      description: The topic of a given rule
+      description: The topic of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.updated_timestamp
-      description: The last updated time for a given rule
+      description: The last updated time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_id
-      description: The user ID of the user that created a given rule
+      description: The user ID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_name
-      description: The user name of the user that created a given rule
+      description: The user name of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user that created a given rule
+      description: The UUID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.errors.code
       description: ''
@@ -23240,50 +23240,50 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.created_timestamp
-      description: The creation time for a given rule
+      description: The creation time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.filter
-      description: The FQL filter contained in a rule and used for searching
+      description: The FQL filter contained in a rule and used for searching.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.id
-      description: The ID of a given rule
+      description: The ID of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.name
-      description: The name for a given rule
+      description: The name for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.permissions
-      description: The permissions of a given rule
+      description: The permissions of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.priority
-      description: The priority of a given rule
+      description: The priority of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status
-      description: The status of a rule
+      description: The status of a rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.status_message
-      description: The detailed status message
+      description: The detailed status message.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.topic
-      description: The topic of a given rule
+      description: The topic of a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.updated_timestamp
-      description: The last updated time for a given rule
+      description: The last updated time for a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_id
-      description: The user ID of the user that created a given rule
+      description: The user ID of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_name
-      description: The user name of the user that created a given rule
+      description: The user name of the user that created a given rule.
       type: String
     - contextPath: CrowdStrike.domainRulesEntitiesResponseV1.resources.user_uuid
-      description: The UUID of the user that created a given rule
+      description: The UUID of the user that created a given rule.
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatesensorupdatepoliciesv1_resources
       required: true
-    description: Update Sensor Update Policies by specifying the ID of the policy and details to update
+    description: Update Sensor Update Policies by specifying the ID of the policy and details to update.
     name: cs-update-sensor-update-policies
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
@@ -23296,58 +23296,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.errors.code
       description: ''
@@ -23359,65 +23359,65 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatesensorupdatepoliciesv2_resources
       required: true
-    description: Update Sensor Update Policies by specifying the ID of the policy and details to update with additional support for uninstall protection
+    description: Update Sensor Update Policies by specifying the ID of the policy and details to update with additional support for uninstall protection.
     name: cs-update-sensor-update-policiesv2
     outputs:
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
@@ -23430,58 +23430,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.errors.code
       description: ''
@@ -23493,58 +23493,58 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesSensorUpdatePoliciesV2.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
   - arguments:
     - description: ''
@@ -23557,7 +23557,7 @@ script:
       required: true
     - description: ''
       name: requests_svexclusionupdatereqv1_value
-    description: Update the sensor visibility exclusions
+    description: Update the sensor visibility exclusions.
     name: cs-update-sensor-visibility-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.errors.code
@@ -23579,31 +23579,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.id
       description: ''
@@ -23642,31 +23642,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesSvExclusionRespV1.resources.id
       description: ''
@@ -23694,7 +23694,7 @@ script:
       name: domain_updateuserfields_firstname
     - description: ''
       name: domain_updateuserfields_lastname
-    description: Modify an existing user's first or last name
+    description: Modify an existing user's first or last name.
     name: cs-update-user
     outputs:
     - contextPath: CrowdStrike.domainUserMetaDataResponse.errors.code
@@ -23796,13 +23796,13 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: AWS Account ID
+    - description: AWS Account ID.
       isArray: true
       name: ids
       required: true
-    - description: Default Region for Account Automation
+    - description: Default Region for Account Automation.
       name: region
-    description: Updates the AWS account per the query  meters provided
+    description: Updates the AWS account per the query  meters provided.
     name: cs-updateaws-account
     outputs:
     - contextPath: CrowdStrike.msaBaseEntitiesResponse.errors.code
@@ -23828,7 +23828,7 @@ script:
       isArray: true
       name: models_updateawsaccountsv1_resources
       required: true
-    description: Update AWS Accounts by specifying the ID of the account and details to update
+    description: Update AWS Accounts by specifying the ID of the account and details to update.
     name: cs-updateaws-accounts
     outputs:
     - contextPath: CrowdStrike.modelsAWSAccountsV1.errors.code
@@ -24007,7 +24007,7 @@ script:
     - description: Default Subscription ID to patch for all subscriptions belonged to a tenant.
       name: subscription_id
       required: true
-    description: Update an Azure default subscription_id in our system for given tenant_id
+    description: Update an Azure default subscription_id in our system for given tenant_id.
     name: cs-updatecspm-azure-tenant-default-subscriptionid
   - arguments:
     - description: ''
@@ -24242,7 +24242,7 @@ script:
     - description: ''
       name: requests_ioaexclusionupdatereqv1_pattern_name
       required: true
-    description: Update the IOA exclusions
+    description: Update the IOA exclusions.
     name: cs-updateioa-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.errors.code
@@ -24273,31 +24273,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.id
       description: ''
@@ -24348,31 +24348,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesIoaExclusionRespV1.resources.id
       description: ''
@@ -24425,7 +24425,7 @@ script:
     - description: ' The type of the indicator. Valid types include:  sha256: A hex-encoded sha256 hash string. Length - min: 64, max: 64.  md5: A hex-encoded md5 hash string. Length - min 32, max: 32.  domain: A domain name. Length - min: 1, max: 200.  ipv4: An IPv4 address. Must be a valid IP address.  ipv6: An IPv6 address. Must be a valid IP address. '
       name: type_
       required: true
-    - description: The string representation of the indicator
+    - description: The string representation of the indicator.
       name: value
       required: true
     description: '    DEPRECATED     Use the new IOC Management endpoint (PATCH /iocs/entities/indicators/v1).     Update an IOC by providing a type and value.'
@@ -24538,7 +24538,7 @@ script:
       required: true
     - description: ''
       name: requests_svexclusionupdatereqv1_value
-    description: Update the ML exclusions
+    description: Update the ML exclusions.
     name: cs-updateml-exclusionsv1
     outputs:
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.errors.code
@@ -24560,31 +24560,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -24623,31 +24623,31 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesMlExclusionRespV1.resources.id
       description: ''
@@ -24668,7 +24668,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: The user id
+    - description: The user id.
       name: X_CS_USERNAME
       required: true
     - description: ''
@@ -24697,7 +24697,7 @@ script:
       required: true
     - description: ''
       name: fwmgr_api_policycontainerupsertrequestv1_tracking
-    description: Update an identified policy container
+    description: Update an identified policy container.
     name: cs-updatepolicycontainer
     outputs:
     - contextPath: CrowdStrike.fwmgrmsaReplyMetaOnly.errors.code
@@ -24719,11 +24719,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: A collection of policies to update
+    - description: A collection of policies to update.
       isArray: true
       name: requests_updatertresponsepoliciesv1_resources
       required: true
-    description: Update Response Policies by specifying the ID of the policy and details to update
+    description: Update Response Policies by specifying the ID of the policy and details to update.
     name: cs-updatert-response-policies
     outputs:
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
@@ -24736,73 +24736,73 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.errors.code
       description: ''
@@ -24814,79 +24814,79 @@ script:
       description: ''
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.description
-      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces
+      description: The description of a policy. Use this field to provide a high level summary of what this policy enforces.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.enabled
-      description: If a policy is enabled it will be used during the course of policy evaluation
+      description: If a policy is enabled it will be used during the course of policy evaluation.
       type: Boolean
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.assignment_rule
-      description: The assignment rule of a group
+      description: The assignment rule of a group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_by
-      description: The email of the user which created the policy
+      description: The email of the user which created the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.created_timestamp
-      description: The time at which the policy was created
+      description: The time at which the policy was created.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.description
-      description: An additional description of the group or the devices it targets
+      description: An additional description of the group or the devices it targets.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.group_type
-      description: The method by which this host group is managed
+      description: The method by which this host group is managed.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.id
-      description: The identifier of this host group
+      description: The identifier of this host group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.groups.name
-      description: The name of the group
+      description: The name of the group.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.id
-      description: The unique id of the policy
+      description: The unique id of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_by
-      description: The email of the user which last modified the policy
+      description: The email of the user which last modified the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.modified_timestamp
-      description: The time at which the policy was last modified
+      description: The time at which the policy was last modified.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.name
-      description: The human readable name of the policy
+      description: The human readable name of the policy.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.platform_name
-      description: The name of the platform
+      description: The name of the platform.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.name
-      description: The name of the category
+      description: The name of the category.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.description
-      description: The human readable description of the setting
+      description: The human readable description of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.id
-      description: The id of the setting
+      description: The id of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.name
-      description: The name of the setting
+      description: The name of the setting.
       type: String
     - contextPath: CrowdStrike.responsesRTResponsePoliciesV1.resources.settings.settings.type
-      description: The type of the setting which can be used as a hint when displaying in the UI
+      description: The type of the setting which can be used as a hint when displaying in the UI.
       type: String
   - arguments:
-    - description: The user id
+    - description: The user id.
       name: X_CS_USERNAME
       required: true
-    - description: Audit log comment for this action
+    - description: Audit log comment for this action.
       name: comment
     - description: ''
       isArray: true
@@ -24909,7 +24909,7 @@ script:
     - description: ''
       name: fwmgr_api_rulegroupmodifyrequestv1_tracking
       required: true
-    description: Update name, description, or enabled status of a rule group, or create, edit, delete, or reorder rules
+    description: Update name, description, or enabled status of a rule group, or create, edit, delete, or reorder rules.
     name: cs-updaterulegroup
     outputs:
     - contextPath: CrowdStrike.fwmgrapiQueryResponse.errors.code
@@ -25426,7 +25426,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: 'Content of the uploaded sample in binary format. For example, use `--data-binary @$FILE_PATH` when using cURL. Max file size: 100 MB.  Accepted file formats:  - Portable executables: `.exe`, `.scr`, `.pif`, `.dll`, `.com`, `.cpl`, etc. - Office documents: `.doc`, `.docx`, `.ppt`, `.pps`, `.pptx`, `.ppsx`, `.xls`, `.xlsx`, `.rtf`, `.pub` - PDF - APK - Executable JAR - Windows script component: `.sct` - Windows shortcut: `.lnk` - Windows help: `.chm` - HTML application: `.hta` - Windows script file: `.wsf` - Javascript: `.js` - Visual Basic: `.vbs`,  `.vbe` - Shockwave Flash: `.swf` - Perl: `.pl` - Powershell: `.ps1`, `.psd1`, `.psm1` - Scalable vector graphics: `.svg` - Python: `.py` - Linux ELF executables - Email files: MIME RFC 822 `.eml`, Outlook `.msg`.'
       isArray: true
@@ -25476,7 +25476,7 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: User UUID
+    - description: User UUID.
       name: X_CS_USERUUID
     - description: 'Content of the uploaded sample in binary format. For example, use `--data-binary @$FILE_PATH` when using cURL. Max file size: 100 MB.  Accepted file formats:  - Portable executables: `.exe`, `.scr`, `.pif`, `.dll`, `.com`, `.cpl`, etc. - Office documents: `.doc`, `.docx`, `.ppt`, `.pps`, `.pptx`, `.ppsx`, `.xls`, `.xlsx`, `.rtf`, `.pub` - PDF - APK - Executable JAR - Windows script component: `.sct` - Windows shortcut: `.lnk` - Windows help: `.chm` - HTML application: `.hta` - Windows script file: `.wsf` - Javascript: `.js` - Visual Basic: `.vbs`,  `.vbe` - Shockwave Flash: `.swf` - Perl: `.pl` - Powershell: `.ps1`, `.psd1`, `.psm1` - Scalable vector graphics: `.svg` - Python: `.py` - Linux ELF executables - Email files: MIME RFC 822 `.eml`, Outlook `.msg`.'
       isArray: true
@@ -25594,11 +25594,11 @@ script:
       description: ''
       type: String
   - arguments:
-    - description: IDs of accounts to verify access on
+    - description: IDs of accounts to verify access on.
       isArray: true
       name: ids
       required: true
-    description: Performs an Access Verification check on the specified AWS Account IDs
+    description: Performs an Access Verification check on the specified AWS Account IDs.
     name: cs-verifyaws-account-access
     outputs:
     - contextPath: CrowdStrike.modelsVerifyAccessResponseV1.errors.code
@@ -25717,7 +25717,7 @@ script:
     - contextPath: CrowdStrike.deviceNetworkHistory.resources.history.timestamp
       description: ''
       type: String
-  dockerimage: demisto/python3:3.10.12.63474
+  dockerimage: demisto/python3:3.10.13.85667
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI_test.py
+++ b/Packs/CrowdStrikeOpenAPI/Integrations/CrowdStrikeOpenAPI/CrowdStrikeOpenAPI_test.py
@@ -1,4 +1,3 @@
-import io
 import json
 
 import pytest
@@ -18,7 +17,7 @@ def client(requests_mock):
 
 
 def util_load_json(path):
-    with io.open(path, mode='r', encoding='utf-8') as f:
+    with open(path, encoding='utf-8') as f:
         return json.loads(f.read())
 
 

--- a/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
+++ b/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
@@ -3,5 +3,5 @@
 
 ##### CrowdStrike OpenAPI (Beta)
 
-- Fixed an issue where the **cs-update-rulesv1** command would not run properly.
+- Fixed an issue where the **cs-update-rulesv1** command would fail due to improper payload structure.
 - Updated the Docker image to: *demisto/python3:3.10.13.85667*.

--- a/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
+++ b/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
@@ -4,3 +4,4 @@
 ##### CrowdStrike OpenAPI (Beta)
 
 - Fixed an issue where the **cs-update-rulesv1** command would not run properly.
+- Updated the Docker image to: *demisto/python3:3.10.13.85667*.

--- a/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
+++ b/Packs/CrowdStrikeOpenAPI/ReleaseNotes/1_0_17.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike OpenAPI (Beta)
+
+- Fixed an issue where the **cs-update-rulesv1** command would not run properly.

--- a/Packs/CrowdStrikeOpenAPI/pack_metadata.json
+++ b/Packs/CrowdStrikeOpenAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike OpenAPI",
     "description": "Use the CrowdStrike OpenAPI integration to interact with CrowdStrike APIs that do not have dedicated integrations in Cortex XSOAR, for example, CrowdStrike FalconX, etc.",
     "support": "xsoar",
-    "currentVersion": "1.0.16",
+    "currentVersion": "1.0.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixing an issue where the `cs-update-rulesv1` command would not run properly, by wrapping the payload with a list ([API expects](https://github.com/CrowdStrike/falconpy/blob/3edfb2b5fb98fc939937942369c58d53d8223cd1/src/falconpy/_payload/_recon.py#L56
) a list of dictionaries)

fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32756