### PR TITLE
[IntezerV2] Remove From The Ignore List

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -135,14 +135,6 @@
             ]
         },
         {
-            "id":"Intezer v2",
-            "reason":"Issue: CIAC-7861",
-            "ignored_native_images":[
-                "native:8.6",
-                "native:candidate"
-            ]
-        },
-        {
             "id":"RegexExtractAll",
             "reason":"Issue: CIAC-6005",
             "ignored_native_images":[


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-10964) to the issue

## Description
In the new version of the native image GA, we have Intezer SDK, so we can remove it from the ignore list.