### PR TITLE
Proofpoint Feed Integration Fix for firstseenbysource and lastseenbysource fields

### DIFF
--- a/Packs/FeedProofpoint/Integrations/FeedProofpoint/FeedProofpoint.py
+++ b/Packs/FeedProofpoint/Integrations/FeedProofpoint/FeedProofpoint.py
@@ -5,6 +5,7 @@ from CommonServerUserPython import *
 """ IMPORTS """
 import urllib3
 import csv
+import datapraser
 from typing import Generator, Tuple, Optional, List
 
 # disable insecure warnings
@@ -116,8 +117,8 @@ class Client(BaseClient):
             "fields": {
                 "tags": tags,
                 "port": item.get("ports", "").split() if isinstance(item.get("ports"), str) else item.get("ports"),
-                "firstseenbysource": item.get("first_seen", ""),
-                "lastseenbysource": item.get("last_seen", ""),
+                "firstseenbysource": datapraser.parse(item.get("first_seen", "")).isoformat(),
+                "lastseenbysource": datapraser.parse(item.get("last_seen", "")).isoformat(),
                 "threattypes": {
                     "threatcategory": item.get("category_name", ""),
                     "threatcategoryconfidence": item.get("score", "")

--- a/Packs/FeedProofpoint/Integrations/FeedProofpoint/FeedProofpoint.py
+++ b/Packs/FeedProofpoint/Integrations/FeedProofpoint/FeedProofpoint.py
@@ -5,7 +5,7 @@ from CommonServerUserPython import *
 """ IMPORTS """
 import urllib3
 import csv
-import datapraser
+import datepraser as dateparser
 from typing import Generator, Tuple, Optional, List
 
 # disable insecure warnings
@@ -110,6 +110,25 @@ class Client(BaseClient):
 
     @staticmethod
     def _process_item(item: dict, tags: list, tlp_color: Optional[str] = None) -> dict:
+        first_seen_raw = item.get("first_seen","")
+        last_seen_raw = item.get("last_seen","")
+
+        if first_seen_raw:
+            try:
+                first_seen = dateparser.parse(first_seen_raw).isoformat()
+            except AttributeError:
+                first_seen = ""
+        else:
+            first_seen = ""
+
+        if last_seen_raw:
+            try:
+                last_seen = dateparser.parse(last_seen_raw).isoformat()
+            except AttributeError:
+                last_seen = ""
+        else:
+            last_seen = ""
+
         indicator_obj = {
             "value": item["value"],
             "type": item["type"],
@@ -117,8 +136,8 @@ class Client(BaseClient):
             "fields": {
                 "tags": tags,
                 "port": item.get("ports", "").split() if isinstance(item.get("ports"), str) else item.get("ports"),
-                "firstseenbysource": datapraser.parse(item.get("first_seen", "")).isoformat(),
-                "lastseenbysource": datapraser.parse(item.get("last_seen", "")).isoformat(),
+                "firstseenbysource": first_seen,
+                "lastseenbysource": last_seen,
                 "threattypes": {
                     "threatcategory": item.get("category_name", ""),
                     "threatcategoryconfidence": item.get("score", "")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Currently, the code in the integration attempts to set XSOAR fields firstseenbysource and lastseenbysource with a date string that XSOAR does not like. This can result in thousands of error lines being printed to the server.log file depending on how many indicators are being fetched, and also it causes those two fields to always be set to N/A in XSOAR.

The code I'm introducing will attempt to format the first_seen and last_seen variables using the dateparser's isoformat() function. If for whatever reason those variables are "None" (i.e: Proofpoint sent them into XSOAR as "None") then it'll just set those variables to an empty string and not attempt to run isoformat() to avoid issues.

I have tested this in my client's environment and it got rid of the error messages in our server.log, while also populating the first seen by source & last seen by source fields. 


## Must have
- [ ] Tests
- [ ] Documentation 
