### PR TITLE
Adopt 'platform' MP to content packs #1

### DIFF
--- a/Packs/3CXDesktopApp_Supply_Chain_Attack/pack_metadata.json
+++ b/Packs/3CXDesktopApp_Supply_Chain_Attack/pack_metadata.json
@@ -25,6 +25,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AHA/pack_metadata.json
+++ b/Packs/AHA/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AMP/Integrations/CiscoAMPEventCollector/CiscoAMPEventCollector.yml
+++ b/Packs/AMP/Integrations/CiscoAMPEventCollector/CiscoAMPEventCollector.yml
@@ -73,6 +73,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/AMP/pack_metadata.json
+++ b/Packs/AMP/pack_metadata.json
@@ -19,7 +19,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "CiscoAMPEventCollector"
+    "defaultDataSource": "CiscoAMPEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ANYRUN/pack_metadata.json
+++ b/Packs/ANYRUN/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/APIVoid/pack_metadata.json
+++ b/Packs/APIVoid/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ARIAPacketIntelligence/pack_metadata.json
+++ b/Packs/ARIAPacketIntelligence/pack_metadata.json
@@ -32,6 +32,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-ACM/pack_metadata.json
+++ b/Packs/AWS-ACM/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-AccessAnalyzer/pack_metadata.json
+++ b/Packs/AWS-AccessAnalyzer/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-Athena/pack_metadata.json
+++ b/Packs/AWS-Athena/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-CloudTrail/pack_metadata.json
+++ b/Packs/AWS-CloudTrail/pack_metadata.json
@@ -23,6 +23,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-CloudWatchLogs/pack_metadata.json
+++ b/Packs/AWS-CloudWatchLogs/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-EC2/Playbooks/playbook-IP_Whitelist_-_AWS_Security_Group.yml
+++ b/Packs/AWS-EC2/Playbooks/playbook-IP_Whitelist_-_AWS_Security_Group.yml
@@ -359,9 +359,7 @@ tasks:
       id: 8a1ec2e1-2f6c-4ab1-86dc-7f587b6fd52a
       version: -1
       name: Revoke IPs from AWS Security Group
-      description: Removes egress rule from a security group. To remove a rule, the
-        values that you specify (for example, ports) must match the existing rule's
-        values exactly.
+      description: Removes egress rule from a security group. To remove a rule, the values that you specify (for example, ports) must match the existing rule's values exactly.
       script: '|||aws-ec2-revoke-security-group-ingress-rule'
       type: regular
       iscommand: true
@@ -875,5 +873,6 @@ fromversion: 5.5.0
 tests:
 - No tests (auto formatted)
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/AWS-EC2/pack_metadata.json
+++ b/Packs/AWS-EC2/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-EKS/pack_metadata.json
+++ b/Packs/AWS-EKS/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Function_Deployment_-_AWS.yml
+++ b/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Function_Deployment_-_AWS.yml
@@ -1815,6 +1815,7 @@ outputs:
 tests:
 - No tests (auto formatted)
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform
 fromversion: 6.10.0

--- a/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Function_Removal_-_AWS.yml
+++ b/Packs/AWS-Enrichment-Remediation/Playbooks/playbook-Function_Removal_-_AWS.yml
@@ -484,6 +484,7 @@ outputs: []
 tests:
 - No tests (auto formatted)
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform
 fromversion: 6.10.0

