### PR TITLE
SplunkPy: fix the `earliest` key in drilldown enrichment

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1111,8 +1111,8 @@ def drilldown_enrichment(service: client.Service, notable_data, num_enrichment_e
             if isinstance(search, dict):
                 query_name = search.get("name", "")
                 query_search = search.get("search", "")
-                earliest_offset = search.get("earliest", "")  # The earliest time to query from.
-                latest_offset = search.get("latest", "")  # The latest time to query to.
+                earliest_offset = search.get("earliest") or search.get("earliest_offset", "")  # The earliest time to query from.
+                latest_offset = search.get("latest") or search.get("latest_offset", "")  # The latest time to query to.
 
             else:
                 # Got a single drilldown search under the 'drilldown_search' key (BC)

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -673,7 +673,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: Splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk-py3:1.0.0.103333
+  dockerimage: demisto/splunksdk-py3:1.0.0.104156
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -1529,9 +1529,20 @@ def test_drilldown_enrichment_get_timeframe(mocker, notable_data, expected_call_
        '| from datamodel:"Authentication"."Authentication" | search src="\'test_src\'"'),
       ('View all test involving user="\'test_user\'"',
        'search index="test"\n| where user = "\'test_user\'"')]),
+    ({'event_id': 'test_id3', 'drilldown_searches':
+        ["{\"name\":\"View all login attempts by system $src$\",\"search\":\"| from datamodel:\\\"Authentication\\\".\\\"Authe"
+            "ntication\\\" | search src=$src|s$\",\"earliest_offset\":1715040000,\"latest_offset\":1715126400}",
+            "{\"name\":\"View all test involving user=\\\"$user$\\\"\",\"search\":\"index=\\\"test\\\"\\n| where "
+         "user = $user|s$\",\"earliest_offset\":1716955500,\"latest_offset\":1716959400}"],
+      '_raw': "src=\'test_src\', user='test_user'"},
+     [("View all login attempts by system 'test_src'",
+       '| from datamodel:"Authentication"."Authentication" | search src="\'test_src\'"'),
+      ('View all test involving user="\'test_user\'"',
+       'search index="test"\n| where user = "\'test_user\'"')]),
 ], ids=[
     "A notable data with one drilldown search enrichment",
-    "A notable data with multiple (two) drilldown searches to enrich"
+    "A notable data with two drilldown searches which contained the earlies in 'earliest' key ",
+    "A notable data with two drilldown searches which contained the earlies in 'earliest_offset' key "
 ])
 def test_drilldown_enrichment(notable_data, expected_result):
     """

--- a/Packs/SplunkPy/ReleaseNotes/3_1_35.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_35.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### SplunkPy
+
+- Fixed an issue where the drilldown enrichment of a multiple drilldown searches has stopped working.
+- Updated the Docker image to: *demisto/splunksdk-py3:1.0.0.104156*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "3.1.34",
+    "currentVersion": "3.1.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-39727

## Description
currently, we trying to get the `earliest` and `latest` of the drilldown search, from the `earliest` and `latest` keys
in some cases, this data stored under `earliest_offset` and `latest_offset` 

`'drilldown_searches': '[{"name":"NAME","search":"index=*","earliest_offset":"1713530640.000000000","latest_offset":"1721306640.000000000"}`

**_new test before fix:_**
<img width="778" alt="image" src="https://github.com/user-attachments/assets/32f86f87-6905-48ba-9587-fad57f89808d">

**_after fix:_**
<img width="669" alt="image" src="https://github.com/user-attachments/assets/4bd70510-e7ee-4fb4-8561-9f82100c23be">
