### PR TITLE
[GetFailedTasks] Return the command name and brand name separately

### DIFF
--- a/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_27.md
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/ReleaseNotes/1_3_27.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### GetFailedTasks
+
+Updated the script to return and display the brand name for integration commands, improving the visibility of failed tasks across different integrations.

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py
@@ -61,7 +61,18 @@ def get_failed_tasks_output(tasks: list, incident: dict, custom_scripts_map_id_a
 
     for task in tasks:
         error_entries = task.get("entries", [])
-        command_id = task.get("task", {}).get("scriptId", '').replace('|||', '')
+        command = task.get("task", {}).get("scriptId", '')
+
+        command_id = None
+        brand_name = None
+
+        if "|||" in command:
+            parts = command.split("|||")
+            command_id = parts[-1]
+            brand_name = parts[0] or None
+        else:
+            command_id = command
+
         entry = {
             "Incident ID": incident.get("id"),
             "Playbook Name": task.get("ancestors", [''])[0],
@@ -71,6 +82,7 @@ def get_failed_tasks_output(tasks: list, incident: dict, custom_scripts_map_id_a
             "Task ID": task.get("id"),
             "Incident Created Date": incident.get("created", ''),
             "Command Name": custom_scripts_map_id_and_name.get(command_id, command_id),
+            "Brand Name": brand_name,
             "Incident Owner": incident["owner"]
         }
         if task.get("task", {}).get("description"):
@@ -284,7 +296,7 @@ def main():
             readable_output=tableToMarkdown("GetFailedTasks:", incidents_output,
                                             ["Incident Created Date", "Incident ID", "Task Name", "Task ID",
                                              "Playbook Name",
-                                             "Command Name", "Error Entry ID"]),
+                                             "Command Name", "Brand Name", "Error Entry ID"]),
             outputs={
                 "GetFailedTasks": incidents_output,
                 "NumberofFailedIncidents": total_failed_incidents,

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
@@ -50,6 +50,7 @@ def test_get_failed_tasks(mocker, rest_api_instacne):
     ([], ([], 0)),
     (json.loads(INTERNAL_TASKS_RESULT.get('body')), ([{
         'Command Name': '',
+        'Brand Name': None,
         'Error Entry ID': ['8@3', '9@3'],
         'Incident Created Date': '2020-09-29T14:02:45.82647067Z',
         'Incident ID': '3',
@@ -76,6 +77,67 @@ def test_get_failed_tasks_output(tasks, expected_outputs):
 
     assert tasks_res == expected_outputs[0]
     assert num_tasks == expected_outputs[1]
+
+
+def test_get_failed_tasks_output_with_tasks(mocker):
+    """
+    Given: A list of failing tasks and an incident object.
+    When: Calling get_failed_tasks_output function.
+    Then: It should return the expected task outputs and the correct number of error entries.
+    """
+    # Mock data
+    tasks = [
+        {
+            "entries": ["error1", "error2"],
+            "task": {"scriptId": "brand1|||script1", "name": "Task 1", "description": "Description 1"},
+            "ancestors": ["Playbook 1"],
+            "id": "task1"
+        },
+        {
+            "entries": ["error3"],
+            "task": {"scriptId": "script2", "name": "Task 2"},
+            "ancestors": ["Playbook 2"],
+            "id": "task2"
+        }
+    ]
+    incident = {"id": "incident1", "created": "2023-01-01", "owner": "admin"}
+    custom_scripts_map = {"script1": "Custom Script 1", "script2": "Custom Script 2"}
+
+    # Expected output
+    expected_outputs = [
+        {
+            "Incident ID": "incident1",
+            "Playbook Name": "Playbook 1",
+            "Task Name": "Task 1",
+            "Error Entry ID": ["error1", "error2"],
+            "Number of Errors": 2,
+            "Task ID": "task1",
+            "Incident Created Date": "2023-01-01",
+            "Command Name": "Custom Script 1",
+            "Brand Name": "brand1",
+            "Incident Owner": "admin",
+            "Command Description": "Description 1"
+        },
+        {
+            "Incident ID": "incident1",
+            "Playbook Name": "Playbook 2",
+            "Task Name": "Task 2",
+            "Error Entry ID": ["error3"],
+            "Number of Errors": 1,
+            "Task ID": "task2",
+            "Incident Created Date": "2023-01-01",
+            "Command Name": "Custom Script 2",
+            "Brand Name": None,
+            "Incident Owner": "admin"
+        }
+    ]
+
+    # Call the function
+    result, total_errors = get_failed_tasks_output(tasks, incident, custom_scripts_map)
+
+    # Assert the results
+    assert result == expected_outputs
+    assert total_errors == 3
 
 
 @pytest.mark.parametrize('response,expected_result', [

--- a/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks_test.py
@@ -26,7 +26,7 @@ def test_get_failed_tasks(mocker, rest_api_instacne):
     main()
 
     human_readable = demisto.results.call_args[0][0].get('HumanReadable')
-    assert '|Incident Created Date|Incident ID|Task Name|Task ID|Playbook Name|Command Name|Error Entry ID|' in \
+    assert '|Incident Created Date|Incident ID|Task Name|Task ID|Playbook Name|Command Name|Brand Name|Error Entry ID|' in \
            human_readable
     assert human_readable.count('AutoFocusPolling') == 3
 
@@ -35,6 +35,7 @@ def test_get_failed_tasks(mocker, rest_api_instacne):
     assert entry_context.get('NumberofFailedIncidents', [])[0].get('total of failed incidents') == 3
 
     assert entry_context.get('GetFailedTasks', [])[1] == {'Command Name': '',
+                                                          'Brand Name': None,
                                                           'Error Entry ID': ['8@3', '9@3'],
                                                           'Incident Created Date': '2020-09-29T14:02:45.82647067Z',
                                                           'Incident ID': '3',

--- a/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
+++ b/Packs/IntegrationsAndIncidentsHealthCheck/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Integrations & Incidents Health Check",
     "description": "Do you know which of your integrations or open incidents failed? With this content, you can view your failed integrations and open incidents",
     "support": "xsoar",
-    "currentVersion": "1.3.26",
+    "currentVersion": "1.3.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-45252)

## Description
Updated the script to return and display the brand name for integration commands, improving the visibility of failed tasks across different integrations.

Before:
![image](https://github.com/user-attachments/assets/922cedb5-5628-4ab2-9424-c4bb51670d8b)

After:
![image](https://github.com/user-attachments/assets/cefc0279-7b1c-482f-b77d-99be504d207c)

## Must have
- [ ] Tests
- [ ] Documentation 
