### PR TITLE
Add platform MP to content packs

### DIFF
--- a/Packs/APIVoid/pack_metadata.json
+++ b/Packs/APIVoid/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ARIAPacketIntelligence/pack_metadata.json
+++ b/Packs/ARIAPacketIntelligence/pack_metadata.json
@@ -32,6 +32,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-ACM/pack_metadata.json
+++ b/Packs/AWS-ACM/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-AccessAnalyzer/pack_metadata.json
+++ b/Packs/AWS-AccessAnalyzer/pack_metadata.json
@@ -17,6 +17,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-Athena/pack_metadata.json
+++ b/Packs/AWS-Athena/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-GuardDuty/Integrations/AWSGuardDutyEventCollector/AWSGuardDutyEventCollector.yml
+++ b/Packs/AWS-GuardDuty/Integrations/AWSGuardDutyEventCollector/AWSGuardDutyEventCollector.yml
@@ -126,6 +126,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No test
 fromversion: 6.8.0

--- a/Packs/AWS-GuardDuty/pack_metadata.json
+++ b/Packs/AWS-GuardDuty/pack_metadata.json
@@ -26,7 +26,9 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "AWS - GuardDuty Event Collector"
+    "defaultDataSource": "AWS - GuardDuty Event Collector",
+    "supportedModules": []
 }

--- a/Packs/AWS-IAMIdentityCenter/pack_metadata.json
+++ b/Packs/AWS-IAMIdentityCenter/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-ILM/pack_metadata.json
+++ b/Packs/AWS-ILM/pack_metadata.json
@@ -14,6 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-NetworkFirewall/pack_metadata.json
+++ b/Packs/AWS-NetworkFirewall/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-SNS-Listener/pack_metadata.json
+++ b/Packs/AWS-SNS-Listener/pack_metadata.json
@@ -17,6 +17,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-SNS/pack_metadata.json
+++ b/Packs/AWS-SNS/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS-SecurityLake/pack_metadata.json
+++ b/Packs/AWS-SecurityLake/pack_metadata.json
@@ -14,6 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AWS_ELB/pack_metadata.json
+++ b/Packs/AWS_ELB/pack_metadata.json
@@ -11,8 +11,12 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["ELB"],
+    "keywords": [
+        "ELB"
+    ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AbnormalSecurity/Integrations/AbnormalSecurityEventCollector/AbnormalSecurityEventCollector.yml
+++ b/Packs/AbnormalSecurity/Integrations/AbnormalSecurityEventCollector/AbnormalSecurityEventCollector.yml
@@ -49,5 +49,6 @@ fromversion: 6.8.0
 supportlevelheader: xsoar
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests

--- a/Packs/AbnormalSecurity/pack_metadata.json
+++ b/Packs/AbnormalSecurity/pack_metadata.json
@@ -22,7 +22,9 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Abnormal Security Event Collector"
+    "defaultDataSource": "Abnormal Security Event Collector",
+    "supportedModules": []
 }

--- a/Packs/AccentureCTI_Feed/pack_metadata.json
+++ b/Packs/AccentureCTI_Feed/pack_metadata.json
@@ -16,10 +16,12 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "CTI.Engineering.Integration@accenture.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": []
 }

--- a/Packs/Aella_StarLight/pack_metadata.json
+++ b/Packs/Aella_StarLight/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Algosec/pack_metadata.json
+++ b/Packs/Algosec/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
+++ b/Packs/AlphaSOC_Network_Behavior_Analytics/pack_metadata.json
@@ -19,6 +19,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ApacheTomcat/pack_metadata.json
+++ b/Packs/ApacheTomcat/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ApacheWebServer/pack_metadata.json
+++ b/Packs/ApacheWebServer/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ApiModules/pack_metadata.json
+++ b/Packs/ApiModules/pack_metadata.json
@@ -14,6 +14,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
-    ]
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ArcusTeam/pack_metadata.json
+++ b/Packs/ArcusTeam/pack_metadata.json
@@ -24,6 +24,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Arduino/pack_metadata.json
+++ b/Packs/Arduino/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AristaSwitch/pack_metadata.json
+++ b/Packs/AristaSwitch/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AsanaConnect/pack_metadata.json
+++ b/Packs/AsanaConnect/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AtlassianJiraServiceManagement/pack_metadata.json
+++ b/Packs/AtlassianJiraServiceManagement/pack_metadata.json
@@ -23,6 +23,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Attlasian/pack_metadata.json
+++ b/Packs/Attlasian/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Auditd/pack_metadata.json
+++ b/Packs/Auditd/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AvayaAuraCommunicationManager/pack_metadata.json
+++ b/Packs/AvayaAuraCommunicationManager/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Axonius/pack_metadata.json
+++ b/Packs/Axonius/pack_metadata.json
@@ -21,6 +21,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AzureAppService/pack_metadata.json
+++ b/Packs/AzureAppService/pack_metadata.json
@@ -19,6 +19,8 @@
         "Azure App Service"
     ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AzureCompute/pack_metadata.json
