### PR TITLE
RestartFailedTasks: correct the arg name

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_21.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_21.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### RestartFailedTasks
+
+Fixed an issue where the **Restart Failed Tasks** script reopen also tasks that succeeded if they have the same task id as the failed task.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_21.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_21.md
@@ -3,4 +3,4 @@
 
 ##### RestartFailedTasks
 
-Fixed an issue where the **Restart Failed Tasks** script reopen also tasks that succeeded if they have the same task id as the failed task.
+Fixed an issue where the **Restart Failed Tasks** script incorrectly reopened successful tasks that share the same task ID with failed tasks.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/RestartFailedTasks/RestartFailedTasks.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/RestartFailedTasks/RestartFailedTasks.py
@@ -63,7 +63,7 @@ def restart_tasks(failed_tasks: list, sleep_time: int, group_size: int):
         task_id, incident_id, playbook_name, task_name =\
             task['Task ID'], task['Incident ID'], task['Playbook Name'], task['Task Name']
         demisto.info(f'Restarting task with id: {task_id} and incident id: {incident_id}')
-        demisto.executeCommand("taskReopen", {'id': task_id, 'incident_id': incident_id})
+        demisto.executeCommand("taskReopen", {'id': task_id, 'incidentId': incident_id})
         body = {'invId': incident_id, 'inTaskID': task_id}
 
         if is_xsoar_version_6_2:

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.3.20",
+    "currentVersion": "1.3.21",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-42792

## Description
the script use the wrong `incident_id` arg for the script `taskReopen`, so this lead to reopen all the task with this id even in the current incident

fixing the arg name to `incidentId` according the command help and server code
