### PR TITLE
[pre-commit] Add again pycln hook

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -26,14 +26,13 @@ repos:
     args:
     - --lock
     files: ^pyproject.toml$
-## CIAC-12536 ##
-# - repo: https://github.com/hadialqattan/pycln
-#   rev: v2.4.0
-#   hooks:
-#   - id: pycln
-#     min_py_version: '3.7'
-#     args:
-#     - --all
+- repo: https://github.com/hadialqattan/pycln
+  rev: v2.5.0
+  hooks:
+  - id: pycln
+    min_py_version: '3.7'
+    args:
+    - --all
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.272
   hooks:


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-12536)

## Description
Since the patch is merged [here](https://github.com/hadialqattan/pycln/pull/250), we can run `pycln` again with version 2.5.0.

## Must have
- [ ] Tests
- [ ] Documentation 
