### PR TITLE
Adopt 'platform' MP to content packs #4

### DIFF
--- a/Packs/BeyondTrust-AuthorizationRequests/pack_metadata.json
+++ b/Packs/BeyondTrust-AuthorizationRequests/pack_metadata.json
@@ -7,15 +7,24 @@
     "url": "",
     "email": "",
     "created": "2024-12-30T14:41:06Z",
-    "categories": ["Identity and Access Management"],
+    "categories": [
+        "Identity and Access Management"
+    ],
     "tags": [],
     "useCases": [],
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "nprenga"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BeyondTrustPrivilegedRemoteAccess/pack_metadata.json
+++ b/Packs/BeyondTrustPrivilegedRemoteAccess/pack_metadata.json
@@ -11,8 +11,23 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["BeyondTrust", "Beyond Trust", "Beyond", "Remote Access", "Privileged Remote Access", "PRA", "Privileged"],
+    "keywords": [
+        "BeyondTrust",
+        "Beyond Trust",
+        "Beyond",
+        "Remote Access",
+        "Privileged Remote Access",
+        "PRA",
+        "Privileged"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BeyondTrustRemoteSupport/pack_metadata.json
+++ b/Packs/BeyondTrustRemoteSupport/pack_metadata.json
@@ -11,8 +11,19 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["Remote Support", "Remote" , "Bomgar"],
+    "keywords": [
+        "Remote Support",
+        "Remote",
+        "Bomgar"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BeyondTrust_Password_Safe/pack_metadata.json
+++ b/Packs/BeyondTrust_Password_Safe/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BigFix/pack_metadata.json
+++ b/Packs/BigFix/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Binalyze/pack_metadata.json
+++ b/Packs/Binalyze/pack_metadata.json
@@ -16,12 +16,19 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "murat.alagoz@binalyze.com"
     ],
     "githubUser": [
         "binalyze-murat"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BitDam/pack_metadata.json
+++ b/Packs/BitDam/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BitSight/pack_metadata.json
+++ b/Packs/BitSight/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Bitbucket/pack_metadata.json
+++ b/Packs/Bitbucket/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BitcoinAbuse/pack_metadata.json
+++ b/Packs/BitcoinAbuse/pack_metadata.json
@@ -30,6 +30,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BitwardenPasswordManager/Integrations/BitwardenPasswordManager/BitwardenPasswordManager.yml
+++ b/Packs/BitwardenPasswordManager/Integrations/BitwardenPasswordManager/BitwardenPasswordManager.yml
@@ -66,6 +66,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.6.0
 tests:
 - No tests (auto formatted)

--- a/Packs/BitwardenPasswordManager/pack_metadata.json
+++ b/Packs/BitwardenPasswordManager/pack_metadata.json
@@ -19,6 +19,13 @@
         "Credentials"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Blockade.io/pack_metadata.json
+++ b/Packs/Blockade.io/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BloodHoundEnterprise/Integrations/BloodHoundEnterprise/BloodHoundEnterprise.yml
+++ b/Packs/BloodHoundEnterprise/Integrations/BloodHoundEnterprise/BloodHoundEnterprise.yml
@@ -70,6 +70,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/BloodHoundEnterprise/pack_metadata.json
+++ b/Packs/BloodHoundEnterprise/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BluecatAddressManager/pack_metadata.json
+++ b/Packs/BluecatAddressManager/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Blueliv/pack_metadata.json
+++ b/Packs/Blueliv/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BluelivThreatCompass/pack_metadata.json
+++ b/Packs/BluelivThreatCompass/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BluelivThreatContext/pack_metadata.json
+++ b/Packs/BluelivThreatContext/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BmcHelixRemedyForce/pack_metadata.json
+++ b/Packs/BmcHelixRemedyForce/pack_metadata.json
@@ -16,6 +16,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BmcITSM/pack_metadata.json
+++ b/Packs/BmcITSM/pack_metadata.json
@@ -16,6 +16,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Bonusly/pack_metadata.json
+++ b/Packs/Bonusly/pack_metadata.json
@@ -19,6 +19,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Box/Integrations/BoxEventsCollector/BoxEventsCollector.yml
+++ b/Packs/Box/Integrations/BoxEventsCollector/BoxEventsCollector.yml
@@ -65,6 +65,7 @@ script:
   isfetchevents: true
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests
 fromversion: 6.6.0

--- a/Packs/Box/pack_metadata.json
+++ b/Packs/Box/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "BoxEventsCollector"
+    "defaultDataSource": "BoxEventsCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Brandefense/pack_metadata.json
+++ b/Packs/Brandefense/pack_metadata.json
@@ -21,9 +21,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "asimsarpkurt"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BreachNotification-US/pack_metadata.json
+++ b/Packs/BreachNotification-US/pack_metadata.json
@@ -25,6 +25,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BreachRx/pack_metadata.json
+++ b/Packs/BreachRx/pack_metadata.json
@@ -20,9 +20,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "support@breachrx.com"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BrocadeSwitch/pack_metadata.json
+++ b/Packs/BrocadeSwitch/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/BruteForce/pack_metadata.json
+++ b/Packs/BruteForce/pack_metadata.json
@@ -55,6 +55,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/C2sec/pack_metadata.json
+++ b/Packs/C2sec/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CIRCL/pack_metadata.json
+++ b/Packs/CIRCL/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CIRCLHashlookup/pack_metadata.json
+++ b/Packs/CIRCLHashlookup/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CSCDomainManager/pack_metadata.json
+++ b/Packs/CSCDomainManager/pack_metadata.json
@@ -15,6 +15,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CTIX/pack_metadata.json
+++ b/Packs/CTIX/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CTM360-CyberBlindspot/pack_metadata.json
+++ b/Packs/CTM360-CyberBlindspot/pack_metadata.json
@@ -21,11 +21,18 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "xsoar@ctm360.com"
     ],
     "githubUser": [],
-    "defaultDataSource": "CTM360_CyberBlindspot"
+    "defaultDataSource": "CTM360_CyberBlindspot",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CVESearch/pack_metadata.json
+++ b/Packs/CVESearch/pack_metadata.json
@@ -20,7 +20,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "hidden": true
+    "hidden": true,
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CVE_2021_40444/pack_metadata.json
+++ b/Packs/CVE_2021_40444/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2021_44228/pack_metadata.json
+++ b/Packs/CVE_2021_44228/pack_metadata.json
@@ -83,6 +83,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2022_26134/pack_metadata.json
+++ b/Packs/CVE_2022_26134/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2022_30190/pack_metadata.json
+++ b/Packs/CVE_2022_30190/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2022_3786_and_CVE_2022_3602_-_OpenSSL_X.509_Buffer_Overflows/pack_metadata.json
+++ b/Packs/CVE_2022_3786_and_CVE_2022_3602_-_OpenSSL_X.509_Buffer_Overflows/pack_metadata.json
@@ -30,6 +30,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2022_41040_and_CVE_2022_41082_-_ProxyNotShell/pack_metadata.json
+++ b/Packs/CVE_2022_41040_and_CVE_2022_41082_-_ProxyNotShell/pack_metadata.json
@@ -38,6 +38,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2023_23397_-_Microsoft_Outlook_EoP/pack_metadata.json
+++ b/Packs/CVE_2023_23397_-_Microsoft_Outlook_EoP/pack_metadata.json
@@ -29,6 +29,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2023_34362_-_MOVEit_SQLI/pack_metadata.json
+++ b/Packs/CVE_2023_34362_-_MOVEit_SQLI/pack_metadata.json
@@ -30,6 +30,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2023_36884_-_Microsoft_Office_and_Windows_RCE/pack_metadata.json
+++ b/Packs/CVE_2023_36884_-_Microsoft_Office_and_Windows_RCE/pack_metadata.json
@@ -36,6 +36,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CVE_2024_47575/pack_metadata.json
+++ b/Packs/CVE_2024_47575/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CadoResponse/pack_metadata.json
+++ b/Packs/CadoResponse/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Camlytics/pack_metadata.json
+++ b/Packs/Camlytics/pack_metadata.json
@@ -14,7 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CarbonBlackCommonFields/pack_metadata.json
+++ b/Packs/CarbonBlackCommonFields/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
BeyondTrust-AuthorizationRequests
BeyondTrustPrivilegedRemoteAccess
BeyondTrustRemoteSupport
BeyondTrust_Password_Safe
BigFix
Binalyze
BitDam
BitSight
Bitbucket
BitcoinAbuse
BitwardenPasswordManager
Blockade.io
BloodHoundEnterprise
BluecatAddressManager
Blueliv
BluelivThreatCompass
BluelivThreatContext
BmcHelixRemedyForce
BmcITSM
Bonusly
Box
Brandefense
BreachNotification-US
BreachRx
BrocadeSwitch
BruteForce
C2sec
CIRCL
CIRCLHashlookup
CSCDomainManager
CTIX
CTM360-CyberBlindspot
CVESearch
CVE_2021_40444
CVE_2021_44228
CVE_2022_26134
CVE_2022_30190
CVE_2022_3786_and_CVE_2022_3602_-_OpenSSL_X.509_Buffer_Overflows
CVE_2022_41040_and_CVE_2022_41082_-_ProxyNotShell
CVE_2023_23397_-_Microsoft_Outlook_EoP
CVE_2023_34362_-_MOVEit_SQLI
CVE_2023_36884_-_Microsoft_Office_and_Windows_RCE
CVE_2024_47575
CadoResponse
Camlytics
CarbonBlackCommonFields
```