### PR TITLE
Add debugging logs to Sophos fetch incidents command

### DIFF
--- a/Packs/SophosCentral/Classifiers/classifier-mapper-incoming-SophosCentral.json
+++ b/Packs/SophosCentral/Classifiers/classifier-mapper-incoming-SophosCentral.json
@@ -12,7 +12,7 @@
                         "filters": [
 
                         ],
-                        "root": "Description",
+                        "root": "description",
                         "transformers": [
                             {
                                 "args": {
@@ -44,7 +44,7 @@
                         "filters": [
 
                         ],
-                        "root": "Description",
+                        "root": "description",
                         "transformers": [
                             {
                                 "args": {
@@ -76,7 +76,7 @@
                         "filters": [
 
                         ],
-                        "root": "Description",
+                        "root": "description",
                         "transformers": [
                             {
                                 "args": {
@@ -113,7 +113,7 @@
                         "filters": [
 
                         ],
-                        "root": "ManagedAgentId",
+                        "root": "managedAgentId",
                         "transformers": [
 
                         ]
@@ -126,7 +126,7 @@
                         "filters": [
 
                         ],
-                        "root": "Id",
+                        "root": "id",
                         "transformers": [
 
                         ]
@@ -139,7 +139,7 @@
                         "filters": [
 
                         ],
-                        "root": "Description",
+                        "root": "description",
                         "transformers": [
 
                         ]
@@ -152,7 +152,7 @@
                         "filters": [
 
                         ],
-                        "root": "Type",
+                        "root": "type",
                         "transformers": [
                             {
                                 "args": {
@@ -187,7 +187,7 @@
                         "filters": [
 
                         ],
-                        "root": "TenantName",
+                        "root": "tenantName",
                         "transformers": [
 
                         ]
@@ -200,7 +200,7 @@
                         "filters": [
 
                         ],
-                        "root": "Person",
+                        "root": "person",
                         "transformers": [
 
                         ]
@@ -213,7 +213,7 @@
                         "filters": [
 
                         ],
-                        "root": "Category",
+                        "root": "category",
                         "transformers": [
 
                         ]
@@ -226,7 +226,7 @@
                         "filters": [
 
                         ],
-                        "root": "Description",
+                        "root": "description",
                         "transformers": [
                             {
                                 "args": {
@@ -258,7 +258,7 @@
                         "filters": [
 
                         ],
-                        "root": "RaisedAt",
+                        "root": "raisedAt",
                         "transformers": [
 
                         ]
@@ -271,7 +271,7 @@
                         "filters": [
 
                         ],
-                        "root": "Severity",
+                        "root": "severity",
                         "transformers": [
 
                         ]

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
@@ -3312,7 +3312,6 @@ def fetch_incidents(
         None,
         max_fetch,
     )
-    demisto.debug(f"Alerts fetched: {alerts}")
     data_fields = [
         "id",
         "description",

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.py
@@ -3287,12 +3287,15 @@ def fetch_incidents(
     Returns:
         Tuple of next_run (millisecond timestamp) and the incidents list
     """
+    demisto.debug(f"Fetching incidents with last_run: {last_run}")
     last_fetch_timestamp = last_run.get("last_fetch", None)
 
     if last_fetch_timestamp:
+        demisto.debug(f"Last fetch time: {last_fetch_timestamp}")
         last_fetch_date = datetime.fromtimestamp(last_fetch_timestamp / 1000)
         last_fetch = last_fetch_date
     else:
+        demisto.debug(f"First fetch time: {first_fetch_time}")
         first_fetch_time_date = dateparser.parse(first_fetch_time)
         assert first_fetch_time_date is not None, f'could not parse {first_fetch_time}'
         first_fetch_date = first_fetch_time_date.replace(tzinfo=None)
@@ -3309,6 +3312,7 @@ def fetch_incidents(
         None,
         max_fetch,
     )
+    demisto.debug(f"Alerts fetched: {alerts}")
     data_fields = [
         "id",
         "description",
@@ -3330,10 +3334,12 @@ def fetch_incidents(
         }
         incidents.append(incident)
     if incidents:
+        demisto.debug(f"Found {len(incidents)} incidents.")
         last_incident_time = incidents[-1].get("occurred", "")
         next_run = datetime.strptime(last_incident_time, DATE_FORMAT)
     next_run += timedelta(milliseconds=1)
     next_run_timestamp = int(datetime.timestamp(next_run) * 1000)
+    demisto.debug(f"Next run: {next_run_timestamp}")
     return {"last_fetch": next_run_timestamp}, incidents
 
 

--- a/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
+++ b/Packs/SophosCentral/Integrations/SophosCentral/SophosCentral.yml
@@ -2415,7 +2415,7 @@ script:
     - contextPath: SophosCentral.DeletedUsers.deletedUserId
       description: Deleted User's Id.
       type: String
-  dockerimage: demisto/python3:3.11.9.101916
+  dockerimage: demisto/python3:3.11.10.116949
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/SophosCentral/ReleaseNotes/1_3_3.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_3.md
@@ -4,3 +4,4 @@
 ##### Sophos Central
 
 - Added additional logging to better diagnose fetch issues.
+- Fixed an issue where the incoming mapper would not correctly parse the given fields.

--- a/Packs/SophosCentral/ReleaseNotes/1_3_3.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_3.md
@@ -5,3 +5,4 @@
 
 - Added additional logging to better diagnose fetch issues.
 - Fixed an issue where the incoming mapper would not correctly parse the given fields.
+- Updated the Docker image to: *demisto/python3:3.11.10.116949*.

--- a/Packs/SophosCentral/ReleaseNotes/1_3_3.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_3.md
@@ -2,7 +2,11 @@
 #### Integrations
 
 ##### Sophos Central
-
-- Added additional logging to better diagnose fetch issues.
-- Fixed an issue where the incoming mapper would not correctly parse the given fields.
 - Updated the Docker image to: *demisto/python3:3.11.10.116949*.
+- Added additional logging to better diagnose fetch issues.
+
+#### Mappers
+
+##### Sophos Central - Incoming Mapper
+
+- Fixed an issue where the incoming mapper would not correctly parse the given fields.

--- a/Packs/SophosCentral/ReleaseNotes/1_3_3.md
+++ b/Packs/SophosCentral/ReleaseNotes/1_3_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Sophos Central
+
+- Added additional logging to better diagnose fetch issues.

--- a/Packs/SophosCentral/pack_metadata.json
+++ b/Packs/SophosCentral/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Sophos Central",
     "description": "The unified console for managing Sophos products",
     "support": "xsoar",
-    "currentVersion": "1.3.2",
+    "currentVersion": "1.3.3",
     "author": "Sophos",
     "url": "",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-42727

## Description
Adding debugging logs to see whats happening during fetch. Suspicion is that there are no incidents being retrieved in the window that's being provided by the fetch samples command.

## Must have
- [ ] Tests
- [ ] Documentation 
