### PR TITLE
Add ignore GR103 to xsoar-support packs/CIAC-11655

### DIFF
--- a/Packs/AWS-EC2/.pack-ignore
+++ b/Packs/AWS-EC2/.pack-ignore
@@ -10,3 +10,6 @@ ignore=PB114
 [known_words]
 ippermissionsfull
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-AWS-EC2Test_actions.yml]
+ignore=GR103

--- a/Packs/AlibabaActionTrail/.pack-ignore
+++ b/Packs/AlibabaActionTrail/.pack-ignore
@@ -7,3 +7,7 @@ ignore=PR101
 [known_words]
 Alibaba
 ActionTrail
+
+# GR103 is temporary, see CIAC-11705
+[file:Trigger_-Alibaba_ActionTrail_-_Multiple_Unauthorized_Action_Attempts_Detected_By_a_User.json]
+ignore=GR103

--- a/Packs/AnsibleTower/.pack-ignore
+++ b/Packs/AnsibleTower/.pack-ignore
@@ -12,3 +12,7 @@ ignore=BA101
 
 [known_words]
 Adhoc
+
+# GR103 is temporary, see CIAC-11705
+[file:AnsibleTower-_Test_playbook.yml]
+ignore=GR103

--- a/Packs/ArcSightESM/.pack-ignore
+++ b/Packs/ArcSightESM/.pack-ignore
@@ -11,3 +11,7 @@ ignore=IM111
 ArcSight
 ESM
 params
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Arcsight_-_Get_events_related_to_the_Case.yml]
+ignore=GR103

--- a/Packs/AzureDevOps/.pack-ignore
+++ b/Packs/AzureDevOps/.pack-ignore
@@ -1,2 +1,6 @@
 [file:AzureDevOps_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-AzureDevOps_Layout.json]
+ignore=GR103

--- a/Packs/BPA/.pack-ignore
+++ b/Packs/BPA/.pack-ignore
@@ -4,3 +4,6 @@ ignore=BA101
 [file:README.md]
 ignore=RM104
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-BPA-Integration-test.yml]
+ignore=GR103

--- a/Packs/Campaign/.pack-ignore
+++ b/Packs/Campaign/.pack-ignore
@@ -24,3 +24,7 @@ ignore=BA124
 
 [file:ShowNumberOfCampaignIncidents.yml]
 ignore=BA124
+
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Campaign_Email_To.json]
+ignore=GR103

--- a/Packs/Carbon_Black_Enterprise_Response/.pack-ignore
+++ b/Packs/Carbon_Black_Enterprise_Response/.pack-ignore
@@ -28,3 +28,9 @@ POSTPOSTPOST
 [file:CBFindIP.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-carbonblackEDR_alerts.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:CBEvents.yml]
+ignore=GR103

--- a/Packs/Carbon_Black_Enterprise_Response/.pack-ignore
+++ b/Packs/Carbon_Black_Enterprise_Response/.pack-ignore
@@ -31,6 +31,5 @@ ignore=BA124
 # GR103 is temporary, see CIAC-11705
 [file:layoutscontainer-carbonblackEDR_alerts.json]
 ignore=GR103
-# GR103 is temporary, see CIAC-11705
 [file:CBEvents.yml]
 ignore=GR103

--- a/Packs/CheckPointHarmonyEndpoint/.pack-ignore
+++ b/Packs/CheckPointHarmonyEndpoint/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11705
+[file:playbook-CheckPointHarmonyEndpoint_Test.yml]
+ignore=GR103

--- a/Packs/CheckPointSandBlast/.pack-ignore
+++ b/Packs/CheckPointSandBlast/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11705
+[file:playbook-CheckPointSandBlast_Test.yml]
+ignore=GR103

--- a/Packs/Cisco-umbrella/.pack-ignore
+++ b/Packs/Cisco-umbrella/.pack-ignore
@@ -4,3 +4,6 @@ ignore=BA108,BA109
 [file:Cisco-umbrella-investigate_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Cisco-Umbrella-Python-Test.yml]
+ignore=GR103

--- a/Packs/CiscoSMA/.pack-ignore
+++ b/Packs/CiscoSMA/.pack-ignore
@@ -10,3 +10,6 @@ ignore=MR108
 [file:CiscoSMAModelingRules_1_3.yml]
 ignore=MR108
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-CiscoSMA_Layout.json]
+ignore=GR103

