### PR TITLE
Google drive xsup 35501

### DIFF
--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2113,6 +2113,8 @@ script:
       description: The name of the file to upload.
     - name: entry_id
       description: The file's Entry ID.
+    - name: user_id
+      description: The user's primary email address. Must be used when uploading to shared drive, if not, will use the user id from the instance configuration.
     - name: parent
       description: The ID of the parent folder which contains the file. If not specified as part of a create request, the file will be placed directly in the user's My Drive folder.
     - auto: PREDEFINED

--- a/Packs/GoogleDrive/ReleaseNotes/1_3_7.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_3_7.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Google Drive
+
+- Fixed an issue where the **user_id** argument was missing in the yml file.

--- a/Packs/GoogleDrive/pack_metadata.json
+++ b/Packs/GoogleDrive/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Drive",
     "description": "Google Drive allows users to store files on their servers, synchronize files across devices, and share files. This integration helps you to create a new drive, query past activity and view change logs performed by the users, as well as list drives and files, and manage their permissions.",
     "support": "xsoar",
-    "currentVersion": "1.3.6",
+    "currentVersion": "1.3.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-35514)

## Description
- Fixed an issue where the **user_id** argument was missing in the yml file.

## Must have
- [ ] Tests
- [ ] Documentation 
