### PR TITLE
[Rasterize] Fix a bug where input doesn't support array

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -658,23 +658,21 @@ def perform_rasterize(path: str,
     if browser:
         support_multithreading()
         with ThreadPoolExecutor(max_workers=MAX_CHROME_TABS_COUNT) as executor:
-            paths = argToList(path)
-            demisto.debug(f"rasterize, {paths=}, {rasterize_type=}")
+            demisto.debug(f"rasterize, {path=}, {rasterize_type=}")
             rasterization_threads = []
             rasterization_results = []
-            for current_path in paths:
-                if not current_path.startswith('http') and not current_path.startswith('file:///'):
-                    current_path = f'http://{current_path}'
+            if not path.startswith('http') and not path.startswith('file:///'):
+                path = f'http://{path}'
 
-                # Start a new thread in group of max_tabs
-                rasterization_threads.append(
-                    executor.submit(
-                        rasterize_thread, browser=browser, chrome_port=chrome_port, path=current_path,
-                        rasterize_type=rasterize_type, wait_time=wait_time, offline_mode=offline_mode,
-                        navigation_timeout=navigation_timeout, include_url=include_url, full_screen=full_screen, width=width,
-                        height=height
-                    )
+            # Start a new thread in group of max_tabs
+            rasterization_threads.append(
+                executor.submit(
+                    rasterize_thread, browser=browser, chrome_port=chrome_port, path=path,
+                    rasterize_type=rasterize_type, wait_time=wait_time, offline_mode=offline_mode,
+                    navigation_timeout=navigation_timeout, include_url=include_url, full_screen=full_screen, width=width,
+                    height=height
                 )
+            )
             # Wait for all tasks to complete
             executor.shutdown(wait=True)
             demisto.info(f"Finished {len(rasterization_threads)} rasterizations, active tabs len: {len(browser.list_tab())}")

--- a/Packs/rasterize/Integrations/rasterize/rasterize.yml
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.yml
@@ -65,7 +65,6 @@ script:
           description: The URL to rasterize. Must be the full URL, including the http
             prefix.
           name: url
-          isArray: true
           required: true
         - defaultValue: 1024px
           description: The page width, for example, 1024px. Specify with or without the px
@@ -355,7 +354,7 @@ script:
         - contextPath: InfoFile.Type
           description: The type of the image/pdf file.
           type: string
-  dockerimage: demisto/chromium:122.0.6261.88727
+  dockerimage: demisto/chromium:122.0.6261.89236
   runonce: false
   script: "-"
   subtype: python3

--- a/Packs/rasterize/ReleaseNotes/2_0_3.md
+++ b/Packs/rasterize/ReleaseNotes/2_0_3.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### Rasterize
-- Fix the input for the command *rasterize* so both inputs file_name and url are similar type.
+- Fixed an issue where `rasterize` did not support and array of urls.
 - Updated the Docker image to: *demisto/chromium:122.0.6261.89236*.

--- a/Packs/rasterize/ReleaseNotes/2_0_3.md
+++ b/Packs/rasterize/ReleaseNotes/2_0_3.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### Rasterize
-- Fixed an issue where `rasterize` did not support and array of urls.
+- Fixed an issue where `rasterize` did not support an array of urls.
 - Updated the Docker image to: *demisto/chromium:122.0.6261.89236*.

--- a/Packs/rasterize/ReleaseNotes/2_0_3.md
+++ b/Packs/rasterize/ReleaseNotes/2_0_3.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Rasterize
+- Fix the input for the command *rasterize* so both inputs file_name and url are similar type.
+- Updated the Docker image to: *demisto/chromium:122.0.6261.89236*.

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "2.0.2",
+    "currentVersion": "2.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
When executing the *rasterize* command with an array of url and an array of file_name so that the filename matches the url to be screenshot the command isn't working properly.
The two input are not the same type: 
- the input *url* the type is  *isArray:True* 
- the input *file_name* the type is *isArray:False*

Therefore the command was launch multiple time for each file_name.

I fix the issue by removing the *isArray* on the input *url*, so now both inputs (url and file_name) for the command *rasterize* have the same type. If there is multiple inputs (an array of url is passed as the input of the command) the command is launch for each url and behave correctly.


## Must have
- [ ] Tests
- [ ] Documentation 
