### PR TITLE
added freeze to sekoia test_arg_to_timestamp unit test

### DIFF
--- a/Packs/SekoiaXDR/Integrations/SekoiaXDR/SekoiaXDR_test.py
+++ b/Packs/SekoiaXDR/Integrations/SekoiaXDR/SekoiaXDR_test.py
@@ -29,6 +29,7 @@ def client():
 
 """ TEST HELPER FUNCTIONS """
 
+
 @freeze_time("2024-09-24 11:25:31 UTC")
 def test_arg_to_timestamp():
     assert (

--- a/Packs/SekoiaXDR/Integrations/SekoiaXDR/SekoiaXDR_test.py
+++ b/Packs/SekoiaXDR/Integrations/SekoiaXDR/SekoiaXDR_test.py
@@ -1,6 +1,7 @@
 from CommonServerPython import *
 
 import SekoiaXDR  # type: ignore
+from freezegun import freeze_time
 
 from datetime import datetime
 import pytest
@@ -28,7 +29,7 @@ def client():
 
 """ TEST HELPER FUNCTIONS """
 
-
+@freeze_time("2024-09-24 11:25:31 UTC")
 def test_arg_to_timestamp():
     assert (
         SekoiaXDR.arg_to_timestamp("2024-04-25T09:20:55", "lastupdate", True)


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [Build failure](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/9003099/raw)

## Description
Adding Freeze to Sekoia tests using timestamps to avoid flakiness.
