### PR TITLE
ServiceNowV2: Hide mirror fileds in XSIAM

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.yml
@@ -185,11 +185,15 @@ configuration:
   display: Mirrored XSOAR Ticket custom close state code
   name: server_close_custom_state
   type: 0
+  hidden:
+  - marketplacev2
   required: false
 - additionalinfo: 'Define how to close the mirrored tickets in Cortex XSOAR with a custom resolution code. Enter a comma-separated list of custom resolution codes and their labels (acceptable format example: “10=Design,11=Development,12=Testing”) to override the default closure method. Note that a matching user-defined list of custom close reasons must be configured as a "Server configuration" in Cortex XSOAR. Not following this format will result in closing the incident with a default close reason.'
   display: Mirrored XSOAR Ticket custom close resolution code (overwrites the custom close state)
   name: server_custom_close_code
   type: 0
+  hidden:
+  - marketplacev2
   required: false
 - additionalinfo: Define how to close the mirrored tickets in ServiceNow. Choose 'resolved' to enable reopening from the UI. Otherwise, choose 'closed'.
   defaultvalue: 'None'
@@ -200,6 +204,8 @@ configuration:
   - None
   - closed
   - resolved
+  hidden:
+  - marketplacev2
   required: false
 - display: Mirrored ServiceNow Ticket custom close state code
   name: close_custom_state
@@ -220,6 +226,8 @@ configuration:
   display: Mirror Existing Notes For New Fetched Incidents
   name: mirror_notes_for_new_incidents
   type: 8
+  hidden:
+  - marketplacev2
   required: false
 - defaultvalue: 'false'
   display: 'Use system proxy settings'

--- a/Packs/ServiceNow/ReleaseNotes/2_7_1.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_7_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ServiceNow v2
+
+Mirror related fields removed in XSIAM context.

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.7.0",
+    "currentVersion": "2.7.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-12318

## Description

Currently there is some mirrir related fileds which are presented in XSIAM - hide them