### PR TITLE
Get Content Roles from Blob

### DIFF
--- a/.github/content_roles.json
+++ b/.github/content_roles.json
@@ -1,15 +1,15 @@
 {
     "CONTRIBUTION_REVIEWERS": [
-        "RotemAmit",
-        "jlevypaloalto",
-        "Shellyber"
+        "cr1",
+        "cr2",
+        "cr3"
     ],
-    "CONTRIBUTION_TL": "BEAdi",
-    "CONTRIBUTION_SECURITY_REVIEWER": "ssokolovich",
+    "CONTRIBUTION_TL": "tl",
+    "CONTRIBUTION_SECURITY_REVIEWER": "sr",
     "ON_CALL_DEVS": [
-        "acarmi",
-        "ypreisler"
+        "ocd1",
+        "ocd2"
     ],
-    "DOC_REVIEWER": "ShirleyDenkberg",
-    "TIM_REVIEWER": "MLainer1"
+    "DOC_REVIEWER": "dr",
+    "TIM_REVIEWER": "tr"
 }

--- a/.github/content_roles.json
+++ b/.github/content_roles.json
@@ -1,15 +1,15 @@
 {
     "CONTRIBUTION_REVIEWERS": [
-        "cr1",
-        "cr2",
-        "cr3"
+        "RotemAmit",
+        "jlevypaloalto",
+        "Shellyber"
     ],
-    "CONTRIBUTION_TL": "tl",
-    "CONTRIBUTION_SECURITY_REVIEWER": "sr",
+    "CONTRIBUTION_TL": "BEAdi",
+    "CONTRIBUTION_SECURITY_REVIEWER": "ssokolovich",
     "ON_CALL_DEVS": [
-        "ocd1",
-        "ocd2"
+        "acarmi",
+        "ypreisler"
     ],
-    "DOC_REVIEWER": "dr",
-    "TIM_REVIEWER": "tr"
+    "DOC_REVIEWER": "ShirleyDenkberg",
+    "TIM_REVIEWER": "MLainer1"
 }

--- a/.github/github_workflow_scripts/handle_external_pr.py
+++ b/.github/github_workflow_scripts/handle_external_pr.py
@@ -2,6 +2,7 @@
 import json
 import os
 from pathlib import Path
+import sys
 import urllib3
 from blessings import Terminal
 from github import Github
@@ -19,9 +20,8 @@ from utils import (
     get_env_var,
     timestamped_print,
     Checkout,
-    load_json,
     get_content_reviewers,
-    CONTENT_ROLES_PATH,
+    get_content_roles,
     get_support_level
 )
 from demisto_sdk.commands.common.tools import get_pack_name
@@ -463,7 +463,12 @@ def main():
 
     # Parse PR reviewers from JSON and assign them
     # Exit if JSON doesn't exist or not parsable
-    content_roles = load_json(CONTENT_ROLES_PATH)
+    content_roles = get_content_roles()
+
+    if not content_roles:
+        print("Unable to retrieve the content roles. Exiting...")
+        sys.exit(1)
+
     content_reviewers, security_reviewer, tim_reviewer = get_content_reviewers(content_roles)
 
     print(f"Content Reviewers: {','.join(content_reviewers)}")

--- a/.github/github_workflow_scripts/utils.py
+++ b/.github/github_workflow_scripts/utils.py
@@ -11,15 +11,16 @@ from pathlib import Path
 from demisto_sdk.commands.common.tools import get_pack_metadata
 from git import Repo
 
-CONTENT_ROOT_PATH = os.path.abspath(os.path.join(__file__, '../../..'))
-CONTENT_ROLES_PATH = Path(os.path.join(CONTENT_ROOT_PATH, ".github", "content_roles.json"))
+CONTENT_ROLES_FILENAME = "content_roles.json"
+CONTENT_ROOT_PATH = os.path.abspath(os.path.join(__file__, '../../..'))  # full path to content root repo
+CONTENT_ROLES_PATH = Path(CONTENT_ROOT_PATH, ".github", CONTENT_ROLES_FILENAME)
 
 DOC_REVIEWER_KEY = "DOC_REVIEWER"
 CONTRIBUTION_REVIEWERS_KEY = "CONTRIBUTION_REVIEWERS"
 CONTRIBUTION_SECURITY_REVIEWER_KEY = "CONTRIBUTION_SECURITY_REVIEWER"
 TIM_REVIEWER_KEY = "TIM_REVIEWER"
 
-CONTENT_ROLES_BLOB_MASTER_URL = "https://raw.githubusercontent.com/demisto/content/master/.github/content_roles.json"
+CONTENT_ROLES_BLOB_MASTER_URL = f"https://raw.githubusercontent.com/demisto/content/master/.github/{CONTENT_ROLES_FILENAME}"
 
 # override print so we have a timestamp with each print
 org_print = print
@@ -269,10 +270,10 @@ def get_content_roles_from_blob() -> dict[str, Any] | None:
         response = requests.get(CONTENT_ROLES_BLOB_MASTER_URL)
         response.raise_for_status()  # Raise an error for bad status codes
         json_data = response.json()
