### PR TITLE
GenerixSQL: update docker image with cryptography

### DIFF
--- a/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
+++ b/Packs/GenericSQL/Integrations/GenericSQL/GenericSQL.yml
@@ -165,7 +165,7 @@ script:
       name: bind_variables_values
     description: Running a sql query.
     name: sql-command
-  dockerimage: demisto/genericsql:1.1.0.116569
+  dockerimage: demisto/genericsql:1.1.0.1836486
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/GenericSQL/ReleaseNotes/1_3_7.md
+++ b/Packs/GenericSQL/ReleaseNotes/1_3_7.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Generic SQL
+
+Updated the Docker image to: *demisto/genericsql:1.1.0.1836486*.

--- a/Packs/GenericSQL/pack_metadata.json
+++ b/Packs/GenericSQL/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Connect and execute sql queries in 5 Databases: MySQL, PostgreSQL, Microsoft SQL Server, Oracle and Teradata",
     "support": "xsoar",
     "serverMinVersion": "5.0.0",
-    "currentVersion": "1.3.6",
+    "currentVersion": "1.3.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixed: https://jira-dc.paloaltonetworks.com/browse/XSUP-43827

## Description

added the cryptography module to the docker image
and updated the integration to use the new docker image

docker repo pr: https://github.com/demisto/dockerfiles/pull/34754