### PR TITLE
[Native Image] Update native image tag

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -29,9 +29,7 @@
                 "chromium",
                 "tesseract",
                 "netutils",
-                "auth-utils",
-                "openpyxl",
-                "python-pptx"
+                "auth-utils"
             ],
             "docker_ref": "demisto/py3-native:8.6.0.88298"
         },

--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -29,7 +29,9 @@
                 "chromium",
                 "tesseract",
                 "netutils",
-                "auth-utils"
+                "auth-utils",
+                "openpyxl",
+                "python-pptx"
             ],
             "docker_ref": "demisto/py3-native:8.6.0.88298"
         },

--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -31,7 +31,7 @@
                 "netutils",
                 "auth-utils"
             ],
-            "docker_ref": "demisto/py3-native:8.6.0.88042"
+            "docker_ref": "demisto/py3-native:8.6.0.88298"
         },
         "native:dev":{
             "supported_docker_images":[


### PR DESCRIPTION
## Description
Update native image tag to `demisto/py3-native:8.6.0.88298`.
After support for `openpyxl` and `python-pptx` packages was added in this PR https://github.com/demisto/dockerfiles/pull/24500, we're upgrading the native image reference to the latest version.

