### PR TITLE
add 5 seconds to sleep - MicrosoftDefender-ATP-IndicatorsSCTest

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/TestPlaybooks/playbook-Microsoft_ATP_indicators_SC_Test.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/TestPlaybooks/playbook-Microsoft_ATP_indicators_SC_Test.yml
@@ -682,7 +682,7 @@ tasks:
       - '2'
     scriptarguments:
       seconds:
-        simple: '5'
+        simple: '10'
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This TPB failed on nightly 1.02.2024 - added 5 seconds to sleep.

## Must have
- [ ] Tests
- [ ] Documentation 
