### PR TITLE
Update `demisto/google-cloud-translate` 25-40 coverage rate

### DIFF
--- a/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
+++ b/Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
@@ -67,7 +67,7 @@ script:
     - contextPath: GoogleCloudTranslate.TranslateText.translated_text
       description: The translated text.
       type: String
-  dockerimage: demisto/google-cloud-translate:1.0.0.63615
+  dockerimage: demisto/google-cloud-translate:1.0.0.85793
   runonce: false
   script: '-'
   type: python

--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -959,7 +959,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/MicrosoftECM/Integrations/MicrosoftECM/MicrosoftECM.yml
+++ b/Packs/MicrosoftECM/Integrations/MicrosoftECM/MicrosoftECM.yml
@@ -1096,7 +1096,7 @@ script:
       description: The unique identifier for this relationship.
       type: number
     description: Gets the relationships between a device and its primary users.
-  dockerimage: demisto/powershell-ubuntu:7.3.0.80529
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
+++ b/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
@@ -328,7 +328,7 @@ script:
     - contextPath: PsRemote.FQDN
       description: The Fully Qualified Domain Name of the host on which the command was invoked.
       type: string
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
   script: ''
   type: powershell
 fromversion: 6.0.0


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/google-cloud-translate` docker image of the following integration/scripts which coverage rate of `25-40`%:

```
Packs/GoogleCloudTranslate/Integrations/GoogleCloudTranslate/GoogleCloudTranslate.yml
```
