### PR TITLE
[PrismaCloudV2] Update The `HeuristicSearch` Parameter

### DIFF
--- a/Packs/PrismaCloud/Integrations/PrismaCloudV2/PrismaCloudV2.py
+++ b/Packs/PrismaCloud/Integrations/PrismaCloudV2/PrismaCloudV2.py
@@ -286,7 +286,7 @@ class Client(BaseClient):
                                     'sort': [{'direction': sort_direction, 'field': sort_field}],
                                     'timeRange': time_range,
                                     'withResourceJson': include_resource_json,
-                                    'HeuristicSearch': 'true'
+                                    'heuristicSearch': 'true'
                                     })
 
         return self._http_request('POST', 'search/config', json_data=data)

--- a/Packs/PrismaCloud/Integrations/PrismaCloudV2/PrismaCloudV2_test.py
+++ b/Packs/PrismaCloud/Integrations/PrismaCloudV2/PrismaCloudV2_test.py
@@ -253,7 +253,7 @@ def test_config_search_command(mocker, prisma_cloud_v2_client):
                                                'sort': [{'direction': 'desc', 'field': 'insertTs'}],
                                                'timeRange': {'type': 'to_now', 'value': 'epoch'},
                                                'withResourceJson': 'true',
-                                               'HeuristicSearch': 'true'
+                                               'heuristicSearch': 'true'
                                                })
 
 

--- a/Packs/PrismaCloud/ReleaseNotes/4_3_14.md
+++ b/Packs/PrismaCloud/ReleaseNotes/4_3_14.md
@@ -3,4 +3,4 @@
 
 ##### Prisma Cloud v2
 
-Fixed an issue where ***prisma-cloud-config-search*** failed 
+Fixed an issue where the ***prisma-cloud-config-search*** command occasionally failed due to intermittent timeouts.

--- a/Packs/PrismaCloud/ReleaseNotes/4_3_14.md
+++ b/Packs/PrismaCloud/ReleaseNotes/4_3_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Prisma Cloud v2
+
+Fixed an issue where ***prisma-cloud-config-search*** failed 

--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud by Palo Alto Networks",
     "description": "Automate and unify security incident response across your cloud environments, while still giving a degree of control to dedicated cloud teams.",
     "support": "xsoar",
-    "currentVersion": "4.3.13",
+    "currentVersion": "4.3.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-42066](https://jira-dc.paloaltonetworks.com/browse/XSUP-42066)

## Description
In the latest version of PrismaCloudV2 (4.3.13), we added the `HeuristicSearch` parameter to the body.
However, this parameter is case-sensitive, meaning we must use a lowercase 'h' instead of an uppercase 'H'. This PR updates the code accordingly.

