### PR TITLE
NIST NVD 2.0 - KEV causing feed to timeout.

### DIFF
--- a/Packs/FeedNVDv2/Integrations/FeedNVDv2/FeedNVDv2.py
+++ b/Packs/FeedNVDv2/Integrations/FeedNVDv2/FeedNVDv2.py
@@ -71,6 +71,7 @@ class Client(BaseClient):
 
         param_string: str = '&'.join([f'{key}={value}' for key, value in params.items()])
         param_string = param_string.replace('noRejected=None', 'noRejected')
+        param_string = param_string.replace('hasKev=True', 'hasKev')
 
         for value in self.cvssv3severity:
             param_string += f'&cvssV3Severity={value}'
@@ -350,7 +351,7 @@ def retrieve_cves(client, start_date: Any, end_date: Any, publish_date: bool):
         param['lastModEndDate'] = end_date.strftime(DATE_FORMAT)
 
     if client.has_kev:
-        url_suffix += '&hasKev'
+        param['hasKev'] = True
 
     if client.keyword_search:
         param['keywordSearch'] = client.keyword_search

--- a/Packs/FeedNVDv2/Integrations/FeedNVDv2/FeedNVDv2_test.py
+++ b/Packs/FeedNVDv2/Integrations/FeedNVDv2/FeedNVDv2_test.py
@@ -131,6 +131,7 @@ def test_parse_cpe(cpe, expected_output, expected_relationships):
     [
         ({"param1": "value1", "noRejected": "None"}, "param1=value1&noRejected&cvssV3Severity=LOW&cvssV3Severity=MEDIUM"),
         ({"noRejected": "None"}, "noRejected&cvssV3Severity=LOW&cvssV3Severity=MEDIUM"),
+        ({"hasKev": "True"}, "hasKev&cvssV3Severity=LOW&cvssV3Severity=MEDIUM"),
     ],
 )
 def test_build_param_string(input_params, expected_param_string):

--- a/Packs/FeedNVDv2/ReleaseNotes/1_0_2.md
+++ b/Packs/FeedNVDv2/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### National Vulnerability Database Feed v2
+
+- Fixed an issue that caused the integration to timeout when kev parameter was selected by the user.

--- a/Packs/FeedNVDv2/ReleaseNotes/1_0_2.md
+++ b/Packs/FeedNVDv2/ReleaseNotes/1_0_2.md
@@ -3,4 +3,4 @@
 
 ##### National Vulnerability Database Feed v2
 
-- Fixed an issue that caused the integration to timeout when kev parameter was selected by the user.
+Fixed an issue that caused the integration to timeout when the *kev* parameter was selected by the user.

--- a/Packs/FeedNVDv2/pack_metadata.json
+++ b/Packs/FeedNVDv2/pack_metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "NVD Feed 2.0",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-37575

## Description
When KEV was requested by the user a malformed URL was created which caused a timeout. 
Fixed the formation of the URL.