### PR TITLE
[Native image] skip ParseEmailFilesV2  GA

### DIFF
--- a/Tests/docker_native_image_config.json
+++ b/Tests/docker_native_image_config.json
@@ -181,6 +181,7 @@
             "id": "ParseEmailFilesV2",
             "reason": "Script uses an updated openssl lib than native, see CIAC-11469",
             "ignored_native_images": [
+                "native:8.8",
                 "native:8.7",
                 "native:8.6",
                 "native:dev",


### PR DESCRIPTION
## Related Issues
fixes: link to the issue

## Description
In #35796, we added ParseEmailFilesV2 to the ignore list of the native. For more details on why we added it, please see [this](https://jira-dc.paloaltonetworks.com/browse/CIAC-11469) ticket.

As part of releasing the new GA version (8.8), we forgot to add the new version to the images that need to be ignored in ParseEmailFilesV2. This caused an issue in the coverage of the UT.
