### PR TITLE
CIAC-8513 Notify when there is more than 1 PR that was contributed by the same author - addition to find internal PR's as well

### DIFF
--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -332,7 +332,7 @@ def find_all_open_prs_by_user(content_repo: Repository, pr_creator: str, pr_numb
     for pr in all_prs:
         if pr.number == pr_number:  # Exclude current PR
             continue
-        existing_pr_author = get_user_from_pr_body(pr) if pr.user.login == "xsoar-bot" else pr.user.login
+        existing_pr_author = get_user_from_pr_body(pr) if pr.user.login in ["xsoar-bot", "content-bot"] else pr.user.login
         if existing_pr_author == pr_creator:
             similar_prs.append(pr)
     print(f'PR\'s by the same author: {similar_prs}')
@@ -371,7 +371,7 @@ def find_reviewer_to_assign(content_repo: Repository, pr: PullRequest, pr_number
     Returns:
     - Reviewer to assign
     """
-    if pr.user.login == "xsoar-bot":
+    if pr.user.login in ["xsoar-bot", "content-bot"]:
         pr_creator = get_user_from_pr_body(pr)
     else:
         pr_creator = pr.user.login


### PR DESCRIPTION
CIAC-8513 Notify when there is more than 1 PR that was contributed by the same author - addition to find internal PR's as well

We found that internal PR's are not found by the solution here [PR](https://github.com/demisto/content/pull/33870),
as Internal PR's are opened by content-bot, they weren't found by the handle_external_pr and missed and not counted.
Added the option to look also for PR's opened by content-bot

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-8513)

