### PR TITLE
Joe-submission-info command Update

### DIFF
--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.yml
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.yml
@@ -625,6 +625,7 @@ script:
     arguments:
     - name: submission_ids
       description: A comma-separated list of submission IDs.
+      required: true
     - name: full_display
       description: When set to true, indicators information, including their DBot Scores, will be displayed.
       defaultValue: "true"

--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/README.md
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/README.md
@@ -719,7 +719,7 @@ Retrieve the submission info.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| submission_ids | A comma-separated list of submission IDs. | Optional | 
+| submission_ids | A comma-separated list of submission IDs. | Required | 
 | full_display | When set to true, indicators information, including their DBot Scores, will be displayed. Possible values are: true, false. Default is true. | Optional | 
 
 

--- a/Packs/JoeSecurity/ReleaseNotes/1_1_21.json
+++ b/Packs/JoeSecurity/ReleaseNotes/1_1_21.json
@@ -1,0 +1,4 @@
+{
+    "breakingChanges": true,
+    "breakingChangesNotes": "The **joe-submission-info** command now requires the *submission_ids* argument."
+}

--- a/Packs/JoeSecurity/ReleaseNotes/1_1_21.md
+++ b/Packs/JoeSecurity/ReleaseNotes/1_1_21.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Joe Security v2
+
+- Updated the **joe-submission-info** command to requires the *submission_ids* argument to be provided.

--- a/Packs/JoeSecurity/ReleaseNotes/1_1_21.md
+++ b/Packs/JoeSecurity/ReleaseNotes/1_1_21.md
@@ -3,4 +3,5 @@
 
 ##### Joe Security v2
 
-- Updated the **joe-submission-info** command to requires the *submission_ids* argument to be provided.
+- **Breaking Change**: The *submission_ids* argument is now required when using the command **joe-submission-info*.
+

--- a/Packs/JoeSecurity/pack_metadata.json
+++ b/Packs/JoeSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Joe Security",
     "description": "Sandbox Cloud",
     "support": "xsoar",
-    "currentVersion": "1.1.20",
+    "currentVersion": "1.1.21",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Description
The `submission_ids` argument of the `joe-submission-info` command is now required because the command's purpose is to retrieve information for a specific ID. Without this argument, the command cannot function as intended. This design ensures that the necessary information is not overlooked.