--- a/Packs/Clarizen/.pack-ignore
+++ b/Packs/Clarizen/.pack-ignore
@@ -1,5 +1,6 @@
+# GR103 is temporary, see CIAC-11705
 [file:classifier-User_Profile_-_Clarizen_(Outgoing).json]
-ignore=MP106
+ignore=MP106,GR103
 
 
 [file:ClarizenIAM_image.png]

--- a/Packs/Code42/.pack-ignore
+++ b/Packs/Code42/.pack-ignore
@@ -13,3 +13,10 @@ ignore=RM106
 [file:Code42FileEventsToMarkdownTable.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-Code42_Security_Alert.json]
+ignore=GR103
+[file:classifier-mapper-incoming-Code42.json]
+ignore=GR103
+[file:playbook-Code42_Get_Code42_Employee_Information.yml]
+ignore=GR103

--- a/Packs/CommonScripts/.pack-ignore
+++ b/Packs/CommonScripts/.pack-ignore
@@ -270,3 +270,9 @@ ignore=BA124
 
 [file:VerdictResult.yml]
 ignore=BA124
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-ReadFile_Test.yml]
+ignore=GR103
+[file:playbook-ConvertCountryCodeCountryName_Test.yml]
+ignore=GR103

--- a/Packs/CommonTypes/.pack-ignore
+++ b/Packs/CommonTypes/.pack-ignore
@@ -266,10 +266,8 @@ ignore=BA101,GR103
 [file:layoutscontainer-EmailV2.json]
 ignore=BA101,GR103
 
-
 [file:layoutscontainer-FileV2.json]
 ignore=BA101,GR103
-
 
 [file:layoutscontainer-IPV2.json]
 ignore=BA101,GR103

--- a/Packs/CommonTypes/.pack-ignore
+++ b/Packs/CommonTypes/.pack-ignore
@@ -255,19 +255,26 @@ ignore=BA101
 [file:layoutscontainer-Threat_ActorV2.json]
 ignore=BA101
 
+[file:layoutscontainer-Attack_PatternV2.json]
+ignore=BA101
+
+# GR103 is temporary, see CIAC-11705
 [file:layoutscontainer-URLV2.json]
 ignore=BA101,GR103
 
-[file:layoutscontainer-Attack_PatternV2.json]
-ignore=BA101
 
 [file:layoutscontainer-EmailV2.json]
 ignore=BA101,GR103
 
+
 [file:layoutscontainer-FileV2.json]
 ignore=BA101,GR103
 
+
 [file:layoutscontainer-IPV2.json]
+ignore=BA101,GR103
+
+[file:layoutscontainer-DomainV2.json]
 ignore=BA101,GR103
 
 [file:layoutscontainer-AccountV2.json]
@@ -275,9 +282,6 @@ ignore=BA101
 
 [file:layoutscontainer-MalwareV2.json]
 ignore=BA101
-
-[file:layoutscontainer-DomainV2.json]
-ignore=BA101,GR103
 
 [file:layoutscontainer-ReportV2.json]
 ignore=BA101
@@ -343,4 +347,36 @@ DN
 PEM
 SPKI
 subkeys
-formatter
+formatter# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Last_Modified_By.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Detected_External_IPs.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Detected_Internal_Hosts.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Detected_Users.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Detected_Internal_IPs.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Detected_External_Hosts.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-osversion.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-hostname.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-description.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-shortdescription.json]
+ignore=GR103
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Last_Modified_On.json]
+ignore=GR103

--- a/Packs/ContentManagement/.pack-ignore
+++ b/Packs/ContentManagement/.pack-ignore
@@ -55,3 +55,6 @@ ignore=BA124
 [file:JobCreator.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-configuration_setup.json]
+ignore=GR103

--- a/Packs/Core/.pack-ignore
+++ b/Packs/Core/.pack-ignore
@@ -20,3 +20,7 @@ ignore=BA101
 
 [file:playbook-XCloud_Cryptomining.yml]
 ignore=BA101
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-Default.json]
+ignore=GR103

--- a/Packs/CortexXDR/.pack-ignore
+++ b/Packs/CortexXDR/.pack-ignore
@@ -160,3 +160,7 @@ ignore=PB105
 
 [file:Cortex_XDR_-_Large_Upload.yml]
 ignore=PB121
+
+# GR103 is temporary, see CIAC-11705
+[file:Test_Playbook_-_Cortex_XDR_-_False_Positive_Incident_Handling.yml]
+ignore=GR103

