### PR TITLE
CiscoUmbrellaReporting: Added optional "categories" argument to supporting commands

### DIFF
--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
@@ -78,6 +78,8 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: List of destinations ordered by the number of requests made in descending order.
     name: umbrella-reporting-destination-list
     outputs:
@@ -175,6 +177,8 @@ script:
       - proxied
     - description: The page number (page size is 50 entries at max). Default is 1.
       name: page
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: List of categories ordered by the number of requests made matching the categories in descending order.
     name: umbrella-reporting-category-list
     outputs:
@@ -252,6 +256,8 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: List of identities ordered by the number of requests made matching the categories in descending order.
     name: umbrella-reporting-identity-list
     outputs:
@@ -326,6 +332,8 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: 'List of event types ordered by the number of requests made for each type of event in descending order. The event types are: domain_security, domain_integration, url_security, url_integration, cisco_amp and antivirus.'
     name: umbrella-reporting-event-type-list
     outputs:
@@ -370,6 +378,8 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: List of files within a time frame. Only returns proxy data.
     name: umbrella-reporting-file-list
     outputs:
@@ -438,6 +448,8 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: List of top threats within a time frame. Returns both DNS and Proxy data.
     name: umbrella-reporting-threat-list
     outputs:
@@ -491,7 +503,7 @@ script:
       name: page
     - description: The number of requested results per page. Default is 50.
       name: page_size
-    - description: 'A comma-separated list of category ids to filter on.'
+    - description: A comma-separated list of category ids to filter on.
       name: categories
     description: List all activity entries (dns/proxy/firewall/ip/intrusion/amp) within the time frame.
     name: umbrella-reporting-activity-list
@@ -690,7 +702,7 @@ script:
       name: signatures
     - description: 'Comma-separated list of intrusion actions. Possible values: would_block, blocked, detected.'
       name: intrusion_action
-    - description: 'A comma-separated list of category ids to filter on.'
+    - description: A comma-separated list of category ids to filter on.
       name: categories
     description: |-
       List all entries within a time frame based on the traffic type selected. Valid activity types are dns, proxy, firewall, intrusion, ip, amp.
@@ -1364,6 +1376,8 @@ script:
       name: signatures
     - description: 'Comma-separated List of intrusion actions. Possible values: would_block, blocked, detected.'
       name: intrusion_action
+    - description: A comma-separated list of category ids to filter on.
+      name: categories
     description: Get the summary.
     name: umbrella-reporting-summary-list
     outputs:

--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
@@ -1546,7 +1546,7 @@ script:
     - contextPath: UmbrellaReporting.SignatureListSummary.signatures.id
       description: Signature ID.
       type: Number
-  dockerimage: demisto/python3:3.11.10.111039
+  dockerimage: demisto/python3:3.11.10.113941
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/README.md
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/README.md
@@ -54,6 +54,7 @@ List of destinations ordered by the number of requests made in descending order.
 | verdict | A verdict string. Possible values are: allowed, blocked, proxied. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 
@@ -230,6 +231,7 @@ List of categories ordered by the number of requests made matching the categorie
 | verdict | A verdict string. Possible values are: allowed, blocked, proxied. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50.| Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 
 #### Context Output
@@ -319,6 +321,7 @@ List of identities ordered by the number of requests made matching the categorie
 | limit | The maximum number of records to return from the collection. Limit default value is 50. If the page_size argument is set by the user then the limit argument will be ignored. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 
@@ -510,6 +513,7 @@ List of files within a time frame. Only returns proxy data.
 | identity_types | An identity type or comma-separated list of identity types. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 
@@ -596,6 +600,7 @@ List of top threats within a time frame. Returns both DNS and Proxy data.
 | threat_types | A threat type or comma-separated list of threat types. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 
@@ -656,7 +661,7 @@ List all activity entries (dns/proxy/firewall/ip/intrusion/amp) within the time 
 | amp_disposition | An Advanced Malware Protection (AMP) disposition string. Possible values are: clean, malicious, unknown. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
