### PR TITLE
Exclusion List for AWSSyncAccounts

### DIFF
--- a/Packs/AWS-EC2/ReleaseNotes/1_4_5.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_4_5.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### AwsEC2SyncAccounts
+
+- Added the argument `exclude_accounts` to support a list of accounts to exclude in the `AWS - Organizations` instance configuration.
+- Updated the Docker image to: *demisto/python3:3.10.14.91134*.

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.py
@@ -78,6 +78,14 @@ def set_instance(instance: dict, accounts: str) -> dict:
     return internal_request('put', '/settings/integration', instance)
 
 
+def remove_excluded_accounts(account_ids: list, accounts_to_exclude: str | None) -> list[str]:
+    return (
+        list(set(account_ids) - set(argToList(accounts_to_exclude)))
+        if accounts_to_exclude
+        else account_ids
+    )
+
+
 def update_ec2_instance(account_ids: list[str], ec2_instance_name: str) -> str:
     '''Update an AWS - EC2 instance with AWS Organization accounts.
 
@@ -108,6 +116,7 @@ def main():
     try:
         args: dict = demisto.args()
         account_ids, readable_output = get_account_ids(args.get('org_instance_name'))
+        account_ids = remove_excluded_accounts(account_ids, args.get('exclude_accounts'))
         result = update_ec2_instance(account_ids, args['ec2_instance_name'])
         return_results(CommandResults(readable_output=f'## {result}  \n---  \n{readable_output}'))
     except Exception as e:

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
@@ -4,6 +4,9 @@ args:
   required: true
 - description: The name of the AWS - Organizations instance to collect account from. If not provided, the primary instance will be used.
   name: org_instance_name
+- description: A comma-separated list of accounts to exclude.
+  name: exclude_accounts
+  isArray: true
 comment: Update an AWS - EC2 instance with a list of accounts in an AWS organization, which will allow EC2 commands to run in all of them.
 commonfields:
   id: AwsEC2SyncAccounts
@@ -17,6 +20,8 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.13.83255
+dockerimage: demisto/python3:3.10.14.91134
 runas: DBotWeakRole
 fromversion: 6.10.0
+tests:
+- No tests (auto formatted)

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
@@ -156,7 +156,7 @@ def test_remove_excluded_accounts():
     assert set(accounts) == {'4', '5'}
 
 
-def test_errors(mocker):
+def test_errors():
     import AwsEC2SyncAccounts as sync
 
     with pytest.raises(DemistoException, match='Unexpected error while configuring AWS - EC2 instance with accounts'):

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
@@ -146,6 +146,16 @@ def test_update_ec2_instance(mocker):
     assert result == "Successfully updated ***AWS - EC2*** with accounts:"
 
 
+def test_remove_excluded_accounts():
+    from AwsEC2SyncAccounts import remove_excluded_accounts
+
+    accounts = ['1', '2', '3', '4', '5']
+
+    accounts = remove_excluded_accounts(accounts, '1,2,3')
+
+    assert accounts == ['4', '5']
+
+
 def test_errors(mocker):
     import AwsEC2SyncAccounts as sync
 

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
@@ -153,7 +153,7 @@ def test_remove_excluded_accounts():
 
     accounts = remove_excluded_accounts(accounts, '1,2,3')
 
-    assert accounts == ['4', '5']
+    assert set(accounts) == {'4', '5'}
 
 
 def test_errors(mocker):

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/README.md
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/README.md
@@ -24,6 +24,7 @@ This script can be run on a schedule to keep an AWS - EC2 instance in sync with 
 | --- | --- |
 | ec2_instance_name | The name of the AWS - EC2 instance integration to update. |
 | org_instance_name | The name of the AWS - Organizations instance to collect account from. If not provided, the primary instance will be used. |
+| exclude_accounts | A comma-separated list of accounts to exclude. |
 
 ## Outputs
 

--- a/Packs/AWS-EC2/pack_metadata.json
+++ b/Packs/AWS-EC2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - EC2",
     "description": "Amazon Web Services Elastic Compute Cloud (EC2)",
     "support": "xsoar",
-    "currentVersion": "1.4.4",
+    "currentVersion": "1.4.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-10153)

## Description
Added the argument `exclude_accounts` to support a list of accounts to exclude in the `AWS - Organizations` instance configuration.

## Must have
- [ ] Tests
- [ ] Documentation 
