### PR TITLE
Adopt 'platform' MP to content packs #3

### DIFF
--- a/Packs/Ataya/pack_metadata.json
+++ b/Packs/Ataya/pack_metadata.json
@@ -16,7 +16,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": "tony19911010"
+    "githubUser": "tony19911010",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/AtlassianConfluenceCloud/pack_metadata.json
+++ b/Packs/AtlassianConfluenceCloud/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AtlassianJiraServiceManagement/pack_metadata.json
+++ b/Packs/AtlassianJiraServiceManagement/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AttackIQFireDrill/pack_metadata.json
+++ b/Packs/AttackIQFireDrill/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AttivoBotsink/pack_metadata.json
+++ b/Packs/AttivoBotsink/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Attlasian/pack_metadata.json
+++ b/Packs/Attlasian/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Auditd/pack_metadata.json
+++ b/Packs/Auditd/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AutoFocus/Playbooks/playbook-AutoFocusPolling.yml
+++ b/Packs/AutoFocus/Playbooks/playbook-AutoFocusPolling.yml
@@ -265,3 +265,8 @@ outputs:
   description: Results of Autofocus tags search
 tests:
 - Autofocus Query Samples, Sessions and Tags Test Playbook
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_File_Indicators_Hunting.yml
+++ b/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_File_Indicators_Hunting.yml
@@ -785,3 +785,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_Hunting_And_Threat_Detection.yml
+++ b/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_Hunting_And_Threat_Detection.yml
@@ -487,3 +487,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_Traffic_Indicators_Hunting.yml
+++ b/Packs/AutoFocus/Playbooks/playbook-Autofocus_-_Traffic_Indicators_Hunting.yml
@@ -1831,3 +1831,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AutoFocus/Playbooks/playbook-Autofocus_Query_Samples_Sessions_and_Tags.yml
+++ b/Packs/AutoFocus/Playbooks/playbook-Autofocus_Query_Samples_Sessions_and_Tags.yml
@@ -951,3 +951,8 @@ tests:
 - Autofocus Query Samples, Sessions and Tags Test Playbook
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AutoFocus/pack_metadata.json
+++ b/Packs/AutoFocus/pack_metadata.json
@@ -26,6 +26,16 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Automox/pack_metadata.json
+++ b/Packs/Automox/pack_metadata.json
@@ -20,7 +20,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "CommonPlaybooks": {
@@ -30,5 +31,11 @@
     },
     "displayedImages": [
         "CommonPlaybooks"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AvayaAuraCommunicationManager/pack_metadata.json
+++ b/Packs/AvayaAuraCommunicationManager/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AwakeSecurity/pack_metadata.json
+++ b/Packs/AwakeSecurity/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Aws-SecretsManager/pack_metadata.json
+++ b/Packs/Aws-SecretsManager/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Axonius/pack_metadata.json
+++ b/Packs/Axonius/pack_metadata.json
@@ -21,6 +21,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Azure-Enrichment-Remediation/pack_metadata.json
+++ b/Packs/Azure-Enrichment-Remediation/pack_metadata.json
@@ -15,7 +15,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
     "dependencies": {
         "AzureCompute": {
@@ -50,5 +51,11 @@
         "AzureLogAnalytics",
         "AzureNetworkSecurityGroups",
         "AzureResourceGraph"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureActiveDirectory/pack_metadata.json
+++ b/Packs/AzureActiveDirectory/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/AzureActiveDirectory/pack_metadata.json
+++ b/Packs/AzureActiveDirectory/pack_metadata.json
@@ -15,6 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureAppService/pack_metadata.json
+++ b/Packs/AzureAppService/pack_metadata.json
@@ -19,6 +19,13 @@
         "Azure App Service"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureCompute/pack_metadata.json
+++ b/Packs/AzureCompute/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureDataExplorer/pack_metadata.json
+++ b/Packs/AzureDataExplorer/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureDevOps/pack_metadata.json
+++ b/Packs/AzureDevOps/pack_metadata.json
@@ -18,6 +18,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureFirewall/pack_metadata.json
+++ b/Packs/AzureFirewall/pack_metadata.json
@@ -27,6 +27,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureKeyVault/pack_metadata.json
+++ b/Packs/AzureKeyVault/pack_metadata.json
@@ -14,6 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureKeyVault/pack_metadata.json
+++ b/Packs/AzureKeyVault/pack_metadata.json
@@ -18,7 +18,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/AzureKubernetesServices/pack_metadata.json
+++ b/Packs/AzureKubernetesServices/pack_metadata.json
@@ -26,6 +26,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureLogAnalytics/Playbooks/AzureLogAnalytics_QuerySavedSearch.yml
+++ b/Packs/AzureLogAnalytics/Playbooks/AzureLogAnalytics_QuerySavedSearch.yml
@@ -157,3 +157,8 @@ outputs:
   type: string
 tests:
 - No tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/AzureLogAnalytics/pack_metadata.json
+++ b/Packs/AzureLogAnalytics/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/AzureLogAnalytics/pack_metadata.json
+++ b/Packs/AzureLogAnalytics/pack_metadata.json
@@ -15,6 +15,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureNetworkSecurityGroups/pack_metadata.json
+++ b/Packs/AzureNetworkSecurityGroups/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureResourceGraph/pack_metadata.json
+++ b/Packs/AzureResourceGraph/pack_metadata.json
@@ -15,6 +15,14 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureResourceGraph/pack_metadata.json
+++ b/Packs/AzureResourceGraph/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/AzureRiskyUsers/pack_metadata.json
+++ b/Packs/AzureRiskyUsers/pack_metadata.json
@@ -17,6 +17,17 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureRiskyUsers/pack_metadata.json
+++ b/Packs/AzureRiskyUsers/pack_metadata.json
@@ -21,7 +21,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/AzureSQLManagement/pack_metadata.json
+++ b/Packs/AzureSQLManagement/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureSecurityCenter/Integrations/MicrosoftDefenderForCloudEventCollector/MicrosoftDefenderForCloudEventCollector.yml
+++ b/Packs/AzureSecurityCenter/Integrations/MicrosoftDefenderForCloudEventCollector/MicrosoftDefenderForCloudEventCollector.yml
@@ -110,6 +110,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/AzureSecurityCenter/pack_metadata.json
+++ b/Packs/AzureSecurityCenter/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureStorage/pack_metadata.json
+++ b/Packs/AzureStorage/pack_metadata.json
@@ -15,6 +15,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureStorageContainer/pack_metadata.json
+++ b/Packs/AzureStorageContainer/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureStorageFileShare/pack_metadata.json
+++ b/Packs/AzureStorageFileShare/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureStorageQueue/pack_metadata.json
+++ b/Packs/AzureStorageQueue/pack_metadata.json
@@ -16,6 +16,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureStorageTable/pack_metadata.json
+++ b/Packs/AzureStorageTable/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/AzureWAF/pack_metadata.json
+++ b/Packs/AzureWAF/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BMCDiscovery/pack_metadata.json
+++ b/Packs/BMCDiscovery/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BPA/pack_metadata.json
+++ b/Packs/BPA/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Barracuda/pack_metadata.json
+++ b/Packs/Barracuda/pack_metadata.json
@@ -19,6 +19,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BarracudaEmailProtection/pack_metadata.json
+++ b/Packs/BarracudaEmailProtection/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BarracudaWAF/pack_metadata.json
+++ b/Packs/BarracudaWAF/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Barracuda_Cloudgen_Firewall/pack_metadata.json
+++ b/Packs/Barracuda_Cloudgen_Firewall/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -27,7 +27,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -23,6 +23,17 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BastilleNetworks/pack_metadata.json
+++ b/Packs/BastilleNetworks/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
Ataya
AtlassianConfluenceCloud
AtlassianJiraServiceManagement
AttackIQFireDrill
AttivoBotsink
Attlasian
Auditd
AutoFocus
Automox
AvayaAuraCommunicationManager
AwakeSecurity
Aws-SecretsManager
Axonius
Azure-Enrichment-Remediation
AzureActiveDirectory
AzureAppService
AzureCompute
AzureDataExplorer
AzureDevOps
AzureFirewall
AzureKeyVault
AzureKubernetesServices
AzureLogAnalytics
AzureNetworkSecurityGroups
AzureResourceGraph
AzureRiskyUsers
AzureSQLManagement
AzureSecurityCenter
AzureSentinel
AzureStorage
AzureStorageContainer
AzureStorageFileShare
AzureStorageQueue
AzureStorageTable
AzureWAF
BMCDiscovery
BPA
Barracuda
BarracudaEmailProtection
BarracudaWAF
Barracuda_Cloudgen_Firewall
Base
BastilleNetworks
```