### PR TITLE
[OpenCTI] Update Documentation

### DIFF
--- a/Packs/OpenCTI/.pack-ignore
+++ b/Packs/OpenCTI/.pack-ignore
@@ -1,5 +1,8 @@
 [file:README.md]
 ignore=RM106
 
+[file:Packs/OpenCTI/ReleaseNotes/1_0_10.md]
+ignore=RN112
+
 [known_words]
 OpenCTI

--- a/Packs/OpenCTI/Integrations/OpenCTI/README.md
+++ b/Packs/OpenCTI/Integrations/OpenCTI/README.md
@@ -1,4 +1,8 @@
-Manages indicators from OpenCTI. Compatible with OpenCTI 4.X API and OpenCTI 5.X API versions.
+Manages indicators from OpenCTI.  
+This integration is compatible with OpenCTI versions from 4.X to 5.11.X.  
+
+**Note**: Due to [breaking changes to the OpenCTI API on version 5.12.0](https://github.com/OpenCTI-Platform/opencti/releases/tag/5.12.0), this integration is not currently compatible with OpenCTI versions 5.12.0 and above.
+
 ## Configure OpenCTI on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.

--- a/Packs/OpenCTI/ReleaseNotes/1_0_10.md
+++ b/Packs/OpenCTI/ReleaseNotes/1_0_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### OpenCTI
+
+- Updated the documentation to specify that versions 5.12.0 and above of OpenCTI are not currently supported due to [breaking changes to the API](https://github.com/OpenCTI-Platform/opencti/releases/tag/5.12.0).

--- a/Packs/OpenCTI/pack_metadata.json
+++ b/Packs/OpenCTI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "OpenCTI",
     "description": "Manages indicators from OpenCTI.",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/XSUP-33614

## Description
Update documentation to specify that versions 5.12.0 of OpenCTI are not currently supported.