### PR TITLE
Un-skip hooks for autoupdate docker PRs

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -180,7 +180,6 @@ repos:
   - id: validate-deleted-files
     name: validate-deleted-files
     entry: validate-deleted-files
-    skip:docker_autoupdate: true
     language: system
     require_serial: true
     pass_filenames: false
@@ -192,7 +191,6 @@ repos:
 
   - id: validate-content-paths
     name: validate-content-paths
-    skip:docker_autoupdate: true
     entry: validate-content-path
     language: system
     require_serial: true
@@ -216,7 +214,6 @@ repos:
     files: Tests/conf.json
     skip:commit: true
     skip:nightly: true
-    skip:docker_autoupdate: true
     entry: validate-conf-json
     pass_filenames: false
     language: system


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Relates: [CIAC-11128](https://jira-dc.paloaltonetworks.com/browse/CIAC-11128).

## Description
As discussed we un-skipped the following hooks: 

- validate-deleted-files
- validate-conf-json
- validate-content-paths

The following hooks remained skipped for auto-update docker PRs: 

- xsoar-lint
- validate
- format

## Must have
- [ ] Tests
- [ ] Documentation 
