### PR TITLE
Update `demisto/sklearn` 0-10 coverage rate

### DIFF
--- a/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
+++ b/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
@@ -34,7 +34,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.49796
+dockerimage: demisto/sklearn:1.0.0.86554
 runas: DBotWeakRole
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/sklearn` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
```
