### PR TITLE
Update `demisto/netutils` 0-50 coverage rate

### DIFF
--- a/Packs/Tufin/Integrations/Tufin/Tufin.yml
+++ b/Packs/Tufin/Integrations/Tufin/Tufin.yml
@@ -280,7 +280,7 @@ script:
       description: Connection comment.
       type: string
     description: Get SecureApp application connections.
-  dockerimage: demisto/netutils:1.0.0.74582
+  dockerimage: demisto/netutils:1.0.0.91356
   subtype: python3
 fromversion: 5.0.0
 tests:


### PR DESCRIPTION


## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/netutils` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/Tufin/Integrations/Tufin/Tufin.yml
```

### Please Note - The branch contained nightly packs- need instances test
