### PR TITLE
Fix DBotPredictURLPhishing failing on rasterize errors

### DIFF
--- a/Packs/PhishingURL/ReleaseNotes/1_1_13.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_13.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotPredictURLPhishing
+
+- Fixed an issue in which an error was raised when more than one URL failed in the `rasterise` command

--- a/Packs/PhishingURL/ReleaseNotes/1_1_13.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_13.md
@@ -3,4 +3,4 @@
 
 ##### DBotPredictURLPhishing
 
-- Fixed an issue in which an error was raised when more than one URL failed in the `rasterise` command
+- Fixed an issue in which an error was raised when more than one URL failed in the `rasterise` command.

--- a/Packs/PhishingURL/ReleaseNotes/1_1_13.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_13.md
@@ -3,4 +3,4 @@
 
 ##### DBotPredictURLPhishing
 
-- Fixed an issue in which an error was raised when more than one URL failed in the `rasterise` command.
+- Fixed an issue in which an error was raised when more than one URL failed to be rasterized.

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -462,9 +462,13 @@ def weed_rasterize_errors(urls: list[str], res_rasterize: list[dict]):
     '''Remove the URLs that failed rasterization and return them.'''
     if len(urls) != len(res_rasterize):
         demisto.debug(f'{res_rasterize=}')
-        raise DemistoException('Unexpected response from the "rasterise" command.'
-                               'Please make sure the Rasterize pack is up-to-date and functional')
-    error_idx = [i for (i, res) in enumerate(res_rasterize) if isinstance(res['Contents'], str)][::-1]
+        raise DemistoException('Unexpected response from the "rasterize" command. '
+                               'Please make sure the Rasterize pack version is above 2.0.7')
+    error_idx = []
+    for (i, res) in enumerate(res_rasterize):
+        if isinstance(res['Contents'], str):
+            error_idx.append(i)
+    error_idx.reverse()
     if error_idx:
         return_results(CommandResults(readable_output=tableToMarkdown(
             'The following URLs failed rasterize and were skipped:',

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -464,11 +464,10 @@ def weed_rasterize_errors(urls: list[str], res_rasterize: list[dict]):
         demisto.debug(f'{res_rasterize=}')
         raise DemistoException('Unexpected response from the "rasterize" command. '
                                'Please make sure the Rasterize pack version is above 2.0.7')
-    error_idx = []
-    for (i, res) in enumerate(res_rasterize):
-        if isinstance(res['Contents'], str):
-            error_idx.append(i)
-    error_idx.reverse()
+    error_idx = [
+        i for (i, res) in enumerate(res_rasterize)
+        if isinstance(res['Contents'], str)
+    ][::-1]  # reverse the list as it will be used to remove elements.
     if error_idx:
         return_results(CommandResults(readable_output=tableToMarkdown(
             'The following URLs failed rasterize and were skipped:',

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -460,7 +460,10 @@ def extract_created_date(entry: dict):
 
 def weed_rasterize_errors(urls: list[str], res_rasterize: list[dict]):
     '''Remove the URLs that failed rasterization and return them.'''
-
+    if len(urls) != len(res_rasterize):
+        demisto.debug(f'{res_rasterize=}')
+        raise DemistoException('Unexpected response from the "rasterise" command.'
+                               'Please make sure the Rasterize pack is up-to-date and functional')
     error_idx = [i for (i, res) in enumerate(res_rasterize) if isinstance(res['Contents'], str)]
     if error_idx:
         return_results(CommandResults(readable_output=tableToMarkdown(

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -464,7 +464,7 @@ def weed_rasterize_errors(urls: list[str], res_rasterize: list[dict]):
         demisto.debug(f'{res_rasterize=}')
         raise DemistoException('Unexpected response from the "rasterise" command.'
                                'Please make sure the Rasterize pack is up-to-date and functional')
-    error_idx = [i for (i, res) in enumerate(res_rasterize) if isinstance(res['Contents'], str)]
+    error_idx = [i for (i, res) in enumerate(res_rasterize) if isinstance(res['Contents'], str)][::-1]
     if error_idx:
         return_results(CommandResults(readable_output=tableToMarkdown(
             'The following URLs failed rasterize and were skipped:',

--- a/Packs/PhishingURL/pack_metadata.json
+++ b/Packs/PhishingURL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing URL",
     "description": "Phishing URL is a project with the goal of detecting phishing URLs using machine learning",
     "support": "xsoar",
-    "currentVersion": "1.1.12",
+    "currentVersion": "1.1.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-36113)

## Description
Fixed an issue in which an error was raised when more than one URL failed in the `rasterise` command.

## Must have
- [ ] Tests
- [ ] Documentation 
