### PR TITLE
Add platform MP to content packs #6

### DIFF
--- a/Packs/Koodous/pack_metadata.json
+++ b/Packs/Koodous/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Kubernetes/pack_metadata.json
+++ b/Packs/Kubernetes/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/LINENotify/pack_metadata.json
+++ b/Packs/LINENotify/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Lacework/pack_metadata.json
+++ b/Packs/Lacework/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Linkshadow/pack_metadata.json
+++ b/Packs/Linkshadow/pack_metadata.json
@@ -19,6 +19,8 @@
     "githubUser": "Devika-LS",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/LinuxEventsCollection/pack_metadata.json
+++ b/Packs/LinuxEventsCollection/pack_metadata.json
@@ -18,6 +18,8 @@
         "linux"
     ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/LogsignSiem/pack_metadata.json
+++ b/Packs/LogsignSiem/pack_metadata.json
@@ -26,6 +26,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Lost_Stolen_Device/pack_metadata.json
+++ b/Packs/Lost_Stolen_Device/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Lost / Stolen Device",
-    "description": "Looking to reduce the multiple triage, response and mitigation steps involved in handling lost/stolen devices? We’ve got just the Content Pack for you!",
+    "description": "Looking to reduce the multiple triage, response and mitigation steps involved in handling lost/stolen devices? We\u2019ve got just the Content Pack for you!",
     "support": "xsoar",
     "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
@@ -10,9 +10,7 @@
     "categories": [
         "IT Services"
     ],
-    "tags": [
-        "Use Case"
-    ],
+    "tags": ["Use Case"],
     "useCases": [
         "Compliance"
     ],
@@ -22,8 +20,6 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2",
-        "platform"
-    ],
-    "supportedModules": []
+        "marketplacev2"
+    ]
 }

--- a/Packs/Lost_Stolen_Device/pack_metadata.json
+++ b/Packs/Lost_Stolen_Device/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Lost / Stolen Device",
-    "description": "Looking to reduce the multiple triage, response and mitigation steps involved in handling lost/stolen devices? We\u2019ve got just the Content Pack for you!",
+    "description": "Looking to reduce the multiple triage, response and mitigation steps involved in handling lost/stolen devices? We’ve got just the Content Pack for you!",
     "support": "xsoar",
     "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
@@ -10,7 +10,9 @@
     "categories": [
         "IT Services"
     ],
-    "tags": ["Use Case"],
+    "tags": [
+        "Use Case"
+    ],
     "useCases": [
         "Compliance"
     ],
@@ -20,6 +22,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Lumu/pack_metadata.json
+++ b/Packs/Lumu/pack_metadata.json
@@ -20,7 +20,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "eparra@lumu.io"
@@ -30,5 +31,6 @@
         "Shellyber",
         "xsoar-bot",
         "content-bot"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/MS-ISAC/pack_metadata.json
+++ b/Packs/MS-ISAC/pack_metadata.json
@@ -16,6 +16,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MacOS/pack_metadata.json
+++ b/Packs/MacOS/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MacVendors/pack_metadata.json
+++ b/Packs/MacVendors/pack_metadata.json
@@ -18,6 +18,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ManageEngine-ADAudit/pack_metadata.json
+++ b/Packs/ManageEngine-ADAudit/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ManageEngine-ADManager/pack_metadata.json
+++ b/Packs/ManageEngine-ADManager/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ManageEngine-ADSelfServicePlus/pack_metadata.json
+++ b/Packs/ManageEngine-ADSelfServicePlus/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/ManageEngine_PAM360/pack_metadata.json
+++ b/Packs/ManageEngine_PAM360/pack_metadata.json
@@ -18,6 +18,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
+++ b/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
@@ -17,10 +17,12 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "chrishultin",
         "adamlevymandiant"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/Mantis/pack_metadata.json
+++ b/Packs/Mantis/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/McAfeeDatabaseSecurity/pack_metadata.json
+++ b/Packs/McAfeeDatabaseSecurity/pack_metadata.json
@@ -16,6 +16,8 @@
         "Sentrigo"
     ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicroFocusSMAX/pack_metadata.json