-| categories | A comma-separated list of category ids to filter on. | Optional |
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 
@@ -880,7 +885,7 @@ Only one activity type can be selected at a time.
 | page_size | The number of requested results per page. Default is 50.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Optional | 
 | signatures | A comma-separated list of Generator id - Signatures ID. Where Generator ID is unique id assigned to the part of the IPS which generated the event and Signature ID is used to uniquely identify signatures. Example:- 1-2,1-4.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Optional | 
 | intrusion_action | Comma-separated list of intrusion actions. Possible values: would_block, blocked, detected.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Optional | 
-| categories | A comma-separated list of category ids to filter on. | Optional |
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 
 #### Context Output for **`traffic_type = dns`** for base command **`umbrella-reporting-activity-get`**
@@ -1681,6 +1686,7 @@ Get the summary.
 | page_size | The number of requested results per page. Default is 50. | Optional | 
 | signatures | A comma-separated list of Generator id - Signatures ID. Where Generator ID is unique id assigned to the part of the IPS which generated the event and Signature ID is used to uniquely identify signatures. Example:- 1-2,1-4. | Optional | 
 | intrusion_action | Comma-separated List of intrusion actions. Possible values: would_block, blocked, detected. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 
 #### Context Output for `summary` for base command `umbrella-reporting-summary-list`

--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/README.md
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/README.md
@@ -426,6 +426,7 @@ List of event types ordered by the number of requests made for each type of even
 | amp_disposition | An Advanced Malware Protection (AMP) disposition string. Possible values are: clean, malicious, unknown. | Optional | 
 | page | The page number. Default is 1. | Optional | 
 | page_size | The number of requested results per page. Default is 50. | Optional | 
+| categories | A comma-separated list of category ids to filter on. | Optional | 
 
 #### Context Output
 

--- a/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_4.md
+++ b/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_4.md
@@ -1,4 +1,11 @@
 #### Integrations
 ##### Cisco Umbrella Reporting
-- Added the optional `categories` argument to all commands which support the category filter.
+- Added the *categories* argument to following commands:
+    - ***umbrella-reporting-destination-list***
+    - ***umbrella-reporting-category-list***
+    - ***umbrella-reporting-identity-list***
+    - ***umbrella-reporting-event-type-list***
+    - ***umbrella-reporting-file-list***
+    - ***umbrella-reporting-threat-list***
+    - ***umbrella-reporting-summary-list***
 - Updated the Docker image to: *demisto/python3:3.11.10.113941*.

--- a/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_4.md
+++ b/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_4.md
@@ -1,0 +1,4 @@
+#### Integrations
+##### Cisco Umbrella Reporting
+- Added the optional `categories` argument to all commands which support the category filter.
+- Updated the Docker image to: *demisto/python3:3.11.10.113941*.

--- a/Packs/CiscoUmbrellaReporting/pack_metadata.json
+++ b/Packs/CiscoUmbrellaReporting/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Umbrella Reporting",
     "description": "Use Cisco Umbrella's Reporting to monitor your Umbrella integration and gain a better understanding of your Umbrella usage. Gain insights into request activity and blocked activity, determining which of your identities are generating blocked requests. Reports help build actionable intelligence in addressing security threats including changes in usage trends over time. The Umbrella Reporting v2 API provides visibility into your core network and security activities and Umbrella logs. This integration was integrated and tested with version 2 of Cisco-umbrella-reporting.",
     "support": "xsoar",
-    "currentVersion": "1.1.3",
+    "currentVersion": "1.1.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This is an addition to the already merged PR #36253 
The optional `categories` argument has been added to all commands which supports it according to the [Cisco Umbrella API](https://developer.cisco.com/docs/cloud-security/api-reference-reports-reporting-overview/) (in the initial PR the argument itself was only added to two of the commands but 7 other commands support it as well).

## Must have
- [ ] Tests
- [ ] Documentation 
