### PR TITLE
RemoteAccess v2: fix issue in case of missing permission.

### DIFF
--- a/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
+++ b/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
@@ -265,7 +265,8 @@ def copy_to_command(ssh_client: SSHClient, args: Dict[str, Any]) -> CommandResul
         try:
             execute_shell_command(ssh_client, args={'cmd': f'mkdir -p {destination_dir}'})
         except Exception as e:
-            # ignore the error of creating the dir, as sometime is already exist and the error are due to permission - otherwise the next operation will fail
+            # ignore the error of creating the dir, as sometime is already exist and the error are due to permission
+            # otherwise the next operation will fail.
             demisto.debug(f'Ignoring the error: {str(e)}, occurred when run the command: mkdir -p {destination_dir}')
 
     perform_copy_command(ssh_client, file_path, destination_path, copy_to_remote=True, socket_timeout=timeout)

--- a/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
+++ b/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
@@ -262,7 +262,11 @@ def copy_to_command(ssh_client: SSHClient, args: Dict[str, Any]) -> CommandResul
 
     # Create all folders to destination_path in the remote machine
     if destination_dir:
-        execute_shell_command(ssh_client, args={'cmd': f'mkdir -p {destination_dir}'})
+        try:
+            execute_shell_command(ssh_client, args={'cmd': f'mkdir -p {destination_dir}'})
+        except Exception as e:
+            # ignore the error of creating the dir, as sometime is already exist and the error are due to permission.
+            demisto.debug(f'Ignoring the error: {str(e)}, occurred when run the command: mkdir -p {destination_dir}')
 
     perform_copy_command(ssh_client, file_path, destination_path, copy_to_remote=True, socket_timeout=timeout)
     return CommandResults(readable_output=f'### The file corresponding to entry ID: {entry_id} was copied to remote'

--- a/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
+++ b/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2.py
@@ -265,7 +265,7 @@ def copy_to_command(ssh_client: SSHClient, args: Dict[str, Any]) -> CommandResul
         try:
             execute_shell_command(ssh_client, args={'cmd': f'mkdir -p {destination_dir}'})
         except Exception as e:
-            # ignore the error of creating the dir, as sometime is already exist and the error are due to permission.
+            # ignore the error of creating the dir, as sometime is already exist and the error are due to permission - otherwise the next operation will fail
             demisto.debug(f'Ignoring the error: {str(e)}, occurred when run the command: mkdir -p {destination_dir}')
 
     perform_copy_command(ssh_client, file_path, destination_path, copy_to_remote=True, socket_timeout=timeout)

--- a/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2_test.py
+++ b/Packs/RemoteAccess/Integrations/RemoteAccessv2/RemoteAccessv2_test.py
@@ -183,6 +183,31 @@ def test_copy_to_command_valid(mocker):
     assert results.readable_output == '### The file corresponding to entry ID: 456 was copied to remote host.'
 
 
+def test_copy_to_command_failed_to_mkdir(mocker):
+    """
+    Given:
+    - Cortex XSOAR arguments
+
+    When:
+    - Calling the copy-to command but failing to run the mkdir.
+
+    Then:
+    - Ensure the error info printed to debug but the command finished successfully.
+    """
+    from RemoteAccessv2 import copy_to_command
+    from paramiko import SSHClient
+    mock_client: SSHClient = SSHClient()
+    mocker.patch.object(demisto, 'getFilePath', return_value={'path': 'test', 'name': 'file-name.txt'})
+    mocker.patch.object(demisto, 'debug')
+    mocker.patch('RemoteAccessv2.perform_copy_command', return_value='')
+    mocker.patch('RemoteAccessv2.execute_shell_command', side_effect=Exception('permission error'))
+
+    results: CommandResults = copy_to_command(mock_client, {'entry': 123, 'entry_id': 456, 'dest-dir': 'test_dir'})
+
+    assert 'permission error, occurred when run the command: mkdir -p test_dir' in demisto.debug.call_args[0][0]
+    assert results.readable_output == '### The file corresponding to entry ID: 456 was copied to remote host.'
+
+
 def test_copy_to_command_invalid_entry_id(mocker):
     """
     Given:

--- a/Packs/RemoteAccess/ReleaseNotes/1_0_35.md
+++ b/Packs/RemoteAccess/ReleaseNotes/1_0_35.md
@@ -3,4 +3,4 @@
 
 ##### RemoteAccess v2
 
-- Fixed an issue where the command ***copy-to*** failed in case of missing permission to create the destination dir.
+- Fixed an issue where the command ***copy-to*** failed in case of missing permission to create the destination dir. The command will now succeed when missing this permission if the folder already exists.

--- a/Packs/RemoteAccess/ReleaseNotes/1_0_35.md
+++ b/Packs/RemoteAccess/ReleaseNotes/1_0_35.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### RemoteAccess v2
+
+- Fixed an issue where the command ***copy-to*** failed in case of missing permission to create the destination dir.

--- a/Packs/RemoteAccess/pack_metadata.json
+++ b/Packs/RemoteAccess/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Remote Access",
     "description": "Transfer files and execute commands via SSH on remote machines.",
     "support": "xsoar",
-    "currentVersion": "1.0.34",
+    "currentVersion": "1.0.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-42283

## Description
currently, when someone run the copy-to command with the destination dir arg, we run the mkdir -p to be sure this dir will be exist
if the dir already exist and the user don't have the permission to create the dir - an error (without detailed desctiption) is occureding

we can ignore the error from the mkdir as, if the dir already exist it will pass and if the dir didn't exist - the process will fail with detailed description in the copy process

**new test before fix:**
<img width="597" alt="image" src="https://github.com/user-attachments/assets/4e395d70-4c4c-4346-8912-20d3099eb80c">

**after fix:**
<img width="628" alt="image" src="https://github.com/user-attachments/assets/3211286d-bf8d-468e-90c6-c0aa134b122e">
