### PR TITLE
Fix retrieve the SDK changelog workflow status while loop

### DIFF
--- a/Tests/sdk_release/create_sdk_pr.py
+++ b/Tests/sdk_release/create_sdk_pr.py
@@ -187,14 +187,13 @@ def main():
             logging.error(response.text)
             sys.exit(1)
 
-        job_data = response.json().get('jobs', [])[0]  
+        job_data = response.json().get('jobs', [])[0]
         status = job_data.get('status')
         if status == "completed":
             logging.info("SDK changelog workflow completed")
             break
 
         logging.info(f'waiting to SDK changelog workflow to finish, current status: {status}')
-
 
         elapsed = time.time() - start
         if elapsed >= TIMEOUT:

--- a/Tests/sdk_release/create_sdk_pr.py
+++ b/Tests/sdk_release/create_sdk_pr.py
@@ -177,6 +177,7 @@ def main():
     ).get('id')
 
     logging.info(f'SDK changelog workflow triggered successfully: {SDK_WORKFLOW_SUFFIX}{workflow_id}')
+    time.sleep(10)
     elapsed: float = 0
     start = time.time()
     while elapsed < TIMEOUT:

--- a/Tests/sdk_release/create_sdk_pr.py
+++ b/Tests/sdk_release/create_sdk_pr.py
@@ -177,7 +177,6 @@ def main():
     ).get('id')
 
     logging.info(f'SDK changelog workflow triggered successfully: {SDK_WORKFLOW_SUFFIX}{workflow_id}')
-
     elapsed: float = 0
     start = time.time()
     while elapsed < TIMEOUT:
@@ -188,8 +187,7 @@ def main():
             logging.error(response.text)
             sys.exit(1)
 
-        job_data = response.json().get('jobs', [])[0]
-        
+        job_data = response.json().get('jobs', [])[0]  
         status = job_data.get('status')
         if status == "completed":
             logging.info("SDK changelog workflow completed")

--- a/Tests/sdk_release/create_sdk_pr.py
+++ b/Tests/sdk_release/create_sdk_pr.py
@@ -177,10 +177,11 @@ def main():
     ).get('id')
 
     logging.info(f'SDK changelog workflow triggered successfully: {SDK_WORKFLOW_SUFFIX}{workflow_id}')
-    time.sleep(10)
+
     elapsed: float = 0
     start = time.time()
     while elapsed < TIMEOUT:
+        time.sleep(10)
         response = requests.request('GET', url, headers=headers, verify=False)
         if response.status_code != requests.codes.ok:
             logging.error('Failed to retrieve SDK changelog workflow status')
@@ -188,13 +189,14 @@ def main():
             sys.exit(1)
 
         job_data = response.json().get('jobs', [])[0]
+        
         status = job_data.get('status')
         if status == "completed":
             logging.info("SDK changelog workflow completed")
             break
 
         logging.info(f'waiting to SDK changelog workflow to finish, current status: {status}')
-        time.sleep(10)
+
 
         elapsed = time.time() - start
         if elapsed >= TIMEOUT:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
moved the sleep(10) to the beginnig of the while loop to get the workflow status, example for failure pipeline:
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/4865011

## Must have
- [ ] Tests
- [ ] Documentation 
