### PR TITLE
Update `demisto/pwsh-infocyte` 0-50 coverage rate

### DIFF
--- a/Packs/Infocyte/Integrations/Infocyte/Infocyte.yml
+++ b/Packs/Infocyte/Integrations/Infocyte/Infocyte.yml
@@ -459,7 +459,7 @@ script:
     - contextPath: Infocyte.Alert.managed
       description: Whether the file has been hash validated as part of a Linux package manager.
       type: boolean
-  dockerimage: demisto/pwsh-infocyte:1.1.0.23036
+  dockerimage: demisto/pwsh-infocyte:1.1.0.55529
   isfetch: true
 fromversion: 5.5.0
 tests:


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/pwsh-infocyte` docker image of the following integration/scripts which coverage rate of `0-50`%:

```
Packs/Infocyte/Integrations/Infocyte/Infocyte.yml
```

### Please Note - The branch contained nightly packs- need instances test
