### PR TITLE
Recorded Future Feed - bug fix: malicious threshold integration parameter

### DIFF
--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
@@ -576,7 +576,7 @@ def main():  # pragma: no cover
         raise DemistoException('API Token must be provided.')
     client = Client(RF_INDICATOR_TYPES[params.get('indicator_type')], api_token, params.get('services'),
                     params.get('risk_rule'), params.get('fusion_file_path'), params.get('insecure'),
-                    params.get('polling_timeout'), params.get('proxy'), params.get('malicious_threshold'),
+                    params.get('polling_timeout'), params.get('proxy'), params.get('threshold'),
                     params.get('suspicious_threshold'), params.get('risk_score_threshold'),
                     argToList(params.get('feedTags')), params.get('tlp_color'))
     command = demisto.command()

--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.py
@@ -576,7 +576,7 @@ def main():  # pragma: no cover
         raise DemistoException('API Token must be provided.')
     client = Client(RF_INDICATOR_TYPES[params.get('indicator_type')], api_token, params.get('services'),
                     params.get('risk_rule'), params.get('fusion_file_path'), params.get('insecure'),
-                    params.get('polling_timeout'), params.get('proxy'), params.get('threshold'),
+                    params.get('polling_timeout'), params.get('proxy'), params.get('malicious_threshold'),
                     params.get('suspicious_threshold'), params.get('risk_score_threshold'),
                     argToList(params.get('feedTags')), params.get('tlp_color'))
     command = demisto.command()

--- a/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.yml
+++ b/Packs/FeedRecordedFuture/Integrations/FeedRecordedFuture/FeedRecordedFuture.yml
@@ -140,7 +140,7 @@ configuration:
     The minimum score from the feed in order to determine whether the indicator is malicious. Default is "65". For more information about Recorded Future scoring go to integration details.
   defaultvalue: '65'
   display: Malicious Threshold
-  name: threshold
+  name: malicious_threshold
   type: 0
   required: false
 - additionalinfo: The minimum score from the feed in order to determine whether the indicator is Suspicious. Ranges up to the Malicious Threshold. Default is "25". For more information about Recorded Future scoring go to integration details.

--- a/Packs/FeedRecordedFuture/ReleaseNotes/1_1_1.md
+++ b/Packs/FeedRecordedFuture/ReleaseNotes/1_1_1.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Recorded Future RiskList Feed
+
+- Fixed an issue when getting the 'threshold' integration parameter.

--- a/Packs/FeedRecordedFuture/ReleaseNotes/1_1_1.md
+++ b/Packs/FeedRecordedFuture/ReleaseNotes/1_1_1.md
@@ -2,4 +2,5 @@
 
 ##### Recorded Future RiskList Feed
 
-- Fixed an issue when getting the 'threshold' integration parameter.
+- Updated the *threshold* integration parameter to *malicious_threshold*.
+- Fixed an issue when getting the *malicious_threshold* integration parameter.

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Recorded Future Feed",
     "description": "Ingests indicators from Recorded Future feeds into Demisto.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
'malicious_threshold' in code did not match 'threshold' integration parameter. We recently contributed PR 32316 which introduced this bug where the integration will always fail. 

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
change 'threshold' integration parameter to 'malicious_threshold' for clarity between 'suspicious_threshold'

## Must have
- [ ] Tests
- [ ] Documentation 
