### PR TITLE
URLScan integration: check response status idiomatically instead of strict comparison against `200`

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -119,7 +119,7 @@ def http_request(client, method, url_suffix, json=None, retries=0):
         return_warning('Your available rate limit remaining is {} and is about to be exhausted. '
                        'The rate limit will reset at {}'.format(str(rate_limit_remaining),
                                                                 r.headers.get("X-Rate-Limit-Reset")))
-    if r.status_code != 200:
+    if not r.ok:
         if r.status_code == 429:
             return {}, ErrorTypes.QUOTA_ERROR, rate_limit_reset_after
 
@@ -174,7 +174,7 @@ def polling(client, uuid):
     if client.user_agent:
         headers['User-Agent'] = client.user_agent
     ready = poll(
-        lambda: requests.get(uri, headers=headers, verify=client.use_ssl).status_code == 200,
+        lambda: requests.get(uri, headers=headers, verify=client.use_ssl).ok,
         step=5,
         ignore_exceptions=(requests.exceptions.ConnectionError),
         timeout=int(TIMEOUT)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Description
Just a suggestion, feel free to reject of course. Might make sense to use the `.ok` attribute as provided by `requests.Response` instead of literally comparing against `200`.

> [!NOTE]
> Technically, this does constitute a behavior change, according to `help(requests.Response.ok)` :

Returns True if :attr:`status_code` is less than 400, False if not.

**This attribute checks if the status code of the response is between
400 and 600 to see if there was a client error or a server error. If
the status code is between 200 and 400, this will return True. This
is **not** a check to see if the response code is ``200 OK``.**

---

Btw, along the lines of failing early or more strict/robust error handling: long term, it might make sense to consider switching from directly checking status codes to instead calling `Response.raise_for_status` and handling any (expected) raised exceptions appropriately, instead. Switching to `.ok` for now would help pave the way towards this, at least a tiny bit.

## Must have
- [ ] Tests
- [ ] Documentation 
