### PR TITLE
[Native Image] Upgrade native:candidate to 8.6

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -94,7 +94,7 @@
                 "netutils",
                 "auth-utils"
             ],
-            "docker_ref": "demisto/py3-native:8.4.0.86696"
+            "docker_ref": "demisto/py3-native:8.6.0.88298"
         }
     },
     "ignored_content_items":[


### PR DESCRIPTION
## Description
Upgrade native:candidate to `demisto/py3-native:8.6.0.88298`.
This upgrade is to handle recently added libraries in native:8.6.