### PR TITLE
Return XML Object

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -8975,7 +8975,7 @@ if 'requests' in sys.modules:
                     if resp_type == 'content':
                         return res.content
                     if resp_type == 'xml':
-                        ET.fromstring(res.text)
+                        return ET.fromstring(res.text)
                     if resp_type == 'response':
                         return res
                     return res


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
When `BaseClient._http_request` is called with `resp_type='xml'`, an XML object is created but not returned. This PR fixes this issue.

## Must have
- [ ] Tests
- [ ] Documentation 
