### PR TITLE
Service Now Event Collector - Improved the fetch events efficiency

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
@@ -47,13 +47,13 @@ class Client:
             "sysparm_query": f"sys_created_on>{from_time}",
             "sysparm_no_count": True
         }
-        demisto.debug("##### Starting the search request with a 1 min timeout #####")
+        demisto.debug("##### Starting the search request with a 4 min timeout #####")
         res = self.sn_client.http_request(
             method="GET",
             full_url=f"{self.api_server_url}{URL[log_type]}",
             url_suffix=None,
             params=remove_empty_elements(params),
-            timeout=60
+            timeout=240
         )
         demisto.debug("##### The search request has finished #####")
         return res.get("result")

--- a/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
@@ -47,12 +47,15 @@ class Client:
             "sysparm_query": f"sys_created_on>{from_time}",
             "sysparm_no_count": True
         }
+        demisto.debug("##### Starting the search request with a 1 min timeout #####")
         res = self.sn_client.http_request(
             method="GET",
             full_url=f"{self.api_server_url}{URL[log_type]}",
             url_suffix=None,
             params=remove_empty_elements(params),
+            timeout=60
         )
+        demisto.debug("##### The search request has finished #####")
         return res.get("result")
 
 

--- a/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.py
@@ -45,6 +45,7 @@ class Client:
             "sysparm_limit": limit,
             "sysparm_offset": offset,
             "sysparm_query": f"sys_created_on>{from_time}",
+            "sysparm_no_count": True
         }
         res = self.sn_client.http_request(
             method="GET",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
In this bug [XSUP-45347](https://jira-dc.paloaltonetworks.com/browse/XSUP-45347) the customer couldn't fetch audit logs since their audit logs table is loaded. 
To fix that we added a use of the `sysparm_no_count` parameter in the fetch query. 
According to this API reference - 
https://www.servicenow.com/docs/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html
The sysparm_no_count parameter:
```
Flag that indicates whether to execute a select count(*) query on the table to return the number of rows in the associated table.
Valid values:
true: Do not execute a select count(*).
false: Execute a select count(*).
Data type: Boolean
Default: false
```
Setting it to True improved the efficiency of the search event function. 

Another reference:
https://www.servicenow.com/community/developer-forum/rest-api-the-dreaded-quot-maximum-execution-time-exceeded-quot/m-p/1706846

## Must have
- [ ] Tests
- [ ] Documentation 
