### PR TITLE
Update rasterize chromium docker image version

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.yml
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.yml
@@ -339,7 +339,7 @@ script:
     - contextPath: InfoFile.Type
       description: The type of the image/pdf file.
       type: string
-  dockerimage: demisto/chromium:130.0.6723.115563
+  dockerimage: demisto/chromium:131.0.6778.116585
   runonce: false
   script: "-"
   subtype: python3

--- a/Packs/rasterize/ReleaseNotes/2_0_27.md
+++ b/Packs/rasterize/ReleaseNotes/2_0_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Rasterize
+
+- Updated the Docker image to: *demisto/chromium:131.0.6778.116585*.

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "2.0.26",
+    "currentVersion": "2.0.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: Customer pointed out the image of chromium on rasterize pack.

## Description
Update chromium image version on rasterize
