### PR TITLE
Dev qradar crn

### DIFF
--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -728,8 +728,7 @@ class Client(BaseClient):
                      fields: Optional[str] = None):
 
         id_suffix = f'/{domain_id}' if domain_id else ''
-        encoded_filter = parse.quote(filter_, safe="") if filter_ else None
-        params = assign_params(fields=fields) if domain_id else assign_params(filter=encoded_filter, fields=fields)
+        params = assign_params(fields=fields) if domain_id else assign_params(filter=filter_, fields=fields)
         additional_headers = {'Range': range_} if not domain_id and range_ else None
         return self.http_request(
             method='GET',

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.yml
@@ -3120,7 +3120,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.8.1983910
   isremotesyncin: true
   longRunning: true
   isFetchSamples: true

--- a/Packs/QRadar/ReleaseNotes/2_5_11.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_11.md
@@ -3,5 +3,5 @@
 
 ##### IBM QRadar v3
 
-- Removed the double encoding issue when using the argument *filter* with commands such as **qradar-domains-list** and **qradar-get-domains**.
+- Fixed an issue when using the argument *filter* with commands such as **qradar-domains-list** and **qradar-get-domains**. 
 - Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/QRadar/ReleaseNotes/2_5_11.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_11.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### IBM QRadar v3
+
+- Removed the double encoding issue whhen using the argument *filter* with commands such as **qradar-domains-list** and **qradar-get-domains**.
+- Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/QRadar/ReleaseNotes/2_5_11.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_11.md
@@ -3,5 +3,5 @@
 
 ##### IBM QRadar v3
 
-- Removed the double encoding issue whhen using the argument *filter* with commands such as **qradar-domains-list** and **qradar-get-domains**.
+- Removed the double encoding issue when using the argument *filter* with commands such as **qradar-domains-list** and **qradar-get-domains**.
 - Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.5.10",
+    "currentVersion": "2.5.11",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description

The last version 2.5.10 introduced a bug when using the argument "filter" with the commands such as "qradar-domains-list" and "qradar-get-domains", which use the python function "domains_list". The param "filter" is already encoded by the function "http_request", so it was encoded twice in the last integration version which caused the following error :

![image](https://github.com/user-attachments/assets/4b6edf38-f37f-44b4-a252-dad1b41586e3)


In the debug log extract, we can see the request with the double encoding on the param "filter" :

```
2025-02-04T17:06:04.1907582+01:00 info: (Qradar Prod_QRadar v3_qradar-domains-list) send: b'GET /api/config/domain_management/domains?filter=id%2520in%2520%25281%252C%25203%2529 HTTP/1.1\r\nHost: X.X.X.X\r\nUser-Agent: python-requests/2.32.3\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nRange: items=0-49\r\nVersion: 20\r\nSEC: <XX_REPLACED>\r\n\r\n'
```

## Must have
- [ ] Tests
- [ ] Documentation 
