### PR TITLE
[ZeroFox] Replace min_timestamp filter with escalated_min_date when only escalated alerts are fetched as incidents

### DIFF
--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
@@ -27,8 +27,12 @@ FetchIncidentsStorage = TypedDict("FetchIncidentsStorage", {
 """ CLIENT """
 
 ALLOWED_SORT_FIELDS = ["timestamp", "last_modified"]
-ALLOWED_ALERT_FILTERS = ["last_modified_min_date",
-                         "min_timestamp", "max_timestamp"]
+ALLOWED_ALERT_FILTERS = [
+    "last_modified_min_date",
+    "escalated_min_date",
+    "min_timestamp",
+    "max_timestamp"
+]
 
 
 class ZFClient(BaseClient):
@@ -154,6 +158,11 @@ class ZFClient(BaseClient):
                         text=raw_response.text
                     )
                 )
+            if raw_response.status_code == 429:
+                raise ZeroFoxAuthException(
+                    cause="The application is sending too many requests to ZeroFox API,\
+                          please contact support."
+                    )
             response = raw_response.json()
             if non_field_errors := response.get("non_field_errors", []):
                 raise ZeroFoxAuthException(cause=non_field_errors[0])
@@ -1301,15 +1310,26 @@ def _build_incidents_given_last_fetch(
     is_valid_alert: Callable[[dict[str, Any]], bool],
 ) -> tuple[list[dict[str, Any]], datetime, list[str]]:
 
-    alerts = [
-        alert for alert in client.get_alerts(
-            filter_by={
-                "min_timestamp": created_since.strftime(DATE_FORMAT)},
-            sort_by="timestamp",
-            sort_direction="asc"
-        )
-        if is_valid_alert(alert)
-    ]
+    if client.only_escalated:
+        alerts = [
+            alert for alert in client.get_alerts(
+                filter_by={
+                    "escalated_min_date": created_since.strftime(DATE_FORMAT)},
+                sort_by="timestamp",
+                sort_direction="asc"
+            )
+            if is_valid_alert(alert)
+        ]
+    else:
+        alerts = [
+            alert for alert in client.get_alerts(
+                filter_by={
+                    "min_timestamp": created_since.strftime(DATE_FORMAT)},
+                sort_by="timestamp",
+                sort_direction="asc"
+            )
+            if is_valid_alert(alert)
+        ]
     if not alerts:
         return [], created_since, []
 

--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
@@ -162,7 +162,7 @@ class ZFClient(BaseClient):
                 raise ZeroFoxAuthException(
                     cause="The application is sending too many requests to ZeroFox API,\
                           please contact support."
-                    )
+                )
             response = raw_response.json()
             if non_field_errors := response.get("non_field_errors", []):
                 raise ZeroFoxAuthException(cause=non_field_errors[0])

--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
@@ -1,4 +1,7 @@
 category: Data Enrichment & Threat Intelligence
+sectionOrder:
+- Connect
+- Collect
 commonfields:
   id: ZeroFox
   version: -1
@@ -7,28 +10,34 @@ configuration:
   display: URL (e.g., https://api.zerofox.com/)
   name: url
   required: true
+  section: Connect
   type: 0
 - display: Username
   name: credentials
   required: true
+  section: Connect
   type: 9
 - display: Fetch only escalated alerts
   name: only_escalated
   type: 8
   required: false
   defaultvalue: "false"
+  section: Collect
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
   required: false
+  section: Connect
 - display: Use system proxy settings
   name: proxy
   type: 8
   required: false
+  section: Connect
 - defaultvalue: "3 days"
   display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)
   name: fetch_time
   required: false
+  section: Collect
   type: 0
 - display: Fetch Limit
   name: fetch_limit
@@ -36,21 +45,25 @@ configuration:
   required: false
   hidden: true
   defaultvalue: "100"
+  section: Collect
 - display: Incidents Fetch Interval
   name: incidentFetchInterval
   type: 19
   required: false
   additionalinfo: This controls how often the integration will perform a fetch_incidents command
   defaultvalue: "10"
+  section: Collect
   advanced: true
 - display: Fetch incidents
   name: isFetch
   type: 8
   required: false
+  section: Collect
 - display: Incident type
   name: incidentType
   type: 13
   required: false
+  section: Collect
 description: Cloud-based SaaS to detect risks found on social media and digital channels.
 display: ZeroFox
 name: ZeroFox

--- a/Packs/ZeroFox/ReleaseNotes/1_3_6.md
+++ b/Packs/ZeroFox/ReleaseNotes/1_3_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ZeroFox
+
+- Fixed missing alerts issue when "only escalated alerts" was enabled.

--- a/Packs/ZeroFox/pack_metadata.json
+++ b/Packs/ZeroFox/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ZeroFox",
     "description": "Cloud-based SaaS to detect risks found on social media and digital channels.",
     "support": "partner",
-    "currentVersion": "1.3.5",
+    "currentVersion": "1.3.6",
     "author": "ZeroFox",
     "url": "https://www.zerofox.com/contact-us/",
     "email": "integration-support@zerofox.com",


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fix an issue identified when restricting the type of ZeroFox alerts ingested as XSOAR Incidents by correcting the filtering parameter in http request

## Must have
- [x] Tests
- [x] Documentation 
