### PR TITLE
Jira V3 forms DC OnPrem handling

### DIFF
--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -1203,8 +1203,10 @@ class JiraOnPremClient(JiraBaseClient):
         )
         if response.status_code == 404:
             return []
-        else:
+        elif response.status_code == 200:
             return response.json()
+        else:
+            demisto.debug(f'EXTRA LOG - GOT OTHER RESPONSE: {response}')
 
 
 class JiraIssueFieldsParser:
@@ -1894,10 +1896,19 @@ def get_issue_forms(client: JiraOnPremClient, issue_id: str) -> tuple[List, List
     :return: The raw JSON response and the formatted outputs
     :rtype: tuple[List, List]
     """
-    response = client.issue_get_forms(issue_id=issue_id)
+    try:
+        response = client.issue_get_forms(issue_id=issue_id)
+    except Exception as e:
+        demisto.debug(f"EXTRA LOG - forms exception {str(e)}")
+        response = {}
+    
     demisto.debug(f'Response from Jira API rest/proforma/api/2/issues/{issue_id}/forms: {json.dumps(response)}')
     outputs = []
+    demisto.debug(f'EXTRA LOG - LOOPING ON {response}')
+
     for form in response:
+        demisto.debug(f'EXTRA LOG - FORMS - Running on {form}')
+
         questions = []
         for question_id, question_data in form.get('design', {}).get('questions').items():
             answer = form.get('state', {}).get('answers', {}).get(question_id)
@@ -3444,6 +3455,8 @@ def get_smallest_id_offset_for_query(client: JiraBaseClient, query: str) -> tupl
     jql_query = f'{query} ORDER BY created ASC' if query else 'ORDER BY created ASC'
     query_params = create_query_params(jql_query=jql_query, max_results=1)
     res = client.run_query(query_params=query_params)
+    demisto.debug('EXTRA LOG -  got lowest id: {res}.')
+
     if (issues := res.get('issues', [])):
         return res, issues[0].get('id', '')
     return res, None
@@ -3513,15 +3526,24 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
     try:
         if query_res := client.run_query(query_params=query_params):
             for issue in query_res.get('issues', []):
+                demisto.debug(f'EXTRA LOG -  Creating an incident for Jira issue: {issue}')
+
                 issue_id: int = int(issue.get('id'))  # The ID returned by the API is an integer
-                demisto.debug(f'Creating an incident for Jira issue with ID: {issue_id}')
+                demisto.debug(f'EXTRA LOG - Creating an incident for Jira issue with ID: {issue_id}')
                 new_issue_ids.append(issue_id)
                 last_fetch_id = issue_id
+                demisto.debug(f'EXTRA LOG -  incident we got so far: {new_issue_ids}')
                 new_fetch_created_time = convert_string_date_to_specific_format(
                     string_date=demisto.get(issue, 'fields.created') or '')
+                demisto.debug(f'EXTRA LOG -  converted created time to {new_fetch_created_time}')
                 new_fetch_updated_time = convert_string_date_to_specific_format(
                     string_date=demisto.get(issue, 'fields.updated') or '')
+                demisto.debug(f'EXTRA LOG -  converted updated time to {new_fetch_updated_time}')
+                demisto.debug('EXTRA LOG -  starting to parse custom fields.')
+
                 parse_custom_fields(issue=issue, issue_fields_id_to_name_mapping=query_res.get('names', {}))
+                demisto.debug('EXTRA LOG -  finished parsing custom fields. Starting build an incident')
+
                 incidents.append(create_incident_from_issue(
                     client=client, issue=issue, fetch_attachments=fetch_attachments, fetch_comments=fetch_comments,
                     mirror_direction=mirror_direction,
@@ -3529,10 +3551,15 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
                     comment_tag_to_jira=comment_tag_to_jira,
                     attachment_tag_from_jira=attachment_tag_from_jira,
                     attachment_tag_to_jira=attachment_tag_to_jira))
+                demisto.debug('EXTRA LOG -  Finished building incident.')
+
     except Exception as e:
+        demisto.debug('EXTRA LOG -  Failure detected: {e}.')
+
         if 'Issue does not exist' in str(e) and issue_field_to_fetch_from == 'id' and str(id_offset) == str(last_fetch_id):
             # If entered here, this means the user wants to fetch using the issue ID, and has given an incorrect issue ID
             # to start fetching from, other than 0.
+            demisto.debug('EXTRA LOG -  Going To IF.')
             _, smallest_issue_id = get_smallest_id_offset_for_query(client=client, query=fetch_query)
             raise DemistoException(
                 f'The smallest issue ID with respect to the fetch query is {smallest_issue_id}, please configure it in the'
@@ -3543,6 +3570,9 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
             ) from e
     # If we did no progress in terms of time (the created, or updated time stayed the same as the last fetch), we should keep the
     # ids of the last fetch until progress is made, so we exclude them in the next fetch.
+    demisto.debug('EXTRA LOG -  Exception has NOT occured. Moving on.')
+    demisto.debug(f'EXTRA LOG -  params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
+
     if (
         (issue_field_to_fetch_from == 'created date'
          and new_fetch_created_time == last_fetch_created_time)
@@ -3550,6 +3580,8 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
             and new_fetch_updated_time == last_fetch_updated_time)
     ):
         new_issue_ids.extend(last_fetch_issue_ids)
+    demisto.debug('EXTRA LOG -  setting last run.')
+
     demisto.setLastRun({
         'issue_ids': new_issue_ids or last_fetch_issue_ids,
         'id': last_fetch_id,
@@ -3719,7 +3751,11 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
     Returns:
         Dict[str, Any]: A dictionary that is represents an incident.
     """
+    demisto.debug(f'EXTRA LOG - create incident - starting. raw data: {issue}')
+
     issue_description: str = JiraIssueFieldsParser.get_description_context(issue_data=issue).get('Description') or ''
+    demisto.debug(f'EXTRA LOG - create incident - manage to get description: {issue_description}')
+
     issue_id = str(issue.get('id'))
     labels = [
         {'type': 'issue', 'value': json.dumps(issue)},
@@ -3736,8 +3772,11 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
         {'type': 'description', 'value': issue_description},
     ]
     issue['parsedDescription'] = issue_description
+    demisto.debug('EXTRA LOG - create incident - extracting extra data.')
+
     issue |= add_extracted_data_to_incident(issue=issue)
     incident_name = f"Jira issue: {issue.get('id')}"
+    demisto.debug('EXTRA LOG - create incident - got so far.')
 
     severity = get_jira_issue_severity(issue_field_priority=demisto.get(issue, 'fields.priority') or {})
 
@@ -3748,6 +3787,7 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
         comments_entries = get_fetched_comments(client, issue_id)
         issue['extractedComments'] = comments_entries
         labels.append({'type': 'comments', 'value': str(comments_entries)})
+    demisto.debug('EXTRA LOG - create incident - got so far 2.')
 
     issue['mirror_direction'] = MIRROR_DIRECTION_DICT.get(mirror_direction)
 
@@ -3759,11 +3799,13 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
     ]
     issue['mirror_instance'] = demisto.integrationInstance()
     issue['extractedAttachments'] = attachments
