### PR TITLE
Upgrade docker images 0-5 coverage rate part 2

### DIFF
--- a/Packs/AnsibleLinux/Integrations/AnsibleACME/AnsibleACME.yml
+++ b/Packs/AnsibleLinux/Integrations/AnsibleACME/AnsibleACME.yml
@@ -468,7 +468,7 @@ script:
     - contextPath: ACME.AcmeInspect.output_json
       description: The output parsed as JSON
       type: unknown
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/AnsibleLinux/Integrations/AnsibleDNS/AnsibleDNS.yml
+++ b/Packs/AnsibleLinux/Integrations/AnsibleDNS/AnsibleDNS.yml
@@ -97,7 +97,7 @@ script:
     - contextPath: DNS.Nsupdate.dns_rc_str
       description: dnspython return code (string representation)
       type: string
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/AnsibleLinux/Integrations/AnsibleLinux/AnsibleLinux.yml
+++ b/Packs/AnsibleLinux/Integrations/AnsibleLinux/AnsibleLinux.yml
@@ -5447,7 +5447,7 @@ script:
     - contextPath: Linux.GetUrl.url
       description: the actual URL used for the request
       type: string
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/AnsibleLinux/Integrations/AnsibleOpenSSL/AnsibleOpenSSL.yml
+++ b/Packs/AnsibleLinux/Integrations/AnsibleOpenSSL/AnsibleOpenSSL.yml
@@ -1183,7 +1183,7 @@ script:
     - contextPath: OpenSSL.GetCertificate.version
       description: The version number of the certificate
       type: string
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/AnsibleMicrosoftWindows/Integrations/AnsibleMicrosoftWindows/AnsibleMicrosoftWindows.yml
+++ b/Packs/AnsibleMicrosoftWindows/Integrations/AnsibleMicrosoftWindows/AnsibleMicrosoftWindows.yml
@@ -4534,7 +4534,7 @@ script:
     - contextPath: MicrosoftWindows.WinXml.err
       description: XML comparison exceptions.
       type: unknown
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/AnsibleVMware/Integrations/AnsibleVMware/AnsibleVMware.yml
+++ b/Packs/AnsibleVMware/Integrations/AnsibleVMware/AnsibleVMware.yml
@@ -3333,7 +3333,7 @@ script:
     - contextPath: VMware.VcenterLicense.licenses
       description: list of license keys after module executed
       type: unknown
-  dockerimage: demisto/ansible-runner:1.0.0.24037
+  dockerimage: demisto/ansible-runner:1.0.0.85785
   script: ''
   subtype: python3
   type: python

--- a/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
+++ b/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
@@ -34,7 +34,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.49796
+dockerimage: demisto/sklearn:1.0.0.86063
 runas: DBotWeakRole
 tests:
 - No tests (auto formatted)

--- a/Packs/Blueliv/Integrations/Blueliv/Blueliv.yml
+++ b/Packs/Blueliv/Integrations/Blueliv/Blueliv.yml
@@ -37,7 +37,7 @@ script:
     name: blueliv-get-attackingips-feed
   - description: 'Data related to the number of hacktivism tweets recently created. Blueliv provides two types of feeds: the first one contains the most popular hacktivism hashtags and the second one contains the countries where more number of hacktivism tweets are coming from.'
     name: blueliv-get-hacktivism-feed
-  dockerimage: demisto/blueliv:1.0.0.52588
+  dockerimage: demisto/blueliv:1.0.0.76921
   runonce: false
   script: ''
   type: python

--- a/Packs/CommonScripts/Scripts/ParseHTMLIndicators/ParseHTMLIndicators.yml
+++ b/Packs/CommonScripts/Scripts/ParseHTMLIndicators/ParseHTMLIndicators.yml
@@ -36,7 +36,7 @@ outputs:
   description: The link for the source of the indicators
 scripttarget: 0
 subtype: python3
-dockerimage: demisto/bs4-tld:1.0.0.21999
+dockerimage: demisto/bs4-tld:1.0.0.85984
 runas: DBotWeakRole
 fromversion: 5.5.0
 tests:

--- a/Packs/CommonScripts/Scripts/VerifyJSON/VerifyJSON.yml
+++ b/Packs/CommonScripts/Scripts/VerifyJSON/VerifyJSON.yml
@@ -18,7 +18,7 @@ tags:
 - JSON
 - Utility
 type: powershell
-dockerimage: demisto/powershell:7.1.3.22028
+dockerimage: demisto/powershell:7.4.0.80528
 fromversion: 5.5.0
 tests:
 - VerifyJSON - Test

