### PR TITLE
Modified parsing rule - Workday

### DIFF
--- a/Packs/Workday/ParsingRules/WorkdayParsingRules/WorkdayParsingRules.xif
+++ b/Packs/Workday/ParsingRules/WorkdayParsingRules/WorkdayParsingRules.xif
@@ -1,4 +1,4 @@
 [INGEST:vendor="workday", product="workday", target_dataset="workday_activity_raw", no_hit = keep]
 // Support only date time of format: YYYY-MM-DDTHH:MM:SS.E3S%z. For example: "2023-07-15T07:00:00.000Z"
 filter to_string(requestTime) ~= "\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{3}Z"
-| alter _time = requestTime;
+| alter _time = parse_timestamp("%FT%R:%E*SZ", requestTime);

--- a/Packs/Workday/ReleaseNotes/1_4_12.md
+++ b/Packs/Workday/ReleaseNotes/1_4_12.md
@@ -1,0 +1,3 @@
+#### Parsing Rules
+##### Workday Parsing Rule
+Improved implementation of _time parsing.

--- a/Packs/Workday/pack_metadata.json
+++ b/Packs/Workday/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Workday",
     "description": "Workday offers enterprise-level software solutions for financial management, human resources, and planning.",
     "support": "xsoar",
-    "currentVersion": "1.4.11",
+    "currentVersion": "1.4.12",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CRTX-134825)

## Description
Added a use of parse_timestamp function to the parsing rule (previous rule contained a simple mapping of _time = requestTime).