### PR TITLE
Make GetIncidentTasks compatible with tenants

### DIFF
--- a/Packs/DemistoRESTAPI/ReleaseNotes/1_3_66.md
+++ b/Packs/DemistoRESTAPI/ReleaseNotes/1_3_66.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetIncidentTasks
+
+- Made compatible with tenants

--- a/Packs/DemistoRESTAPI/Scripts/GetIncidentTasks/GetIncidentTasks.py
+++ b/Packs/DemistoRESTAPI/Scripts/GetIncidentTasks/GetIncidentTasks.py
@@ -93,7 +93,10 @@ def get_task_command(args: dict[str, Any]) -> CommandResults:
     tag = args.get('tag')
     states = get_states(argToList(args.get('states')))
     inc_id = args['inc_id']
-    res = demisto.executeCommand('core-api-get', {'uri': f'/investigation/{inc_id}/workplan'})
+    acc = get_tenant_account_name()
+    if acc:
+        acc += '/'
+    res = demisto.executeCommand('core-api-get', {'uri': f'/{acc}investigation/{inc_id}/workplan'})
     if not res or isError(res[0]):
         raise Exception(res)
 

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex REST API",
     "description": "Use Demisto REST APIs",
     "support": "xsoar",
-    "currentVersion": "1.3.65",
+    "currentVersion": "1.3.66",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
The GetIncidentTasks automation from the Cortex REST API Content Pack fails for incidents on tenants with "Work plan for incident XY has no tasks.". This minor change addresses this while maintaining backwards compatibility for non-tenant incidents.

## Must have
- [x] Tests
- [x] Documentation