### PR TITLE
RedCanary: fix detection without relationship

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -300,16 +300,14 @@ def detections_to_entry(detections, show_timeline=False):
     fixed_detections = [detection_to_context(d) for d in detections]
     endpoints = []
     for d in detections:
-        if 'affected_endpoint' in d['relationships']:
-            endpoints.append(
-                get_endpoint_context(endpoint_id=d['relationships']['affected_endpoint']['data']['id']))
+        if endpoint_id := demisto.get(d, 'relationships.affected_endpoint.data.id'):
+            endpoints.append(get_endpoint_context(endpoint_id=endpoint_id))
 
     endpoints = sum(endpoints, [])  # type: list
     endpoint_users = []
     for d in detections:
-        if 'related_endpoint_user' in d['relationships']:
-            endpoint_users.append(
-                get_endpoint_user_context(endpoint_user_id=d['relationships']['related_endpoint_user']['data']['id']))
+        if endpoint_user_id := demisto.get(d, 'relationships.related_endpoint_user.data.id'):
+            endpoint_users.append(get_endpoint_user_context(endpoint_user_id=endpoint_user_id))
     endpoint_users = sum(endpoint_users, [])  # type: list
 
     domains, files, ips, processes = [], [], [], []  # type:ignore

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
@@ -47,7 +47,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.10.13.78960
+  dockerimage: demisto/python3:3.10.14.91134
   commands:
   - name: redcanary-acknowledge-detection
     arguments:

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
@@ -193,7 +193,7 @@ def test_detections_to_entry_without_endpoint(mocker):
     assert result['Contents'][0] == expected_result
 
 
-def test_detections_to_entry_without_erelationships(mocker):
+def test_detections_to_entry_without_relationships(mocker):
     """
     Given:
      - detection data with missing 'relationship' details

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
@@ -220,7 +220,7 @@ def test_detections_to_entry_without_relationships(mocker):
                 'last_acknowledged_by': None,
                 'associated_releasable_intelligence_profiles': []
             }
-            
+
         }
     ]
 
@@ -235,7 +235,6 @@ def test_detections_to_entry_without_relationships(mocker):
     result = RedCanary.detections_to_entry(detection_data)
     # Assert that the result is as expected
     assert result['Contents'][0] == expected_result
-
 
 
 def test_fetch_multiple_times_when_already_fetched_incident_keep(mocker):

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary_test.py
@@ -193,6 +193,51 @@ def test_detections_to_entry_without_endpoint(mocker):
     assert result['Contents'][0] == expected_result
 
 
+def test_detections_to_entry_without_erelationships(mocker):
+    """
+    Given:
+     - detection data with missing 'relationship' details
+
+    Then:
+     - Ensure detections_to_entry runs successfully
+    """
+    detection_data = [
+        {
+            'type': 'Detection',
+            'id': 1,
+            'attributes': {
+                'headline': 'Suspicious Activity',
+                'confirmed_at': '2023-09-18T21:32:52.039Z',
+                'summary': 'A user made a series of API calls to expose instance passwords.',
+                'severity': 'high',
+                'last_activity_seen_at': '2023-09-18T20:47:23.609Z',
+                'classification': {
+                    'superclassification': 'Suspicious Activity',
+                    'subclassification': ['Reconnaissance']
+                },
+                'time_of_occurrence': '2023-09-18T20:47:23.609Z',
+                'last_acknowledged_at': None,
+                'last_acknowledged_by': None,
+                'associated_releasable_intelligence_profiles': []
+            }
+            
+        }
+    ]
+
+    expected_result = {'Type': 'RedCanaryDetection', 'ID': 1, 'Headline': 'Suspicious Activity', 'Severity': 'high',
+                       'Summary': 'A user made a series of API calls to expose instance passwords.',
+                       'Classification': 'Suspicious Activity', 'Subclassification': ['Reconnaissance'],
+                       'Time': '2023-09-18T20:47:23Z', 'Acknowledged': True, 'RemediationStatus': '', 'Reason': '',
+                       'EndpointID': '', 'EndpointUserID': ''}
+    # Call the function with the sample data
+    endpoint_users = [{'Username': 'username'}]
+    mocker.patch.object(RedCanary, "get_endpoint_user_context", return_value=endpoint_users)
+    result = RedCanary.detections_to_entry(detection_data)
+    # Assert that the result is as expected
+    assert result['Contents'][0] == expected_result
+
+
+
 def test_fetch_multiple_times_when_already_fetched_incident_keep(mocker):
     """Unit test
     Given

--- a/Packs/RedCanary/ReleaseNotes/1_1_20.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_20.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Red Canary
+
+- Fixed an issue where the ***redcanary-get-detection*** command would fail if a detection did not contain relationships.
+- Updated the Docker image to: *demisto/python3:3.10.14.91134*.

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Red Canary",
     "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
     "support": "xsoar",
-    "currentVersion": "1.1.19",
+    "currentVersion": "1.1.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-35357

## Description
If a detection not contain relationships, the command failed.


**added test before fix:**
<img width="729" alt="image" src="https://github.com/demisto/content/assets/79846863/b777c7dd-3762-468d-8058-d7db6098f4d4">

**after fix:**
<img width="840" alt="image" src="https://github.com/demisto/content/assets/79846863/7c636fdd-8f19-4d4d-932d-101679720cf9">

