### PR TITLE
Fix Contributions Board Cron Jobs

### DIFF
--- a/.github/workflows/project_manager_daily.yml
+++ b/.github/workflows/project_manager_daily.yml
@@ -2,9 +2,6 @@ name: Manage Contribution Board - Daily
 on:
   schedule:
     - cron: "0 0 * * *"
-permissions:
-  contents: read
-
 jobs:
   manage_project_board:
     runs-on: ubuntu-latest
@@ -23,4 +20,4 @@ jobs:
         run: |
           github-automation manage -c .github/project_conf/contributions.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}

--- a/.github/workflows/project_manager_hourly.yml
+++ b/.github/workflows/project_manager_hourly.yml
@@ -2,8 +2,6 @@ name: Manage Contribution Board - Hourly
 on:
   schedule:
     - cron: "0 * * * *"
-permissions:
-  contents: read
 
 jobs:
   manage_project_board:
@@ -23,4 +21,4 @@ jobs:
         run: |
           github-automation manage -c .github/project_conf/contributions.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [CIAC-10425](https://jira-dc.paloaltonetworks.com/browse/CIAC-10425). 

## Description
The contributions board cron jobs (Manage Contribution Board - Daily, Manage Contribution Board - Hourly) have stopped running as described in the above-mentioned issue. 
In this PR I did the following: 
1. Changed the used token from the default Github Token to a more powerful token (reason explained in the issue).
2. Removed the permission section (cause it is relevant only for the Github Token which isn't used anymore). 


## Must have
- [x] Tests
- [ ] Documentation 
