### PR TITLE
Update `demisto/teams` 0-10 coverage rate

### DIFF
--- a/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
+++ b/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
@@ -63,7 +63,7 @@ script:
     name: workday-generate-terminate-event
   - description: Reset the integration context to fetch the first run reports.
     name: initialize-context
-  dockerimage: demisto/teams:1.0.0.14902
+  dockerimage: demisto/teams:1.0.0.86482
   longRunning: true
   longRunningPort: true
   script: '-'


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/teams` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
```
