### PR TITLE
Fix issue when finding reviewer and reviewer already finished the review updated

### DIFF
--- a/.github/github_workflow_scripts/handle_external_pr.py
+++ b/.github/github_workflow_scripts/handle_external_pr.py
@@ -351,8 +351,9 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     """
     content_reviewers_set = set(content_reviewers)
     for pr in other_prs_by_same_user:
-        reviewer_names = {reviewer.login for reviewer in pr.requested_reviewers}
-        existing_reviewer = content_reviewers_set.intersection(reviewer_names)
+        print(f'the requested assignees are : {pr.assignees}')
+        assignee_names = {assignee.login for assignee in pr.assignees}
+        existing_reviewer = content_reviewers_set.intersection(assignee_names)
         if existing_reviewer:
             return existing_reviewer.pop()
         else:

--- a/.github/github_workflow_scripts/handle_external_pr.py
+++ b/.github/github_workflow_scripts/handle_external_pr.py
@@ -343,6 +343,7 @@ def reviewer_of_prs_from_current_round(other_prs_by_same_user: list, content_rev
     """
     Get all PR's that are currently open from the same author, filter the list and return reviewer if reviewer is part
     of the current contribution round
+    The check for reviewer is done with assignees because reviewers list after initial review is empty.
     Arguments:
     - other_prs_by_same_user - list of opened PR's
 


### PR DESCRIPTION
**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-8513)

## Description
After reviewer done with review - github "requested_reviewers" is empty, until re-review is requested.
So need to switch the lookup for assignees and not reviewers

The fix was tested in this [PR](https://github.com/demisto/content/pull/34754) and this [check](https://github.com/demisto/content/pull/34754/checks) that was opened to the branch of this PR