### PR TITLE
Add comments to getuser override implementation in Vertica

### DIFF
--- a/Packs/Vertica/Integrations/Vertica/README.md
+++ b/Packs/Vertica/Integrations/Vertica/README.md
@@ -3,7 +3,7 @@
 <p>This integration was integrated and tested with Vertica v4.1.</p>
 </div>
 <div class="cl-preview-section">
-<h2 id="configure-vertica-on-demisto">Configure Vertica on Cortex XSOAR</h2>
+<h2 id="configure-vertica-on-xsoar">Configure Vertica on Cortex XSOAR</h2>
 </div>
 <div class="cl-preview-section">
 <ol>

--- a/Packs/Vertica/Integrations/Vertica/Vertica.py
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.py
@@ -9,6 +9,7 @@ import getpass
 
 class FixGetPass():
     """Class to override the getuser function such that it returns a default value on error."""
+
     def __init__(self):
         # Obtain the original getuser function address.
         self.getpass_getuser_org = getpass.getuser

--- a/Packs/Vertica/Integrations/Vertica/Vertica.py
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.py
@@ -8,22 +8,32 @@ import getpass
 
 
 class FixGetPass():
+    """Class to override the getuser function such that it returns a default value on error."""
     def __init__(self):
+        # Obtain the original getuser function address.
         self.getpass_getuser_org = getpass.getuser
 
+        # Define new getuser function that does not fail.
         def getuser_no_fail():
+            """Safe getuser function that returns a default value on error."""
             # getuser() fails on some systems. Provide a sane default.
             user = 'vertica'
             try:
+                # Check if the getpass_getuser_org function exists and was not overriden after init.
                 if self.getpass_getuser_org:
+                    # If so, obtain the user by calling it.
                     user = self.getpass_getuser_org()
             except (NameError, KeyError):
+                # If getpass_getuser_org() returns an error use the default user value.
                 pass
             return user
+        # Override the getpass.getuser function with our safe function.
         getpass.getuser = getuser_no_fail
 
     def __del__(self):
+        # If the getpass_getuser_org and getpass objects are still intact
         if self.getpass_getuser_org and getpass:
+            # return the state to as it was before the override.
             getpass.getuser = self.getpass_getuser_org
 
 

--- a/Packs/Vertica/Integrations/Vertica/Vertica.yml
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.yml
@@ -36,7 +36,7 @@ script:
       required: true
       description: A SQL query to perform on the Vertica database.
     - name: limit
-      description: The maximum number of results to be returned from the query. (Use 0 for all results)
+      description: The maximum number of results to be returned from the query. (Use 0 for all results).
       defaultValue: "50"
     outputs:
     - contextPath: Vertica.Query
@@ -46,7 +46,7 @@ script:
       description: The content of rows.
       type: string
     description: Executes a query on the Vertica database.
-  dockerimage: demisto/py3-tools:1.0.0.91504
+  dockerimage: demisto/py3-tools:1.0.0.108682
   subtype: python3
 tests:
 - Vertica Test

--- a/Packs/Vertica/Integrations/Vertica/Vertica.yml
+++ b/Packs/Vertica/Integrations/Vertica/Vertica.yml
@@ -4,7 +4,7 @@ commonfields:
 name: Vertica
 display: Vertica
 category: Database
-description: Analytic database management software
+description: Analytic database management software.
 configuration:
 - display: Host (myhost.example.com)
   name: url

--- a/Packs/Vertica/ReleaseNotes/1_0_5.md
+++ b/Packs/Vertica/ReleaseNotes/1_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Vertica
+
+Added comments to clarify implementation of getting the username from the environment.

--- a/Packs/Vertica/ReleaseNotes/1_0_5.md
+++ b/Packs/Vertica/ReleaseNotes/1_0_5.md
@@ -3,4 +3,5 @@
 
 ##### Vertica
 
-Added comments to clarify implementation of getting the username from the environment.
+- Added comments to clarify implementation of getting the username from the environment.
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.108682*.

--- a/Packs/Vertica/pack_metadata.json
+++ b/Packs/Vertica/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Vertica",
     "description": "Analytic database management software",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11664)

## Description
In Vertica the implementation of getting a user from the env is overridden with a safer function. Some of its' implementation seems redundant but after closer inspection everything has meaning. Added some code comments to clarify what is going on.

## Must have
- [ ] Tests
- [ ] Documentation 
