### PR TITLE
Change Poetry Dependency Group for Branch Protection Rule Purge

### DIFF
--- a/.github/workflows/purge_branch_protection_rules.yml
+++ b/.github/workflows/purge_branch_protection_rules.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          poetry install --with ci
+          poetry install --with github-actions
 
           # Override PyGithub version to include GraphQL support and bug fix
           # TODO remove when https://github.com/PyGithub/PyGithub/issues/3001 is fixed


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates:https://jira-dc.paloaltonetworks.com/browse/CIAC-9027

## Description
After merging https://github.com/demisto/content/pull/35604, the pipeline to purge branch protection rules was triggered as a result of the head branch deletion from that PR.

The [job failed](https://github.com/demisto/content/actions/runs/10265796864/job/28402738696#step:5:18) installing dependencies because of a missing Poetry dependency group:

```
Group(s) not found: ci (via --with)
```

This is a result of changes done in https://github.com/demisto/content/pull/35570.

This PR was opened to update the Poetry group to `github-actions` to align the rest of the GitHub workflows.

## Must have
- [ ] Tests
- [ ] Documentation 
