### PR TITLE
Fix mypy error flaky for google.cloud library

### DIFF
--- a/Packs/Core/Integrations/CoreIOCs/CoreIOCs.py
+++ b/Packs/Core/Integrations/CoreIOCs/CoreIOCs.py
@@ -7,7 +7,7 @@ from datetime import timezone
 from dateparser import parse
 from urllib3 import disable_warnings
 from math import ceil
-from google.cloud import storage
+from google.cloud import storage  # type: ignore[attr-defined]
 from CoreIRApiModule import *
 
 disable_warnings()

--- a/Packs/GoogleCloudStorage/Integrations/GoogleCloudStorage/GoogleCloudStorage.py
+++ b/Packs/GoogleCloudStorage/Integrations/GoogleCloudStorage/GoogleCloudStorage.py
@@ -3,7 +3,7 @@ from CommonServerPython import *  # noqa: F401
 
 ''' IMPORTS '''
 
-from google.cloud import storage
+from google.cloud import storage  # type: ignore[attr-defined]
 from typing import Any
 import requests
 import traceback


### PR DESCRIPTION

## Description
Following a mypy error that sometimes occurs, ignore was added to the import line of the google.cloud library