--- a/Packs/CortexXpanse/.pack-ignore
+++ b/Packs/CortexXpanse/.pack-ignore
@@ -6,3 +6,7 @@ APIS
 assignee
 mapper
 mappers
+
+# GR103 is temporary, see CIAC-11705
+[file:classifier-Xpanse_-_Classifier.json]
+ignore=GR103

--- a/Packs/CrowdStrikeFalconX/.pack-ignore
+++ b/Packs/CrowdStrikeFalconX/.pack-ignore
@@ -5,3 +5,7 @@ ignore=RM104
 X
 csfalconx
 FalconX
+
+# GR103 is temporary, see CIAC-11705
+[file:CrowdStrike_Falcon_X_-Test-Detonate_URL.yml]
+ignore=GR103

--- a/Packs/DatadogCloudSIEM/.pack-ignore
+++ b/Packs/DatadogCloudSIEM/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11705
+[file:classifier-mapper-Datadog_Cloud_SIEM_-_Incoming_Mapper.json]
+ignore=GR103

--- a/Packs/EDL/.pack-ignore
+++ b/Packs/EDL/.pack-ignore
@@ -9,3 +9,15 @@ ignore=RM106
 
 [file:playbook-PAN-OS_EDL_Service_Configuration.yml]
 ignore=PB116
+
+# GR103 is temporary, see CIAC-11705
+[file:Tag_massive_and_internal_IOCs_to_avoid_EDL_listing.yml]
+ignore=GR103
+[file:incidentfield-EDL_Indicator_Type.json]
+ignore=GR103
+[file:incidentfield-EDL_Indicators_List.json]
+ignore=GR103
+[file:incidentfield-EDL_Tag.json]
+ignore=GR103
+[file:incidentfield-EDL_Action.json]
+ignore=GR103

--- a/Packs/ExpanseV2/.pack-ignore
+++ b/Packs/ExpanseV2/.pack-ignore
@@ -9,11 +9,8 @@ ignore=BA110
 
 [file:classifier-ExpanseV2_-_Incoming_Mapper.json]
 ignore=BA101
-[file:incidentfield-Expanse_Issue_ID.json]
-ignore=IF100
 
-[file:incidentfield-Expanse_Issue_Type.json]
-ignore=IF100
+
 
 [file:ExpanseV2_image.png]
 ignore=IM111
@@ -30,3 +27,62 @@ domainStatuses
 
 [file:classifier-ExpanseV2.json]
 ignore=BA101
+
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Expanse_Issue_ID.json]
+ignore=IF100,GR103
+
+[file:incidentfield-Expanse_Issue_Type.json]
+ignore=IF100,GR103
+[file:incidentfield-Expanse_Geolocation.json]
+ignore=GR103
+[file:incidentfield-Expanse_Progress_Status.json]
+ignore=GR103
+[file:incidentfield-Expanse_Shadow_IT.json]
+ignore=GR103
+[file:incidentfield-Expanse_Provider.json]
+ignore=GR103
+[file:incidentfield-Expanse_Asset.json]
+ignore=GR103
+[file:incidentfield-Expanse_Activity_Status.json]
+ignore=GR103
+[file:incidentfield-Expanse_Cloud_Management_Status.json]
+ignore=GR103
+[file:incidentfield-Expanse_Port.json]
+ignore=GR103
+[file:incidentfield-Expanse_Category.json]
+ignore=GR103
+[file:incidentfield-Expanse_Tags.json]
+ignore=GR103
+[file:incidentfield-Expanse_Protocol.json]
+ignore=GR103
+[file:incidentfield-Expanse_Region.json]
+ignore=GR103
+[file:incidentfield-Expanse_Initial_Evidence.json]
+ignore=GR103
+[file:incidentfield-Expanse_ML_Features.json]
+ignore=GR103
+[file:incidentfield-Expanse_Domain.json]
+ignore=GR103
+[file:incidentfield-Expanse_Latest_Evidence.json]
+ignore=GR103
+[file:incidentfield-Expanse_Created.json]
+ignore=GR103
+[file:incidentfield-Expanse_Asset_Owner.json]
+ignore=GR103
+[file:incidentfield-Expanse_Certificate.json]
+ignore=GR103
+[file:incidentfield-Expanse_Service.json]
+ignore=GR103
+[file:incidentfield-Expanse_Modified.json]
+ignore=GR103
+[file:incidentfield-Expanse_Business_Units.json]
+ignore=GR103
+[file:incidentfield-Expanse_Asset_Organization_Unit.json]
+ignore=GR103
+[file:incidentfield-Expanse_Priority.json]
+ignore=GR103
+[file:incidentfield-Expanse_Assignee.json]
+ignore=GR103
+[file:incidentfield-Expanse_IP.json]
+ignore=GR103

