### PR TITLE
Fix CloseLinkedIncidentsPostProcessing Error

### DIFF
--- a/Packs/CaseManagement-Generic/ReleaseNotes/1_4_7.md
+++ b/Packs/CaseManagement-Generic/ReleaseNotes/1_4_7.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### CloseLinkedIncidentsPostProcessing
+
+- Fixed an issue where the `!CloseLinkedIncidentsPostProcessing` command raised an error when an incident's `closeNotes` field was empty.
+- Updated the Docker image to: *demisto/python3:3.10.14.91134*.

--- a/Packs/CaseManagement-Generic/Scripts/CloseLinkedIncidentsPostProcessing/CloseLinkedIncidentsPostProcessing.py
+++ b/Packs/CaseManagement-Generic/Scripts/CloseLinkedIncidentsPostProcessing/CloseLinkedIncidentsPostProcessing.py
@@ -9,7 +9,7 @@ def main():
     incident_id = incident.get("id")
     linked_incidents = incident.get("linkedIncidents")
 
-    if linked_incidents and not close_notes.startswith("Closed from parent Incident"):
+    if linked_incidents and not str(close_notes).startswith("Closed from parent Incident"):
         demisto.executeCommand("executeCommandAt",
                                {"command": "closeInvestigation",
                                 "arguments": {

--- a/Packs/CaseManagement-Generic/Scripts/CloseLinkedIncidentsPostProcessing/CloseLinkedIncidentsPostProcessing.yml
+++ b/Packs/CaseManagement-Generic/Scripts/CloseLinkedIncidentsPostProcessing/CloseLinkedIncidentsPostProcessing.yml
@@ -2,7 +2,7 @@ comment: 'Post Processing Script that will close linked Incidents when the Incid
 commonfields:
   id: CloseLinkedIncidentsPostProcessing
   version: -1
-dockerimage: demisto/python3:3.10.12.63474
+dockerimage: demisto/python3:3.10.14.91134
 enabled: true
 name: CloseLinkedIncidentsPostProcessing
 runas: DBotWeakRole

--- a/Packs/CaseManagement-Generic/pack_metadata.json
+++ b/Packs/CaseManagement-Generic/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CaseManagement-Generic",
     "description": "Case Management - Generic\n\nBuilt by the Cortex Customer Success Team to provide quick deployment of Case Management with XSOAR",
     "support": "community",
-    "currentVersion": "1.4.6",
+    "currentVersion": "1.4.7",
     "author": "Cortex XSOAR Customer Success",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-35719](https://jira-dc.paloaltonetworks.com/browse/XSUP-35719)

## Description
Fixed an issue where the `!CloseLinkedIncidentsPostProcessing` command raised an error when an incident's `closeNotes` field was empty.

**Before:**
![Screenshot 2024-04-10 at 21 15 24](https://github.com/demisto/content/assets/129657918/e8d66856-866f-4278-b1dc-15d1c51aa59a)

**After:**
![Screenshot 2024-04-10 at 21 17 19](https://github.com/demisto/content/assets/129657918/e92e0bc3-fb23-4e91-9cdf-cbd741780938)

## Must have
- [ ] Tests
- [ ] Documentation 