+++ b/Packs/AzureCompute/pack_metadata.json
@@ -16,6 +16,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
-    ]
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/AzureResourceGraph/pack_metadata.json
+++ b/Packs/AzureResourceGraph/pack_metadata.json
@@ -15,6 +15,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
-    ]
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Barracuda/pack_metadata.json
+++ b/Packs/Barracuda/pack_metadata.json
@@ -19,6 +19,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/BarracudaEmailProtection/pack_metadata.json
+++ b/Packs/BarracudaEmailProtection/pack_metadata.json
@@ -20,6 +20,8 @@
     ],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/BarracudaWAF/pack_metadata.json
+++ b/Packs/BarracudaWAF/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Barracuda_Cloudgen_Firewall/pack_metadata.json
+++ b/Packs/Barracuda_Cloudgen_Firewall/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/BeyondTrust-AuthorizationRequests/pack_metadata.json
+++ b/Packs/BeyondTrust-AuthorizationRequests/pack_metadata.json
@@ -7,15 +7,19 @@
     "url": "",
     "email": "",
     "created": "2024-12-30T14:41:06Z",
-    "categories": ["Identity and Access Management"],
+    "categories": [
+        "Identity and Access Management"
+    ],
     "tags": [],
     "useCases": [],
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "nprenga"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/BeyondTrustPrivilegedRemoteAccess/pack_metadata.json
+++ b/Packs/BeyondTrustPrivilegedRemoteAccess/pack_metadata.json
@@ -11,8 +11,18 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["BeyondTrust", "Beyond Trust", "Beyond", "Remote Access", "Privileged Remote Access", "PRA", "Privileged"],
+    "keywords": [
+        "BeyondTrust",
+        "Beyond Trust",
+        "Beyond",
+        "Remote Access",
+        "Privileged Remote Access",
+        "PRA",
+        "Privileged"
+    ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/BeyondTrustRemoteSupport/pack_metadata.json
+++ b/Packs/BeyondTrustRemoteSupport/pack_metadata.json
@@ -11,8 +11,14 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["Remote Support", "Remote" , "Bomgar"],
+    "keywords": [
+        "Remote Support",
+        "Remote",
+        "Bomgar"
+    ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }


### PR DESCRIPTION
Updating the following packs: APIVoid
ARIAPacketIntelligence
AWS-ACM
AWS-AccessAnalyzer
AWS-Athena
AWS-GuardDuty
AWS-IAMIdentityCenter
AWS-ILM
AWS-NetworkFirewall
AWS-SNS
AWS-SNS-Listener
AWS-SecurityLake
AWS_ELB
AbnormalSecurity
AccentureCTI_Feed
Aella_StarLight
Algosec
AlphaSOC_Network_Behavior_Analytics
ApacheTomcat
ApacheWebServer
ApiModules
ArcusTeam
Arduino
AristaSwitch
AsanaConnect
AtlassianJiraServiceManagement
Attlasian
Auditd
AvayaAuraCommunicationManager
Axonius
AzureAppService
AzureCompute
AzureResourceGraph
Barracuda
BarracudaEmailProtection
BarracudaWAF
Barracuda_Cloudgen_Firewall
BeyondTrust-AuthorizationRequests
BeyondTrustPrivilegedRemoteAccess
BeyondTrustRemoteSupport