### PR TITLE
remove zipfile from native ignore

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -183,14 +183,6 @@
                 "native:8.6",
                 "native:candidate"
             ]
-        },
-        {
-            "id": "ZipFile",
-            "reason": "see CIAC-10361",
-            "ignored_native_images": [
-                "native:8.6",
-                "native:candidate"
-            ]
         }
     ],
     "flags_versions_mapping":{


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-10936

## Description
Remove ZipFile from skip list. The package was originally ignored because of an issue with pyminizip as described in CIAC-1036. Later, pyminizip was replaced altogether so ignoring ZipFile is no longer necessary. 
