### PR TITLE
Add new parameters for Sophos Central API

### DIFF
--- a/Packs/SophosCentral/CONTRIBUTORS.json
+++ b/Packs/SophosCentral/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+    "nikstuckenbrock"
+]

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
@@ -2009,7 +2009,7 @@ def sophos_central_endpoint_list_command(client: Client, args: dict) -> CommandR
         args.get("ids"),
         args.get("view"),
         min(int(args.get("limit", "")), 100),
-        args.get("ip_addresses", []).split(","),
+        argToList(args.get("ip_addresses")),
     )
     full_match_ip = args.get("full_match_ip") == "true" if args.get("full_match_ip") else None,
     items = results.get("items")
@@ -2029,7 +2029,7 @@ def sophos_central_endpoint_list_command(client: Client, args: dict) -> CommandR
             object_data = {field: item.get(field) for field in table_headers}
             # The Sophos API does partial string matching, which can be unwanted for IP addresses.
             if full_match_ip:
-                query_ips = args.get("ip_addresses", []).split(",")
+                query_ips = argToList(args.get("ip_addresses"))
                 ips = []
                 if (data := object_data.get("ipv4Addresses", [])) is not None:
                     ips.extend(data)

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
@@ -4,7 +4,6 @@ from CommonServerUserPython import *
 
 '''IMPORTS'''
 import dateparser
-from typing import Dict, Tuple
 
 '''GLOBAL VARS'''
 
@@ -172,7 +171,7 @@ class Client(BaseClient):
         set_integration_context(context)
 
     @staticmethod
-    def get_client_data(tenant_id: str, bearer_token: str) -> Tuple[dict, str]:
+    def get_client_data(tenant_id: str, bearer_token: str) -> tuple[dict, str]:
         """
         Validate the given tenant ID.
 
@@ -334,7 +333,7 @@ class Client(BaseClient):
             "hostname",
         )
 
-    def list_alert(self, limit: Optional[int]) -> Dict:
+    def list_alert(self, limit: Optional[int]) -> dict:
         """
         List all alerts connected to a tenant.
 
@@ -350,7 +349,7 @@ class Client(BaseClient):
             method="GET", url_suffix=url_suffix, headers=self.headers, params=params
         )
 
-    def get_alert(self, alert_id: str) -> Dict:
+    def get_alert(self, alert_id: str) -> dict:
         """
         Get a single alert based on ID.
 
@@ -370,7 +369,7 @@ class Client(BaseClient):
         alert_id: str,
         action: str,
         message: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """
         Take action against one alert.
 
@@ -401,7 +400,7 @@ class Client(BaseClient):
         severity: Optional[List[str]],
         ids: Optional[List[str]],
         limit: Optional[int],
-    ) -> Dict:
+    ) -> dict:
         """
         Search alerts based on parameters.
 
@@ -449,7 +448,7 @@ class Client(BaseClient):
         view: Optional[str],
         limit: Optional[int],
         ip_addresses: Optional[List[str]],
-    ) -> Dict:
+    ) -> dict:
         """
         List all endpoints for a tenant.
 
@@ -486,7 +485,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def scan_endpoint(self, endpoint_id: str) -> Dict:
+    def scan_endpoint(self, endpoint_id: str) -> dict:
         """
         Initiate a scan on an endpoint.
 
@@ -501,7 +500,7 @@ class Client(BaseClient):
             method="POST", headers=self.headers, json_data={}, url_suffix=url_suffix
         )
 
-    def get_tamper(self, endpoint_id: str) -> Dict:
+    def get_tamper(self, endpoint_id: str) -> dict:
         """
         Get tamper protection of an endpoint.
 
@@ -516,7 +515,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, url_suffix=url_suffix
         )
 
-    def update_tamper(self, endpoint_id: str, enabled: bool) -> Dict:
+    def update_tamper(self, endpoint_id: str, enabled: bool) -> dict:
         """
         Get tamper protection of an endpoin.
 
@@ -540,7 +539,7 @@ class Client(BaseClient):
         self,
         page_size: Optional[int],
         page: Optional[int],
-    ) -> Dict:
+    ) -> dict:
         """
         List all allowed items for a tenant.
 
