### PR TITLE
Updating listen port in taxii server secret

### DIFF
--- a/Packs/FeedTAXII/TestPlaybooks/playbook-TAXII_Feed_Test.yml
+++ b/Packs/FeedTAXII/TestPlaybooks/playbook-TAXII_Feed_Test.yml
@@ -512,3 +512,4 @@ view: |-
 inputs: []
 outputs: []
 fromversion: 5.0.0
+

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
@@ -941,7 +941,6 @@ def main():
         host_name = server_link_parts.hostname
         if not http_server:
             scheme = 'https'
-
         service_address = params.get('service_address')
         SERVER = TAXIIServer(scheme, str(host_name), port, collections,
                              certificate, private_key, http_server, credentials, service_address)

--- a/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
+++ b/Packs/TAXIIServer/Integrations/TAXIIServer/TAXIIServer.py
@@ -941,6 +941,7 @@ def main():
         host_name = server_link_parts.hostname
         if not http_server:
             scheme = 'https'
+
         service_address = params.get('service_address')
         SERVER = TAXIIServer(scheme, str(host_name), port, collections,
                              certificate, private_key, http_server, credentials, service_address)


### PR DESCRIPTION
This is a pr for updating the secret for TAXII Server because of a bug. Added listen port = 7000 to the secret. 