### PR TITLE
Upgrade docker images 60-70 coverage rate

### DIFF
--- a/Packs/Base/Scripts/DBotPredictPhishingWords/DBotPredictPhishingWords.yml
+++ b/Packs/Base/Scripts/DBotPredictPhishingWords/DBotPredictPhishingWords.yml
@@ -98,7 +98,7 @@ tags:
 - phishing
 timeout: 60µs
 type: python
-dockerimage: demisto/ml:1.0.0.32340
+dockerimage: demisto/ml:1.0.0.86077
 runonce: true
 tests:
 - Create Phishing Classifier V2 ML Test

--- a/Packs/FeedDHS/Integrations/DHS_Feed/DHS_Feed.yml
+++ b/Packs/FeedDHS/Integrations/DHS_Feed/DHS_Feed.yml
@@ -159,7 +159,7 @@ script:
     - contextPath: DHS.tlp
       description: The traffic light protocol.
       type: string
-  dockerimage: demisto/xml-feed:1.0.0.63829
+  dockerimage: demisto/xml-feed:1.0.0.85995
   feed: true
   runonce: false
   script: '-'

--- a/Packs/MicrosoftAdvancedThreatAnalytics/Integrations/MicrosoftAdvancedThreatAnalytics/MicrosoftAdvancedThreatAnalytics.yml
+++ b/Packs/MicrosoftAdvancedThreatAnalytics/Integrations/MicrosoftAdvancedThreatAnalytics/MicrosoftAdvancedThreatAnalytics.yml
@@ -418,7 +418,7 @@ script:
     - contextPath: MicrosoftATA.Entity.Profile.UpdateTime
       description: The update time of the entity profile.
       type: Date
-  dockerimage: demisto/ntlm:1.0.0.44693
+  dockerimage: demisto/ntlm:1.0.0.85814
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml
+++ b/Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml
@@ -366,7 +366,7 @@ tags:
 - Utility
 timeout: '0'
 type: python
-dockerimage: demisto/pcap-miner:1.0.0.10664
+dockerimage: demisto/pcap-miner:1.0.0.85918
 runas: DBotWeakRole
 runonce: true
 tests:

--- a/Packs/Syslog/Integrations/SyslogSender/SyslogSender.yml
+++ b/Packs/Syslog/Integrations/SyslogSender/SyslogSender.yml
@@ -184,7 +184,7 @@ script:
       - LOG_LOCAL7
     description: Sends a message to Syslog.
     name: syslog-send
-  dockerimage: demisto/syslog:1.0.0.48738
+  dockerimage: demisto/syslog:1.0.0.85951
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/TrendMicroApex/Integrations/TrendMicroApex/TrendMicroApex.yml
+++ b/Packs/TrendMicroApex/Integrations/TrendMicroApex/TrendMicroApex.yml
@@ -641,7 +641,7 @@ script:
     - contextPath: TrendMicroApex.InvestigationResult.errorServers
       description: Error response if server communication is unsuccessful.
       type: String
-  dockerimage: demisto/pycef:1.0.0.61516
+  dockerimage: demisto/pycef:1.0.0.85928
   runonce: false
   script: '-'
   subtype: python3


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `not_basic_python3` docker image of the following integration/scripts which coverage rate of 60-70%:

```
        "Packs/Base/Scripts/DBotPredictPhishingWords/DBotPredictPhishingWords.yml",
        "Packs/FeedDHS/Integrations/DHS_Feed/DHS_Feed.yml",
        "Packs/MicrosoftAdvancedThreatAnalytics/Integrations/MicrosoftAdvancedThreatAnalytics/MicrosoftAdvancedThreatAnalytics.yml",
        "Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml",
        "Packs/Syslog/Integrations/SyslogSender/SyslogSender.yml",
        "Packs/TrendMicroApex/Integrations/TrendMicroApex/TrendMicroApex.yml"
```