### PR TITLE
URLSSLVerification:improve performance

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_54.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_54.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### URLSSLVerification
+
+- %%UPDATE_RN%%
+- Updated the Docker image to: *demisto/python3:3.11.9.107902*.

--- a/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification.py
+++ b/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification.py
@@ -36,9 +36,21 @@ def mark_http_as_suspicious(set_http_as_suspicious):
     return set_http_as_suspicious != 'false'
 
 
+def unique_urls(urls):
+    """return a set of unique urls with the protocol://domain only
+
+    Args:
+        urls (list): the url list
+    """
+    pattern = r"(?<=[a-zA-Z0-9\.\_\#])(/|\?).*"
+    return {
+        re.sub(pattern, "", url) for url in urls
+    }
+
+
 def main():     # pragma: no cover
     url_arg = demisto.get(demisto.args(), "url")
-    urls = arg_to_list_with_regex(url_arg)
+    urls = unique_urls(arg_to_list_with_regex(url_arg))
 
     set_http_as_suspicious = demisto.args().get('set_http_as_suspicious')
 

--- a/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification.yml
+++ b/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification.yml
@@ -47,6 +47,6 @@ outputs:
   type: number
 scripttarget: 0
 fromversion: 5.0.0
-dockerimage: demisto/python3:3.10.13.86272
+dockerimage: demisto/python3:3.11.9.107902
 tests:
 - No tests (auto formatted)

--- a/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification_test.py
+++ b/Packs/CommonScripts/Scripts/URLSSLVerification/URLSSLVerification_test.py
@@ -1,5 +1,5 @@
 import pytest
-from URLSSLVerification import mark_http_as_suspicious, arg_to_list_with_regex
+from URLSSLVerification import mark_http_as_suspicious, arg_to_list_with_regex, unique_urls
 
 
 @pytest.mark.parametrize('arg, expected_result', [
@@ -19,3 +19,13 @@ def test_is_http_should_be_suspicious(arg, expected_result):
 ])
 def test_arg_to_list_with_regex(arg, expected_result):
     assert arg_to_list_with_regex(arg) == expected_result
+
+
+def test_unique_urls():
+    urls = [
+        'https://some_url.com',
+        'https://some_url.com/resource_1',
+        'https://some_url.com/resource_2',
+        'https://some_url.com?a=a'
+    ]
+    assert unique_urls(urls) == {'https://some_url.com'}

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.53",
+    "currentVersion": "1.15.54",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-40765

## Description
currently, we run `requests.get` on each of the urls in the list, to check if it pass the SSL connection
this lead to performance issues when there is a lot of urls to check.

suggestion fix:
group the urls according the domain, and try to do `requests.get` only for the domain
and the result of that will be the result of all the urls in this domain.

statistics:
from a url list from a customer of about 800 urls, there was only ~ 250 domains.
