### PR TITLE
[GetFailedTasks] New argument - get_scripts_name

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_23.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_23.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetFailedTasks
+
+Added the *get_scripts_name* argument that enables the script to retrieve and display custom script names instead of script IDs.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
@@ -40,7 +40,7 @@ def get_tenant_name():
     return tenant_name
 
 
-def get_failed_tasks_output(tasks: list, incident: dict, custom_scripts_map_id_and_name: dict[str, str]):
+def get_failed_tasks_output(tasks: list, incident: dict, custom_scripts_map_id_and_name: dict[str, str] = {}):
     """
         Converts the failing task objects of an incident to context outputs.
 

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.yml
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.yml
@@ -7,6 +7,12 @@ args:
   name: max_incidents
 - description: Rest API instance to use.
   name: rest_api_instance
+- auto: PREDEFINED
+  description: Whether to replace the scripts ids to their name in case of custom scripts.
+  name: get_scripts_name
+  predefined:
+  - 'true'
+  - 'false'
 comment: |-
   Gets failed tasks details for incidents based on a query. Limited to 1000 incidents.
 

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.3.22",
+    "currentVersion": "1.3.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-44352)

## Description
Added the *get_scripts_name* argument that enables the script to retrieve and display custom script names instead of script IDs.

## Must have
- [ ] Tests
- [ ] Documentation 
