### PR TITLE
Upgrade docker images 20-35 coverage rate

### DIFF
--- a/Packs/AWS-Lambda/Integrations/AWS_Lambda/AWS_Lambda.yml
+++ b/Packs/AWS-Lambda/Integrations/AWS_Lambda/AWS_Lambda.yml
@@ -977,7 +977,7 @@ script:
       name: qualifier
     description: Deletes a Lambda function. To delete a specific function version, use the Qualifier parameter. Otherwise, all versions and aliases are deleted.
     name: aws-lambda-delete-function
-  dockerimage: demisto/boto3py3:1.0.0.63019
+  dockerimage: demisto/boto3py3:1.0.0.86056
   runonce: false
   subtype: python3
   script: ''

--- a/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
+++ b/Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml
@@ -266,7 +266,7 @@ script:
     - name: roleSessionDuration
       description: The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration setting for the role.
     description: Deletes the messages in a queue specified by the QueueURL parameter.
-  dockerimage: demisto/boto3py3:1.0.0.48955
+  dockerimage: demisto/boto3py3:1.0.0.86056
   isfetch: true
 tests:
 - AWS - SQS Test Playbook

--- a/Packs/Base/Scripts/DBotBuildPhishingClassifier/DBotBuildPhishingClassifier.yml
+++ b/Packs/Base/Scripts/DBotBuildPhishingClassifier/DBotBuildPhishingClassifier.yml
@@ -83,7 +83,7 @@ tags:
 - ml
 timeout: 12µs
 type: python
-dockerimage: demisto/ml:1.0.0.45981
+dockerimage: demisto/ml:1.0.0.86077
 runonce: true
 tests:
 - Create Phishing Classifier V2 ML Test

--- a/Packs/Base/Scripts/DBotTrainTextClassifierV2/DBotTrainTextClassifierV2.yml
+++ b/Packs/Base/Scripts/DBotTrainTextClassifierV2/DBotTrainTextClassifierV2.yml
@@ -121,7 +121,7 @@ tags:
 - ml
 timeout: 12µs
 type: python
-dockerimage: demisto/ml:1.0.0.62124
+dockerimage: demisto/ml:1.0.0.86077
 runonce: true
 tests:
 - Create Phishing Classifier V2 ML Test

--- a/Packs/Base/Scripts/ValidateContent/ValidateContent.yml
+++ b/Packs/Base/Scripts/ValidateContent/ValidateContent.yml
@@ -43,6 +43,6 @@ scripttarget: 0
 timeout: 600ns
 runas: DBotWeakRole
 fromversion: 5.5.0
-dockerimage: demisto/xsoar-tools:1.0.0.58259
+dockerimage: demisto/xsoar-tools:1.0.0.85955
 tests:
 - ValidateContent - Test

--- a/Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml
+++ b/Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml
@@ -54,5 +54,5 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.86064
 fromversion: 5.0.0

--- a/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/FeedAlienVaultOTXTaxii.yml
+++ b/Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/FeedAlienVaultOTXTaxii.yml
@@ -120,7 +120,7 @@ script:
       name: begin_date
     description: Gets the indicators from AlienVault OTX.
     name: alienvaultotx-get-indicators
-  dockerimage: demisto/taxii:1.0.0.43208
+  dockerimage: demisto/taxii:1.0.0.85985
   feed: true
   runonce: false
   script: '-'

--- a/Packs/FeedAzureADConnectHealth/Integrations/AzureADConnectHealthFeed/AzureADConnectHealthFeed.yml
+++ b/Packs/FeedAzureADConnectHealth/Integrations/AzureADConnectHealthFeed/AzureADConnectHealthFeed.yml
@@ -101,6 +101,6 @@ script:
       description: The maximum number of results to return. The default value is 10.
       defaultValue: "0"
     description: Gets indicators from the feed.
-  dockerimage: demisto/btfl-soup:1.0.1.45563
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   feed: true
   subtype: python3

--- a/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/FeedMicrosoftIntune.yml
+++ b/Packs/FeedMicrosoftIntune/Integrations/FeedMicrosoftIntune/FeedMicrosoftIntune.yml
@@ -100,6 +100,6 @@ script:
       description: The maximum number of results to return. The default value is 10.
       defaultValue: "0"
     description: Gets indicators from the feed.
-  dockerimage: demisto/btfl-soup:1.0.1.45563
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   feed: true
   subtype: python3

--- a/Packs/FeedZoom/Integrations/FeedZoom/FeedZoom.yml
+++ b/Packs/FeedZoom/Integrations/FeedZoom/FeedZoom.yml
@@ -122,7 +122,7 @@ script:
       description: The maximum number of results to return. The default value is 10.
       defaultValue: "10"
     description: Gets indicators from the feed.
-  dockerimage: demisto/btfl-soup:1.0.1.45563
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   feed: true
   subtype: python3
 tests:

--- a/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
+++ b/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
@@ -73,7 +73,7 @@ script:
       required: true
     description: Manual command to fetch events and display them.
     name: github-get-events
-  dockerimage: demisto/fastapi:1.0.0.64474
+  dockerimage: demisto/fastapi:1.0.0.85885
   isfetchevents: true
   subtype: python3
 marketplaces:

