### PR TITLE
Upgrade image

### DIFF
--- a/Packs/Anomali_ThreatStream/Scripts/ThreatstreamBuildIocImportJson/ThreatstreamBuildIocImportJson.yml
+++ b/Packs/Anomali_ThreatStream/Scripts/ThreatstreamBuildIocImportJson/ThreatstreamBuildIocImportJson.yml
@@ -41,7 +41,7 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.11.54132
+dockerimage: demisto/python3:3.10.14.90585
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/python3` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/Anomali_ThreatStream/Scripts/ThreatstreamBuildIocImportJson/ThreatstreamBuildIocImportJson.yml
```

### Please Note - The branch contained nightly packs- need instances test
