### PR TITLE
MS Sentinel - Added missing classification reason for BenignPositive classification when closing incident

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -74,7 +74,8 @@ OUTGOING_MIRRORED_FIELDS = {'etag', 'title', 'description', 'severity', 'status'
 OUTGOING_MIRRORED_FIELDS = {filed: pascalToSpace(filed) for filed in OUTGOING_MIRRORED_FIELDS}
 
 LEVEL_TO_SEVERITY = {0: 'Informational', 0.5: 'Informational', 1: 'Low', 2: 'Medium', 3: 'High', 4: 'High'}
-CLASSIFICATION_REASON = {'FalsePositive': 'InaccurateData', 'TruePositive': 'SuspiciousActivity'}
+CLASSIFICATION_REASON = {'FalsePositive': 'InaccurateData', 'TruePositive': 'SuspiciousActivity',
+                         'BenignPositive': 'SuspiciousButExpected'}
 
 
 class AzureSentinelClient:

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_41.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_41.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Sentinel
+
+- Fixed an issue where mirroring fails during incident closing when classification is 'BenignPositive'.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Sentinel",
     "description": "Microsoft Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.5.40",
+    "currentVersion": "1.5.41",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-37051)

## Description
Fixes mirroring issue when closing a Microsoft Sentinel incident with classification 'BenignPositive'.
Without this fix the following error can be observed:
`Error in Microsoft Sentinel outgoing mirror for incident <ID>. Error message: [BadRequest 400] classification 'BenignPositive' must have classificationReason.`

Will also add here that it seems puzzling that the classificationReason from the outgoing mapper is not used. Maybe there is a reason for it, so I decided not to change it here. However, the form of override as seen in L709 is not intuitive to the users.

Did not find any relevant tests to any of this logic, so no tests added.

## Must have
- [ ] Tests
- [ ] Documentation 
