### PR TITLE
Update `demisto/powershell-teams` 0-50 coverage rate

### DIFF
--- a/Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml
+++ b/Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml
@@ -28,7 +28,7 @@ outputs:
 script: '-'
 timeout: '0'
 type: powershell
-dockerimage: demisto/powershell-teams:1.0.0.22275
+dockerimage: demisto/powershell-teams:1.0.0.80546
 fromversion: 5.5.0
 tests:
 - No test


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/powershell-teams` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/MicrosoftTeams/Scripts/ConfigureAzureApplicationAccessPolicy/ConfigureAzureApplicationAccessPolicy.yml
```

### Please Note - The branch contained nightly packs- need instances test
