### PR TITLE
[MicrosoftCloudAppSecurity] Fix the fetch in XSOAR 8

### DIFF
--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.py
@@ -959,9 +959,9 @@ def main():  # pragma: no cover
         elif command == 'fetch-incidents':
             first_fetch = params.get('first_fetch')
             max_results = params.get('max_fetch')
-            severity = params.get('severity')
+            severity = params.get('severity') or []
             look_back = arg_to_number(params.get('look_back')) or 0
-            resolution_status = params.get('resolution_status')
+            resolution_status = params.get('resolution_status') or []
             if params.get('custom_filter'):
                 filters = json.loads(str(params.get('custom_filter')))
             else:

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftCloudAppSecurity/MicrosoftCloudAppSecurity.yml
@@ -888,7 +888,7 @@ script:
     - contextPath: MicrosoftCloudAppSecurity.UsersAccounts.userGroups.usersCount
       description: The number of users in the user group.
       type: Number
-  dockerimage: demisto/crypto:1.0.0.87358
+  dockerimage: demisto/crypto:1.0.0.91402
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/2_1_58.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/2_1_58.md
@@ -4,6 +4,6 @@
 ##### Microsoft Defender for Cloud Apps
 
 <~XSOAR_SAAS>
-- Fixed an issue in **Fetch Incidents** when the *Incident severity* or *Incident resolution status* parameters was not provided.
+- Fixed an issue with **Fetch Incidents** that caused an error when empty values were used in the *Incident severity* or *Incident resolution status* parameters.
 </~XSOAR_SAAS>
 - Updated the Docker image to: *demisto/crypto:1.0.0.91402*.

--- a/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/2_1_58.md
+++ b/Packs/MicrosoftCloudAppSecurity/ReleaseNotes/2_1_58.md
@@ -1,0 +1,9 @@
+
+#### Integrations
+
+##### Microsoft Defender for Cloud Apps
+
+<~XSOAR_SAAS>
+- Fixed an issue in **Fetch Incidents** when the *Incident severity* or *Incident resolution status* parameters was not provided.
+</~XSOAR_SAAS>
+- Updated the Docker image to: *demisto/crypto:1.0.0.91402*.

--- a/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
+++ b/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Cloud Apps",
     "description": "Microsoft Cloud App Security Integration, a Cloud Access Security Broker that supports various deployment modes",
     "support": "xsoar",
-    "currentVersion": "2.1.57",
+    "currentVersion": "2.1.58",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-35352)

## Description
Fixed an issue in **Fetch Incidents** when the *Incident severity* or *Incident resolution status* parameters was not provided in **XSOAR 8**.