### PR TITLE
VectraXDR and CortexXpanse - Removed the use of the get_pack_version function

### DIFF
--- a/Packs/CortexXpanse/Integrations/CortexXpanse/CortexXpanse.py
+++ b/Packs/CortexXpanse/Integrations/CortexXpanse/CortexXpanse.py
@@ -18,7 +18,7 @@ TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 TIME_FORMAT_Z = "%Y-%m-%dT%H:%M:%SZ"
 V1_URL_SUFFIX = "/public_api/v1"
 V2_URL_SUFFIX = "/public_api/v2"
-PACK_VERSION = get_pack_version()
+PACK_VERSION = "1.2.6"
 DEMISTO_VERSION = demisto.demistoVersion()
 SEVERITY_DICT = {
     'informational': IncidentSeverity.INFO,

--- a/Packs/CortexXpanse/ReleaseNotes/1_2_6.md
+++ b/Packs/CortexXpanse/ReleaseNotes/1_2_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cortex Xpanse
+
+- Enhanced integration run time performance.

--- a/Packs/CortexXpanse/pack_metadata.json
+++ b/Packs/CortexXpanse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Xpanse",
     "description": "Content for working with Attack Surface Management (ASM).",
     "support": "xsoar",
-    "currentVersion": "1.2.5",
+    "currentVersion": "1.2.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/VectraXDR/Integrations/VectraXDR/VectraXDR.py
+++ b/Packs/VectraXDR/Integrations/VectraXDR/VectraXDR.py
@@ -37,7 +37,7 @@ DEFAULT_URGENCY_SCORE_MEDIUM_THRESHOLD = 50
 DEFAULT_URGENCY_SCORE_HIGH_THRESHOLD = 80
 MAX_MIRRORING_LIMIT = 5000
 MAX_OUTGOING_NOTE_LIMIT = 8000
-PACK_VERSION = get_pack_version(pack_name='Vectra XDR') or '1.0.0'
+PACK_VERSION = "1.0.10"
 UTM_PIVOT = f"?pivot=Vectra-XSOAR-{PACK_VERSION}"
 EMPTY_ASSIGNMENT = [{"id": "", "date_assigned": "", "date_resolved": "", "assigned_to": {"username": ""},
                      "resolved_by": {"username": ""}, "assigned_by": {"username": ""}, "outcome": {"title": ""}}]

--- a/Packs/VectraXDR/ReleaseNotes/1_0_10.md
+++ b/Packs/VectraXDR/ReleaseNotes/1_0_10.md
@@ -1,0 +1,12 @@
+
+#### Integrations
+
+##### Vectra XDR
+
+- Enhanced integration run time performance.
+
+#### Scripts
+
+##### VectraXDRDisplayEntityDetections
+
+- Enhanced integration run time performance.

--- a/Packs/VectraXDR/ReleaseNotes/1_0_10.md
+++ b/Packs/VectraXDR/ReleaseNotes/1_0_10.md
@@ -9,4 +9,4 @@
 
 ##### VectraXDRDisplayEntityDetections
 
-- Enhanced integration run time performance.
+- Enhanced automation run time performance.

--- a/Packs/VectraXDR/Scripts/VectraXDRDisplayEntityDetections/VectraXDRDisplayEntityDetections.py
+++ b/Packs/VectraXDR/Scripts/VectraXDRDisplayEntityDetections/VectraXDRDisplayEntityDetections.py
@@ -6,7 +6,7 @@ import json
 
 """ CONSTANTS """
 
-UTM_PIVOT = f"?pivot=Vectra-XSOAR-{get_pack_version(pack_name='Vectra XDR') or '1.0.0'}"
+UTM_PIVOT = f"?pivot=Vectra-XSOAR-1.0.10"
 
 
 def trim_api_version(url: str) -> str:

--- a/Packs/VectraXDR/pack_metadata.json
+++ b/Packs/VectraXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Vectra XDR",
     "description": "Vectra XDR pack empowers the SOC to create incidents using Vectra AI's Attack Signal Intelligence.",
     "support": "partner",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Vectra AI",
     "url": "https://support.vectra.ai",
     "email": "support@vectra.ai",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
It turns out that the call to the `get_pack_version()` function causes performance issues, therefore we temporarily replace this call with a hardcoded string of the current pack version.

## Must have
- [ ] Tests
- [ ] Documentation 