-        print("Successfully retrieved content_roles.json from blob")
+        print(f"Successfully retrieved {CONTENT_ROLES_FILENAME} from blob")
         roles = json_data
     except (requests.RequestException, requests.HTTPError, json.JSONDecodeError, TypeError) as e:
-        print(f"{e.__class__.__name__} getting content_roles.json from blob: {e}.")
+        print(f"{e.__class__.__name__} getting {CONTENT_ROLES_FILENAME} from blob: {e}.")
     finally:
         return roles
 
@@ -287,11 +288,11 @@ def get_content_roles(res_path: Path = CONTENT_ROLES_PATH) -> dict[str, Any] | N
     - `dict[str, Any]` representing the content roles.
     """
 
-    print(f"Attempting to retrieve 'content_roles.json' from blob {CONTENT_ROLES_BLOB_MASTER_URL}...")
+    print(f"Attempting to retrieve '{CONTENT_ROLES_FILENAME}' from blob {CONTENT_ROLES_BLOB_MASTER_URL}...")
     roles = get_content_roles_from_blob()
 
     if not roles:
-        print("Unable to retrieve 'content_roles.json' from blob. Attempting to retrieve from the filesystem...")
+        print("Unable to retrieve '{CONTENT_ROLES_FILENAME}' from blob. Attempting to retrieve from the filesystem...")
         roles = load_json(res_path)
 
     return roles

--- a/.github/github_workflow_scripts/utils.py
+++ b/.github/github_workflow_scripts/utils.py
@@ -3,21 +3,22 @@
 import os
 import sys
 import json
+import requests
 from datetime import datetime
 from typing import Any
 from collections.abc import Generator, Iterable
 from pathlib import Path
 from demisto_sdk.commands.common.tools import get_pack_metadata
-import requests
 from git import Repo
+
+CONTENT_ROOT_PATH = os.path.abspath(os.path.join(__file__, '../../..'))
+CONTENT_ROLES_PATH = Path(os.path.join(CONTENT_ROOT_PATH, ".github", "content_roles.json"))
 
 DOC_REVIEWER_KEY = "DOC_REVIEWER"
 CONTRIBUTION_REVIEWERS_KEY = "CONTRIBUTION_REVIEWERS"
 CONTRIBUTION_SECURITY_REVIEWER_KEY = "CONTRIBUTION_SECURITY_REVIEWER"
 TIM_REVIEWER_KEY = "TIM_REVIEWER"
 
-CONTENT_ROOT_PATH = os.path.abspath(os.path.join(__file__, '../../..'))
-CONTENT_ROLES_PATH = Path(os.path.join(CONTENT_ROOT_PATH, ".github", "content_roles.json"))
 CONTENT_ROLES_BLOB_MASTER_URL = "https://raw.githubusercontent.com/demisto/content/master/.github/content_roles.json"
 
 # override print so we have a timestamp with each print

--- a/.github/github_workflow_scripts/utils.py
+++ b/.github/github_workflow_scripts/utils.py
@@ -271,8 +271,7 @@ def get_content_roles_from_blob() -> dict[str, Any] | None:
         response = requests.get(CONTENT_ROLES_BLOB_MASTER_URL)
         response.raise_for_status()  # Raise an error for bad status codes
         print(f"Successfully retrieved {CONTENT_ROLES_FILENAME} from blob")
-        json_data = response.json()
-        roles = json_data
+        roles = response.json()
     except (requests.RequestException, requests.HTTPError, json.JSONDecodeError, TypeError) as e:
         print(f"{e.__class__.__name__} getting {CONTENT_ROLES_FILENAME} from blob: {e}.")
     finally:

--- a/.github/github_workflow_scripts/utils.py
+++ b/.github/github_workflow_scripts/utils.py
@@ -282,7 +282,7 @@ def get_content_roles(res_path: Path = CONTENT_ROLES_PATH) -> dict[str, Any] | N
     """
     Helper method to retrieve the content roles config.
     We first attempt to retrieve the content roles from `demisto/content` master blob.
-    If this attempt fails, we attempt to retrieve it from the filesystem. 
+    If this attempt fails, we attempt to retrieve it from the filesystem.
 
     Returns:
     - `dict[str, Any]` representing the content roles.

--- a/.github/github_workflow_scripts/utils_test.py
+++ b/.github/github_workflow_scripts/utils_test.py
@@ -2,7 +2,6 @@
 import json
 from pathlib import Path
 import pytest
-from pytest_mock import MockerFixture
 import requests_mock
 from typing import Any
 from utils import (

--- a/.github/github_workflow_scripts/utils_test.py
+++ b/.github/github_workflow_scripts/utils_test.py
@@ -15,8 +15,10 @@ from utils import (
     get_doc_reviewer,
     CONTENT_ROLES_BLOB_MASTER_URL,
     get_content_roles,
-    CONTENT_ROLES_FILENAME
+    CONTENT_ROLES_FILENAME,
+    GITHUB_HIDDEN_DIR
 )
+from git import Repo
 
 
 class TestGetEnvVar:
@@ -365,12 +367,14 @@ class TestGetContentRoles:
             status_code=404
         )
 
