### PR TITLE
XSUP-36299 FortiSIEM Fix Fetch Incident

### DIFF
--- a/Packs/FortiSIEM/Integrations/FortiSIEMV2/FortiSIEMV2.py
+++ b/Packs/FortiSIEM/Integrations/FortiSIEMV2/FortiSIEMV2.py
@@ -1386,7 +1386,7 @@ def format_outputs_time_attributes_to_iso(outputs: List[dict]) -> List[dict]:
     for entity in outputs:
         for key, value in entity.items():
             if any(time_key in key for time_key in time_keys) and value:
-                entity[key] = FormatIso8601(datetime.fromtimestamp(int(value) / 1000))
+                entity[key] = FormatIso8601(datetime.fromtimestamp(int(float(value)) / 1000))
 
     return outputs
 

--- a/Packs/FortiSIEM/Integrations/FortiSIEMV2/test_data/triggered_events.json
+++ b/Packs/FortiSIEM/Integrations/FortiSIEMV2/test_data/triggered_events.json
@@ -10,7 +10,7 @@
         "attributes": {
             "Source TCP/UDP Port": 62835,
             "Source Interface SNMP Index": 29034,
-            "Event Receive Time": 1646760881000,
+            "Event Receive Time": "0.00",
             "Reporting IP": "192.168.30.254",
             "IP Protocol": 17,
             "Destination Country Code": "US",

--- a/Packs/FortiSIEM/ReleaseNotes/2_0_35.md
+++ b/Packs/FortiSIEM/ReleaseNotes/2_0_35.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### FortiSIEM v2
+
+- Fixed an issue where the **fetch-incident** command failed to parse the time field correctly.

--- a/Packs/FortiSIEM/pack_metadata.json
+++ b/Packs/FortiSIEM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FortiSIEM",
     "description": "Search and update events of FortiSIEM and manage resource lists.",
     "support": "xsoar",
-    "currentVersion": "2.0.34",
+    "currentVersion": "2.0.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link to the issue
](https://jira-dc.paloaltonetworks.com/browse/XSUP-36299)
## Description
Fixing an issue where the `fetch-incident` command fails to parse the response time field.