@@ -557,7 +556,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def get_allowed_item(self, allowed_item_id: str) -> Dict:
+    def get_allowed_item(self, allowed_item_id: str) -> dict:
         """
         Get a single allowed item.
 
@@ -581,7 +580,7 @@ class Client(BaseClient):
         path: Optional[str],
         sha256: Optional[str],
         origin_endpoint_id: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """
         Add a new allowed item.
 
@@ -617,7 +616,7 @@ class Client(BaseClient):
             url_suffix=url_suffix,
         )
 
-    def update_allowed_item(self, allowed_item_id: str, comment: str) -> Dict:
+    def update_allowed_item(self, allowed_item_id: str, comment: str) -> dict:
         """
         Update an existing allowed item.
 
@@ -637,7 +636,7 @@ class Client(BaseClient):
             url_suffix=url_suffix,
         )
 
-    def delete_allowed_item(self, allowed_item_id: str) -> Dict:
+    def delete_allowed_item(self, allowed_item_id: str) -> dict:
         """
         Delete an existing allowed item.
 
@@ -656,7 +655,7 @@ class Client(BaseClient):
         self,
         page_size: Optional[int],
         page: Optional[int],
-    ) -> Dict:
+    ) -> dict:
         """
         List all blocked items for a tenant.
 
@@ -673,7 +672,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def get_blocked_item(self, allowed_item_id: str) -> Dict:
+    def get_blocked_item(self, allowed_item_id: str) -> dict:
         """
         Get a single blocked item.
 
@@ -697,7 +696,7 @@ class Client(BaseClient):
         path: Optional[str],
         sha256: Optional[str],
         origin_endpoint_id: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """
         Add a new blocked item.
 
@@ -733,7 +732,7 @@ class Client(BaseClient):
             url_suffix=url_suffix,
         )
 
-    def delete_blocked_item(self, allowed_item_id: str) -> Dict:
+    def delete_blocked_item(self, allowed_item_id: str) -> dict:
         """
         Delete an existing blocked item.
 
@@ -753,7 +752,7 @@ class Client(BaseClient):
         exclusion_type: Optional[str],
         page_size: Optional[int],
         page: Optional[int],
-    ) -> Dict:
+    ) -> dict:
         """
         List all scan exclusions.
 
@@ -773,7 +772,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def get_scan_exclusion(self, exclusion_id: str) -> Dict:
+    def get_scan_exclusion(self, exclusion_id: str) -> dict:
         """
         Get a single scan exclusion.
 
@@ -794,7 +793,7 @@ class Client(BaseClient):
         scan_mode: Optional[str],
         exclusion_type: str,
         value: str,
-    ) -> Dict:
+    ) -> dict:
         """
         Add a new scan exclusion.
 
@@ -829,7 +828,7 @@ class Client(BaseClient):
         scan_mode: Optional[str],
         exclusion_id: str,
         value: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """
         Update an existing scan exclusion.
 
@@ -853,7 +852,7 @@ class Client(BaseClient):
             url_suffix=url_suffix,
         )
 
-    def delete_scan_exclusion(self, exclusion_id: str) -> Dict:
+    def delete_scan_exclusion(self, exclusion_id: str) -> dict:
         """
         Delete an existing scan exclusion.
 
@@ -874,7 +873,7 @@ class Client(BaseClient):
         page_size: Optional[int],
         page: Optional[int],
         modified: Optional[bool],
-    ) -> Dict:
+    ) -> dict:
         """
         List all exploit mitigations.
 
