### PR TITLE
[CSP] Increasing timeout for generic_http_request to 60 seconds

### DIFF
--- a/Packs/Base/ReleaseNotes/1_34_20.md
+++ b/Packs/Base/ReleaseNotes/1_34_20.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CommonServerPython
+
+Update the request timeout for the **generic_http_request** function to 60 seconds.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -9300,7 +9300,7 @@ if 'requests' in sys.modules:
 
 def generic_http_request(method,
                          server_url,
-                         timeout=10,
+                         timeout=60,
                          verify=True,
                          proxy=False,
                          client_headers=None,

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.34.19",
+    "currentVersion": "1.34.20",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-10853)

## Description
Update the request timeout for the **generic_http_request** function to 60 seconds.

## Must have
- [ ] Tests
- [ ] Documentation 