--- a/Packs/AWS-Enrichment-Remediation/pack_metadata.json
+++ b/Packs/AWS-Enrichment-Remediation/pack_metadata.json
@@ -15,7 +15,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
     "dependencies": {
         "AWS-IAM": {
@@ -45,5 +46,11 @@
         "AWS-EC2",
         "AWS-S3",
         "AWS_SystemManager"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-GuardDuty/Integrations/AWSGuardDutyEventCollector/AWSGuardDutyEventCollector.yml
+++ b/Packs/AWS-GuardDuty/Integrations/AWSGuardDutyEventCollector/AWSGuardDutyEventCollector.yml
@@ -126,6 +126,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No test
 fromversion: 6.8.0

--- a/Packs/AWS-GuardDuty/pack_metadata.json
+++ b/Packs/AWS-GuardDuty/pack_metadata.json
@@ -26,7 +26,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "AWS - GuardDuty Event Collector"
+    "defaultDataSource": "AWS - GuardDuty Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/AWS-IAM/pack_metadata.json
+++ b/Packs/AWS-IAM/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-IAMIdentityCenter/pack_metadata.json
+++ b/Packs/AWS-IAMIdentityCenter/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-ILM/pack_metadata.json
+++ b/Packs/AWS-ILM/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-Lambda/pack_metadata.json
+++ b/Packs/AWS-Lambda/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-NetworkFirewall/pack_metadata.json
+++ b/Packs/AWS-NetworkFirewall/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-Organizations/Integrations/AWSOrganizations/AWSOrganizations.yml
+++ b/Packs/AWS-Organizations/Integrations/AWSOrganizations/AWSOrganizations.yml
@@ -703,5 +703,6 @@ marketplaces:
 - xsoar
 - marketplacev2
 - xpanse
+- platform
 tests:
 - Test - AWS_Organizations

--- a/Packs/AWS-Organizations/pack_metadata.json
+++ b/Packs/AWS-Organizations/pack_metadata.json
@@ -15,6 +15,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-Route53/pack_metadata.json
+++ b/Packs/AWS-Route53/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-S3/pack_metadata.json
+++ b/Packs/AWS-S3/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-SNS-Listener/pack_metadata.json
+++ b/Packs/AWS-SNS-Listener/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-SNS/pack_metadata.json
+++ b/Packs/AWS-SNS/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-SQS/pack_metadata.json
+++ b/Packs/AWS-SQS/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS-SecurityHub/Integrations/AWSSecurityHubEventCollector/AWSSecurityHubEventCollector.yml
+++ b/Packs/AWS-SecurityHub/Integrations/AWSSecurityHubEventCollector/AWSSecurityHubEventCollector.yml
@@ -132,6 +132,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/AWS-SecurityHub/pack_metadata.json
+++ b/Packs/AWS-SecurityHub/pack_metadata.json
@@ -17,10 +17,17 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "itemPrefix": [
         "AWS Security Hub"
     ],
-    "defaultDataSource": "AWS Security Hub Event Collector"
+    "defaultDataSource": "AWS Security Hub Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/AWS-SecurityLake/pack_metadata.json
+++ b/Packs/AWS-SecurityLake/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS_DynamoDB/pack_metadata.json
+++ b/Packs/AWS_DynamoDB/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS_ELB/pack_metadata.json
+++ b/Packs/AWS_ELB/pack_metadata.json
@@ -11,8 +11,17 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["ELB"],
+    "keywords": [
+        "ELB"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS_Sagemaker/pack_metadata.json
+++ b/Packs/AWS_Sagemaker/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS_SystemManager/Integrations/AWSSystemManager/AWSSystemManager.yml
+++ b/Packs/AWS_SystemManager/Integrations/AWSSystemManager/AWSSystemManager.yml
@@ -2391,5 +2391,6 @@ marketplaces:
 - xsoar
 - marketplacev2
 - xpanse
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/AWS_SystemManager/pack_metadata.json
+++ b/Packs/AWS_SystemManager/pack_metadata.json
@@ -17,6 +17,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AWS_WAF/pack_metadata.json
+++ b/Packs/AWS_WAF/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AbnormalSecurity/Integrations/AbnormalSecurityEventCollector/AbnormalSecurityEventCollector.yml
+++ b/Packs/AbnormalSecurity/Integrations/AbnormalSecurityEventCollector/AbnormalSecurityEventCollector.yml
@@ -49,5 +49,6 @@ fromversion: 6.8.0
 supportlevelheader: xsoar
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests

--- a/Packs/AbnormalSecurity/pack_metadata.json
+++ b/Packs/AbnormalSecurity/pack_metadata.json
@@ -22,7 +22,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Abnormal Security Event Collector"
+    "defaultDataSource": "Abnormal Security Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Absolute/pack_metadata.json
+++ b/Packs/Absolute/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AbuseDB/pack_metadata.json
+++ b/Packs/AbuseDB/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AcalvioShadowplex/pack_metadata.json
+++ b/Packs/AcalvioShadowplex/pack_metadata.json
@@ -19,6 +19,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AccentureCTI/pack_metadata.json
+++ b/Packs/AccentureCTI/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AccentureCTI_Feed/pack_metadata.json
+++ b/Packs/AccentureCTI_Feed/pack_metadata.json
@@ -16,10 +16,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "CTI.Engineering.Integration@accenture.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/AccessInvestigation/pack_metadata.json
+++ b/Packs/AccessInvestigation/pack_metadata.json
@@ -36,6 +36,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Accessdata/pack_metadata.json
+++ b/Packs/Accessdata/pack_metadata.json
@@ -20,6 +20,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
3CXDesktopApp_Supply_Chain_Attack
AHA
AMP
ANYRUN
APIVoid
ARIAPacketIntelligence
AWS-ACM
AWS-AccessAnalyzer
AWS-Athena
AWS-CloudTrail
AWS-CloudWatchLogs
AWS-EC2
AWS-EKS
AWS-Enrichment-Remediation
AWS-GuardDuty
AWS-IAM
AWS-IAMIdentityCenter
AWS-ILM
AWS-Lambda
AWS-NetworkFirewall
AWS-Organizations
AWS-Route53
AWS-S3
AWS-SNS
AWS-SNS-Listener
AWS-SQS
AWS-SecurityHub
AWS-SecurityLake
AWS_DynamoDB
AWS_ELB
AWS_Sagemaker
AWS_SystemManager
AWS_WAF
AbnormalSecurity
Absolute
AbuseDB
AcalvioShadowplex
AccentureCTI
AccentureCTI_Feed
AccessInvestigation
Accessdata
```