--- a/Packs/F5Silverline/.pack-ignore
+++ b/Packs/F5Silverline/.pack-ignore
@@ -7,8 +7,10 @@ ignore=IF100
 [file:incident_f5silverlineipintelligenceevent.json]
 ignore=IF100
 
+# GR103 is temporary, see CIAC-11705
 [file:classifier-F5Silverline_mapper.json]
-ignore=BA101
+ignore=BA101,GR103
+
 
 [file:incident_f5silverlineactionreason.json]
 ignore=BA113

--- a/Packs/FireEyeEX/.pack-ignore
+++ b/Packs/FireEyeEX/.pack-ignore
@@ -5,3 +5,7 @@ ignore=BA101
 utc
 blockedlist
 fireeye
+
+# GR103 is temporary, see CIAC-11705
+[file:incidenttype-FireEye_EX_Alert.json]
+ignore=GR103

--- a/Packs/ForescoutEyeInspect/.pack-ignore
+++ b/Packs/ForescoutEyeInspect/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-ForescoutEyeInspect_General_Layout.json]
+ignore=GR103

--- a/Packs/FortiSIEM/.pack-ignore
+++ b/Packs/FortiSIEM/.pack-ignore
@@ -1,3 +1,6 @@
 [file:FortiSIEM.yml]
 ignore=IN126,BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:classifier-mapper-incoming-FortiSIEM_v2.json]
+ignore=GR103

--- a/Packs/FreshworksFreshservice/.pack-ignore
+++ b/Packs/FreshworksFreshservice/.pack-ignore
@@ -24,3 +24,7 @@ ignore=IF116
 
 [file:incidentfield-FreshworksFreshservice_Problem_Status.json]
 ignore=IF116
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-FreshworkFreshservice_Test.yml]
+ignore=GR103

--- a/Packs/GDPR/.pack-ignore
+++ b/Packs/GDPR/.pack-ignore
@@ -4,3 +4,6 @@ ignore=BA101
 [file:GDPRContactAuthorities.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-GDPR_Breach_Notification.yml]
+ignore=GR103

--- a/Packs/GuardiCore/.pack-ignore
+++ b/Packs/GuardiCore/.pack-ignore
@@ -7,3 +7,7 @@ ignore=IN144
 
 [file:GuardiCore_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-guardicore.json]
+ignore=GR103

--- a/Packs/IronPort/.pack-ignore
+++ b/Packs/IronPort/.pack-ignore
@@ -3,3 +3,7 @@ ignore=IM111
 
 [file:IronPort_1_3.yml]
 ignore=MR108
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-CiscoESA_Layout.json]
+ignore=GR103

--- a/Packs/Kafka/.pack-ignore
+++ b/Packs/Kafka/.pack-ignore
@@ -7,3 +7,6 @@ ignore=IM111
 [file:Kafka_V2_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-KafkaV3_Test.yml]
+ignore=GR103

--- a/Packs/MITRECoA/.pack-ignore
+++ b/Packs/MITRECoA/.pack-ignore
@@ -159,3 +159,19 @@ ignore=BA124
 
 [file:1_0_4.md]
 ignore=RN116
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-PAN-OS_-_Enforce_URL_Filtering_Best_Practices_Profile.yml]
+ignore=GR103
+[file:playbook-CoA_-_T1078_-_Valid_Accounts.yml]
+ignore=GR103
+[file:playbook-PAN-OS_-_Enforce_Anti-Virus_Best_Practices_Profile.yml]
+ignore=GR103
+[file:playbook-PAN-OS_-_Enforce_Vulnerability_Protection_Best_Practices_Profile.yml]
+ignore=GR103
+[file:playbook-PAN-OS_-_Enforce_Anti-Spyware_Best_Practices_Profile.yml]
+ignore=GR103
+[file:playbook-PAN-OS_-_Enforce_WildFire_Best_Practices_Profile.yml]
+ignore=GR103
+[file:playbook-PAN-OS_-_Enforce_File_Blocking_Best_Practices_Profile.yml]
+ignore=GR103

