### PR TITLE
Update RN111 to be a warning

### DIFF
--- a/validation_config.toml
+++ b/validation_config.toml
@@ -42,7 +42,7 @@ select = [
     "DA100", "DA101",
     "IT100", "IT101", "IT102", "IT103",
     "MR100", "MR101", "MR106", "MR107", "MR108",
-    "RN103", "RN105", "RN106", "RN107", "RN108", "RN111", "RN112", "RN113", "RN114", "RN115", "RN116",
+    "RN103", "RN105", "RN106", "RN107", "RN108", "RN112", "RN113", "RN114", "RN115", "RN116",
     "LO107",
     "GR101", "GR102", "GR103", "GR104", "GR105", "GR106", "GR107", "GR108",
     "CR102",
@@ -51,7 +51,7 @@ select = [
     "ST110", 
 ]
 
-warning = ["DS107", "GR107"]
+warning = ["DS107", "GR107", "RN111"]
 
 [path_based_validations]
 select = [


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Because of a possible bug that causes RN111 to fail when it shouldn't (the docker image in the yml file and in the RN are identical), I move it to be a warning until further investigation.

## Must have
- [ ] Tests
- [ ] Documentation 
