### PR TITLE
JAMF - Add Get configuration-profiles-by-id commands

### DIFF
--- a/Packs/jamf/Integrations/jamfV2/command_examples.txt
+++ b/Packs/jamf/Integrations/jamfV2/command_examples.txt
@@ -37,3 +37,5 @@ jamf-get-mobile-device-configuration-profiles-subset identifier=id identifier_va
 jamf-get-computers-by-application application=safar* limit=3
 jamf-mobile-device-lost-mode id=114
 jamf-mobile-device-erase id=114
+jamf-get-computer-configuration-profiles-by-id id=1
+jamf-get-mobile-configuration-profiles-by-id id=1

--- a/Packs/jamf/Integrations/jamfV2/jamfV2.py
+++ b/Packs/jamf/Integrations/jamfV2/jamfV2.py
@@ -1,13 +1,14 @@
 import demistomock as demisto
 from CommonServerPython import *  # noqa # pylint: disable=unused-wildcard-import
-from CommonServerUserPython import *  # noqa
-
+from CommonServerUserPython import *
 import dateparser
 import requests
 import traceback
 from typing import Any
 from bs4 import BeautifulSoup
 import urllib3
+
+from Packs.XSOAR_EDL_Checker.Scripts.XSOARAllEDLCheckerAutomation.XSOARAllEDLCheckerAutomation import readable
 
 # Disable insecure warnings
 urllib3.disable_warnings()  # pylint: disable=no-member
@@ -401,6 +402,24 @@ class Client(BaseClient):
 
         json_response = json.loads(xml2json(res.content))
         return json_response
+
+    def get_mobiledeviceconfigurationprofiles_by_id(self, id):
+        """
+        API link: https://developer.jamf.com/jamf-pro/reference/findmobiledeviceconfigurationprofilesbyid
+        """
+        uri = f'/mobiledeviceconfigurationprofiles/id/{id}'
+        res = self._classic_api_get(url_suffix=uri, error_handler=self._generic_error_handler)
+        return res
+
+
+    def get_osxconfigurationprofiles_by_id(self, id):
+        """
+        API link: https://developer.jamf.com/jamf-pro/reference/findosxconfigurationprofilesbyid
+        """
+        uri = f'/osxconfigurationprofiles/id/{id}'
+        res = self._classic_api_get(url_suffix=uri, error_handler=self._generic_error_handler)
+        return res
+
 
 
 ''' HELPER FUNCTIONS '''
