### PR TITLE
Update Demisto/XSOAR- Tools 0-50 coverage rate

### DIFF
--- a/Packs/ContentManagement/Scripts/ConfigurationSetup/ConfigurationSetup.yml
+++ b/Packs/ContentManagement/Scripts/ConfigurationSetup/ConfigurationSetup.yml
@@ -35,7 +35,7 @@ tags:
 - Content Management
 timeout: '0'
 type: python
-dockerimage: demisto/xsoar-tools:1.0.0.36076
+dockerimage: demisto/xsoar-tools:1.0.0.90942
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0

--- a/Packs/ContentManagement/Scripts/ListCreator/ListCreator.yml
+++ b/Packs/ContentManagement/Scripts/ListCreator/ListCreator.yml
@@ -21,7 +21,7 @@ tags:
 - Content Management
 timeout: '0'
 type: python
-dockerimage: demisto/xsoar-tools:1.0.0.19258
+dockerimage: demisto/xsoar-tools:1.0.0.90942
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the demisto/xsoar-tools docker image of the following integration/scripts which coverage rate of `0-50%`:
