### PR TITLE
XDR_Disconnected_Endpoints_Fix

### DIFF
--- a/Packs/CortexXDR/Playbooks/playbook-Cortex_XDR_disconnected_endpoints.yml
+++ b/Packs/CortexXDR/Playbooks/playbook-Cortex_XDR_disconnected_endpoints.yml
@@ -441,7 +441,7 @@ tasks:
             - operator: isEqualString
               left:
                 value:
-                  simple: PaloAltoNetworksXDR.EndpoiPaloAltoNetworksXDR.Endpoint.endpoint_status
+                  simple: PaloAltoNetworksXDR.Endpoint.endpoint_status
                 iscontext: true
               right:
                 value:

--- a/Packs/CortexXDR/ReleaseNotes/6_1_79.md
+++ b/Packs/CortexXDR/ReleaseNotes/6_1_79.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Cortex XDR disconnected endpoints
+
+Fixed an issue with incorrect context key usage in the 'Set Disconnected Endpoints' task.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "6.1.78",
+    "currentVersion": "6.1.79",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixed an issue with incorrect context key usage in the 'Set Disconnected Endpoints' task.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-11928

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
