### PR TITLE
Fix SDK Slack Notifier Being Triggered For Non-relevant Pipelines

### DIFF
--- a/.gitlab/ci/.gitlab-ci.sdk-nightly.yml
+++ b/.gitlab/ci/.gitlab-ci.sdk-nightly.yml
@@ -526,7 +526,7 @@ demisto-sdk-nightly:trigger-slack-notify:
     PIPELINE_TO_QUERY: $CI_PIPELINE_ID
     WORKFLOW: "Demisto SDK Nightly"
     JOB_NAME: "demisto-sdk-nightly:fan-in"
-    DEMISTO_SDK_NIGHTLY: "true"
+    DEMISTO_SDK_NIGHTLY: $DEMISTO_SDK_NIGHTLY
     OVERRIDE_SDK_REF: $OVERRIDE_SDK_REF
     SDK_REF: $SDK_REF
     SLACK_CHANNEL: $SLACK_CHANNEL


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-9556

## Description
On https://github.com/demisto/content/pull/32403 an issue was introduced where the `demisto-sdk-nightly:trigger-slack-notify` step was added to unrelated pipelines. This PR fixes this issue.

Link to a "Build Machine Cleanup" pipeline from before the changes:
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/789797

Link to a "Build Machine Cleanup" pipeline following the changes:
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/790605

SDK Nightly following the changes (job should be added for this pipeline)
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/790656

Content nightly following the changes:
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/790660
