### PR TITLE
XSOAR TIM - Fix to manual indicator review playbook

### DIFF
--- a/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Process_Indicators_Manual_Review.yml
+++ b/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Process_Indicators_Manual_Review.yml
@@ -454,7 +454,7 @@ tasks:
     nexttasks:
       '#none#':
       - "7"
-    separatecontext: true
+    separatecontext: false
     view: |-
       {
         "position": {

--- a/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Review_Indicators_Manually.yml
+++ b/Packs/TIM_Processing/Playbooks/playbook-TIM_-_Review_Indicators_Manually.yml
@@ -513,7 +513,7 @@ inputs:
   required: false
   description: ""
   playbookInputQuery:
-    query: tags:pending_review and -tags:being_reviewed
+    query: tags:"pending_review" and -tags:"being_reviewed"
     queryEntity: indicators
     results: null
     daterange:

--- a/Packs/TIM_Processing/ReleaseNotes/1_1_26.md
+++ b/Packs/TIM_Processing/ReleaseNotes/1_1_26.md
@@ -1,0 +1,8 @@
+
+#### Playbooks
+
+##### TIM - Process Indicators - Manual Review
+- Fixed an issue with the playbook inputs query.
+
+##### TIM - Review Indicators Manually
+- Fixed an issue with the subplaybook context not being set as global.

--- a/Packs/TIM_Processing/pack_metadata.json
+++ b/Packs/TIM_Processing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TIM - Indicator Auto-Processing",
     "description": "Too many threat feeds? This Content Pack automates the processing of indicators at scale, significantly reducing busywork for your analysts.",
     "support": "xsoar",
-    "currentVersion": "1.1.25",
+    "currentVersion": "1.1.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-38796

## Description
Fixes an issue with the playbook failing due to wrong query and the subplaybook context not being shared globaly.

## Must have
- [ ] Tests
- [ ] Documentation 
