### PR TITLE
Add platform MP to content packs #4

### DIFF
--- a/Packs/FTP/pack_metadata.json
+++ b/Packs/FTP/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "jieliau"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedDHS/pack_metadata.json
+++ b/Packs/FeedDHS/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.yml
+++ b/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.yml
@@ -130,5 +130,6 @@ description: 'Ingest articles with indicators, entities and relationships from F
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/FeedFeedly/pack_metadata.json
+++ b/Packs/FeedFeedly/pack_metadata.json
@@ -17,7 +17,9 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": []
 }

--- a/Packs/FeedGCPWhitelist/pack_metadata.json
+++ b/Packs/FeedGCPWhitelist/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedGitHub/Integrations/FeedGitHub/FeedGitHub.yml
+++ b/Packs/FeedGitHub/Integrations/FeedGitHub/FeedGitHub.yml
@@ -206,6 +206,7 @@ description: This is the Feed GitHub integration for getting started with your f
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)
 sectionOrder:

--- a/Packs/FeedGitHub/pack_metadata.json
+++ b/Packs/FeedGitHub/pack_metadata.json
@@ -26,6 +26,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedGreyNoiseIndicator/pack_metadata.json
+++ b/Packs/FeedGreyNoiseIndicator/pack_metadata.json
@@ -24,6 +24,8 @@
     "itemPrefix": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedIntel471/pack_metadata.json
+++ b/Packs/FeedIntel471/pack_metadata.json
@@ -21,6 +21,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedMISPThreatActors/pack_metadata.json
+++ b/Packs/FeedMISPThreatActors/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedMajesticMillion/pack_metadata.json
+++ b/Packs/FeedMajesticMillion/pack_metadata.json
@@ -20,6 +20,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedMalwareBazaar/pack_metadata.json
+++ b/Packs/FeedMalwareBazaar/pack_metadata.json
@@ -18,6 +18,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedNVDv2/pack_metadata.json
+++ b/Packs/FeedNVDv2/pack_metadata.json
@@ -14,6 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedORKL/pack_metadata.json
+++ b/Packs/FeedORKL/pack_metadata.json
@@ -18,6 +18,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedOpenCTI/pack_metadata.json
+++ b/Packs/FeedOpenCTI/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
+++ b/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
@@ -27,6 +27,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedThreatConnect/pack_metadata.json
+++ b/Packs/FeedThreatConnect/pack_metadata.json
@@ -17,6 +17,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedThreatFox/pack_metadata.json
+++ b/Packs/FeedThreatFox/pack_metadata.json
@@ -14,6 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedThreatVault/pack_metadata.json
+++ b/Packs/FeedThreatVault/pack_metadata.json
@@ -10,8 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-    ],
+    "tags": [],
     "useCases": [
         "Threat Intelligence Management"
     ],
@@ -19,10 +18,11 @@
         "threatvault",
         "threat intelligence"
     ],
-    "dependencies": {
-    },
+    "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FeedTorExitAddresses/pack_metadata.json
+++ b/Packs/FeedTorExitAddresses/pack_metadata.json
@@ -20,6 +20,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FidelisEndpoint/pack_metadata.json
+++ b/Packs/FidelisEndpoint/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FileOrbis/pack_metadata.json
+++ b/Packs/FileOrbis/pack_metadata.json
@@ -18,6 +18,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FlashpointFeed/pack_metadata.json
+++ b/Packs/FlashpointFeed/pack_metadata.json
@@ -23,6 +23,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ForcepointDLP/Integrations/ForcepointEventCollector/ForcepointEventCollector.yml
+++ b/Packs/ForcepointDLP/Integrations/ForcepointEventCollector/ForcepointEventCollector.yml
@@ -81,5 +81,6 @@ script:
 fromversion: 8.2.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/ForcepointDLP/pack_metadata.json