@@ -900,7 +899,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def get_exploit_mitigation(self, mitigation_id: str) -> Dict:
+    def get_exploit_mitigation(self, mitigation_id: str) -> dict:
         """
         Get a single exploit mitigation.
 
@@ -917,7 +916,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, url_suffix=url_suffix
         )
 
-    def add_exploit_mitigation(self, path: str) -> Dict:
+    def add_exploit_mitigation(self, path: str) -> dict:
         """
         Add a new exploit mitigation.
 
@@ -938,7 +937,7 @@ class Client(BaseClient):
 
     def update_exploit_mitigation(
         self, mitigation_id: str, path: Optional[str]
-    ) -> Dict:
+    ) -> dict:
         """
         Update an existing exploit mitigation.
 
@@ -960,7 +959,7 @@ class Client(BaseClient):
             url_suffix=url_suffix,
         )
 
-    def delete_exploit_mitigation(self, mitigation_id: str) -> Dict:
+    def delete_exploit_mitigation(self, mitigation_id: str) -> dict:
         """
         Update an existing exploit mitigation.
 
@@ -982,7 +981,7 @@ class Client(BaseClient):
         page_size: Optional[int],
         page: Optional[int],
         thumbprint_not_in: Optional[str],
-    ) -> Dict:
+    ) -> dict:
         """
         List all detected exploits.
 
@@ -1004,7 +1003,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, params=params, url_suffix=url_suffix
         )
 
-    def get_detected_exploit(self, detected_exploit_id: str) -> Dict:
+    def get_detected_exploit(self, detected_exploit_id: str) -> dict:
         """
         Get a single detected exploit.
 
@@ -1022,7 +1021,7 @@ class Client(BaseClient):
             method="GET", headers=self.headers, url_suffix=url_suffix
         )
 
-    def isolate_endpoint(self, endpoint_id: List[str], comment: Optional[str]) -> Dict:
+    def isolate_endpoint(self, endpoint_id: List[str], comment: Optional[str]) -> dict:
         """
         Initiate isolation request on the given endpoint(s).
 
@@ -1043,7 +1042,7 @@ class Client(BaseClient):
 
     def deisolate_endpoint(
         self, endpoint_id: List[str], comment: Optional[str]
-    ) -> Dict:
+    ) -> dict:
         """
         Initiate de-isolation request on the given endpoint(s).
 
@@ -1065,7 +1064,7 @@ class Client(BaseClient):
     def get_endpoints_group(
         self,
         group_id: str
-    ) -> Dict:
+    ) -> dict:
         """
             Get endpoints in a group
 
@@ -1086,7 +1085,7 @@ class Client(BaseClient):
         self,
         group_id: str,
         ids: List[str]
-    ) -> Dict:
+    ) -> dict:
         """
             Add endpoints to the group.
 
@@ -1114,7 +1113,7 @@ class Client(BaseClient):
         self,
         group_id: str,
         ids: str
-    ) -> Dict:
+    ) -> dict:
         """
             Remove endpoints from endpoint group.
 
@@ -1145,7 +1144,7 @@ class Client(BaseClient):
         self,
         group_id: str,
         endpoint_id: str
-    ) -> Dict:
+    ) -> dict:
         """
             Remove endpoint from endpoint group.
 
@@ -1165,7 +1164,7 @@ class Client(BaseClient):
             url_suffix=url_suffix
         )
 
-    def get_endpoint_policies(self, policy_type: Optional[str], page_size: Optional[int], page: Optional[int]) -> Dict:
+    def get_endpoint_policies(self, policy_type: Optional[str], page_size: Optional[int], page: Optional[int]) -> dict:
         """
         Get all endpoint policy.
 
@@ -1185,7 +1184,7 @@ class Client(BaseClient):
             url_suffix=url_suffix
         )
 
-    def get_endpoint_policy(self, policy_id: str) -> Dict:
+    def get_endpoint_policy(self, policy_id: str) -> dict:
         """
         Get details of Policy by ID.
 
@@ -1201,7 +1200,7 @@ class Client(BaseClient):
             url_suffix=url_suffix
         )
 
