### PR TITLE
VT Update

### DIFF
--- a/Packs/VirusTotal/Integrations/VirusTotalV3/README.md
+++ b/Packs/VirusTotal/Integrations/VirusTotalV3/README.md
@@ -18,6 +18,7 @@ The integration was integrated and tested with version v3 API of VirusTotal.
     | Premium Subscription | Whether to use premium subscription. (For advanced reputation analyze. See [Premium analysis - Relationship Files Threshold](#premium-analysis---relationship-files-threshold)) | False |
     | File Malicious Threshold. Minimum number of positive results from VT scanners to consider the file malicious. | See [Indicator Thresholds](#indicator-thresholds). | False |
     | File Suspicious Threshold. Minimum number of positive and suspicious results from VT scanners to consider the file suspicious. | See [Indicator Thresholds](#indicator-thresholds). | False |
+    | Excluded File Types | Pipe delimited list of file types to exclude from the file reputation check when the information is available in the context. | False |
     | IP Malicious Threshold. Minimum number of positive results from VT scanners to consider the IP malicious. | See [Indicator Thresholds](#indicator-thresholds). | False |
     | IP Suspicious Threshold. Minimum number of positive and suspicious results from VT scanners to consider the IP suspicious. | See [Indicator Thresholds](#indicator-thresholds). | False |
     | Disable reputation lookups for private IP addresses | To reduce the number of lookups made to the VT API, this option can be selected to gracefully skip enrichment of any IP addresses allocated for private networks. | False |

--- a/Packs/VirusTotal/Integrations/VirusTotalV3/VirusTotalV3.py
+++ b/Packs/VirusTotal/Integrations/VirusTotalV3/VirusTotalV3.py
@@ -1850,7 +1850,7 @@ def file_command(client: Client, score_calculator: ScoreCalculator, args: dict, 
     return results
 
 
-def private_file_command(client: Client, args: dict, excluded_extensions:list) -> List[CommandResults]:
+def private_file_command(client: Client, args: dict) -> List[CommandResults]:
     """
     1 API Call
     """

--- a/Packs/VirusTotal/ReleaseNotes/2_6_18.md
+++ b/Packs/VirusTotal/ReleaseNotes/2_6_18.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### VirusTotal (API v3)
+
+- Added support for excluding specific file types from being uploaded to VT when using the ***file*** command through the addition of an *excluded_extensions* instance parameter.

--- a/Packs/VirusTotal/pack_metadata.json
+++ b/Packs/VirusTotal/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VirusTotal",
     "description": "Analyze suspicious hashes, URLs, domains and IP addresses",
     "support": "partner",
-    "currentVersion": "2.6.17",
+    "currentVersion": "2.6.18",
     "author": "VirusTotal",
     "url": "https://www.virustotal.com",
     "email": "contact@virustotal.com",


### PR DESCRIPTION
## Status
- [ x ] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
Adds the capability to prevent the "file" reputation command from retrieving details from VirusTotal where a file name is present in the context and the extension is present in the instance parameter. This will prevent over-usage of VirusTotal licences in constrained environments. 

## Must have
- [ ] Tests
- [ ] Documentation 
