### PR TITLE
Update conf.json nightly pack

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -6138,7 +6138,6 @@
     "nightly_packs": [
         "CommonScripts",
         "CommonPlaybooks",
-        "CIRCL",
         "rasterize",
         "Phishing",
         "Base",
@@ -6165,7 +6164,6 @@
         "AlienVault_OTX",
         "MicrosoftGraphMail",
         "MISP",
-        "Threat_Crowd",
         "Slack",
         "CrowdStrikeFalconX",
         "FeedMitreAttackv2",
@@ -6175,17 +6173,17 @@
         "Shodan",
         "MailListener",
         "FeedOffice365",
-        "GenericSQL",
         "PANWComprehensiveInvestigation",
         "CortexDataLake",
         "PrismaCloud",
-        "FeedAWS",
         "AzureSecurityCenter",
         "PrismaCloudCompute",
-        "ExpanseV2",
+        "CortexXpanse",
         "PrismaSaasSecurity",
         "PaloAltoNetworks_IoT",
-        "PaloAltoNetworksAIOps"
+        "PaloAltoNetworksAIOps",
+        "Jira",
+        "Campaign"
     ],
     "unmockable_integrations": {
         "NetscoutArborSightline": "Uses timestamp",


### PR DESCRIPTION
## Description
Updated content nightly packs (periodic update)
removed: CIRCL, Threat_Crowd, GenericSQL, FeedAWS, ExpanseV2
Added: Jira, Campaign, CortexXpanse

left room for 2 more packs as explained in the issue: https://jira-dc.paloaltonetworks.com/browse/CIAC-9643?focusedId=10371303&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-10371303

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-9643
