### PR TITLE
ThreatConnect add indicator owner argument fix

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/README.md
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/README.md
@@ -432,8 +432,9 @@ Adds a new indicator to ThreatConnect.
 | hashType | The type of hash for the file indicator. Possible values are: md5, sha1, sha256. | Optional | 
 | rating | The threat rating of the indicator. Can be "0" - "Unknown", "1" - "Suspicious", "2" - "Low", "3" - Moderate, "4" - High, or "5" - "Critical". | Optional | 
 | confidence | The confidence rating of the indicator. Can be "0%" - "Unknown," "1% " - "Discredited", "2-29%" - "Improbable," "30-49%" - "Doubtful," "50-69%" - "Possible", "70-89%" - "Probable," or "90-100%" - "Confirmed". | Optional | 
-| description | The description of the indicator. | Optional | 
 | tags | A comma-separated list of the tags to apply to the campaign. | Optional | 
+| description | The description of the indicator. | Optional | 
+| owner | The name of the owner to which the Indicator belongs. | Optional | 
 
 #### Context Output
 

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -1172,6 +1172,7 @@ def tc_add_indicator_command(client: Client, args: dict, rating: str = '0', indi
     indicator = args.get('indicator', indicator)
     indicator_type = args.get('indicatorType', indicator_type)
     description = args.get('description', description)
+    owner = args.get('owner', demisto.params().get('defaultOrg'))
     if tags:
         tmp = []
         for tag in tags:
@@ -1182,6 +1183,7 @@ def tc_add_indicator_command(client: Client, args: dict, rating: str = '0', indi
         "type": indicator_type,
         "confidence": confidence,
         "rating": rating,
+        "ownerName": owner,
         "tags": {
             "data": tags
         },

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
@@ -783,6 +783,8 @@ script:
       name: tags
     - description: The description of the indicator.
       name: description
+    - description: The name of the owner to which the Indicator belongs.
+      name: owner
     description: Adds a new indicator to ThreatConnect.
     name: tc-add-indicator
     outputs:

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_6.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ThreatConnect v3
+
+- Added support for the *owner* argument in the ***tc-add-indicator*** command.

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "3.1.5",
+    "currentVersion": "3.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: [XSUP-36658](https://jira-dc.paloaltonetworks.com/browse/XSUP-36658)

## Description
Added the missing argument `owner` to the `add-indicator` command

## Must have
- [x] Documentation 
