### PR TITLE
Update parse emails files docker image

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_14_37.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_14_37.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+- Added support for Apple HFS file type.
+- Updated the Docker image to: *demisto/parse-emails:1.0.0.93148*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -116,4 +116,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.92018
+dockerimage: demisto/parse-emails:1.0.0.93148

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.14.36",
+    "currentVersion": "1.14.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: [XSUP-36063](https://jira-dc.paloaltonetworks.com/browse/XSUP-36063)

## Description
Added support to Apple HFS file type.

