### PR TITLE
RSAArcherV2: add option for the OtherText property

### DIFF
--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.py
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.py
@@ -1089,6 +1089,9 @@ def generate_field_value(client, field_name, field_data, field_val, depth):
     if field_type == 4:
         field_data = client.get_field_value_list(field_data["FieldId"], depth)
         list_ids = []
+        other_text = None
+        if isinstance(field_val, dict) and (other_text := field_val.get('OtherText', None)):
+            field_val = field_val.get('ValuesList')
         if not isinstance(field_val, list):
             field_val = [field_val]
         for item in field_val:
@@ -1101,7 +1104,10 @@ def generate_field_value(client, field_name, field_data, field_val, depth):
                 raise Exception(
                     f"Failed to create the field: {field_name} with the value: {item}"
                 )
-        return "Value", {"ValuesListIds": list_ids}
+        res = {"ValuesListIds": list_ids}
+        if other_text:
+            res['OtherText'] = other_text
+        return "Value", res
 
     # when field type is External Links
     # for example: {"Patch URL":[{"value":"github", "link": "https://github.com"}]}

--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.yml
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2.yml
@@ -417,7 +417,7 @@ script:
   - arguments: []
     description: Prints the Archer's integration cache.
     name: archer-print-cache
-  dockerimage: demisto/python3-deb:3.10.13.87666
+  dockerimage: demisto/python3-deb:3.10.14.93258
   isfetch: true
   script: ''
   subtype: python3

--- a/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2_test.py
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/ArcherV2_test.py
@@ -614,7 +614,7 @@ class TestArcherV2:
         requests_mock.get(BASE_URL + 'api/core/system/valueslistvalue/valueslist/62', json=VALUE_LIST_RES)
         client = Client(BASE_URL, '', '', '', '', 400)
         field_data = client.get_field_value_list(304, 1)
-        assert VALUE_LIST_FIELD_DATA == field_data
+        assert field_data == VALUE_LIST_FIELD_DATA
 
     @pytest.mark.parametrize('args, expected_response', [(0, RES_DEPTH_0), (1, RES_DEPTH_1), (2, RES_DEPTH_2)])
     def test_get_field_value_list_nested_response(self, requests_mock, args, expected_response):
@@ -680,6 +680,27 @@ class TestArcherV2:
                                                       {"depth": 1})
         assert field_key == 'Value'
         assert field_value == {"UserList": [{"ID": 20}], "GroupList": [{"ID": 30}]}
+
+    def test_generate_field_values_list_with_other(self, requests_mock, mocker):
+        """
+            Given:
+                list values with "OtherText" from dictionary type under "fieldsToValues" argument
+
+            When:
+                - running archer-update-record
+
+            Then:
+                - assert fields are generated correctly
+
+        """
+        mocker.patch.object(Client, 'get_field_value_list', return_value={'ValuesList': [{"Name": "NA", "Id": 222}]})
+
+        client = Client(BASE_URL, '', '', '', '', 400)
+        field_key, field_value = generate_field_value(client, "", {'Type': 4, 'FieldId': 1234},
+                                                      {"ValuesList": ["NA"], "OtherText": "test"},
+                                                      {"depth": 1})
+        assert field_key == 'Value'
+        assert field_value == {'ValuesListIds': [222], 'OtherText': 'test'}
 
     def test_generate_invalid_field_users_groups_input(self):
         """

--- a/Packs/ArcherRSA/Integrations/ArcherV2/README.md
+++ b/Packs/ArcherRSA/Integrations/ArcherV2/README.md
@@ -423,6 +423,7 @@ Creates a new content record in the given application.
 Note: When creating a new record, make sure the values are sent through the *fieldsToValues* argument properly.
 
 - Example for the *Values List* field type: {"Type": ["Switch"], fieldname: [value1, value2]}
+- Example for the *Values List* field type with *OtherText* property: {"Patch Type": {"ValuesList": ["Custom Type"], "OtherText": "actuall text"}, field_name_without_other: [value1, value2]}
 - Example for the *External Links* field type: {"Patch URL": [{"value":"github", "link": "https://github.com"}]}
 - Example for the *Users/Groups List* field type: {"Policy Owner":{"users": [20],"groups": [30]}}
 - Example for the *Cross- Reference* field type: {"Area Reference(s)": [20]}

--- a/Packs/ArcherRSA/ReleaseNotes/1_2_17.md
+++ b/Packs/ArcherRSA/ReleaseNotes/1_2_17.md
@@ -1,0 +1,9 @@
+
+#### Integrations
+
+##### RSA Archer v2
+
+- Fixed an issue where the ***archer-update-record*** command would fail in case of a *Values List* field with *Other* property enabled.
+- Updated the Docker image to: *demisto/python3-deb:3.10.14.93258*.
+
+

--- a/Packs/ArcherRSA/pack_metadata.json
+++ b/Packs/ArcherRSA/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "RSA Archer",
     "description": "The RSA Archer GRC Platform provides a common foundation for managing policies, controls, risks, assessments and deficiencies across lines of business.",
     "support": "xsoar",
-    "currentVersion": "1.2.16",
+    "currentVersion": "1.2.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-37262

## Description
Currently in case of a record with a ValueList filed with an value that enable the Other property, we failed to update the record

FIx:
added the option to update the record by giving the `fieldsToValues` like in following:
```
!archer-update-record applicationId=5 contentId=246169 fieldsToValues=`{"Patch Type": {"ValuesList": ["OtherEnabled"], "OtherText": "short description"}}`
```

