### PR TITLE
[Port Scan - External Source] Add ignore GR107

### DIFF
--- a/Packs/PortScan/.pack-ignore
+++ b/Packs/PortScan/.pack-ignore
@@ -1,2 +1,4 @@
 [file:Port_Scan_-_Internal_Source_6_0.yml]
 ignore=PB118
+[file:Port_Scan_-_External_Source_6_0.yml]
+ignore=GR107


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Since DomainTools has become deprecated [here](https://github.com/demisto/content/pull/38725), we need to add ignore to GR107.

## Must have
- [ ] Tests
- [ ] Documentation 
