### PR TITLE
fix openssl mode

### DIFF
--- a/Packs/Troubleshoot/ReleaseNotes/2_1_0.md
+++ b/Packs/Troubleshoot/ReleaseNotes/2_1_0.md
@@ -1,0 +1,8 @@
+
+#### Scripts
+
+##### CertificatesTroubleshoot
+
+- Fixed an issue where openssl mode was not supported by the docker.
+- Added -debug and -msg flags to openssl when run with debug-mode=true.
+- Updated the Docker image to: *demisto/auth-utils:1.0.0.103532*.

--- a/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
+++ b/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
@@ -4,7 +4,7 @@ import os
 import socket
 import ssl
 from pathlib import Path
-from typing import List, Dict, Optional, Any
+from typing import Any
 import subprocess
 import re
 import pem
@@ -14,7 +14,7 @@ from cryptography.x509.extensions import ExtensionNotFound
 from cryptography.hazmat.backends import default_backend
 
 
-def parse_certificate_object_identifier_name(certificate: x509.Name, oid: x509.ObjectIdentifier) -> Optional[List[str]]:
+def parse_certificate_object_identifier_name(certificate: x509.Name, oid: x509.ObjectIdentifier) -> list[str] | None:
     """ Get attribute from decoded certificate.
 
     Args:
@@ -30,7 +30,7 @@ def parse_certificate_object_identifier_name(certificate: x509.Name, oid: x509.O
 
 
 def parse_certificate_object_identifier_extentions(certificate: x509.Extensions, oid: x509.ObjectIdentifier) -> \
-    Optional[List[str]]:
+        list[str] | None:
     """ Get attribute from decoded certificate extension.
 
     Args:
@@ -138,7 +138,7 @@ def parse_certificate(certificate: str) -> dict:
     }
 
 
-def parse_all_certificates(certifcates: str) -> List[Dict[Any, Any]]:
+def parse_all_certificates(certifcates: str) -> list[dict[Any, Any]]:
     """ Parse all certificates in a given string.
 
     Args:
@@ -207,8 +207,8 @@ def get_certificate_openssl(endpoint, port):
     try:
         debug_args = ['-msg', '-debug'] if is_debug_mode() else []
         demisto.debug('before opening openssl process')
-        process = subprocess.Popen(['openssl', 's_client', *debug_args, '-connect', f'{endpoint}:{port}', '-showcerts'], text=True,
-                                   stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        process = subprocess.Popen(['openssl', 's_client', *debug_args, '-connect', f'{endpoint}:{port}', '-showcerts'],
+                                   text=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         demisto.debug('opened process')
         openssl_res, _ = process.communicate('Q\n', timeout=10)
         demisto.debug(f'openssl process return code {process.returncode}')
@@ -220,6 +220,7 @@ def get_certificate_openssl(endpoint, port):
         demisto.error(f"openssl command timed out after 10 seconds {e}")
         demisto.error(f'Partial openssl output: {openssl_res}')
         return_error('openssl command timed out, see logs for more details.')
+
 
 def endpoint_certificate(endpoint: str, port: str) -> dict:
     """ Get certificate issuer from endpoint.

