### PR TITLE
Fixed a problem where closing and incident in XDR with 'duplicate' cl…

### DIFF
--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule.py
@@ -13,7 +13,7 @@ TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 XSOAR_RESOLVED_STATUS_TO_XDR = {
     'Other': 'resolved_other',
-    'Duplicate': 'resolved_duplicate_incident',
+    'Duplicate': 'resolved_duplicate',
     'False Positive': 'resolved_false_positive',
     'Resolved': 'resolved_true_positive',
     'Security Testing': 'resolved_security_testing',
@@ -22,6 +22,7 @@ XSOAR_RESOLVED_STATUS_TO_XDR = {
 XDR_RESOLVED_STATUS_TO_XSOAR = {
     'resolved_known_issue': 'Other',
     'resolved_duplicate_incident': 'Duplicate',
+    'resolved_duplicate': 'Duplicate',
     'resolved_false_positive': 'False Positive',
     'resolved_true_positive': 'Resolved',
     'resolved_security_testing': 'Security Testing',

--- a/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
+++ b/Packs/ApiModules/Scripts/CoreIRApiModule/CoreIRApiModule_test.py
@@ -3860,21 +3860,21 @@ def test_handle_outgoing_issue_closure(args, expected_delta):
                                                   "resolved_true_positive", "resolved_security_testing", "resolved_other"]),
 
                              # Expecting default mapping to be used when no mapping provided.
-                             ("", ["resolved_other", "resolved_duplicate_incident", "resolved_false_positive",
+                             ("", ["resolved_other", "resolved_duplicate", "resolved_false_positive",
                                    "resolved_true_positive", "resolved_security_testing", "resolved_other"]),
 
                              # Expecting default mapping to be used when improper mapping is provided.
                              ("Duplicate=RANDOM1, Other=Random2",
-                              ["resolved_other", "resolved_duplicate_incident", "resolved_false_positive",
+                              ["resolved_other", "resolved_duplicate", "resolved_false_positive",
                                "resolved_true_positive", "resolved_security_testing", "resolved_other"]),
 
                              ("Random1=Duplicate Incident",
-                              ["resolved_other", "resolved_duplicate_incident", "resolved_false_positive",
+                              ["resolved_other", "resolved_duplicate", "resolved_false_positive",
                                "resolved_true_positive", "resolved_security_testing", "resolved_other"]),
 
                              # Expecting default mapping to be used when improper mapping *format* is provided.
                              ("Duplicate=Other False Positive=Other",
-                              ["resolved_other", "resolved_duplicate_incident", "resolved_false_positive",
+                              ["resolved_other", "resolved_duplicate", "resolved_false_positive",
                                "resolved_true_positive", "resolved_security_testing", "resolved_other"]),
 
                              # Expecting default mapping to be used for when improper key-value pair *format* is provided.

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -785,14 +785,14 @@ def test_get_incident_extra_data(mocker):
                          [
                              ("Known Issue=Other,Duplicate Incident=Duplicate,False Positive=False Positive,"
                               "True Positive=Resolved,Security Testing=Other,Other=Other",
-                              ["Other", "Duplicate", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
+                              ["Other", "Duplicate", "Duplicate", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
 
                              ("Known Issue=Other,Duplicate Incident=Other,False Positive=False Positive,"
                               "True Positive=Resolved,Security Testing=Other,Other=Other",
-                              ["Other", "Other", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
+                              ["Other", "Other", "Duplicate", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
 
                              ("Duplicate Incident=Other,Security Testing=Other,Other=Other",
-                              ["Other", "Other", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
+                              ["Other", "Other", "Duplicate", "False Positive", "Resolved", "Other", "Other", "Resolved"]),
 
                              # Expecting default mapping to be used when no mapping provided.
                              ("", list(XDR_RESOLVED_STATUS_TO_XSOAR.values())),
@@ -807,7 +807,7 @@ def test_get_incident_extra_data(mocker):
 
                              # Expecting default mapping to be used for when improper key-value pair *format* is provided.
                              ("Duplicate Incident=Other, False Positive=Other True Positive=Other",
-                              ["Other", "Other", "False Positive", "Resolved", "Security Testing", "Other",
+                              ["Other", "Other", "Duplicate", "False Positive", "Resolved", "Security Testing", "Other",
                                "Resolved"]),
 
                          ],


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-35810)

## Description
Fixed an issue where closing an incident in XDR with 'duplicate' close reason, it would not be closed.

