### PR TITLE
Upgrade docker images 0-5 coverage rate part 3

### DIFF
--- a/Packs/FeedPublicDNS/Integrations/FeedPublicDNS/FeedPublicDNS.yml
+++ b/Packs/FeedPublicDNS/Integrations/FeedPublicDNS/FeedPublicDNS.yml
@@ -96,7 +96,7 @@ script:
       name: limit
     description: Gets indicators from the feed.
     name: public-dns-get-indicators
-  dockerimage: demisto/netutils:1.0.0.74582
+  dockerimage: demisto/netutils:1.0.0.86137
   feed: true
   runonce: false
   script: '-'

--- a/Packs/GoogleResourceManager/Integrations/GoogleResourceManager/GoogleResourceManager.yml
+++ b/Packs/GoogleResourceManager/Integrations/GoogleResourceManager/GoogleResourceManager.yml
@@ -397,7 +397,7 @@ script:
     - contextPath: GRM.Project.Parent.Type
       description: Type of the parent resource.
       type: String
-  dockerimage: demisto/googleapi-python3:1.0.0.63869
+  dockerimage: demisto/googleapi-python3:1.0.0.85803
   runonce: false
   script: ''
   type: python

--- a/Packs/GoogleVault/Integrations/GoogleVault/GoogleVault.yml
+++ b/Packs/GoogleVault/Integrations/GoogleVault/GoogleVault.yml
@@ -540,7 +540,7 @@ script:
     - contextPath: GoogleVault.Matter.Export.Results.To
       description: The address the message was sent to
       type: string
-  dockerimage: demisto/googleapi-python3:1.0.0.64742
+  dockerimage: demisto/googleapi-python3:1.0.0.85803
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleVisionAPI/Integrations/GoogleVisionAPI/GoogleVisionAPI.yml
+++ b/Packs/GoogleVisionAPI/Integrations/GoogleVisionAPI/GoogleVisionAPI.yml
@@ -44,7 +44,7 @@ script:
     - contextPath: GoogleVisionAPI.Logo.Score
       description: The certainty score provided by the Google Vision API.
       type: Unknown
-  dockerimage: demisto/google-vision-api:1.0.0.63870
+  dockerimage: demisto/google-vision-api:1.0.0.85801
   runonce: false
   script: '-'
   type: python

--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
@@ -939,7 +939,7 @@ script:
   runonce: false
   script: "-"
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -959,7 +959,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.3.0.80529
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml
+++ b/Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml
@@ -33,7 +33,7 @@ tags:
 - basescript
 timeout: '0'
 type: powershell
-dockerimage: demisto/pwsh-exchange:1.0.0.34118
+dockerimage: demisto/pwsh-exchange:1.0.0.80545
 fromversion: 5.5.0
 tests:
 - CreateCertificate-Test

--- a/Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml
+++ b/Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml
@@ -28,7 +28,7 @@ outputs:
 script: '-'
 timeout: '0'
 type: powershell
-dockerimage: demisto/powershell-teams:1.0.0.22275
+dockerimage: demisto/powershell-teams:1.0.0.80546
 fromversion: 5.5.0
 tests:
 - No test

--- a/Packs/Nmap/Integrations/Nmap/Nmap.yml
+++ b/Packs/Nmap/Integrations/Nmap/Nmap.yml
@@ -57,4 +57,4 @@ script:
       description: Additional parseable fields from the script output.
     description: Scan targets with the given parameters
     execution: true
-  dockerimage: demisto/netutils:1.0.0.74582
+  dockerimage: demisto/netutils:1.0.0.86137

--- a/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
+++ b/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
@@ -153,7 +153,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 5.5.0
 tests:
 - Audit Log - Test

--- a/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
+++ b/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
@@ -328,7 +328,7 @@ script:
     - contextPath: PsRemote.FQDN
       description: The Fully Qualified Domain Name of the host on which the command was invoked.
       type: string
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.3.0.80529
   script: ''
   type: powershell
 fromversion: 6.0.0

--- a/Packs/PrismaAccess/Integrations/PrismaAccess/PrismaAccess.yml
+++ b/Packs/PrismaAccess/Integrations/PrismaAccess/PrismaAccess.yml
@@ -99,7 +99,7 @@ script:
       description: Active Users on Prisma Access
     description: Query currently active users.
     deprecated: true
-  dockerimage: demisto/netmiko:1.0.0.61830
+  dockerimage: demisto/netmiko:1.0.0.85812
   subtype: python3
 fromversion: 5.0.0
 tests:

--- a/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
+++ b/Packs/SMB/Integrations/SMB_v2/SMB_v2.yml
@@ -162,7 +162,7 @@ script:
     - name: password
       description: The password to use for authentication. If empty, the password from the instance configuration is used.
     description: Removes a directory from the given path.
-  dockerimage: demisto/smbprotocol:1.0.0.63639
+  dockerimage: demisto/smbprotocol:1.0.0.85835
   runonce: false
   script: '-'
   type: python

--- a/Packs/Symantec_Messaging_Gateway/Integrations/SymantecMessagingGateway/SymantecMessagingGateway.yml
+++ b/Packs/Symantec_Messaging_Gateway/Integrations/SymantecMessagingGateway/SymantecMessagingGateway.yml
@@ -118,7 +118,7 @@ script:
   - name: smg-get-blocked-ips
     arguments: []
     description: Returns a list of all blocked IP addresses.
-  dockerimage: demisto/bs4-py3:1.0.0.48637
+  dockerimage: demisto/bs4-py3:1.0.0.85861
 fromversion: 5.0.0
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `not_basic_python3` docker image of the following integration/scripts which coverage rate of 0-5% part 3:

```
Packs/FeedPublicDNS/Integrations/FeedPublicDNS/FeedPublicDNS.yml,
Packs/Nmap/Integrations/Nmap/Nmap.yml,
Packs/Symantec_Messaging_Gateway/Integrations/SymantecMessagingGateway/SymantecMessagingGateway.yml,
Packs/GoogleResourceManager/Integrations/GoogleResourceManager/GoogleResourceManager.yml,
Packs/GoogleVault/Integrations/GoogleVault/GoogleVault.yml,
Packs/GoogleVisionAPI/Integrations/GoogleVisionAPI/GoogleVisionAPI.yml,
Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml,
Packs/MicrosoftECM/Integrations/MicrosoftECM/MicrosoftECM.yml,
Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml,
Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml,
Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.yml,
Packs/MicrosoftExchangeOnline/Integrations/SecurityAndComplianceV2/SecurityAndComplianceV2.yml,
Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml,
Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml,
Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml,
Packs/PrismaAccess/Integrations/PrismaAccess/PrismaAccess.yml,
Packs/SMB/Integrations/SMB_v2/SMB_v2.yml```