### PR TITLE
Update `demisto/sane-pdf-reports` 75-100-Nightly coverage rate

### DIFF
--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
@@ -45,7 +45,7 @@ tags:
 - pdf
 timeout: '0'
 type: python
-dockerimage: demisto/sane-pdf-reports:1.0.0.84389
+dockerimage: demisto/sane-pdf-reports:1.0.0.88753
 runas: DBotWeakRole
 tests:
 - No Test

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
@@ -4,7 +4,7 @@ args:
   name: sane_pdf_report_base64
   required: true
 - defaultValue: portrait
-  description: Orientation of the report.
+  description: orientation of the report.
   name: orientation
 - defaultValue: A4
   description: the paper size of the report.

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
@@ -4,7 +4,7 @@ args:
   name: sane_pdf_report_base64
   required: true
 - defaultValue: portrait
-  description: orientation of the report.
+  description: Orientation of the report.
   name: orientation
 - defaultValue: A4
   description: the paper size of the report.


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/sane-pdf-reports` docker image of the following integration/scripts which coverage rate of `75-100-Nightly`%:

```
Packs/Base/Scripts/SanePdfReport/SanePdfReport.yml
```

### Please Note - The branch contained nightly packs- need instances test
