### PR TITLE
Deprecate O365 Defender SafeLinks - Single User

### DIFF
--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -3,7 +3,7 @@ sectionOrder:
 - Connect
 - Collect
 commonfields:
-  id: O365 Defender SafeLinks - Single User
+  id: O365 Defender SafeLinks - Single User (Deprecated)
   version: -1
 configuration:
 - display: Exchange Online URL
@@ -24,7 +24,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-description: Enables URL scanning, rewriting inbound email messages in the mail flow, time-of-click URL verification, and links in email messages and other locations.
+description: Deprecated. Use O365 Defender SafeLinks instead. Enables URL scanning, rewriting inbound email messages in the mail flow, time-of-click URL verification, and links in email messages and other locations.
 display: O365 Defender SafeLinks - Single User
 name: O365 Defender SafeLinks - Single User
 script:
@@ -960,6 +960,7 @@ script:
   script: '-'
   type: powershell
   dockerimage: demisto/powershell-ubuntu:7.4.1.86201
+deprecated: true
 fromversion: 6.0.0
 tests:
 - No Test

--- a/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
+++ b/Packs/Microsoft365Defender/Integrations/O365DefenderSafeLinksSingleUser/O365DefenderSafeLinksSingleUser.yml
@@ -3,7 +3,7 @@ sectionOrder:
 - Connect
 - Collect
 commonfields:
-  id: O365 Defender SafeLinks - Single User (Deprecated)
+  id: O365 Defender SafeLinks - Single User
   version: -1
 configuration:
 - display: Exchange Online URL
@@ -25,7 +25,7 @@ configuration:
   advanced: true
   required: false
 description: Deprecated. Use O365 Defender SafeLinks instead. Enables URL scanning, rewriting inbound email messages in the mail flow, time-of-click URL verification, and links in email messages and other locations.
-display: O365 Defender SafeLinks - Single User
+display: O365 Defender SafeLinks - Single User (Deprecated)
 name: O365 Defender SafeLinks - Single User
 script:
   commands:

--- a/Packs/Microsoft365Defender/ReleaseNotes/4_5_27.md
+++ b/Packs/Microsoft365Defender/ReleaseNotes/4_5_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### O365 Defender SafeLinks - Single User (Deprecated)
+
+- Deprecated. Use O365 Defender SafeLinks instead.

--- a/Packs/Microsoft365Defender/ReleaseNotes/4_5_27.md
+++ b/Packs/Microsoft365Defender/ReleaseNotes/4_5_27.md
@@ -3,4 +3,4 @@
 
 ##### O365 Defender SafeLinks - Single User (Deprecated)
 
-- Deprecated. Use O365 Defender SafeLinks instead.
+Deprecated. Use O365 Defender SafeLinks instead.

--- a/Packs/Microsoft365Defender/pack_metadata.json
+++ b/Packs/Microsoft365Defender/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft 365 Defender",
     "description": "Microsoft Defender XDR (formerly Microsoft 365 Defender) is a unified pre- and post-breach enterprise defense suite that natively coordinates detection, prevention, investigation, and response across endpoints, identities, email, and applications to provide integrated protection against sophisticated attacks.",
     "support": "xsoar",
-    "currentVersion": "4.5.26",
+    "currentVersion": "4.5.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-37913)

## Description
Safelink single-user is being deprecated because Microsoft no longer allows single user authentication

## Must have
- [ ] Tests
- [ ] Documentation 
