### PR TITLE
Pre-Commit gitlab - update graph instead of create in nightly

### DIFF
--- a/.gitlab/ci/.gitlab-ci.global.yml
+++ b/.gitlab/ci/.gitlab-ci.global.yml
@@ -506,6 +506,7 @@
     - gcloud auth revoke "${GCS_ARTIFACTS_ACCOUNT_NAME}" >> "${ARTIFACTS_FOLDER}/logs/gcloud_auth.log" 2>&1
     - gcloud auth configure-docker ${DOCKER_IO_DOMAIN} >> "${ARTIFACTS_FOLDER}/logs/configure_docker_with_registry.log" 2>&1
     - section_end "Revoking GCP Auth and Configure Docker"
+    - unset DEMISTO_SDK_GRAPH_FORCE_CREATE  # we need to use update graph in content nightly
     # temp solution not to spam the build
     - SHOULD_LINT_ALL=$(./Tests/scripts/should_lint_all.sh)
     - PRE_COMMIT_SUCCESS=0


### PR DESCRIPTION
In the pre-commit -a in gitlab we first set up the graph and then run the command, which will set up a new graph if necessary. We need to unset the DEMISTO_SDK_GRAPH_FORCE_CREATE variable so we will use the created graph