-    def delete_endpoint_policy(self, policy_id: str) -> Dict:
+    def delete_endpoint_policy(self, policy_id: str) -> dict:
         """
         Delete an existing endpoint policy.
 
@@ -1216,7 +1215,7 @@ class Client(BaseClient):
             method="DELETE", headers=self.headers, url_suffix=url_suffix
         )
 
-    def clone_endpoint_policy(self, policy_id: str, name: Optional[str]) -> Dict:
+    def clone_endpoint_policy(self, policy_id: str, name: Optional[str]) -> dict:
         """
         Clone an existing endpoint policy.
 
@@ -1235,7 +1234,7 @@ class Client(BaseClient):
             json_data=body,
         )
 
-    def update_endpoint_policy(self, policy_id: str, priority: str) -> Dict:
+    def update_endpoint_policy(self, policy_id: str, priority: str) -> dict:
         """
         Update order priority an endpoint policy.
 
@@ -1264,7 +1263,7 @@ class Client(BaseClient):
         user_id: Optional[str],
         page: Optional[int],
         page_size: Optional[int]
-    ) -> Dict:
+    ) -> dict:
         """
         List all usergroups.
 
@@ -1303,7 +1302,7 @@ class Client(BaseClient):
             url_suffix="common/v1/directory/user-groups",
         )
 
-    def get_usergroup(self, group_id: str) -> Dict:
+    def get_usergroup(self, group_id: str) -> dict:
         """
         Get a single usergroup based on ID.
 
@@ -1319,7 +1318,7 @@ class Client(BaseClient):
             url_suffix=f"common/v1/directory/user-groups/{group_id}"
         )
 
-    def create_usergroup(self, group_name: str, description: Optional[str], user_ids: List[str]) -> Dict:
+    def create_usergroup(self, group_name: str, description: Optional[str], user_ids: List[str]) -> dict:
         """Create a usergroup
 
         Args:
@@ -1335,7 +1334,7 @@ class Client(BaseClient):
             json_data=body,
         )
 
-    def update_usergroup(self, group_id: str, group_name: str, description: Optional[str]) -> Dict:
+    def update_usergroup(self, group_id: str, group_name: str, description: Optional[str]) -> dict:
         """Update a specific usergroup based on ID.
 
         Args:
@@ -1351,7 +1350,7 @@ class Client(BaseClient):
             json_data=body,
         )
 
-    def delete_usergroup(self, group_id: str) -> Dict:
+    def delete_usergroup(self, group_id: str) -> dict:
         """Delete a usergroup with given ID.
 
         Args:
@@ -1371,7 +1370,7 @@ class Client(BaseClient):
             source_type: Optional[str],
             page: int,
             page_size: int
-    ) -> Dict:
+    ) -> dict:
         """
         Add multiple users to the specified group.
 
@@ -1403,7 +1402,7 @@ class Client(BaseClient):
 
     def add_users_to_usergroup(
             self, group_id: str, ids: List[str]
-    ) -> Dict:
+    ) -> dict:
         """
         Add multiple users to the specified group.
 
@@ -1422,7 +1421,7 @@ class Client(BaseClient):
 
     def delete_user_from_usergroup(
             self, group_id: str, user_id: str
-    ) -> Dict:
+    ) -> dict:
         """
         Delete a user from the specified group.
 
@@ -1446,7 +1445,7 @@ class Client(BaseClient):
         source_type: Optional[str],
         page_size: Optional[int],
         page: Optional[int]
-    ) -> Dict:
+    ) -> dict:
         """
         List all users.
 
@@ -1485,7 +1484,7 @@ class Client(BaseClient):
     def get_user(
         self,
         user_id: str
-    ) -> Dict:
+    ) -> dict:
         """
         Get a single user based on id.
 
@@ -1606,7 +1605,7 @@ class Client(BaseClient):
             url_suffix=url_suffix
         )
 
-    def get_endpoint_group(self, limit: Optional[int], page: Optional[int]) -> Dict:
+    def get_endpoint_group(self, limit: Optional[int], page: Optional[int]) -> dict:
         """
         List all endpoint group connected to a tenant
 
