### PR TITLE
Fortigate fix

### DIFF
--- a/Packs/FortiGate/Integrations/FortiGate/FortiGate.py
+++ b/Packs/FortiGate/Integrations/FortiGate/FortiGate.py
@@ -2660,7 +2660,6 @@ def build_policy_outputs(raw_response: list | dict, name: str | None) -> list:
         list: The context outputs.
     """
     outputs: list = []
-    found_output = None
     # Handle VDOM == *
     responses = raw_response if isinstance(raw_response, list) else [raw_response]
 
@@ -2669,15 +2668,13 @@ def build_policy_outputs(raw_response: list | dict, name: str | None) -> list:
         response_vdom = response.get("vdom")
 
         for result in response_results:
+            if name and name != result.get("name"):
+                continue
+
             output = map_keys(result, POLICY_MAPPINGS) | build_security(result) | {"VDOM": response_vdom}
-
-            if name and name == result.get("name"):
-                found_output = [output]
-                break
-
             outputs.append(output)
 
-    return remove_empty_elements(found_output or outputs)
+    return remove_empty_elements(outputs)
 
 
 """ Mappings + Params with helpers """

--- a/Packs/FortiGate/Integrations/FortiGate/FortiGate.yml
+++ b/Packs/FortiGate/Integrations/FortiGate/FortiGate.yml
@@ -2249,7 +2249,7 @@ script:
       description: Comma-separated list of IPs to unban. Both IPv4 and IPv6 addresses are supported. IPs can be retrieved with the command `fortigate-list-banned-ips`.
       required: true
       isArray: true
-  dockerimage: demisto/python3:3.10.13.87159
+  dockerimage: demisto/python3:3.11.9.107902
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/FortiGate/Integrations/FortiGate/FortiGate_test.py
+++ b/Packs/FortiGate/Integrations/FortiGate/FortiGate_test.py
@@ -1800,3 +1800,30 @@ def test_update_firewall_policy_command_error(mock_client: FortiGate.Client):
         FortiGate.update_firewall_policy_command(mock_client, {"keep_original_data": "true"})
 
     assert str(exc_info.value) == "If 'keep_original_data' is set to True, 'add_or_remove' must also be set."
+
+
+def test_list_firewall_policies_return_all_policy_name(mock_client: FortiGate.Client, requests_mock):
+    """
+        Given: Args to run list_firewall_policies command with policyName to filter by which does not match any policy.
+        When: Running list_firewall_policies command.
+        Then: Validate no results are returned.
+    """
+
+    args = {
+        "vdom": "Pokemon",
+        "filter_field": "Lior",
+        "filter_value": "SB",
+        "format_fields": ["I", "Choose", "You"],
+        "policyName": "Non-exist-policy"
+    }
+
+    response = load_mock_response("policy_response.json")
+
+    requests_mock.get(
+        url=CommonServerPython.urljoin(API_URL, FortiGate.Client.POLICY_ENDPOINT),
+        json=response,
+    )
+
+    command_results = FortiGate.list_firewall_policies_command(mock_client, args)
+
+    assert len(command_results.outputs) == 0

--- a/Packs/FortiGate/ReleaseNotes/2_0_3.md
+++ b/Packs/FortiGate/ReleaseNotes/2_0_3.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### FortiGate
+- Updated the Docker image to: *demisto/python3:3.11.9.107902*.
 
 - Fixed an issue with **fortigate-list-firewall-policies** command which caused all policies to be displayed when filtering by a policyName that did not have any matches.

--- a/Packs/FortiGate/ReleaseNotes/2_0_3.md
+++ b/Packs/FortiGate/ReleaseNotes/2_0_3.md
@@ -4,4 +4,4 @@
 ##### FortiGate
 - Updated the Docker image to: *demisto/python3:3.11.9.107902*.
 
-- Fixed an issue with **fortigate-list-firewall-policies** command which caused all policies to be displayed when filtering by a policyName that did not have any matches.
+-  Fixed an issue where the ***fortigate-list-firewall-policies*** command retrieved all policies when filtering by a policy name that did not match any existing policies.

--- a/Packs/FortiGate/ReleaseNotes/2_0_3.md
+++ b/Packs/FortiGate/ReleaseNotes/2_0_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### FortiGate
+
+- Fixed an issue with **fortigate-list-firewall-policies** command which caused all policies to be displayed when filtering by a policyName that did not have any matches.

--- a/Packs/FortiGate/pack_metadata.json
+++ b/Packs/FortiGate/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FortiGate",
     "description": "Manage FortiGate Firewall",
     "support": "xsoar",
-    "currentVersion": "2.0.2",
+    "currentVersion": "2.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-40743)

## Description
Fixed an issue with **fortigate-list-firewall-policies** command which caused all policies to be displayed when filtering by a policyName that did not have any matches.

## Must have
- [ ] Tests
- [ ] Documentation 
