### PR TITLE
Add a check for Security Approved for contributions

### DIFF
--- a/.github/workflows/security-label-check.yml
+++ b/.github/workflows/security-label-check.yml
@@ -1,7 +1,7 @@
 name: Security Label Check
 on:
   pull_request:
-    types: [opened, edited, labeled, synchronize]
+    types: [opened, edited, labeled, synchronize, unlabeled]
 jobs:
   security-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-label-check.yml
+++ b/.github/workflows/security-label-check.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   security-check:
     runs-on: ubuntu-latest
-    if: 'startsWith(github.head_ref, ''contrib'') || (github.event.pull_request.head.repo.fork == true && contains(github.event.pull_request.base.ref, ''contrib''))'
+    if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/security-label-check.yml
+++ b/.github/workflows/security-label-check.yml
@@ -19,6 +19,8 @@ jobs:
             if [[ "$LABELS" != *"Security Approved"* ]]; then
               echo "Security Approved label is missing. The PR still requires a review from the security team."
               exit 1
+            else
+              echo "Security Approved label is present."
             fi
           else
             echo "Security Review label is not added. Security review is not required."

--- a/.github/workflows/security-label-check.yml
+++ b/.github/workflows/security-label-check.yml
@@ -1,0 +1,25 @@
+name: Security Label Check
+on:
+  pull_request:
+    types: [opened, edited, labeled, synchronize]
+jobs:
+  security-check:
+    runs-on: ubuntu-latest
+    if: 'startsWith(github.head_ref, ''contrib'') || (github.event.pull_request.head.repo.fork == true && contains(github.event.pull_request.base.ref, ''contrib''))'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Check if PR base branch starts with "contrib" and labels are correct
+      id: security_check
+      run: |
+        BASE_BRANCH=$(jq --raw-output .pull_request.base.ref "$GITHUB_EVENT_PATH")
+        LABELS=$(jq --raw-output '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
+          if [[ "$LABELS" == *"Security Review"* ]]; then
+            echo "Security Review label present. Checking if Security Approved label is added..."
+            if [[ "$LABELS" != *"Security Approved"* ]]; then
+              echo "Security Approved label is missing. The PR still requires a review from the security team."
+              exit 1
+            fi
+          else
+            echo "Security Review label is not added. Security review is not required."
+          fi


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12235

## Description
If a contributor has opened a PR which requires the Security team to review it, then the merge should be blocked until they have reviewed the PR. This check will block a merge only if the PR is from a contribution and only if the "Security Review" label has been added.

## Must have
- [ ] Tests
- [ ] Documentation 
