### PR TITLE
Locked dependencies of core packs

### DIFF
--- a/Packs/ThreatIntelReports/ReleaseNotes/1_0_20.md
+++ b/Packs/ThreatIntelReports/ReleaseNotes/1_0_20.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### PublishThreatIntelReport
+
+Locked dependencies of the pack to ensure stability for versioned core packs. No changes in this release.

--- a/Packs/ThreatIntelReports/pack_metadata.json
+++ b/Packs/ThreatIntelReports/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Threat Intel Reports (BETA)",
     "description": "Threat Intel Reports gives the user the ability to create, review, publish, and export threat intelligence reports.",
     "support": "xsoar",
-    "currentVersion": "1.0.17",
+    "currentVersion": "1.0.20",
     "serverMinVersion": "6.5.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/Whois/ReleaseNotes/1_5_20.md
+++ b/Packs/Whois/ReleaseNotes/1_5_20.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Whois
+
+Locked dependencies of the pack to ensure stability for versioned core packs. No changes in this release.

--- a/Packs/Whois/pack_metadata.json
+++ b/Packs/Whois/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Whois",
     "description": "This Content Pack helps you run Whois commands as playbook tasks or real-time actions within Cortex XSOAR to obtain valuable domain metadata.",
     "support": "xsoar",
-    "currentVersion": "1.5.19",
+    "currentVersion": "1.5.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
As a result of[ this PR](https://github.com/demisto/content/pull/38083), the [upload failed](https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/pipelines/1966213) because they did not release a version for the `Whois` and `ThreatIntelReports` packs.
