### PR TITLE
[ProofpointEmailSecurityEventCollector] Python 3.11

### DIFF
--- a/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.py
+++ b/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.py
@@ -96,7 +96,7 @@ def fetch_events(event_type: EventType, connection: Connection, fetch_interval: 
         event["event_type"] = event_type.value
         events.append(event)
         event_ids.add(event_id)
-    demisto.debug(f"Fetched {len(events)} events of type {event_type}")
+    demisto.debug(f"Fetched {len(events)} events of type {event_type.value}")
     demisto.debug("The fetched events ids are: " + ", ".join([str(event_id) for event_id in event_ids]))
     return events
 

--- a/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.yml
+++ b/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.yml
@@ -45,7 +45,7 @@ script:
   script: ""
   type: python
   commands: []
-  dockerimage: demisto/netutils:1.0.0.99804
+  dockerimage: demisto/netutils:1.0.0.103292
   longRunning: true
   subtype: python3
 marketplaces:

--- a/Packs/ProofpointEmailSecurity/ReleaseNotes/1_0_3.md
+++ b/Packs/ProofpointEmailSecurity/ReleaseNotes/1_0_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Proofpoint Email Security Event Collector
+
+Updated the Docker image to: *demisto/netutils:1.0.0.103292*.

--- a/Packs/ProofpointEmailSecurity/pack_metadata.json
+++ b/Packs/ProofpointEmailSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Email Security",
     "description": "Proofpoint Email Security pack provides visibility into email security threats and protects your organization from phishing, malware, and compliance risks.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-11182) to the issue

## Description

In python 3.11 you must use `.value` to get the value of Enum

![image](https://github.com/user-attachments/assets/a1813baa-355b-42bf-96ab-51aedf3827bd)

