### PR TITLE
Fix UnboundLocalError when updating module health in Qualys VMDR 'fetch-assets' command

### DIFF
--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -3322,7 +3322,7 @@ def fetch_assets_and_vulnerabilities_by_date(client: Client, last_run: dict[str,
         vulnerabilities, new_last_run = fetch_vulnerabilities(client, last_run)
         demisto.debug(f'Sending {len(vulnerabilities)} vulnerabilities to XSIAM.')
         send_data_to_xsiam(data=vulnerabilities, vendor=VENDOR, product='vulnerabilities', data_type='assets')
- 
+
     demisto.setAssetsLastRun(new_last_run)
     demisto.debug(f'Finished fetch assets and vulnerabilities run (by date). Last assets run object: {new_last_run}')
 

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -3315,16 +3315,15 @@ def fetch_assets_and_vulnerabilities_by_date(client: Client, last_run: dict[str,
                                snapshot_id=snapshot_id, items_count=str(total_assets_to_report),
                                should_update_health_module=False)
 
-        demisto.setAssetsLastRun(new_last_run)
-        demisto.updateModuleHealth({'assetsPulled': cumulative_assets_count})
+            demisto.updateModuleHealth({'assetsPulled': cumulative_assets_count})
 
     elif fetch_stage == 'vulnerabilities':
 
         vulnerabilities, new_last_run = fetch_vulnerabilities(client, last_run)
         demisto.debug(f'Sending {len(vulnerabilities)} vulnerabilities to XSIAM.')
         send_data_to_xsiam(data=vulnerabilities, vendor=VENDOR, product='vulnerabilities', data_type='assets')
-        demisto.setAssetsLastRun(new_last_run)
-
+ 
+    demisto.setAssetsLastRun(new_last_run)
     demisto.debug(f'Finished fetch assets and vulnerabilities run (by date). Last assets run object: {new_last_run}')
 
 

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -3317,13 +3317,15 @@ def fetch_assets_and_vulnerabilities_by_date(client: Client, last_run: dict[str,
 
             demisto.updateModuleHealth({'assetsPulled': cumulative_assets_count})
 
+        demisto.setAssetsLastRun(new_last_run)
+
     elif fetch_stage == 'vulnerabilities':
 
         vulnerabilities, new_last_run = fetch_vulnerabilities(client, last_run)
         demisto.debug(f'Sending {len(vulnerabilities)} vulnerabilities to XSIAM.')
         send_data_to_xsiam(data=vulnerabilities, vendor=VENDOR, product='vulnerabilities', data_type='assets')
+        demisto.setAssetsLastRun(new_last_run)
 
-    demisto.setAssetsLastRun(new_last_run)
     demisto.debug(f'Finished fetch assets and vulnerabilities run (by date). Last assets run object: {new_last_run}')
 
 

--- a/Packs/qualys/ReleaseNotes/3_2_1.md
+++ b/Packs/qualys/ReleaseNotes/3_2_1.md
@@ -3,4 +3,4 @@
 
 ##### Qualys VMDR
 
-Fixed an issue with updating module health during asset and vulnerability fetching when response timeouts occurred or command execution times were exceeded.
+Fixed an issue where fetching assets by date failed due to timeouts.

--- a/Packs/qualys/ReleaseNotes/3_2_1.md
+++ b/Packs/qualys/ReleaseNotes/3_2_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Qualys VMDR
+
+Fixed an issue with updating module health during asset and vulnerability fetching when response timeouts occurred or command execution times were exceeded.

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Qualys",
     "description": "Qualys Vulnerability Management let's you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance",
     "support": "xsoar",
-    "currentVersion": "3.2.0",
+    "currentVersion": "3.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-46857)

## Description
Fixed an issue with updating module health during asset and vulnerability fetching when response timeouts occurred or command execution times were exceeded.

## Must have
- [x] Tests

