### PR TITLE
Update `demisto/py3-tools` 0-10 coverage rate

### DIFF
--- a/Packs/ActiveMQ/Integrations/ActiveMQ/ActiveMQ.yml
+++ b/Packs/ActiveMQ/Integrations/ActiveMQ/ActiveMQ.yml
@@ -81,7 +81,7 @@ script:
       name: queue-name
     description: Subscribes to and reads messages from a topic or queue. Must provide either queue-name or topic-name. You can't provide both.
     name: activemq-subscribe
-  dockerimage: demisto/py3-tools:1.0.0.49475
+  dockerimage: demisto/py3-tools:1.0.0.86691
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/ActiveMQ/ReleaseNotes/1_1_14.md
+++ b/Packs/ActiveMQ/ReleaseNotes/1_1_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ActiveMQ
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.

--- a/Packs/ActiveMQ/pack_metadata.json
+++ b/Packs/ActiveMQ/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ActiveMQ",
     "description": "Uses Durable Topic Subscribers to fetch messages and ingest them as incidents in Demisto.",
     "support": "xsoar",
-    "currentVersion": "1.1.13",
+    "currentVersion": "1.1.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedFastly/Integrations/FeedFastly/FeedFastly.yml
+++ b/Packs/FeedFastly/Integrations/FeedFastly/FeedFastly.yml
@@ -92,7 +92,7 @@ script:
       name: limit
     description: Fetches indicators from the feed.
     name: fastly-get-indicators
-  dockerimage: demisto/py3-tools:1.0.0.47433
+  dockerimage: demisto/py3-tools:1.0.0.86691
   feed: true
   runonce: false
   script: '-'

--- a/Packs/FeedFastly/ReleaseNotes/1_1_27.md
+++ b/Packs/FeedFastly/ReleaseNotes/1_1_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Fastly Feed
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.

--- a/Packs/FeedFastly/pack_metadata.json
+++ b/Packs/FeedFastly/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Fastly Feed",
     "description": "Indicators feed from Fastly",
     "support": "xsoar",
-    "currentVersion": "1.1.26",
+    "currentVersion": "1.1.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FeedJSON/Integrations/FeedJSON/FeedJSON.yml
+++ b/Packs/FeedJSON/Integrations/FeedJSON/FeedJSON.yml
@@ -135,7 +135,7 @@ script:
       name: limit
     description: Gets the feed indicators.
     name: json-get-indicators
-  dockerimage: demisto/py3-tools:1.0.0.47376
+  dockerimage: demisto/py3-tools:1.0.0.86691
   feed: true
   runonce: false
   script: '-'

--- a/Packs/FeedJSON/ReleaseNotes/1_1_30.md
+++ b/Packs/FeedJSON/ReleaseNotes/1_1_30.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### JSON Feed
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.

--- a/Packs/FeedJSON/pack_metadata.json
+++ b/Packs/FeedJSON/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "JSON Feed",
     "description": "Indicators feed from a JSON file",
     "support": "xsoar",
-    "currentVersion": "1.1.29",
+    "currentVersion": "1.1.30",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ImpossibleTraveler/ReleaseNotes/1_2_11.md
+++ b/Packs/ImpossibleTraveler/ReleaseNotes/1_2_11.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CalculateGeoDistance
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.

--- a/Packs/ImpossibleTraveler/Scripts/CalculateGeoDistance/CalculateGeoDistance.yml
+++ b/Packs/ImpossibleTraveler/Scripts/CalculateGeoDistance/CalculateGeoDistance.yml
@@ -22,7 +22,7 @@ outputs:
 - contextPath: Geo.Coordinates
   description: List of coordinates used in the calculation.
 scripttarget: 0
-dockerimage: demisto/py3-tools:1.0.0.49929
+dockerimage: demisto/py3-tools:1.0.0.86691
 runas: DBotWeakRole
 tests:
 - Impossible Traveler - Test

--- a/Packs/ImpossibleTraveler/pack_metadata.json
+++ b/Packs/ImpossibleTraveler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Impossible Traveler",
     "description": "Catch the impossible traveler. This Content Pack helps you quickly determine the legitimacy of remote access attempts and contain malicious activity.",
     "support": "xsoar",
-    "currentVersion": "1.2.10",
+    "currentVersion": "1.2.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MongoDB/Integrations/MongoDBKeyValueStore/MongoDBKeyValueStore.yml
+++ b/Packs/MongoDB/Integrations/MongoDBKeyValueStore/MongoDBKeyValueStore.yml
@@ -114,7 +114,7 @@ script:
     name: mongodb-get-keys-number
   - description: Lists all incidents in the collection.
     name: mongodb-list-incidents
-  dockerimage: demisto/py3-tools:1.0.0.45685
+  dockerimage: demisto/py3-tools:1.0.0.86691
   runonce: false
   script: '-'
   type: python

--- a/Packs/MongoDB/Integrations/MongoDBLog/MongoDBLog.yml
+++ b/Packs/MongoDB/Integrations/MongoDBLog/MongoDBLog.yml
@@ -78,7 +78,7 @@ script:
       type: String
   - description: Returns the number of log entries.
     name: mongodb-logs-number
-  dockerimage: demisto/py3-tools:1.0.0.45685
+  dockerimage: demisto/py3-tools:1.0.0.86691
   runonce: true
   script: '-'
   type: python

--- a/Packs/MongoDB/ReleaseNotes/1_3_1.md
+++ b/Packs/MongoDB/ReleaseNotes/1_3_1.md
@@ -1,0 +1,9 @@
+
+#### Integrations
+
+##### MongoDB Key Value Store
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.
+##### MongoDB Log
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.86691*.

--- a/Packs/MongoDB/pack_metadata.json
+++ b/Packs/MongoDB/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MongoDB",
     "description": "Use the MongoDB integration to search and query entries in your MongoDB.",
     "support": "xsoar",
-    "currentVersion": "1.3.0",
+    "currentVersion": "1.3.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/py3-tools` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/ActiveMQ/Integrations/ActiveMQ/ActiveMQ.yml
Packs/FeedFastly/Integrations/FeedFastly/FeedFastly.yml
Packs/FeedJSON/Integrations/FeedJSON/FeedJSON.yml
Packs/ImpossibleTraveler/Scripts/CalculateGeoDistance/CalculateGeoDistance.yml
Packs/MongoDB/Integrations/MongoDBKeyValueStore/MongoDBKeyValueStore.yml
Packs/MongoDB/Integrations/MongoDBLog/MongoDBLog.yml
```
