### PR TITLE
Return demisto-sdk secrets to pre-commit

### DIFF
--- a/.github/workflows/pre-commit-reuse.yml
+++ b/.github/workflows/pre-commit-reuse.yml
@@ -53,7 +53,7 @@ jobs:
           demisto-sdk pre-commit -g --mode=packwise --show-diff-on-failure --verbose
         else
           echo "Not in docker auto update branch, pre commit on CI mode."
-          demisto-sdk pre-commit -g --validate --no-secrets --show-diff-on-failure --verbose --mode=ci
+          demisto-sdk pre-commit -g --validate --show-diff-on-failure --verbose --mode=ci
         fi
 
     - name: "Check coverage.xml exists"


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11768

## Description
Use `demisto-sdk secrets` in `pre-commit`, so contributors will be able to see failures in it.

## Must have
- [ ] Tests
- [ ] Documentation 
