### PR TITLE
TheHive custom fields fix

### DIFF
--- a/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.py
+++ b/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.py
@@ -928,7 +928,7 @@ def update_remote_system_command(client: Client, args: dict) -> str:
     changes = {k: v for k, v in parsed_args.delta.items() if k in parsed_args.data}
     demisto.debug(f'Changes from update_remote_system: {changes}')
     # Convert the values: severity, pap and tlp to integer as the api request
-    changes = {k: (int(v) if v.isdigit() else v) for k, v in changes.items()}
+    changes = {k: (int(v) if isinstance(v, str) and v.isdigit() else v) for k, v in changes.items()}
     if parsed_args.remote_incident_id:
         # Apply the updates
         client.update_case(case_id=parsed_args.remote_incident_id, updates=changes)

--- a/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.yml
+++ b/Packs/TheHiveProject/Integrations/TheHiveProject/TheHiveProject.yml
@@ -1445,7 +1445,7 @@ script:
   - name: get-modified-remote-data
     arguments: []
     description: Gets the list of incidents that were modified since the last update time. Note that this method is here for debugging purposes. The get-modified-remote-data command is used as part of a Mirroring feature, which is available from version 6.1.
-  dockerimage: demisto/python3:3.11.9.106968
+  dockerimage: demisto/python3:3.11.9.107902
   isfetch: true
   subtype: python3
   ismappable: true

--- a/Packs/TheHiveProject/ReleaseNotes/1_1_22.md
+++ b/Packs/TheHiveProject/ReleaseNotes/1_1_22.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TheHive Project
+
+- Fixed an issue where mirror out would fail when changing *custom fields*.

--- a/Packs/TheHiveProject/ReleaseNotes/1_1_22.md
+++ b/Packs/TheHiveProject/ReleaseNotes/1_1_22.md
@@ -4,3 +4,4 @@
 ##### TheHive Project
 
 - Fixed an issue where mirror out would fail when changing *custom fields*.
+- Updated the Docker image to: *demisto/python3:3.11.9.107902*.

--- a/Packs/TheHiveProject/pack_metadata.json
+++ b/Packs/TheHiveProject/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TheHive Project",
     "description": "Provides an integration, incident type and layout for use with TheHive Project.",
     "support": "xsoar",
-    "currentVersion": "1.1.21",
+    "currentVersion": "1.1.22",
     "author": "aburt-demisto",
     "url": "",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: [XSUP-40322](https://jira-dc.paloaltonetworks.com/browse/XSUP-40322)

## Description
Fixed an issue where mirror-out would fail when trying to update custom fields (which are handled as dictionary) 
