### PR TITLE
Link Service Now test playbook to integration yml

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1642,4 +1642,4 @@ fromversion: 5.0.0
 tests:
 - servicenow_test_v2
 - ServiceNow_OAuth_Test
-- ServiceNow Fetch Incidents Test
+- ServiceNow_Fetch_Incidents_Test

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -1642,3 +1642,4 @@ fromversion: 5.0.0
 tests:
 - servicenow_test_v2
 - ServiceNow_OAuth_Test
+- ServiceNow Fetch Incidents Test

--- a/Packs/ServiceNow/TestPlaybooks/ServiceNow_Fetch_Incidents_Test.yml
+++ b/Packs/ServiceNow/TestPlaybooks/ServiceNow_Fetch_Incidents_Test.yml
@@ -1,6 +1,6 @@
-id: ServiceNow Fetch Incidents Test
+id: ServiceNow_Fetch_Incidents_Test
 version: -1
-name: ServiceNow Fetch Incidents Test
+name: ServiceNow_Fetch_Incidents_Test
 starttaskid: "0"
 tasks:
   "0":

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4173,7 +4173,7 @@
                 "ServiceNow v2",
                 "Core REST API"
             ],
-            "playbookID": "ServiceNow Fetch Incidents Test",
+            "playbookID": "ServiceNow_Fetch_Incidents_Test",
             "instance_names": "snow_basic_auth",
             "fromversion": "6.8.0",
             "is_mockable": false,


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: https://jira-dc.paloaltonetworks.com/browse/CIAC-11520

## Description:
link the test playbook "ServiceNow Fetch Incidents Test" to service now V2 integration yml, where it was missing in the tests section.
