### PR TITLE
use `fetch-depth:0` in `legacy-validate`

### DIFF
--- a/.github/workflows/run-legacy-validate-for-contribution.yml
+++ b/.github/workflows/run-legacy-validate-for-contribution.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1000 # prevent fetching all history
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Since we [get](https://github.com/demisto/content/actions/runs/10440792032/job/28911130320?pr=35886) 
```
Traceback (most recent call last):
  File "/home/runner/work/content/content/.venv/bin/demisto-sdk", line 8, in <module>
    sys.exit(main())
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line [16](https://github.com/demisto/content/actions/runs/10440792032/job/28911130320?pr=35886#step:6:17)88, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/demisto_sdk/__main__.py", line [18](https://github.com/demisto/content/actions/runs/10440792032/job/28911130320?pr=35886#step:6:19)0, in wrapper
    return func(*args, **kwargs)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/demisto_sdk/__main__.py", line 885, in validate
    validator = OldValidateManager(
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/demisto_sdk/commands/validate/old_validate_manager.py", line 294, in __init__
    self.prev_ver = self.setup_prev_ver(prev_ver)
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/demisto_sdk/commands/validate/old_validate_manager.py", line [23](https://github.com/demisto/content/actions/runs/10440792032/job/28911130320?pr=35886#step:6:24)04, in setup_prev_ver
    _, branch = self.git_util.handle_prev_ver()
  File "/home/runner/work/content/content/.venv/lib/python3.10/site-packages/demisto_sdk/commands/common/git_util.py", line 868, in handle_prev_ver
    raise Exception(
Exception: Unable to find main or master branch from current working directory - aborting.
```
