### PR TITLE
DBotUpdateLogoURLPhishing_test : change tasks order

### DIFF
--- a/Packs/CommonScripts/TestPlaybooks/DBotUpdateLogoURLPhishing_test.yml
+++ b/Packs/CommonScripts/TestPlaybooks/DBotUpdateLogoURLPhishing_test.yml
@@ -57,7 +57,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 370
+          "y": 545
         }
       }
     note: false
@@ -116,7 +116,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "1"
+      - "10"
     scriptarguments:
       all:
         simple: "yes"
@@ -165,7 +165,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 545
+          "y": 720
         }
       }
     note: false
@@ -206,7 +206,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 720
+          "y": 895
         }
       }
     note: false
@@ -231,7 +231,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "10"
+      - "3"
     scriptarguments:
       action:
         simple: ModifiedDomainForLogo
@@ -245,7 +245,7 @@ tasks:
       {
         "position": {
           "x": 50,
-          "y": 895
+          "y": 1070
         }
       }
     note: false
@@ -270,19 +270,20 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "3"
+      - "1"
     scriptarguments:
       action:
         simple: RemoveLogo
       logoName:
         simple: dbot
     separatecontext: false
+    continueonerror: true
     continueonerrortype: ""
     view: |-
       {
         "position": {
           "x": 50,
-          "y": 1070
+          "y": 370
         }
       }
     note: false


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11311

## Description
Currently, the TPB add image and after that delete it
in case of error in deletion, the next add Image will fail with the message `This logo name already exists in the model. Please use another logo name`
like happened in [nightly](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/7251229/raw#L9741)

fix:
change the tasks order, the first step after delete context will try to delete the image and will pass even in case of error (image not exist)


PB before:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/25bc3a52-bba2-450c-98cd-986338c513de">

PB after:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/1df20e16-e2a8-4fd2-bb20-41c1f2e8e5eb">

