### PR TITLE
Update `demisto/py3-tools` 40-55 coverage rate

### DIFF
--- a/Packs/FeedRSS/Integrations/FeedRSS/FeedRSS.yml
+++ b/Packs/FeedRSS/Integrations/FeedRSS/FeedRSS.yml
@@ -109,7 +109,7 @@ script:
       name: limit
     description: Gets the reports from the RSS feed.
     name: rss-get-indicators
-  dockerimage: demisto/py3-tools:1.0.0.31193
+  dockerimage: demisto/py3-tools:1.0.0.86691
   feed: true
   runonce: false
   script: '-'


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/py3-tools` docker image of the following integration/scripts which coverage rate of `40-55`%:

```
Packs/FeedRSS/Integrations/FeedRSS/FeedRSS.yml
```
