### PR TITLE
SplunkPy: raise error in case error msg return from Splunk 

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -386,12 +386,15 @@ def fetch_notables(service: client.Service, mapper: UserMappingObject, comment_t
     oneshotsearch_results = service.jobs.oneshot(fetch_query, **kwargs_oneshot)
     reader = results.JSONResultsReader(oneshotsearch_results)
 
+    error_message = ''
     incidents = []
     notables = []
     incident_ids_to_add = []
     num_of_dropped = 0
     for item in reader:
         if handle_message(item):
+            if 'Error' in str(item.message) or 'error' in str(item.message):
+                error_message = f'{error_message}\n{item.message}' 
             continue
         extensive_log(f'[SplunkPy] Incident data before parsing to notable: {item}')
         notable_incident = Notable(data=item)
@@ -409,6 +412,8 @@ def fetch_notables(service: client.Service, mapper: UserMappingObject, comment_t
             num_of_dropped += 1
             extensive_log(f'[SplunkPy] - Dropped incident {incident_id} due to duplication.')
 
+    if error_message and not incident_ids_to_add:
+        raise DemistoException(f'Failed to fetch incidents, check the provided query in Splunk web search - {error_message}')
     extensive_log(f'[SplunkPy] Size of last_run_fetched_ids before adding new IDs: {len(last_run_fetched_ids)}')
     for incident_id in incident_ids_to_add:
         last_run_fetched_ids[incident_id] = {'occurred_time': latest_time}

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -1381,6 +1381,25 @@ def test_get_remote_data_command_with_message(mocker):
     assert info_message == "Splunk-SDK message: test message"
 
 
+def test_fetch_with_error_in_message(mocker):
+    """
+    Given - fetch result from Splunk return Error message
+    When - fetch incidents
+    Then - assert DemistoException is raised
+    """
+
+    mock_params = {'fetchQuery': "something", "parseNotableEventsRaw": True}
+    mocker.patch('demistomock.getLastRun', return_value={'time': '2018-10-24T14:13:20'})
+    mocker.patch('demistomock.params', return_value=mock_params)
+    mocker.patch('splunklib.results.JSONResultsReader', return_value=[results.Message("FATAL", "Error")])
+
+    # run
+    service = mocker.patch('splunklib.client.connect')
+    with pytest.raises(DemistoException) as e:
+        splunk.fetch_incidents(service, None, None, None)
+    assert 'Failed to fetch incidents, check the provided query in Splunk web search' in e.value.message
+
+
 @pytest.mark.parametrize("notable_data, func_call_kwargs, expected_closure_data",
                          [({'status_label': 'New', 'event_id': 'id', 'status_end': 'false',
                             'comment': 'new comment from splunk', 'reviewer': 'admin',

--- a/Packs/SplunkPy/ReleaseNotes/3_1_26.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_26.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SplunkPy
+
+- Fixed an issue where the fetch incidents completed successfully even though an error was returned from Splunk.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "3.1.25",
+    "currentVersion": "3.1.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-35748

## Description
Splunk return status 200 even if there is error in the search query 
but the response contained error message in the response body

<img width="1034" alt="image" src="https://github.com/demisto/content/assets/79846863/f0538c9f-7b29-433b-9d52-80d2f1b3832a">
 

Fix:
raise error in case this error message is returned.

