### PR TITLE
Duo array log type not updating

### DIFF
--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
@@ -402,7 +402,8 @@ def handle_request_types(demisto_params, last_run):
         last_run (dict): The dict containing the order of the events types.
 
     Returns:
-        _type_: _description_
+        request_order (list): The valid list of the request order after filtering out
+                            events types that do not exist in the logs_type_array parameter.
     """
     logs_type_array = (demisto_params.get('logs_type_array',
                                              f'{LogType.AUTHENTICATION},{LogType.ADMINISTRATION},{LogType.TELEPHONY}'))

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.py
@@ -393,6 +393,7 @@ def calculate_window(params: dict):
     demisto.debug(f'{fetch_delay=} {end_window=}')
     params['end_window'] = end_window
 
+
 def handle_request_types(demisto_params, last_run):
     """
     In this collector each fetch iteration is calling one event type.
@@ -406,7 +407,7 @@ def handle_request_types(demisto_params, last_run):
                             events types that do not exist in the logs_type_array parameter.
     """
     logs_type_array = (demisto_params.get('logs_type_array',
-                                             f'{LogType.AUTHENTICATION},{LogType.ADMINISTRATION},{LogType.TELEPHONY}'))
+                                          f'{LogType.AUTHENTICATION},{LogType.ADMINISTRATION},{LogType.TELEPHONY}'))
     logs_type_array = argToList(logs_type_array)
     request_order = last_run.get('request_order', logs_type_array)
     request_order = [log_type.upper() for log_type in request_order if log_type in logs_type_array]
@@ -415,7 +416,8 @@ def handle_request_types(demisto_params, last_run):
 
     demisto.debug(f'The request order is : {request_order}')
     return request_order
-    
+
+
 def main():
     try:
         demisto_params = demisto.params() | demisto.args()

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
@@ -85,7 +85,7 @@ script:
       required: false
     description: Manual command to fetch events and display them.
     name: duo-get-events
-  dockerimage: demisto/vendors-sdk:1.0.0.115493
+  dockerimage: demisto/vendors-sdk:1.0.0.116188
   isfetchevents: true
   subtype: python3
 marketplaces:

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
@@ -706,15 +706,43 @@ def test_check_window_before_call_5_sec_time_delta():
     assert client.check_window_before_call(mintime=mintime.timestamp())
 
 
-def test_handle_request_types():
+def test_handle_request_types_remove_type():
     """
     Given:
         The log_type_array dict and the last run object.
     When:
-        Some of the types in the last_run do not exist in the last_run object any more.
+        Some of the types in the last_run do not exist in the logs_type_array param any more.
     Then:
         assert that only events that are specified in the log_type_array exists.
     """
     demisto_params = {'logs_type_array': 'AUTHENTICATION, ADMINISTRATION'}
     last_run = {'request_order': ['ADMINISTRATION', 'AUTHENTICATION', 'TELEPHONY']}
+    assert handle_request_types(demisto_params, last_run) == ['ADMINISTRATION', 'AUTHENTICATION']
+
+
+def test_handle_request_types_add_new_type():
+    """
+    Given:
+        The log_type_array dict and the last run object.
+    When:
+        The configuration of the instance was changed and a new event_type was added to the logs_type_array.
+    Then:
+        assert that all events that are specified in the log_type_array exists.
+    """
+    demisto_params = {'logs_type_array': 'AUTHENTICATION, ADMINISTRATION, TELEPHONY'}
+    last_run = {'request_order': ['ADMINISTRATION', 'AUTHENTICATION']}
+    assert handle_request_types(demisto_params, last_run) == ['ADMINISTRATION', 'AUTHENTICATION', 'TELEPHONY']
+
+
+def test_handle_request_type_no_changes():
+    """
+    Given:
+        The log_type_array dict and the last run object.
+    When:
+        No configuration was changed
+    Then:
+        assert that all events specified in the last_run object remain.
+    """
+    demisto_params = {'logs_type_array': 'AUTHENTICATION, ADMINISTRATION'}
+    last_run = {'request_order': ['ADMINISTRATION', 'AUTHENTICATION']}
     assert handle_request_types(demisto_params, last_run) == ['ADMINISTRATION', 'AUTHENTICATION']

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
@@ -709,11 +709,11 @@ def test_check_window_before_call_5_sec_time_delta():
 def test_handle_request_types():
     """
     Given:
