### PR TITLE
Add ignore GR103 to non XSOAR support packs

### DIFF
--- a/Packs/AccentureCTI/.pack-ignore
+++ b/Packs/AccentureCTI/.pack-ignore
@@ -8,3 +8,9 @@ CustomCVE
 acti
 getThreatIntelReport
 get-fundamentals-by-uuid
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-ACTI_Intelligence_Report.json]
+ignore=GR103
+[file:layoutscontainer-ACTI_Intelligence_Alert.json]
+ignore=GR103

--- a/Packs/Armis/.pack-ignore
+++ b/Packs/Armis/.pack-ignore
@@ -1,17 +1,21 @@
+# GR103 is temporary, see CIAC-11656
 [file:incidentfields_Armis_Alert_Desctiption.json]
-ignore=IF100
+ignore=IF100,GR103
 
 [file:incidentfields_Armis_Alert_ID.json]
-ignore=IF100
+ignore=IF100,GR103
 
 [file:incidentfields_Armis_Alert_Severity.json]
-ignore=IF100
+ignore=IF100,GR103
 
 [file:incidentfields_Armis_Alert_Status.json]
 ignore=IF100,BA113
 
 [file:incidentfields_Armis_Alert_Type.json]
-ignore=IF100
+ignore=IF100,GR103
+
+[file:classifier-Armis_mapper-incoming.json]
+ignore=GR103
 
 [file:Armis_image.png]
 ignore=IM111

--- a/Packs/Claroty/.pack-ignore
+++ b/Packs/Claroty/.pack-ignore
@@ -4,8 +4,12 @@ ignore=IN126
 [file:README.md]
 ignore=RM104
 
+# GR103 is temporary, see CIAC-11656
 [file:classifier-mapper-incoming-Claroty.json]
-ignore=BA101
+ignore=BA101,GR103
+
+[file:incidentfield-Claroty_Site_ID.json]
+ignore=GR103
 
 [file:Claroty_image.png]
 ignore=IM111

--- a/Packs/Confluera/.pack-ignore
+++ b/Packs/Confluera/.pack-ignore
@@ -25,3 +25,9 @@ ignore=BA124
 [file:ConflueraDetectionsData.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11656
+[file:report-Iqhub_Report.json]
+ignore=GR103
+
+[file:dashboard-Confluera.json]
+ignore=GR103

--- a/Packs/Cryptosim/.pack-ignore
+++ b/Packs/Cryptosim/.pack-ignore
@@ -1,0 +1,6 @@
+# GR103 is temporary, see CIAC-11656
+[file:classifier-CRYPTTECH_Generic.json]
+ignore=GR103
+
+[file:layoutscontainer-Correlation_Alerts.json]
+ignore=GR103

--- a/Packs/Cyberpion/.pack-ignore
+++ b/Packs/Cyberpion/.pack-ignore
@@ -1,0 +1,6 @@
+# GR103 is temporary, see CIAC-11656
+[file:classifier-Cyberpion_-_Mapper.json]
+ignore=GR103
+
+[file:layoutscontainer-Cyberpion_-_Action_Item.json]
+ignore=GR103

--- a/Packs/CybleEvents/.pack-ignore
+++ b/Packs/CybleEvents/.pack-ignore
@@ -6,3 +6,10 @@ ignore=BA101
 
 [known_words]
 cyble
+
+# GR103 is temporary, see CIAC-11656
+[file:incidenttype-Cyble_Intel_Alert.json]
+ignore=GR103
+
+[file:layoutscontainer-Cyble_Intel_Alert.json]
+ignore=GR103

--- a/Packs/Cymulate/.pack-ignore
+++ b/Packs/Cymulate/.pack-ignore
@@ -34,3 +34,6 @@ ignore=BA101
 [file:Cymulate_Immediate_Threats_Playbook.yml]
 ignore=PB121
 
+# GR103 is temporary, see CIAC-11656
+[file:incidenttype-cymulate.json]
+ignore=GR103

--- a/Packs/CyrenInboxSecurity/.pack-ignore
+++ b/Packs/CyrenInboxSecurity/.pack-ignore
@@ -10,3 +10,6 @@ ignore=BA124
 [file:CyrenShowThreatIndicators.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Cyren_Inbox_Security_layout.json]
+ignore=GR103

--- a/Packs/Darktrace/.pack-ignore
+++ b/Packs/Darktrace/.pack-ignore
@@ -13,3 +13,9 @@ ignore=BA101
 [file:playbook-HandleDarktraceModelBreach.yml]
 ignore=PB121
 
+# GR103 is temporary, see CIAC-11656
+[file:classifier-Darktrace_Model_Breach.json]
+ignore=GR103
+
+[file:layoutscontainer-Darktrace_MBs_Layout.json]
+ignore=GR103

--- a/Packs/DevSecOps/.pack-ignore
+++ b/Packs/DevSecOps/.pack-ignore
@@ -30,3 +30,9 @@ ignore=RM112
 
 [file:1_1_8.md]
 ignore=RN116
+
+# GR103 is temporary, see CIAC-11656
+[file:DevSecOps_-_Fetch_PR_-_Triage.yml]
+ignore=GR103
+[file:DevSecOps_-_LGTM_-_Analysis_-_SubPB.yml]
+ignore=GR103

--- a/Packs/ExodusIntelligence/.pack-ignore
+++ b/Packs/ExodusIntelligence/.pack-ignore
@@ -1,3 +1,6 @@
 [file:ExodusVulnerabilityEnrichment.yml]
 ignore=RM110
 
+# GR103 is temporary, see CIAC-11656
+[file:ExodusIntelligence.json]
+ignore=GR103

--- a/Packs/GigamonThreatINSIGHT/.pack-ignore
+++ b/Packs/GigamonThreatINSIGHT/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Gigamon_ThreatINSIGHT_Detection.json]
+ignore=GR103

