### PR TITLE
Fix set-junk-rules regular and global commands

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
@@ -794,16 +794,18 @@ class ExchangeOnlinePowershellV3Client
             # Import and Execute command
             $cmd_params = @{
                 "Identity"                 = $mailbox
-                "BlockedSendersAndDomains" = @{Add = $add_blocked_senders_and_domains
-                    Remove                         = $remove_blocked_senders_and_domains
-                }
-                "TrustedSendersAndDomains" = @{Add = $add_trusted_senders_and_domains
-                    Remove                         = $remove_trusted_senders_and_domains
-                }
                 "TrustedListsOnly"         = $trusted_lists_only
                 "ContactsTrusted"          = $contacts_trusted
                 "Enabled"                  = $enabled
                 "Confirm"                  = $false
+            }
+            $blocked_senders_and_domains = CreateAddAndRemoveSections $add_blocked_senders_and_domains $remove_blocked_senders_and_domains
+            if ($blocked_senders_and_domains -ne $null){
+                $cmd_params["BlockedSendersAndDomains"] = $blocked_senders_and_domains
+            }
+            $trusted_senderns_and_domains = CreateAddAndRemoveSections $add_trusted_senders_and_domains $remove_trusted_senders_and_domains
+            if ($trusted_senderns_and_domains -ne $null){
+                $cmd_params["TrustedSendersAndDomains"] = $trusted_senderns_and_domains
             }
             Set-MailboxJunkEmailConfiguration @cmd_params
         }
@@ -855,16 +857,18 @@ class ExchangeOnlinePowershellV3Client
             $this.CreateSession()
             # Import and Execute command
             $cmd_params = @{
-                "BlockedSendersAndDomains" = @{Add = $add_blocked_senders_and_domains
-                    Remove                         = $remove_blocked_senders_and_domains
-                }
-                "TrustedSendersAndDomains" = @{Add = $add_trusted_senders_and_domains
-                    Remove                         = $remove_trusted_senders_and_domains
-                }
                 "TrustedListsOnly"         = $trusted_lists_only
                 "ContactsTrusted"          = $contacts_trusted
                 "Enabled"                  = $enabled
                 "Confirm"                  = $false
+            }
+            $blocked_senders_and_domains = CreateAddAndRemoveSections $add_blocked_senders_and_domains $remove_blocked_senders_and_domains
+            if ($blocked_senders_and_domains -ne $null){
+                $cmd_params["BlockedSendersAndDomains"] = $blocked_senders_and_domains
+            }
+            $trusted_senderns_and_domains = CreateAddAndRemoveSections $add_trusted_senders_and_domains $remove_trusted_senders_and_domains
+            if ($trusted_senderns_and_domains -ne $null){
+                $cmd_params["TrustedSendersAndDomains"] = $trusted_senderns_and_domains
             }
             Get-Mailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited | ForEach-Object {
                 Set-MailboxJunkEmailConfiguration -Identity $_.Name @cmd_params
@@ -1758,6 +1762,22 @@ function SetJunkRulesCommand([ExchangeOnlinePowershellV3Client]$client, [hashtab
     $entry_context = @{}
 
     return $human_readable, $entry_context, $raw_response
+}
+
+function  CreateAddAndRemoveSections([string[]]$items_to_add, [string[]]$items_to_remove ){
+    if ((-not [string]::IsNullOrEmpty($items_to_add)) -and (-not [string]::IsNullOrEmpty($items_to_remove))){
+        return  @{Add = $items_to_add
+            Remove                         = $items_to_remove
+        }
+    }
+    elseif (-not [string]::IsNullOrEmpty($items_to_add)){
+        return  @{Add = $items_to_add
+        }
+    }
+    elseif (-not [string]::IsNullOrEmpty($items_to_remove)){
+        return  @{Remove = $items_to_remove
+        }
+    }
 }
 
 function SetGlobalJunkRulesCommand([ExchangeOnlinePowershellV3Client]$client, [hashtable]$kwargs) {

--- a/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
@@ -1765,19 +1765,14 @@ function SetJunkRulesCommand([ExchangeOnlinePowershellV3Client]$client, [hashtab
 }
 
 function  CreateAddAndRemoveSections([string[]]$items_to_add, [string[]]$items_to_remove ){
-    if ((-not [string]::IsNullOrEmpty($items_to_add)) -and (-not [string]::IsNullOrEmpty($items_to_remove))){
-        return  @{Add = $items_to_add
-            Remove                         = $items_to_remove
-        }
+    $params = @{}
+    if (-not [string]::IsNullOrEmpty($items_to_add)){
+        $params["Add"] = $items_to_add
     }
-    elseif (-not [string]::IsNullOrEmpty($items_to_add)){
-        return  @{Add = $items_to_add
-        }
+    if (-not [string]::IsNullOrEmpty($items_to_remove)){
+        $params["Remove"] =  $items_to_remove
     }
-    elseif (-not [string]::IsNullOrEmpty($items_to_remove)){
-        return  @{Remove = $items_to_remove
-        }
-    }
+    return $params
 }
 
 function SetGlobalJunkRulesCommand([ExchangeOnlinePowershellV3Client]$client, [hashtable]$kwargs) {

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_4_5.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_4_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS Extension Online Powershell v3
+
+- Fixed an issue where **ews-global-junk-rules-set** and **ews-junk-rules-set** would fail on empty values for trusted and blocked domains and email sections.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.4.4",
+    "currentVersion": "1.4.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-40124](https://jira-dc.paloaltonetworks.com/browse/XSUP-40124)

## Description
Fixed an issue where **ews-global-junk-rules-set** and **ews-junk-rules-set** would fail on empty values for trusted and blocked domains and email sections.
