### PR TITLE
Update `demisto/google-k8s-engine` 0-50 coverage rate

### DIFF
--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: demisto/google-k8s-engine:1.0.0.91030
+  dockerimage: demisto/google-k8s-engine:1.0.0.64696
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -406,7 +406,7 @@ script:
     name: gcloud-clusters-set-muster-auth
     outputs:
     - contextPath: GKE.Operation.Name
-      description: The server-assigned ID for the operation
+      description: The server-assigned ID for the operation.
       type: String
     - contextPath: GKE.Operation.Zone
       description: The name of the Google Compute Engine zone in which the operation is taking place. This field is deprecated, use location instead.
@@ -458,7 +458,7 @@ script:
     name: gcloud-clusters-set-addons
     outputs:
     - contextPath: GKE.Operation.Name
-      description: The server-assigned ID for the operation
+      description: The server-assigned ID for the operation.
       type: String
     - contextPath: GKE.Operation.Zone
       description: The name of the Google Compute Engine zone in which the operation is taking place. This field is deprecated, use location instead.

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: devdemisto/google-k8s-engine:1.0.0.91123
+  dockerimage: devdemisto/google-k8s-engine:1.0.0.91124
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: demisto/google-k8s-engine:1.0.0.64696
+  dockerimage: demisto/google-k8s-engine:1.0.0.91030
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: devdemisto/google-k8s-engine:1.0.0.91122
+  dockerimage: devdemisto/google-k8s-engine:1.0.0.91123
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: devdemisto/google-k8s-engine:1.0.0.91124
+  dockerimage: demisto/google-k8s-engine:1.0.0.91030
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
+++ b/Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
@@ -947,7 +947,7 @@ script:
       required: true
     description: Cancel operation by operation name.
     name: gcloud-operations-cancel
-  dockerimage: demisto/google-k8s-engine:1.0.0.64696
+  dockerimage: devdemisto/google-k8s-engine:1.0.0.91122
   runonce: false
   script: '-'
   subtype: python3


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/google-k8s-engine` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/GoogleKubernetesEngine/Integrations/GoogleKubernetesEngine/GoogleKubernetesEngine.yml
```

