### PR TITLE
Update `demisto/py3-tools` 75-100-Nightly coverage rate

### DIFF
--- a/Packs/CommonScripts/Scripts/FetchIndicatorsFromFile/FetchIndicatorsFromFile.py
+++ b/Packs/CommonScripts/Scripts/FetchIndicatorsFromFile/FetchIndicatorsFromFile.py
@@ -47,6 +47,9 @@ def xls_file_to_indicator_list(file_path, sheet_name, col_num, starting_row, aut
 
     # TODO: add run on all columns functionality
 
+    # Ensure that the has_iter will not be reseted after opening the workbook.
+    xlrd.xlsx.ensure_elementtree_imported(False, None)
+    xlrd.xlsx.Element_has_iter = True
     xl_woorkbook = xlrd.open_workbook(file_path)
     if sheet_name and sheet_name != 'None':
         xl_sheet = xl_woorkbook.sheet_by_name(sheet_name)

--- a/Packs/CommonScripts/Scripts/FetchIndicatorsFromFile/FetchIndicatorsFromFile.yml
+++ b/Packs/CommonScripts/Scripts/FetchIndicatorsFromFile/FetchIndicatorsFromFile.yml
@@ -64,7 +64,7 @@ tags:
 - indicators
 timeout: '0'
 type: python
-dockerimage: demisto/py3-tools:1.0.0.46591
+dockerimage: demisto/py3-tools:1.0.0.89345
 fromversion: 6.5.0
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/py3-tools` docker image of the following integration/scripts which coverage rate of `75-100-Nightly`%:

```
Packs/CommonScripts/Scripts/FetchIndicatorsFromFile/FetchIndicatorsFromFile.yml
```

### Please Note - The branch contained nightly packs- need instances test
