### PR TITLE
remove `poetry-export`, replace `poetry-lock` hook with `poetry-check --lock`

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -19,9 +19,8 @@ repos:
   rev: 1.8.2
   hooks:
   - id: poetry-check
-  - id: poetry-lock
     args:
-    - --check
+    - --lock
     files: ^pyproject.toml$
 - repo: https://github.com/hadialqattan/pycln
   rev: v2.1.2


### PR DESCRIPTION
- following https://github.com/demisto/demisto-sdk/pull/4225, `poetry-export` is no longer necessary.
- `poetry-check` hook with with `--lock` has been deprecated. Replacing with `poetry-lock --check`