### PR TITLE
added a fix to GenericPollingScheduledTask

### DIFF
--- a/Packs/CommonPlaybooks/TestPlaybooks/playbook-GenericPollingTest.yml
+++ b/Packs/CommonPlaybooks/TestPlaybooks/playbook-GenericPollingTest.yml
@@ -58,7 +58,7 @@ tasks:
       AdditionalPollingCommandArgNames:
         simple: arg1,arg2
       AdditionalPollingCommandArgValues:
-        simple: test,test2
+        simple: test,"test2"
       Ids:
         simple: ${GP.Dummy.ID}
       Interval:
@@ -108,7 +108,7 @@ tasks:
       arg1:
         simple: test
       arg2:
-        simple: test2
+        simple: '"test2"'
       ids:
         simple: LetersNumbersSign&85 space, קצת עברית,$%$$%%dd
     separatecontext: false
@@ -213,7 +213,7 @@ tasks:
       arg1:
         simple: test
       arg2:
-        simple: test2
+        simple: '"test2"'
       ids:
         simple: ${GP.Dummy.ID}
     separatecontext: false

--- a/Packs/CommonScripts/ReleaseNotes/1_15_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_54.md
@@ -7,4 +7,4 @@
 - Updated the Docker image to: *demisto/python3:3.11.9.107902*.
 ##### GenericPollingScheduledTask
 
-- Fixed an issue where the script failed when given values containing quotations.
+- Fixed an issue where the script failed when given values containing quotation marks.

--- a/Packs/CommonScripts/ReleaseNotes/1_15_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_54.md
@@ -3,7 +3,7 @@
 
 ##### ScheduleGenericPolling
 
-- Fixed an issue where the script failed when given values containing quotations.
+- Fixed an issue where the script failed when given values containing quotation marks.
 - Updated the Docker image to: *demisto/python3:3.11.9.107902*.
 ##### GenericPollingScheduledTask
 

--- a/Packs/CommonScripts/ReleaseNotes/1_15_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_54.md
@@ -1,0 +1,10 @@
+
+#### Scripts
+
+##### ScheduleGenericPolling
+
+- Fixed an issue where the script failed when given values containing quotations.
+- Updated the Docker image to: *demisto/python3:3.11.9.107902*.
+##### GenericPollingScheduledTask
+
+- Fixed an issue where the script failed when given values containing quotations.

--- a/Packs/CommonScripts/Scripts/GenericPollingScheduledTask/GenericPollingScheduledTask.js
+++ b/Packs/CommonScripts/Scripts/GenericPollingScheduledTask/GenericPollingScheduledTask.js
@@ -103,7 +103,7 @@ function setNextRun(ids, playbookId, pollingCommand, pollingCommandArgName, pend
     }
     var cmd = '!GenericPollingScheduledTask pollingCommand="' + pollingCommand + '" pollingCommandArgName="' + pollingCommandArgName + '"' + playbookIdStr;
     cmd += ' ids="' + idsStr + '" pendingIds="' + pendingIds.replace(/"/g,'\\"') + '" interval="' + interval + '" timeout="' + (parseInt(timeout) - parseInt(interval)) + '" tag="' + tag + '"';
-    cmd += ' additionalPollingCommandArgNames="' + additionalArgNames + '" additionalPollingCommandArgValues="' + additionalArgValues + '"';
+    cmd += ' additionalPollingCommandArgNames="' + additionalArgNames.replace(/"/g,'\\"') + '" additionalPollingCommandArgValues="' + additionalArgValues.replace(/"/g,'\\"') + '"';
     if (extractMode !== undefined) {
         cmd += ' extractMode="' + extractMode + '" auto-extract="' + extractMode + '"';
     }

--- a/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling.py
+++ b/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling.py
@@ -79,8 +79,9 @@ def get_command_string(ids, pollingCommand, pollingCommandArgName, playbookId, d
               pendingIds="{}" interval="{}" timeout="{}" tag="{}" additionalPollingCommandArgNames="{}" \
               additionalPollingCommandArgValues="{}"'''.format(ids.replace('"', r'\"'), pollingCommand,
                                                                pollingCommandArgName, playbookId,
-                                                               dt.replace('"', r'\"'), interval, timeout,
-                                                               tag, args_names, args_values)
+                                                               dt.replace('"', r'\"'), interval, timeout, tag,
+                                                               args_names.replace('"', r'\"'),
+                                                               args_values.replace('"', r'\"'),)
     if extract_mode:
         command_string += f" auto-extract={extract_mode} extractMode={extract_mode}"
 

--- a/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling.yml
+++ b/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling.yml
@@ -49,4 +49,4 @@ args:
 scripttarget: 0
 tests:
 - Generic Polling Test
-dockerimage: demisto/python3:3.10.13.89009
+dockerimage: demisto/python3:3.11.9.107902

--- a/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling_test.py
+++ b/Packs/CommonScripts/Scripts/ScheduleGenericPolling/ScheduleGenericPolling_test.py
@@ -164,10 +164,11 @@ def test_get_command_string_fail():
 
     expected_command_String = '!GenericPollingScheduledTask ids="123" pollingCommand="jira-get-issue" pollingCommandArgName=' \
         '"issueId"pi               pendingIds="Ticket(val.Status != \'Done\').Id" interval="3"' \
-        ' timeout="5" tag="None" additionalPollingCommandArgNames="my_arg_name"' \
-        '               additionalPollingCommandArgValues="hihi" pollingCommand="Set"  ids="payload"' \
-        ' pendingIds=".=\'payload\'"  pollingCommandArgName="key"' \
-        ' additionalPollingCommandArgNames="value" additionalPollingCommandArgValues="bar"'
+        ' timeout="5" tag="None" additionalPollingCommandArgNames="my_arg_name"               ' \
+                              'additionalPollingCommandArgValues="hihi\\" pollingCommand=\\"Set\\"  ' \
+                              'ids=\\"payload\\" pendingIds=\\".=\'payload\'\\"  ' \
+                              'pollingCommandArgName=\\"key\\" additionalPollingCommandArgNames=\\"value\\" ' \
+                              'additionalPollingCommandArgValues=\\"bar"'
 
     assert command_String == expected_command_String
     result = is_command_sanitized(command_String)

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.53",
+    "currentVersion": "1.15.54",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-40734

## Description
Added escaping for quotations in arg names and values both in **ScheduleGenericPolling** and **GenericPollingScedulledTask**

## Must have
- [x] Tests