@@ -1625,7 +1624,7 @@ class Client(BaseClient):
         type: str,
         name: str,
         endpointIds: Optional[List[str]]
-    ) -> Dict:
+    ) -> dict:
         """
             List all endpoint group connected to a tenant.
 
@@ -1659,7 +1658,7 @@ class Client(BaseClient):
         groupId: str,
         name: Optional[str],
         description: Optional[str]
-    ) -> Dict:
+    ) -> dict:
         """
             List all endpoint group connected to a tenant.
 
@@ -1689,7 +1688,7 @@ class Client(BaseClient):
     def fetch_group(
         self,
         groupId: str
-    ) -> Dict:
+    ) -> dict:
         """
             List all endpoint group connected to a tenant.
 
@@ -1710,7 +1709,7 @@ class Client(BaseClient):
     def delete_group(
         self,
         groupId: str
-    ) -> Dict:
+    ) -> dict:
         """
             Delete endpoint group connected to a tenant.
 
@@ -1747,8 +1746,8 @@ def flip_chars(id_to_flip: str) -> str:
 
 
 def create_alert_output(
-    client: Client, item: Dict, table_headers: List[str]
-) -> Dict[str, Optional[Any]]:
+    client: Client, item: dict, table_headers: List[str]
+) -> dict[str, Optional[Any]]:
     """
     Create the complete output dictionary for an alert.
 
@@ -1785,7 +1784,7 @@ def create_alert_output(
 
 
 def sophos_central_alert_list_command(
-    client: Client, args: Dict[str, str]
+    client: Client, args: dict[str, str]
 ) -> CommandResults:
     """
     List all alerts.
@@ -2011,7 +2010,7 @@ def sophos_central_endpoint_list_command(client: Client, args: dict) -> CommandR
         min(int(args.get("limit", "")), 100),
         argToList(args.get("ip_addresses")),
     )