--- a/Packs/GoogleCloudSCC/.pack-ignore
+++ b/Packs/GoogleCloudSCC/.pack-ignore
@@ -13,3 +13,6 @@ ignore=IF100
 [file:incidentfield-GoogleCloudSCC_Finding_OrganizationID.json]
 ignore=IF115
 
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Google_Cloud_SCC_Finding.json]
+ignore=GR103

--- a/Packs/GroupIB_ThreatIntelligenceAttribution/.pack-ignore
+++ b/Packs/GroupIB_ThreatIntelligenceAttribution/.pack-ignore
@@ -18,3 +18,37 @@ ignore=BA101
 
 [file:1_4_1.md]
 ignore=RN116
+
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-GIB_Screenshot.json]
+ignore=GR103
+[file:incidentfield-GIB_Related_Indicators_Data.json]
+ignore=GR103
+[file:incidentfield-GIB_Date_Expired.json]
+ignore=GR103
+[file:incidentfield-GIB_Phishing_Status.json]
+ignore=GR103
+[file:incidentfield-GIB_HTML.json]
+ignore=GR103
+[file:incidentfield-GIB_Date_Created.json]
+ignore=GR103
+[file:incidentfield-GIB_Address.json]
+ignore=GR103
+[file:incidentfield-GIB_Phishing_Domain.json]
+ignore=GR103
+[file:incidentfield-GIB_Phishing_Type.json]
+ignore=GR103
+[file:incidentfield-GIB_Title.json]
+ignore=GR103
+[file:classifier-Group-IB_Threat_Intelligence_mapper.json]
+ignore=GR103
+[file:incidentfield-GIB_Name_Servers.json]
+ignore=GR103
+[file:incidentfield-GIB_Email.json]
+ignore=GR103
+[file:incidentfield-GIB_Person.json]
+ignore=GR103
+[file:incidentfield-GIB_ID.json]
+ignore=GR103
+[file:incidentfield-GIB_Favicon.json]
+ignore=GR103

--- a/Packs/Gurucul/.pack-ignore
+++ b/Packs/Gurucul/.pack-ignore
@@ -7,3 +7,6 @@ ignore=RM102
 [file:GRAAnomaliesDisplay.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-GRACaseLayout.json]
+ignore=GR103

--- a/Packs/HealthCheck/.pack-ignore
+++ b/Packs/HealthCheck/.pack-ignore
@@ -13,3 +13,16 @@ ignore=BA124
 [file:HealthCheckOutdatedPacks.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-XSOAR_Dev-Prod.json]
+ignore=GR103
+[file:incidentfield-Health_Check_Installed_Packs.json]
+ignore=GR103
+[file:incidentfield-XSOAR_Architecture.json]
+ignore=GR103
+[file:incidentfield-XSOAR_DR.json]
+ignore=GR103
+[file:incidentfield-Health_Check_Total_Packs_Installed.json]
+ignore=GR103
+[file:HealthCheckGetLargestInputsAndOutputsInIncidents.yml]
+ignore=GR103

