### PR TITLE
Add Documentation Approved Check

### DIFF
--- a/.github/workflows/check-docs-approved.yml
+++ b/.github/workflows/check-docs-approved.yml
@@ -1,0 +1,13 @@
+name: Check Documentation Approved
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  check-docs-approved:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Check docs-approved Label
+          uses: egmacke/action-check-label@v3
+          with:
+            label: docs-approved


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10226

## Description
Add a new check for `docs-approved` label.

## Must have
- [x] Tests - Add `docs-approved` to [PR](https://github.com/demisto/content/pull/34648/)

<img width="976" alt="image" src="https://github.com/demisto/content/assets/85439776/8aae91fa-db53-4cd6-8d37-c117ac694508">

- [x] Tests - Remove `docs-approved` to [PR](https://github.com/demisto/content/pull/34648/)

<img width="970" alt="image" src="https://github.com/demisto/content/assets/85439776/d33d7b7d-f8d6-451a-a995-567a45c9c89a">

- [ ] Documentation 