-    full_match_ip = argToBoolean(args.get("full_match_ip"))
+    full_match_ip = argToBoolean(args.get("full_match_ip", "false"))
     items = results.get("items")
     table_headers = [
         "id",
@@ -2219,7 +2218,7 @@ def sophos_central_endpoint_tamper_update_command(
     )
 
 
-def create_item_output(item: Dict) -> Dict:
+def create_item_output(item: dict) -> dict:
     """
     Create the complete output dictionary for an allowed / blocked item.
 
@@ -2255,7 +2254,7 @@ def create_item_output(item: Dict) -> Dict:
     return item_data
 
 
-def validate_item_fields(args: Dict[str, str]):
+def validate_item_fields(args: dict[str, str]):
     """
     Validate parameters exist before they are sent to the API.
 
@@ -3077,7 +3076,7 @@ def sophos_central_exploit_mitigation_delete_command(
     )
 
 
-def create_detected_exploit_output(item: Dict) -> Dict:
+def create_detected_exploit_output(item: dict) -> dict:
     """
     Create the complete output dictionary for a detected exploit.
 
@@ -3255,12 +3254,12 @@ def sophos_central_deisolate_endpoint_command(
 
 def fetch_incidents(
     client: Client,
-    last_run: Dict[str, int],
+    last_run: dict[str, int],
     first_fetch_time: str,
     fetch_severity: Optional[List[str]],
     fetch_category: Optional[List[str]],
     max_fetch: Optional[int],
-) -> Tuple[Dict[str, int], List[dict]]:
+) -> tuple[dict[str, int], List[dict]]:
     """
     Fetch incidents (alerts) each minute (by default).
 
@@ -3351,11 +3350,10 @@ def sophos_central_group_list(
                 "page_size must be equal or less than 1000."
             )
 
-    if number_of_page is not None:
-        if number_of_page < 0:
-            raise ValueError(
-                "page must be a positive number."
-            )
+    if number_of_page is not None and number_of_page < 0:
+        raise ValueError(
+            "page must be a positive number."
+        )
 
     try:
         results = client.get_endpoint_group(page_size, number_of_page)
@@ -3566,8 +3564,8 @@ def sophos_central_group_delete(
 
 
 def create_policy_output(
-        item: Dict
-) -> Dict[str, Optional[Any]]:
+        item: dict
+) -> dict[str, Optional[Any]]:
     """
     Create the complete output dictionary for an endpoint policy.
 
@@ -3839,11 +3837,10 @@ def sophos_central_endpoint_policy_search_command(
                 "page_size must be equal or less than 200"
             )
 
-    if number_of_page is not None:
-        if number_of_page < 0:
-            raise ValueError(
-                "page must be a positive number"
-            )
+    if number_of_page is not None and number_of_page < 0:
+        raise ValueError(
+            "page must be a positive number"
+        )
 
     result = client.get_endpoint_policies(
         args.get("policy_type", ""),
@@ -4021,8 +4018,8 @@ def sophos_central_endpoint_policy_reorder_command(
 
 
 def create_usergroup_output(
-    item: Dict, table_headers: List[str]
-) -> Dict:
+    item: dict, table_headers: List[str]
+) -> dict:
     """
     Create the complete output dictionary for an usergroup.
 
@@ -4042,7 +4039,7 @@ def create_usergroup_output(
 
 
 def sophos_central_usergroups_get_command(
-    client: Client, args: Dict
+    client: Client, args: dict
 ) -> CommandResults:
     """
     Get a specific usergroups by ID.
@@ -4083,7 +4080,7 @@ def sophos_central_usergroups_get_command(
 
 
 def sophos_central_usergroups_create_command(
-    client: Client, args: Dict
+    client: Client, args: dict
 ) -> CommandResults:
     """
     Create a usergroup.
@@ -4116,7 +4113,7 @@ def sophos_central_usergroups_create_command(
 
 
 def sophos_central_usergroups_list_command(
-    client: Client, args: Dict
+    client: Client, args: dict
 ) -> CommandResults:
     """
     Returns a list of all user groups that match the search criteria (optional).
@@ -4197,7 +4194,7 @@ def sophos_central_usergroups_list_command(
 
 
 def sophos_central_usergroups_update_command(
-    client: Client, args: Dict
+    client: Client, args: dict
 ) -> CommandResults:
     """
     Update a usergroup.
@@ -4228,7 +4225,7 @@ def sophos_central_usergroups_update_command(
 
 
 def sophos_central_usergroups_delete_command(
-    client: Client, args: Dict
+    client: Client, args: dict
 ) -> CommandResults:
     """
     Delete a usergroup.
@@ -4659,7 +4656,7 @@ def test_module(client: Client) -> str:
 
 
 def retrieve_jwt_token(
-    client_id: str, client_secret: str, integration_context: Dict
+    client_id: str, client_secret: str, integration_context: dict
 ) -> str:
     """
     Get the JWT token from the integration context or create a new one.
@@ -4675,9 +4672,8 @@ def retrieve_jwt_token(
     bearer_token = integration_context.get("bearer_token", "")
     valid_until = integration_context.get("valid_until", "")
     time_now = int(time.time())
-    if bearer_token and valid_until:
-        if time_now < int(valid_until):
-            return bearer_token
+    if bearer_token and valid_until and time_now < int(valid_until):
+        return bearer_token
     bearer_token_dict = Client.get_jwt_token_from_api(client_id, client_secret)
     if bearer_token_dict:
         bearer_token = str(bearer_token_dict.get("access_token", ""))

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
@@ -2011,7 +2011,7 @@ def sophos_central_endpoint_list_command(client: Client, args: dict) -> CommandR
         min(int(args.get("limit", "")), 100),
         argToList(args.get("ip_addresses")),
     )
-    full_match_ip = args.get("full_match_ip") == "true" if args.get("full_match_ip") else None,
+    full_match_ip = argToBoolean(args.get("full_match_ip"))
     items = results.get("items")
     table_headers = [
         "id",

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
@@ -2407,7 +2407,7 @@ script:
     - contextPath: SophosCentral.DeletedUsers.deletedUserId
       description: Deleted User's Id.
       type: String
-  dockerimage: demisto/python3:3.10.13.89009
+  dockerimage: demisto/python3:3.11.9.101916
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
@@ -443,6 +443,15 @@ script:
     - defaultValue: '50'
       description: The maximum number of items to return. Default is "50". Maximum is "100".
       name: limit
+    - name: ip_addresses
+      isArray: true
+      description: 'List of IP addresses to find endpoints for.'
+    - auto: PREDEFINED
+      name: full_match_ip
+      description: 'Whether the IP addresses should match full or not (partial/default).'
+      predefined:
+      - 'true'
+      - 'false'
     description: List all endpoints for a tenant.
     name: sophos-central-endpoint-list
     outputs:

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral_test.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral_test.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 import pytest
 import requests
-from pytest import raises
 import demistomock as demisto
 from CommonServerPython import (
     DemistoException,
@@ -25,7 +24,7 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 @pytest.fixture
 def argtest():
     def _argtest(**_kwargs):
-        class TestArgs(object):
+        class TestArgs:
             def __call__(self, *args, **kwargs):
                 self.args = list(args)
                 self.kwargs = kwargs
@@ -57,7 +56,7 @@ def load_mock_response(file_name: str) -> dict:
     Args:
         file_name (str): Name of the mock response JSON file to return.
     """
-    with open(f"test_data/{file_name}", mode="r", encoding="utf-8") as json_file:
+    with open(f"test_data/{file_name}", encoding="utf-8") as json_file:
         return json.loads(json_file.read())
 
 
@@ -1386,7 +1385,7 @@ def test_validate_item_fields() -> None:
     args = {"item_type": "certificateSigner", "certificate_signer": "xxx"}
     validate_item_fields(args)
     args = {"item_type": "certificateSigner", "path": "xxx"}
-    with raises(DemistoException):
+    with pytest.raises(DemistoException):
         validate_item_fields(args)
 
 
@@ -1771,7 +1770,7 @@ def test_whoami_failure(requests_mock):
 
     requests_mock.get(f"{COMMON_BASE_URL}/whoami/v1", status_code=401)
 
-    with raises(
+    with pytest.raises(
         DemistoException,
         match="An HTTP error occurred while validating the given tenant ID: ",
     ):
@@ -1809,7 +1808,7 @@ def test_whoami_exceptions(requests_mock, exception, error):
 
     requests_mock.get(f"{COMMON_BASE_URL}/whoami/v1", exc=exception)
 
-    with raises(DemistoException, match=error):
+    with pytest.raises(DemistoException, match=error):
         Client._whoami(bearer_token="dummy_token")
 
 
@@ -1904,7 +1903,7 @@ def test_get_tenant_base_url_exceptions(requests_mock, exception, error):
         f"{COMMON_BASE_URL}/partner/v1/tenants/dummy-tenant-id", exc=exception
     )
 
-    with raises(DemistoException, match=error):
+    with pytest.raises(DemistoException, match=error):
         Client._get_tenant_base_url(
             bearer_token="dummy-token",
             entity_id="dummy-entity-id",
@@ -1973,7 +1972,7 @@ def test_get_client_data_case2(requests_mock) -> None:
 
     error_msg = "Value provided in tenant ID field is not same as configured tenant whose credentials are entered."
 
-    with raises(DemistoException, match=error_msg):
+    with pytest.raises(DemistoException, match=error_msg):
         Client.get_client_data(
             tenant_id="dummy-tenant-id", bearer_token="dummy-bearer-token"
         )
@@ -2069,7 +2068,7 @@ def test_get_client_data_case4(requests_mock, creds_type) -> None:
         f"Value provided in tenant ID is not from managed tenants of "
         f"configured {creds_type} whose credentials are entered"
     )
-    with raises(DemistoException, match=error_msg):
+    with pytest.raises(DemistoException, match=error_msg):
         Client.get_client_data(tenant_id=tenant_id, bearer_token="dummy-bearer-token")
 
     cache = get_integration_context()
@@ -2112,7 +2111,7 @@ def test_get_client_data_case5(requests_mock, creds_type) -> None:
     error_msg = (
         f"Tenant ID field is mandatory to configure {creds_type} user's credential"
     )
-    with raises(DemistoException, match=error_msg):
+    with pytest.raises(DemistoException, match=error_msg):
         Client.get_client_data(tenant_id=tenant_id, bearer_token="dummy-bearer-token")
 
     cache = get_integration_context()
@@ -2398,7 +2397,7 @@ def test_insecure_connection(requests_mock):
     requests_mock.get(f"{COMMON_BASE_URL}/whoami/v1", exc=requests.exceptions.SSLError)
 
     # assert that a valid exception is raised with proper error message
-    with raises(DemistoException, match="SSL Certificate Verification Failed.*"):
+    with pytest.raises(DemistoException, match="SSL Certificate Verification Failed.*"):
         Client._whoami(bearer_token="dummy_token")
 
 
@@ -2417,7 +2416,7 @@ def test_proxy_error(requests_mock):
     )
 
     # assert that a valid exception is raised with proper error message
-    with raises(DemistoException, match="Proxy Error.*"):
+    with pytest.raises(DemistoException, match="Proxy Error.*"):
         Client._whoami(bearer_token="dummy_token")
 
 
@@ -2894,7 +2893,7 @@ def test_sophos_central_group_list_validate_page_size_min(page_size, page, reque
     from SophosCentral import sophos_central_group_list
     client = init_mock_client(requests_mock)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         sophos_central_group_list(client, {
             "page_size": page_size,
             "page": page
@@ -3101,7 +3100,7 @@ def test_sophos_central_group_delete_exception(requests_mock) -> None:
     requests_mock.delete(f"{BASE_URL}/endpoint/v1/endpoint-groups/fake-id", json=mock_response)
     client = init_mock_client(requests_mock)
 
-    with raises(DemistoException):
+    with pytest.raises(DemistoException):
         sophos_central_group_delete(client, {
             "groupId": "fake-id"
         })
@@ -3175,7 +3174,7 @@ def test_sophos_central_endpoint_policy_search_with_page_size_or_page_negative_v
 
     client = init_mock_client(requests_mock)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         sophos_central_endpoint_policy_search_command(client, {
             "page_size": page_size,
             "page": page

--- a/Packs/SophosCentral/ReleaseNotes/1_3_1.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_1.md
@@ -1,4 +1,4 @@
 #### Integrations
 ##### Sophos Central
-- Added new parameter to query endpoints by IP addresses
-- Added new parameter to check IP addresses for full match instead of partial (default API behavior)
+- Added new argument to sophos-central-endpoint-list to query endpoints by IP addresses
+- Added new argument to sophos-central-endpoint-list to check IP addresses for full match instead of partial (default API behavior)

--- a/Packs/SophosCentral/ReleaseNotes/1_3_1.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_1.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Sophos Central
+- Added new parameter to query endpoints by IP addresses
+- Added new parameter to check IP addresses for full match instead of partial (default API behavior)

--- a/Packs/SophosCentral/pack_metadata.json
+++ b/Packs/SophosCentral/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Sophos Central",
     "description": "The unified console for managing Sophos products",
     "support": "xsoar",
-    "currentVersion": "1.3.0",
+    "currentVersion": "1.3.1",
     "author": "Sophos",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The Sophos Central Endpoint API provides a parameter for looking up devices by IP addresses. This PR adds this parameter to the related command. Furthermore the Sophos API does a partial string matching to check the IP. In probably the most cases you want a full match, therefor I also added an optional parameter to do a full match after retreiving the results.

## Must have
- [x] Tests
- [x] Documentation 
