### PR TITLE
removing redundant whitespaces from service tag name

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
@@ -450,7 +450,7 @@ class MarkAsJunk(EWSAccountService):
 
     def get_payload(self, item_id, move_item):  # pragma: no cover
         junk = create_element(
-            f"m: {self.SERVICE_NAME}",
+            f"m:{self.SERVICE_NAME}",
             {"IsJunk": "true", "MoveItem": "true" if move_item else "false"},
         )
 
@@ -498,7 +498,7 @@ class GetSearchableMailboxes(EWSService):
         ]
 
     def get_payload(self):
-        element = create_element(f"m: {self.SERVICE_NAME}")
+        element = create_element(f"m:{self.SERVICE_NAME}")
         return element
 
 
@@ -536,7 +536,7 @@ class ExpandGroup(EWSService):
             sys.exit()
 
     def get_payload(self, email_address):
-        element = create_element(f"m: {self.SERVICE_NAME}")
+        element = create_element(f"m:{self.SERVICE_NAME}")
         mailbox_element = create_element("m:Mailbox")
         add_xml_child(mailbox_element, "t:EmailAddress", email_address)
         element.append(mailbox_element)

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_5_4.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_5_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS O365
+
+- Fixed an issue where service tag name contained a whitespace that caused a value error.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.5.3",
+    "currentVersion": "1.5.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-41053](https://jira-dc.paloaltonetworks.com/browse/XSUP-41053)

## Description
Removing redundant whitespaces from service tag name that caused a value error in `ews-expand-group` command

