### PR TITLE
Ignore content validations in packwise flow 

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -287,6 +287,13 @@ repos:
     - --config-path=validation_config.toml
     - --ignore=DO106
     - --ignore=CJ105
+    - --ignore=ST111
+    - --ignore=DS108
+    - --ignore=RM108
+    - --ignore=BA103
+    - --ignore=RM110
+    - --ignore=RM109
+    - --ignore=DS104
     pass_filenames: false
     language: system
     require_serial: true


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue
Related to the following effort:
https://jira-dc.paloaltonetworks.com/browse/CIAC-7094

## Description
As part of enforcing ruff on content ignore the following validations for the process. 


## Must have
- [ ] Tests
- [ ] Documentation 
