### PR TITLE
[Microsoft Graph Mail] Enhance msgraph-mail-get-attachment command

### DIFF
--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1293,7 +1293,7 @@ class GraphMailUtils:
         item = raw_attachment.get('item', {})
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:
-            return_message_attachment_as_downloadable_file = client and argToBoolean(
+            return_message_attachment_as_downloadable_file: bool = client and argToBoolean(
                 args.get('should_download_message_attachment', False))
             if return_message_attachment_as_downloadable_file:
                 # return the message attachment as a file result

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1267,7 +1267,7 @@ class GraphMailUtils:
         return 1
 
     @staticmethod
-    def item_result_creator(raw_attachment, user_id, args={}, client=None) -> dict[str, Any] | CommandResults:
+    def item_result_creator(raw_attachment, user_id, args, client) -> dict[str, Any] | CommandResults:
         """
         Create a result object for an attachment item.
         This method processes raw attachment data and returns either an XSOAR file result or a command result
@@ -1294,6 +1294,7 @@ class GraphMailUtils:
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:
             if client and argToBoolean(args.get('should_download_message_attachment', False)):
+                # return the message attachment as a file result
                 attachment_content = client._get_attachment_mime(
                     args.get('message_id'),
                     args.get('attachment_id'),
@@ -1303,6 +1304,7 @@ class GraphMailUtils:
                 demisto.debug(f'Email attachment of type "microsoft.graph.message" acquired successfully, {attachment_name=}')
                 return fileResult(attachment_name, attachment_content)
             else:
+                # return the message attachment as a command result
                 message_id = raw_attachment.get('id')
                 item['id'] = message_id
                 mail_context = GraphMailUtils.build_mail_object(item, user_id=user_id, get_body=True)
@@ -1347,7 +1349,7 @@ class GraphMailUtils:
             raise DemistoException('Attachment could not be decoded')
 
     @staticmethod
-    def create_attachment(raw_attachment, user_id, args={}, client=None, legacy_name=False) -> CommandResults | dict:
+    def create_attachment(raw_attachment, user_id, args, client, legacy_name=False) -> CommandResults | dict:
         attachment_type = raw_attachment.get('@odata.type', '')
         # Documentation about the different attachment types
         # https://docs.microsoft.com/en-us/graph/api/attachment-get?view=graph-rest-1.0&tabs=http

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1267,7 +1267,7 @@ class GraphMailUtils:
         return 1
 
     @staticmethod
-    def item_result_creator(raw_attachment, user_id, args, client=None):
+    def item_result_creator(raw_attachment, user_id, args={}, client=None):
         item = raw_attachment.get('item', {})
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:
@@ -1325,12 +1325,12 @@ class GraphMailUtils:
             raise DemistoException('Attachment could not be decoded')
 
     @staticmethod
-    def create_attachment(args, raw_attachment, user_id, client, legacy_name=False) -> CommandResults | dict:
+    def create_attachment(raw_attachment, user_id, args={}, client=None, legacy_name=False) -> CommandResults | dict:
         attachment_type = raw_attachment.get('@odata.type', '')
         # Documentation about the different attachment types
         # https://docs.microsoft.com/en-us/graph/api/attachment-get?view=graph-rest-1.0&tabs=http
         if 'itemAttachment' in attachment_type:
-            return GraphMailUtils.item_result_creator(raw_attachment, user_id, args, client=client)
+            return GraphMailUtils.item_result_creator(raw_attachment, user_id, args, client)
         elif 'fileAttachment' in attachment_type:
             return GraphMailUtils.file_result_creator(raw_attachment, legacy_name)
         else:
@@ -1841,9 +1841,8 @@ def get_attachment_command(client: MsGraphMailBaseClient, args) -> list[CommandR
     kwargs = {arg_key: args.get(arg_key) for arg_key in ['message_id', 'folder_id', 'attachment_id']}
     kwargs['user_id'] = args.get('user_id', client._mailbox_to_fetch)
     raw_response = client.get_attachment(**kwargs)
-    return [GraphMailUtils.create_attachment(args, raw_attachment=attachment, user_id=kwargs['user_id'], client=client,
-                                             legacy_name=client.legacy_name)
-            for attachment in raw_response]
+    return [GraphMailUtils.create_attachment(raw_attachment=attachment, user_id=kwargs['user_id'], args=args, client=client,
+                                             legacy_name=client.legacy_name) for attachment in raw_response]
 
 
 def create_folder_command(client: MsGraphMailBaseClient, args) -> CommandResults:

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1267,7 +1267,29 @@ class GraphMailUtils:
         return 1
 
     @staticmethod
-    def item_result_creator(raw_attachment, user_id, args={}, client=None):
+    def item_result_creator(raw_attachment, user_id, args={}, client=None) -> dict[str, Any] | CommandResults:
+        """
+        Create a result object for an attachment item.
+        This method processes raw attachment data and returns either an XSOAR file result or a command result
+        based on the attachment type and provided arguments.
+
+        Args:
+            raw_attachment (dict): The raw attachment data from the API response.
+            user_id (str): The ID of the user associated with the attachment.
+            args (dict): Additional arguments for processing the attachment.
+            client (MsGraphMailBaseClient, optional): The client instance for making additional API calls.
+
+        Returns:
+            dict[str, Any] | CommandResults:
+                - If the attachment is a message and should be downloaded, returns a dict containing file result.
+                - If the attachment is a message but should not be downloaded, returns a CommandResults with message details.
+                - If the attachment is of an unsupported type, returns a CommandResults with an error message.
+
+        Note:
+            - The method handles different types of attachments, particularly focusing on message attachments.
+              It can either return the attachment as a downloadable file or as structured data in the command results.
+            - 'client' function argument is only relevant when 'should_download_message_attachment' command argument is True.
+        """
         item = raw_attachment.get('item', {})
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1276,7 +1276,9 @@ class GraphMailUtils:
                     args.get('message_id'),
                     args.get('attachment_id'),
                     user_id, False)
-                attachment_name = f'{item.get("name", "untitled_attachment")}.eml'
+                attachment_name: str = (item.get("name") or item.get('subject')
+                                        or "untitled_attachment").replace(' ', '_') + '.eml'
+                demisto.debug(f'Email attachment of type "microsoft.graph.message" acquired successfully, {attachment_name=}')
                 return fileResult(attachment_name, attachment_content)
             else:
                 message_id = raw_attachment.get('id')

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1293,7 +1293,8 @@ class GraphMailUtils:
         item = raw_attachment.get('item', {})
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:
-            if client and argToBoolean(args.get('should_download_message_attachment', False)):
+            return_message_attachment_as_downloadable_file = client and argToBoolean(args.get('should_download_message_attachment', False))
+            if return_message_attachment_as_downloadable_file:
                 # return the message attachment as a file result
                 attachment_content = client._get_attachment_mime(
                     args.get('message_id'),

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -1293,7 +1293,8 @@ class GraphMailUtils:
         item = raw_attachment.get('item', {})
         item_type = item.get('@odata.type', '')
         if 'message' in item_type:
-            return_message_attachment_as_downloadable_file = client and argToBoolean(args.get('should_download_message_attachment', False))
+            return_message_attachment_as_downloadable_file = client and argToBoolean(
+                args.get('should_download_message_attachment', False))
             if return_message_attachment_as_downloadable_file:
                 # return the message attachment as a file result
                 attachment_content = client._get_attachment_mime(

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.yml
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.yml
@@ -13,7 +13,7 @@ system: true
 scripttarget: 0
 dependson: {}
 timeout: 0s
-dockerimage: demisto/crypto:1.0.0.98336
+dockerimage: demisto/crypto:1.0.0.111961
 fromversion: 6.5.0
 tests:
 - No test

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
@@ -733,7 +733,8 @@ def test_get_attachment(client):
     with open('test_data/mail_with_attachment.txt') as mail_json:
         user_id = 'ex@example.com'
         raw_response = json.load(mail_json)
-        res = GraphMailUtils.item_result_creator(raw_response, user_id)
+        args = {}
+        res = GraphMailUtils.item_result_creator(raw_response, user_id, args, client)
         assert isinstance(res, CommandResults)
         output = res.to_context().get('EntryContext', {})
         assert output.get(output_prefix).get('ID') == 'exampleID'

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
@@ -790,8 +790,9 @@ def test_get_attachment_unsupported_type(client):
     from MicrosoftGraphListener import GraphMailUtils
     with open('test_data/mail_with_unsupported_attachment.txt') as mail_json:
         user_id = 'ex@example.com'
+        args = {}
         raw_response = json.load(mail_json)
-        res = GraphMailUtils.item_result_creator(raw_response, user_id)
+        res = GraphMailUtils.item_result_creator(raw_response, user_id, args, client)
         assert isinstance(res, CommandResults)
         output = res.to_context().get('HumanReadable', '')
         assert 'Integration does not support attachments from type #microsoft.graph.contact' in output

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -455,7 +455,7 @@ script:
       name: folder_id
     - description: The ID of the attachment. In case not supplied, the command will return all the attachments.
       name: attachment_id
-    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return them as a command result.
+    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return this attachment inside a command result.
       additionalinfo: "Setting this argument to true will override the default behavior of the command, and return message attachment of type 'microsoft.graph.message' (Also known as 'Outlook item' or '.eml') as a downloadable file instead of a default command result."
       name: should_download_message_attachment
       defaultvalue: 'false'

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -455,8 +455,8 @@ script:
       name: folder_id
     - description: The ID of the attachment. In case not supplied, the command will return all the attachments.
       name: attachment_id
-    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return this attachment inside a command result.
-      additionalinfo: "Setting this argument to true will override the default behavior of the command, and return message attachment of type 'microsoft.graph.message' (Also known as 'Outlook item' or '.eml') as a downloadable file instead of a default command result."
+    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return this attachment type inside a command result.
+      additionalinfo: "Setting this argument to true will override the default behavior of the command and return message attachment of type 'microsoft.graph.message' (also known as 'Outlook item' or '.eml') as a downloadable file instead of inside a command result."
       name: should_download_message_attachment
       defaultvalue: 'false'
     - deprecated: true

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -455,10 +455,8 @@ script:
       name: folder_id
     - description: The ID of the attachment. In case not supplied, the command will return all the attachments.
       name: attachment_id
-    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return this attachment type inside a command result.
-      additionalinfo: "Setting this argument to true will override the default behavior of the command and return message attachment of type 'microsoft.graph.message' (also known as 'Outlook item' or '.eml') as a downloadable file instead of inside a command result."
+    - description: Setting this argument to 'true' will return message attachments of type 'microsoft.graph.message' (also known as 'Outlook item' or '.eml') as downloadable files. Default value is 'false'. Default behavior is to return 'microsoft.graph.message' attachments inside a command result.
       name: should_download_message_attachment
-      defaultvalue: 'false'
     - deprecated: true
       description: flag for rate limit retry.
       name: ran_once_flag

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -455,6 +455,10 @@ script:
       name: folder_id
     - description: The ID of the attachment. In case not supplied, the command will return all the attachments.
       name: attachment_id
+    - description: Attachments of type "microsoft.graph.message" will be returned as downloadable files. Default behavior is to return them as a command result.
+      additionalinfo: "Setting this argument to true will override the default behavior of the command, and return message attachment of type 'microsoft.graph.message' (Also known as 'Outlook item' or '.eml') as a downloadable file instead of a default command result."
+      name: should_download_message_attachment
+      defaultvalue: 'false'
     - deprecated: true
       description: flag for rate limit retry.
       name: ran_once_flag

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
@@ -717,9 +717,9 @@ def test_get_attachment_unsupported_type(client):
         assert 'Integration does not support attachments from type #microsoft.graph.contact' in output
 
 
-@pytest.mark.parametrize('function_name, attachment_type, args, client', [('file_result_creator', 'fileAttachment', {}, oproxy_client()),
-                                                                          ('item_result_creator', 'itemAttachment', {}, oproxy_client())])
-def test_create_attachment(mocker, function_name, attachment_type, args, client):
+@pytest.mark.parametrize('function_name, attachment_type, client', [('file_result_creator', 'fileAttachment', oproxy_client()),
+                                                                    ('item_result_creator', 'itemAttachment', oproxy_client())])
+def test_create_attachment(mocker, function_name, attachment_type, client):
     """
     Given:
         - raw response returned from api:
@@ -736,6 +736,7 @@ def test_create_attachment(mocker, function_name, attachment_type, args, client)
     mocker.patch(f'MicrosoftGraphMail.GraphMailUtils.{function_name}', return_value=function_name)
     raw_response = {'@odata.type': f'#microsoft.graph.{attachment_type}'}
     user_id = 'ex@example.com'
+    args = {}
     called_function = GraphMailUtils.create_attachment(raw_response, user_id, args, client)
     assert called_function == function_name
 

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_18.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_18.md
@@ -1,0 +1,10 @@
+
+#### Integrations
+
+##### O365 Outlook Mail (Using Graph API)
+
+- Added a command argument *should_download_message_attachment* to ***msgraph-mail-get-attachment*** command, which allows to return email attachments of type "Outlook item" and ".eml" as downloadable files.
+
+##### Microsoft Graph Mail Single User
+
+- Added a command argument *should_download_message_attachment* to ***msgraph-mail-get-attachment*** command, which allows to return email attachments of type "Outlook item" and ".eml" as downloadable files.

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_18.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_6_18.md
@@ -3,8 +3,8 @@
 
 ##### O365 Outlook Mail (Using Graph API)
 
-- Added a command argument *should_download_message_attachment* to ***msgraph-mail-get-attachment*** command, which allows to return email attachments of type "Outlook item" and ".eml" as downloadable files.
+Added a command argument *should_download_message_attachment* to the ***msgraph-mail-get-attachment*** command, which allows returning email attachments of type "Outlook item" and ".eml" as downloadable files.
 
 ##### Microsoft Graph Mail Single User
 
-- Added a command argument *should_download_message_attachment* to ***msgraph-mail-get-attachment*** command, which allows to return email attachments of type "Outlook item" and ".eml" as downloadable files.
+Added a command argument *should_download_message_attachment* to the ***msgraph-mail-get-attachment*** command, which allows returning email attachments of type "Outlook item" and ".eml" as downloadable files.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph lets your app get authorized access to a user's Outlook mail data in a personal or organization account.",
     "support": "xsoar",
-    "currentVersion": "1.6.17",
+    "currentVersion": "1.6.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-42649](https://jira-dc.paloaltonetworks.com/browse/XSUP-42649)

## Description
Add ability to download 'microsoft.graph.message' attachment types via new `msgraph-mail-get-attachment` command argument.

## Must have
- [ ] Tests
- [ ] Documentation 
