### PR TITLE
urlscan country option

### DIFF
--- a/Packs/UrlScan/CONTRIBUTORS.json
+++ b/Packs/UrlScan/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+    "Ryan McVicar"
+]

--- a/Packs/UrlScan/Integrations/UrlScan/README.md
+++ b/Packs/UrlScan/Integrations/UrlScan/README.md
@@ -12,6 +12,7 @@
 <li><strong>API Key (needed only for submitting URLs for scanning)</strong></li>
 <li><strong>Scan Visibility</strong>: Determines the visibility level of the scan. This will override the 'public submissions' setting.</li>
 <li><strong>Source Reliability.</strong> Reliability of the source providing the intelligence data. (The default value is C - Fairly reliable)</li>
+<li><strong>Scan Country.</strong> Specify which country the scan should be performed from. If you omit this value, urlscan will try to do automatic country detection based on the TLD of the URL, GeoIP information of the server and of the user.</li>
 <li><strong>Trust any certificate (not secure)</strong></li>
 <li><strong>Use system proxy settings</strong></li>
 <li>

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -252,7 +252,7 @@ def urlscan_submit_url(client, url):
         submission_dict['customagent'] = demisto.args().get('useragent')
     elif demisto.params().get('useragent'):
         submission_dict['customagent'] = demisto.params().get('useragent')
-        
+
     if client.country:
         submission_dict['country'] = client.country.split(' ')[0]
 
@@ -833,7 +833,7 @@ def main():
     use_ssl = not params.get('insecure', False)
     reliability = params.get('integrationReliability')
     reliability = reliability if reliability else DBotScoreReliability.C
-    country = params.get('country','')
+    country = params.get('country', '')
     
     if DBotScoreReliability.is_valid_type(reliability):
         reliability = DBotScoreReliability.get_dbot_score_reliability_from_str(reliability)
@@ -849,7 +849,7 @@ def main():
         threshold=threshold,
         use_ssl=use_ssl,
         reliability=reliability,
-        country = country
+        country=country
     )
 
     demisto.debug(f'Command being called is {demisto.command()}')

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -45,7 +45,7 @@ RELATIONSHIP_TYPE = {
 
 class Client:
     def __init__(self, api_key='', user_agent='', scan_visibility=None, threshold=None, use_ssl=False,
-                 reliability=DBotScoreReliability.C):
+                 reliability=DBotScoreReliability.C, country=None):
         self.base_url = 'https://urlscan.io/'
         self.base_api_url = 'https://urlscan.io/api/v1/'
         self.api_key = api_key
@@ -54,6 +54,7 @@ class Client:
         self.scan_visibility = scan_visibility
         self.use_ssl = use_ssl
         self.reliability = reliability
+        self.country = country
 
 
 '''HELPER FUNCTIONS'''
@@ -251,6 +252,9 @@ def urlscan_submit_url(client, url):
         submission_dict['customagent'] = demisto.args().get('useragent')
     elif demisto.params().get('useragent'):
         submission_dict['customagent'] = demisto.params().get('useragent')
+        
+    if client.country:
+        submission_dict['country'] = (client.country).split(' ')[0]
 
     sub_json = json.dumps(submission_dict)
     retries = int(demisto.args().get('retries', 0))
@@ -829,7 +833,8 @@ def main():
     use_ssl = not params.get('insecure', False)
     reliability = params.get('integrationReliability')
     reliability = reliability if reliability else DBotScoreReliability.C
-
+    country = params.get('country','')
+    
     if DBotScoreReliability.is_valid_type(reliability):
         reliability = DBotScoreReliability.get_dbot_score_reliability_from_str(reliability)
     else:
@@ -843,7 +848,8 @@ def main():
         scan_visibility=scan_visibility,
         threshold=threshold,
         use_ssl=use_ssl,
-        reliability=reliability
+        reliability=reliability,
+        country = country
     )
 
     demisto.debug(f'Command being called is {demisto.command()}')

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -254,7 +254,7 @@ def urlscan_submit_url(client, url):
         submission_dict['customagent'] = demisto.params().get('useragent')
         
     if client.country:
-        submission_dict['country'] = (client.country).split(' ')[0]
+        submission_dict['country'] = client.country.split(' ')[0]
 
     sub_json = json.dumps(submission_dict)
     retries = int(demisto.args().get('retries', 0))

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.py
@@ -834,7 +834,7 @@ def main():
     reliability = params.get('integrationReliability')
     reliability = reliability if reliability else DBotScoreReliability.C
     country = params.get('country', '')
-    
+
     if DBotScoreReliability.is_valid_type(reliability):
         reliability = DBotScoreReliability.get_dbot_score_reliability_from_str(reliability)
     else:

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -38,6 +38,36 @@ configuration:
   required: true
   type: 15
   section: Collect
+- additionalinfo: Specify which country the scan should be performed 
+  defaultvalue: 
+  display: Scan Country
+  name: country
+  options:
+    - "AT - Austria"
+    - "AU - Australia"
+    - "CA - Canada"
+    - "CH - Switzerland"
+    - "DE - Germany"
+    - "DK - Denmark"
+    - "ES - Spain"
+    - "FI - Finland"
+    - "FR - France"
+    - "GB - United Kingdom"
+    - "IL - Israel"
+    - "IS - Iceland"
+    - "IT - Italy"
+    - "JP - Japan"
+    - "NL - Netherlands"
+    - "NO - Norway"
+    - "NZ - New Zealand"
+    - "PL - Poland"
+    - "PT - Portugal"
+    - "SE - Sweden"
+    - "SG - Singapore"
+    - "US - United States"
+  required: false
+  type: 15
+  section: Collect
 - defaultvalue: '1'
   display: URL Threshold. Minimum number of positive results from urlscan.io to consider the URL malicious.
   name: url_threshold

--- a/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
+++ b/Packs/UrlScan/Integrations/UrlScan/UrlScan.yml
@@ -39,7 +39,6 @@ configuration:
   type: 15
   section: Collect
 - additionalinfo: Specify which country the scan should be performed 
-  defaultvalue: 
   display: Scan Country
   name: country
   options:

--- a/Packs/UrlScan/ReleaseNotes/1_2_15.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_15.md
@@ -1,0 +1,5 @@
+
+#### Integrations
+
+##### urlscan.io
+Added support for the integration parameter `country`, which enables you to chose what country to originate scans from.

--- a/Packs/UrlScan/ReleaseNotes/1_2_15.md
+++ b/Packs/UrlScan/ReleaseNotes/1_2_15.md
@@ -2,4 +2,4 @@
 #### Integrations
 
 ##### urlscan.io
-Added support for the integration parameter `country`, which enables you to chose what country to originate scans from.
+Added support for the *country* integration parameter, which enables you to choose what country to originate scans from.

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "URLScan.io",
     "description": "urlscan.io Web Threat Intelligence",
     "support": "partner",
-    "currentVersion": "1.2.14",
+    "currentVersion": "1.2.15",
     "author": "urlscan GmbH",
     "url": "https://urlscan.io",
     "email": "support@urlscan.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
No related issues

## Description
Added the option to specify what country to scan from at the integration instance level. The available countries are listed in the [api/v1/availableCountries endpoint](https://urlscan.io/api/v1/availableCountries/), and have been implemented in the instance choice as a single choice field. 


## Must have
- [ ] Tests
- [x] Documentation 
