### PR TITLE
[Microsoft Defender for Endpoint] fix for GCC High

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/Microsoft365DefenderEventCollector/Microsoft365DefenderEventCollector.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/Microsoft365DefenderEventCollector/Microsoft365DefenderEventCollector.py
@@ -207,6 +207,7 @@ class DefenderAuthenticator(BaseModel):
             if not self.ms_client:
                 demisto.debug(f"try init the ms client for the first time, {self.url=}")
                 self.ms_client = MicrosoftClient(
+                    endpoint=self.endpoint_type,
                     base_url=self.url,
                     tenant_id=self.tenant_id,
                     auth_id=self.client_id,

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/MicrosoftDefenderAdvancedThreatProtection/MicrosoftDefenderAdvancedThreatProtection.py
@@ -1220,6 +1220,7 @@ class MsClient:
         client_args = assign_params(
             self_deployed=self_deployed,
             auth_id=auth_id,
+            endpoint=endpoint_type,
             token_retrieval_url=token_retrieval_url,
             grant_type=grant_type,
             base_url=base_url,

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_17_3.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_17_3.md
@@ -1,0 +1,9 @@
+
+#### Integrations
+
+##### Microsoft Defender for Endpoint
+
+- Fixed an issue where the Client Credentials Flow in GCC High was redirecting to the wrong endpoint.
+##### Microsoft Defender for Endpoint Alerts
+
+- Fixed an issue where the Client Credentials Flow in GCC High was redirecting to the wrong endpoint.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.17.2",
+    "currentVersion": "1.17.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-43570)

## Description
- Fixed an issue where the Client Credentials Flow in GCC High was redirecting to the wrong endpoint.
## Must have
- [ ] Tests
- [ ] Documentation 
