### PR TITLE
Ews powershell bug

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
@@ -16,7 +16,7 @@ $script:INTEGRATION_NAME = "EWS extension"
 $script:COMMAND_PREFIX = "ews"
 $script:INTEGRATION_ENTRY_CONTEXT = "EWS"
 $script:JUNK_RULE_ENTRY_CONTEXT = "$script:INTEGRATION_ENTRY_CONTEXT.Rule.Junk(val.Email && val.Email == obj.Email)"
-$script:MESSAGE_TRACE_ENTRY_CONTEXT = "$script:INTEGRATION_ENTRY_CONTEXT.MessageTrace(val.MessageId && val.MessageId == obj.MessageId)"
+$script:MESSAGE_TRACE_ENTRY_CONTEXT = "$script:INTEGRATION_ENTRY_CONTEXT.MessageTrace(val.messageTraceId.value && val.messageTraceId.value == obj.messageTraceId.value)"
 
 
 function ParseJunkRulesToEntryContext([PSObject]$raw_response) {

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_5_17.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_5_17.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS Extension Online Powershell v3
+
+- Fixed an issue where the ***ews-message-trace-get*** command returned invalid context outputs.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.5.16",
+    "currentVersion": "1.5.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-44009

## Description
Fixed an issue where the ***ews-message-trace-get*** command returned invalid context outputs.

## Must have
- [ ] Tests
- [ ] Documentation 
