### PR TITLE
[AwsEC2SyncAccounts] new argument "max_accounts"

### DIFF
--- a/Packs/AWS-EC2/ReleaseNotes/1_4_12.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_4_12.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### AwsEC2SyncAccounts
+
+- Added the new argument `max_accounts` which sets the maximum number of accounts to retrieve.
+- Updated the Docker image to: *demisto/python3:3.11.9.110419*.

--- a/Packs/AWS-EC2/ReleaseNotes/1_4_12.md
+++ b/Packs/AWS-EC2/ReleaseNotes/1_4_12.md
@@ -3,5 +3,5 @@
 
 ##### AwsEC2SyncAccounts
 
-- Added the new argument `max_accounts` which sets the maximum number of accounts to retrieve.
+- Added the new argument *max_accounts* which sets the maximum number of accounts to retrieve.
 - Updated the Docker image to: *demisto/python3:3.11.9.110419*.

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.py
@@ -23,14 +23,14 @@ def internal_request(method: str, uri: str, body: dict = {}) -> dict:
     )[0]['Contents']['response']  # type: ignore
 
 
-def get_account_ids(ec2_instance_name: str | None) -> tuple[list[str], str]:
+def get_account_ids(ec2_instance_name: str | None, limit: int | None) -> tuple[list[str], str]:
     '''Get the AWS organization accounts using the `aws-org-account-list` command.
 
     Returns:
         list[str]: A list of AWS account IDs.
     '''
     try:
-        command_args = {'using': ec2_instance_name} if ec2_instance_name else {}
+        command_args = assign_params(limit=limit, using=ec2_instance_name)
         account_list_result: list[dict] = demisto.executeCommand(ACCOUNT_LIST_COMMAND, command_args)  # type: ignore
         accounts = dict_safe_get(
             account_list_result, (0, 'EntryContext', 'AWS.Organizations.Account(val.Id && val.Id == obj.Id)'), []
@@ -117,7 +117,8 @@ def update_ec2_instance(account_ids: list[str], ec2_instance_name: str) -> str:
 def main():
     try:
         args: dict = demisto.args()
-        account_ids, readable_output = get_account_ids(args.get('org_instance_name'))
+        account_ids, readable_output = get_account_ids(
+            args.get('org_instance_name'), arg_to_number(args.get('max_accounts')))
         account_ids = remove_excluded_accounts(account_ids, args.get('exclude_accounts'))
         result = update_ec2_instance(account_ids, args['ec2_instance_name'])
         return_results(CommandResults(readable_output=f'## {result}  \n---  \n{readable_output}'))

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
@@ -23,7 +23,7 @@ tags:
 timeout: '0'
 type: python
 subtype: python3
-dockerimage: demisto/python3:3.10.14.91134
+dockerimage: demisto/python3:3.11.9.110419
 runas: DBotWeakRole
 fromversion: 6.10.0
 tests:

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts.yml
@@ -7,6 +7,9 @@ args:
 - description: A comma-separated list of accounts to exclude.
   name: exclude_accounts
   isArray: true
+- description: The maximum number of accounts to retrieve.
+  name: max_accounts
+  defaultValue: '50'
 comment: Update an AWS - EC2 instance with a list of accounts in an AWS organization, which will allow EC2 commands to run in all of them.
 commonfields:
   id: AwsEC2SyncAccounts

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
@@ -38,7 +38,7 @@ def test_get_account_ids(mocker):
     account_ids = get_account_ids('instance_name', 2)
 
     assert account_ids == (["1234", "5678"], "human_readable")
-    mock_execute_command.assert_called_with("aws-org-account-list", {'using': 'instance_name'})
+    mock_execute_command.assert_called_with("aws-org-account-list", {'limit': 2, 'using': 'instance_name'})
 
 
 def test_set_instance(mocker):

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/AwsEC2SyncAccounts_test.py
@@ -35,7 +35,7 @@ def test_get_account_ids(mocker):
         }
     ]
 
-    account_ids = get_account_ids('instance_name')
+    account_ids = get_account_ids('instance_name', 2)
 
     assert account_ids == (["1234", "5678"], "human_readable")
     mock_execute_command.assert_called_with("aws-org-account-list", {'using': 'instance_name'})
@@ -165,4 +165,4 @@ def test_errors():
 
     with pytest.raises(DemistoException, match="Unexpected output from 'aws-org-account-list':\nNone"):
         sync.demisto.executeCommand = lambda *_: {}['key']
-        sync.get_account_ids('')
+        sync.get_account_ids('', 0)

--- a/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/README.md
+++ b/Packs/AWS-EC2/Scripts/AwsEC2SyncAccounts/README.md
@@ -25,6 +25,7 @@ This script can be run on a schedule to keep an AWS - EC2 instance in sync with 
 | ec2_instance_name | The name of the AWS - EC2 instance integration to update. |
 | org_instance_name | The name of the AWS - Organizations instance to collect account from. If not provided, the primary instance will be used. |
 | exclude_accounts | A comma-separated list of accounts to exclude. |
+| max_accounts | The maximum number of accounts to retrieve. Default is 50. |
 
 ## Outputs
 

--- a/Packs/AWS-EC2/pack_metadata.json
+++ b/Packs/AWS-EC2/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - EC2",
     "description": "Amazon Web Services Elastic Compute Cloud (EC2)",
     "support": "xsoar",
-    "currentVersion": "1.4.11",
+    "currentVersion": "1.4.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-41400)

## Description
Add the new argument `max_accounts` to `AwsEC2SyncAccounts` which controls the amount of accounts pulled.

## Must have
- [ ] Tests
- [ ] Documentation 
