### PR TITLE
ServiceNowV2: fix bug in upload-file command

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -1,7 +1,6 @@
 import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 import re
-import shutil
 from collections.abc import Callable, Iterable
 
 
@@ -709,8 +708,8 @@ class Client(BaseClient):
                 try:
                     file_entry = file['id']
                     file_name = file['name']
-                    shutil.copy(demisto.getFilePath(file_entry)['path'], file_name)
-                    with open(file_name, 'rb') as f:
+                    file_path = demisto.getFilePath(file_entry)['path']
+                    with open(file_path, 'rb') as f:
                         file_info = (file_name, f, self.get_content_type(file_name))
                         if self.use_oauth:
                             access_token = self.snow_client.get_access_token()
@@ -723,7 +722,6 @@ class Client(BaseClient):
                             res = requests.request(method, url, headers=headers, data=body, params=params,
                                                    files={'file': file_info}, auth=self._auth,
                                                    verify=self._verify, proxies=self._proxies)
-                    shutil.rmtree(demisto.getFilePath(file_entry)['name'], ignore_errors=True)
                 except Exception as err:
                     raise Exception('Failed to upload file - ' + str(err))
             else:

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1610,7 +1610,7 @@ script:
     - contextPath: ServiceNow.Generic.Response
       description: Generic response to servicenow api.
       type: string
-  dockerimage: demisto/python3:3.10.13.86272
+  dockerimage: demisto/python3:3.10.13.87159
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/ServiceNow/ReleaseNotes/2_5_54.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_54.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ServiceNow v2
+
+- Fixed an issue where the ***servicenow-upload-file*** command failed in case the file name contained invalid characters.
+- Updated the Docker image to: *demisto/python3:3.10.13.87159*.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.5.53",
+    "currentVersion": "2.5.54",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-33532

## Description
_Problem_:
In the `upload-file` command there is redundant `copy` to copy the file from fileEntry path to local 
this cause an exception when the file name contain invalid characters (especial `/`).
_Fix_:
Remove the redundant code that cause the bug.

