### PR TITLE
Added Compatibility with new Allowed Indicator Module in CTIX 3.6

### DIFF
--- a/Packs/CTIX/Integrations/CTIX/CTIX.py
+++ b/Packs/CTIX/Integrations/CTIX/CTIX.py
@@ -13,7 +13,7 @@ import json
 import requests
 import urllib.parse
 import urllib3
-from typing import Any, Dict
+from typing import Any
 
 # Disable insecure warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -233,7 +233,7 @@ def test_module(client: Client):
     demisto.results('ok')
 
 
-def ip_details_command(client: Client, args: Dict[str, Any]) -> List[CommandResults]:
+def ip_details_command(client: Client, args: dict[str, Any]) -> List[CommandResults]:
     """
     ip command: Returns IP details for a list of IPs
     """
@@ -304,7 +304,7 @@ def ip_details_command(client: Client, args: Dict[str, Any]) -> List[CommandResu
     return ip_data_list
 
 
-def domain_details_command(client: Client, args: Dict[str, Any]) -> List[CommandResults]:
+def domain_details_command(client: Client, args: dict[str, Any]) -> List[CommandResults]:
     """
     domain command: Returns domain details for a list of domains
     """
@@ -374,7 +374,7 @@ def domain_details_command(client: Client, args: Dict[str, Any]) -> List[Command
     return domain_data_list
 
 
-def url_details_command(client: Client, args: Dict[str, Any]) -> List[CommandResults]:
+def url_details_command(client: Client, args: dict[str, Any]) -> List[CommandResults]:
     """
     url command: Returns URL details for a list of URL
     """
@@ -443,7 +443,7 @@ def url_details_command(client: Client, args: Dict[str, Any]) -> List[CommandRes
     return url_data_list
 
 
-def file_details_command(client: Client, args: Dict[str, Any]) -> List[CommandResults]:
+def file_details_command(client: Client, args: dict[str, Any]) -> List[CommandResults]:
     """
     file command: Returns FILE details for a list of FILE
     """
@@ -489,7 +489,7 @@ def file_details_command(client: Client, args: Dict[str, Any]) -> List[CommandRe
             elif hash_type == "sha256":
                 file_standard_context.sha256 = file_key
             elif hash_type == "sha512":
-                file_standard_context.sha512 == file_key
+                file_standard_context.sha512 = file_key
 
             file_data_list.append(CommandResults(
                 readable_output=tableToMarkdown('File Data', file_data, removeNull=True),
@@ -517,7 +517,7 @@ def file_details_command(client: Client, args: Dict[str, Any]) -> List[CommandRe
             elif hash_type == "sha256":
                 file_standard_context.sha256 = file_key
             elif hash_type == "sha512":
-                file_standard_context.sha512 == file_key
+                file_standard_context.sha512 = file_key
 
             file_data_list.append(CommandResults(
                 readable_output=f'No matches found for FILE {file_key}',
@@ -529,7 +529,7 @@ def file_details_command(client: Client, args: Dict[str, Any]) -> List[CommandRe
     return file_data_list
 
 
-def create_intel_command(client: Client, args: Dict[str, Any]) -> Dict:
+def create_intel_command(client: Client, args: dict[str, Any]) -> dict:
     """
     create_intel command: Creates Intel in CTIX
     """

--- a/Packs/CTIX/Integrations/CTIX/CTIX.yml
+++ b/Packs/CTIX/Integrations/CTIX/CTIX.yml
@@ -784,7 +784,7 @@ script:
     - contextPath: CTIX.Intel.status
       description: Status code returned from the api.
       type: String
-  dockerimage: demisto/python3:3.10.13.84405
+  dockerimage: demisto/python3:3.10.13.87159
   subtype: python3
 tests:
 - No tests

--- a/Packs/CTIX/Integrations/CTIX/CTIX_test.py
+++ b/Packs/CTIX/Integrations/CTIX/CTIX_test.py
@@ -1,4 +1,3 @@
-import io
 import json
 
 '''CONSTANTS'''
@@ -9,7 +8,7 @@ SECRET_KEY = "secret_key"
 
 
 def util_load_json(path):
-    with io.open(path, mode='r', encoding='utf-8') as f:
+    with open(path, encoding='utf-8') as f:
         return json.loads(f.read())
 
 
@@ -276,6 +275,6 @@ def test_create_intel(requests_mock):
     }
     response = create_intel_command(client, post_data)
 
-    assert 'data', 'status' in response['CTIX']['Intel']['response']
+    assert all(k in response['CTIX']['Intel']['response'] for k in ('data', 'status'))
     assert 'status' in response['CTIX']['Intel']
     assert response['CTIX']['Intel']['response']['status'] == 201

--- a/Packs/CTIX/Integrations/CTIXv3/CTIXv3.yml
+++ b/Packs/CTIX/Integrations/CTIXv3/CTIXv3.yml
@@ -1859,7 +1859,7 @@ script:
     - contextPath: DBotScore.Score
       description: The actual score.
       type: Number
-  dockerimage: demisto/python3:3.10.13.84405
+  dockerimage: demisto/python3:3.10.13.87159
   subtype: python3
 tests:
 - No tests (auto formatted)

--- a/Packs/CTIX/ReleaseNotes/2_2_16.md
+++ b/Packs/CTIX/ReleaseNotes/2_2_16.md
@@ -1,0 +1,6 @@
+#### Integrations
+##### Cyware Threat Intelligence eXchange
+- Updated the Docker image to: *demisto/python3:3.10.13.87159*.
+##### CTIX v3
+- Added Compatibility with new Allowed Indicator Module.
+- Updated the Docker image to: *demisto/python3:3.10.13.87159*.

--- a/Packs/CTIX/pack_metadata.json
+++ b/Packs/CTIX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CTIX",
     "description": "Cyware Threat Intelligence eXchange",
     "support": "partner",
-    "currentVersion": "2.2.15",
+    "currentVersion": "2.2.16",
     "author": "Cyware Labs",
     "url": "https://cyware.com/",
     "email": "connector-dev@cyware.com",


### PR DESCRIPTION
I also ran all of the pre-commit hooks and resolved all of those issues.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The main goal of this PR is to make the `ctix-allowed-iocs` and `ctix-get-allowed-iocs` compatible with CTIX 3.6 as the endpoint used by those two commands changed in that version. For both commands, we'll make a call to the new endpoint first, and if that returns a 404 (which it will if the user has CTIX < 3.6), make a call to the previous endpoint.

The rest of the changes are all done by running the pre-commit hooks.

## Must have
- [x] Tests
- [x] Documentation 
