### PR TITLE
Make all AbnormalSecurity Incident Fields searchable

### DIFF
--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Attack_Type.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Attack_Type.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_First_Reported.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_First_Reported.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_From_Address.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_From_Address.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_From_Name.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_From_Name.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Judgement_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Judgement_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Last_Reported.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Last_Reported.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Message_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Message_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Overall_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Overall_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Recipient_Address.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Recipient_Address.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Recipient_Name.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Recipient_Name.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Subject.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Abuse_Campaign_Subject.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Affected_Employee.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Affected_Employee.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Analysis.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Analysis.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attachment_Count.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attachment_Count.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attachment_Names.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attachment_Names.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Strategy.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Strategy.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Type.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Type.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Vector.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attack_Vector.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attacked_Party.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Attacked_Party.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Auto_Remediated.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Auto_Remediated.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_CC_Emails.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_CC_Emails.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Campaign_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Campaign_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Case_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Case_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Case_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Case_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Customer_Visible_Time.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Customer_Visible_Time.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_First_Observed_Time.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_First_Observed_Time.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_First_Reported.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_First_Reported.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_From_Address.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_From_Address.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_From_Name.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_From_Name.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Impersonated_Party.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Impersonated_Party.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Internet_Message_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Internet_Message_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Is_Read.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Is_Read.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Judgement_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Judgement_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Last_Reported.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Last_Reported.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Message_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Message_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Overall_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Overall_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Portal_URL.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Portal_URL.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Post_Remediated.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Post_Remediated.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Received_Time.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Received_Time.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Recipient_Address.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Recipient_Address.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Recipient_Name.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Recipient_Name.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Remediation_Status.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Remediation_Status.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Remediation_Timestamp.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Remediation_Timestamp.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Reply_To_Emails.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Reply_To_Emails.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Return_Path.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Return_Path.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sender_Domain.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sender_Domain.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sender_IP_Address.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sender_IP_Address.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sent_Time.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Sent_Time.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Severity.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Severity.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Severity_Level.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Severity_Level.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Subject.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Subject.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Summary_Insights.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Summary_Insights.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Threat_ID.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Threat_ID.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Threat_IDs.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Threat_IDs.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_To_Addresses.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_To_Addresses.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,

--- a/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Url_Count.json
+++ b/Packs/AbnormalSecurity/IncidentFields/incidentfields_Abnormal_Security_Url_Count.json
@@ -23,7 +23,7 @@
     ],
     "associatedToAll": false,
     "unmapped": false,
-    "unsearchable": true,
+    "unsearchable": false,
     "caseInsensitive": true,
     "sla": 0,
     "threshold": 72,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
None of the Abnormal Security Incident Fields are searchable in the Incidents table.  This is also particularly problematic because this also means they can't be used with the built-in Pre-Processing Rules to handle duplication of incidents being generated (i.e. Abnormal Security Case ID incident field).  

## Must have
- [ ] Tests
- [ ] Documentation 
