### PR TITLE
resolve CVEs in py-ews (kill the image)

### DIFF
--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.py
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.py
@@ -28,9 +28,12 @@ from exchangelib.util import add_xml_child, create_element
 from exchangelib.version import (EXCHANGE_2007, EXCHANGE_2010,
                                  EXCHANGE_2010_SP2, EXCHANGE_2013,
                                  EXCHANGE_2016, EXCHANGE_2019)
+from exchangelib.protocol import NoVerifyHTTPAdapter  # noqa: E402
+
 from future import utils as future_utils
 from requests.exceptions import ConnectionError
 from exchangelib.version import VERSIONS as EXC_VERSIONS
+import ssl
 
 
 # Exchange2 2019 patch - server dosen't connect with 2019 but with other versions creating an error mismatch (see CIAC-3086),
@@ -415,9 +418,7 @@ def prepare_context(credentials):  # pragma: no cover
 
 def prepare():  # pragma: no cover
     if NON_SECURE:
-        BaseProtocol.HTTP_ADAPTER_CLS = exchangelibSSLAdapter
-    else:
-        BaseProtocol.HTTP_ADAPTER_CLS = requests.adapters.HTTPAdapter
+        BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
 
     global AUTO_DISCOVERY, VERSION_STR, AUTH_METHOD_STR, USERNAME
     AUTO_DISCOVERY = not EWS_SERVER

--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
@@ -1103,7 +1103,7 @@ script:
       name: from
     description: Replies to an email using EWS.
     name: reply-mail
-  dockerimage: demisto/py3ews:1.0.0.89402
+  dockerimage: devdemisto/py3ews:1.0.0.89548
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Integrations/EWSv2/EWSv2.yml
@@ -1103,7 +1103,7 @@ script:
       name: from
     description: Replies to an email using EWS.
     name: reply-mail
-  dockerimage: demisto/py-ews:5.0.3.84262
+  dockerimage: demisto/py3ews:1.0.0.89402
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_1_2.md
+++ b/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_1_2.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### EWS v2
+
+- Updated the Docker image to: *demisto/py3ews:1.0.0.89402*.

--- a/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange On-Premise",
     "description": "Exchange Web Services",
     "support": "xsoar",
-    "currentVersion": "2.1.1",
+    "currentVersion": "2.1.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress


## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-9764)

## Description
updating the docker image to py3ews, since the old docker image ewsv2 contains cve. This cve is because the image is PowerShell based. All commands needing pwsh were deprecated a while ago. 