### PR TITLE
Adopt 'platform' MP to content packs #10

### DIFF
--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ASM_Alert.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ASM_Alert.yml
@@ -3573,3 +3573,8 @@ outputSections:
 - description: Generic group for outputs
   name: General (Outputs group)
   outputs: []
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_AWS_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_AWS_Enrichment.yml
@@ -2356,3 +2356,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Active_Directory_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Active_Directory_Enrichment.yml
@@ -1038,3 +1038,8 @@ tests:
 fromversion: 6.10.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Azure_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Azure_Enrichment.yml
@@ -1776,3 +1776,8 @@ inputs:
 fromversion: 6.5.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_CMDB_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_CMDB_Enrichment.yml
@@ -553,3 +553,8 @@ tests:
 - No tests
 fromversion: 6.5.0
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Certificate_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Certificate_Enrichment.yml
@@ -780,3 +780,8 @@ view: |-
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Cortex_Endpoint_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Cortex_Endpoint_Enrichment.yml
@@ -1429,3 +1429,8 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
 description: 'This playbook is used to pull information from Cortex Endpoint (XSIAM/XDR) systems for enrichment purposes.'
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Cortex_Endpoint_Remediation.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Cortex_Endpoint_Remediation.yml
@@ -523,3 +523,8 @@ quiet: true
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Decision.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Decision.yml
@@ -344,3 +344,8 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Detect_Service.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Detect_Service.yml
@@ -191,3 +191,8 @@ tests:
 - No tests (auto formatted)
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Domain_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Domain_Enrichment.yml
@@ -794,3 +794,8 @@ view: |-
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Email_Notification.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Email_Notification.yml
@@ -269,3 +269,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Enrichment.yml
@@ -1847,3 +1847,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Extract_IP_Indicator.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Extract_IP_Indicator.yml
@@ -249,3 +249,8 @@ tests:
 - No tests
 fromversion: 6.5.0
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_GCP_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_GCP_Enrichment.yml
@@ -2731,3 +2731,8 @@ tests:
 fromversion: 6.8.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Instant_Message.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Instant_Message.yml
@@ -336,3 +336,8 @@ view: |-
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Jira_Notification.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Jira_Notification.yml
@@ -354,3 +354,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_On_Prem_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_On_Prem_Enrichment.yml
@@ -1408,3 +1408,8 @@ tests:
 fromversion: 6.8.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_On_Prem_Remediation.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_On_Prem_Remediation.yml
@@ -409,3 +409,8 @@ tests:
 fromversion: 6.8.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Prisma_Cloud_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Prisma_Cloud_Enrichment.yml
@@ -1265,3 +1265,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Qualys_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Qualys_Enrichment.yml
@@ -749,3 +749,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Rapid7_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Rapid7_Enrichment.yml
@@ -1252,3 +1252,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation.yml
@@ -911,3 +911,8 @@ outputs: []
 fromversion: 6.10.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Confirmation_Scan.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Confirmation_Scan.yml
@@ -617,3 +617,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Guidance.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Guidance.yml
@@ -380,3 +380,8 @@ tests:
 fromversion: 6.5.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Objectives.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Objectives.yml
@@ -879,3 +879,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Path_Rules.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Remediation_Path_Rules.yml
@@ -2241,3 +2241,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_SNMP_Check.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_SNMP_Check.yml
@@ -336,3 +336,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_CMDB_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_CMDB_Enrichment.yml
@@ -1046,3 +1046,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_ITSM_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_ITSM_Enrichment.yml
@@ -532,3 +532,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_Notification.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_ServiceNow_Notification.yml
@@ -327,3 +327,8 @@ outputSections:
 - description: Generic group for outputs.
   name: General (Outputs group)
   outputs: []
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Service_Ownership.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Service_Ownership.yml
@@ -242,3 +242,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Splunk_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Splunk_Enrichment.yml
@@ -510,3 +510,8 @@ outputs: []
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Tenable.io_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Tenable.io_Enrichment.yml
@@ -793,3 +793,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Vulnerability_Management_Enrichment.yml
+++ b/Packs/CortexAttackSurfaceManagement/Playbooks/Cortex_ASM_-_Vulnerability_Management_Enrichment.yml
@@ -644,3 +644,8 @@ tests:
 - No tests
 fromversion: 6.5.0
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/CortexAttackSurfaceManagement/pack_metadata.json
+++ b/Packs/CortexAttackSurfaceManagement/pack_metadata.json
@@ -100,7 +100,8 @@
     },
     "marketplaces": [
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
     "itemPrefix": [
         "ASM"
@@ -121,5 +122,14 @@
         "Jira",
         "Tenable_io",
         "Venafi"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
CortexAttackSurfaceManagement
```