### PR TITLE
Change Token in Contributions Board Github actions

### DIFF
--- a/.github/workflows/project_manager_daily.yml
+++ b/.github/workflows/project_manager_daily.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Get project manager
         run: |
           pip install --upgrade pip
-          pip install github-automation
+          pip install github-automation==0.2.3
       - name: Manage project
         run: |
           github-automation manage -c .github/project_conf/contributions.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.CONTENTBOT_BOARD_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project_manager_hourly.yml
+++ b/.github/workflows/project_manager_hourly.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Get project manager
         run: |
           pip install --upgrade pip
-          pip install github-automation
+          pip install github-automation==0.2.3
       - name: Manage project
         run: |
           github-automation manage -c .github/project_conf/contributions.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.CONTENTBOT_BOARD_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-10425)

## Description
It seems that the Token used in the following GitHub actions is revoked which causes them to fail:
-Manage Contribution Board - Daily
-Manage Contribution Board - Hourly

As discussed with @glicht it is better to use the GitHub default token. 

In this PR I:
1. Replaced the old token with the github default token.
2. Set the version of the github automation package to the last version for (best practice). 

## Must have
- [ ] Tests
- [ ] Documentation 
