### PR TITLE
Update `demisto/argus-toolbelt` 50-100 coverage rate

### DIFF
--- a/Packs/mnemonicMDR/Integrations/ArgusManagedDefence/ArgusManagedDefence.yml
+++ b/Packs/mnemonicMDR/Integrations/ArgusManagedDefence/ArgusManagedDefence.yml
@@ -6031,7 +6031,7 @@ script:
       required: true
       description: Case ID
     description: Download all attachments related to Argus Case.
-  dockerimage: demisto/argus-toolbelt:2.0.0.29288
+  dockerimage: demisto/argus-toolbelt:3.0.0.91320
   isfetch: true
   subtype: python3
   isremotesyncin: true


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/argus-toolbelt` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/mnemonicMDR/Integrations/ArgusManagedDefence/ArgusManagedDefence.yml
```

### Please Note - The branch contained nightly packs- need instances test