--- a/Packs/Inventa/.pack-ignore
+++ b/Packs/Inventa/.pack-ignore
@@ -1,0 +1,5 @@
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-Inventa_Vehicle_Number.json]
+ignore=GR103
+[file:layoutscontainer-Inventa_DSAR_Layout.json]
+ignore=GR103

--- a/Packs/IronDefense/.pack-ignore
+++ b/Packs/IronDefense/.pack-ignore
@@ -30,3 +30,6 @@ ignore=IM111
 
 [file:classifier-IronDefense.json]
 ignore=BA101
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-IronDefense_Event_Notification.json]
+ignore=GR103

--- a/Packs/Lumu/.pack-ignore
+++ b/Packs/Lumu/.pack-ignore
@@ -52,5 +52,9 @@ ignore=IF113
 [file:incidentfield-Lumu-lumu_event_type.json]
 ignore=IF113
 
+# GR103 is temporary, see CIAC-11656
 [file:classifier-mapper-incoming-Lumu.json]
-ignore=MP106
+ignore=MP106,GR103
+
+[file:layoutscontainer-layouts-Lumu.json]
+ignore=GR103

--- a/Packs/OTSecurity/.pack-ignore
+++ b/Packs/OTSecurity/.pack-ignore
@@ -3,3 +3,9 @@ ignore=BA101
 
 [file:1_0_3.md]
 ignore=RN116
+
+# GR103 is temporary, see CIAC-11656
+[file:classifier-mapper-incoming-OTSecurity_API_Incoming_Mapper_v1.json]
+ignore=GR103
+[file:OTSecurity_-_Rogue_Device_Investigation.yml]
+ignore=GR103

--- a/Packs/PingCastle/.pack-ignore
+++ b/Packs/PingCastle/.pack-ignore
@@ -4,3 +4,6 @@ ignore=PB115
 [file:PingCastle_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11656
+[file:incidenttype-PingCastle.json]
+ignore=GR103

--- a/Packs/Qintel/.pack-ignore
+++ b/Packs/Qintel/.pack-ignore
@@ -12,3 +12,7 @@ ignore=RM113
 
 [file:QintelPMI.yml]
 ignore=IN154
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Qintel_-_QWatch_Alert.json]
+ignore=GR103

--- a/Packs/RSANetWitness_v11_1/.pack-ignore
+++ b/Packs/RSANetWitness_v11_1/.pack-ignore
@@ -16,3 +16,11 @@ RSANetWitness
 
 [file:incidentfield-RSA_Metas_Events.json]
 ignore=IF115
+
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-RSA_Event_Count.json]
+ignore=GR103
+[file:incidentfield-RSA_Alert_Count.json]
+ignore=GR103
+[file:incidentfield-RSA_Rule_Id.json]
+ignore=GR103

--- a/Packs/RecordedFuture/.pack-ignore
+++ b/Packs/RecordedFuture/.pack-ignore
@@ -6,3 +6,7 @@ ignore=PB121
 
 [file:playbook-Recorded_Future_Playbook_Alert.yml]
 ignore=BA110
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Recorded_Future_Vulnerability_Layout.json]
+ignore=GR103

--- a/Packs/Respond/.pack-ignore
+++ b/Packs/Respond/.pack-ignore
@@ -19,3 +19,6 @@ ignore=IM111
 [file:classifier-Mandiant_Automated_Defense.json]
 ignore=BA101
 
+# GR103 is temporary, see CIAC-11656
+[file:incidenttype-Mandiant_Automated_Defense_Incident.json]
+ignore=GR103

--- a/Packs/SOCRadar/.pack-ignore
+++ b/Packs/SOCRadar/.pack-ignore
@@ -7,3 +7,6 @@ ignore=IM111
 [file:README.md]
 ignore=RM108
 
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-SOCRadar_Incident.json]
+ignore=GR103

--- a/Packs/SSLCertificates/.pack-ignore
+++ b/Packs/SSLCertificates/.pack-ignore
@@ -1,2 +1,6 @@
 [file:README.md]
 ignore=RM104
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-SSL_Certificates.json]
+ignore=GR103

