### PR TITLE
Skip python2 not support csp test

### DIFF
--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -9796,7 +9796,7 @@ def test_get_server_config(mocker):
     server_config = get_server_config()
     assert server_config == {'incident.closereasons': 'CustomReason1, CustomReason 2, Foo', 'versn': 40}
 
-
+@pytest.mark.skipif(not IS_PY3, reason='test not supported in py2')
 def test_get_server_config_fail(mocker):
     mock_response = {
         'body': 'NOT A VALID JSON',

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -9796,6 +9796,7 @@ def test_get_server_config(mocker):
     server_config = get_server_config()
     assert server_config == {'incident.closereasons': 'CustomReason1, CustomReason 2, Foo', 'versn': 40}
 
+
 @pytest.mark.skipif(not IS_PY3, reason='test not supported in py2')
 def test_get_server_config_fail(mocker):
     mock_response = {


### PR DESCRIPTION

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/6950579)

## Description
Skipping a CSP test which is not supported when executed in python 2.7 env.

