### PR TITLE
PrintToParentIncident skip name change

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_13.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_13.md
@@ -1,0 +1,6 @@
+#### Scripts
+
+##### PrintToParentIncident
+
+- Added the `skipprepare` attribute to prevent scripts and tasks containing the word incident from being replaced with the word alert.
+- - Updated the Docker image to: *demisto/python3:3.10.14.98471*.

--- a/Packs/CommonScripts/Scripts/PrintToParentIncident/PrintToParentIncident.yml
+++ b/Packs/CommonScripts/Scripts/PrintToParentIncident/PrintToParentIncident.yml
@@ -15,9 +15,11 @@ timeout: '0'
 runas: DBotWeakRole
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.14.97374
+dockerimage: demisto/python3:3.10.14.98471
 fromversion: 8.7.0
 marketplaces:
 - marketplacev2
 tests:
 - No test - unit test
+skipprepare:
+- script-name-incident-to-alert

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.12",
+    "currentVersion": "1.15.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-38559

## Description
Added the `skipprepare` attribute to prevent scripts and tasks containing the word incident from being replaced with the word alert.

## Must have
- [ ] Tests
- [ ] Documentation 