--- a/Packs/GoogleCloudFunctions/Integrations/GoogleCloudFunctions/GoogleCloudFunctions.yml
+++ b/Packs/GoogleCloudFunctions/Integrations/GoogleCloudFunctions/GoogleCloudFunctions.yml
@@ -114,7 +114,7 @@ script:
     - contextPath: GoogleCloudFunctions.Execution.error
       description: Either a system or user-function generated error. Set if the execution was not successful.
       type: String
-  dockerimage: demisto/google-api-py3:1.0.0.64100
+  dockerimage: demisto/google-api-py3:1.0.0.85792
   runonce: false
   script: '-'
   type: python

--- a/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
+++ b/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
@@ -67,7 +67,7 @@ script:
     - contextPath: GoogleCloudTranslate.TranslateText.translated_text
       description: The translated text.
       type: String
-  dockerimage: demisto/google-cloud-translate:1.0.0.63615
+  dockerimage: demisto/google-cloud-translate:1.0.0.85793
   runonce: false
   script: '-'
   type: python

--- a/Packs/GoogleKeyManagementService/Integrations/GoogleKeyManagementService/GoogleKeyManagementService.yml
+++ b/Packs/GoogleKeyManagementService/Integrations/GoogleKeyManagementService/GoogleKeyManagementService.yml
@@ -1237,7 +1237,7 @@ script:
     - contextPath: GoogleKMS.PublicKey.Algorithm
       description: The algorithm used in the CryptoKey
       type: String
-  dockerimage: demisto/google-kms:1.0.0.62005
+  dockerimage: demisto/google-kms:1.0.0.85797
   runonce: false
   script: '-'
   type: python

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: demisto/google-k8s-engine:1.0.0.64696
+  dockerimage: demisto/google-k8s-engine:1.0.0.85799
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/McAfee-MAR/Integrations/McAfee-MAR/McAfee-MAR.yml
+++ b/Packs/McAfee-MAR/Integrations/McAfee-MAR/McAfee-MAR.yml
@@ -496,7 +496,7 @@ script:
     - contextPath: MAR.HostInfo.Os
       description: Host operation system
     description: Gets host information from McAfee Active Response
-  dockerimage: demisto/dxl:1.0.0.63890
+  dockerimage: demisto/dxl:1.0.0.85668
 fromversion: 5.0.0
 tests:
 - No tests (auto formatted)

--- a/Packs/McAfee_DXL/Integrations/McAfee_DXL/McAfee_DXL.yml
+++ b/Packs/McAfee_DXL/Integrations/McAfee_DXL/McAfee_DXL.yml
@@ -141,7 +141,7 @@ script:
       name: topic
     description: The push hash to the DXL fabric.
     name: dxl-push-hash
-  dockerimage: demisto/dxl:1.0.0.35274
+  dockerimage: demisto/dxl:1.0.0.85668
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -54,7 +54,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.75080
+  dockerimage: demisto/taxii-server:1.0.0.85996
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/Vertica/Integrations/Vertica/Vertica.yml
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.yml
@@ -46,7 +46,7 @@ script:
       description: The content of rows.
       type: string
     description: Executes a query on the Vertica database.
-  dockerimage: demisto/py3-tools:0.0.1.30715
+  dockerimage: demisto/py3-tools:1.0.0.86064
   subtype: python3
 tests:
 - Vertica Test

--- a/Packs/WindowsForensics/Scripts/Etl2Pcap/Etl2Pcap.yml
+++ b/Packs/WindowsForensics/Scripts/Etl2Pcap/Etl2Pcap.yml
@@ -6,7 +6,7 @@ args:
 commonfields:
   id: Etl2Pcap
   version: -1
-dockerimage: demisto/etl2pcap:1.0.0.19032
+dockerimage: demisto/etl2pcap:1.0.0.85882
 enabled: true
 name: Etl2Pcap
 outputs:

--- a/Packs/jamf/Integrations/jamfV2/jamfV2.yml
+++ b/Packs/jamf/Integrations/jamfV2/jamfV2.yml
@@ -2585,7 +2585,7 @@ script:
     - contextPath: Endpoint.Vendor
       description: The integration name of the endpoint vendor.
       type: String
-  dockerimage: demisto/btfl-soup:1.0.1.46582
+  dockerimage: demisto/btfl-soup:1.0.1.85862
   runonce: false
   script: '-'
   subtype: python3


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `not_basic_python3` docker image of the following integration/scripts which coverage rate of 20-35%:

```
Packs/AWS-Lambda/Integrations/AWS_Lambda/AWS_Lambda.yml,
Packs/AWS-SQS/Integrations/AWS-SQS/AWS-SQS.yml,
Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml,
Packs/Base/Scripts/ValidateContent/ValidateContent.yml,
Packs/FeedAlienVault/Integrations/FeedAlienVaultOTXTaxii/FeedAlienVaultOTXTaxii.yml,
Packs/Base/Scripts/DBotTrainTextClassifierV2/DBotTrainTextClassifierV2.yml,
Packs/FeedAzureADConnectHealth/Integrations/AzureADConnectHealthFeed/AzureADConnectHealthFeed.yml,
Packs/GoogleCloudFunctions/Integrations/GoogleCloudFunctions/GoogleCloudFunctions.yml,
Packs/GoogleKeyManagementService/Integrations/GoogleKeyManagementService/GoogleKeyManagementService.yml,
Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml,
Packs/McAfee-MAR/Integrations/McAfee-MAR/McAfee-MAR.yml,
Packs/McAfee_DXL/Integrations/McAfee_DXL/McAfee_DXL.yml```