### PR TITLE
InvestigationDetailedSummaryParse - 'value' vs 'Value' key while parsing an attack

### DIFF
--- a/Packs/MalwareInvestigationAndResponse/ReleaseNotes/2_0_16.md
+++ b/Packs/MalwareInvestigationAndResponse/ReleaseNotes/2_0_16.md
@@ -3,4 +3,4 @@
 
 ##### InvestigationDetailedSummaryParse
 
-- Added support for retriving the 'value' key while parsing an attack without a 'Value' key.
+- Added support for retrieving the 'value' key while parsing an attack without a 'Value' key.

--- a/Packs/MalwareInvestigationAndResponse/ReleaseNotes/2_0_16.md
+++ b/Packs/MalwareInvestigationAndResponse/ReleaseNotes/2_0_16.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### InvestigationDetailedSummaryParse
+
+- Added support for retriving the 'value' key while parsing an attack without a 'Value' key.

--- a/Packs/MalwareInvestigationAndResponse/Scripts/InvestigationDetailedSummaryParse/InvestigationDetailedSummaryParse.py
+++ b/Packs/MalwareInvestigationAndResponse/Scripts/InvestigationDetailedSummaryParse/InvestigationDetailedSummaryParse.py
@@ -65,7 +65,7 @@ class ContextParser:
 
         result = []
         for attack_dict in attack_pattern_context:
-            if 'Value' not in attack_dict:  # outdated MITREv2 pack, <= v1.1.0
+            if 'value' not in (k.lower() for k in attack_dict):  # outdated MITREv2 pack, <= v1.1.0
                 raise DemistoException('please make sure the MITRE ATT&CK v2 pack is up-to-date (v1.1.1 or newer)')
 
             result.append(FoundTechnique(mitre_id=attack_dict.get('MITREID', ''),

--- a/Packs/MalwareInvestigationAndResponse/Scripts/InvestigationDetailedSummaryParse/InvestigationDetailedSummaryParse.py
+++ b/Packs/MalwareInvestigationAndResponse/Scripts/InvestigationDetailedSummaryParse/InvestigationDetailedSummaryParse.py
@@ -69,7 +69,7 @@ class ContextParser:
                 raise DemistoException('please make sure the MITRE ATT&CK v2 pack is up-to-date (v1.1.1 or newer)')
 
             result.append(FoundTechnique(mitre_id=attack_dict.get('MITREID', ''),
-                                         name=attack_dict.get('Value', ''),
+                                         name=attack_dict.get('Value', '') or attack_dict.get('value', ''),
                                          tactics=attack_dict.get('KillChainPhases', []),
                                          ))
         return tuple(result)  # type:ignore[return-value]

--- a/Packs/MalwareInvestigationAndResponse/pack_metadata.json
+++ b/Packs/MalwareInvestigationAndResponse/pack_metadata.json
@@ -5,7 +5,7 @@
     "videos": [
         "https://www.youtube.com/watch?v=DtGIefyoTao"
     ],
-    "currentVersion": "2.0.15",
+    "currentVersion": "2.0.16",
     "serverMinVersion": "6.5.0",
     "author": "Cortex XSOAR",
     "hidden": false,


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-48083

## Description
 Added support for retrieving the 'value' key while parsing an attack without a 'Value' key.

## Must have
- [ ] Tests
- [ ] Documentation 
