### PR TITLE
Added large files hook enforce all to include committed files

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -16,7 +16,7 @@ repos:
     min_py_version: '3.7'
     files: .+_test.py$
   - id: check-added-large-files
-    args: ['--maxkb=5120']
+    args: ['--maxkb=5120', --enforce-all]
 - repo: https://github.com/python-poetry/poetry
   rev: 1.8.2
   hooks:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-7098

## Related PRs
https://github.com/demisto/content/pull/36057

## Description
Added the `--enforce-all` [flag](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-added-large-files) to include all files (not only staged)

## Must have
- [ ] Tests
- [ ] Documentation 