+++ b/Packs/MicroFocusSMAX/pack_metadata.json
@@ -15,6 +15,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftDHCP/pack_metadata.json
+++ b/Packs/MicrosoftDHCP/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftDefenderforIdentity/pack_metadata.json
+++ b/Packs/MicrosoftDefenderforIdentity/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftExchangeServer/pack_metadata.json
+++ b/Packs/MicrosoftExchangeServer/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftGraphSearch/pack_metadata.json
+++ b/Packs/MicrosoftGraphSearch/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "randomizerxd"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftGraphTeams/pack_metadata.json
+++ b/Packs/MicrosoftGraphTeams/pack_metadata.json
@@ -15,9 +15,11 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "invent0r"
-    ]
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftIISWebServer/pack_metadata.json
+++ b/Packs/MicrosoftIISWebServer/pack_metadata.json
@@ -18,6 +18,8 @@
         "Internet Information Services"
     ],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftIntune/pack_metadata.json
+++ b/Packs/MicrosoftIntune/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftNPS/pack_metadata.json
+++ b/Packs/MicrosoftNPS/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftWSUS/pack_metadata.json
+++ b/Packs/MicrosoftWSUS/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftWindowsEvents/pack_metadata.json
+++ b/Packs/MicrosoftWindowsEvents/pack_metadata.json
@@ -27,6 +27,8 @@
         }
     },
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MicrosoftWindowsSysmon/pack_metadata.json
+++ b/Packs/MicrosoftWindowsSysmon/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MinervaLabsAntiEvasionPlatform/pack_metadata.json
+++ b/Packs/MinervaLabsAntiEvasionPlatform/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/MongoDBAtlas/Integrations/MongoDBAtlasEventCollector/MongoDBAtlasEventCollector.yml
+++ b/Packs/MongoDBAtlas/Integrations/MongoDBAtlasEventCollector/MongoDBAtlasEventCollector.yml
@@ -73,5 +73,6 @@ script:
 fromversion: 6.10.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/MongoDBAtlas/pack_metadata.json
+++ b/Packs/MongoDBAtlas/pack_metadata.json
@@ -21,7 +21,9 @@
         "event collector"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "MongoDBAtlasEventCollector"
+    "defaultDataSource": "MongoDBAtlasEventCollector",
+    "supportedModules": []
 }

--- a/Packs/MySQLEnterprise/pack_metadata.json
+++ b/Packs/MySQLEnterprise/pack_metadata.json
@@ -13,6 +13,8 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/NationalVulnerabilityDatabaseFeed/pack_metadata.json
+++ b/Packs/NationalVulnerabilityDatabaseFeed/pack_metadata.json
@@ -20,6 +20,8 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Ncurion/pack_metadata.json
+++ b/Packs/Ncurion/pack_metadata.json
@@ -18,6 +18,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/Neosec/pack_metadata.json
+++ b/Packs/Neosec/pack_metadata.json
@@ -14,8 +14,10 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [],
-    "created": "2022-11-27T09:39:30Z"
+    "created": "2022-11-27T09:39:30Z",
+    "supportedModules": []
 }

--- a/Packs/mcafeeDam/pack_metadata.json
+++ b/Packs/mcafeeDam/pack_metadata.json
@@ -15,6 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }

--- a/Packs/mnemonicMDR/pack_metadata.json
+++ b/Packs/mnemonicMDR/pack_metadata.json
@@ -23,6 +23,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
-    ]
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": []
 }


### PR DESCRIPTION
Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs: 
```
Koodous
Kubernetes
LINENotify
Lacework
Linkshadow
LinuxEventsCollection
LogsignSiem
Lost_Stolen_Device
Lumu
MS-ISAC
MacOS
MacVendors
ManageEngine-ADAudit
ManageEngine-ADManager
ManageEngine-ADSelfServicePlus
ManageEngine_PAM360
MandiantAdvantageThreatIntelligence
Mantis
McAfeeDatabaseSecurity
MicroFocusSMAX
MicrosoftDHCP
MicrosoftDefenderforIdentity
MicrosoftExchangeServer
MicrosoftGraphSearch
MicrosoftGraphTeams
MicrosoftIISWebServer
MicrosoftIntune
MicrosoftNPS
MicrosoftWSUS
MicrosoftWindowsEvents
MicrosoftWindowsSysmon
MinervaLabsAntiEvasionPlatform
MongoDBAtlas
MySQLEnterprise
NationalVulnerabilityDatabaseFeed
Ncurion
Neosec
mcafeeDam
mnemonicMDR
```