--- a/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
+++ b/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
@@ -210,14 +210,14 @@ def get_certificate_openssl(endpoint, port):
         process = subprocess.Popen(['openssl', 's_client', *debug_args, '-connect', f'{endpoint}:{port}', '-showcerts'],
                                    text=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         demisto.debug('opened process')
-        openssl_res, _ = process.communicate('Q\n', timeout=10)
+        openssl_res, _ = process.communicate('Q\n', timeout=60)
         demisto.debug(f'openssl process return code {process.returncode}')
         demisto.debug(f'openssl output: {openssl_res}')
         return '\n'.join(re.findall(r'^-----BEGIN CERT.*?^-----END CERTIFICATE-----', openssl_res, re.DOTALL | re.MULTILINE))
     except subprocess.TimeoutExpired as e:
         process.kill()  # Terminate the process
         openssl_res, _ = process.communicate()  # Capture any remaining output
-        demisto.error(f"openssl command timed out after 10 seconds {e}")
+        demisto.error(f"openssl command timed out after 60 seconds {e}")
         demisto.error(f'Partial openssl output: {openssl_res}')
         return_error('openssl command timed out, see logs for more details.')
 

--- a/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
+++ b/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.py
@@ -30,7 +30,7 @@ def parse_certificate_object_identifier_name(certificate: x509.Name, oid: x509.O
 
 
 def parse_certificate_object_identifier_extentions(certificate: x509.Extensions, oid: x509.ObjectIdentifier) -> \
-        Optional[List[str]]:
+    Optional[List[str]]:
     """ Get attribute from decoded certificate extension.
 
     Args:
@@ -42,7 +42,7 @@ def parse_certificate_object_identifier_extentions(certificate: x509.Extensions,
     """
     try:
         values = certificate.get_extension_for_oid(oid).value
-        attributes = [item.value for item in values]    # type: ignore[attr-defined]
+        attributes = [item.value for item in values]  # type: ignore[attr-defined]
     except ExtensionNotFound:
         attributes = []
 
@@ -188,11 +188,7 @@ def get_certificates(endpoint: str, port: str) -> str:
     """
     mode = demisto.getArg('mode') or 'python'
     if mode == "openssl":
-        openssl_res = subprocess.check_output(['openssl', 's_client', '-servername', endpoint,
-                                               '-host', endpoint, '-port', port, '-showcerts'], text=True,
-                                              stderr=subprocess.STDOUT)
-        demisto.debug(f'openssl output: {openssl_res}')
-        return '\n'.join(re.findall(r'^-----BEGIN CERT.*?^-----END CERTIFICATE-----', openssl_res, re.DOTALL | re.MULTILINE))
+        return get_certificate_openssl(endpoint, port)
     else:
         hostname = endpoint
         conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -206,6 +202,24 @@ def get_certificates(endpoint: str, port: str) -> str:
         else:
             return ""
 
+
+def get_certificate_openssl(endpoint, port):
+    try:
+        debug_args = ['-msg', '-debug'] if is_debug_mode() else []
+        demisto.debug('before opening openssl process')
+        process = subprocess.Popen(['openssl', 's_client', *debug_args, '-connect', f'{endpoint}:{port}', '-showcerts'], text=True,
+                                   stderr=subprocess.STDOUT, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        demisto.debug('opened process')
+        openssl_res, _ = process.communicate('Q\n', timeout=10)
+        demisto.debug(f'openssl process return code {process.returncode}')
+        demisto.debug(f'openssl output: {openssl_res}')
+        return '\n'.join(re.findall(r'^-----BEGIN CERT.*?^-----END CERTIFICATE-----', openssl_res, re.DOTALL | re.MULTILINE))
+    except subprocess.TimeoutExpired as e:
+        process.kill()  # Terminate the process
+        openssl_res, _ = process.communicate()  # Capture any remaining output
+        demisto.error(f"openssl command timed out after 10 seconds {e}")
+        demisto.error(f'Partial openssl output: {openssl_res}')
+        return_error('openssl command timed out, see logs for more details.')
 
 def endpoint_certificate(endpoint: str, port: str) -> dict:
     """ Get certificate issuer from endpoint.

--- a/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.yml
+++ b/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot.yml
@@ -337,7 +337,7 @@ tags:
 - Utility
 timeout: '0'
 type: python
-dockerimage: demisto/auth-utils:1.0.0.91447
+dockerimage: demisto/auth-utils:1.0.0.103532
 runas: DBotWeakRole
 tests:
 - No tests (auto formatted)

--- a/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot_test.py
+++ b/Packs/Troubleshoot/Scripts/CertificatesTroubleshoot/CertificatesTroubleshoot_test.py
@@ -7,7 +7,7 @@ import demistomock as demisto
 
 
 def load_json_file(path):
-    with open(path, 'r') as json_file:
+    with open(path) as json_file:
         return json.load(json_file)
 
 
@@ -17,7 +17,11 @@ def test_parse_all_certificates(datadir):
 
 
 def test_openssl(mocker: MockerFixture, datadir):
-    mocker.patch('subprocess.check_output', return_value=Path(datadir['openssl-github-output.txt']).read_text())
+    process_mock = mocker.MagicMock()
+    certificate = Path(datadir['openssl-github-output.txt']).read_text()
+    process_mock.communicate.return_value = (certificate, None)
+
+    mocker.patch('subprocess.Popen', return_value=process_mock)
     mocker.patch.object(demisto, 'args', return_value={
         'endpoint': 'api.github.com',
         'port': '443',

--- a/Packs/Troubleshoot/pack_metadata.json
+++ b/Packs/Troubleshoot/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Troubleshoot",
     "description": "Use this pack to troubleshoot your environment.",
     "support": "xsoar",
-    "currentVersion": "2.0.20",
+    "currentVersion": "2.1.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11115)

## Description
added openssl to the docker. 
in case of successful connections the openssl subprocess just would timeout on an open succesful connection, so now sending Q in to quit


## Must have
- [x] Tests
- [x] Documentation 
