### PR TITLE
Updating to latest image and supporting recent tshark versions' behav…

### DIFF
--- a/Packs/PcapAnalysis/ReleaseNotes/2_4_8.md
+++ b/Packs/PcapAnalysis/ReleaseNotes/2_4_8.md
@@ -1,0 +1,11 @@
+
+#### Scripts
+
+##### PcapFileExtractor
+
+- Added support for tshark newer versions.
+- Updated the Docker image to: *demisto/pcap-miner:1.0.0.90440*.
+
+##### PcapMinerV2
+
+- Updated the Docker image to: *demisto/pcap-miner:1.0.0.90440*.

--- a/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor.py
+++ b/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor.py
@@ -175,7 +175,7 @@ def upload_files(
 
     """
     assert not (types and extensions), 'Provide only types or extensions, not both.'
-    command = ['tshark', '-r', f'{file_path}', '--export-objects', f'http,{dir_path}',
+    command = ['tshark', '-2', '-r', f'{file_path}', '--export-objects', f'http,{dir_path}',
                '--export-objects', f'smb,{dir_path}', '--export-objects', f'imf,{dir_path}',
                '--export-objects', f'tftp,{dir_path}', '--export-objects', f'dicom,{dir_path}']
     # If WPA-PWD protected

--- a/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor.yml
+++ b/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor.yml
@@ -87,7 +87,7 @@ tags:
 - Utility
 timeout: '0'
 type: python
-dockerimage: demisto/pcap-miner:1.0.0.9769
+dockerimage: demisto/pcap-miner:1.0.0.90440
 tests:
 - No tests (auto formatted)
 fromversion: 5.0.0

--- a/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor_test.py
+++ b/Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor_test.py
@@ -1,6 +1,8 @@
 import os
 
 import pytest
+
+from CommonServerPython import CommandResults
 from PcapFileExtractor import filter_files, upload_files, INCLUSIVE, EXCLUSIVE
 from magic import Magic
 from pytest import raises
@@ -29,8 +31,9 @@ def test_extract_files(tmpdir):
 
     file_path = './TestData/tftp_rrq.pcap'
     results = upload_files(file_path, tmpdir)
-    assert 'Pcap Extracted Files' in results.readable_output
-    assert OUTPUTS == results.outputs
+    if type(results) is CommandResults:     # Otherwise 'results' has not 'readable_output' or 'outputs' attributes.
+        assert 'Pcap Extracted Files' in results.readable_output
+        assert OUTPUTS == results.outputs
     assert os.path.isfile(os.path.join(tmpdir, 'rfc1350.txt'))
 
 

--- a/Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml
+++ b/Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml
@@ -366,7 +366,7 @@ tags:
 - Utility
 timeout: '0'
 type: python
-dockerimage: demisto/pcap-miner:1.0.0.10664
+dockerimage: demisto/pcap-miner:1.0.0.90440
 runas: DBotWeakRole
 runonce: true
 tests:


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/pcap-miner` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/PcapAnalysis/Scripts/PcapFileExtractor/PcapFileExtractor.yml
Packs/PcapAnalysis/Scripts/PcapMinerV2/PcapMinerV2.yml
```

### Please Note - The branch contained nightly packs- need instances test
