### PR TITLE
URLScan integration: properly handle timeouts by returning an error (instead of just reporting via normal results + debug)

### DIFF
--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -220,7 +220,7 @@ def poll(target, step, args=(), kwargs=None, timeout=60,
         values.put(last_item)
         tries += 1
         if max_time is not None and time.time() >= max_time:
-            demisto.results('The operation timed out. Please try again with a longer timeout period.')
+            demisto.error('The operation timed out. Please try again with a longer timeout period.')
             demisto.debug('The operation timed out.')
             return False
         time.sleep(step)  # pylint: disable=sleep-exists

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -220,9 +220,8 @@ def poll(target, step, args=(), kwargs=None, timeout=60,
         values.put(last_item)
         tries += 1
         if max_time is not None and time.time() >= max_time:
-            demisto.error('The operation timed out. Please try again with a longer timeout period.')
             demisto.debug('The operation timed out.')
-            return False
+            demisto.error('The operation timed out. Please try again with a longer timeout period.')
         time.sleep(step)  # pylint: disable=sleep-exists
         step = step_function(step)
 

--- a/Packs/UrlScan/ReleaseNotes/1_2_15.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_15.md
@@ -1,0 +1,4 @@
+
+#### Integrations
+##### urlscan.io
+- Polling timeouts now cause an error (previously only showed up as command result)

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.2.14",
+    "currentVersion": "1.2.15",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
As part of one of the use cases I've delevoped in the XSOAR instance of my org for automatically triaging, analyzing and responding to suspicious requests blocked/logged by our firewall/IPS, there is a subplaybook which tries to reconstruct what caused a request by a given user to be fired off (e.g. could be directly clicking on a link in an E-Mail/messenger, being redirected directly from another site, clicking on a hyperlink, arriving from a search machine query etc).

As part of this subcomponent of the investigation, I'm using URLScan (for inspecting HTTP transactions, hrefs etc for a given site which is suspected as a "referrer"). Recently, I've noticed a lot of failures in subsequent playbook steps. I tracked the cause down to URLScan submissions failing in the polling stage without causing an actual failure in technical terms (XSOAR warroom/context results). There is just a normal results message which states "The operation timed out. Please try again with a longer timeout period.", but no error.

This causes actual error handling (which would be in place otherwise) to be skipped and the playbook to instead fail on subsequent tasks which depend on expected URLScan output in the context. I've since quickly worked on a workaround for that playbook, but to avoid such unexpected behavior generally, we need to actually fail on polling timeouts, instead of just emitting them like a normal result.

## Must have
- [ ] Tests
- [ ] Documentation 
