### PR TITLE
skipping autopep8 on nightlies

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -50,6 +50,7 @@ repos:
     - community
     exclude_support_level:nightly:
     - community
+    skip:nightly: true
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.982
   hooks:


### PR DESCRIPTION
## Description
Skipping the autopep8 on pre-commit nightlies due to an issue with this step.
