### PR TITLE
Pre-Commit - graph fix and make exit code 0

### DIFF
--- a/.gitlab/ci/.gitlab-ci.global.yml
+++ b/.gitlab/ci/.gitlab-ci.global.yml
@@ -512,6 +512,8 @@
     - |
       if [[ -n "${SHOULD_LINT_ALL}" ]]; then
         echo "Pre Commit all files"
+        # if we need to pre-commit all anyway we need the graph, and it's better to create it here.
+        demisto-sdk graph update
         demisto-sdk pre-commit -a --mode=nightly
       else
         echo "Pre Commit only changed files"

--- a/.gitlab/ci/.gitlab-ci.global.yml
+++ b/.gitlab/ci/.gitlab-ci.global.yml
@@ -507,18 +507,21 @@
     - gcloud auth revoke "${GCS_ARTIFACTS_ACCOUNT_NAME}" >> "${ARTIFACTS_FOLDER}/logs/gcloud_auth.log" 2>&1
     - gcloud auth configure-docker ${DOCKER_IO_DOMAIN} >> "${ARTIFACTS_FOLDER}/logs/configure_docker_with_registry.log" 2>&1
     - section_end "Revoking GCP Auth and Configure Docker"
-
+    # temp solution not to spam the build
+    - PRE_COMMIT_SUCCESS=0
     - SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
     - |
       if [[ -n "${SHOULD_LINT_ALL}" ]]; then
         echo "Pre Commit all files"
         # if we need to pre-commit all anyway we need the graph, and it's better to create it here.
         demisto-sdk graph update
-        demisto-sdk pre-commit -a --mode=nightly
+        demisto-sdk pre-commit -a --mode=nightly || PRE_COMMIT_SUCCESS=1
       else
         echo "Pre Commit only changed files"
-        demisto-sdk pre-commit --mode=ci
+        demisto-sdk pre-commit --mode=ci || PRE_COMMIT_SUCCESS=1
       fi
+
+    - echo "PRE_COMMIT_SUCCESS=$PRE_COMMIT_SUCCESS"
     - job-done
 
 

--- a/.gitlab/ci/.gitlab-ci.global.yml
+++ b/.gitlab/ci/.gitlab-ci.global.yml
@@ -513,7 +513,7 @@
     - |
       if [[ -n "${SHOULD_LINT_ALL}" ]]; then
         echo "Pre Commit all files"
-        # if we need to pre-commit all anyway we need the graph, and it's better to create it here.
+        # if we need to pre-commit all anyway we need the graph, and it's better (resource-wise) to create it here.
         demisto-sdk graph update
         demisto-sdk pre-commit -a --mode=nightly || PRE_COMMIT_SUCCESS=1
       else


### PR DESCRIPTION
* Returning exit code 0 in pre-commit so the build will not be spammed for now
* If we `pre-commit -a`, we need to create the content graph in advance so we will not use too much resources in the command (as we parse all integrations scripts and all the packs seperately).

