### PR TITLE
GoogleDrive: fix error in `file-upload` command

### DIFF
--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -1226,6 +1226,8 @@ def file_upload_command(client: 'GSuiteClient', args: dict[str, str]) -> Command
     file_path = demisto.getFilePath(file_entry_id)
 
     user_id = args.get('user_id') or client.user_id
+    supports_all_drives = argToBoolean(args.get('supports_all_drives', False))
+
     client.set_authorized_http(scopes=COMMAND_SCOPES['FILES'], subject=user_id)
     drive_service = discovery.build(serviceName=SERVICE_NAME, version=API_VERSION, http=client.authorized_http)
     body: dict[str, str] = assign_params(
@@ -1238,6 +1240,7 @@ def file_upload_command(client: 'GSuiteClient', args: dict[str, str]) -> Command
     media = MediaFileUpload(file_path['path'])
     file = drive_service.files().create(body=body,
                                         media_body=media,
+                                        supportsAllDrives=supports_all_drives,
                                         fields='*'
                                         ).execute()
     return handle_response_file_single(file, args)

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2115,6 +2115,13 @@ script:
       description: The file's Entry ID.
     - name: parent
       description: The ID of the parent folder which contains the file. If not specified as part of a create request, the file will be placed directly in the user's My Drive folder.
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: 'Whether the requesting application supports both My Drives and shared drives.'
+      name: supports_all_drives
+      predefined:
+      - "true"
+      - "false"
     outputs:
     - contextPath: GoogleDrive.File.File.id
       description: The ID of the file.

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -820,6 +820,7 @@ Creates a new file.
 | file_name | The name of the file to upload. | Optional | 
 | entry_id | The file's Entry ID. | Optional | 
 | parent | The ID of the parent folder which contains the file. If not specified as part of a create request, the file will be placed directly in the user's My Drive folder. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values: "true" and "false". Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 

--- a/Packs/GoogleDrive/ReleaseNotes/1_3_5.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_3_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Google Drive
+
+Fixed an issue where **google-drive-file-upload** command failed to upload file to a shared drive.

--- a/Packs/GoogleDrive/pack_metadata.json
+++ b/Packs/GoogleDrive/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Drive",
     "description": "Google Drive allows users to store files on their servers, synchronize files across devices, and share files. This integration helps you to create a new drive, query past activity and view change logs performed by the users, as well as list drives and files, and manage their permissions.",
     "support": "xsoar",
-    "currentVersion": "1.3.3",
+    "currentVersion": "1.3.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-34266

## Description
Fixed an issue of command fail when uploading to a shared drive