--- a/Packs/MajorBreachesInvestigationandResponse/.pack-ignore
+++ b/Packs/MajorBreachesInvestigationandResponse/.pack-ignore
@@ -57,3 +57,7 @@ ignore=RN113,RN114
 
 [file:1_6_36.md]
 ignore=RN116
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-Rapid_Breach_Response.json]
+ignore=GR103

--- a/Packs/Malware/.pack-ignore
+++ b/Packs/Malware/.pack-ignore
@@ -21,3 +21,7 @@ Path(s
 
 [file:1_4_4.md]
 ignore=RN113,RN114
+
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Parent_Process_ID.json]
+ignore=GR103

--- a/Packs/McAfee_ESM/.pack-ignore
+++ b/Packs/McAfee_ESM/.pack-ignore
@@ -3,3 +3,9 @@ ignore=IN126,BA108,BA109
 
 [file:McAfee_ESM_v2_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:McAfee_ESM_v2_(v11.3)_-_Test.yml]
+ignore=GR103
+[file:McAfee_ESM_v2_-_Test.yml]
+ignore=GR103

--- a/Packs/Microsoft365Defender/.pack-ignore
+++ b/Packs/Microsoft365Defender/.pack-ignore
@@ -7,3 +7,6 @@ ignore=BA124
 [file:MS365DefenderCountIncidentCategories.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-Microsoft_365_Defender_-_Layout.json]
+ignore=GR103

--- a/Packs/MicrosoftExchangeOnline/.pack-ignore
+++ b/Packs/MicrosoftExchangeOnline/.pack-ignore
@@ -26,3 +26,6 @@ attachmentName
 [file:GetEWSFolder.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Office_365_Search_and_Delete.yml]
+ignore=GR103

--- a/Packs/Netskope/.pack-ignore
+++ b/Packs/Netskope/.pack-ignore
@@ -4,3 +4,6 @@ ignore=MR108
 [file:NetskopeEventCollector_1_3.yml]
 ignore=MR108
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-NetskopeAPIv2_Test.yml]
+ignore=GR103

--- a/Packs/OpsGenie/.pack-ignore
+++ b/Packs/OpsGenie/.pack-ignore
@@ -7,8 +7,10 @@ ignore=IM111
 [file:OpsGenie_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11705
 [file:classifier-OpsGenie_-_Classifier.json]
-ignore=BA101
+ignore=BA101,GR103
+
 
 [file:incidentfield-OpsGenie_AlertId.json]
 ignore=IF115

--- a/Packs/PAN-OS/.pack-ignore
+++ b/Packs/PAN-OS/.pack-ignore
@@ -46,3 +46,6 @@ sourceuser
 [file:PanoramaCVECoverage.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:classifier-Panorama_Classifier.json]
+ignore=GR103

--- a/Packs/PANWComprehensiveInvestigation/.pack-ignore
+++ b/Packs/PANWComprehensiveInvestigation/.pack-ignore
@@ -1,8 +1,10 @@
 [file:PANWComprehensiveInvestigation]
 ignore=PA116
 
+# GR103 is temporary, see CIAC-11705
 [file:layoutscontainer-PANW_Endpoint_Malware.json]
-ignore=BA101
+ignore=BA101,GR103
+
 
 [file:Palo_Alto_Networks_-_Endpoint_Malware_Investigation_v3_README.md]
 ignore=RM106

--- a/Packs/PaloAltoNetworks_SecurityAdvisories/.pack-ignore
+++ b/Packs/PaloAltoNetworks_SecurityAdvisories/.pack-ignore
@@ -2,3 +2,7 @@
 cvssversion
 cvsstable
 cvssscore
+
+# GR103 is temporary, see CIAC-11705
+[file:PaloAltoNetworks_SecurityAdvisories.yml]
+ignore=GR103

--- a/Packs/Phishing/.pack-ignore
+++ b/Packs/Phishing/.pack-ignore
@@ -13,8 +13,10 @@ ignore=BA101,BA110
 [file:Process_Email_-_Generic_v2.yml]
 ignore=PB118
 
+# GR103 is temporary, see CIAC-11705
 [file:Process_Email_-_Core_v2.yml]
-ignore=PB118
+ignore=PB118,GR103
+
 
 [file:Phishing_-_Generic_v3.yml]
 ignore=PB106
@@ -64,4 +66,6 @@ UseOldHTMLFields
 QR
 
 [file:LinkToPhishingCampaign.yml]
-ignore=BA124
+ignore=BA124# GR103 is temporary, see CIAC-11705
+[file:incidentfield-bclscore.json]
+ignore=GR103

--- a/Packs/Phishing/.pack-ignore
+++ b/Packs/Phishing/.pack-ignore
@@ -66,6 +66,8 @@ UseOldHTMLFields
 QR
 
 [file:LinkToPhishingCampaign.yml]
-ignore=BA124# GR103 is temporary, see CIAC-11705
+ignore=BA124
+
+# GR103 is temporary, see CIAC-11705
 [file:incidentfield-bclscore.json]
 ignore=GR103

--- a/Packs/Pipl/.pack-ignore
+++ b/Packs/Pipl/.pack-ignore
@@ -6,3 +6,7 @@ ignore=IM111
 
 [known_words]
 pipl
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Pipl_Test.yml]
+ignore=GR103

