### PR TITLE
[pre-commit] Skip pycln hook

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -26,13 +26,14 @@ repos:
     args:
     - --lock
     files: ^pyproject.toml$
-- repo: https://github.com/hadialqattan/pycln
-  rev: v2.1.2
-  hooks:
-  - id: pycln
-    min_py_version: '3.7'
-    args:
-    - --all
+## CIAC-12536 ##
+# - repo: https://github.com/hadialqattan/pycln
+#   rev: v2.4.0
+#   hooks:
+#   - id: pycln
+#     min_py_version: '3.7'
+#     args:
+#     - --all
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.272
   hooks:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-12536)

## Description
Temporarily skips pre-commit pycln hook, until it is fixed as part of CIAC-12536.

## Must have
- [ ] Tests
- [ ] Documentation 
