### PR TITLE
Temporary ignore GR-107 until CIAC-12403 is resolved

### DIFF
--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/.pack-ignore
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/.pack-ignore
@@ -68,3 +68,19 @@ ignore=MR108
 
 [file:Microsoft365DefenderEventCollector.yml]
 ignore=MR108
+
+# Temporary ignore GR-107 until CIAC-12403 is resolved
+[file:playbook-MDE_-_Search_And_Block_Software.yml]
+ignore=GR107
+[file:playbook-MDE_-_Search_and_Compare_Process_Executions.yml]
+ignore=GR107
+[file:playbook-MDE_-_Host_Advanced_Hunting.yml]
+ignore=GR107
+[file:playbook-MDE_-_False_Positive_Incident_Handling.yml]
+ignore=GR107
+[file:playbook-MDE_-_True_Positive_Incident_Handling.yml]
+ignore=GR107
+[file:playbook-MDE_SIEM_ingestion_-_Get_Incident_Data.yml]
+ignore=GR107
+[file:playbook-MDE_Malware_-_Incident_Enrichment.yml]
+ignore=GR107

--- a/Packs/ProactiveThreatHunting/.pack-ignore
+++ b/Packs/ProactiveThreatHunting/.pack-ignore
@@ -27,3 +27,8 @@ ignore=IF113
 
 [file:playbook-Proactive_Threat_Hunting_-_Block_Indicators.yml]
 ignore=PB121
+
+
+# Temporary ignore GR-107 until CIAC-12403 is resolved
+[file:playbook-Proactive_Threat_Hunting_-_Execute_Query.yml]
+ignore=GR107


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-12403
relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-12304

## Description
After merging the deprecation of multiple MS commands, the [validation](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/12314979) started failing because the playbooks team hadn’t finished removing the deprecated commands from the playbooks using them. In the PR, these validation errors will be ignored until the playbook updates are complete.
## Must have
- [ ] Tests
- [ ] Documentation 
