### PR TITLE
feat: add issue_details_get_command

### DIFF
--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/README.md
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/README.md
@@ -414,4 +414,24 @@ This command does not require any arguments.
 | SecurityScorecard.AlertRules.Rule.name | String | Alert Rule name. | 
 | SecurityScorecard.AlertRules.Rule.target | String | Target of the Rule. | 
 | SecurityScorecard.AlertRules.Rule.updated_at | Date | Timestamp when the alert rule was last updated. | 
-| SecurityScorecard.AlertRules.Rule.paused_at | String | Timestamp when the alert rule was paused. | 
+| SecurityScorecard.AlertRules.Rule.paused_at | String | Timestamp when the alert rule was paused. |
+
+### securityscorecard-issue-details-get
+
+***
+Retrieve issue details for a specific issue type and domain.
+
+##### Base Command
+
+`securityscorecard-issue-details-get`
+
+##### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| domain | The domain to get the issue details for. | Required |
+| issue_type | The issue type to get the details for. | Required |
+
+#### Context Output
+
+There is no context output for this command.

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/README.md
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/README.md
@@ -434,4 +434,17 @@ Retrieve issue details for a specific issue type and domain.
 
 #### Context Output
 
-There is no context output for this command.
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| SecurityScorecard.IssueDetails.issue_id | String | Unique UUID for this measurement. | 
+| SecurityScorecard.IssueDetails.parent_domain | String | Parent domain aka vendor. | 
+| SecurityScorecard.IssueDetails.issue_type | String | issue_type of the findings. | 
+| SecurityScorecard.IssueDetails.count | Number | The number of findings. | 
+| SecurityScorecard.IssueDetails.group_status | String | If findings are active or not. |
+| SecurityScorecard.IssueDetails.first_seen_time | Date | Epoch of observation in nanoseconds. |
+| SecurityScorecard.IssueDetails.last_seen_time | Date | Epoch of observation in nanoseconds. |
+| SecurityScorecard.IssueDetails.port | Number | Port number of the observation if applicable. |
+| SecurityScorecard.IssueDetails.domain | String | Domain of the observation if applicable. |
+| SecurityScorecard.IssueDetails.ip | String | IP address of the observation if applicable. |
+| SecurityScorecard.IssueDetails.protocol | String | Protocol of the observation if applicable. |
+| SecurityScorecard.IssueDetails.observations | String | Observation data in raw JSON format. |

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.py
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.py
@@ -1504,7 +1504,7 @@ def issue_details_get_command(
         elif "ip_address" in entry:
             ip = entry.get("ip_address")
         elif "connection_attributes" in entry:
-            ip = entry.get("connection_attributes").get("dst_ip")
+            ip = entry.get("connection_attributes", {}).get("dst_ip")
         else:
             ip = ""
 
@@ -1513,14 +1513,14 @@ def issue_details_get_command(
         elif "scheme" in entry:
             protocol = entry.get("scheme")
         elif "connection_attributes" in entry:
-            protocol = entry.get("connection_attributes").get("protocol")
+            protocol = entry.get("connection_attributes", {}).get("protocol")
         else:
             protocol = ""
 
         if "port" in entry:
             port = entry.get("port")
         elif "connection_attributes" in entry:
-            port = entry.get("connection_attributes").get("dst_port")
+            port = entry.get("connection_attributes", {}).get("dst_port")
         else:
             port = ""
 

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.py
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.py
@@ -1477,6 +1477,9 @@ def issue_details_get_command(
     domain = args.get("domain")
     issue_type = args.get("issue_type")
 
+    if not issue_type or not domain:
+        raise ValueError("Both 'issue_type' and 'domain' arguments are required and cannot be None.")
+
     response = client.get_company_issue_findings(domain=domain, issue_type=issue_type)
 
     entries = response.get('entries', [])

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.yml
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.yml
@@ -504,9 +504,42 @@ script:
       description: The issue type to get the details for.
       required: true
     outputs:
-    - contextPath: SecurityScorecard.IssueDetails
-      description: Issue details for the specified domain and issue type.
-      type: unknown
+    - contextPath: SecurityScorecard.IssueDetails.issue_id
+      description: Unique UUID for this measurement.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.parent_domain
+      description: Parent domain aka vendor.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.issue_type
+      description: issue_type of the findings.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.count
+      description: The number of findings.
+      type: Number
+    - contextPath: SecurityScorecard.IssueDetails.group_status
+      description: If findings are active or not.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.first_seen_time
+      description: Epoch of observation in nanoseconds.
+      type: Date
+    - contextPath: SecurityScorecard.IssueDetails.last_seen_time
+      description: Epoch of observation in nanoseconds.
+      type: Date
+    - contextPath: SecurityScorecard.IssueDetails.port
+      description: Port number of the observation if applicable.
+      type: Number
+    - contextPath: SecurityScorecard.IssueDetails.domain
+      description: Domain of the observation if applicable.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.ip
+      description: IP address of the observation if applicable.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.protocol
+      description: Protocol of the observation if applicable.
+      type: String
+    - contextPath: SecurityScorecard.IssueDetails.observations
+      description: Observation data in raw JSON format.
+      type: String
   runonce: false
 sectionorder:
 - Connect

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.yml
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard.yml
@@ -494,6 +494,19 @@ script:
     - contextPath: SecurityScorecard.AlertRules.Rule.paused_at
       description: Timestamp when the alert rule was paused.
       type: Date
+  - name: securityscorecard-issue-details-get
+    description: Retrieve issue details for a specific issue type and domain.
+    arguments:
+    - name: domain
+      description: The domain to get the issue details for.
+      required: true
+    - name: issue_type
+      description: The issue type to get the details for.
+      required: true
+    outputs:
+    - contextPath: SecurityScorecard.IssueDetails
+      description: Issue details for the specified domain and issue type.
+      type: unknown
   runonce: false
 sectionorder:
 - Connect

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard_test.py
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard_test.py
@@ -15,7 +15,8 @@ from SecurityScorecard import \
     issue_metadata_get_command, \
     company_events_get_command, \
     company_event_findings_get_command, \
-    alert_rules_list_command
+    alert_rules_list_command, \
+    issue_details_get_command
 
 from unittest.mock import MagicMock
 
@@ -914,3 +915,79 @@ def test_alert_rules_list_command(mocker):
     assert alert_rules == alert_rules_mock.get("entries")
     assert response_cmd_res.outputs_prefix == "SecurityScorecard.AlertRules.Rule"
     assert response_cmd_res.outputs_key_field == "id"
+
+
+def test_issue_details_get_command_success(mocker):
+    """
+    Given:
+        - A domain and issue type
+    When:
+        - Retrieving issue details for the specified domain and issue type
+    Then:
+        - Ensure the issue details are returned correctly
+    """
+    mock_response = {
+        "entries": [
+            {
+                "domain": "example.com",
+                "issue_id": "1",
+                "issue_type": "spf_record_missing",
+                "count": "2",
+                "status": "active",
+                "first_seen_time": "2023-01-01T00:00:00Z",
+                "last_seen_time": "2023-01-02T00:00:00Z",
+                "description": "SPF record is missing",
+                "recommendation": "Add SPF record"
+            }
+        ]
+    }
+
+    mocker.patch.object(client, "get_company_issue_findings", return_value=mock_response)
+
+    args = {"domain": "example.com", "issue_type": "spf_record_missing"}
+    result = issue_details_get_command(client, args)
+
+    assert isinstance(result, CommandResults)
+    assert result.outputs == mock_response["entries"]
+    assert result.outputs_prefix == "SecurityScorecard.IssueDetails"
+    assert result.outputs_key_field == "issue_id"
+    assert result.readable_output.startswith("### Domain example.com Findings for spf_record_missing")
+
+
+def test_issue_details_get_command_no_results(mocker):
+    """
+    Given:
+        - A domain and issue type
+    When:
+        - No issue details are found for the specified domain and issue type
+    Then:
+        - Ensure an empty result is returned
+    """
+    mock_response = {"entries": []}
+
+    mocker.patch.object(client, "get_company_issue_findings", return_value=mock_response)
+
+    args = {"domain": "example.com", "issue_type": "spf_record_missing"}
+    result = issue_details_get_command(client, args)
+
+    assert isinstance(result, CommandResults)
+    assert result.outputs == []
+    assert result.outputs_prefix == "SecurityScorecard.IssueDetails"
+    assert result.outputs_key_field == "issue_id"
+    assert "No findings were found" in result.readable_output
+
+
+def test_issue_details_get_command_invalid_domain(mocker):
+    """
+    Given:
+        - An invalid domain and issue type
+    When:
+        - Retrieving issue details for the specified domain and issue type
+    Then:
+        - Ensure an error is raised
+    """
+    mocker.patch.object(client, "get_company_issue_findings", side_effect=DemistoException("Invalid domain"))
+
+    args = {"domain": "invalid.com", "issue_type": "spf_record_missing"}
+    with pytest.raises(DemistoException, match="Invalid domain"):
+        issue_details_get_command(client, args)

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard_test.py
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/SecurityScorecard_test.py
@@ -951,7 +951,7 @@ def test_issue_details_get_command_success(mocker):
     assert result.outputs == mock_response["entries"]
     assert result.outputs_prefix == "SecurityScorecard.IssueDetails"
     assert result.outputs_key_field == "issue_id"
-    assert result.readable_output.startswith("### Domain example.com Findings for spf_record_missing")
+    assert result.readable_output.startswith("### Domain example.com -- Findings for spf_record_missing")
 
 
 def test_issue_details_get_command_no_results(mocker):

--- a/Packs/SecurityScorecard/Integrations/SecurityScorecard/command_examples.txt
+++ b/Packs/SecurityScorecard/Integrations/SecurityScorecard/command_examples.txt
@@ -13,3 +13,4 @@
 !securityscorecard-company-findings-get date=2024-08-13 domain=groupe.schmidt issue_type=tlscert_expired
 !securityscorecard-issue-metadata issue_type=spf_record_missing
 !securityscorecard-alert-rules-list
+!securityscorecard-issue-details-get domain=example.com issue_type=spf_record_missing

--- a/Packs/SecurityScorecard/ReleaseNotes/1_0_12.md
+++ b/Packs/SecurityScorecard/ReleaseNotes/1_0_12.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SecurityScorecard
+
+- Added new command _!securityscorecard-issue-details-get_ that retrieves issue details for a specific issue type and domain.

--- a/Packs/SecurityScorecard/pack_metadata.json
+++ b/Packs/SecurityScorecard/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SecurityScorecard",
     "description": "Provides security scorecards and alerts for domains.",
     "support": "partner",
-    "currentVersion": "1.0.11",
+    "currentVersion": "1.0.12",
     "author": "SecurityScorecard",
     "url": "https://securityscorecard.com/contact-us",
     "email": "support@securityscorecard.io",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Adds a new command  `!securityscorecard-issue-details-get` internally calling `issue_details_get_command()`
It fetches the list of findings for a given domain and given issue-type detected by securityscorecard.
The list is a markdown table with a set of columns relevant to all issue-types
Since the list can be quite long (thousands of findings some times), there will a limit added to the endpoint call to SSC

## Must have
- [x] Tests
- [x] Documentation 

## Test passing
![Screenshot 2025-02-17 at 14 37 04](https://github.com/user-attachments/assets/209df834-5dee-4f8a-b16b-848449dd4296)

## Demo
https://github.com/user-attachments/assets/9ba62114-ee44-4c2f-83c9-c4b48e65a585