--- a/Packs/SafeBreach/.pack-ignore
+++ b/Packs/SafeBreach/.pack-ignore
@@ -4,3 +4,22 @@ ignore=BA108,BA109
 [file:SafeBreach_v2_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11656
+[file:reputation-SafeBreach_IP.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_URL.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Command.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Domain.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Hash.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Protocol.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Registry.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Process.json]
+ignore=GR103
+[file:layoutscontainer-SafeBreach_Port.json]
+ignore=GR103

--- a/Packs/SafeNet_Trusted_Access/.pack-ignore
+++ b/Packs/SafeNet_Trusted_Access/.pack-ignore
@@ -13,3 +13,8 @@ ignore=PR101
 [file:SafeNetTrustedAccessModelingRules.yml]
 ignore=MR108
 
+# GR103 is temporary, see CIAC-11656
+[file:classifier-SafeNet_Trusted_Access_–_Alert_Classifier.json]
+ignore=GR103
+[file:classifier-SafeNet_Trusted_Access_–_Push_Reject_Alert_Classifier.json]
+ignore=GR103

--- a/Packs/SalesforceV2/.pack-ignore
+++ b/Packs/SalesforceV2/.pack-ignore
@@ -1,0 +1,21 @@
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-SalesforceV2_Priority.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Last_Modified_Date.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Owner.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Case_Number.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Origin.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Status.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Escalated.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Subject.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Milestone_Status.json]
+ignore=GR103
+[file:incidentfield-SalesforceV2_Closed_Date.json]
+ignore=GR103

--- a/Packs/SecurityScorecard/.pack-ignore
+++ b/Packs/SecurityScorecard/.pack-ignore
@@ -1,2 +1,6 @@
 [known_words]
 SecurityScorecard
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-SecurityScorecard_Alert_Layout.json]
+ignore=GR103

--- a/Packs/SocialEngineeringDomainAnalysis/.pack-ignore
+++ b/Packs/SocialEngineeringDomainAnalysis/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11656
+[file:incidentfield-Social_Engineering_Domain_Summary.json]
+ignore=GR103

--- a/Packs/SumoLogic_Cloud_SIEM/.pack-ignore
+++ b/Packs/SumoLogic_Cloud_SIEM/.pack-ignore
@@ -4,3 +4,6 @@ ignore=IM111
 [known_words]
 sumourl
 
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Sumo_Logic_Insight.json]
+ignore=GR103

--- a/Packs/Trello/.pack-ignore
+++ b/Packs/Trello/.pack-ignore
@@ -1,2 +1,6 @@
 [file:README.md]
 ignore=RM104
+
+# GR103 is temporary, see CIAC-11656
+[file:playbook-Trello_-_Generic.yml]
+ignore=GR103

--- a/Packs/UncoverUnknownMalwareUsingSSDeep/.pack-ignore
+++ b/Packs/UncoverUnknownMalwareUsingSSDeep/.pack-ignore
@@ -1,2 +1,6 @@
 [file:incidentfield-Similar_File_Hashes_Based_on_SSDeep.json]
 ignore=IF113
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Uncover_Unknown_Malware_Using_SSDeep.json]
+ignore=GR103

--- a/Packs/XDRBestPracticeAssessment/.pack-ignore
+++ b/Packs/XDRBestPracticeAssessment/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11656
+[file:incidenttype-XDR_Best_Practice_Assessment.json]
+ignore=GR103

--- a/Packs/XsoarWebserver/.pack-ignore
+++ b/Packs/XsoarWebserver/.pack-ignore
@@ -1,0 +1,7 @@
+# GR103 is temporary, see CIAC-11656
+[file:playbook-xsoarwebserver-email-data-collection.yml]
+ignore=GR103
+[file:playbook-xsoarwebserver-data-collection-response-tracking.yml]
+ignore=GR103
+[file:playbook-xsoarwebserver-email-acknowledgement.yml]
+ignore=GR103

--- a/Packs/knowbe4Phisher/.pack-ignore
+++ b/Packs/knowbe4Phisher/.pack-ignore
@@ -1,2 +1,6 @@
 [known_words]
 PhishER
+
+# GR103 is temporary, see CIAC-11656
+[file:layoutscontainer-Phisher.json]
+ignore=GR103


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-11655

## Description
In the [new GR103](https://jira-dc.paloaltonetworks.com/browse/CIAC-11656), we are converting all warnings in the old version to errors. This results in 217 errors when running with the -a flag. The task is to fix the Content repo to allow the validation to pass.

To simplify the process for now, we will only fix content items that are XSOAR-supported. For all other support levels, we will add an "ignore GR103" to the pack and open a [ticket](https://jira-dc.paloaltonetworks.com/browse/CIAC-11656) to address it in the future.

In this PR, the "ignore GR103" field is applied to all non-XSOAR-supported items.

Requested a force merge as validation is failing due to unrelated issues (like a missing README) that I don't want to address, since this content is not XSOAR-supported.

## Must have
- [ ] Tests
- [ ] Documentation 
