### PR TITLE
[pre-commit] - do not run ruff with parelleisem

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -41,6 +41,7 @@ repos:
   rev: v0.0.272
   hooks:
   - id: ruff
+    parallel: false
     min_py_version: '3.7'
     args:
     - --fix


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Do not run ruff hooks in parallel, as the ruff runs on the entire repo extremely quick (1 second)

## Must have
- [x] Tests
- [ ] Documentation 
