### PR TITLE
Ciac 12033 - Hide includeinformational argument in SearchAlertsV2 script in XSOAR using hidden in yml

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_78.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_78.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### SearchIncidentsV2
+
+- Documentation and metadata improvements.

--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.py
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.py
@@ -157,8 +157,6 @@ def search_incidents(args: Dict):  # pragma: no cover
             args.pop('trimevents')
 
     if includeinformational := argToBoolean(args.get('includeinformational', False)):
-        if not is_xsiam():
-            raise ValueError('The includeinformational argument is supported only in XSIAM.')
         if not (args.get('fromdate') and args.get('todate')):
             raise ValueError('The includeinformational argument requires fromdate and todate arguments.')
 

--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2.yml
@@ -64,13 +64,15 @@ args:
   predefined:
   - "false"
   - "true"
-- description: Supported only in XSIAM. When the value is set to 'True', informational severity alerts will return as part of the results. The ‘fromdate’ and ‘todate’ arguments must be provided to use this argument. The maximum value currently supported for the 'fromdate' argument to retrieve informational incidents is 5 hours. If a value greater than this is provided, it will be adjusted to 5 hours ago. To retrieve only informational incidents, use the `query` argument and include this limitation within the query. Default is false.
+- description: When the value is set to 'True', informational severity alerts will return as part of the results. The ‘fromdate’ and ‘todate’ arguments must be provided to use this argument. The maximum value currently supported for the 'fromdate' argument to retrieve informational incidents is 5 hours. If a value greater than this is provided, it will be adjusted to 5 hours ago. To retrieve only informational incidents, use the `query` argument and include this limitation within the query. Default is false.
   name: includeinformational
   auto: PREDEFINED
   predefined:
   - "false"
   - "true"
   defaultValue: "false"
+  hidden: true
+  hidden:marketplacev2: false
 - description: A comma seperated list of fields to add to context when using summarized version, (default- id,name,type,severity,status,owner,created,closed).
   name: add_fields_to_summarize_context
 comment: |-

--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2_test.py
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2_test.py
@@ -304,7 +304,6 @@ def test_includeinformational_logic(mocker, args, expected_filtered_args, expect
         assert execute_mock.call_args[0][1] == expected_filtered_args
 
 
-
 @pytest.mark.parametrize('platform, version, link_type, expected_result', [
     ('x2', '', 'alertLink', 'alerts?action:openAlertDetails='),
     ('xsoar', '6.10.0', 'incidentLink', '#/Details/'),

--- a/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2_test.py
+++ b/Packs/CommonScripts/Scripts/SearchIncidentsV2/SearchIncidentsV2_test.py
@@ -304,14 +304,6 @@ def test_includeinformational_logic(mocker, args, expected_filtered_args, expect
         assert execute_mock.call_args[0][1] == expected_filtered_args
 
 
-def test_includeinformational_raises_error_in_xsoar(mocker):
-    import SearchIncidentsV2
-    mocker.patch.object(SearchIncidentsV2, 'is_xsiam', return_value=False)
-    mocker.patch.object(SearchIncidentsV2, 'execute_command', side_effect=get_incidents_mock_include_informational)
-
-    with pytest.raises(ValueError):
-        SearchIncidentsV2.search_incidents({'includeinformational': 'true'})
-
 
 @pytest.mark.parametrize('platform, version, link_type, expected_result', [
     ('x2', '', 'alertLink', 'alerts?action:openAlertDetails='),

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.77",
+    "currentVersion": "1.15.78",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12033

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
