### PR TITLE
Fix for the 'Entity Enrichment - Generic v3' playbook

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/Entity_Enrichment_-_Generic_v3.yml
+++ b/Packs/CommonPlaybooks/Playbooks/Entity_Enrichment_-_Generic_v3.yml
@@ -353,17 +353,29 @@ tasks:
     isautoswitchedtoquietmode: false
   "24":
     id: "24"
-    taskid: 7f313517-52cb-4653-8c77-08819d4910f3
+    taskid: 3543872e-d47e-47a3-8456-39ff9ccfcabd
     type: playbook
     task:
-      id: 7f313517-52cb-4653-8c77-08819d4910f3
+      id: 3543872e-d47e-47a3-8456-39ff9ccfcabd
       version: -1
       name: Account Enrichment - Generic v2.1
       playbookName: Account Enrichment - Generic v2.1
       type: playbook
       iscommand: false
       brand: ""
-      description: ''
+      description: |-
+        Enrich accounts using one or more integrations.
+        Supported integrations:
+        - Active Directory
+        - Microsoft Graph User
+        - SailPoint IdentityNow
+        - SailPoint IdentityIQ
+        - PingOne
+        - Okta
+        - AWS IAM
+        - Cortex XDR (account enrichment and reputation)
+
+        Also, the playbook supports the generic command 'iam-get-user' (implemented in IAM integrations. For more information, visit https://xsoar.pan.dev/docs/integrations/iam-integrations.
     nexttasks:
       '#none#':
       - "26"
@@ -372,6 +384,11 @@ tasks:
       Username:
         complex:
           root: inputs.Username
+          transformers:
+          - operator: uniq
+      Domain:
+        complex:
+          root: inputs.AccountDomain
           transformers:
           - operator: uniq
     separatecontext: true
@@ -623,6 +640,13 @@ inputs:
     simple: "False"
   required: false
   description: Whether to execute the reputation command on the indicator.
+  playbookInputQuery:
+- key: AccountDomain
+  value: {}
+  required: false
+  description: |-
+    Optional - This input is needed for the IAM-get-user command (used in the Account Enrichment - IAM playbook). Please provide the domain name that the user is related to.
+    Example: @xsoar.com
   playbookInputQuery:
 outputs:
 - contextPath: IP

--- a/Packs/CommonPlaybooks/Playbooks/Entity_Enrichment_-_Generic_v3_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/Entity_Enrichment_-_Generic_v3_README.md
@@ -6,14 +6,14 @@ This playbook uses the following sub-playbooks, integrations, and scripts.
 
 ### Sub-playbooks
 
-* CVE Enrichment - Generic v2
-* URL Enrichment - Generic v2
-* Domain Enrichment - Generic v2
+* IP Enrichment - Generic v2
 * Account Enrichment - Generic v2.1
 * Email Address Enrichment - Generic v2.1
-* IP Enrichment - Generic v2
+* Domain Enrichment - Generic v2
 * Endpoint Enrichment - Generic v2.1
 * File Enrichment - Generic v2
+* URL Enrichment - Generic v2
+* CVE Enrichment - Generic v2
 
 ### Integrations
 
@@ -48,6 +48,7 @@ This playbook does not use any commands.
 | CVE | CVE ID to enrich. | CVE.ID | Optional |
 | URLSSLVerification | Whether to verify SSL certificates for URLs.<br/>Can be True or False. | False | Optional |
 | UseReputationCommand | Whether to execute the reputation command on the indicator. | False | Optional |
+| AccountDomain | Optional - This input is needed for the IAM-get-user command \(used in the Account Enrichment - IAM playbook\). Please provide the domain name that the user is related to.<br/>Example: @xsoar.com |  | Optional |
 
 ## Playbook Outputs
 

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_6_19.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_6_19.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Entity Enrichment - Generic v3
+
+- Added a new playbook input for providing the user's domain name for the account enrichment sub-playbook.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.6.18",
+    "currentVersion": "2.6.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9929

## Description
I added a new playbook input named "AccountDomain". It provides the user's domain name for the account enrichment sub-playbook.
