### PR TITLE
Update `demisto/pwsh-exchange` 75-100-Nightly coverage rate

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml
+++ b/Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml
@@ -33,7 +33,7 @@ tags:
 - basescript
 timeout: '0'
 type: powershell
-dockerimage: demisto/pwsh-exchange:1.0.0.34118
+dockerimage: demisto/pwsh-exchange:1.0.0.88372
 fromversion: 5.5.0
 tests:
 - CreateCertificate-Test


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/pwsh-exchange` docker image of the following integration/scripts which coverage rate of `75-100-Nightly`%:

```
Packs/MicrosoftExchangeOnline/Scripts/CreateCertificate/CreateCertificate.yml
```

### Please Note - The branch contained nightly packs- need instances test
