### PR TITLE
Taxii default long running port.

### DIFF
--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
@@ -701,7 +701,7 @@ def get_port(params: dict = demisto.params()) -> int:
     """
     Gets port from the integration parameters.
     """
-    port_mapping: str = params.get('longRunningPort', '')
+    port_mapping: str = params.get('longRunningPort', '1111')
     port: int
     if port_mapping:
         if ':' in port_mapping:

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.yml
@@ -54,7 +54,7 @@ description: This integration provides TAXII Services for system indicators (Out
 display: TAXII Server
 name: TAXII Server
 script:
-  dockerimage: demisto/taxii-server:1.0.0.90974
+  dockerimage: demisto/taxii-server:1.0.0.117317
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/TAXIIServer/ReleaseNotes/2_0_71.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_0_71.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### TAXII Server
+
+- Updated the default value of *Listen Port* parameter for use on XSIAM and XSOAR-SaaS.
+- Updated the Docker image to: *demisto/taxii-server:1.0.0.117317*.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "2.0.70",
+    "currentVersion": "2.0.71",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
bump version.
rn.

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-43935)

## Description
Added a default long running port in case server auto allocation does not work.