-        # Create content_roles in fs
-        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
+        # Create repo and content_roles.json in fs
+        Repo.init(tmp_path)
+        (tmp_path / GITHUB_HIDDEN_DIR).mkdir()
+        content_roles_path = tmp_path / GITHUB_HIDDEN_DIR / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text(json.dumps(self.content_roles, indent=4))
 
-        actual_content_roles = get_content_roles(content_roles_path)
+        actual_content_roles = get_content_roles(tmp_path)
 
         assert actual_content_roles
         assert CONTRIBUTION_REVIEWERS_KEY in actual_content_roles
@@ -401,12 +405,14 @@ class TestGetContentRoles:
             json={"only_key"}
         )
 
-        # Create content_roles in fs
-        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
+        # Create repo and content_roles.json in fs
+        Repo.init(tmp_path)
+        (tmp_path / GITHUB_HIDDEN_DIR).mkdir()
+        content_roles_path = tmp_path / GITHUB_HIDDEN_DIR / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text(json.dumps(self.content_roles, indent=4))
 
-        actual_content_roles = get_content_roles(content_roles_path)
+        actual_content_roles = get_content_roles(tmp_path)
 
         assert actual_content_roles
         assert CONTRIBUTION_REVIEWERS_KEY in actual_content_roles
@@ -438,11 +444,13 @@ class TestGetContentRoles:
             json={"only_key"}
         )
 
-        # Create content_roles in fs
-        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
+        # Create repo and content_roles.json in fs
+        Repo.init(tmp_path)
+        (tmp_path / GITHUB_HIDDEN_DIR).mkdir()
+        content_roles_path = tmp_path / GITHUB_HIDDEN_DIR / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text("{\"only_key\"}")
 
-        actual_content_roles = get_content_roles(content_roles_path)
+        actual_content_roles = get_content_roles(tmp_path)
 
         assert not actual_content_roles

--- a/.github/github_workflow_scripts/utils_test.py
+++ b/.github/github_workflow_scripts/utils_test.py
@@ -304,12 +304,12 @@ def test_exit_get_doc_reviewer(
 class TestGetContentRoles:
 
     content_roles: dict[str, Any] = {
-        'CONTRIBUTION_REVIEWERS': ['prr1', 'prr2', 'prr3'],
+        CONTRIBUTION_REVIEWERS_KEY: ['prr1', 'prr2', 'prr3'],
         'CONTRIBUTION_TL': 'tl1',
-        'CONTRIBUTION_SECURITY_REVIEWER': 'sr1',
+        CONTRIBUTION_SECURITY_REVIEWER_KEY: 'sr1',
         'ON_CALL_DEVS': ['ocd1', 'ocd2'],
-        'DOC_REVIEWER': 'dr1',
-        'TIM_REVIEWER': 'tr1'
+        DOC_REVIEWER_KEY: 'dr1',
+        TIM_REVIEWER_KEY: 'tr1'
     }
 
     def test_get_content_roles_success(

--- a/.github/github_workflow_scripts/utils_test.py
+++ b/.github/github_workflow_scripts/utils_test.py
@@ -15,7 +15,8 @@ from utils import (
     DOC_REVIEWER_KEY,
     get_doc_reviewer,
     CONTENT_ROLES_BLOB_MASTER_URL,
-    get_content_roles
+    get_content_roles,
+    CONTENT_ROLES_FILENAME
 )
 
 
@@ -366,7 +367,7 @@ class TestGetContentRoles:
         )
 
         # Create content_roles in fs
-        content_roles_path = tmp_path / "content_roles.json"
+        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text(json.dumps(self.content_roles, indent=4))
 
@@ -402,7 +403,7 @@ class TestGetContentRoles:
         )
 
         # Create content_roles in fs
-        content_roles_path = tmp_path / "content_roles.json"
+        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text(json.dumps(self.content_roles, indent=4))
 
@@ -439,7 +440,7 @@ class TestGetContentRoles:
         )
 
         # Create content_roles in fs
-        content_roles_path = tmp_path / "content_roles.json"
+        content_roles_path = tmp_path / CONTENT_ROLES_FILENAME
         content_roles_path.touch()
         content_roles_path.write_text("{\"only_key\"}")
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/CIAC-10855

## Description
Retrieve the `content_roles.json` from `demisto/content` `master` blob instead of from the filesystem. If we can't get it from the `master` blob, we use the one from the filesystem as a fallback.

This is to fix an issue where contributions coming from forks have an outdated `content_roles.json` file and incorrectly assigns PR reviewers.

## Must have
- [x] Unit Tests
- [x] Test PR from fork https://github.com/demisto/content/pull/34934, [handle-external-pr job log](https://github.com/demisto/content/actions/runs/9581550016/job/26418600264?pr=34934#step:8:569).

![image](https://github.com/demisto/content/assets/85439776/481cb63f-a329-4d67-b11d-70b61b3bd7c9)

