### PR TITLE
Office process creates a scheduled task fix

### DIFF
--- a/Packs/CortexResponseAndRemediation/Playbooks/playbook-Office_process_creates_a_scheduled_task_via_file_access.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/playbook-Office_process_creates_a_scheduled_task_via_file_access.yml
@@ -1018,6 +1018,7 @@ tasks:
       regex:
         simple: (?i)(\\Downloads\\|\\INetCache\\Content.Outlook\\)
     separatecontext: false
+    continueonerror: true
     continueonerrortype: ""
     view: |-
       {

--- a/Packs/CortexResponseAndRemediation/ReleaseNotes/1_0_3.md
+++ b/Packs/CortexResponseAndRemediation/ReleaseNotes/1_0_3.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Office process creates a scheduled task via file access
+
+Added the 'continue on error' option when the regex for the suspicious Office path did not match.

--- a/Packs/CortexResponseAndRemediation/pack_metadata.json
+++ b/Packs/CortexResponseAndRemediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Response And Remediation",
     "description": "The Cortex Response & Remediation Pack delivers a powerful collection of automated playbooks designed to streamline incident response and remediation processes. Built to support an Autonomous SOC vision.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
fix for the playbook "Office process creates a scheduled task via file access".
Added the 'continue on error' option when the regex for the suspicious Office path did not match.

## Must have
- [ ] Tests
- [ ] Documentation 
