### PR TITLE
Unskip secrets in pre-commit

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -319,7 +319,6 @@ repos:
     - --ignore-entropy
     pass_filenames: false
     language: system
-    skip:ci: true
     skip:nightly: true
 
   - id: merge-pytest-reports


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11768
In continuation to https://github.com/demisto/content/pull/36412

## Description
Use demisto-sdk secrets in pre-commit, so contributors will be able to see failures in it.

## Must have
- [ ] Tests
- [ ] Documentation 
