### PR TITLE
[ReadPDFFileV2] Fix issue where the script failed to handle binary data

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_15_92.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_15_92.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### ReadPDFFileV2
+
+Fixed an issue where the script failed to handle binary data in PDF annotation objects.

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2.py
@@ -458,6 +458,8 @@ def extract_urls_and_emails_from_annot_objects(annot_objects: list | Any):
         extracted_object = extract_url_from_annot_object(annot_object)
         # Separates URLs and Emails:
         if extracted_object:
+            if isinstance(extracted_object, bytes):
+                extracted_object = extracted_object.decode()
             if url := extract_url(extracted_object):
                 urls.add(url)
             if email := extract_email(extracted_object):

--- a/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2_test.py
+++ b/Packs/CommonScripts/Scripts/ReadPDFFileV2/ReadPDFFileV2_test.py
@@ -528,3 +528,25 @@ def test_handle_error_read_only_failed(mocker):
             'The error is not due to a problem with write permissions to the file'
         )
     assert str(e.value) == 'The error is not due to a problem with write permissions to the file'
+
+
+def test_extract_urls_and_emails_from_annot_objects_with_binary_data(mocker):
+    """
+    Given:
+        A list of annotation objects where one object contains binary data.
+    When:
+        The extract_urls_and_emails_from_annot_objects function is called with these objects.
+    Then:
+        The function should correctly decode the binary data and extract the URL and email.
+    """
+    from ReadPDFFileV2 import extract_urls_and_emails_from_annot_objects
+    mock_annot_object = mocker.Mock()
+    mock_annot_object.get_object.return_value = mocker.Mock()
+
+    binary_data = b'https://example.com user@example.com'
+    mocker.patch('ReadPDFFileV2.extract_url_from_annot_object', return_value=binary_data)
+
+    urls, emails = extract_urls_and_emails_from_annot_objects([mock_annot_object])
+
+    assert urls == {'https://example.com'}
+    assert emails == {'user@example.com'}

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.15.91",
+    "currentVersion": "1.15.92",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-44142)

## Description
Fixed an issue where the script failed to handle binary data in PDF annotation objects.

## Must have
- [x] Tests
- [ ] Documentation 
