### PR TITLE
avoid collect draft prs in autobump

### DIFF
--- a/.github/github_workflow_scripts/autobump_rn.py
+++ b/.github/github_workflow_scripts/autobump_rn.py
@@ -192,6 +192,9 @@ class AutoBumperManager:
         for pr in self.github_repo_obj.get_pulls(
             state="open", sort="created", base=BASE
         ):
+            if pr.draft:
+                continue
+
             print(
                 f"{t.yellow}Looking on pr number [{pr.number}]: last updated: "
                 f"{str(pr.updated_at)}, branch={pr.head.ref}"

--- a/.github/github_workflow_scripts/autobump_rn.py
+++ b/.github/github_workflow_scripts/autobump_rn.py
@@ -193,6 +193,7 @@ class AutoBumperManager:
             state="open", sort="created", base=BASE
         ):
             if pr.draft:
+                # The bot does not go through a PR that is in draft
                 continue
 
             print(

--- a/.github/workflows/autobump_rn.yml
+++ b/.github/workflows/autobump_rn.yml
@@ -1,5 +1,8 @@
 name: Autobump Version
-on: push
+on:
+  push:
+    branches:
+      - master
 
 permissions:
   pull-requests: write

--- a/.github/workflows/autobump_rn.yml
+++ b/.github/workflows/autobump_rn.yml
@@ -1,8 +1,5 @@
 name: Autobump Version
-on:
-  push:
-    branches:
-      - master
+on: push
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Added filtering so that the autoBump does not collect PRs that are defined as draft
An example PR that didn't need to be collected and crashed the bot run: https://github.com/demisto/content/pull/34228

## Must have
- [ ] Tests
- [ ] Documentation 
