### PR TITLE
[Ruff] Added The W291-trailing-whitespace Rule

### DIFF
--- a/nightly_ruff.toml
+++ b/nightly_ruff.toml
@@ -179,6 +179,8 @@ select = [
     "UP033", # lru-cache-with-maxsize-none
     "UP037", # quoted-annotation
 
+    "W291", # trailing-whitespace
+
     "YTT101", # sys-version-slice3
     "YTT102", # sys-version2
     "YTT103", # sys-version-cmp-str3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,6 +452,8 @@ select = [
     "UP037", # quoted-annotation
     "UP038", # non-pep604-isinstance
 
+    "W291", # trailing-whitespace
+
     "YTT101", # sys-version-slice3
     "YTT102", # sys-version2
     "YTT103", # sys-version-cmp-str3


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:[ link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9676)


## Description
Adding the W291-trailing-whitespace rule to both `pyproject.toml`, and `nightly_ruff.toml`.
Blocked by https://github.com/demisto/content/pull/32855
