### PR TITLE
Prisma Cloud Compute custom feeds ip remove (CIAC-11607)

### DIFF
--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
@@ -1288,7 +1288,7 @@ def remove_custom_ip_feeds(client: PrismaCloudComputeClient, args: dict) -> Comm
     ignored_ips = ips - ips_to_remove
 
     if not ips_to_remove:
-        return CommandResults(readable_output='IPs to remove are not currently in the custom IP feeds.')
+        return CommandResults(readable_output=f'Could not find {ignored_ips} in the custom IP feeds.')
 
     filtered_feeds = list(current_ip_feeds - ips_to_remove)
 

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
@@ -1269,6 +1269,29 @@ def add_custom_ip_feeds(client: PrismaCloudComputeClient, args: dict) -> Command
     return CommandResults(readable_output="Successfully updated the custom IP feeds")
 
 
+def remove_custom_ip_feeds(client: PrismaCloudComputeClient, args: dict) -> CommandResults:
+    """
+    Remove a list of IPs from the system's block list.
+    Implements the command 'prisma-cloud-compute-custom-feeds-ip-remove'
+
+    Args:
+        client (PrismaCloudComputeClient): prisma-cloud-compute client.
+        args (dict): prisma-cloud-compute-custom-feeds-ip-remove command arguments.
+
+    Returns:
+        CommandResults: command-results object.
+    """
+    # Command flow is identical to add_custom_ip_feeds with the combining being removal instead of addition.
+    current_ip_feeds = (client.get_custom_ip_feeds() or {}).get('feed') or []
+    ips_to_remove = argToList(arg=args.pop('ip'))
+
+    filtered_feeds = list({ip for ip in current_ip_feeds if ip not in ips_to_remove})
+
+    client.add_custom_ip_feeds(feeds=filtered_feeds)
+
+    return CommandResults(readable_output=f'Custom IP feed {ips_to_remove} was successfully removed')
+
+
 def get_custom_malware_feeds(client: PrismaCloudComputeClient, args: dict) -> CommandResults:
     """
     List all custom uploaded md5 malware records.
@@ -2714,6 +2737,8 @@ def main():
             return_results(results=get_profile_host_forensic_list(client=client, args=demisto.args()))
         elif requested_command == 'prisma-cloud-compute-custom-feeds-ip-add':
             return_results(results=add_custom_ip_feeds(client=client, args=demisto.args()))
+        elif requested_command == 'prisma-cloud-compute-custom-feeds-ip-remove':
+            return_results(results=remove_custom_ip_feeds(client=client, args=demisto.args()))
         elif requested_command == 'prisma-cloud-compute-console-version-info':
             return_results(results=get_console_version(client=client))
         elif requested_command == 'prisma-cloud-compute-custom-feeds-ip-list':

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.py
@@ -1296,7 +1296,7 @@ def remove_custom_ip_feeds(client: PrismaCloudComputeClient, args: dict) -> Comm
 
     if ignored_ips:
         hr = f'''Successfully removed {ips_to_remove} from the custom IP feeds.
-        {ignored_ips} already not in the custom IP feeds.'''
+        Could not find {ignored_ips} in the custom IP feeds.'''
     else:
         hr = f'Successfully removed {ips_to_remove} from the custom IP feeds'
 

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
@@ -754,6 +754,15 @@ script:
       isArray: true
       defaultValue: ""
     outputs: []
+  - name: prisma-cloud-compute-custom-feeds-ip-remove
+    description: Remove a list of IPs from the system's block list.
+    arguments:
+    - name: ip
+      description: A comma-separated list of custom IP addresses to remove from the banned IPs list. For example ip=1.1.1.1,2.2.2.2.
+      required: true
+      isArray: true
+      defaultValue: ""
+    outputs: []
   - name: prisma-cloud-compute-custom-feeds-malware-list
     description: List all custom uploaded md5 malwares.
     arguments:

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/PaloAltoNetworks_PrismaCloudCompute.yml
@@ -74,7 +74,7 @@ description: Use the Prisma Cloud Compute integration to fetch incidents from yo
 display: Palo Alto Networks - Prisma Cloud Compute
 name: PaloAltoNetworks_PrismaCloudCompute
 script:
-  dockerimage: demisto/python3:3.10.14.95137
+  dockerimage: demisto/python3:3.11.10.113941
   isfetch: true
   runonce: false
   script: "-"

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/README.md
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/README.md
@@ -934,6 +934,31 @@ There is no context output for this command.
 #### Human Readable Output
 >Successfully updated the custom IP feeds
 
+### prisma-cloud-compute-custom-feeds-ip-remove
+
+***
+Remove a list of IPs from the system's block list.
+
+#### Base Command
+
+`prisma-cloud-compute-custom-feeds-ip-remove`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| ip | A comma-separated list of custom IP addresses to remove from the banned IPs list. For example ip=1.1.1.1,2.2.2.2. | Required | 
+
+#### Context Output
+
+There is no context output for this command.
+#### Command example
+```!prisma-cloud-compute-custom-feeds-ip-remove ip=2.2.2.2,5.6.7.8```
+#### Human Readable Output
+
+>Successfully removed {'2.2.2.2'} from the custom IP feeds.
+>        Could not find {'5.6.7.8'} in the custom IP feeds.
+
 ### prisma-cloud-compute-custom-feeds-malware-list
 ***
 List all custom uploaded md5 malwares.

--- a/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/commands.txt
+++ b/Packs/PrismaCloudCompute/Integrations/PaloAltoNetworks_PrismaCloudCompute/commands.txt
@@ -6,6 +6,7 @@
 !prisma-cloud-compute-console-version-info
 !prisma-cloud-compute-custom-feeds-ip-list
 !prisma-cloud-compute-custom-feeds-ip-add ip=1.1.1.1,2.2.2.2
+!prisma-cloud-compute-custom-feeds-ip-remove ip=2.2.2.2,5.6.7.8
 !prisma-cloud-compute-custom-feeds-malware-list limit=2
 !prisma-cloud-compute-custom-feeds-malware-add name=test md5=md5_hash1,md5_hash2,md5_hash3
 !cve cve_id=cve-2016-223,cve-2020-3546

--- a/Packs/PrismaCloudCompute/ReleaseNotes/1_7_5.md
+++ b/Packs/PrismaCloudCompute/ReleaseNotes/1_7_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks - Prisma Cloud Compute
+
+- Added new command `prisma-cloud-compute-custom-feeds-ip-remove`

--- a/Packs/PrismaCloudCompute/ReleaseNotes/1_7_5.md
+++ b/Packs/PrismaCloudCompute/ReleaseNotes/1_7_5.md
@@ -4,3 +4,4 @@
 ##### Palo Alto Networks - Prisma Cloud Compute
 
 - Added new command `prisma-cloud-compute-custom-feeds-ip-remove`
+- Updated the Docker image to: *demisto/python3:3.11.10.113941*.

--- a/Packs/PrismaCloudCompute/pack_metadata.json
+++ b/Packs/PrismaCloudCompute/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud Compute by Palo Alto Networks",
     "description": "Use the Prisma Cloud Compute integration to fetch incidents from your Prisma Cloud Compute environment.",
     "support": "xsoar",
-    "currentVersion": "1.7.4",
+    "currentVersion": "1.7.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-11607](https://jira-dc.paloaltonetworks.com/browse/CIAC-11607)

## Description
Added new command to remove blocked IPs from the custom feeds

## Must have
- [ ] Tests
- [ ] Documentation 
