### PR TITLE
New Arg 'language'

### DIFF
--- a/Packs/ML/ReleaseNotes/1_4_11.md
+++ b/Packs/ML/ReleaseNotes/1_4_11.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### DBotPredictOutOfTheBoxV2
+
+- Added the argument `language` as an option.
+- Updated the Docker image to: *demisto/ml:1.0.0.88591*.

--- a/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
+++ b/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
@@ -73,7 +73,7 @@ script: '-'
 subtype: python3
 timeout: 60µs
 type: python
-dockerimage: demisto/ml:1.0.0.32340
+dockerimage: demisto/ml:1.0.0.88591
 runonce: true
 tests:
 - DbotPredictOufOfTheBoxTestV2

--- a/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
+++ b/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/DBotPredictOutOfTheBoxV2.yml
@@ -34,6 +34,20 @@ args:
   predefined:
   - 'true'
   - 'false'
+- auto: PREDEFINED
+  defaultValue: Any
+  description: The language of the input. Default is "Any". Can be "Any", "English", "German", "French", "Spanish", "Portuguese", "Italian", "Dutch", or "Other". If "Any"  or "Other" is selected, the script pre-process the entire input, no matter what its actual language is. If a specific language is selected, the script filters out any other language from the output text.
+  name: language
+  predefined:
+  - Any
+  - English
+  - German
+  - French
+  - Spanish
+  - Portuguese
+  - Italian
+  - Dutch
+  - Other
 commonfields:
   id: DBotPredictOutOfTheBoxV2
   version: -1

--- a/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/README.md
+++ b/Packs/ML/Scripts/DBotPredictOutOfTheBoxV2/README.md
@@ -1,6 +1,7 @@
 Predict phishing incidents using the out-of-the-box pre-trained model.
 
 ## Script Data
+
 ---
 
 | **Name** | **Description** |
@@ -9,7 +10,25 @@ Predict phishing incidents using the out-of-the-box pre-trained model.
 | Tags | phishing, ml |
 | Cortex XSOAR Version | 5.5.0 |
 
+## Dependencies
+
+---
+This script uses the following commands and scripts.
+
+* GetMLModelEvaluation
+* DBotPredictPhishingWords
+
+## Used In
+
+---
+This script is used in the following playbooks and scripts.
+
+* VerifyOOBV2Predictions-Test
+* DbotPredictOufOfTheBoxTestV2
+* Phishing - Machine Learning Analysis
+
 ## Inputs
+
 ---
 
 | **Argument Name** | **Description** |
@@ -24,8 +43,10 @@ Predict phishing incidents using the out-of-the-box pre-trained model.
 | confidenceThreshold | The confidence threshold. The model will provide predictions only if their confidence is above this threshold. |
 | returnError | Whether to return an error when there is no prediction. Default is "true". |
 | setIncidentFields | Whether to set Cortex XSOAR out-of-the-box DBot fields. |
+| language | The language of the input. Default is "Any". Can be "Any", "English", "German", "French", "Spanish", "Portuguese", "Italian", "Dutch", or "Other". If "Any"  or "Other" is selected, the script pre-process the entire input, no matter what its actual language is. If a specific language is selected, the script filters out any other language from the output text. |
 
 ## Outputs
+
 ---
 
 | **Path** | **Description** | **Type** |

--- a/Packs/ML/pack_metadata.json
+++ b/Packs/ML/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Machine Learning",
     "description": "Help to manage machine learning models in Cortex XSOAR",
     "support": "xsoar",
-    "currentVersion": "1.4.10",
+    "currentVersion": "1.4.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-34213)

## Description
Add the 'language' arg to the `DBotPredictOutOfTheBoxV2` script. The args in this script are forwarded to `DBotPredictPhishingWords`.

## Must have
- [ ] Tests
- [ ] Documentation 
