### PR TITLE
ServiceNow mirror: fix bug when mirror not started

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2394,7 +2394,7 @@ def get_remote_data_command(client: Client, args: dict[str, Any], params: dict) 
         arg_name='lastUpdate',
         required=True
     )
-    demisto.debug(f'last_update of {ticket_id=} is {last_update}')
+    demisto.debug(f'last_update is {last_update}')
 
     ticket_type = client.ticket_type
     result = client.get(ticket_type, ticket_id)

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -2394,13 +2394,13 @@ def get_remote_data_command(client: Client, args: dict[str, Any], params: dict) 
         arg_name='lastUpdate',
         required=True
     )
-    demisto.debug(f'last_update is {last_update}')
+    demisto.debug(f'last_update of {ticket_id=} is {last_update}')
 
     ticket_type = client.ticket_type
     result = client.get(ticket_type, ticket_id)
 
     if not result or 'result' not in result:
-        return 'Ticket was not found.'
+        return f'Ticket {ticket_id=} was not found.'
 
     if isinstance(result['result'], list):
         if len(result['result']) == 0:
@@ -2417,13 +2417,15 @@ def get_remote_data_command(client: Client, args: dict[str, Any], params: dict) 
         required=False
     )
 
-    demisto.debug(f'ticket_last_update is {ticket_last_update}')
-
-    if last_update > ticket_last_update:
-        demisto.debug('Nothing new in the ticket')
+    demisto.debug(f'ticket_last_update of {ticket_id=} is {ticket_last_update}')
+    is_fetch = demisto.params().get('isFetch')
+    if is_fetch and last_update > ticket_last_update:
+        demisto.debug(f'Nothing new in the ticket {ticket_id=}')
         ticket = {}
 
     else:
+        # in case we use SNOW just to mirror by setting the incident with mirror fields
+        # is_fetch will be false, so we will update even the XSOAR incident will be updated then SNOW ticket.
         demisto.debug(f'ticket is updated: {ticket}')
 
     parse_dict_ticket_fields(client, ticket)

--- a/Packs/ServiceNow/ReleaseNotes/2_5_55.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_5_55.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ServiceNow v2
+
+- Fixed an issue where mirroring did not work in case mirror fields set direct after ServiceNow ticket is created.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.5.54",
+    "currentVersion": "2.5.55",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-33571

## Description
In case of [trigger-incident-is-not-servicenow](https://xsoar.pan.dev/docs/reference/integrations/service-now-v2#configure-incident-mirroring-when-the-trigger-incident-is-not-servicenow)
there is cases when we create the SNOW ticket and after that set the XSOAR incident mirror related fields
this cause the incident to be updated then the SNOW ticket, and `get-remote-date` to return empty

_**Fix:**_
check if `isFetch` is False (in `rigger-incident-is-not-servicenow` it will be False and then return the remote data even the XSOAR incident are updated then the SNOW ticket, 