### PR TITLE
Extract Indicators From File PB: not convert docx to pdf

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -1106,10 +1106,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "14":
     id: "14"
-    taskid: b00731f6-af3b-4011-8be2-3680f778777e
+    taskid: a81da43e-d75f-4860-8c79-d59851d1410c
     type: regular
     task:
-      id: b00731f6-af3b-4011-8be2-3680f778777e
+      id: a81da43e-d75f-4860-8c79-d59851d1410c
       version: -1
       name: Extract text from images
       description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
@@ -1170,8 +1170,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 2640,
-          "y": 1320
+          "x": 2190,
+          "y": 1310
         }
       }
     note: false
@@ -1314,6 +1314,22 @@ tasks:
                       value:
                         simple: CDFV2 Encrypted
                     ignorecase: true
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                    right:
+                      value:
+                        simple: docx
+                - - operator: isNotEqualString
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                    right:
+                      value:
+                        simple: doc
                 accessor: EntryID
                 transformers:
                 - operator: uniq
@@ -1601,7 +1617,7 @@ tasks:
       - "10"
       "yes":
       - "13"
-      - "28"
+      - "24"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -1813,10 +1829,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "24":
     id: "24"
-    taskid: ca969180-8bc8-43a8-8018-6fc398457815
+    taskid: 424f69f0-0339-42f1-8a9e-c73f4e171412
     type: regular
     task:
-      id: ca969180-8bc8-43a8-8018-6fc398457815
+      id: 424f69f0-0339-42f1-8a9e-c73f4e171412
       version: -1
       name: Extract Text from QR Code
       description: Extracts the text from a QR code. The output of this script includes the output of the script "extractIndicators" run on the text extracted from the QR code.
@@ -1835,28 +1851,12 @@ tasks:
           - - operator: containsGeneral
               left:
                 value:
-                  simple: inputs.File.Info
+                  simple: inputs.File.Type
                 iscontext: true
               right:
                 value:
-                  simple: image/png
+                  simple: image
               ignorecase: true
-            - operator: isEqualString
-              left:
-                value:
-                  simple: inputs.File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: image/jpeg
-            - operator: isEqualString
-              left:
-                value:
-                  simple: inputs.File.Info
-                iscontext: true
-              right:
-                value:
-                  simple: image/jpg
           accessor: EntryID
           transformers:
           - operator: append
@@ -1878,8 +1878,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 1320,
-          "y": 1330
+          "x": 1530,
+          "y": 1310
         }
       }
     note: false
@@ -2138,66 +2138,6 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
-  "28":
-    id: "28"
-    taskid: ff1834e4-8544-4395-86e4-81f108cf6920
-    type: condition
-    task:
-      id: ff1834e4-8544-4395-86e4-81f108cf6920
-      version: -1
-      name: Does ReadQRCode support the image?
-      type: condition
-      iscommand: false
-      brand: ""
-      description: ""
-    nexttasks:
-      '#default#':
-      - "19"
-      "yes":
-      - "24"
-    separatecontext: false
-    conditions:
-    - label: "yes"
-      condition:
-      - - operator: isEqualString
-          left:
-            value:
-              simple: inputs.File.Info
-            iscontext: true
-          right:
-            value:
-              simple: image/png
-        - operator: isEqualString
-          left:
-            value:
-              simple: inputs.File.Info
-            iscontext: true
-          right:
-            value:
-              simple: image/jpeg
-        - operator: isEqualString
-          left:
-            value:
-              simple: inputs.File.Info
-            iscontext: true
-          right:
-            value:
-              simple: image/jpg
-    continueonerrortype: ""
-    view: |-
-      {
-        "position": {
-          "x": 1820,
-          "y": 1050
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
-    isoversize: false
-    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -2218,7 +2158,7 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1815,
-        "width": 3995,
+        "width": 3545,
         "x": -975,
         "y": -10
       }

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -1472,6 +1472,22 @@ tasks:
                 value:
                   simple: xlsb
               ignorecase: true
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: docx
+          - - operator: isNotEqualString
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+              right:
+                value:
+                  simple: doc
           - - operator: notContainsGeneral
               left:
                 value:

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -756,7 +756,12 @@ tasks:
                       value:
                         simple: pptx
                     ignorecase: true
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -785,7 +790,12 @@ tasks:
                     right:
                       value:
                         simple: xlsm
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -793,7 +803,12 @@ tasks:
                     right:
                       value:
                         simple: docm
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -1007,7 +1022,12 @@ tasks:
               right:
                 value:
                   simple: xlsm
-          - - operator: isNotEqualString
+          - - operator: isNotExists
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+            - operator: isNotEqualString
               left:
                 value:
                   simple: inputs.File.Extension
@@ -1296,7 +1316,12 @@ tasks:
                       value:
                         simple: text/rtf
                     ignorecase: true
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -1314,7 +1339,12 @@ tasks:
                       value:
                         simple: CDFV2 Encrypted
                     ignorecase: true
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -1322,7 +1352,12 @@ tasks:
                     right:
                       value:
                         simple: docx
-                - - operator: isNotEqualString
+                - - operator: isNotExists
+                    left:
+                      value:
+                        simple: inputs.File.Extension
+                      iscontext: true
+                  - operator: isNotEqualString
                     left:
                       value:
                         simple: inputs.File.Extension
@@ -1463,7 +1498,12 @@ tasks:
                 value:
                   simple: text/rtf
               ignorecase: true
-          - - operator: isNotEqualString
+          - - operator: isNotExists
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+            - operator: isNotEqualString
               left:
                 value:
                   simple: inputs.File.Extension
@@ -1472,7 +1512,12 @@ tasks:
                 value:
                   simple: xlsb
               ignorecase: true
-          - - operator: isNotEqualString
+          - - operator: isNotExists
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+            - operator: isNotEqualString
               left:
                 value:
                   simple: inputs.File.Extension
@@ -1480,7 +1525,12 @@ tasks:
               right:
                 value:
                   simple: docx
-          - - operator: isNotEqualString
+          - - operator: isNotExists
+              left:
+                value:
+                  simple: inputs.File.Extension
+                iscontext: true
+            - operator: isNotEqualString
               left:
                 value:
                   simple: inputs.File.Extension

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -1106,10 +1106,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "14":
     id: "14"
-    taskid: a81da43e-d75f-4860-8c79-d59851d1410c
+    taskid: b00731f6-af3b-4011-8be2-3680f778777e
     type: regular
     task:
-      id: a81da43e-d75f-4860-8c79-d59851d1410c
+      id: b00731f6-af3b-4011-8be2-3680f778777e
       version: -1
       name: Extract text from images
       description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
@@ -1170,8 +1170,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 2190,
-          "y": 1310
+          "x": 2640,
+          "y": 1320
         }
       }
     note: false
