### PR TITLE
added setting to dateparser

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -842,7 +842,8 @@ def get_modified_remote_data_command(client, args):
 
     demisto.debug(f'Performing get-modified-remote-data command. Last update is: {last_update}')
 
-    last_update_utc = dateparser.parse(last_update, settings={'TIMEZONE': 'UTC'})  # convert to utc format
+    last_update_utc = dateparser.parse(last_update,
+                                       settings={'TIMEZONE': 'UTC', 'RETURN_AS_TIMEZONE_AWARE': False})  # convert to utc format
     if last_update_utc:
         last_update_without_ms = last_update_utc.isoformat().split('.')[0]
 

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -612,7 +612,7 @@ def test_get_modified_remote_data_command(requests_mock):
     client = Client(
         base_url=f'{XDR_URL}/public_api/v1', verify=False, timeout=120, proxy=False)
     args = {
-        'lastUpdate': '2020-11-18T13:16:52.005381+02:00'
+        'lastUpdate': '2020-11-18T13:16:52.00000000005381+02:00'
     }
 
     response = get_modified_remote_data_command(client, args)

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -593,7 +593,10 @@ def test_get_remote_data_command_sync_owners(requests_mock, mocker):
     assert response.entries == []
 
 
-def test_get_modified_remote_data_command(requests_mock):
+@pytest.mark.parametrize('last_update',
+                         ['2020-11-18T13:16:52.005381+02:00',
+                          '2024-03-21T17:02:02.000000645Z'])
+def test_get_modified_remote_data_command(requests_mock, last_update):
     """
     Given:
         - an XDR client
@@ -612,7 +615,7 @@ def test_get_modified_remote_data_command(requests_mock):
     client = Client(
         base_url=f'{XDR_URL}/public_api/v1', verify=False, timeout=120, proxy=False)
     args = {
-        'lastUpdate': '2020-11-18T13:16:52.00000000005381+02:00'
+        'lastUpdate': last_update
     }
 
     response = get_modified_remote_data_command(client, args)

--- a/Packs/CortexXDR/ReleaseNotes/6_1_30.md
+++ b/Packs/CortexXDR/ReleaseNotes/6_1_30.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+
+- Fixed an issue where outgoing mirroring failed with specific time parsing.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "6.1.29",
+    "currentVersion": "6.1.30",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-36389

## Description
On specific cases, where the ms in the time parsing is starting with many 0, the parser doesn't return the ms and therfore the splitting doesn't change the value, leading to the last_update_without_ms to contain the timezone offset. As we do not use this offset, removed it from the return value. 

failing test
![image](https://github.com/demisto/content/assets/86777474/ec3e04e0-34bc-4edc-a05d-0c146c9bc2cb)