@@ -1337,6 +1356,36 @@ def check_authentication_parameters(client_id: str | None, client_secret: str | 
     return None
 
 
+def get_profile_configuration_osx( client: Client, args: dict[str, Any]) -> CommandResults:
+    profile_id = args.get('id')
+    profile_response = client.get_osxconfigurationprofiles_by_id(profile_id)
+    readable_output = profile_response.get('os_x_configuration_profile')
+    return CommandResults(
+        readable_output=tableToMarkdown(
+            f'Jamf get profile configuration result for profile ID:{profile_id}',
+            readable_output, removeNull=True
+        ),
+        outputs_prefix='JAMF.OSX.ProfileConfiguration',
+        outputs=readable_output,
+        raw_response=profile_response
+    )
+
+
+def get_profile_configuration_mobile(client: Client, args: dict[str, Any]) -> CommandResults:
+    profile_id = args.get('id')
+    profile_response = client.get_mobiledeviceconfigurationprofiles_by_id(profile_id)
+    readable_output = profile_response.get('configuration_profile')
+    return CommandResults(
+        readable_output=tableToMarkdown(
+            f'Jamf get profile configuration result for profile ID:{profile_id}',
+            readable_output, removeNull=True
+        ),
+        outputs_prefix='JAMF.Mobile.ProfileConfiguration',
+        outputs=readable_output,
+        raw_response=profile_response
+    )
+
+
 ''' MAIN FUNCTION '''
 
 
@@ -1478,6 +1527,12 @@ def main() -> None:
 
         elif demisto.command() == 'endpoint':
             return_results(endpoint_command(client, demisto.args()))
+
+        elif demisto.command() == 'jamf-get-mobile-configuration-profiles-by-id':
+            return_results(get_profile_configuration_mobile(client, demisto.args()))
+
+        elif demisto.command() == 'jamf-get-computer-configuration-profiles-by-id':
+            return_results(get_profile_configuration_osx(client, demisto.args()))
 
     # Log exceptions and return errors
     except Exception as e:

--- a/Packs/jamf/Integrations/jamfV2/jamfV2.yml
+++ b/Packs/jamf/Integrations/jamfV2/jamfV2.yml
@@ -2592,6 +2592,85 @@ script:
     - contextPath: Endpoint.Vendor
       description: The integration name of the endpoint vendor.
       type: String
+  - arguments:
+      - description: The ID of the mobile device.
+        name: id
+        required: true
+    name: jamf-get-mobile-configuration-profiles-by-id
+    description: Returns the configuration profiles subset for a specific mobile device according to the given arguments.
+    outputs:
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.id
+        description: The ID of the configuration profile.
+        type: Number
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.name
+        description: The name of the configuration profile.
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.description
+        description: The mobile device configuration description.
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.level
+        description: Level of the configuration profile (System or User)
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.site
+        description: Site of the configuration profile
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.category
+        description: Category of the configuration profile
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.uuid
+        description: Unique identifier of the mobile profile configuration
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.deployment_method
+        description: Install Automatically or Make Available in Self Service
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.general.payloads
+        description: Install Automatically or Make Available in Self Service
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.scope
+        description: Scope object of the configuration profile
+        type: String
+      - contextPath: JAMF.Mobile.ProfileConfiguration.self_service
+        description: Self-service object of the configuration profile
+        type: String
+  - arguments:
+      - description: The ID of the mobile device.
+        name: id
+        required: true
+    name: jamf-get-computer-configuration-profiles-by-id
+    description: Returns the configuration profiles subset for a specific mobile device according to the given arguments.
+    outputs:
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.id
+        description: The ID of the configuration profile.
+        type: Number
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.name
+        description: The name of the configuration profile.
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.description
+        description: The mobile device configuration description.
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.level
+        description: Level of the configuration profile (System or User)
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.site
+        description: Site of the configuration profile
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.category
+        description: Category of the configuration profile
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.uuid
+        description: Unique identifier of the mobile profile configuration
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.distribution_method
+        description: Install Automatically or Make Available in Self Service
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.general.payloads
+        description: Install Automatically or Make Available in Self Service
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.scope
+        description: Scope object of the configuration profile
+        type: String
+      - contextPath: JAMF.OSX.ProfileConfiguration.self_service
+        description: Self-service object of the configuration profile
+        type: String
   dockerimage: demisto/btfl-soup:1.0.1.115405
   runonce: false
   script: '-'

--- a/Packs/jamf/Integrations/jamfV2/jamfV2_test.py
+++ b/Packs/jamf/Integrations/jamfV2/jamfV2_test.py
@@ -586,3 +586,43 @@ def test_generate_token(mocker):
 
     Client(base_url="https://example.com", verify=False, proxy=False, username="username", password="password")
     assert basic_auth_token.call_count == 1
+
+
+def test_get_computer_configuration_profiles_by_id(mocker):
+    """
+    Given:
+        - Computer ID
+    When:
+        - get_profile_configuration_osx is called
+    Then:
+        - Ensure the function returns the correct output
+    """
+    from jamfV2 import Client, get_profile_configuration_osx
+    mocker.patch.object(Client, '_get_token')
+    client = Client(base_url='https://paloaltonfr3.jamfcloud.com', verify=False)
+    args = {'id': 1}
+    mock_response = util_load_json('test_data/get_computer_configuration_profiles/get_computer_configuration_profiles_by_id_raw_response.json')
+    mocker.patch.object(client, 'get_osxconfigurationprofiles_by_id', return_value=mock_response)
+
+    outputs = get_profile_configuration_osx(client, args)
+    assert outputs.outputs["general"]["id"] == 1
+
+
+def test_get_mobile_configuration_profiles_by_id(mocker):
+    """
+    Given:
+        - Mobile ID
+    When:
+        - get_profile_configuration_mobile is called
+    Then:
+        - Ensure the function returns the correct output
+    """
+    from jamfV2 import Client, get_profile_configuration_mobile
+    mocker.patch.object(Client, '_get_token')
+    client = Client(base_url='https://paloaltonfr3.jamfcloud.com', verify=False)
+    args = {'id': 1}
+    mock_response = util_load_json('test_data/get_mobile_configuration_profiles/get_mobile_configuration_profiles_by_id_raw_response.json')
+    mocker.patch.object(client, 'get_mobiledeviceconfigurationprofiles_by_id', return_value=mock_response)
+
+    outputs = get_profile_configuration_mobile(client, args)
+    assert outputs.outputs["general"]["id"] == 1

--- a/Packs/jamf/Integrations/jamfV2/test_data/get_computer_configuration_profiles/get_computer_configuration_profiles_by_id_raw_response.json
+++ b/Packs/jamf/Integrations/jamfV2/test_data/get_computer_configuration_profiles/get_computer_configuration_profiles_by_id_raw_response.json
@@ -1,0 +1,216 @@
+{
+    "os_x_configuration_profile":
+    {
+      "general": {
+        "id": 1,
+        "name": "Corporate Wireless",
+        "description": "string",
+        "site": {
+          "id": -1,
+          "name": "None"
+        },
+        "category": {
+          "id": -1,
+          "name": "Unknown"
+        },
+        "distribution_method": "Install Automatically",
+        "user_removable": true,
+        "level": "computer",
+        "uuid": "88F8C1DB-D92A-4D10-95FB-CE7EDE82B93E",
+        "redeploy_on_update": "Newly Assigned",
+        "payloads": "string"
+      },
+      "scope": {
+        "all_computers": false,
+        "all_jss_users": false,
+        "computers": [
+          {
+            "computer": {
+              "id": 1,
+              "name": "Admins MacBook Pro",
+              "udid": "55900BDC-347C-58B1-D249-F32244B11D30"
+            }
+          }
+        ],
+        "buildings": [
+          {
+            "building": {
+              "id": 1,
+              "name": "string"
+            }
+          }
+        ],
+        "departments": [
+          {
+            "department": {
+              "id": 1,
+              "name": "string"
+            }
+          }
+        ],
+        "computer_groups": [
+          {
+            "computer_group": {
+              "id": 1,
+              "name": "string"
+            }
+          }
+        ],
+        "jss_users": [
+          {
+            "users": {
+              "id": 1,
+              "name": "string"
+            }
+          }
+        ],
+        "jss_user_groups": [
+          {
+            "jss_user_group": {
+              "id": 1,
+              "name": "string"
+            }
+          }
+        ],
+        "limitations": {
+          "users": [
+            {
+              "user": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "user_groups": [
+            {
+              "user_group": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "network_segments": [
+            {
+              "network_segment": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "ibeacons": [
+            {
+              "ibeacon": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ]
+        },
+        "exclusions": {
+          "computers": [
+            {
+              "computer": {
+                "id": 1,
+                "name": "Johns iMac",
+                "udid": "55900BDC-347C-58B1-D249-F32244B11D30"
+              }
+            }
+          ],
+          "buildings": [
+            {
+              "building": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "departments": [
+            {
+              "department": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "computer_groups": [
+            {
+              "computer_group": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "users": [
+            {
+              "user": {
+                "name": "Adam"
+              }
+            }
+          ],
+          "user_groups": [
+            {
+              "user_group": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "network_segments": [
+            {
+              "network_segment": {
+                "id": 1,
+                "uid": "string",
+                "name": "New York"
+              }
+            }
+          ],
+          "ibeacons": [
+            {
+              "ibeacon": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "jss_users": [
+            {
+              "jss_user": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ],
+          "jss_user_groups": [
+            {
+              "jss_user_group": {
+                "id": 1,
+                "name": "string"
+              }
+            }
+          ]
+        }
+      },
+      "self_service": {
+        "install_button_text": "Install",
+        "self_service_description": "string",
+        "force_users_to_view_description": true,
+        "self_service_icon": {
+          "id": 1,
+          "uri": "https://company.jamfcloud.com/iconservlet/?id=1",
+          "data": "string"
+        },
+        "feature_on_main_page": true,
+        "self_service_categories": {
+          "category": {
+            "id": 1,
+            "name": "Compliance",
+            "display_in": true,
+            "feature_in": false
+          }
+        },
+        "notification": "string",
+        "notification_subject": "Install Me!!!",
+        "notification_message": "You need access to corporate resources. Install this profile to get the premium WiFis."
+      }
+    }
+}

--- a/Packs/jamf/Integrations/jamfV2/test_data/get_mobile_configuration_profiles/get_mobile_configuration_profiles_by_id_raw_response.json
+++ b/Packs/jamf/Integrations/jamfV2/test_data/get_mobile_configuration_profiles/get_mobile_configuration_profiles_by_id_raw_response.json
@@ -1,0 +1,216 @@
+{
+    "configuration_profile": {
+        "general": {
+            "id": 1,
+            "name": "Corporate Wireless",
+            "description": "string",
+            "level": "System",
+            "site": {
+                "id": -1,
+                "name": "None"
+            },
+            "category": {
+                "id": -1,
+                "name": "Unknown"
+            },
+            "uuid": "55900BDC-347C-58B1-D249-F32244B11D30",
+            "deployment_method": "Install Automatically",
+            "redeploy_on_update": "Newly Assigned",
+            "redeploy_Dayss_before_certificate_expires": 0,
+            "payloads": "string"
+        },
+        "scope": {
+            "all_mobile_devices": true,
+            "all_jss_users": true,
+            "mobile_devices": [
+                {
+                    "mobile_device": {
+                        "id": 1,
+                        "name": "Admins iPad",
+                        "udid": "270aae10800b6e61a2ee2bbc285eb967050b5984",
+                        "wifi_mac_address": "E0:AC:CB:97:36:G4"
+                    }
+                }
+            ],
+            "buildings": [
+                {
+                    "building": {
+                        "id": 1,
+                        "name": "string"
+                    }
+                }
+            ],
+            "departments": [
+                {
+                    "department": {
+                        "id": 1,
+                        "name": "string"
+                    }
+                }
+            ],
+            "mobile_device_groups": [
+                {
+                    "mobile_device_group": {
+                        "id": 1,
+                        "name": "string"
+                    }
+                }
+            ],
+            "jss_users": [
+                {
+                    "user": {
+                        "id": 1,
+                        "name": "string"
+                    }
+                }
+            ],
+            "jss_user_groups": [
+                {
+                    "user_group": {
+                        "id": 1,
+                        "name": "string"
+                    }
+                }
+            ],
+            "limitations": {
+                "users": [
+                    {
+                        "user": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "user_groups": [
+                    {
+                        "user_group": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "network_segments": [
+                    {
+                        "network_segment": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "ibeacons": [
+                    {
+                        "ibeacon": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ]
+            },
+            "exclusions": {
+                "mobile_devices": [
+                    {
+                        "mobile_device": {
+                            "id": 1,
+                            "name": "Johns iPad",
+                            "udid": "270aae10800b6e61a2ee2bbc285eb967050b5984",
+                            "wifi_mac_address": "E0:AC:CB:97:36:G4"
+                        }
+                    }
+                ],
+                "buildings": [
+                    {
+                        "building": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "departments": [
+                    {
+                        "department": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "mobile_device_groups": [
+                    {
+                        "mobile_device_group": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "users": [
+                    {
+                        "user": {
+                            "name": "Adam"
+                        }
+                    }
+                ],
+                "user_groups": [
+                    {
+                        "user_group": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "network_segments": [
+                    {
+                        "network_segment": {
+                            "id": 1,
+                            "uid": "string",
+                            "name": "New York"
+                        }
+                    }
+                ],
+                "ibeacons": [
+                    {
+                        "ibeacon": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "jss_users": [
+                    {
+                        "user": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ],
+                "jss_user_groups": [
+                    {
+                        "user_group": {
+                            "id": 1,
+                            "name": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "self_service": {
+            "self_service_description": "Install this profile to access resources on the corporate network",
+            "security_name": {
+                "removal_disallowed": "Never"
+            },
+            "self_service_icon": {
+                "filename": "WiFi.png",
+                "uri": "https://company.jamfcloud.com/iconservelet/?id=1",
+                "data": "string"
+            },
+            "feature_on_main_page": true,
+            "self_service_categories": [
+                {
+                    "category": {
+                        "id": 1,
+                        "name": "Applications",
+                        "priority": 9
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Implement commands to get Configuration profiles for OS X or Mobile devices managed by JAMF.

See JAMF documentation:
- https://developer.jamf.com/jamf-pro/reference/findmobiledeviceconfigurationprofilesbyid
- https://developer.jamf.com/jamf-pro/reference/findosxconfigurationprofilesbyid

## Must have
- [ X] Tests
- [ ] Documentation 
