### PR TITLE
update data modeling rule to properly handle integrity level

### DIFF
--- a/Packs/SentinelOne/ModelingRules/SentinelOneModelingRules/SentinelOneModelingRules.xif
+++ b/Packs/SentinelOne/ModelingRules/SentinelOneModelingRules/SentinelOneModelingRules.xif
@@ -52,7 +52,8 @@ filter eventType = "Threat"
 filter eventType = "Alert"
 | alter
     osFamily = json_extract_scalar(agentDetectionInfo, "$.osFamily"),
-    loginType = json_extract_scalar(alertInfo, "$.loginType")
+    loginType = json_extract_scalar(alertInfo, "$.loginType"),
+    lower_tgtProcIntegrityLevel = lowercase(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel"))
 | alter
     xdm.event.type = eventType,
     xdm.source.host.hostname = json_extract_scalar(agentDetectionInfo, "$.name"),
@@ -87,11 +88,12 @@ filter eventType = "Alert"
     xdm.target.file_before.path = json_extract_scalar(targetProcessInfo, "$.tgtFileOldPath"),
     xdm.target.process.command_line = json_extract_scalar(targetProcessInfo, "$.tgtProcCmdLine"),
     xdm.target.process.executable.filename = json_extract_scalar(targetProcessInfo, "$.tgtProcName"),
-    xdm.target.process.integrity_level = if(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "protected", 20480, 
-                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "system", 16384, 
-                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "high", 12288, 
-                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "medium", 8192, 
-                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "low", 4096, 
-                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "unknown", 0, 
-                                            to_integer(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel"))),
+    xdm.target.process.integrity_level = if(lower_tgtProcIntegrityLevel = "protected", 20480,
+                                            lower_tgtProcIntegrityLevel = "system", 16384,
+                                            lower_tgtProcIntegrityLevel = "high", 12288,
+                                            lower_tgtProcIntegrityLevel = "medium_plus", 8448,
+                                            lower_tgtProcIntegrityLevel = "medium", 8192,
+                                            lower_tgtProcIntegrityLevel = "low", 4096, 
+                                            lower_tgtProcIntegrityLevel = "untrusted", 0, 
+                                            null),
     xdm.target.process.pid = to_integer(json_extract_scalar(targetProcessInfo, "$.tgtProcPid"));

--- a/Packs/SentinelOne/ModelingRules/SentinelOneModelingRules/SentinelOneModelingRules.xif
+++ b/Packs/SentinelOne/ModelingRules/SentinelOneModelingRules/SentinelOneModelingRules.xif
@@ -87,5 +87,11 @@ filter eventType = "Alert"
     xdm.target.file_before.path = json_extract_scalar(targetProcessInfo, "$.tgtFileOldPath"),
     xdm.target.process.command_line = json_extract_scalar(targetProcessInfo, "$.tgtProcCmdLine"),
     xdm.target.process.executable.filename = json_extract_scalar(targetProcessInfo, "$.tgtProcName"),
-    xdm.target.process.integrity_level = to_integer(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel")),
+    xdm.target.process.integrity_level = if(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "protected", 20480, 
+                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "system", 16384, 
+                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "high", 12288, 
+                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "medium", 8192, 
+                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "low", 4096, 
+                                            json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel") contains "unknown", 0, 
+                                            to_integer(json_extract_scalar(targetProcessInfo, "$.tgtProcIntegrityLevel"))),
     xdm.target.process.pid = to_integer(json_extract_scalar(targetProcessInfo, "$.tgtProcPid"));

--- a/Packs/SentinelOne/ReleaseNotes/3_2_24.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_24.md
@@ -1,3 +1,6 @@
+
 #### Modeling Rules
+
 ##### SentinelOne Modeling Rule
+
 - Updated the handling of the *xdm.target.process.integrity_level* field to convert human-readable values to their associated and expected numeric values

--- a/Packs/SentinelOne/ReleaseNotes/3_2_24.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_24.md
@@ -3,4 +3,4 @@
 
 ##### SentinelOne Modeling Rule
 
-- Updated the handling of the *xdm.target.process.integrity_level* field to convert human-readable values to their associated and expected numeric values
+Updated the handling of the *xdm.target.process.integrity_level* field to convert human-readable values to their associated and expected numeric values.

--- a/Packs/SentinelOne/ReleaseNotes/3_2_24.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_24.md
@@ -1,0 +1,3 @@
+#### Modeling Rules
+##### SentinelOne Modeling Rule
+- Updated the handling of the *xdm.target.process.integrity_level* field to convert human-readable values to their associated and expected numeric values

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "Endpoint protection",
     "support": "partner",
-    "currentVersion": "3.2.23",
+    "currentVersion": "3.2.24",
     "author": "SentinelOne",
     "url": "https://www.sentinelone.com/support/",
     "email": "support@sentinelone.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Resolves runtime errors seen on ingestion
`unable to add field xdm.target.process.integrity_level: runtime error on to_integer (cant convert "medium" to int)`

## Description
Updating the data model rule to properly handle the target process integrity level. which per [the standard](https://docs-cortex.paloaltonetworks.com/r/Cortex-Data-Model-Schema-Guide/xdm.target?section=xdm.target.process.integrity_level) needs to be a Number, but is coming up as a human-readable level name in the logs. This handles properly, and gracefully falls back if the logs ever indeed change to containing a numeric value.

## Must have
- [ ] Tests
- [ ] Documentation 