--- a/Packs/ContentManagement/Scripts/ConfigurationSetup/ConfigurationSetup.yml
+++ b/Packs/ContentManagement/Scripts/ConfigurationSetup/ConfigurationSetup.yml
@@ -35,7 +35,7 @@ tags:
 - Content Management
 timeout: '0'
 type: python
-dockerimage: demisto/xsoar-tools:1.0.0.36076
+dockerimage: demisto/xsoar-tools:1.0.0.85955
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0

--- a/Packs/ContentManagement/Scripts/ListCreator/ListCreator.yml
+++ b/Packs/ContentManagement/Scripts/ListCreator/ListCreator.yml
@@ -21,7 +21,7 @@ tags:
 - Content Management
 timeout: '0'
 type: python
-dockerimage: demisto/xsoar-tools:1.0.0.19258
+dockerimage: demisto/xsoar-tools:1.0.0.85955
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0

--- a/Packs/GraphQL/Integrations/GraphQL/GraphQL.yml
+++ b/Packs/GraphQL/Integrations/GraphQL/GraphQL.yml
@@ -84,7 +84,7 @@ script:
       - 'false'
     description: Executes a mutation request to the GraphQL server.
     name: graphql-mutation
-  dockerimage: demisto/graphql:1.0.0.45620
+  dockerimage: demisto/graphql:1.0.0.85893
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/ML/Scripts/DBotPredictIncidentsBatch/DBotPredictIncidentsBatch.yml
+++ b/Packs/ML/Scripts/DBotPredictIncidentsBatch/DBotPredictIncidentsBatch.yml
@@ -46,7 +46,7 @@ tags:
 - ml
 timeout: '0'
 type: python
-dockerimage: demisto/ml:1.0.0.45981
+dockerimage: demisto/ml:1.0.0.86077
 fromversion: 5.0.0
 tests:
 - VerifyOOBV2Predictions-Test

--- a/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
+++ b/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
@@ -59,7 +59,7 @@ script: '-'
 subtype: python3
 timeout: 60µs
 type: python
-dockerimage: demisto/ml:1.0.0.32340
+dockerimage: demisto/ml:1.0.0.86077
 runonce: true
 tests:
 - DbotPredictOufOfTheBoxTestV2

--- a/Packs/ML/Scripts/EvaluateMLModllAtProduction/EvaluateMLModllAtProduction.yml
+++ b/Packs/ML/Scripts/EvaluateMLModllAtProduction/EvaluateMLModllAtProduction.yml
@@ -42,7 +42,7 @@ outputs:
 script: '-'
 subtype: python3
 type: python
-dockerimage: demisto/ml:1.0.0.45981
+dockerimage: demisto/ml:1.0.0.86077
 runas: DBotWeakRole
 fromversion: 5.0.0
 tags:

--- a/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
+++ b/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
@@ -63,7 +63,7 @@ script:
     name: workday-generate-terminate-event
   - description: Reset the integration context to fetch the first run reports.
     name: initialize-context
-  dockerimage: demisto/teams:1.0.0.14902
+  dockerimage: demisto/teams:1.0.0.85994
   longRunning: true
   longRunningPort: true
   script: '-'


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `not_basic_python3` docker image of the following integration/scripts which coverage rate of 0-5% part 2:

```
Packs/AnsibleLinux/Integrations/AnsibleLinux/AnsibleLinux.yml,
Packs/AnsibleLinux/Integrations/AnsibleOpenSSL/AnsibleOpenSSL.yml,
Packs/AnsibleLinux/Integrations/AnsibleACME/AnsibleACME.yml,
Packs/AnsibleLinux/Integrations/AnsibleDNS/AnsibleDNS.yml,
Packs/AnsibleMicrosoftWindows/Integrations/AnsibleMicrosoftWindows/AnsibleMicrosoftWindows.yml,
Packs/AnsibleVMware/Integrations/AnsibleVMware/AnsibleVMware.yml,
Packs/ContentManagement/Scripts/ListCreator/ListCreator.yml,
Packs/ContentManagement/Scripts/ConfigurationSetup/ConfigurationSetup.yml,
Packs/ML/Scripts/EvaluateMLModllAtProduction/EvaluateMLModllAtProduction.yml,
Packs/ML/Scripts/DBotPredictIncidentsBatch/DBotPredictIncidentsBatch.yml,
Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml,
Packs/CommonScripts/Scripts/VerifyJSON/VerifyJSON.yml,
Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml,
Packs/Blueliv/Integrations/Blueliv/Blueliv.yml,
Packs/GraphQL/Integrations/GraphQL/GraphQL.yml,
Packs/CommonScripts/Scripts/ParseHTMLIndicators/ParseHTMLIndicators.yml,
Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml```