### PR TITLE
Whois return JSON in raw_response

### DIFF
--- a/Packs/Whois/Integrations/Whois/Whois.py
+++ b/Packs/Whois/Integrations/Whois/Whois.py
@@ -9086,7 +9086,7 @@ def whois_and_domain_command(command: str, reliability: str) -> list[CommandResu
                         headers=hr_headers,
                         removeNull=True,
                     ),
-                    raw_response=str(domain_data),
+                    raw_response=dict(domain_data),
                 )
             )
         except Exception as e:

--- a/Packs/Whois/Integrations/Whois/Whois_test.py
+++ b/Packs/Whois/Integrations/Whois/Whois_test.py
@@ -895,6 +895,19 @@ def test_new_test_command(mocker: MockerFixture):
 
 
 def test_whois_and_domain_command(mocker: MockerFixture):
+    """
+    Test the new whois/domain command.
+
+    Given:
+    - Mock response for WHOIS call.
+
+    When:
+    - 2 results are returned.
+
+    Then:
+    - The first result raw response is JSON.
+    """
+
     from Whois import whois_and_domain_command
     import whois
 
@@ -910,6 +923,7 @@ def test_whois_and_domain_command(mocker: MockerFixture):
     )
     res = whois_and_domain_command("domain", DBotScoreReliability.B)
     assert len(res) == 2
+    assert isinstance(res[0].raw_response, dict)
 
 
 @pytest.mark.parametrize(

--- a/Packs/Whois/ReleaseNotes/1_5_16.json
+++ b/Packs/Whois/ReleaseNotes/1_5_16.json
@@ -1,0 +1,4 @@
+{
+    "breakingChanges": true,
+    "breakingChangesNotes": "Commands <code>domain</code> and <code>whois</code> will now return a dictionary instead of a string when 'Use legacy context' is not enabled. "
+}

--- a/Packs/Whois/ReleaseNotes/1_5_16.md
+++ b/Packs/Whois/ReleaseNotes/1_5_16.md
@@ -3,4 +3,4 @@
 
 ##### Whois
 
-- Commands **domain** and **whois** will now return a dictionary instead of a string when 'Use legacy context' is not enabled. 
+- Commands **domain** and **whois** will now return a dictionary when argument **raw-response=true** is specified and 'Use legacy context' configuration is disabled. 

--- a/Packs/Whois/ReleaseNotes/1_5_16.md
+++ b/Packs/Whois/ReleaseNotes/1_5_16.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Whois
+
+- Commands **domain** and **whois** will now return a dictionary instead of a string when 'Use legacy context' is not enabled. 

--- a/Packs/Whois/pack_metadata.json
+++ b/Packs/Whois/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Whois",
     "description": "This Content Pack helps you run Whois commands as playbook tasks or real-time actions within Cortex XSOAR to obtain valuable domain metadata.",
     "support": "xsoar",
-    "currentVersion": "1.5.15",
+    "currentVersion": "1.5.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-41040

## Description
Return a dictionary as raw response in the new flow when calling `domain` or `whois` commands.

## Must have
- [x] Tests
- [x] Documentation 
