### PR TITLE
Fixed a typo in the SSL Labs pack metadata

### DIFF
--- a/Packs/SSLLabs/pack_metadata.json
+++ b/Packs/SSLLabs/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "SSL Labs",
-    "description": "This pack integrations with Qualys SSL Labs. A free online service performs a deep analysis of the configuration of any SSL web server on the public Internet",
+    "description": "This pack integrates with Qualys SSL Labs. A free online service performs a deep analysis of the configuration of any SSL web server on the public Internet",
     "support": "community",
     "currentVersion": "1.0.0",
     "author": "Rich Fontaine",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
The pack metadata had a typo in the description. This PR fixes that issue see below

Before: 
"This pack integrations with Qualys SSL Labs. A free online service performs a deep analysis of the configuration of any SSL web server on the public Internet"

After:
"description": "This pack integrates with Qualys SSL Labs. A free online service performs a deep analysis of the configuration of any SSL web server on the public Internet"

## Must have
- [ ] Tests
- [ ] Documentation 
