### PR TITLE
Update `demisto/py3-tools` 75-100-Nightly coverage rate 

### DIFF
--- a/Packs/CommonScripts/Scripts/ExifRead/ExifRead.yml
+++ b/Packs/CommonScripts/Scripts/ExifRead/ExifRead.yml
@@ -22,7 +22,7 @@ outputs:
   description: Exif tag value
   type: string
 scripttarget: 0
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 fromversion: 6.5.0
 tests:
 - ExifReadTest

--- a/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.yml
+++ b/Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.yml
@@ -13,7 +13,7 @@ args:
   description: The URL(s) or Email(s) to process
   isArray: true
 scripttarget: 0
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 runas: DBotWeakRole
 subtype: python3
 tests:

--- a/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.yml
+++ b/Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.yml
@@ -14,7 +14,7 @@ tags:
 - indicator-format
 timeout: '0'
 type: python
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 runas: DBotWeakRole
 subtype: python3
 tests:

--- a/Packs/CommonScripts/Scripts/LanguageDetect/LanguageDetect.yml
+++ b/Packs/CommonScripts/Scripts/LanguageDetect/LanguageDetect.yml
@@ -20,7 +20,7 @@ outputs:
 - contextPath: langDetect.probability
   description: Probability of language detection
 scripttarget: 0
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 fromversion: 5.0.0
 tests:
   - LanguageDetect-Test

--- a/Packs/CommonScripts/Scripts/ParseExcel/ParseExcel.yml
+++ b/Packs/CommonScripts/Scripts/ParseExcel/ParseExcel.yml
@@ -16,7 +16,7 @@ outputs:
 - contextPath: ParseExcel
   description: ParseExcel
 scripttarget: 0
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 tests:
 - ParseExcel-test
 fromversion: 5.0.0

--- a/Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml
+++ b/Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml
@@ -54,5 +54,5 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/py3-tools:1.0.0.49703
+dockerimage: demisto/py3-tools:1.0.0.91504
 fromversion: 5.0.0


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/py3-tools` docker image of the following integration/scripts which coverage rate of `75-100-Nightly`%:

```
Packs/CommonScripts/Scripts/ExtractDomainFromUrlFormat/ExtractDomainFromUrlFormat.yml
Packs/CommonScripts/Scripts/ExifRead/ExifRead.yml
Packs/CommonScripts/Scripts/ParseExcel/ParseExcel.yml
Packs/CommonScripts/Scripts/ExtractFQDNFromUrlAndEmail/ExtractFQDNFromUrlAndEmail.yml
Packs/CommonScripts/Scripts/ZipFile/ZipFile.yml
Packs/CommonScripts/Scripts/LanguageDetect/LanguageDetect.yml
```

### Please Note - The branch contained nightly packs- need instances test
