### PR TITLE
[Microsoft Sentinel] Fix issue in mirroring the AlertsCount field

### DIFF
--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel.py
@@ -562,7 +562,8 @@ def get_remote_incident_data(client: AzureSentinelClient, incident_id: str):
     updated_object: Dict[str, Any] = {}
 
     for field in INCOMING_MIRRORED_FIELDS:
-        if value := incident_mirrored_data.get(field):
+        value = incident_mirrored_data.get(field)
+        if value is not None:
             updated_object[field] = value
 
     return mirrored_data, updated_object

--- a/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
+++ b/Packs/AzureSentinel/Integrations/AzureSentinel/AzureSentinel_test.py
@@ -1581,11 +1581,14 @@ def test_get_remote_incident_data(mocker):
         Verify the function returns the expected mirrored data and updated object
     """
     client = mock_client()
-    mock_response = {'name': 'id-incident-1', 'properties': {'title': 'title-incident-1'}}
+    mock_response = {'name': 'id-incident-1', 'properties': {'title': 'title-incident-1', 'additionalData': {'alertsCount': 0}}}
     mocker.patch.object(client, 'http_request', return_value=mock_response)
 
     result = get_remote_incident_data(client, 'id-incident-1')
-    assert result == (mock_response, {'ID': 'id-incident-1', 'Title': 'title-incident-1'})
+    assert result == (
+        mock_response,
+        {'ID': 'id-incident-1', 'Title': 'title-incident-1', 'AlertsCount': 0, 'tags': [], 'relatedAnalyticRuleIds': []}
+    )
 
 
 @pytest.mark.parametrize("incident, expected_contents", [

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_49.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_49.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Sentinel
+
+Fixed an issue where the **get-remote-data** (mirroring) command was not working properly for *Alerts Count* field.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Sentinel",
     "description": "Microsoft Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.5.48",
+    "currentVersion": "1.5.49",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-42696)

## Description
Fixed an issue where the **get-remote-data** (mirroring) command was not working properly for *Alerts Count* field.

## Must have
- [x] Tests
