### PR TITLE
Update `demisto/pwsh-exchangev3` 0-10 coverage rate

### DIFF
--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
@@ -939,7 +939,7 @@ script:
   runonce: false
   script: "-"
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
+++ b/Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
@@ -153,7 +153,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/pwsh-exchangev3:1.0.0.49863
+  dockerimage: demisto/pwsh-exchangev3:1.0.0.80547
 fromversion: 5.5.0
 tests:
 - Audit Log - Test


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/pwsh-exchangev3` docker image of the following integration/scripts which coverage rate of `0-10`%:

```
Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinks/O365DefenderSafeLinks.yml
Packs/Office365AndAzureAuditLog/Integrations/MicrosoftPolicyAndComplianceAuditLog/MicrosoftPolicyAndComplianceAuditLog.yml
```
