### PR TITLE
add x2 fields

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_13_34.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_13_34.md
@@ -1,0 +1,9 @@
+
+#### Scripts
+
+##### AssignAnalystToIncident
+
+- Documentation and metadata improvements.
+##### AssignToMeButton
+
+- Documentation and metadata improvements.

--- a/Packs/CommonScripts/Scripts/AssignAnalystToIncident/AssignAnalystToIncident.yml
+++ b/Packs/CommonScripts/Scripts/AssignAnalystToIncident/AssignAnalystToIncident.yml
@@ -15,6 +15,15 @@ comment: |-
   less-busy-user: The less busy analyst will be picked to be the incident owner.
   online: The analyst is picked randomly from all online analysts, according to the provided roles (if no roles provided, will fetch all users).
   current: The user that executed the command
+comment_x2: |-
+  Assign analyst to incident. NOTE: in XSIAM, it only works when executed in the alert warroom, or in a playbook running in an alert.
+  By default,  the analyst is picked randomly from the available users, according to the provided roles (if no roles provided, will fetch all users).
+  Otherwise, the analyst will be picked according to the 'assignBy' arguments.
+  machine-learning: DBot will calculated and decide who is the best analyst for the job.
+  top-user: The user that is most commonly owns this type of incident
+  less-busy-user: The less busy analyst will be picked to be the incident owner.
+  online: The analyst is picked randomly from all online analysts, according to the provided roles (if no roles provided, will fetch all users).
+  current: The user that executed the command
 enabled: true
 args:
 - name: roles

--- a/Packs/CommonScripts/Scripts/AssignToMeButton/AssignToMeButton.yml
+++ b/Packs/CommonScripts/Scripts/AssignToMeButton/AssignToMeButton.yml
@@ -1,4 +1,5 @@
 comment: 'Assigns the current Incident to the Cortex XSOAR user who clicked the button '
+comment_x2: 'Assigns the current Incident to the Cortex XSOAR user who clicked the button. NOTE: in XSIAM, it only works when executed in the alert warroom, or in a playbook running in an alert.'
 commonfields:
   id: AssignToMeButton
   version: -1

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.13.33",
+    "currentVersion": "1.13.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Adding a description to `AssignAnalystToIncident`, `AssignToMeButton`, saying that `NOTE: in XSIAM, it only works when executed in the alert warroom, or in a playbook running in an alert`

Fixes: https://jira-dc.paloaltonetworks.com/browse/CRTX-104969