### PR TITLE
Fix issue when finding reviewer and reviewer already finished the review

### DIFF
--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -350,9 +350,12 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     - Reviewer of the found pr's
     """
     content_reviewers_set = set(content_reviewers)
+    print (f"Content reviewers are : {content_reviewers_set}")
     for pr in other_prs_by_same_user:
         reviewer_names = {reviewer.login for reviewer in pr.requested_reviewers}
+        print(f'reviewer names are : {reviewer_names}')
         existing_reviewer = content_reviewers_set.intersection(reviewer_names)
+        print(f'existing reviewer {existing_reviewer}')
         if existing_reviewer:
             return existing_reviewer.pop()
         else:
@@ -376,7 +379,7 @@ def find_reviewer_to_assign(content_repo: Repository, pr: PullRequest, pr_number
     else:
         pr_creator = pr.user.login
 
-    other_prs_by_same_user = find_all_open_prs_by_user(content_repo, pr_creator, pr_number)
+    other_prs_by_same_user = find_all_open_prs_by_user(content_repo, "enes-oezdemir", pr_number)
 
     reviewer_to_assign = reviewer_of_prs_from_current_round(other_prs_by_same_user, content_reviewers)
     if reviewer_to_assign:

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -332,7 +332,7 @@ def find_all_open_prs_by_user(content_repo: Repository, pr_creator: str, pr_numb
     for pr in all_prs:
         if pr.number == pr_number:  # Exclude current PR
             continue
-        if pr.number == "34741":
+        if int(pr.number) == 34741:
             continue
         existing_pr_author = get_user_from_pr_body(pr) if pr.user.login == "xsoar-bot" else pr.user.login
         if existing_pr_author == pr_creator:

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -355,10 +355,10 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     print (f"Content reviewers are : {content_reviewers_set}")
     for pr in other_prs_by_same_user:
         print (f'the PR is: {pr}')
-        print (f'the requested reviewers are : {pr.requested_reviewers}')
-        reviewer_names = {reviewer.login for reviewer in pr.requested_reviewers}
-        print(f'reviewer names are : {reviewer_names}')
-        existing_reviewer = content_reviewers_set.intersection(reviewer_names)
+        print (f'the requested reviewers are : {pr.assignees}')
+        assignee_names = {reviewer.login for reviewer in pr.assignees}
+        print(f'reviewer names are : {assignee_names}')
+        existing_reviewer = content_reviewers_set.intersection(assignee_names)
         print(f'existing reviewer {existing_reviewer}')
         if existing_reviewer:
             return existing_reviewer.pop()

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -352,6 +352,8 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     content_reviewers_set = set(content_reviewers)
     print (f"Content reviewers are : {content_reviewers_set}")
     for pr in other_prs_by_same_user:
+        print (f'the PR is: {pr}')
+        print (f'the requested reviewers are : {pr.requested_reviewers}')
         reviewer_names = {reviewer.login for reviewer in pr.requested_reviewers}
         print(f'reviewer names are : {reviewer_names}')
         existing_reviewer = content_reviewers_set.intersection(reviewer_names)

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -332,6 +332,8 @@ def find_all_open_prs_by_user(content_repo: Repository, pr_creator: str, pr_numb
     for pr in all_prs:
         if pr.number == pr_number:  # Exclude current PR
             continue
+        if pr.number == "34741":
+            continue
         existing_pr_author = get_user_from_pr_body(pr) if pr.user.login == "xsoar-bot" else pr.user.login
         if existing_pr_author == pr_creator:
             similar_prs.append(pr)

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -332,8 +332,6 @@ def find_all_open_prs_by_user(content_repo: Repository, pr_creator: str, pr_numb
     for pr in all_prs:
         if pr.number == pr_number:  # Exclude current PR
             continue
-        if int(pr.number) == 34741:
-            continue
         existing_pr_author = get_user_from_pr_body(pr) if pr.user.login == "xsoar-bot" else pr.user.login
         if existing_pr_author == pr_creator:
             similar_prs.append(pr)
@@ -352,14 +350,10 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     - Reviewer of the found pr's
     """
     content_reviewers_set = set(content_reviewers)
-    print (f"Content reviewers are : {content_reviewers_set}")
     for pr in other_prs_by_same_user:
-        print (f'the PR is: {pr}')
-        print (f'the requested reviewers are : {pr.assignees}')
-        assignee_names = {reviewer.login for reviewer in pr.assignees}
-        print(f'reviewer names are : {assignee_names}')
+        print (f'the requested assignees are : {pr.assignees}')
+        assignee_names = {assignee.login for assignee in pr.assignees}
         existing_reviewer = content_reviewers_set.intersection(assignee_names)
-        print(f'existing reviewer {existing_reviewer}')
         if existing_reviewer:
             return existing_reviewer.pop()
         else:
@@ -383,7 +377,7 @@ def find_reviewer_to_assign(content_repo: Repository, pr: PullRequest, pr_number
     else:
         pr_creator = pr.user.login
 
-    other_prs_by_same_user = find_all_open_prs_by_user(content_repo, "enes-oezdemir", pr_number)
+    other_prs_by_same_user = find_all_open_prs_by_user(content_repo, pr_creator, pr_number)
 
     reviewer_to_assign = reviewer_of_prs_from_current_round(other_prs_by_same_user, content_reviewers)
     if reviewer_to_assign:

--- a/Utils/github_workflow_scripts/handle_external_pr.py
+++ b/Utils/github_workflow_scripts/handle_external_pr.py
@@ -343,6 +343,7 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     """
     Get all PR's that are currently open from the same author, filter the list and return reviewer if reviewer is part
     of the current contribution round
+    The check for reviewer is done with assignees because reviewers list after initial review is empty.
     Arguments:
     - other_prs_by_same_user - list of opened PR's
 


### PR DESCRIPTION
**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-8513)

## Description
After reviewer done with review - github "requested_reviewers" is empty, until re-review is requested.
So need to switch the lookup for assignees and not reviewers

The fix was tested in this [PR](https://github.com/demisto/content/pull/34754) and this [check](https://github.com/demisto/content/pull/34754/checks) that was opened to the branch of this PR