+++ b/Packs/ForcepointDLP/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ForcepointEmailSecurity/pack_metadata.json
+++ b/Packs/ForcepointEmailSecurity/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ForcepointSWG/pack_metadata.json
+++ b/Packs/ForcepointSWG/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Fortanix-DSM/pack_metadata.json
+++ b/Packs/Fortanix-DSM/pack_metadata.json
@@ -40,6 +40,8 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FortiAuthenticator/pack_metadata.json
+++ b/Packs/FortiAuthenticator/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/FullHunt/pack_metadata.json
+++ b/Packs/FullHunt/pack_metadata.json
@@ -19,9 +19,11 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "Sam0x90"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/Gamma/pack_metadata.json
+++ b/Packs/Gamma/pack_metadata.json
@@ -41,6 +41,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Gatewatcher-LIS/pack_metadata.json
+++ b/Packs/Gatewatcher-LIS/pack_metadata.json
@@ -14,10 +14,12 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "CesarGW",
         "Liolaeus"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/GenetecSecurityCenter/Integrations/GenetecSecurityCenterEventCollector/GenetecSecurityCenterEventCollector.yml
+++ b/Packs/GenetecSecurityCenter/Integrations/GenetecSecurityCenterEventCollector/GenetecSecurityCenterEventCollector.yml
@@ -65,6 +65,7 @@ script:
   isfetchevents: true
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GenetecSecurityCenter/pack_metadata.json
+++ b/Packs/GenetecSecurityCenter/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Genians/pack_metadata.json
+++ b/Packs/Genians/pack_metadata.json
@@ -17,6 +17,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/GigamonThreatINSIGHT/pack_metadata.json
+++ b/Packs/GigamonThreatINSIGHT/pack_metadata.json
@@ -14,10 +14,12 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "apps@gigamon.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": []
 }

--- a/Packs/Giphy/pack_metadata.json
+++ b/Packs/Giphy/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/GitGuardian/Integrations/GitGuardianEventCollector/GitGuardianEventCollector.yml
+++ b/Packs/GitGuardian/Integrations/GitGuardianEventCollector/GitGuardianEventCollector.yml
@@ -74,6 +74,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GitGuardian/pack_metadata.json
+++ b/Packs/GitGuardian/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/GithubMaltrailFeed/pack_metadata.json
+++ b/Packs/GithubMaltrailFeed/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "asantamarina"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/GoogleChatViaWebhook/pack_metadata.json
+++ b/Packs/GoogleChatViaWebhook/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "edibleShell"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/GoogleChrome/pack_metadata.json
+++ b/Packs/GoogleChrome/pack_metadata.json
@@ -20,6 +20,8 @@
         "browser"
     ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/GoogleCloudLogging/pack_metadata.json
+++ b/Packs/GoogleCloudLogging/pack_metadata.json
@@ -14,6 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/GoogleVertexAI/pack_metadata.json
+++ b/Packs/GoogleVertexAI/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "sepaprivate"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/Gophish/pack_metadata.json
+++ b/Packs/Gophish/pack_metadata.json
@@ -16,6 +16,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }


### PR DESCRIPTION
Updating the following packs: 
```
FTP
FeedDHS
FeedFeedly
FeedGCPWhitelist
FeedGitHub
FeedGreyNoiseIndicator
FeedIntel471
FeedMISPThreatActors
FeedMajesticMillion
FeedMalwareBazaar
FeedNVDv2
FeedORKL
FeedOpenCTI
FeedReversingLabsRansomwareAndRelatedToolsApp
FeedThreatConnect
FeedThreatFox
FeedThreatVault
FeedTorExitAddresses
FidelisEndpoint
FileOrbis
FlashpointFeed
ForcepointDLP
ForcepointEmailSecurity
ForcepointSWG
Fortanix-DSM
FortiAuthenticator
FullHunt
Gamma
Gatewatcher-LIS
GenetecSecurityCenter
Genians
GigamonThreatINSIGHT
Giphy
GitGuardian
GithubMaltrailFeed
GoogleChatViaWebhook
GoogleChrome
GoogleCloudLogging
GoogleVertexAI
Gophish
```