### PR TITLE
Add IN161 ignore to AtlassianConfluenceCloud.yml

### DIFF
--- a/Packs/AtlassianConfluenceCloud/.pack-ignore
+++ b/Packs/AtlassianConfluenceCloud/.pack-ignore
@@ -1,0 +1,2 @@
+[file:AtlassianConfluenceCloud.yml]
+ignore=IN161


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Upload packs to the marketplace failed because of the IN161 validation - this validation didn't failed in the [PR](https://github.com/demisto/content/pull/36077/files) but failed in the upload flow. add this validation to the ignore.

## Must have
- [ ] Tests
- [ ] Documentation 