--- a/Packs/PrismaCloud/.pack-ignore
+++ b/Packs/PrismaCloud/.pack-ignore
@@ -63,3 +63,10 @@ ignore=BA101
 [file:PrismaCloud.yml]
 ignore=PR101,MR108
 
+# GR103 is temporary, see CIAC-11705
+[file:incidenttype-Azure_AKS_Misconfiguration.json]
+ignore=GR103
+[file:incidenttype-Azure_Network_Misconfiguration.json]
+ignore=GR103
+[file:incidenttype-Azure_SQL_Misconfiguration.json]
+ignore=GR103

--- a/Packs/ProofpointTAP/.pack-ignore
+++ b/Packs/ProofpointTAP/.pack-ignore
@@ -24,3 +24,7 @@ ignore=MR108
 
 [file:ProofpointTAPModelingRules_1_3.yml]
 ignore=MR108
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-ProofPointTAP_Message_Layout.json]
+ignore=GR103

--- a/Packs/QualysFIM/.pack-ignore
+++ b/Packs/QualysFIM/.pack-ignore
@@ -18,3 +18,7 @@ ignore=IF100
 
 [file:classifier-QualysFim_Classifier.json]
 ignore=BA101
+
+# GR103 is temporary, see CIAC-11705
+[file:customIncidentTypes.json]
+ignore=GR103

--- a/Packs/RDPCacheHunting/.pack-ignore
+++ b/Packs/RDPCacheHunting/.pack-ignore
@@ -3,3 +3,7 @@ ignore=BA116
 
 [file:incidentfield-String_Sifter.json]
 ignore=BA116
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-RDP_Sessions.json]
+ignore=GR103

--- a/Packs/Ransomware/.pack-ignore
+++ b/Packs/Ransomware/.pack-ignore
@@ -7,3 +7,6 @@ ignore=BA124
 [file:RansomwareHostWidget.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Post_Intrusion_Ransomware_Investigation_6_5.yml]
+ignore=GR103

--- a/Packs/ServiceNow/.pack-ignore
+++ b/Packs/ServiceNow/.pack-ignore
@@ -52,3 +52,7 @@ ignore=BA101
 
 [file:ServiceNowIncidentStatus.yml]
 ignore=BA124
+
+# GR103 is temporary, see CIAC-11705
+[file:incidenttype-ServiceNow_Create_Ticket_and_Mirror.json]
+ignore=GR103

--- a/Packs/SkyhighSecurity/.pack-ignore
+++ b/Packs/SkyhighSecurity/.pack-ignore
@@ -1,0 +1,5 @@
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-SkyhighSecurity_Alert.json]
+ignore=GR103
+[file:layoutscontainer-SkyhighSecurity_Threat.json]
+ignore=GR103

--- a/Packs/Slack/.pack-ignore
+++ b/Packs/Slack/.pack-ignore
@@ -19,3 +19,7 @@ ignore=MR108
 
 [file:SlackModelingRules.yml]
 ignore=MR108
+
+# GR103 is temporary, see CIAC-11705
+[file:classifier-Slack_Mapper.json]
+ignore=GR103

--- a/Packs/SolarWinds/.pack-ignore
+++ b/Packs/SolarWinds/.pack-ignore
@@ -88,3 +88,7 @@ ignore=BA101
 
 [file:classifier-SolarWinds.json]
 ignore=BA101
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-SolarWinds_Alert.json]
+ignore=GR103

