### PR TITLE
RN- removing invalid header(content item doesn't exist)

### DIFF
--- a/Packs/Lacework/.pack-ignore
+++ b/Packs/Lacework/.pack-ignore
@@ -1,6 +1,9 @@
 [file:Lacework_image.png]
 ignore=IM111
 
+[file:2_0_0.md]
+ignore=RN115
+
 [known_words]
 aws
 cve
@@ -10,4 +13,3 @@ namespace
 severities
 suppressions
 workloads
-

--- a/Packs/Lacework/ReleaseNotes/2_0_0.md
+++ b/Packs/Lacework/ReleaseNotes/2_0_0.md
@@ -2,8 +2,6 @@
 #### Classifiers
 ##### Lacework - Classifier
 - Updated default incident type to 'Lacework Alert'
-##### Lacework
-- Updated default incident type to 'Lacework Alert'
 
 #### Incident Fields
 - **Lacework Recommendation Account ID**


### PR DESCRIPTION
## Description
Fixing the last RN of Lacework, since it contained a mapper header that doesn't exist in the classifier folder.
