### PR TITLE
Update `demisto/powershell-ubuntu` 0-50 coverage rate

### DIFF
--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -959,7 +959,7 @@ script:
   runonce: false
   script: '-'
   type: powershell
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
+++ b/Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
@@ -328,7 +328,7 @@ script:
     - contextPath: PsRemote.FQDN
       description: The Fully Qualified Domain Name of the host on which the command was invoked.
       type: string
-  dockerimage: demisto/powershell-ubuntu:7.2.2.29705
+  dockerimage: demisto/powershell-ubuntu:7.4.1.86201
   script: ''
   type: powershell
 fromversion: 6.0.0


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/powershell-ubuntu` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
Packs/PowershellRemoting/Integrations/PowerShellRemoting/PowerShellRemoting.yml
```

### Please Note - The branch contained nightly packs- need instances test
