### PR TITLE
[File Reputation PB] Fixed the data path for VirusTotal malicious file count

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-File_Reputation.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-File_Reputation.yml
@@ -189,7 +189,7 @@ tasks:
           left:
             value:
               complex:
-                root: VirusTotal.SearchResults.attributes.last_analysis_stats
+                root: VirusTotal.File.attributes.last_analysis_stats
                 accessor: malicious
             iscontext: true
           right:

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_6_37.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_6_37.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### File Reputation
+
+Fixed the data path for VirusTotal malicious file count.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.6.36",
+    "currentVersion": "2.6.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11387)

## Description
[File Reputation PB] Fixed the data path for VirusTotal malicious file count.
