### PR TITLE
AfterRelativeDate: fix offset-awere date

### DIFF
--- a/Packs/FiltersAndTransformers/ReleaseNotes/1_2_77.md
+++ b/Packs/FiltersAndTransformers/ReleaseNotes/1_2_77.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### AfterRelativeDate
+
+- Fixed an issue where script fail to compare date to an offset-aware date. 
+- Updated the Docker image to: *demisto/python3:3.11.9.107902*.

--- a/Packs/FiltersAndTransformers/ReleaseNotes/1_2_77.md
+++ b/Packs/FiltersAndTransformers/ReleaseNotes/1_2_77.md
@@ -3,5 +3,5 @@
 
 ##### AfterRelativeDate
 
-- Fixed an issue where script fail to compare date to an offset-aware date. 
+- Fixed an issue where the script failed to compare offset-aware dates.
 - Updated the Docker image to: *demisto/python3:3.11.9.107902*.

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.py
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.py
@@ -5,7 +5,7 @@ import dateparser
 
 
 def check_date(value, relative_date):
-    settings = {'RETURN_AS_TIMEZONE_AWARE': False}
+    settings = {'TO_TIMEZONE': 'UTC', 'RETURN_AS_TIMEZONE_AWARE': False}
     v = dateparser.parse(value, settings=settings)  # type: ignore[arg-type]
     da = dateparser.parse(relative_date, settings=settings)  # type: ignore[arg-type]
     return v > da  # type: ignore

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.py
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.py
@@ -5,8 +5,9 @@ import dateparser
 
 
 def check_date(value, relative_date):
-    v = dateparser.parse(value)
-    da = dateparser.parse(relative_date)
+    settings = {'RETURN_AS_TIMEZONE_AWARE': False}
+    v = dateparser.parse(value, settings=settings)  # type: ignore[arg-type]
+    da = dateparser.parse(relative_date, settings=settings)  # type: ignore[arg-type]
     return v > da  # type: ignore
 
 

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
@@ -1,8 +1,8 @@
 args:
-- description: Date value to check - Can be any non-timezone aware time format. ex. "2020-01-01T00:00:00"
+- description: Date value to check - Can be any non-timezone aware time format. ex. "2020-01-01T00:00:00".
   name: left
   required: true
-- description: Relative time ex. "6 months ago"
+- description: Relative time ex. "6 months ago".
   name: right
   required: true
 comment: Checks the given datetime has occured after the provided relative time.

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
@@ -1,5 +1,5 @@
 args:
-- description: Date value to check - Can be any non-timezone aware time format. ex. "2020-01-01T00:00:00".
+- description: Date value to check - Can be any time format. ex. "2020-01-01T00:00:00".
   name: left
   required: true
 - description: Relative time ex. "6 months ago".

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate.yml
@@ -19,7 +19,7 @@ tags:
 - Condition
 timeout: '0'
 type: python
-dockerimage: demisto/python3:3.10.13.86272
+dockerimage: demisto/python3:3.11.9.107902
 runas: DBotWeakRole
 fromversion: 5.0.0
 tests:

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate_test.py
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/AfterRelativeDate_test.py
@@ -47,3 +47,18 @@ def test_date_no_match(mocker):
     main()
 
     demisto.results.assert_called_with(False)
+
+
+def test_date_with_timezone(mocker):
+    """
+    Given a date and relative date, when the date is older than the relative date and is specified with time zone, return false.
+    """
+    args_value = {
+        "left": "2023-08-21 17:22:13 UTC",
+        "right": "1 day ago"
+    }
+    mocker.patch.object(demisto, "args", return_value=args_value)
+    mocker.patch.object(demisto, "results")
+    main()
+
+    demisto.results.assert_called_with(False)

--- a/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/README.md
+++ b/Packs/FiltersAndTransformers/Scripts/AfterRelativeDate/README.md
@@ -16,7 +16,7 @@ Checks the given datetime has occurred after the provided relative time.
 
 | **Argument Name** | **Description** |
 | --- | --- |
-| left | Date value to check - Can be any non-timezone aware time format. ex. "2020-01-01T00:00:00" |
+| left | Date value to check - Can be any time format. ex. "2020-01-01T00:00:00" |
 | right | Relative time ex. "6 months ago" |
 
 ## Outputs

--- a/Packs/FiltersAndTransformers/pack_metadata.json
+++ b/Packs/FiltersAndTransformers/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Filters And Transformers",
     "description": "Frequently used filters and transformers pack.",
     "support": "xsoar",
-    "currentVersion": "1.2.76",
+    "currentVersion": "1.2.77",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-40818

## Description
currently, when using the `AfterRelativeDate` automation with date argument like `21 Aug 13:00 UTC` the following error is appear `TypeError: can't compare offset-naive and offset-aware datetimes`

fix:
parsing the time as `offset-naive`

**test before:**
<img width="618" alt="image" src="https://github.com/user-attachments/assets/1f435269-e48c-4e56-b468-a6fc49e56ce4">

**test after:**
<img width="610" alt="image" src="https://github.com/user-attachments/assets/deb9d2b3-ff41-43ae-9bc6-fa63c0bf31cf">

