### PR TITLE
[Tanium v2] Fixed an issue in tn-get-question-metadata command

### DIFF
--- a/Packs/Tanium/Integrations/Tanium_v2/Tanium_v2.py
+++ b/Packs/Tanium/Integrations/Tanium_v2/Tanium_v2.py
@@ -372,7 +372,7 @@ class Client(BaseClient):
             'QueryText': question.get('query_text')
         }
 
-        saved_question_id = question.get('saved_question').get('id')
+        saved_question_id = (question.get('saved_question') or {}).get('id')
         if saved_question_id:
             item['SavedQuestionId'] = saved_question_id
 

--- a/Packs/Tanium/ReleaseNotes/1_0_34.md
+++ b/Packs/Tanium/ReleaseNotes/1_0_34.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Tanium v2
+
+Fixed an issue where the **tn-get-question-metadata** command was raising an error when the saved_question field was empty.

--- a/Packs/Tanium/pack_metadata.json
+++ b/Packs/Tanium/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tanium",
     "description": "Tanium endpoint security and systems management",
     "support": "xsoar",
-    "currentVersion": "1.0.33",
+    "currentVersion": "1.0.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-43089)

## Description
Fixed an issue where the **tn-get-question-metadata** command was raising an error when the saved_question field was empty.

## Must have
- [ ] Tests
- [ ] Documentation 
