### PR TITLE
Update `demisto/nltk` 70-100 coverage rate

### DIFF
--- a/Packs/CommonScripts/Scripts/WordTokenizeTest/WordTokenizeTest.yml
+++ b/Packs/CommonScripts/Scripts/WordTokenizeTest/WordTokenizeTest.yml
@@ -47,7 +47,7 @@ outputs:
   type: string
 scripttarget: 0
 runonce: true
-dockerimage: demisto/nltk:2.0.0.19143
+dockerimage: demisto/nltk:2.0.0.86396
 fromversion: 5.0.0
 tests:
 - No tests


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/nltk` docker image of the following integration/scripts which coverage rate of `70-100`%:

```
Packs/CommonScripts/Scripts/WordTokenizeTest/WordTokenizeTest.yml
```
