### PR TITLE
Update `demisto/exodusintelligence` 50-100-Non-Nightly coverage rate

### DIFF
--- a/Packs/ExodusIntelligence/Integrations/ExodusVulnerabilityEnrichment/ExodusVulnerabilityEnrichment.yml
+++ b/Packs/ExodusIntelligence/Integrations/ExodusVulnerabilityEnrichment/ExodusVulnerabilityEnrichment.yml
@@ -123,7 +123,7 @@ script:
     - contextPath: ExodusVulnerabilityEnrichment.ResetDataStream.end_ts
       description: New date data stream is set to.
       type: String
-  dockerimage: demisto/exodusintelligence:1.0.0.34185
+  dockerimage: demisto/exodusintelligence:1.0.0.91256
   feed: true
   isFetchSamples: true
   runonce: true


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/exodusintelligence` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/ExodusIntelligence/Integrations/ExodusVulnerabilityEnrichment/ExodusVulnerabilityEnrichment.yml
```

### Please Note - The branch contained nightly packs- need instances test
