### PR TITLE
Upgrade docker images 35-50 coverage rate

### DIFF
--- a/Packs/Base/Scripts/DBotBuildPhishingClassifier/DBotBuildPhishingClassifier.yml
+++ b/Packs/Base/Scripts/DBotBuildPhishingClassifier/DBotBuildPhishingClassifier.yml
@@ -83,7 +83,7 @@ tags:
 - ml
 timeout: 12µs
 type: python
-dockerimage: demisto/ml:1.0.0.45981
+dockerimage: demisto/ml:1.0.0.86077
 runonce: true
 tests:
 - Create Phishing Classifier V2 ML Test

--- a/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/FeedMicrosoftIntune.yml
+++ b/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/FeedMicrosoftIntune.yml
@@ -100,6 +100,6 @@ script:
       description: The maximum number of results to return. The default value is 10.
       defaultValue: "0"
     description: Gets indicators from the feed.
-  dockerimage: demisto/btfl-soup:1.0.1.45563
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   feed: true
   subtype: python3

--- a/Packs/FeedZoom/Integrations/FeedZoom/FeedZoom.yml
+++ b/Packs/FeedZoom/Integrations/FeedZoom/FeedZoom.yml
@@ -122,7 +122,7 @@ script:
       description: The maximum number of results to return. The default value is 10.
       defaultValue: "10"
     description: Gets indicators from the feed.
-  dockerimage: demisto/btfl-soup:1.0.1.45563
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   feed: true
   subtype: python3
 tests:

--- a/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
+++ b/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
@@ -73,7 +73,7 @@ script:
       required: true
     description: Manual command to fetch events and display them.
     name: github-get-events
-  dockerimage: demisto/fastapi:1.0.0.64474
+  dockerimage: demisto/fastapi:1.0.0.85885
   isfetchevents: true
   subtype: python3
 marketplaces:

--- a/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
+++ b/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
@@ -67,7 +67,7 @@ script:
     - contextPath: GoogleCloudTranslate.TranslateText.translated_text
       description: The translated text.
       type: String
-  dockerimage: demisto/google-cloud-translate:1.0.0.63615
+  dockerimage: demisto/google-cloud-translate:1.0.0.85793
   runonce: false
   script: '-'
   type: python

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -54,7 +54,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.75080
+  dockerimage: demisto/taxii-server:1.0.0.85996
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/Vertica/Integrations/Vertica/Vertica.yml
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.yml
@@ -46,7 +46,7 @@ script:
       description: The content of rows.
       type: string
     description: Executes a query on the Vertica database.
-  dockerimage: demisto/py3-tools:0.0.1.30715
+  dockerimage: demisto/py3-tools:1.0.0.86064
   subtype: python3
 tests:
 - Vertica Test

--- a/Packs/WindowsForensics/Scripts/Etl2Pcap/Etl2Pcap.yml
+++ b/Packs/WindowsForensics/Scripts/Etl2Pcap/Etl2Pcap.yml
@@ -6,7 +6,7 @@ args:
 commonfields:
   id: Etl2Pcap
   version: -1
-dockerimage: demisto/etl2pcap:1.0.0.19032
+dockerimage: demisto/etl2pcap:1.0.0.85882
 enabled: true
 name: Etl2Pcap
 outputs:

--- a/Packs/jamf/Integrations/jamfV2/jamfV2.yml
+++ b/Packs/jamf/Integrations/jamfV2/jamfV2.yml
@@ -2585,7 +2585,7 @@ script:
     - contextPath: Endpoint.Vendor
       description: The integration name of the endpoint vendor.
       type: String
-  dockerimage: demisto/btfl-soup:1.0.1.46582
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   runonce: false
   script: '-'
   subtype: python3


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `not_basic_python3` docker image of the following integration/scripts which coverage rate of 35-50%:

```
Packs/Vertica/Integrations/Vertica/Vertica.yml,
Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml,
Packs/Base/Scripts/DBotBuildPhishingClassifier/DBotBuildPhishingClassifier.yml,
Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/FeedMicrosoftIntune.yml,
Packs/FeedZoom/Integrations/FeedZoom/FeedZoom.yml,
Packs/jamf/Integrations/jamfV2/jamfV2.yml,
Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml,
Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml,
Packs/WindowsForensics/Scripts/Etl2Pcap/Etl2Pcap.yml```