### PR TITLE
[imagecompare] mypy

### DIFF
--- a/Packs/SuspiciousDomainHunting/ReleaseNotes/1_0_5.md
+++ b/Packs/SuspiciousDomainHunting/ReleaseNotes/1_0_5.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### imagecompare
+
+- Fixed an issue where the script would fail with an ImportError.
+- Updated the Docker image to: *demisto/processing-image-file:1.0.0.108564*.

--- a/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.py
+++ b/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.py
@@ -1,36 +1,36 @@
 import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 
-from cv2 import cv2
+import cv2
 from skimage.metrics import structural_similarity as compare_ssim
 
 
 def calculate_mse(image_path1, image_path2):
     # Load the images
-    img1 = cv2.imread(image_path1)
-    img2 = cv2.imread(image_path2)
+    img1 = cv2.imread(image_path1)  # pylint: disable=[E1101]
+    img2 = cv2.imread(image_path2)  # pylint: disable=[E1101]
 
     # Check if the images are loaded successfully
     if img1 is None or img2 is None:
         return None
 
     # Calculate Mean Squared Error (MSE)
-    mse = ((img1 - img2) ** 2).mean()
+    mse = ((img1 - img2) ** 2).mean()  # type: ignore[operator]
     return mse
 
 
 def calculate_ssim(image_path1, image_path2):
     # Load the images
-    img1 = cv2.imread(image_path1)
-    img2 = cv2.imread(image_path2)
+    img1 = cv2.imread(image_path1)  # pylint: disable=[E1101]
+    img2 = cv2.imread(image_path2)  # pylint: disable=[E1101]
 
     # Check if the images are loaded successfully
     if img1 is None or img2 is None:
         return None
 
     # Convert images to grayscale
-    img1_gray = cv2.cvtColor(img1, cv2.COLOR_BGR2GRAY)
-    img2_gray = cv2.cvtColor(img2, cv2.COLOR_BGR2GRAY)
+    img1_gray = cv2.cvtColor(img1, cv2.COLOR_BGR2GRAY)  # pylint: disable=[E1101]
+    img2_gray = cv2.cvtColor(img2, cv2.COLOR_BGR2GRAY)  # pylint: disable=[E1101]
 
     # Calculate Structural Similarity Index (SSIM)
     ssim = compare_ssim(img1_gray, img2_gray)

--- a/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.py
+++ b/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.py
@@ -2,7 +2,7 @@ import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 
 import cv2
-from skimage.metrics import structural_similarity as compare_ssim
+from skimage import metrics
 
 
 def calculate_mse(image_path1, image_path2):
@@ -33,7 +33,7 @@ def calculate_ssim(image_path1, image_path2):
     img2_gray = cv2.cvtColor(img2, cv2.COLOR_BGR2GRAY)  # pylint: disable=[E1101]
 
     # Calculate Structural Similarity Index (SSIM)
-    ssim = compare_ssim(img1_gray, img2_gray)
+    ssim = metrics.structural_similarity(img1_gray, img2_gray)
     return ssim
 
 

--- a/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.yml
+++ b/Packs/SuspiciousDomainHunting/Scripts/Imagecompare/Imagecompare.yml
@@ -15,7 +15,7 @@ args:
 scripttarget: 0
 subtype: python3
 runonce: false
-dockerimage: demisto/processing-image-file:1.0.0.89250
+dockerimage: demisto/processing-image-file:1.0.0.108564
 runas: DBotWeakRole
 engineinfo: {}
 tests:

--- a/Packs/SuspiciousDomainHunting/pack_metadata.json
+++ b/Packs/SuspiciousDomainHunting/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Suspicious Domain Hunting",
     "description": "This pack provides all the necessary tools for the Suspicious Domain Hunting use case. It uses the CertStream integration to ingest new SSL certificates and alert for type-squatting domains with SSL certificate, these alerts are then analyzed and mitigated.",
     "support": "community",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://live.paloaltonetworks.com/t5/cortex-xsoar-discussions/bd-p/Cortex_XSOAR_Discussions",
     "email": "",


### PR DESCRIPTION
## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-10508)

## Description
mypy failed on 
```
Module "cv2" does not explicitly export attribute "cv2"  [attr-defined]
    from cv2 import cv2
```
and the script failed on the platform
![Screenshot 2024-08-27 at 16 24 59](https://github.com/user-attachments/assets/df3ad66a-5f79-40c0-8f52-497ad3e1b39f)

Seems to be related to BC that happened in version 4.6. (we are using 4.10.0.84)

see  https://github.com/opencv/opencv-python/issues/676