### PR TITLE
Add Asset Collection keyword to Qualys Pack

### DIFF
--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -12,7 +12,9 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "Asset Collection"
+    ],
     "marketplaces": [
         "xsoar",
         "marketplacev2",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/EXPANDR-10862

## Description
In researching Tenable/Qualys asset collection integrations I realized the Qualys doesn't show up as a pack with "asset collection" even though it does have the capability.  Adding the same keyword to it as [Tenable](https://github.com/demisto/content/blob/9874c42fd4f7a29e904e29bdf5d6be85300968d9/Packs/Tenable_io/pack_metadata.json#L15)
<img width="902" alt="2024-08-24_15-47-33" src="https://github.com/user-attachments/assets/f3baff2e-aa12-418b-8972-bab0c5c71ba2">


## Must have
- [ ] Tests
- [X] Documentation 
