### PR TITLE
SplunkPy - Fixed a Mirror In issue (XSUP-43248)

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -3451,7 +3451,7 @@ def main():  # pragma: no cover
                                              mapper=mapper,
                                              comment_tag_from_splunk=comment_tag_from_splunk)
         except Exception as e:
-            demisto.error(f"An error occurred during the Mirror In: {e}")
+            return_error(f"An error occurred during the Mirror In: {e}")
     elif command == 'update-remote-system':
         demisto.info('########### MIRROR OUT #############')
         return_results(update_remote_system_command(args, params, service, auth_token, mapper, comment_tag_to_splunk))

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -3451,7 +3451,7 @@ def main():  # pragma: no cover
                                              mapper=mapper,
                                              comment_tag_from_splunk=comment_tag_from_splunk)
         except Exception as e:
-            return_error(f"An error occurred during the Mirror In get_modified_remote_data_command: {e}")
+            return_error(f"An error occurred during the Mirror In - in get_modified_remote_data_command: {e}")
     elif command == 'update-remote-system':
         demisto.info('########### MIRROR OUT #############')
         return_results(update_remote_system_command(args, params, service, auth_token, mapper, comment_tag_to_splunk))

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -3451,7 +3451,7 @@ def main():  # pragma: no cover
                                              mapper=mapper,
                                              comment_tag_from_splunk=comment_tag_from_splunk)
         except Exception as e:
-            return_error(f"An error occurred during the Mirror In: {e}")
+            return_error(f"An error occurred during the Mirror In get_modified_remote_data_command: {e}")
     elif command == 'update-remote-system':
         demisto.info('########### MIRROR OUT #############')
         return_results(update_remote_system_command(args, params, service, auth_token, mapper, comment_tag_to_splunk))

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -3443,12 +3443,15 @@ def main():  # pragma: no cover
         raise NotImplementedError(f'the {command} command is not implemented, use get-modified-remote-data instead.')
     elif command == 'get-modified-remote-data':
         demisto.info('########### MIRROR IN #############')
-        get_modified_remote_data_command(service=service, args=args,
-                                         close_incident=params.get('close_incident'),
-                                         close_end_statuses=params.get('close_end_status_statuses'),
-                                         close_extra_labels=argToList(params.get('close_extra_labels', '')),
-                                         mapper=mapper,
-                                         comment_tag_from_splunk=comment_tag_from_splunk)
+        try:
+            get_modified_remote_data_command(service=service, args=args,
+                                             close_incident=params.get('close_incident'),
+                                             close_end_statuses=params.get('close_end_status_statuses'),
+                                             close_extra_labels=argToList(params.get('close_extra_labels', '')),
+                                             mapper=mapper,
+                                             comment_tag_from_splunk=comment_tag_from_splunk)
+        except Exception as e:
+            demisto.error(f"An error occuerred during the Mirror In - {e}")
     elif command == 'update-remote-system':
         demisto.info('########### MIRROR OUT #############')
         return_results(update_remote_system_command(args, params, service, auth_token, mapper, comment_tag_to_splunk))

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -3451,7 +3451,7 @@ def main():  # pragma: no cover
                                              mapper=mapper,
                                              comment_tag_from_splunk=comment_tag_from_splunk)
         except Exception as e:
-            demisto.error(f"An error occuerred during the Mirror In - {e}")
+            demisto.error(f"An error occurred during the Mirror In: {e}")
     elif command == 'update-remote-system':
         demisto.info('########### MIRROR OUT #############')
         return_results(update_remote_system_command(args, params, service, auth_token, mapper, comment_tag_to_splunk))

--- a/Packs/SplunkPy/ReleaseNotes/3_2_3.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_2_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SplunkPy
+
+- Fixed an issue where the *Mirror In* mechanism has stopped working once an error was raised during the run of the ***get-modified-remote-data*** command.

--- a/Packs/SplunkPy/ReleaseNotes/3_2_3.md
+++ b/Packs/SplunkPy/ReleaseNotes/3_2_3.md
@@ -3,4 +3,4 @@
 
 ##### SplunkPy
 
-- Fixed an issue where the *Mirror In* mechanism has stopped working once an error was raised during the run of the ***get-modified-remote-data*** command.
+- Fixed an issue where the *Mirror In* mechanism has stopped when ***get-modified-remote-data*** command failed on error.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Run queries on Splunk servers.",
     "support": "xsoar",
-    "currentVersion": "3.2.2",
+    "currentVersion": "3.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-43248](https://jira-dc.paloaltonetworks.com/browse/XSUP-43248).

## Description
It appears that when an error is raised during the run of the `get-modified-remote-data` command, the server will stop running this command and will call the `get-remote-data` command instead.
In the Splunkpy integration, the `get-remote-data` command is not implemented (since version 3.2.0). Therefore we are getting into an endless loop of calling an unimplemented command over and over, and the 'Mirror In' mechanism just stops.

In this PR we fix that issue by wrapping the `get-modified-remote-data` command with a try-except block, catching the error and logging it's content instead of raising the exception. 

## Must have
- [ ] Tests
- [ ] Documentation 
