### PR TITLE
XSUP-34767 - treat utfbom8 flag as string and not bool

### DIFF
--- a/Packs/Base/ReleaseNotes/1_33_45.md
+++ b/Packs/Base/ReleaseNotes/1_33_45.md
@@ -2,4 +2,4 @@
 
 ##### SanePdfReports
 
-- Fixed an issue where script flag arguments treated as bool instead of string when using them as internal command arguments.
+Fixed an issue where script flag arguments were treated as boolean instead of string when using them as internal command arguments.

--- a/Packs/Base/ReleaseNotes/1_33_45.md
+++ b/Packs/Base/ReleaseNotes/1_33_45.md
@@ -1,0 +1,5 @@
+#### Scripts
+
+##### SanePdfReports
+
+- Fixed an issue where script flag arguments treated as bool instead of string when use them as internal command args.

--- a/Packs/Base/ReleaseNotes/1_33_45.md
+++ b/Packs/Base/ReleaseNotes/1_33_45.md
@@ -2,4 +2,4 @@
 
 ##### SanePdfReports
 
-- Fixed an issue where script flag arguments treated as bool instead of string when use them as internal command args.
+- Fixed an issue where script flag arguments treated as bool instead of string when using them as internal command arguments.

--- a/Packs/Base/Scripts/SanePdfReport/SanePdfReport.py
+++ b/Packs/Base/Scripts/SanePdfReport/SanePdfReport.py
@@ -129,8 +129,8 @@ def main():
         pageSize = demisto.args().get('paperSize', 'letter')
         disableHeaders = demisto.args().get('disableHeaders', '')
         tableTextMaxLength = demisto.args().get('tableTextMaxLength', '300')
-        forceServerFormattedTimeString = argToBoolean(demisto.args().get('forceServerFormattedTimeString', 'false'))
-        addUtf8Bom = argToBoolean(demisto.args().get('addUtf8Bom', 'false'))
+        forceServerFormattedTimeString = demisto.args().get('forceServerFormattedTimeString', 'false')
+        addUtf8Bom = demisto.args().get('addUtf8Bom', 'false')
 
         # Note: After headerRightImage the empty one is for legacy argv in server.js
         extra_cmd = f"{orientation} {resourceTimeout} {reportType} " + \

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.33.44",
+    "currentVersion": "1.33.45",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: XSUP-34767

## Description
we pass the flag as an argument to os command thus we need to pass it as string and not bool.
Sane app did not handle the arg as bool correctly hence the flags was not enforced 
