### PR TITLE
Fix logic error in AdoptionMetrics script

### DIFF
--- a/Packs/CommonDashboards/ReleaseNotes/1_7_6.md
+++ b/Packs/CommonDashboards/ReleaseNotes/1_7_6.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### AdoptionMetrics
+
+- Fixed an issue where the "Business Email Compromise Coverage" row in the widget could never get a checkmark.

--- a/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics.py
+++ b/Packs/CommonDashboards/Scripts/AdoptionMetrics/AdoptionMetrics.py
@@ -73,10 +73,9 @@ def get_use_cases() -> Dict[str, Any]:
         category = details.get('category', '').lower()
         brand = details.get('brand', '').lower()
         state = details.get('state')
-        incident_types = details.get('incident_types', [])
 
         if brand != 'builtin' and state == 'active' and category != 'utilities':
-            if category in ['email', 'messaging', 'messaging and conferencing'] and 'phishing' in incident_types:
+            if category in ['email', 'messaging', 'messaging and conferencing']:
                 if phishing_incidents:
                     use_cases_in_production.add('Business Email Compromise Coverage')
                 else:

--- a/Packs/CommonDashboards/pack_metadata.json
+++ b/Packs/CommonDashboards/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Dashboards",
     "description": "Frequently used dashboards pack.",
     "support": "xsoar",
-    "currentVersion": "1.7.5",
+    "currentVersion": "1.7.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
n/a

## Description
Small fix to the `AdoptionMetrics` script that is used to populate a widget in the 'XSOAR Automation Insights' dashboard. This was necessary because the script currently checks for an invalid key, `incident_types`. The condition that checks the `incident_types` key will never return true, and therefore it is impossible for the "Business Email Compromise Coverage" category to ever get a green checkmark.
![Screenshot 2024-09-24 at 1 34 03 PM](https://github.com/user-attachments/assets/eda6ea8a-e07c-4b3f-a53e-d4d842c06f74)

## Must have
- [ ] Tests
- [ ] Documentation 
