### PR TITLE
Increased the memory threshold for CrowdStrike_FalconX TPB

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4910,7 +4910,8 @@
             "memory_threshold": 250,
             "integrations": [
                 "CrowdStrike Falcon X"
-            ]
+            ],
+            "is_mockable": false
         },
         {
             "playbookID": "Phishing - Core - Test - Actual Incident",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -4907,7 +4907,7 @@
         {
             "playbookID": "CrowdStrike_FalconX_Test",
             "fromversion": "6.1.0",
-            "memory_threshold": 160,
+            "memory_threshold": 250,
             "integrations": [
                 "CrowdStrike Falcon X"
             ]


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://gitlab.xdr.pan.local/xdr/cortex-content/content/-/jobs/13317625#L1483

## Description
```
ker stats --no-stream --no-trunc --format "{{json .}}" | grep -Ei "demistopython33.11.10.115186--"'
[2025-01-09 23:55:28] - [10.184.214.33-0 (execute_tests)] - [ERROR] - Failed docker resource test. Docker container demistoserver_pyexec-67196338-54a0-4032-88e7-19ebd0792e96-demistopython33.11.10.115186--45 exceeded the memory threshold, configured: 160 MiB and actual memory usage is 224.4 MiB.
Fix container memory usage or add `memory_threshold` key to failed test in conf.json with value that is greater than 224.4
[2025-01-09 23:55:28] - [10.184.214.33-0 (execute_tests)] - [ERROR] - Test failed: playbook: "CrowdStrike_FalconX_Test" with integration(s): ["CrowdStrike Falcon X"]
```

## Must have
- [ ] Tests
- [ ] Documentation 
