### PR TITLE
[Cortex XDR - IR] Fix multiple incidents pulled

### DIFF
--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -1161,7 +1161,7 @@ def fetch_incidents(client, first_fetch_time, integration_instance, exclude_arti
         next_run['incidents_from_previous_run'] = []
 
     next_run['time'] = last_fetch
-    next_run['incidents_at_last_timestamp'] = new_incidents_at_last_timestamp or incidents_at_last_timestamp
+    next_run['incidents_at_last_timestamp'] = new_incidents_at_last_timestamp or last_run.get('incidents_at_last_timestamp', [])
 
     return next_run, incidents
 

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR.py
@@ -1161,7 +1161,7 @@ def fetch_incidents(client, first_fetch_time, integration_instance, exclude_arti
         next_run['incidents_from_previous_run'] = []
 
     next_run['time'] = last_fetch
-    next_run['incidents_at_last_timestamp'] = new_incidents_at_last_timestamp
+    next_run['incidents_at_last_timestamp'] = new_incidents_at_last_timestamp or incidents_at_last_timestamp
 
     return next_run, incidents
 

--- a/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
+++ b/Packs/CortexXDR/Integrations/CortexXDRIR/CortexXDRIR_test.py
@@ -1639,7 +1639,7 @@ def test_fetch_incidents_dedup():
     assert 'XDR Incident 4' in result_2[1]['name']
     assert last_run['incidents_at_last_timestamp'] == ['4']
 
-    # run empty test and assert last_run['incidents_at_last_timestamp'] is empty
+    # run empty test and assert last_run['incidents_at_last_timestamp'] stays the same
     last_run, result_2 = fetch_incidents(
         client=mock_client,
         first_fetch_time='3 days',
@@ -1649,4 +1649,4 @@ def test_fetch_incidents_dedup():
         max_fetch=0,
     )
 
-    assert last_run['incidents_at_last_timestamp'] == []
+    assert last_run['incidents_at_last_timestamp'] == ['4']

--- a/Packs/CortexXDR/ReleaseNotes/6_1_62.md
+++ b/Packs/CortexXDR/ReleaseNotes/6_1_62.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks Cortex XDR - Investigation and Response
+
+- Fixed an issue in which an incident was fetched multiple times.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "6.1.61",
+    "currentVersion": "6.1.62",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-40446)

## Description
Fixed an issue in which multiple incidents were created.

The problem was caused as the list `incidents_at_last_timestamp` in `last_run` which held a list of all previously created incidents which occurred on the exact same time as the next run will be queried with, so that we can delete any duplicate s that are fetched.

The issue happened when the list was deleted after an empty run even though the last fetch time stayed the same. This caused the next run not to delete the new incident pulled even though it was a duplicate.

In this PR, the `incidents_at_last_timestamp` list is kept if an empty run is executed.

## Must have
- [ ] Tests
- [ ] Documentation 
