### PR TITLE
DockerHardening - fix test check cpu test

### DIFF
--- a/Packs/CommonScripts/Scripts/DockerHardeningCheck/DockerHardeningCheck_test.py
+++ b/Packs/CommonScripts/Scripts/DockerHardeningCheck/DockerHardeningCheck_test.py
@@ -36,7 +36,8 @@ def test_check_cpus(mocker):
     def intensive_calc(i):
         global a
         time.sleep(a * 0.1)
-        a += 1
+        # make the run be slower in next executions
+        a += 5
     mocker.patch.object(DockerHardeningCheck, "intensive_calc", side_effect=intensive_calc)
     assert "CPU processing power increased significantly" in check_cpus(1)
 


### PR DESCRIPTION
The test makes the next runs of `intensive_calc` slower in next runs, so the test will think that there more than one CPU