### PR TITLE
Xsup 35421 fix nonetype

### DIFF
--- a/Packs/Tanium/Integrations/Tanium_v2/Tanium_v2.py
+++ b/Packs/Tanium/Integrations/Tanium_v2/Tanium_v2.py
@@ -1095,8 +1095,8 @@ def get_action_result(client, data_args):
 
 def main():
     params = demisto.params()
-    username = params.get('credentials').get('identifier')
-    password = params.get('credentials').get('password')
+    username = params.get('credentials', {}).get('identifier')
+    password = params.get('credentials', {}).get('password')
     domain = params.get('domain')
     # Remove trailing slash to prevent wrong URL path to service
     server = params['url'].strip('/')

--- a/Packs/Tanium/ReleaseNotes/1_0_31.md
+++ b/Packs/Tanium/ReleaseNotes/1_0_31.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Tanium v2
+
+Fixed an issue where authentication failed when using the **API Token** parameter.

--- a/Packs/Tanium/pack_metadata.json
+++ b/Packs/Tanium/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tanium",
     "description": "Tanium endpoint security and systems management",
     "support": "xsoar",
-    "currentVersion": "1.0.30",
+    "currentVersion": "1.0.31",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-35421

## Description
credentials retrieved as null when not used at all, so added default value to the get method

## Must have
- [ ] Tests
- [ ] Documentation 
