### PR TITLE
[ThreatConnect & Native] Added To Ignore List

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -146,7 +146,17 @@
             "ignored_native_images": [
                 "native:8.6"
             ]
+        },
+        {
+            "id": "ThreatConnect v3",
+            "reason": "",
+            "ignored_native_images": [
+                "native:8.6",
+                "native:dev",
+                "native:candidate"
+            ]
         }
+        
     ],
     "flags_versions_mapping":{
         "native:dev":"native:dev",

--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -149,7 +149,7 @@
         },
         {
             "id": "ThreatConnect v3",
-            "reason": "",
+            "reason": "CIAC-11146",
             "ignored_native_images": [
                 "native:8.6",
                 "native:dev",


### PR DESCRIPTION

## Related Issues
related: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-11146) to the issue

## Description
After updating the Docker image in `ThreatConnectV3` to Python 3.11,
the following unit tests are failing: `test_create_context` and `test_create_header`.


