### PR TITLE
[Native Image] Ignore Python 3.11 Integrations

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -146,6 +146,22 @@
             "ignored_native_images": [
                 "native:8.6"
             ]
+        },
+        {
+            "id":"CyrenThreatInDepthRenderRelated",
+            "reason": "This integration support only from python 3.11",
+            "ignored_native_images":[
+                "native:8.6",
+                "native:candidate"
+            ]
+        },
+        {
+            "id": "rapid7_threat_command",
+            "reason": "This integration support only from python 3.11",
+            "ignored_native_images": [
+                "native:8.6",
+                "native:candidate"
+            ]
         }
     ],
     "flags_versions_mapping":{


### PR DESCRIPTION
## Description
The `rapid7_threat_command` and `CyrenThreatInDepthRenderRelated` integrations require a Python 3.11 image.

In PR #35455, we updated the `rapid7_threat_command` integration to support Python 3.11.
In PR #35456, we updated the `CyrenThreatInDepthRenderRelated` integration to support Python 3.11.

Until the native images for `GA` and `candidate` are updated to support Python 3.11, these items are unsuitable for the native image.