### PR TITLE
Adopt 'platform' MP to content packs #13

### DIFF
--- a/Packs/DeepL/pack_metadata.json
+++ b/Packs/DeepL/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DelineaALM/pack_metadata.json
+++ b/Packs/DelineaALM/pack_metadata.json
@@ -15,6 +15,13 @@
         "Thycotic"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DelineaDSV/pack_metadata.json
+++ b/Packs/DelineaDSV/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DelineaSS/pack_metadata.json
+++ b/Packs/DelineaSS/pack_metadata.json
@@ -27,6 +27,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DellEMCUnity/pack_metadata.json
+++ b/Packs/DellEMCUnity/pack_metadata.json
@@ -11,8 +11,21 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["Dell", "EMC", "Unity", "Dell EMC", "Dell EMC Unity"],
+    "keywords": [
+        "Dell",
+        "EMC",
+        "Unity",
+        "Dell EMC",
+        "Dell EMC Unity"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DemistoLocking/Integrations/CoreLock/CoreLock.yml
+++ b/Packs/DemistoLocking/Integrations/CoreLock/CoreLock.yml
@@ -81,6 +81,7 @@ script:
     description: Release all locks
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 5.0.0
 tests:
 - No tests

--- a/Packs/DemistoLocking/Integrations/DemistoLock/DemistoLock.yml
+++ b/Packs/DemistoLocking/Integrations/DemistoLock/DemistoLock.yml
@@ -72,6 +72,7 @@ script:
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 fromversion: 5.0.0
 tests:
 - No tests

--- a/Packs/DemistoLocking/TestPlaybooks/playbook-DemistoLockingTest.yml
+++ b/Packs/DemistoLocking/TestPlaybooks/playbook-DemistoLockingTest.yml
@@ -1165,3 +1165,4 @@ fromversion: 5.0.0
 marketplaces:
   - xsoar
   - marketplacev2
+  - platform

--- a/Packs/DemistoLocking/pack_metadata.json
+++ b/Packs/DemistoLocking/pack_metadata.json
@@ -19,6 +19,16 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -19,6 +19,16 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DevSecOps/pack_metadata.json
+++ b/Packs/DevSecOps/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DeveloperTools/pack_metadata.json
+++ b/Packs/DeveloperTools/pack_metadata.json
@@ -36,12 +36,19 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "displayedImages": [
         "DemistoRESTAPI",
         "CommonScripts",
         "GenericSQL",
         "CommonTypes"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Devo/pack_metadata.json
+++ b/Packs/Devo/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DigitalGuardian/Integrations/DigitalGuardianARCEventCollector/DigitalGuardianARCEventCollector.yml
+++ b/Packs/DigitalGuardian/Integrations/DigitalGuardianARCEventCollector/DigitalGuardianARCEventCollector.yml
@@ -29,8 +29,8 @@ configuration:
   type: 16  # Multi Select
   defaultvalue: defaultExportProfile
   options:
-    - defaultExportProfile
-    - demisto
+  - defaultExportProfile
+  - demisto
   section: Collect
 - display: Number of Export Requests per Fetch
   additionalinfo: Number of API calls per fetch to export events for each configured Digital Guardian ARC export profile. Use with extreme caution as this might impact data ingestion quota limits and performance. Consult with the engineering team before changing this value.
@@ -87,6 +87,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/DigitalGuardian/pack_metadata.json
+++ b/Packs/DigitalGuardian/pack_metadata.json
@@ -19,7 +19,14 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "DigitalGuardianARCEventCollector"
+    "defaultDataSource": "DigitalGuardianARCEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/DigitalShadows/Integrations/ReliaQuestGreyMatterDRPEventCollector/ReliaQuestGreyMatterDRPEventCollector.yml
+++ b/Packs/DigitalShadows/Integrations/ReliaQuestGreyMatterDRPEventCollector/ReliaQuestGreyMatterDRPEventCollector.yml
@@ -72,5 +72,6 @@ fromversion: 8.0.0
 supportlevelheader: xsoar
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/DigitalShadows/pack_metadata.json
+++ b/Packs/DigitalShadows/pack_metadata.json
@@ -41,7 +41,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "CommonScripts": {
@@ -72,5 +73,11 @@
         "Digital Shadows",
         "SearchLight"
     ],
-    "defaultDataSource": "ReliaQuest GreyMatter DRP Incidents"
+    "defaultDataSource": "ReliaQuest GreyMatter DRP Incidents",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Digital_Defense_FrontlineVM/pack_metadata.json
+++ b/Packs/Digital_Defense_FrontlineVM/pack_metadata.json
@@ -16,6 +16,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Discord/pack_metadata.json
+++ b/Packs/Discord/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "BarHalifa"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DomainTools/pack_metadata.json
+++ b/Packs/DomainTools/pack_metadata.json
@@ -17,6 +17,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DomainToolsIrisDetect/pack_metadata.json
+++ b/Packs/DomainToolsIrisDetect/pack_metadata.json
@@ -14,7 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/DomainTools_Iris/pack_metadata.json
+++ b/Packs/DomainTools_Iris/pack_metadata.json
@@ -16,6 +16,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DragosWorldview/pack_metadata.json
+++ b/Packs/DragosWorldview/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Dragos_Platform/pack_metadata.json
+++ b/Packs/Dragos_Platform/pack_metadata.json
@@ -18,6 +18,13 @@
         "OT"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Drift/pack_metadata.json
+++ b/Packs/Drift/pack_metadata.json
@@ -14,12 +14,19 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "adiaz@paloaltonetworks.com"
     ],
     "githubUser": [
         "AdrianaRoseDiaz"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Dropbox/Integrations/DropboxEventCollector/DropboxEventCollector.yml
+++ b/Packs/Dropbox/Integrations/DropboxEventCollector/DropboxEventCollector.yml
@@ -86,6 +86,7 @@ script:
   isfetchevents: true
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests
 fromversion: 6.8.0

--- a/Packs/Dropbox/Playbooks/DropBox_-_Massive_scale_operations_on_files.yml
+++ b/Packs/Dropbox/Playbooks/DropBox_-_Massive_scale_operations_on_files.yml
@@ -981,4 +981,4 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.6.0
-marketplaces: ["marketplacev2"]
+marketplaces: ["marketplacev2", "platform"]

--- a/Packs/Dropbox/pack_metadata.json
+++ b/Packs/Dropbox/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Druva/Integrations/DruvaEventCollector/DruvaEventCollector.yml
+++ b/Packs/Druva/Integrations/DruvaEventCollector/DruvaEventCollector.yml
@@ -58,6 +58,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Druva/pack_metadata.json
+++ b/Packs/Druva/pack_metadata.json
@@ -23,6 +23,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
+++ b/Packs/DuoAdminApi/Integrations/DuoEventCollector/DuoEventCollector.yml
@@ -71,9 +71,9 @@ script:
       required: false
       auto: PREDEFINED
       predefined:
-        - "AUTHENTICATION"
-        - "ADMINISTRATION"
-        - "TELEPHONY"
+      - "AUTHENTICATION"
+      - "ADMINISTRATION"
+      - "TELEPHONY"
     - defaultValue: 1 day
       description: Date from which to get events (e.g. <number> <time unit>, for example, 12 hours, 7 days, 3 months, 1 year or 2023-13-30T03:11:29Z).
       name: after
@@ -90,6 +90,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests

--- a/Packs/DuoAdminApi/pack_metadata.json
+++ b/Packs/DuoAdminApi/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/DuoAuth/pack_metadata.json
+++ b/Packs/DuoAuth/pack_metadata.json
@@ -13,9 +13,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar_saas",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "cheersmann"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -25,6 +25,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EDLMonitor/pack_metadata.json
+++ b/Packs/EDLMonitor/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "amurret"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EasyVista/pack_metadata.json
+++ b/Packs/EasyVista/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EclecticIQ/pack_metadata.json
+++ b/Packs/EclecticIQ/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Edgescan/pack_metadata.json
+++ b/Packs/Edgescan/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -15,6 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EmailHippo/pack_metadata.json
+++ b/Packs/EmailHippo/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/EmailRepIO/pack_metadata.json
+++ b/Packs/EmailRepIO/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Endace/pack_metadata.json
+++ b/Packs/Endace/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Endgame/pack_metadata.json
+++ b/Packs/Endgame/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Envoy/pack_metadata.json
+++ b/Packs/Envoy/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Exabeam/pack_metadata.json
+++ b/Packs/Exabeam/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "itemPrefix": [
         "Exabeam"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ExabeamDataLake/pack_metadata.json
+++ b/Packs/ExabeamDataLake/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ExabeamSecurityOperationsPlatform/pack_metadata.json
+++ b/Packs/ExabeamSecurityOperationsPlatform/pack_metadata.json
@@ -14,9 +14,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "itemPrefix": [
         "Exabeam"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ExceedLMS/pack_metadata.json
+++ b/Packs/ExceedLMS/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Exchange2016_Compliance/pack_metadata.json
+++ b/Packs/Exchange2016_Compliance/pack_metadata.json
@@ -20,6 +20,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ExodusIntelligence/pack_metadata.json
+++ b/Packs/ExodusIntelligence/pack_metadata.json
@@ -20,7 +20,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "an-hel"
@@ -33,5 +34,11 @@
     },
     "displayedImages": [
         "CommonTypes"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
DeepL
DelineaALM
DelineaDSV
DelineaSS
DellEMCUnity
DemistoLocking
DemistoRESTAPI
DevSecOps
DeveloperTools
Devo
DigitalGuardian
DigitalShadows
Digital_Defense_FrontlineVM
Discord
DomainTools
DomainToolsIrisDetect
DomainTools_Iris
DragosWorldview
Dragos_Platform
Drift
Dropbox
Druva
DuoAdminApi
DuoAuth
EDL
EDLMonitor
EasyVista
EclecticIQ
Edgescan
Elasticsearch
EmailHippo
EmailRepIO
Endace
Endgame
Envoy
Exabeam
ExabeamDataLake
ExabeamSecurityOperationsPlatform
ExceedLMS
Exchange2016_Compliance
ExodusIntelligence
```