### PR TITLE
DBotPredictURLPhishing - remove mailto urls

### DIFF
--- a/Packs/PhishingURL/ReleaseNotes/1_1_20.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_20.md
@@ -3,5 +3,5 @@
 
 ##### DBotPredictURLPhishing
 
-- Removed the URLs that started with `mailto:` from *urls* argument.
+- Removed the URLs that start with `mailto:` from the *urls* argument.
 - Updated the Docker image to: *demisto/mlurlphishing:1.0.0.115323*.

--- a/Packs/PhishingURL/ReleaseNotes/1_1_20.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_20.md
@@ -3,4 +3,5 @@
 
 ##### DBotPredictURLPhishing
 
-Removed the URLs that started with `mailto:` from *urls* argument.
+- Removed the URLs that started with `mailto:` from *urls* argument.
+- Updated the Docker image to: *demisto/mlurlphishing:1.0.0.115323*.

--- a/Packs/PhishingURL/ReleaseNotes/1_1_20.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_20.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotPredictURLPhishing
+
+Removed the URLs that started with `mailto:` from *urls* argument.

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -674,6 +674,15 @@ def get_urls_to_run(
     else:
         urls_only = urls_argument.split()
     urls = list(set(urls_email_body + urls_only + urls_email_html))
+
+    # create a list with all the paths that start with "mailto:"
+    mailto_urls = [url for url in urls if url.startswith("mailto:")]
+
+    # remove the mailto urls from urls list
+    urls = [item for item in urls if item not in mailto_urls]
+
+    return_results(CommandResults(readable_output=f'URLs that start with "mailto:" cannot be rasterized.\nURL: {mailto_urls}'))
+
     if not urls:
         msg_list.append(MSG_NO_URL_GIVEN)
         return_results(MSG_NO_URL_GIVEN)

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.yml
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.yml
@@ -92,7 +92,7 @@ tags:
 - ml
 timeout: 480ns
 type: python
-dockerimage: demisto/mlurlphishing:1.0.0.103417
+dockerimage: demisto/mlurlphishing:1.0.0.115323
 runas: DBotRole
 tests:
 - DBotPredictURLPhishing_test

--- a/Packs/PhishingURL/pack_metadata.json
+++ b/Packs/PhishingURL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing URL",
     "description": "Phishing URL is a project with the goal of detecting phishing URLs using machine learning",
     "support": "xsoar",
-    "currentVersion": "1.1.19",
+    "currentVersion": "1.1.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-42753)

## Description
Removed the URLs that started with `mailto:` from *urls* argument.

## Must have
- [ ] Tests
- [ ] Documentation 
