### PR TITLE
Teams add health ep

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -2484,6 +2484,12 @@ def message_handler(integration_context: dict, request_body: dict, channel_data:
                         return
 
 
+@APP.route('/health', methods=['GET'])
+def health_check():
+    demisto.debug("Microsoft Teams Integration received a local health check")
+    return Response('Microsoft Teams long running integration server is up.', status=200, mimetype='text/plain')
+
+
 @APP.route('/', methods=['POST'])
 def messages() -> Response:
     """

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -92,7 +92,7 @@ configuration:
   - Critical
   required: false
   hidden:
-    - marketplacev2
+  - marketplacev2
 - display: Disable Automatic Notifications
   name: auto_notifications
   type: 8
@@ -711,7 +711,7 @@ script:
   - description: Run this command if you need to rerun the authentication process.
     name: microsoft-teams-auth-reset
     arguments: []
-  dockerimage: demisto/teams:1.0.0.99724
+  dockerimage: demisto/teams:1.0.0.108119
   longRunning: true
   longRunningPort: true
   script: ''

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_4_67.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_4_67.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Microsoft Teams
+
+- Added support for health endpoint. Enables checking if the Microsoft Teams Long Running integration is operational.
+- Updated the Docker image to: *demisto/teams:1.0.0.108119*.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.4.66",
+    "currentVersion": "1.4.67",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Added a health endpoint for Teams Long Running integration. It allows fast testing to see if the endpoint / server is up.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/c566108e-a851-48a8-9687-e45c1113d46c">

