### PR TITLE
ParseEmailFilesV2: fix a bug of 'gbk' decoding in MSG file

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_35.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_35.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### ParseEmailFilesV2
+
+- Updated the Docker image to: *demisto/parse-emails:1.0.0.104899*.

--- a/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
+++ b/Packs/CommonScripts/Scripts/ParseEmailFilesV2/ParseEmailFilesV2.yml
@@ -116,4 +116,4 @@ type: python
 fromversion: 5.0.0
 tests:
 - ParseEmailFilesV2-test
-dockerimage: demisto/parse-emails:1.0.0.93148
+dockerimage: demisto/parse-emails:1.0.0.104899

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.34",
+    "currentVersion": "1.15.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-39649
dockerfiles PR: https://github.com/demisto/dockerfiles/pull/29953
## Description
Due to a bug in version >=0.1.0 of the `RTFDE` module
we lock the version to 0.0.2 in the `demisto/parse-emails` docker image