### PR TITLE
Add support for microsoft-teams-get-team-members command.

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -737,6 +737,11 @@ script:
         If your instance configuration involves a Cortex XSOAR engine, provide the engine's IP (or DNS name) and the port in use in the following format - `https://IP:port` or `http://IP:port`.
         For example - `https://my-engine.name:443`, `http://1.1.1.1:443`.   
       name: engine_url
+  - description: Handle failed send-notification to added users. This command will pull members added to a team.
+    name: microsoft-teams-get-team-members
+    arguments:
+    - description: Specify in which team to pull members from.
+      name: team_name
   dockerimage: demisto/teams:1.0.0.1860894
   longRunning: true
   longRunningPort: true

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_13.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_13.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Teams
+
+- Added support for **microsoft-teams-get-team-members** command to handle failed send-notification for added users. This command will pull members added to a team.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.5.12",
+    "currentVersion": "1.5.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: link to the issue

## Description
Adding a manual get-team-member command which does not depend on the event teamMemberAdded from Teams

## Must have
- [ ] Tests
- [ ] Documentation 
