### PR TITLE
Update demisto/stringsifter 50-100-Non-Nightly coverage rate 

### DIFF
--- a/Packs/StringSifter/Scripts/StringSifter/StringSifter.yml
+++ b/Packs/StringSifter/Scripts/StringSifter/StringSifter.yml
@@ -22,5 +22,5 @@ outputs:
 script: ''
 type: python
 subtype: python3
-dockerimage: demisto/stringsifter:3.20230711.65151
+dockerimage: devdemisto/stringsifter:3.20230711.91507
 fromversion: 6.1.0

--- a/Packs/StringSifter/Scripts/StringSifter/StringSifter.yml
+++ b/Packs/StringSifter/Scripts/StringSifter/StringSifter.yml
@@ -22,5 +22,5 @@ outputs:
 script: ''
 type: python
 subtype: python3
-dockerimage: devdemisto/stringsifter:3.20230711.91507
+dockerimage: demisto/stringsifter:3.20230711.91564
 fromversion: 6.1.0


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/stringsifter` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/StringSifter/Scripts/StringSifter/StringSifter.yml
```

## Must have
- [ ] Tests
- [ ] Documentation 
