### PR TITLE
[Native & Github Feed] Remove From The Ignore List Of `candidate` Image

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -153,8 +153,7 @@
             "id": "Github Feed",
             "reason": "update docker image",
             "ignored_native_images": [
-                "native:8.6",
-                "native:candidate"
+                "native:8.6"
             ]
         }
     ],


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-11003) to the issue

## Description
The reason why the Github Feed was in the ignore list is because we added 2 new libraries, yara-python and plyara, to the native image.
Now, after [updating](https://github.com/demisto/content/pull/34767) the candidate image, 
these libraries are present on the candidate image (py3-native:8.6.0.98251),
so we can remove the GitHub Feed from the ignore list of the candidate image only.
