### PR TITLE
exclude 'dbotscore' from deletions

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_66.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_66.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DeleteContext
+
+- Fixed an issue where 'DBotScore' key was not excluded from deletion, causing performance issues.

--- a/Packs/CommonScripts/ReleaseNotes/1_15_66.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_66.md
@@ -3,4 +3,4 @@
 
 ##### DeleteContext
 
-- Fixed an issue where 'DBotScore' key was not excluded from deletion, causing performance issues.
+Fixed an issue where *DBotScore* key was not excluded from deletion.

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -13,13 +13,13 @@ function errorEntry(text) {
  * @param {Array<string>} keysToDelete - An array of keys to delete.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = [], _keysToKeep = []) {
+function deleteKeys(keysToDelete = [], _keysToKeep = [], keepDBotScore = false) {
     var deletedKeys = []
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
-        if (key === DBOT_SCORE_KEY){
+        if (DBOT_SCORE_KEY in _keysToKeep){
             continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -14,13 +14,13 @@ function errorEntry(text) {
  * @param {Array<string>} _keysToKeep - An array of keys to keep.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = [], _keysToKeep = []) {
+function deleteKeys(keysToDelete = [], _keysToKeep = [], KeepDBotScoreKey = false) {
     var deletedKeys = []
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
-        if (DBOT_SCORE_KEY in _keysToKeep){
+        if (DBOT_SCORE_KEY in _keysToKeep && KeepDBotScoreKey){
             continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;
@@ -63,7 +63,15 @@ if (!shouldDeleteAll && !args.key) {
 
 if (shouldDeleteAll) {
     var keysToKeepObj = {};
+    var KeepDBotScoreKey = false;
     var value;
+    
+    index = keysToKeep.indexOf("DBotScore");
+    if (index > -1) {
+        keysToKeep.splice(index, 1);
+        KeepDBotScoreKey = true;
+    }
+    
     // Collect all the keys to keep.
     for (var i = 0; i < keysToKeep.length; i++) {
         value = dq(invContext, keysToKeep[i]);
@@ -84,7 +92,7 @@ if (shouldDeleteAll) {
     }
     var keysToDelete = Object.keys(invContext);
     // Delete all the keys, do not state deletion of keysToKeep since they are re-created.
-    var message = deleteKeys(keysToDelete, keysToKeep);
+    var message = deleteKeys(keysToDelete, keysToKeep, KeepDBotScoreKey);
 
     return {
         Type: entryTypes.note,

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -19,7 +19,6 @@ function deleteKeys(keysToDelete = [], _keysToKeep = [], keepDBotScoreKey = fals
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
-        // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
         if (key == DBOT_SCORE_KEY && keepDBotScoreKey){
             continue;
         }

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -13,7 +13,7 @@ function errorEntry(text) {
  * @param {Array<string>} keysToDelete - An array of keys to delete.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = []) {
+function deleteKeys(keysToDelete = [], _keysToKeep = []) {
     var deletedKeys = []
     var errors = []
     var message = '';

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -14,13 +14,13 @@ function errorEntry(text) {
  * @param {Array<string>} _keysToKeep - An array of keys to keep.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = [], _keysToKeep = [], KeepDBotScoreKey = false) {
+function deleteKeys(keysToDelete = [], _keysToKeep = [], keepDBotScoreKey = false) {
     var deletedKeys = []
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
-        if (DBOT_SCORE_KEY in _keysToKeep && KeepDBotScoreKey){
+        if (DBOT_SCORE_KEY in _keysToKeep && keepDBotScoreKey){
             continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;
@@ -63,13 +63,13 @@ if (!shouldDeleteAll && !args.key) {
 
 if (shouldDeleteAll) {
     var keysToKeepObj = {};
-    var KeepDBotScoreKey = false;
+    var keepDBotScoreKey = false;
     var value;
     
     index = keysToKeep.indexOf("DBotScore");
     if (index > -1) {
         keysToKeep.splice(index, 1);
-        KeepDBotScoreKey = true;
+        keepDBotScoreKey = true;
     }
     
     // Collect all the keys to keep.
@@ -92,7 +92,7 @@ if (shouldDeleteAll) {
     }
     var keysToDelete = Object.keys(invContext);
     // Delete all the keys, do not state deletion of keysToKeep since they are re-created.
-    var message = deleteKeys(keysToDelete, keysToKeep, KeepDBotScoreKey);
+    var message = deleteKeys(keysToDelete, keysToKeep, keepDBotScoreKey);
 
     return {
         Type: entryTypes.note,

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -20,7 +20,7 @@ function deleteKeys(keysToDelete = [], _keysToKeep = []) {
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
         if (key === "DBotScore"){
-            continue
+            continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;
         const keyToDelete = isSubPlaybookKey ? 'subplaybook-${currentPlaybookID}.' + originalKey: originalKey;

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -20,7 +20,7 @@ function deleteKeys(keysToDelete = [], _keysToKeep = [], keepDBotScoreKey = fals
     var message = '';
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
-        if (DBOT_SCORE_KEY in _keysToKeep && keepDBotScoreKey){
+        if (key == DBOT_SCORE_KEY && keepDBotScoreKey){
             continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -18,6 +18,10 @@ function deleteKeys(keysToDelete = [], _keysToKeep = []) {
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
+        // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
+        if (key === "DBotScore"){
+            continue
+        }
         const originalKey = typeof key === "string" ? key.trim() : key;
         const keyToDelete = isSubPlaybookKey ? 'subplaybook-${currentPlaybookID}.' + originalKey: originalKey;
         const result = executeCommand('delContext', { key: keyToDelete });

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -11,6 +11,7 @@ function errorEntry(text) {
 /**
  * Deletes keys from the context and handles errors.
  * @param {Array<string>} keysToDelete - An array of keys to delete.
+ * @param {Array<string>} _keysToKeep - An array of keys to keep.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
 function deleteKeys(keysToDelete = [], _keysToKeep = []) {

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -13,13 +13,13 @@ function errorEntry(text) {
  * @param {Array<string>} keysToDelete - An array of keys to delete.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = [], _keysToKeep = []) {
+function deleteKeys(keysToDelete = []) {
     var deletedKeys = []
     var errors = []
     var message = '';
     for (var key of keysToDelete) {
         // 'DBotScore' key shall not be deleted in order to prevent caching it repeatedly and impacting performance.
-        if (key === "DBotScore"){
+        if (key === DBOT_SCORE_KEY){
             continue;
         }
         const originalKey = typeof key === "string" ? key.trim() : key;
@@ -40,10 +40,10 @@ function deleteKeys(keysToDelete = [], _keysToKeep = []) {
     return errors.join(LINE_SEPARATOR) + LINE_SEPARATOR + message;
 }
 
+const DBOT_SCORE_KEY = 'DBotScore';
 var shouldDeleteAll = (args.all === 'yes');
 var isSubPlaybookKey = (args.subplaybook === 'yes');
 var keysToKeep = (args.keysToKeep) ? args.keysToKeep.split(',').map(item => item.trim()) : [];
-
 if (args.subplaybook === 'auto') {
     var res = executeCommand('Print', { value: 'id=${currentPlaybookID}' });
     if (res && res[0].Contents && res[0].Contents.startsWith('id=')) {
@@ -62,7 +62,6 @@ if (!shouldDeleteAll && !args.key) {
 
 if (shouldDeleteAll) {
     var keysToKeepObj = {};
-    var KeepDBotScoreKey = false;
     var value;
     // Collect all the keys to keep.
     for (var i = 0; i < keysToKeep.length; i++) {

--- a/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
+++ b/Packs/CommonScripts/Scripts/DeleteContext/DeleteContext.js
@@ -13,7 +13,7 @@ function errorEntry(text) {
  * @param {Array<string>} keysToDelete - An array of keys to delete.
  * @returns {string} A message summarizing the outcome of the delete operation.
  */
-function deleteKeys(keysToDelete = [], _keysToKeep = [], keepDBotScore = false) {
+function deleteKeys(keysToDelete = [], _keysToKeep = []) {
     var deletedKeys = []
     var errors = []
     var message = '';

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.65",
+    "currentVersion": "1.15.66",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-42280](https://jira-dc.paloaltonetworks.com/browse/XSUP-42280)

## Description
'DBotScore' key is now excluded from context deletion, in order to prevent caching it repeatadly and causing performance issues.
