### PR TITLE
added arg to the command

### DIFF
--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.py
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.py
@@ -1699,11 +1699,11 @@ def get_limited_number_of_messages_from_qs(qs, limit):  # pragma: no cover
 
 
 def search_items_in_mailbox(query=None, message_id=None, folder_path='', limit=100, target_mailbox=None,
-                            is_public=None, selected_fields='all'):  # pragma: no cover
+                            is_public=None, selected_fields='all', surround_id_with_angle_brackets=True):  # pragma: no cover
     if not query and not message_id:
         return_error("Missing required argument. Provide query or message-id")
 
-    if message_id and message_id[0] != '<' and message_id[-1] != '>':
+    if argToBoolean(surround_id_with_angle_brackets) and message_id and message_id[0] != '<' and message_id[-1] != '>':
         message_id = f'<{message_id}>'
 
     account = get_account(target_mailbox or ACCOUNT_EMAIL)

--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
@@ -348,6 +348,12 @@ script:
       name: selected-fields
       predefined:
       - ''
+    - auto: PREDEFINED
+      description: Whether to surround the message id with angle brackets (<>) if not exist. Default is 'True'.
+      name: surround_id_with_angle_brackets
+      predefined:
+      - 'True'
+      - 'False'
     description: Searches for items in the specified mailbox. Specific permissions are needed for this operation to search in a target mailbox other than the default.
     name: ews-search-mailbox
     outputs:

--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/README.md
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/README.md
@@ -316,7 +316,6 @@ The number of mailboxes to search in may be limited by Microsoft Exchange. See [
 | limit | Maximum number of results to return. Default is 250. | Optional | 
 | email_addresses | CSV list or array of email addresses. | Optional | 
 
-
 #### Context Output
 
 | **Path** | **Type** | **Description** |
@@ -464,6 +463,8 @@ Searches for items in the specified mailbox. Specific permissions are needed for
 | is-public | Whether the folder is a Public Folder?. Possible values are: True, False. | Optional | 
 | message-id | The message ID of the email. This will be ignored if a query argument is provided. | Optional | 
 | selected-fields | A CSV list of fields to retrieve. Possible values are: . Default is all. | Optional | 
+| surround_id_with_angle_brackets | Whether to surround the message id with angle brackets (<>) if not exist. Default is 'True'. | Optional | 
+
 
 
 #### Context Output

--- a/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_1_1.md
+++ b/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_1_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS v2
+
+- Added argument *surround_id_with_angle_brackets* to **ews-search-mailboxes** command.

--- a/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange On-Premise",
     "description": "Exchange Web Services",
     "support": "xsoar",
-    "currentVersion": "2.1.0",
+    "currentVersion": "2.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-33736

## Description
**_Problem:_**
The `message-id` may have  `<>` and may not 
in case it's not have, currently we add it in the code.
this cause a bug when the original id not contained them - the search will not find the message by searching by `<ID>`
**_Fix_:**
Added the argument *surround_id_with_angle_brackets* (default: True) to the **ews-search-mailboxes** command
and only it's `True` add the `<>`

## Must have
- [x] Documentation 
