### PR TITLE
Update `demisto/pwsh-exchangev3` 0-10 coverage rate

### DIFF
--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
@@ -939,7 +939,7 @@ script:
   runonce: false
   script: "-"
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -959,7 +959,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/MicrosoftECM/Integrations/MicrosoftECM/MicrosoftECM.yml
+++ b/Packs/MicrosoftECM/Integrations/MicrosoftECM/MicrosoftECM.yml
@@ -1096,7 +1096,7 @@ script:
       description: The unique identifier for this relationship.
       type: number
     description: Gets the relationships between a device and its primary users.
-  dockerimage: demisto/powershell-ubuntu:7.3.0.80529
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
+++ b/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
@@ -153,7 +153,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 5.5.0
 tests:
 - Audit Log - Test

--- a/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
+++ b/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
@@ -328,7 +328,7 @@ script:
     - contextPath: PsRemote.FQDN
       description: The Fully Qualified Domain Name of the host on which the command was invoked.
       type: string
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
   script: ''
   type: powershell
 fromversion: 6.0.0


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/pwsh-exchangev3` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
```
