### PR TITLE
Starting Kubernetes 1.24, Secrets are not automatically created. Add manually create method to description files

### DIFF
--- a/Packs/AnsibleKubernetes/Integrations/AnsibleKubernetes/AnsibleKubernetes_description.md
+++ b/Packs/AnsibleKubernetes/Integrations/AnsibleKubernetes/AnsibleKubernetes_description.md
@@ -18,7 +18,21 @@ metadata:
 EOF
 ```
 
-2. Grant the service account an appropriate role. Refer to [Kubernetes RBAC docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) if granting more fine grain or scoped access.
+2. Create secret for the above service account
+```
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: xsoar-secret
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: xsoar
+EOF
+```
+
+3. Grant the service account an appropriate role. Refer to [Kubernetes RBAC docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) if granting more fine grain or scoped access.
 ```
 kubectl apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,14 +49,13 @@ subjects:
   namespace: kube-system
 EOF
 ```
-3. Retrieve the token object name created into a env var called TOKEN
+
+4. Generate the service account token
 ```
-TOKENNAME=`kubectl -n kube-system get serviceaccount/xsoar -o jsonpath='{.secrets[0].name}'`
+kubectl create token xsoar -n kube-system
 ```
-4. Output the API token value
-```
-kubectl -n kube-system get secret $TOKENNAME -o jsonpath='{.data.token}' | base64 -d
-```
+
+5. Copy the output token and paste it into the API field
 
 ## Testing
 

--- a/Packs/AnsibleKubernetes/Integrations/AnsibleKubernetes/README.md
+++ b/Packs/AnsibleKubernetes/Integrations/AnsibleKubernetes/README.md
@@ -17,7 +17,21 @@ metadata:
 EOF
 ```
 
-2. Grant the service account an appropriate role. Refer to [Kubernetes RBAC docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) if granting more fine grain or scoped access.
+2. Create secret for the above service account
+```
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: xsoar-secret
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: xsoar
+EOF
+```
+
+3. Grant the service account an appropriate role. Refer to [Kubernetes RBAC docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) if granting more fine grain or scoped access.
 ```
 kubectl apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,14 +48,14 @@ subjects:
   namespace: kube-system
 EOF
 ```
-3. Retrieve the token object name created into a env var called TOKEN
+
+4. Generate the service account token
 ```
-TOKENNAME=`kubectl -n kube-system get serviceaccount/xsoar -o jsonpath='{.secrets[0].name}'`
+kubectl create token xsoar -n kube-system
 ```
-4. Output the API token value
-```
-kubectl -n kube-system get secret $TOKENNAME -o jsonpath='{.data.token}' | base64 -d
-```
+
+5. Copy the output token and paste it into the API field
+
 ## Configure Ansible Kubernetes on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.

--- a/Packs/AnsibleKubernetes/ReleaseNotes/1_0_7.md
+++ b/Packs/AnsibleKubernetes/ReleaseNotes/1_0_7.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Ansible Kubernetes
+
+- Starting Kubernetes 1.24, Secrets are not automatically generated when Service Account are created. Minor update to manually create secret to get token.


### PR DESCRIPTION
…n Service Account are created. Minor update to manually create secret to get token.

Changed the following description files to affect this change

Changes to be committed:
	modified:   Integrations/AnsibleKubernetes/AnsibleKubernetes_description.md
	modified:   Integrations/AnsibleKubernetes/README.md
	new file:   ReleaseNotes/1_0_7.md

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
