### PR TITLE
adding timeout param

### DIFF
--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -1304,7 +1304,7 @@ def searchRelationships(args):
     return {'data': []}
 
 
-def _apiCall(name=None, params=None, data=None, headers=None, method=None, path=None):
+def _apiCall(name=None, params=None, data=None, headers=None, method=None, path=None, timeout=None):
     """
     Special apiCall to internal xdr api. Only available to OOB content.
 
@@ -1315,6 +1315,7 @@ def _apiCall(name=None, params=None, data=None, headers=None, method=None, path=
         headers: headers to pass. Use a dictionary such as: `{"key":"value"}`
         method: HTTP method to use.
         path: path to append to the base url.
+        timeout: The amount of time (in seconds) that a request will wait for a client to send data before the request is aborted.
 
         *Note if data is empty then a GET request is performed instead of a POST.
 


### PR DESCRIPTION

## Status
- [x]  Ready

## Related Issues
fixes: None
related: https://github.com/demisto/content/pull/34620

## Description
Adding timeout parameter since it was added to the function by server, and also so the related pr won't fail on 
`Unexpected keyword argument 'timeout' `