-        mintime - a timestamp represents the minimum time from which to get events.
+        The log_type_array dict and the last run object.
     When:
-        calling check_window_before_call.
+        Some of the types in the last_run do not exist in the last_run object any more.
     Then:
-        True is returned, the API call should be performed, we are in the time window.
+        assert that only events that are specified in the log_type_array exists.
     """
     demisto_params = {'logs_type_array': 'AUTHENTICATION, ADMINISTRATION'}
     last_run = {'request_order': ['ADMINISTRATION', 'AUTHENTICATION', 'TELEPHONY']}

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 import demistomock as demisto
 from unittest.mock import MagicMock, patch
 from DuoEventCollector import (Client, GetEvents, LogType, Params, parse_events, main,
-                               parse_mintime, validate_request_order_array, calculate_window)
+                               parse_mintime, validate_request_order_array, calculate_window, handle_request_types)
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 
@@ -704,3 +704,17 @@ def test_check_window_before_call_5_sec_time_delta():
     # min time 13 sec less than the end time return true (more then 5 sec delta)
     mintime = datetime.strptime("2020-01-24 15:11:20", DATE_FORMAT)
     assert client.check_window_before_call(mintime=mintime.timestamp())
+    
+    
+def test_handle_request_types():
+    """
+    Given:
+        mintime - a timestamp represents the minimum time from which to get events.
+    When:
+        calling check_window_before_call.
+    Then:
+        True is returned, the API call should be performed, we are in the time window.
+    """
+    demisto_params = {'logs_type_array': 'AUTHENTICATION, ADMINISTRATION'}
+    last_run = {'request_order': ['ADMINISTRATION', 'AUTHENTICATION', 'TELEPHONY']}
+    assert handle_request_types(demisto_params, last_run) == ['ADMINISTRATION', 'AUTHENTICATION']

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector_test.py
@@ -704,8 +704,8 @@ def test_check_window_before_call_5_sec_time_delta():
     # min time 13 sec less than the end time return true (more then 5 sec delta)
     mintime = datetime.strptime("2020-01-24 15:11:20", DATE_FORMAT)
     assert client.check_window_before_call(mintime=mintime.timestamp())
-    
-    
+
+
 def test_handle_request_types():
     """
     Given:

--- a/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
+++ b/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
@@ -2,5 +2,5 @@
 #### Integrations
 
 ##### Duo Event Collector
-
+- Updated the Docker image to: *demisto/vendors-sdk:1.0.0.116188*.
 - Fixed an issue where the *logs_type_array* did not always update properly when changes were made to the instance configuration.

--- a/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
+++ b/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Duo Event Collector
+
+- Fixed an issue where the *logs_type_array* did not update properly when changes were made to the instance configuration.

--- a/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
+++ b/Packs/DuoAdminApi/ReleaseNotes/4_0_24.md
@@ -3,4 +3,4 @@
 
 ##### Duo Event Collector
 
-- Fixed an issue where the *logs_type_array* did not update properly when changes were made to the instance configuration.
+- Fixed an issue where the *logs_type_array* did not always update properly when changes were made to the instance configuration.

--- a/Packs/DuoAdminApi/pack_metadata.json
+++ b/Packs/DuoAdminApi/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "DUO Admin",
     "description": "DUO for admins.\nMust have access to the admin api in order to use this",
     "support": "xsoar",
-    "currentVersion": "4.0.23",
+    "currentVersion": "4.0.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-42369)

## Description
Fixed an issue where the log type array parameter would not get update when changed if a last run object already exists.

## Must have
- [ ] Tests
- [ ] Documentation 
