### PR TITLE
GetIndicatorDBotScoreFromCache bug

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_13_27.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_13_27.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetIndicatorDBotScoreFromCache
+
+- Fixed a bug where the ***GetIndicatorDBotScoreFromCache*** script automation would fail when no IOCs were returned from the cache. 

--- a/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/GetIndicatorDBotScoreFromCache.py
+++ b/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/GetIndicatorDBotScoreFromCache.py
@@ -16,28 +16,27 @@ def main():
     )
 
     return_entries = []
+    iocs = res.get('iocs') or []
+    for data in iocs:
+        score = data["score"]
+        vendor = "XSOAR"
+        reliability = data.get("aggregatedReliability")
+        indicatorType = data["indicator_type"]
+        expirationStatus = data.get("expirationStatus") != "active"
+        value: str = data["value"]
 
-    if 'iocs' in res and len(res['iocs']) > 0:
-        for data in res['iocs']:
-            score = data["score"]
-            vendor = "XSOAR"
-            reliability = data.get("aggregatedReliability")
-            indicatorType = data["indicator_type"]
-            expirationStatus = data.get("expirationStatus") != "active"
-            value: str = data["value"]
+        dbotscore = {
+            "Indicator": value,
+            "Type": indicatorType,
+            "Vendor": vendor,
+            "Score": score,
+            "Reliability": reliability,
+            "Expired": expirationStatus
+        }
 
-            dbotscore = {
-                "Indicator": value,
-                "Type": indicatorType,
-                "Vendor": vendor,
-                "Score": score,
-                "Reliability": reliability,
-                "Expired": expirationStatus
-            }
-
-            return_entries.append(dbotscore)
-            with contextlib.suppress(KeyError):  # for multiple IOCs with same value but different casing
-                unique_values.remove(value.lower())
+        return_entries.append(dbotscore)
+        with contextlib.suppress(KeyError):  # for multiple IOCs with same value but different casing
+            unique_values.remove(value.lower())
 
     values_not_found = list({v for v in values if v.lower() in unique_values})  # return the values with the original casing
 

--- a/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/GetIndicatorDBotScoreFromCache_test.py
+++ b/Packs/CommonScripts/Scripts/GetIndicatorDBotScoreFromCache/GetIndicatorDBotScoreFromCache_test.py
@@ -158,3 +158,25 @@ def test_query_values(mocker):
         'value:("test2~.com" "test~.com")',
         'value:("test~.com" "test2~.com")',
     ]
+
+
+def test_no_iocs_returned_from_search_indicators(mocker):
+    """
+    Given:
+        A single indicator value (Test.com) with no cache.
+    When:
+        Running GetIndicatorDBotScoreFromCache script.
+    Then:
+        Ensure no iocs were returned.
+    """
+
+    mocker.patch.object(demisto, "args", return_value=["Test.com"])
+    mocker.patch.object(demisto, "searchIndicators", return_value={'iocs': None})
+    mocker.patch.object(GetIndicatorDBotScoreFromCache, "return_results")
+
+    GetIndicatorDBotScoreFromCache.main()
+    return_results_calls = GetIndicatorDBotScoreFromCache.return_results.call_args_list
+
+    indicators_results = return_results_calls[0][0][0]["Contents"]
+    assert {i["Indicator"] for i in indicators_results} == {}
+

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.13.26",
+    "currentVersion": "1.13.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-32779

## Description
Fixed a bug where the ***GetIndicatorDBotScoreFromCache*** script automation would fail when no IOCs were returned from the cache. 

## Must have
- [ ] Tests
- [ ] Documentation 
