### PR TITLE
Fix the style of ReleaseNotes

### DIFF
--- a/Packs/FeedDHS/ReleaseNotes/2_0_35.md
+++ b/Packs/FeedDHS/ReleaseNotes/2_0_35.md
@@ -2,5 +2,4 @@
 #### Integrations
 
 ##### DHS Feed v2
-
-- Update to the latest version of ApiModules.
+Updated the version of ApiModules.

--- a/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_31.md
+++ b/Packs/FeedMitreAttackv2/ReleaseNotes/1_1_31.md
@@ -2,5 +2,4 @@
 #### Integrations
 
 ##### MITRE ATT&CK
-
-- Update to the latest version of ApiModules.
+Updated the version of ApiModules.

--- a/Packs/FeedTAXII/ReleaseNotes/1_2_10.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_2_10.md
@@ -2,4 +2,4 @@
 #### Integrations
 
 ##### TAXII 2 Feed
-- Updated to the latest version of ApiModules.
+Updated the version of ApiModules.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
This fixes the style of releasenotes, which fails in the internal PR: #33361.
The reason for this is the fact, that current messages does not start with the required prefixes, which are:
```
'Added support for '
'Added the '
'Added a'
'Added an '
'Fixed an issue '
'Improved implementation '
'Updated the'
'You can now '
'Deprecated. '
'Deprecated the'
'Improved layout'
'Created a new layout'
'Playbook now supports'
'Created a new playbook'
```