### PR TITLE
[ThreatConnectV3] Support Python 3.11

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -60,14 +60,14 @@ class Client(BaseClient):
         headers = self.create_header(url_suffix, method)
         if content_type:
             headers['Content-Type'] = content_type
-        response = self._http_request(method=method, url_suffix=url_suffix, data=payload, resp_type=responseType,  # type: ignore
+        response = self._http_request(method=method.value, url_suffix=url_suffix, data=payload, resp_type=responseType,
                                       params=params,
                                       headers=headers)
         return response
 
     def create_header(self, url_suffix: str, method: Method) -> dict:
         timestamp = round(time.time())
-        to_sign = f'{url_suffix}:{method}:{timestamp}'
+        to_sign = f'{url_suffix}:{method.value}:{timestamp}'
         hash = base64.b64encode(
             hmac.new(self.api_secret.encode('utf8'), to_sign.encode('utf8'), hashlib.sha256).digest()).decode()
         return {'Authorization': f'TC {self.api_id}:{hash}', 'Timestamp': str(timestamp),

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
@@ -2963,7 +2963,7 @@ script:
     - contextPath: TC.AttributeType.TC.AttributeType.validationRule.version
       description: The attribute type validation rule version.
       type: string
-  dockerimage: demisto/python3:3.10.14.99865
+  dockerimage: demisto/python3:3.11.9.103066
   isfetch: true
   script: ''
   subtype: python3

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_8.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_8.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ThreatConnect v3
+
+- Documentation and metadata improvements.
+- Updated the Docker image to: *demisto/python3:3.11.9.103066*.

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "3.1.7",
+    "currentVersion": "3.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-11146) to the issue

## Description
In Python 3.11, there is a [change](https://docs.python.org/3.11/whatsnew/3.11.html#enum) in how the `f-string` is handled on the Enum object.
```python
class Method(str, Enum):
    GET = 'GET'
print(format(Method.GET))
```
in Python 3.10 this will output `GET` in Python 3.11 `Method.GET`
