### PR TITLE
[Native Image & Ping] Remove From The Ignore List

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -141,15 +141,6 @@
             ]
         },
         {
-            "id":"Ping",
-            "reason":"see CIAC-8493",
-            "ignored_native_images":[
-                "native:8.6",
-                "native:dev",
-                "native:candidate"
-            ]
-        },
-        {
             "id": "Github Feed",
             "reason": "update docker image",
             "ignored_native_images": [


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-11000](https://jira-dc.paloaltonetworks.com/browse/CIAC-11000)
relates: [CIAC-8493](https://jira-dc.paloaltonetworks.com/browse/CIAC-8493)

## Description
Unskip Ping from the native image, since skipping it in https://github.com/demisto/content/pull/29576 was unnecessary.

