### PR TITLE
SymantecMessagingGateway: fix an ssl connection error

### DIFF
--- a/Packs/Symantec_Messaging_Gateway/Integrations/SymantecMessagingGateway/SymantecMessagingGateway.py
+++ b/Packs/Symantec_Messaging_Gateway/Integrations/SymantecMessagingGateway/SymantecMessagingGateway.py
@@ -1,7 +1,6 @@
 import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 import urllib3
-import requests
 from bs4 import BeautifulSoup
 
 # disable insecure warnings
@@ -19,6 +18,7 @@ TOKEN: str
 BAD_DOMAINS_EMAILS_GROUP = 'Local Bad Sender Domains'
 BAD_IPS_GROUP = 'Local Bad Sender IPs'
 
+client = BaseClient(base_url=BASE_URL, verify=USE_SSL)
 ''' HELPER FUNCTIONS '''
 
 
@@ -26,7 +26,7 @@ def http_request(method, url_suffix, cookies=COOKIES, data=None, headers=None):
     LOG('running request with url={}\tdata={}\theaders={}'.format(BASE_URL + url_suffix,
                                                                   data, headers))
     try:
-        res = requests.request(
+        res = client._session.request(
             method,
             BASE_URL + url_suffix,
             verify=USE_SSL,

--- a/Packs/Symantec_Messaging_Gateway/ReleaseNotes/1_0_17.md
+++ b/Packs/Symantec_Messaging_Gateway/ReleaseNotes/1_0_17.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Symantec Messaging Gateway
+
+Fixed an issue where an SSL error has occurred when trying to connect to Symantec server.

--- a/Packs/Symantec_Messaging_Gateway/ReleaseNotes/1_0_17.md
+++ b/Packs/Symantec_Messaging_Gateway/ReleaseNotes/1_0_17.md
@@ -3,4 +3,4 @@
 
 ##### Symantec Messaging Gateway
 
-Fixed an issue where an SSL error has occurred when trying to connect to Symantec server.
+Fixed an issue where commands failed with SSL errors when trying to connect to Symantec server.

--- a/Packs/Symantec_Messaging_Gateway/pack_metadata.json
+++ b/Packs/Symantec_Messaging_Gateway/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Symantec Messaging Gateway",
     "description": "Symantec Messaging Gateway protects against spam, malware, and targeted attacks and provides advanced content filtering, data loss prevention, and email encryption.",
     "support": "xsoar",
-    "currentVersion": "1.0.16",
+    "currentVersion": "1.0.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-33687

## Description
After upgrading the docker image to `demisto/bs4-py3:1.0.0.86348`
the following ssl error is occurred 
`SSLV3_ALERT_HANDSHAKE_FAILURE`

this comes from the `urllib3` version installed in that docker image (2.1.0)

fix:
instead of call `requests.request` directly , use the `BaseClient` session, which contain a workaround already

@JudahSchwartz FYI