+    demisto.debug('EXTRA LOG - create incident - got so far 3.')
 
     # Fetch any forms for the issue
     if isinstance(client, JiraOnPremClient):
         _, forms = get_issue_forms(client, str(issue.get('key')))
         issue['forms'] = forms
+    demisto.debug('EXTRA LOG - create incident - got so far 4.')
 
     return {
         "name": incident_name,

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -3568,7 +3568,8 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
     # If we did no progress in terms of time (the created, or updated time stayed the same as the last fetch), we should keep the
     # ids of the last fetch until progress is made, so we exclude them in the next fetch.
     demisto.debug(
-        f'Params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
+        f'Params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, 
+        {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
 
     if (
         (issue_field_to_fetch_from == 'created date'

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -3568,8 +3568,10 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
     # If we did no progress in terms of time (the created, or updated time stayed the same as the last fetch), we should keep the
     # ids of the last fetch until progress is made, so we exclude them in the next fetch.
     demisto.debug(
-        f'Params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, 
-        {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
+        f'Params to validate: {issue_field_to_fetch_from=}'
+        f'{new_fetch_created_time=}, {last_fetch_created_time=}'
+        f'{new_fetch_updated_time=},{last_fetch_updated_time=}'
+    )
 
     if (
         (issue_field_to_fetch_from == 'created date'

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -1207,7 +1207,7 @@ class JiraOnPremClient(JiraBaseClient):
             return response.json()
         else:
             demisto.debug('Received unexpected response.')
-            return {} 
+            return []
 
 
 class JiraIssueFieldsParser:
@@ -1901,8 +1901,8 @@ def get_issue_forms(client: JiraOnPremClient, issue_id: str) -> tuple[List, List
         response = client.issue_get_forms(issue_id=issue_id)
     except Exception as e:
         raise DemistoException(f"Forms fetching exception {str(e)}")
-    
-    demisto.debug(f'Finished getting forms.')
+
+    demisto.debug('Finished getting forms.')
     outputs = []
 
     for form in response:
@@ -3567,7 +3567,8 @@ def fetch_incidents(client: JiraBaseClient, issue_field_to_fetch_from: str, fetc
             ) from e
     # If we did no progress in terms of time (the created, or updated time stayed the same as the last fetch), we should keep the
     # ids of the last fetch until progress is made, so we exclude them in the next fetch.
-    demisto.debug(f'Params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
+    demisto.debug(
+        f'Params to validate: {issue_field_to_fetch_from=}, {new_fetch_created_time=}, {last_fetch_created_time=}, {new_fetch_updated_time=},{last_fetch_updated_time=}')
 
     if (
         (issue_field_to_fetch_from == 'created date'
@@ -3799,10 +3800,10 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
         try:
             _, forms = get_issue_forms(client, str(issue.get('key')))
             issue['forms'] = forms
-        except DemistoException as e:
+        except DemistoException:
             demisto.debug(f'Failed to get reports for {issue_id}, Not retrieving. Error: {traceback.format_exc()}')
             pass
-            
+
     demisto.debug(f'Incident for issue {issue_id} is being created.')
 
     return {

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -1901,7 +1901,6 @@ def get_issue_forms(client: JiraOnPremClient, issue_id: str) -> tuple[List, List
         response = client.issue_get_forms(issue_id=issue_id)
     except Exception as e:
         raise DemistoException(f"Forms fetching exception {str(e)}")
-        response = {}
     
     demisto.debug(f'Finished getting forms.')
     outputs = []
@@ -3800,10 +3799,11 @@ def create_incident_from_issue(client: JiraBaseClient, issue: Dict[str, Any], fe
         try:
             _, forms = get_issue_forms(client, str(issue.get('key')))
             issue['forms'] = forms
-        except Exception as e:
-            demisto.debug(f'Failed to get reports for {issue_id}. Error: {traceback.format_exc()}')
+        except DemistoException as e:
+            demisto.debug(f'Failed to get reports for {issue_id}, Not retrieving. Error: {traceback.format_exc()}')
+            pass
             
-    demisto.debug(f'Incident for ticket {issue_id} is being created.')
+    demisto.debug(f'Incident for issue {issue_id} is being created.')
 
     return {
         "name": incident_name,

--- a/Packs/Jira/ReleaseNotes/3_2_11.md
+++ b/Packs/Jira/ReleaseNotes/3_2_11.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Atlassian Jira v3
+
+- Fixed an issue in **fetch-incidents** where getting forms from issues in OnPrem DataCenter failed the fetch.

--- a/Packs/Jira/ReleaseNotes/3_2_11.md
+++ b/Packs/Jira/ReleaseNotes/3_2_11.md
@@ -3,4 +3,4 @@
 
 ##### Atlassian Jira v3
 
-- Fixed an issue in **fetch-incidents** failing when getting forms from issues in OnPrem DataCenter.
+- Fixed an issue where **fetch-incidents** failed when getting forms from issues in OnPrem DataCenter.

--- a/Packs/Jira/ReleaseNotes/3_2_11.md
+++ b/Packs/Jira/ReleaseNotes/3_2_11.md
@@ -3,4 +3,4 @@
 
 ##### Atlassian Jira v3
 
-- Fixed an issue in **fetch-incidents** where getting forms from issues in OnPrem DataCenter failed the fetch.
+- Fixed an issue in **fetch-incidents** failing when getting forms from issues in OnPrem DataCenter.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Cortex XSOAR incidents from Jira projects.",
     "support": "xsoar",
-    "currentVersion": "3.2.10",
+    "currentVersion": "3.2.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/XSUP-43839

## Description
When customers are using OnPrem version of Jira DataCenter, the fetch is trying to retrieve reports like done on OnPrem but in DC it is not possible, therefore they encounter an error.
This PR adds logs and handling the exception for this case (and in general) so the fetch will not fail when reports are not being fetched.

## Must have
- [ ] Tests
- [x] Documentation 
