### PR TITLE
Update `demisto/taxii-server` 0-50 coverage rate

### DIFF
--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
@@ -574,7 +574,7 @@ def get_stix_indicator(indicator: dict) -> stix.core.STIXPackage:
         id_ = f'{NAMESPACE}:indicator-{uuid.uuid4()}'
 
         if type_ == 'URL':
-            indicator_value = werkzeug.urls.iri_to_uri(value, safe_conversion=True)
+            indicator_value = werkzeug.urls.iri_to_uri(value)
         else:
             indicator_value = value
 

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -54,7 +54,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.75080
+  dockerimage: demisto/taxii-server:1.0.0.90081
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -54,7 +54,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.90081
+  dockerimage: demisto/taxii-server:1.0.0.90974
   longRunning: true
   longRunningPort: true
   script: '-'


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/taxii-server` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
```

### Please Note - The branch contained nightly packs- need instances test
