### PR TITLE
CIAC-11672/AdoptionMetrics

### DIFF
--- a/Packs/CommonDashboards/ReleaseNotes/1_7_5.md
+++ b/Packs/CommonDashboards/ReleaseNotes/1_7_5.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### AdoptionMetrics
+
+- Fixed an issue where an uninformative error display in the "use case adoption coverage" widget for misconfiguration of **Core REST API** integration.

--- a/Packs/CommonDashboards/ReleaseNotes/1_7_5.md
+++ b/Packs/CommonDashboards/ReleaseNotes/1_7_5.md
@@ -3,4 +3,4 @@
 
 ##### AdoptionMetrics
 
-- Fixed an issue where an uninformative error display in the "use case adoption coverage" widget for misconfiguration of **Core REST API** integration.
+- Fixed an issue where an uninformative error was displayed in the "use case adoption coverage" widget because of misconfiguration of the **Core REST API** integration.

--- a/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics.py
+++ b/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics.py
@@ -26,6 +26,9 @@ def is_rapid_breach_response_installed() -> bool | DemistoException:
     try:
         res = demisto.executeCommand("core-api-get", {"uri": "/contentpacks/metadata/installed"})
         if res:
+            for entry in res:
+                if is_error(entry):
+                    return_error(get_error(entry))
             installed_packs = res[0].get("Contents", {}).get("response")
             return any(pack["name"] == "Rapid Breach Response" for pack in installed_packs)
         return False

--- a/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
+++ b/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
@@ -35,7 +35,7 @@ def test_check_phishing_incidents(mocker, data, expected_result):
 CASES_RAPID_BREACH_RESPONSE = [
     ([{"Contents": {"response": []}, "Type": EntryType.NOTE}], False),  # No content packs are installed.
     # content packs are installed.
-    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}, "Type": eEntryType.NOTE}], True)
+    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}, "Type": EntryType.NOTE}], True)
 ]
 
 

--- a/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
+++ b/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
@@ -33,9 +33,9 @@ def test_check_phishing_incidents(mocker, data, expected_result):
 
 
 CASES_RAPID_BREACH_RESPONSE = [
-    ([{"Contents": {"response": []}, "Type": entryTypes["note"]}], False),  # No content packs are installed.
+    ([{"Contents": {"response": []}, "Type": EntryType.NOTE}], False),  # No content packs are installed.
     # content packs are installed.
-    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}, "Type": entryTypes["note"]}], True)
+    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}, "Type": eEntryType.NOTE}], True)
 ]
 
 

--- a/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
+++ b/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics_test.py
@@ -33,8 +33,9 @@ def test_check_phishing_incidents(mocker, data, expected_result):
 
 
 CASES_RAPID_BREACH_RESPONSE = [
-    ([{"Contents": {"response": []}}], False),  # No content packs are installed.
-    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}}], True)  # content packs are installed.
+    ([{"Contents": {"response": []}, "Type": entryTypes["note"]}], False),  # No content packs are installed.
+    # content packs are installed.
+    ([{"Contents": {"response": [{"name": "Rapid Breach Response"}]}, "Type": entryTypes["note"]}], True)
 ]
 
 

--- a/Packs/CommonDashboards/pack_metadata.json
+++ b/Packs/CommonDashboards/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Dashboards",
     "description": "Frequently used dashboards pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.4",
+    "currentVersion": "1.7.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11672

## Description
Fixed an issue where an uninformative error was displayed in the "use case adoption coverage" widget because of misconfiguration of the **Core REST API** integration.

## Must have
- [ ] Tests
- [ ] Documentation 
