### PR TITLE
[DBotPredictURLPhishing] Fix mailto URLs fail with rasterize responses.

### DIFF
--- a/Packs/PhishingURL/ReleaseNotes/1_1_19.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_19.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotPredictURLPhishing
+
+- Fixed an issue in which the response from the `rasterize` command for `mailto` URLs would not be parsed correctly and cause an error.

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -472,7 +472,7 @@ def weed_rasterize_errors(urls: list[str], res_rasterize: list[Union[dict, str]]
     '''Remove the URLs that failed rasterization and return them.'''
     error_idx = [
         i for (i, res) in enumerate(res_rasterize)
-        if isinstance(res, str)
+        if not isinstance(res, dict)
     ][::-1]  # reverse the list as it will be used to remove elements.
     if error_idx:
         return_results(CommandResults(readable_output=tableToMarkdown(
@@ -494,7 +494,7 @@ def rasterize_command(urls: Union[list[str], str], rasterize_timeout: int) -> li
     )
     demisto.debug(f'Rasterize Data: {res_rasterize}')
     return_and_remove_additional_results(res_rasterize, len(urls) if isinstance(urls, list) else 1)
-    return [res['Contents'] for res in res_rasterize]
+    return [res['Contents'] or res['HumanReadable'] for res in res_rasterize]
 
 
 def rasterize_urls(urls: list[str], rasterize_timeout: int) -> list[dict]:

--- a/Packs/PhishingURL/pack_metadata.json
+++ b/Packs/PhishingURL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing URL",
     "description": "Phishing URL is a project with the goal of detecting phishing URLs using machine learning",
     "support": "xsoar",
-    "currentVersion": "1.1.18",
+    "currentVersion": "1.1.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-40525)

## Description
Fixed an issue in which the response from `rasterize` for `mailto` URLs would not be parsed correctly as the `DBotPredictURLPhishing` filtered out all responses from `rasterize` in which the `Contents` key was a string and assumed all other responses were dictionaries, as was the case when this logic was written.
In the latest version of Rasterize, responses for `mailto` URLs are returned in this format:
```python
{
  'Type': 11,
   'ContentsFormat': 'json',
   'Contents': None,
   'HumanReadable': '<messsage>',
   'EntryContext': {},
   'IndicatorTimeline': [],
   'IgnoreAutoExtract': False,
   'Note': False,
   'Relationships': []
}
```
In this case, the `Contents` key contains a `NoneType` causing the error: `AttributeError: 'NoneType' object has no attribute 'get'`
In this PR, the key `HumanReadable` is used when the `Contents` key is "falsy" and all non-dictionary responses are dealt with as errors.

## Must have
- [ ] Tests
- [ ] Documentation 
