### PR TITLE
Improve internet protocol version detection/classification (URLScan integration)

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -60,7 +60,7 @@ class Client:
 '''HELPER FUNCTIONS'''
 
 
-def detect_ip_type(ip_string):
+def to_ip_feed_indicator_type(ip_string):
     """Categorize a given IP address into its feed indicator type - default (v4) or v6."""
     try:
         socket.inet_aton(ip_string)
@@ -288,7 +288,7 @@ def create_list_relationships(scans_dict, url, reliability):
                     pass
                 # For a case where the type of the IP indicator should be detected, whether its IPv6/IP
                 if not indicator_type and relationship_dict.get('detect_type'):
-                    indicator_type = detect_ip_type(indicator)
+                    indicator_type = to_ip_feed_indicator_type(indicator)
                 relationship = create_relationship(scan_type=scan_name, field=field, entity_a=url,
                                                    entity_a_type=FeedIndicatorType.URL, entity_b=indicator,
                                                    entity_b_type=indicator_type, reliability=reliability)

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -60,12 +60,10 @@ class Client:
 '''HELPER FUNCTIONS'''
 
 
-def detect_ip_type(indicator):
-    """
-    Helper function which detects whether an IP is a IP or IPv6 by string
-    """
+def detect_ip_type(ip_string):
+    """Categorize a given IP address into its feed indicator type - default (v4) or v6."""
     try:
-        socket.inet_aton(indicator)
+        socket.inet_aton(ip_string)
         return FeedIndicatorType.IP
     except OSError:
         return FeedIndicatorType.IPv6

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -62,7 +62,7 @@ class Client:
 
 def detect_ip_type(indicator):
     """
-    Helper function which detects wheather an IP is a IP or IPv6 by string
+    Helper function which detects whether an IP is a IP or IPv6 by string
     """
     try:
         socket.inet_aton(indicator)

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -7,6 +7,7 @@ import collections
 import json as JSON
 import time
 from urllib.parse import urlparse
+import socket
 
 import requests
 from requests.utils import quote  # type: ignore
@@ -63,12 +64,11 @@ def detect_ip_type(indicator):
     """
     Helper function which detects wheather an IP is a IP or IPv6 by string
     """
-    indicator_type = ''
-    if '::' in indicator:
-        indicator_type = FeedIndicatorType.IPv6
-    else:
-        indicator_type = FeedIndicatorType.IP
-    return indicator_type
+    try:
+        socket.inet_aton(indicator)
+        return FeedIndicatorType.IP
+    except OSError:
+        return FeedIndicatorType.IPv6
 
 
 def schedule_polling(items_to_schedule, next_polling_interval):

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
@@ -214,9 +214,9 @@ def test_format_results_check_lists(mocker):
 
 def test_ipv_classification():
     from UrlScan import FeedIndicatorType, to_ip_feed_indicator_type
-    
+
     assert to_ip_feed_indicator_type("123.123.123.123") == FeedIndicatorType.IP
-    
+
     assert to_ip_feed_indicator_type("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF") == FeedIndicatorType.IPv6
     assert to_ip_feed_indicator_type("2001:db8::") == FeedIndicatorType.IPv6
     assert to_ip_feed_indicator_type("::1234:5678") == FeedIndicatorType.IPv6

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
@@ -213,7 +213,7 @@ def test_format_results_check_lists(mocker):
 
 
 def test_ipv_classification():
-    from UrlScan import to_ip_feed_indicator_type
+    from UrlScan import FeedIndicatorType, to_ip_feed_indicator_type
     
     assert to_ip_feed_indicator_type("123.123.123.123") == FeedIndicatorType.IP
     

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan_test.py
@@ -210,3 +210,16 @@ def test_format_results_check_lists(mocker):
         "http://capitalne.com/about",
         "https://urlscan.io/"
     ]
+
+
+def test_ipv_classification():
+    from UrlScan import to_ip_feed_indicator_type
+    
+    assert to_ip_feed_indicator_type("123.123.123.123") == FeedIndicatorType.IP
+    
+    assert to_ip_feed_indicator_type("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF") == FeedIndicatorType.IPv6
+    assert to_ip_feed_indicator_type("2001:db8::") == FeedIndicatorType.IPv6
+    assert to_ip_feed_indicator_type("::1234:5678") == FeedIndicatorType.IPv6
+    assert to_ip_feed_indicator_type("2001:db8::1234:5678") == FeedIndicatorType.IPv6
+
+    # function under test assumes input to be valid ipv4 or v6 input, garbage would also lead to an ipv6 output


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
I filled out the contribution form, as required. This is ready for review.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
- improved IP address version detection
  - given the way the given function is used, we are already assuming any input to either be a valid IPv4 address, or a valid IPv6 address alternatively
  - assuming IPv4, validating with `socket.inet_aton` and falling back on IPv6 on error should serve us better than a dodgy search of the string for double colons (inet_aton has proven to be reliable for [such usecases in my experience](https://github.com/luis261/symantec-cloud-edr-xsoar-integration/blob/a7fe919a0a94d927dc48fac655098d3177895cde/integration_code.py#L501C1-L505C74))
- made the given docstring PEP257 compliant
  - There’s no blank line either before or after the docstring.
  - The closing quotes are on the same line as the opening quotes. This looks better for one-liners.
  - etc (see https://peps.python.org/pep-0257/)
- renamed the affected helper function to have a more fitting, descriptive name (IMO)

## Must have
- [ ] Tests
- [x] Documentation 
