### PR TITLE
Fix-wildfire-malware-playbook

### DIFF
--- a/Packs/Core/Playbooks/playbook-WildFire_Malware.yml
+++ b/Packs/Core/Playbooks/playbook-WildFire_Malware.yml
@@ -722,11 +722,19 @@ tasks:
       - - operator: greaterThan
           left:
             value:
-              simple: alert.autime
+              complex:
+                root: alert
+                accessor: autime
+                transformers:
+                - operator: division
+                  args:
+                    by:
+                      value:
+                        simple: "1000000"
             iscontext: true
           right:
             value:
-              simple: TimeNowUnix
+              simple: LastDayTimeNowUnix
             iscontext: true
     view: |-
       {

--- a/Packs/Core/ReleaseNotes/3_2_10.md
+++ b/Packs/Core/ReleaseNotes/3_2_10.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### WildFire Malware
+
+Fixed an issue with unix timestamp returned in nano seconds instead of milliseconds

--- a/Packs/Core/ReleaseNotes/3_2_11.md
+++ b/Packs/Core/ReleaseNotes/3_2_11.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### WildFire Malware
+
+Fixed an issue with unix timestamp returned in nano seconds instead of milliseconds

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.2.9",
+    "currentVersion": "3.2.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.2.10",
+    "currentVersion": "3.2.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-12496)

## Description
Fixed an issue with the condition that checks if the alert was generated in the last 24h.
The fixes includes the following:
- fixed the context key path with the right prefix
- fixed the unix timestamp to be in millieseconds instead of nano seconds

## Must have
- [ ] Tests
- [ ] Documentation 
