### PR TITLE
raising an error when suddenDeath chosen in incremental feed

### DIFF
--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
@@ -551,7 +551,9 @@ def main():
     proxy = params.get('proxy', False)
     command = demisto.command()
     args = demisto.args()
-
+    if params.get('feedIncremental') and params.get('feedExpirationPolicy') == 'suddenDeath':
+        raise DemistoException('In order to use the feedIncremental parameter, the feedExpirationPolicy must be set to '
+                               'a value other than suddenDeath.')
     demisto.debug(f'Command being called is {command}')
     try:
         client = Client(

--- a/Packs/FeedMISP/ReleaseNotes/1_0_34.md
+++ b/Packs/FeedMISP/ReleaseNotes/1_0_34.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### MISP Feed
+
+- Fixed an issue where ***suddenDeath*** could be chosen as ***feedExpirationPolicy*** when ***FeedMisp*** is a Incremental Feed.

--- a/Packs/FeedMISP/pack_metadata.json
+++ b/Packs/FeedMISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP Feed",
     "description": "Indicators feed from MISP",
     "support": "xsoar",
-    "currentVersion": "1.0.33",
+    "currentVersion": "1.0.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready


## Related Issues
None 

## Description
raising an error when "suddenDeath" was chosen in incremental feed.
