### PR TITLE
ReadPDFFileV2 open in binary mode

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_11.md
@@ -1,0 +1,4 @@
+##### ReadPDFFileV2
+
+- Updated the Docker image to: *demisto/readpdf:1.0.0.98214*.
+- Fixed an issue where the script failed to open and extract the PDF's data.

--- a/Packs/CommonScripts/ReleaseNotes/1_15_11.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_11.md
@@ -1,3 +1,5 @@
+#### Scripts
+
 ##### ReadPDFFileV2
 
 - Updated the Docker image to: *demisto/readpdf:1.0.0.98214*.

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/README.md
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/README.md
@@ -18,6 +18,7 @@ Load a PDF file's content and metadata into context. Supports extraction of hash
 | entryID | The War Room entryID of the file to read. |
 | userPassword | The password for the file, if encrypted. |
 | maxImages | The maximum number of images to extract from the PDF file. |
+| unescape_url | To unescape URLs that have been escaped as part of the URLs extraction. Invalid characters will be ignored. Default is true.|
 
 ## Outputs
 ---

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
@@ -240,9 +240,9 @@ def get_pdf_htmls_content(pdf_path: str, output_folder: str, unescape_url: bool 
     html_file_names = get_files_names_in_path(output_folder, "*.html")
     html_content = ""
     for file_name in html_file_names:
-        with open(file_name) as f:
+        with open(file_name, "rb") as f:
             for line in f:
-                html_content += html.unescape(line) if unescape_url else line
+                html_content += html.unescape(str(line)) if unescape_url else str(line)
     return html_content
 
 

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.yml
@@ -129,7 +129,7 @@ tags:
 - ingestion
 timeout: "0"
 type: python
-dockerimage: demisto/readpdf:1.0.0.93363
+dockerimage: demisto/readpdf:1.0.0.98214
 runas: DBotRole
 tests:
 - Extract Indicators From File - Generic v2 - Test

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.10",
+    "currentVersion": "1.15.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-38422

## Description
Fixed an issue where the pdf file was no open in binary mode before extracting data.

## Must have
- [ ] Tests
- [ ] Documentation 
