### PR TITLE
Remove wildfire polling fields

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Detonate_File_-_Generic.yml
@@ -764,10 +764,6 @@ tasks:
           root: inputs.File
           transformers:
           - operator: uniq
-      Interval:
-        simple: "1"
-      Timeout:
-        simple: "8"
     separatecontext: true
     continueonerrortype: ""
     loop:

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_6_49.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_6_49.md
@@ -3,4 +3,4 @@
 
 ##### Detonate File - Generic
 
-Removed timeout for WildFire - Detonate file v2 task.
+Removed timeout input for WildFire - Detonate file v2 task, the playbook's default configuration will be used instead.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_6_49.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_6_49.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Detonate File - Generic
+
+Removed timeout for WildFire - Detonate file v2 task.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.6.48",
+    "currentVersion": "2.6.49",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-44693

## Description
Removed timeout input for WildFire - Detonate file v2 task, the playbook's default configuration will be used instead.
