### PR TITLE
[GetFailedTasks] Improved performance when using the get_scripts_name argument

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_26.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_26.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetFailedTasks
+
+Improved performance when using the get_scripts_name argument.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.3.25",
+    "currentVersion": "1.3.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-44352)

## Description
Improved performance when using the get_scripts_name argument.

## Must have
- [x] Tests
- [ ] Documentation 
