### PR TITLE
Crowdstrike: added argument polling_timeout to cs-falcon-rtr-retrieve-file command

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -5128,11 +5128,12 @@ def rtr_polling_retrieve_file_command(args: dict):
             args['hosts_and_requests_ids'] = hosts_and_requests_ids
             args.pop('request_ids')
             args.pop('SHA256')
+            polling_timeout = arg_to_number(args.get('polling_timeout', 600))
             scheduled_command = ScheduledCommand(
                 command=cmd,
                 next_run_in_seconds=interval_in_secs,
                 args=args,
-                timeout_in_seconds=600)
+                timeout_in_seconds=polling_timeout)
             command_results = CommandResults(scheduled_command=scheduled_command,
                                              readable_output="Waiting for the polling execution")
             return command_results

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -2604,6 +2604,8 @@ script:
       defaultValue: false
     - name: timeout
       description: The amount of time (in seconds) that a request will wait for a client to establish a connection to a remote machine before a timeout occurs.
+    - name: polling_timeout
+      description: Timeout for polling. Default is 600 seconds.
     description: Gets the RTR extracted file contents for the specified file path.
     name: cs-falcon-rtr-retrieve-file
     outputs:

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -5017,7 +5017,7 @@ script:
     - contextPath: CrowdStrike.IOARules.version_ids
       description: The IOA Rule's version ID.
       type: String
-  dockerimage: demisto/py3-tools:1.0.0.91603
+  dockerimage: demisto/py3-tools:1.0.0.91908
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/README.md
@@ -4144,6 +4144,7 @@ Gets the RTR extracted file contents for the specified file path.
 | SHA256 | This is an internal argument used for the polling process, not to be used by the user. | Optional | 
 | queue_offline | Whether the command will run against an offline-queued session and be queued for execution when the host comes online. | Optional | 
 | timeout | The amount of time (in seconds) that a request will wait for a client to establish a connection to a remote machine before a timeout occurs. | Optional | 
+| polling_timeout | Timeout for polling. Default is 600 seconds. | Optional | 
 
 #### Context Output
 

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_4.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Added a new argument **polling_timeout** to the **cs-falcon-rtr-retrieve-file** command to set the polling timeout.

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_5.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Added a new argument **polling_timeout** to the **cs-falcon-rtr-retrieve-file** command to set the polling timeout.

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_5.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/1_13_5.md
@@ -4,3 +4,4 @@
 ##### CrowdStrike Falcon
 
 - Added a new argument **polling_timeout** to the **cs-falcon-rtr-retrieve-file** command to set the polling timeout.
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.91908*.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.13.3",
+    "currentVersion": "1.13.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "1.13.4",
+    "currentVersion": "1.13.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-35743)

## Description
Added a new argument **polling_timeout** to the **cs-falcon-rtr-retrieve-file** command to set the polling timeout. 
## Must have
- [ ] Tests
- [ ] Documentation 
