### PR TITLE
CTM360-CBS bug fix expecting `list` but getting `dict`

### DIFF
--- a/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.py
+++ b/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.py
@@ -147,7 +147,7 @@ class Client(BaseClient):
         log(DEBUG, 'at client\'s test function')
         if response.get('statusCode') != 200:
             raise DemistoException(f'Error received: {response.get("errors")}')
-        return response
+        return response.get('hits', [])
 
     def fetch_incidents(self, params: dict[str, Any]) -> list[dict[str, Any]]:
         """Send request to fetch list of incidents

--- a/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.py
+++ b/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.py
@@ -146,7 +146,7 @@ class Client(BaseClient):
         )
         log(DEBUG, 'at client\'s test function')
         if response.get('statusCode') != 200:
-            raise DemistoException(f'Error received: {response.get("errors")}')
+            raise DemistoException(f'Error received: {response.get("errors", "request was not successful")}')
         return response.get('hits', [])
 
     def fetch_incidents(self, params: dict[str, Any]) -> list[dict[str, Any]]:

--- a/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.yml
+++ b/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot.yml
@@ -210,7 +210,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.11.10.116949
+  dockerimage: demisto/python3:3.12.8.1983910
 fromversion: 6.10.0
 tests:
 - No tests (auto formatted)

--- a/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot_test.py
+++ b/Packs/CTM360-CyberBlindspot/Integrations/CyberBlindspot/CyberBlindspot_test.py
@@ -410,6 +410,52 @@ def test_to_snake_case(mock_input, mock_assert):
     assert to_snake_case(mock_input) == mock_assert
 
 
+@pytest.mark.parametrize(
+    "mock_response",
+    [
+        {
+            'hits': [{'testkey': 'testval'}],
+            'statusCode': 200
+        },
+        {
+            'statusCode': 200
+        },
+        {
+            'errors': 'Invalid API-KEY',
+            'statusCode': 400
+        },
+        {
+            'statusCode': 500
+        },
+    ]
+)
+def test_test_configuration(mock_response, mock_client, mocker):
+    """
+    Given:
+        - CyberBlindspot Client.
+    When:
+        - test_configuration is called.
+    Then:
+        - The returned value must be a list.
+    """
+
+    mocker.patch.object(
+        mock_client,
+        "_http_request",
+        return_value=mock_response
+    )
+
+    if mock_response.get('statusCode') > 200:
+        # Expecting an exception
+        with pytest.raises(DemistoException) as e:
+            incidents = mock_client.test_configuration({})
+            if type(e) is DemistoException:
+                assert e == mock_response.get("errors", "request was not successful")
+    else:
+        incidents = mock_client.test_configuration({})
+        assert type(incidents) is list
+
+
 """ COMMAND TESTS """
 
 

--- a/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
+++ b/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CTM360 CyberBlindspot
+
+- Updated the CTM360_CyberBlindspot integration's `test_configuration()` to consistently return a list, preventing the occurrence of an unexpected exception caused by attempting to slice a dictionary.

--- a/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
+++ b/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
@@ -3,6 +3,6 @@
 
 ##### CTM360 CyberBlindspot
 
-- Fixed a bug in CTM360_CyberBlindspot integration command `test-module` wherein an error was thrown.
+- Fixed a bug in CTM360_CyberBlindspot integration test command wherein an error was thrown.
 
 - Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
+++ b/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
@@ -4,3 +4,5 @@
 ##### CTM360 CyberBlindspot
 
 - Updated the CTM360_CyberBlindspot integration's `test_configuration()` to consistently return a list, preventing the occurrence of an unexpected exception caused by attempting to slice a dictionary.
+
+- Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
+++ b/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
@@ -3,6 +3,5 @@
 
 ##### CTM360 CyberBlindspot
 
-- Fixed a bug in CTM360_CyberBlindspot integration test command wherein an error was thrown.
-
+- Fixed a bug in the CTM360_CyberBlindspot integration test command where an error was thrown.
 - Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
+++ b/Packs/CTM360-CyberBlindspot/ReleaseNotes/2_1_1.md
@@ -3,6 +3,6 @@
 
 ##### CTM360 CyberBlindspot
 
-- Updated the CTM360_CyberBlindspot integration's `test_configuration()` to consistently return a list, preventing the occurrence of an unexpected exception caused by attempting to slice a dictionary.
+- Fixed a bug in CTM360_CyberBlindspot integration command `test-module` wherein an error was thrown.
 
 - Updated the Docker image to: *demisto/python3:3.12.8.1983910*.

--- a/Packs/CTM360-CyberBlindspot/pack_metadata.json
+++ b/Packs/CTM360-CyberBlindspot/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CTM360",
     "description": "Take action on incidents derived from threat intelligence that is directly linked to your organization.",
     "support": "partner",
-    "currentVersion": "2.1.0",
+    "currentVersion": "2.1.1",
     "author": "CTM360",
     "url": "https://www.ctm360.com",
     "email": "xsoar@ctm360.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: slicing error caused by attempting to slice a dict instead of a list.

## Description
This is to fix a `test_module` bug where the returned value is not a list causing an exception upon slicing that value.

## Must have
- [x] Tests
- [x] Documentation 
