### PR TITLE
CTF Packs - Removed XSOAR on-prem Marketplace

### DIFF
--- a/Packs/CTF02/ReleaseNotes/1_0_4.md
+++ b/Packs/CTF02/ReleaseNotes/1_0_4.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CTF_2_BF
+
+- Updated the Docker image to: *demisto/python3:3.10.14.99865*.

--- a/Packs/CTF02/Scripts/CTF2BF/CTF2BF.yml
+++ b/Packs/CTF02/Scripts/CTF2BF/CTF2BF.yml
@@ -26,7 +26,7 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.13.87159
+dockerimage: demisto/python3:3.10.14.99865
 runas: DBotWeakRole
 engineinfo: {}
 fromversion: 8.2.0

--- a/Packs/CTF02/pack_metadata.json
+++ b/Packs/CTF02/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Capture The Flag - 02",
     "description": "XSOAR's Capture the flag (CTF)",
     "support": "xsoar",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CTF02/pack_metadata.json
+++ b/Packs/CTF02/pack_metadata.json
@@ -15,7 +15,6 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "xsoar",
         "xsoar_saas"
     ],
     "dependencies": {

--- a/Packs/ctf01/Integrations/CortexXDRIRCTF/CortexXDRIRCTF.yml
+++ b/Packs/ctf01/Integrations/CortexXDRIRCTF/CortexXDRIRCTF.yml
@@ -725,7 +725,7 @@ script:
       description: Whether the alert is starred or not.
       type: Boolean
     description: "Returns a list of alerts and their metadata, which you can filter by built-in arguments or use the custom_filter to input a JSON filter object. \nMultiple filter arguments will be concatenated using the AND operator, while arguments that support a comma-separated list of values will use an OR operator between each value."
-  dockerimage: demisto/python3:3.10.13.87159
+  dockerimage: demisto/python3:3.10.14.99865
   isfetch: true
   runonce: false
   subtype: python3

--- a/Packs/ctf01/Integrations/OHMYVTCTF/OHMYVTCTF.yml
+++ b/Packs/ctf01/Integrations/OHMYVTCTF/OHMYVTCTF.yml
@@ -27,7 +27,7 @@ configuration:
 script:
   script: ''
   type: python
-  dockerimage: demisto/python3:3.10.13.87159
+  dockerimage: demisto/python3:3.10.14.99865
   runonce: false
   subtype: python3
   isfetch: true

--- a/Packs/ctf01/ReleaseNotes/1_0_19.md
+++ b/Packs/ctf01/ReleaseNotes/1_0_19.md
@@ -1,0 +1,16 @@
+
+#### Integrations
+
+##### Cortex XDR - IR CTF
+
+- Updated the Docker image to: *demisto/python3:3.10.14.99865*.
+
+##### OHMYVT_CTF
+
+- Updated the Docker image to: *demisto/python3:3.10.14.99865*.
+
+#### Scripts
+
+##### CTF_1
+
+- Updated the Docker image to: *demisto/python3:3.10.14.99865*.

--- a/Packs/ctf01/Scripts/CTF1/CTF1.yml
+++ b/Packs/ctf01/Scripts/CTF1/CTF1.yml
@@ -23,7 +23,7 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/python3:3.10.13.87159
+dockerimage: demisto/python3:3.10.14.99865
 runas: DBotWeakRole
 engineinfo: {}
 fromversion: 8.2.0

--- a/Packs/ctf01/pack_metadata.json
+++ b/Packs/ctf01/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Capture The Flag - 01",
     "description": "XSOAR's Capture the flag (CTF)",
     "support": "xsoar",
-    "currentVersion": "1.0.18",
+    "currentVersion": "1.0.19",
     "serverMinVersion": "8.2.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/ctf01/pack_metadata.json
+++ b/Packs/ctf01/pack_metadata.json
@@ -25,7 +25,6 @@
         }
     },
     "marketplaces": [
-        "xsoar",
         "xsoar_saas"
     ]
 }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
In this [nightly job](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/6791397), we see an error related to installing ctf01 and ctf02 packs on an XSOAR6 machine. 


## Description
The CTF01, CTF02 packs, shouldn't be installed on XSAOR 6, only on XSOAR8 (you can see in the packs' metadata files that "serverMinVersion" is "8.2.0").
Therefore, in this PR we removed the XSAOR marketplace from the pack metadata files. 

## Must have
- [ ] Tests
- [ ] Documentation 