@@ -1617,7 +1617,7 @@ tasks:
       - "10"
       "yes":
       - "13"
-      - "24"
+      - "28"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -1829,10 +1829,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "24":
     id: "24"
-    taskid: 424f69f0-0339-42f1-8a9e-c73f4e171412
+    taskid: ca969180-8bc8-43a8-8018-6fc398457815
     type: regular
     task:
-      id: 424f69f0-0339-42f1-8a9e-c73f4e171412
+      id: ca969180-8bc8-43a8-8018-6fc398457815
       version: -1
       name: Extract Text from QR Code
       description: Extracts the text from a QR code. The output of this script includes the output of the script "extractIndicators" run on the text extracted from the QR code.
@@ -1851,12 +1851,28 @@ tasks:
           - - operator: containsGeneral
               left:
                 value:
-                  simple: inputs.File.Type
+                  simple: inputs.File.Info
                 iscontext: true
               right:
                 value:
-                  simple: image
+                  simple: image/png
               ignorecase: true
+            - operator: isEqualString
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: image/jpeg
+            - operator: isEqualString
+              left:
+                value:
+                  simple: inputs.File.Info
+                iscontext: true
+              right:
+                value:
+                  simple: image/jpg
           accessor: EntryID
           transformers:
           - operator: append
@@ -1878,8 +1894,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 1530,
-          "y": 1310
+          "x": 1320,
+          "y": 1330
         }
       }
     note: false
@@ -2138,6 +2154,66 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+  "28":
+    id: "28"
+    taskid: ff1834e4-8544-4395-86e4-81f108cf6920
+    type: condition
+    task:
+      id: ff1834e4-8544-4395-86e4-81f108cf6920
+      version: -1
+      name: Does ReadQRCode support the image?
+      type: condition
+      iscommand: false
+      brand: ""
+      description: ""
+    nexttasks:
+      '#default#':
+      - "19"
+      "yes":
+      - "24"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isEqualString
+          left:
+            value:
+              simple: inputs.File.Info
+            iscontext: true
+          right:
+            value:
+              simple: image/png
+        - operator: isEqualString
+          left:
+            value:
+              simple: inputs.File.Info
+            iscontext: true
+          right:
+            value:
+              simple: image/jpeg
+        - operator: isEqualString
+          left:
+            value:
+              simple: inputs.File.Info
+            iscontext: true
+          right:
+            value:
+              simple: image/jpg
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 1820,
+          "y": 1050
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -2158,7 +2234,7 @@ view: |-
     "paper": {
       "dimensions": {
         "height": 1815,
-        "width": 3545,
+        "width": 3995,
         "x": -975,
         "y": -10
       }

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_6_43.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_6_43.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Extract Indicators From File - Generic v2
+
+Fixed an issue where the file conversion tasks attempted to convert a doc/docx file although these files are not supposed to be converted.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.6.42",
+    "currentVersion": "2.6.43",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-41176

## Description
currently, we consider a file which contain `xml` in the `file.info` - as file to be converted to pdf
this lead to convert also a docx file with `vnd.openxmlformats-officedocument.wordprocessingml.document` in the `file.info`

adding additional check to filter out `doc/docx` files