### PR TITLE
Update `demisto/xsoar-tools` 50-100-Non-Nightly coverage rate

### DIFF
--- a/Packs/ContentManagement/Scripts/CommitFiles/CommitFiles.yml
+++ b/Packs/ContentManagement/Scripts/CommitFiles/CommitFiles.yml
@@ -31,7 +31,7 @@ commonfields:
 contentitemexportablefields:
   contentitemfields:
     fromServerVersion: ''
-dockerimage: demisto/xsoar-tools:1.0.0.69232
+dockerimage: demisto/xsoar-tools:1.0.0.90942
 enabled: true
 name: CommitFiles
 outputs:


### PR DESCRIPTION

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CIAC-9308

## Description
Update the `demisto/xsoar-tools` docker image of the following integration/scripts which coverage rate of `50-100-Non-Nightly`%:

```
Packs/ContentManagement/Scripts/CommitFiles/CommitFiles.yml
```

### Please Note - The branch contained nightly packs- need instances test
