### PR TITLE
Added xsoar-supported and deprecation filters to download_packs

### DIFF
--- a/Utils/download_packs_and_docker_images.py
+++ b/Utils/download_packs_and_docker_images.py
@@ -95,7 +95,27 @@ def get_pack_names(pack_display_names: list, id_set_json: dict) -> dict:
     return pack_names
 
 
-def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: str, verify_ssl: bool) -> None:
+def should_filter_out_pack(pack_data: dict, fields: dict, deprecated: bool = False):
+    """
+    Check if the pack should be filtered out based on given fields.
+    
+    Parameters:
+    pack_data (dict): The dictionary containing the actual data. Based on id_set.
+    fields (dict): The dictionary containing the expected values for certain keys.
+    deprecated (bool): If False, keys including "(Deprecated)" are ignored. Default is False.
+
+
+    Returns:
+    bool: True if all the values in fields match the values in data for the given keys, False otherwise.
+    """
+    if not deprecated and "(Deprecated)" in pack_data['name']:
+        return True
+
+    return any(pack_data.get(key) != value for key, value in fields.items())
+    
+
+def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: str, verify_ssl: bool, 
+                            all_packs: bool = False) -> None:
     """ Download and save packs under """
     if 'Packs' not in id_set_json:
         raise ValueError('Packs missing from id_set.json.')
@@ -107,6 +127,11 @@ def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: st
             if pack_name not in id_set_packs:
                 print(f"\tCouldn't find {pack_d_name} in id_set.json. Skipping pack download.")
                 continue
+            # In case no input is given and we automatically get all packs, we want to get only relevant packs. 
+            if all_packs and should_filter_out_pack(id_set_packs[pack_name], fields={"author": 'Cortex XSOAR'}):
+                print(f"\t{pack_d_name} filtered out. Skipping pack download.")
+                continue
+
             pack_version = id_set_packs[pack_name]['current_version']
             print(f"\tDownloading {pack_d_name} Pack")
             r = requests.request(method='GET',
@@ -186,7 +211,10 @@ def main():
     pack_names = get_pack_names(pack_display_names, id_set_json)
     Path(output_path).mkdir(parents=True, exist_ok=True)
     if not options.skip_packs and pack_names:
-        download_and_save_packs(pack_names, id_set_json, os.path.join(output_path, 'packs'), verify_ssl)
+        download_and_save_packs(pack_names, id_set_json,
+                                os.path.join(output_path, 'packs'),
+                                verify_ssl,
+                                all_packs=not bool(packs))
     else:
         print('Skipping packs.zip creation')
     if pack_names:

--- a/contribution/utils/download_packs_and_docker_images.py
+++ b/contribution/utils/download_packs_and_docker_images.py
@@ -93,8 +93,27 @@ def get_pack_names(pack_display_names: list, id_set_json: dict) -> dict:
         pack_names[d_name] = d_names_id_set[d_name]
     return pack_names
 
+def should_filter_out_pack(pack_data: dict, fields: dict, deprecated: bool = False):
+    """
+    Check if the pack should be filtered out based on given fields.
+    
+    Parameters:
+    pack_data (dict): The dictionary containing the actual data. Based on id_set.
+    fields (dict): The dictionary containing the expected values for certain keys.
+    deprecated (bool): If False, keys including "(Deprecated)" are ignored. Default is False.
 
-def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: str, verify_ssl: bool) -> None:
+
+    Returns:
+    bool: True if all the values in fields match the values in data for the given keys, False otherwise.
+    """
+    if not deprecated and "(Deprecated)" in pack_data['name']:
+        return True
+
+    return any(pack_data.get(key) != value for key, value in fields.items())
+    
+    
+def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: str, verify_ssl: bool, 
+                            all_packs: bool = False) -> None:
     """ Download and save packs under """
     if 'Packs' not in id_set_json:
         raise ValueError('Packs missing from id_set.json.')
@@ -106,6 +125,11 @@ def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: st
             if pack_name not in id_set_packs:
                 print(f"\tCouldn't find {pack_d_name} in id_set.json. Skipping pack download.")
                 continue
+            # In case no input is given and we automatically get all packs, we want to get only relevant packs. 
+            if all_packs and should_filter_out_pack(id_set_packs[pack_name], fields={"author": 'Cortex XSOAR'}):
+                print(f"\t{pack_d_name} filtered out. Skipping pack download.")
+                continue
+
             pack_version = id_set_packs[pack_name]['current_version']
             print(f"\tDownloading {pack_d_name} Pack")
             r = requests.request(method='GET',
@@ -116,6 +140,7 @@ def download_and_save_packs(pack_names: dict, id_set_json: dict, output_path: st
         zip_folder(temp_dir.name, output_path)
     finally:
         temp_dir.cleanup()
+
 
 
 def download_and_save_docker_images(docker_images: set, output_path: str) -> None:
@@ -184,7 +209,10 @@ def main():
     pack_names = get_pack_names(pack_display_names, id_set_json)
     Path(output_path).mkdir(parents=True, exist_ok=True)
     if not options.skip_packs and pack_names:
-        download_and_save_packs(pack_names, id_set_json, os.path.join(output_path, 'packs'), verify_ssl)
+        download_and_save_packs(pack_names, id_set_json,
+                                os.path.join(output_path, 'packs'),
+                                verify_ssl,
+                                all_packs=not bool(packs))
     else:
         print('Skipping packs.zip creation')
     if pack_names:


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-10967)

## Description
When no input is given, instead of getting all packs we will now only take the non-depracated xsoar supported packs.

## Must have
- [ ] Tests
- [ ] Documentation 