--- a/Packs/SplunkPy/.pack-ignore
+++ b/Packs/SplunkPy/.pack-ignore
@@ -29,3 +29,6 @@ ignore=BA124
 [file:SplunkShowAsset.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:incidentfield-Notable_-_ID.json]
+ignore=GR103

--- a/Packs/TheHiveProject/.pack-ignore
+++ b/Packs/TheHiveProject/.pack-ignore
@@ -20,3 +20,7 @@ ignore=IN153
 
 [file:TheHiveProject_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-Hive_layout_custom.json]
+ignore=GR103

--- a/Packs/ThreatIntelReports/.pack-ignore
+++ b/Packs/ThreatIntelReports/.pack-ignore
@@ -4,3 +4,14 @@ ignore=BA124
 [file:UnpublishThreatIntelReport.yml]
 ignore=BA124
 
+# GR103 is temporary, see CIAC-11705
+[file:layoutscontainer-ThreatIntelReport-ThreatActorReport.json]
+ignore=GR103
+[file:layoutscontainer-ThreatIntelReport-ExecutiveBriefReport.json]
+ignore=GR103
+[file:layoutscontainer-ThreatIntelReport-VulnerabilityReport.json]
+ignore=GR103
+[file:layoutscontainer-ThreatIntelReport-CampaignReport.json]
+ignore=GR103
+[file:layoutscontainer-ThreatIntelReport-MalwareReport.json]
+ignore=GR103

--- a/Packs/Tidy/.pack-ignore
+++ b/Packs/Tidy/.pack-ignore
@@ -6,3 +6,7 @@ ignore=RM104
 
 [file:Tidy_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:incidenttype-Tidy_install.json]
+ignore=GR103

--- a/Packs/Traps/.pack-ignore
+++ b/Packs/Traps/.pack-ignore
@@ -1,8 +1,10 @@
 [file:PaloAlto_TrapsESM_Beta.yml]
 ignore=IN110,IN109,BA108,BA109,BA124
 
+# GR103 is temporary, see CIAC-11705
 [file:layoutscontainer-Traps.json]
-ignore=BA101
+ignore=BA101,GR103
+
 
 [file:PaloAltoNetworks_Traps.yml]
 ignore=BA108,BA109

--- a/Packs/Twitter/.pack-ignore
+++ b/Packs/Twitter/.pack-ignore
@@ -1,3 +1,6 @@
 [file:Twitter_image.png]
 ignore=IM111
 
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Remove_Excluded_Accounts.yml]
+ignore=GR103

--- a/Packs/Volatility/.pack-ignore
+++ b/Packs/Volatility/.pack-ignore
@@ -1,0 +1,3 @@
+# GR103 is temporary, see CIAC-11705
+[file:AnalyzeMemImage.yml]
+ignore=GR103

--- a/Packs/ctf01/.pack-ignore
+++ b/Packs/ctf01/.pack-ignore
@@ -18,3 +18,7 @@ ignore=IM111
 CTF
 
 [file:CortexXDRIR.yml]
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Cortex_XDR_Alerts_Handling_CTF.yml]
+ignore=GR103

--- a/Packs/nessus/.pack-ignore
+++ b/Packs/nessus/.pack-ignore
@@ -1,2 +1,6 @@
 [file:Nessus_image.png]
 ignore=IM111
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Nessus_Test.yml]
+ignore=GR103

--- a/Packs/rasterize/.pack-ignore
+++ b/Packs/rasterize/.pack-ignore
@@ -6,3 +6,7 @@ pychrome
 [tests_require_network]
 Rasterize
 Rasterize v2 Pre-Release
+
+# GR103 is temporary, see CIAC-11705
+[file:playbook-Process_Email_-_Generic_for_rasterize.yml]
+ignore=GR103


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11655
## Description
In the new GR103, we are converting all warnings in the old version to errors. This results in 246 errors when running with the -a flag.

To simplify the process for now,  we will add an "ignore GR103" to the pack and open a ticket to address it in the future.
https://jira-dc.paloaltonetworks.com/browse/CIAC-11705

In this PR, the "ignore GR103" field is applied to all XSOAR-supported items. (129 items).

Requested a force merge as validation is failing due to unrelated issues (like IF113) 

## Must have
- [ ] Tests
- [ ] Documentation 
