### PR TITLE
Rename "SentinelOne Event Collector" to "SentinelOne Activity and Alerts"

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/README.md
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/README.md
@@ -3,10 +3,10 @@ This integration was integrated and tested with API version 2.1 of SentinelOne.
 
 This is the default integration for this content pack when configured by the Data Onboarder in Cortex XSIAM.
 
-## Configure SentinelOne Event Collector on Cortex XSIAM
+## Configure SentinelOne Activity and Alerts Collector on Cortex XSIAM
 
 1. Navigate to **Settings** > **Configurations** > **Data Collection** > **Automation & Feed Integrations**.
-2. Search for SentinelOne Event Collector.
+2. Search for SentinelOne Activity and Alerts Collector.
 3. Click **Add instance** to create and configure a new integration instance.
 
     | **Parameter** | **Description** | **Required** |

--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/README.md
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/README.md
@@ -3,10 +3,10 @@ This integration was integrated and tested with API version 2.1 of SentinelOne.
 
 This is the default integration for this content pack when configured by the Data Onboarder in Cortex XSIAM.
 
-## Configure SentinelOne Activity and Alerts Collector on Cortex XSIAM
+## Configure SentinelOne Activity and Alerts on Cortex XSIAM
 
 1. Navigate to **Settings** > **Configurations** > **Data Collection** > **Automation & Feed Integrations**.
-2. Search for SentinelOne Activity and Alerts Collector.
+2. Search for SentinelOne Activity and Alerts.
 3. Click **Add instance** to create and configure a new integration instance.
 
     | **Parameter** | **Description** | **Required** |

--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
@@ -54,7 +54,7 @@ configuration:
   section: Collect
   required: false
 description: This integration fetches activities, threats, and alerts from SentinelOne.
-display: SentinelOne Activity and Alert Collector
+display: SentinelOne Activity and Alerts Collector
 name: SentinelOneEventCollector
 supportlevelheader: xsoar
 script:

--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
@@ -54,7 +54,7 @@ configuration:
   section: Collect
   required: false
 description: This integration fetches activities, threats, and alerts from SentinelOne.
-display: SentinelOne Event Collector
+display: SentinelOne Activity and Alert Collector
 name: SentinelOneEventCollector
 supportlevelheader: xsoar
 script:
@@ -72,7 +72,7 @@ script:
       name: limit
     description: Gets events from SentinelOne.
     name: sentinelone-get-events
-  dockerimage: demisto/python3:3.10.13.87159
+  dockerimage: demisto/python3:3.11.10.111526
   isfetchevents: true
   script: '-'
   subtype: python3

--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
@@ -54,7 +54,7 @@ configuration:
   section: Collect
   required: false
 description: This integration fetches activities, threats, and alerts from SentinelOne.
-display: SentinelOne Activity and Alerts Collector
+display: SentinelOne Activity and Alerts
 name: SentinelOneEventCollector
 supportlevelheader: xsoar
 script:

--- a/Packs/SentinelOne/ReleaseNotes/3_2_32.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_32.md
@@ -1,7 +1,7 @@
 
 #### Integrations
 
-##### SentinelOne Activity and Alert Collector
+##### SentinelOne Activity and Alerts Collector
 
-- Renamed the integration **SentinelOne Event Collector** to **SentinelOne Activity and Alert Collector**.
+- Renamed the integration **SentinelOne Event Collector** to **SentinelOne Activity and Alerts Collector**.
 - Updated the Docker image to: *demisto/python3:3.11.10.111526*.

--- a/Packs/SentinelOne/ReleaseNotes/3_2_32.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_32.md
@@ -1,7 +1,7 @@
 
 #### Integrations
 
-##### SentinelOne Activity and Alerts Collector
+##### SentinelOne Activity and Alerts
 
-- Renamed the integration **SentinelOne Event Collector** to **SentinelOne Activity and Alerts Collector**.
+- Renamed the integration **SentinelOne Event Collector** to **SentinelOne Activity and Alerts**.
 - Updated the Docker image to: *demisto/python3:3.11.10.111526*.

--- a/Packs/SentinelOne/ReleaseNotes/3_2_32.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_2_32.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### SentinelOne Activity and Alert Collector
+
+- Renamed the integration **SentinelOne Event Collector** to **SentinelOne Activity and Alert Collector**.
+- Updated the Docker image to: *demisto/python3:3.11.10.111526*.

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "Endpoint protection",
     "support": "partner",
-    "currentVersion": "3.2.31",
+    "currentVersion": "3.2.32",
     "author": "SentinelOne",
     "url": "https://www.sentinelone.com/support/",
     "email": "support@sentinelone.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11847)

## Description
Rename "SentinelOne Event Collector" to "SentinelOne Activity and Alerts".

## Must have
- [ ] Tests
- [ ] Documentation 
