### PR TITLE
Aws sns listener documentation edits

### DIFF
--- a/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
+++ b/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
@@ -14,7 +14,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: "Runs the service on this port from within Cortex XSOAR. Requires a unique port for each long-running integration instance. Do not use the same port for multiple instances. Note: If you click the test button more than once, a failure may occur mistakenly indicating that the port is already in use. (For Cortex XSOAR 8 and Cortex XSIAM) If you do not enter a Listen Port, an unused port for AWS SNS Listener will automatically be generated when the instance is saved. However, if using an engine, you must enter a Listen Port."
+- additionalinfo: "Runs the service on this port from within Cortex XSOAR. Requires a unique port for each long-running integration instance. Do not use the same port for multiple instances. Note: If you click the test button more than once, a failure may occur mistakenly indicating that the port is already in use."
   display: Listen Port
   name: longRunningPort
   type: 0

--- a/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
+++ b/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
@@ -61,7 +61,7 @@ display: AWS-SNS-Listener
 name: AWS-SNS-Listener
 script:
   commands: []
-  dockerimage: demisto/fastapi:1.0.0.93128
+  dockerimage: demisto/fastapi:0.110.3.93571
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/README.md
+++ b/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/README.md
@@ -10,7 +10,7 @@ This integration was integrated and tested with version January 2024 of AWS-SNS-
     | **Parameter** | **Description** | **Required** |
     | --- | --- | --- |
     | Long running instance |  Integration is long running by default| |
-    | Listen Port | Runs the service on this port from within Cortex XSOAR. Requires a unique port for each long-running integration instance. Do not use the same port for multiple instances. Note: If you click the test button more than once, a failure may occur mistakenly indicating that the port is already in use. \(For Cortex XSOAR 8 and Cortex XSIAM\) If you do not enter a Listen Port, an unused port for AWS SNS Listener will automatically be generated when the instance is saved. However, if using an engine, you must enter a Listen Port. | False |
+    | Listen Port | Runs the service on this port from within Cortex XSOAR. Requires a unique port for each long-running integration instance. Do not use the same port for multiple instances. Note: If you click the test button more than once, a failure may occur mistakenly indicating that the port is already in use. | False |
     | Username | Uses basic authentication for accessing the list. If empty, no authentication is enforced. \(For Cortex XSOAR 8 and Cortex XSIAM\) Optional for engines, otherwise mandatory. | False |
     | Password |  | False |
     | Endpoint | Set the endpoint of your listener. example: /snsv2 | False |
@@ -20,6 +20,7 @@ This integration was integrated and tested with version January 2024 of AWS-SNS-
     | Use system proxy settings |  | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
+
 
 ## Commands
 

--- a/Packs/AWS-SNS-Listener/ReleaseNotes/1_0_3.md
+++ b/Packs/AWS-SNS-Listener/ReleaseNotes/1_0_3.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### AWS-SNS-Listener
+
+- Updated the Docker image to: *demisto/fastapi:0.110.3.93571*.
+- Documentation and metadata improvements.

--- a/Packs/AWS-SNS-Listener/pack_metadata.json
+++ b/Packs/AWS-SNS-Listener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS-SNS-Listener",
     "description": "A long running AWS SNS Listener service that can subscribe to an SNS topic and create incidents from the messages received.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Description
Current status all long running integrations (except for EDL) is that they do not get a long running port assigned automatically on XSOAR8 / XSIAM.
This is in constrast to the the documentation.
This PR fixes the documentation for AWS-SNS-Listener.
Until server will fix the auto port allocation on their side.

