### PR TITLE
SplunkPy: better error handling in `splunk-search`

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -2424,6 +2424,32 @@ def parse_batch_of_results(current_batch_of_results, max_results_to_add, app):
     return parsed_batch_results, batch_dbot_scores
 
 
+def handle_failed_job(job):
+    """
+    Handle the case that the search job failed due to dome reason like parsing issues etc
+    raise DemistoException in case there is a fatal error in the search job.
+    see https://docs.splunk.com/Documentation/Splunk/9.3.0/RESTTUT/RESTsearches#:~:text=the%20results%20returned.-,dispatchState,-dispatchState%20is%20one
+
+    Args:
+        job (Job): the created search job
+
+    Raises:
+        Exception: DemistoException in case there is a fatal error
+    """
+    err_msg = None
+    try:
+        if job and job['dispatchState'] == 'FAILED':
+            messages = job['messages']
+            for err_type in ['fatal', 'error']:
+                if messages.get(err_type):
+                    err_msg = ','.join(messages[err_type])
+                    break
+    except Exception:
+        pass
+    if err_msg:
+        raise DemistoException(f'Failed to run the search in Splunk: {err_msg}')
+
+
 def splunk_search_command(service: client.Service, args: dict) -> CommandResults | list[CommandResults]:
     query = build_search_query(args)
     polling = argToBoolean(args.get("polling", False))
@@ -2436,6 +2462,8 @@ def splunk_search_command(service: client.Service, args: dict) -> CommandResults
         search_job = service.jobs.create(query, **search_kwargs)
         job_sid = search_job["sid"]
         args['sid'] = job_sid
+        handle_failed_job(search_job)
+
     status_cmd_result: CommandResults | None = None
     if polling:
         status_cmd_result = splunk_job_status(service, args)

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -2424,7 +2424,7 @@ def parse_batch_of_results(current_batch_of_results, max_results_to_add, app):
     return parsed_batch_results, batch_dbot_scores
 
 
-def handle_failed_job(job):
+def raise_error_for_failed_job(job):
     """
     Handle the case that the search job failed due to dome reason like parsing issues etc
     raise DemistoException in case there is a fatal error in the search job.
@@ -2462,7 +2462,7 @@ def splunk_search_command(service: client.Service, args: dict) -> CommandResults
         search_job = service.jobs.create(query, **search_kwargs)
         job_sid = search_job["sid"]
         args['sid'] = job_sid
-        handle_failed_job(search_job)
+        raise_error_for_failed_job(search_job)
 
     status_cmd_result: CommandResults | None = None
     if polling:

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -673,7 +673,7 @@ script:
     - contextPath: Splunk.UserMapping.SplunkUser
       description: Splunk user mapping.
       type: String
-  dockerimage: demisto/splunksdk-py3:1.0.0.104156
+  dockerimage: demisto/splunksdk-py3:1.0.0.108075
   isfetch: true
   ismappable: true
   isremotesyncin: true

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy_test.py
@@ -217,6 +217,7 @@ class Jobs:
     def create(self, query, **kwargs):
         job = client.Job(sid='123456', service=self.service, **kwargs)
         job.resultCount = 0
+        job._state = self.state
         return job
 
 
@@ -2308,6 +2309,34 @@ def test_splunk_search_command(mocker, polling, status):
         assert search_result.outputs['Splunk.Result'] == []
         assert search_result.readable_output == '### Splunk Search results for query:\n' \
                                                 'sid: 123456\n**No entries.**\n'
+
+
+@pytest.mark.parametrize('messages,expected_msg', [
+    ({'fatal': ['fatal msg']}, 'fatal msg'),
+    ({'error': ['error msg']}, 'error msg')
+])
+def test_err_in_splunk_search(mocker, messages, expected_msg):
+    """
+    Given:
+        A wrong search query.
+
+    When:
+        Running the splunk_search_command.
+
+    Then:
+        Ensure the result as expected in polling and in regular search.
+    """
+    mock_args = {
+        "query": "wrong search query",
+        "earliest_time": "2021-11-23T10:10:10",
+        "latest_time": "2020-10-20T10:10:20",
+        "fast_mode": "false",
+    }
+    service = Service(status="FAILED")
+    service.jobs.state.content['messages'] = messages
+    with pytest.raises(DemistoException) as e:
+        splunk.splunk_search_command(service, mock_args)
+    assert f'Failed to run the search in Splunk: {expected_msg}' in str(e)
 
 
 @pytest.mark.parametrize(

--- a/Packs/SplunkPy/ReleaseNotes/3_1_37.json
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_37.json
@@ -1,0 +1,1 @@
+{"breakingChanges":true,"breakingChangesNotes":"Any query error in the ***splunk-search*** command will now throw an exception instead of ignoring it."}

--- a/Packs/SplunkPy/ReleaseNotes/3_1_37.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_37.md
@@ -3,5 +3,5 @@
 
 ##### SplunkPy
 
-- improved error handling in the ***splunk-search*** command. 
+- Improved error handling in the ***splunk-search*** command. 
 - Updated the Docker image to: *demisto/splunksdk-py3:1.0.0.108075*.

--- a/Packs/SplunkPy/ReleaseNotes/3_1_37.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_1_37.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### SplunkPy
+
+- improved error handling in the ***splunk-search*** command. 
+- Updated the Docker image to: *demisto/splunksdk-py3:1.0.0.108075*.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "3.1.36",
+    "currentVersion": "3.1.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-40336

## Description
currently, in `splunk-search` we create the search by the given `query` arg, and then check if it's have results.
in case there is `fatal` error (invalid syntax of the query for example) we return message that there is no results,
but the `splunk-sdk` `Job` instance contains the indications about the failure but no exception was raised.

in the fix, i check the status in the `Job` instance, and raise `DemistoException` according with the `Job` failure message.

**unit test befor fix:**
<img width="620" alt="image" src="https://github.com/user-attachments/assets/3ea53b7e-747a-4ade-a715-9c198212fd69">


**unit test after fix:**
<img width="593" alt="image" src="https://github.com/user-attachments/assets/1d93dfe2-819e-433a-ba26-21a47866146a">


**playground:**
command to reproduce 
```
!splunk-search query="`notable` | where 1= | head 1"
```

<img width="1185" alt="image" src="https://github.com/user-attachments/assets/045d52a5-df4d-40c6-9ade-a76b2bb6963d">




