### PR TITLE
Fix CS Falcon X TPB

### DIFF
--- a/Packs/CrowdStrikeFalconX/TestPlaybooks/CrowdStrike_Falcon_X_-Test-Detonate_File.yml
+++ b/Packs/CrowdStrikeFalconX/TestPlaybooks/CrowdStrike_Falcon_X_-Test-Detonate_File.yml
@@ -83,13 +83,13 @@ tasks:
       - "4"
     scriptarguments:
       filename:
-        simple: "# test.pdf"
+        simple: "# script.py"
       method:
         simple: GET
       saveAsFile:
         simple: "yes"
       url:
-        simple: http://www.pdf995.com/samples/pdf.pdf
+        simple: https://raw.githubusercontent.com/demisto/content/3ef746414beb35924fd5ce4c74bf646867ccbba6/Packs/CrowdStrikeFalconX/Integrations/CrowdStrikeFalconX/CrowdStrikeFalconX.py
     separatecontext: false
     view: |-
       {


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-8659)

## Description
Test playbook `CrowdStrike_Falcon_X_-Test-Detonate_File` is failing nightly because it downloaded a PDF file that no longer exists.
This PR changes the download file to a file in this repo that won't be removed.

## Must have
- [ ] Tests
- [ ] Documentation 
