### PR TITLE
DBotPredictURLPhishing - use argToList for urls argument

### DIFF
--- a/Packs/PhishingURL/ReleaseNotes/1_1_22.md
+++ b/Packs/PhishingURL/ReleaseNotes/1_1_22.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotPredictURLPhishing
+
+Fixed an issue where the **urls** argument failed to parse list of urls from playbooks.

--- a/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
+++ b/Packs/PhishingURL/Scripts/DBotPredictURLPhishing/DBotPredictURLPhishing.py
@@ -669,10 +669,8 @@ def get_urls_to_run(
         urls_email_html = extract_embedded_urls_from_html(email_html)
     else:
         urls_email_html = []
-    if isinstance(urls_argument, list):
-        urls_only = urls_argument
-    else:
-        urls_only = urls_argument.split()
+
+    urls_only = argToList(urls_argument)
     urls = list(set(urls_email_body + urls_only + urls_email_html))
 
     # create a list with all the paths that start with "mailto:"

--- a/Packs/PhishingURL/pack_metadata.json
+++ b/Packs/PhishingURL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing URL",
     "description": "Phishing URL is a project with the goal of detecting phishing URLs using machine learning",
     "support": "xsoar",
-    "currentVersion": "1.1.21",
+    "currentVersion": "1.1.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-43435)

## Description
Use **argToList** in to parse the `urls` argument in `get_urls_to_run` method

## Must have
- [ ] Tests
- [ ] Documentation 
