### PR TITLE
Update `demisto/boto3` 0-10 coverage rate

### DIFF
--- a/Packs/AWS-CloudTrail/Integrations/AWS-CloudTrail/AWS-CloudTrail.yml
+++ b/Packs/AWS-CloudTrail/Integrations/AWS-CloudTrail/AWS-CloudTrail.yml
@@ -371,7 +371,7 @@ script:
     - contextPath: AWS.CloudTrail.Events.CloudTrailEvent
       description: A JSON string that contains a representation of the event returned.
       type: string
-  dockerimage: demisto/boto3:2.0.0.52592
+  dockerimage: demisto/boto3:2.0.0.76921
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/AWS-CloudTrail/ReleaseNotes/1_0_10.md
+++ b/Packs/AWS-CloudTrail/ReleaseNotes/1_0_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### AWS - CloudTrail
+
+- Updated the Docker image to: *demisto/boto3:2.0.0.76921*.

--- a/Packs/AWS-CloudTrail/pack_metadata.json
+++ b/Packs/AWS-CloudTrail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - CloudTrail",
     "description": "Amazon Web Services CloudTrail.",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/boto3` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/AWS-CloudTrail/Integrations/AWS-CloudTrail/AWS-CloudTrail.yml
```
