### PR TITLE
[Gitlab V2] Update deprecated request params

### DIFF
--- a/Packs/GitLab/Integrations/GitLabv2/GitLabv2.py
+++ b/Packs/GitLab/Integrations/GitLabv2/GitLabv2.py
@@ -1080,8 +1080,8 @@ def commit_list_command(client: Client, args: dict[str, Any]) -> CommandResults:
         response_title = 'List Commits'
         page_number = arg_to_number(args.get('page')) or 1
         limit = arg_to_number(args.get('limit')) or 50
-        params = assign_params(ref_name=args.get('ref_name'), created_before=return_date_arg_as_iso(args.get('created_before')),
-                               created_after=return_date_arg_as_iso(args.get('created_after')), path=args.get('path'),
+        params = assign_params(ref_name=args.get('ref_name'), until=return_date_arg_as_iso(args.get('created_before')),
+                               since=return_date_arg_as_iso(args.get('created_after')), path=args.get('path'),
                                with_stats=args.get('with_stats'), first_parent=args.get('first_parent'),
                                order=args.get('order'), all_=args.get('all'))
         response = response_according_pagination(client.commit_list_request, limit, page_number, params, None)

--- a/Packs/GitLab/ReleaseNotes/2_2_23.md
+++ b/Packs/GitLab/ReleaseNotes/2_2_23.md
@@ -3,4 +3,4 @@
 
 ##### GitLab v2
 
-- Updated the ***gitlab-commit-list*** command to use *since* instead of *created_after* and *until* instead of *created_before* due to API changes.
+- Fixed an issue in the ***gitlab-commit-list*** command where the *created_after* and *created_before* arguments did not filter the response entries within the requested time frame due to API changes.

--- a/Packs/GitLab/ReleaseNotes/2_2_23.md
+++ b/Packs/GitLab/ReleaseNotes/2_2_23.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### GitLab v2
+
+- Fixed an issue in ***gitlab-commit-list*** command where *created_after* and *created_before* didn't filter commits properly.

--- a/Packs/GitLab/ReleaseNotes/2_2_23.md
+++ b/Packs/GitLab/ReleaseNotes/2_2_23.md
@@ -3,4 +3,4 @@
 
 ##### GitLab v2
 
-- Fixed an issue in ***gitlab-commit-list*** command where *created_after* and *created_before* didn't filter commits properly.
+- Updated the ***gitlab-commit-list*** command to use *since* instead of *created_after* and *until* instead of *created_before* due to API changes.

--- a/Packs/GitLab/pack_metadata.json
+++ b/Packs/GitLab/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GitLab",
     "description": "Pack for handling gitlab operations",
     "support": "xsoar",
-    "currentVersion": "2.2.22",
+    "currentVersion": "2.2.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-42366](https://jira-dc.paloaltonetworks.com/browse/XSUP-42366)

## Description
Replace deprecated request parameters in [Commits API](https://docs.gitlab.com/ee/api/commits.html). More information in the attached Jira ticket.

## Screenshots
Before changes - some entries in the response are out of the desired time-frame:
![SCR-20241014-dth](https://github.com/user-attachments/assets/85230a39-e3ca-44a0-9acf-7ef9991103a0)

After changes - All entries in the response are in the desired time-frame:
![SCR-20241014-dud](https://github.com/user-attachments/assets/84c99113-1818-4ccf-81b5-c9e6815f1c74)
