### PR TITLE
demisto/teams:1.0.0.2027266 | from coverage = '0'

### DIFF
--- a/Packs/CommonScripts/Scripts/GenerateAsBuilt/GenerateAsBuilt.yml
+++ b/Packs/CommonScripts/Scripts/GenerateAsBuilt/GenerateAsBuilt.yml
@@ -22,7 +22,7 @@ subtype: python3
 timeout: '0'
 type: python
 fromversion: 6.0.0
-dockerimage: demisto/teams:1.0.0.116912
+dockerimage: demisto/teams:1.0.0.2027266
 tests:
 - No tests (auto formatted)
 marketplaces:

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
@@ -767,7 +767,7 @@ script:
         If your instance configuration involves a Cortex XSOAR engine, provide the engine's IP (or DNS name) and the port in use in the following format - `https://IP:port` or `http://IP:port`.
         For example - `https://my-engine.name:443`, `http://1.1.1.1:443`.   
       name: engine_url
-  dockerimage: demisto/teams:1.0.0.1860894
+  dockerimage: demisto/teams:1.0.0.2027266
   longRunning: true
   longRunningPort: true
   script: ''

--- a/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
+++ b/Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
@@ -63,7 +63,7 @@ script:
     name: workday-generate-terminate-event
   - description: Reset the integration context to fetch the first run reports.
     name: initialize-context
-  dockerimage: demisto/teams:1.0.0.116912
+  dockerimage: demisto/teams:1.0.0.2027266
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/Workday/Integrations/WorkdaySignonEventGenerator/WorkdaySignonEventGenerator.yml
+++ b/Packs/Workday/Integrations/WorkdaySignonEventGenerator/WorkdaySignonEventGenerator.yml
@@ -22,7 +22,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/teams:1.0.0.116912
+  dockerimage: demisto/teams:1.0.0.2027266
   longRunning: true
   longRunningPort: true
 fromversion: 6.8.0


### PR DESCRIPTION
Auto updated docker tags for the following content items:
Packs/CommonScripts/Scripts/GenerateAsBuilt/GenerateAsBuilt.yml
Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.yml
Packs/Workday/Integrations/WorkdayIAMEventsGenerator/WorkdayIAMEventsGenerator.yml
Packs/Workday/Integrations/WorkdaySignonEventGenerator/WorkdaySignonEventGenerator.yml