### PR TITLE
[demistomock] Ruff Exclude `demistomock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -474,7 +474,7 @@ ignore = [
 
     "W605", # invalid-escape-sequence
 ]
-extend-exclude = ["CommonServerPython", "test_data", "conftest.py"]
+extend-exclude = ["CommonServerPython", "test_data", "conftest.py", "demistomock.py"]
 
 unfixable = [
     "RUF001"  # ambiguous-unicode-character-string


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-10461) to the issue

## Description
Add `demistomock` file to the `extend-exclude` config in `pyproject.toml`

