### PR TITLE
Adopt 'platform' MP to content packs #14

### DIFF
--- a/Packs/Exterro/pack_metadata.json
+++ b/Packs/Exterro/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ExtraHop/pack_metadata.json
+++ b/Packs/ExtraHop/pack_metadata.json
@@ -19,7 +19,8 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "CommonScripts": {
@@ -44,5 +45,11 @@
         "CoreAlertFields",
         "CommonTypes",
         "CommonPlaybooks"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5/pack_metadata.json
+++ b/Packs/F5/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5APM/pack_metadata.json
+++ b/Packs/F5APM/pack_metadata.json
@@ -21,6 +21,13 @@
         "Access Policy Manager"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5ASM/pack_metadata.json
+++ b/Packs/F5ASM/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5BigIPAWAF/pack_metadata.json
+++ b/Packs/F5BigIPAWAF/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5LTM/pack_metadata.json
+++ b/Packs/F5LTM/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/F5Silverline/pack_metadata.json
+++ b/Packs/F5Silverline/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FTP/pack_metadata.json
+++ b/Packs/FTP/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "jieliau"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedAWS/pack_metadata.json
+++ b/Packs/FeedAWS/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedAlienVault/pack_metadata.json
+++ b/Packs/FeedAlienVault/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedAzure/pack_metadata.json
+++ b/Packs/FeedAzure/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedAzureADConnectHealth/pack_metadata.json
+++ b/Packs/FeedAzureADConnectHealth/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedBambenekConsulting/pack_metadata.json
+++ b/Packs/FeedBambenekConsulting/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedBlocklist_de/pack_metadata.json
+++ b/Packs/FeedBlocklist_de/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedBruteForceBlocker/pack_metadata.json
+++ b/Packs/FeedBruteForceBlocker/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCSV/pack_metadata.json
+++ b/Packs/FeedCSV/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCloudflare/pack_metadata.json
+++ b/Packs/FeedCloudflare/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCofense/pack_metadata.json
+++ b/Packs/FeedCofense/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCognyteLuminar/pack_metadata.json
+++ b/Packs/FeedCognyteLuminar/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCyCognito/Integrations/FeedCyCognito/FeedCyCognito.yml
+++ b/Packs/FeedCyCognito/Integrations/FeedCyCognito/FeedCyCognito.yml
@@ -285,4 +285,5 @@ tests:
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 fromversion: 6.2.0

--- a/Packs/FeedCyCognito/pack_metadata.json
+++ b/Packs/FeedCyCognito/pack_metadata.json
@@ -21,9 +21,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "crestdatasystems"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCyjax/pack_metadata.json
+++ b/Packs/FeedCyjax/pack_metadata.json
@@ -24,6 +24,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedCyrenThreatInDepth/pack_metadata.json
+++ b/Packs/FeedCyrenThreatInDepth/pack_metadata.json
@@ -40,6 +40,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedDHS/pack_metadata.json
+++ b/Packs/FeedDHS/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "DHS Feed",
-    "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency’s (CISA’s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
+    "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency\u2019s (CISA\u2019s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
     "support": "xsoar",
     "currentVersion": "2.0.48",
     "author": "Cortex XSOAR",
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedDHS/pack_metadata.json
+++ b/Packs/FeedDHS/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "DHS Feed",
-    "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency\u2019s (CISA\u2019s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
+    "description": "Provides cyber threat indicators from the Cybersecurity and Infrastructure Security Agency’s (CISA’s) free Automated Indicator Sharing (AIS) by the Department of Homeland Security (DHS).",
     "support": "xsoar",
     "currentVersion": "2.0.48",
     "author": "Cortex XSOAR",

--- a/Packs/FeedDShield/pack_metadata.json
+++ b/Packs/FeedDShield/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedDomainTools/Integrations/FeedDomainTools/FeedDomainTools.yml
+++ b/Packs/FeedDomainTools/Integrations/FeedDomainTools/FeedDomainTools.yml
@@ -200,6 +200,7 @@ sectionOrder:
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)
 

--- a/Packs/FeedDomainTools/pack_metadata.json
+++ b/Packs/FeedDomainTools/pack_metadata.json
@@ -15,6 +15,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedElasticsearch/pack_metadata.json
+++ b/Packs/FeedElasticsearch/pack_metadata.json
@@ -22,6 +22,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedFastly/pack_metadata.json
+++ b/Packs/FeedFastly/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.yml
+++ b/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.yml
@@ -130,5 +130,6 @@ description: 'Ingest articles with indicators, entities and relationships from F
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/FeedFeedly/pack_metadata.json
+++ b/Packs/FeedFeedly/pack_metadata.json
@@ -17,7 +17,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/FeedFeodoTracker/pack_metadata.json
+++ b/Packs/FeedFeodoTracker/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedFireEye/pack_metadata.json
+++ b/Packs/FeedFireEye/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedGCPWhitelist/pack_metadata.json
+++ b/Packs/FeedGCPWhitelist/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedGitHub/Integrations/FeedGitHub/FeedGitHub.yml
+++ b/Packs/FeedGitHub/Integrations/FeedGitHub/FeedGitHub.yml
@@ -206,6 +206,7 @@ description: This is the Feed GitHub integration for getting started with your f
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)
 sectionOrder:

--- a/Packs/FeedGitHub/pack_metadata.json
+++ b/Packs/FeedGitHub/pack_metadata.json
@@ -26,6 +26,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedGreyNoiseIndicator/pack_metadata.json
+++ b/Packs/FeedGreyNoiseIndicator/pack_metadata.json
@@ -24,6 +24,13 @@
     "itemPrefix": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedIntel471/pack_metadata.json
+++ b/Packs/FeedIntel471/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedJSON/pack_metadata.json
+++ b/Packs/FeedJSON/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedLOLBAS/pack_metadata.json
+++ b/Packs/FeedLOLBAS/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMISP/pack_metadata.json
+++ b/Packs/FeedMISP/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMISPThreatActors/pack_metadata.json
+++ b/Packs/FeedMISPThreatActors/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMajesticMillion/pack_metadata.json
+++ b/Packs/FeedMajesticMillion/pack_metadata.json
@@ -20,6 +20,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMalwareBazaar/pack_metadata.json
+++ b/Packs/FeedMalwareBazaar/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMalwareDomainList/pack_metadata.json
+++ b/Packs/FeedMalwareDomainList/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMandiant/pack_metadata.json
+++ b/Packs/FeedMandiant/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMicrosoftIntune/pack_metadata.json
+++ b/Packs/FeedMicrosoftIntune/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMitreAttack/pack_metadata.json
+++ b/Packs/FeedMitreAttack/pack_metadata.json
@@ -30,6 +30,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedMitreAttackv2/pack_metadata.json
+++ b/Packs/FeedMitreAttackv2/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
Exterro
ExtraHop
F5
F5APM
F5ASM
F5BigIPAWAF
F5LTM
F5Silverline
FTP
FeedAWS
FeedAlienVault
FeedAzure
FeedAzureADConnectHealth
FeedBambenekConsulting
FeedBlocklist_de
FeedBruteForceBlocker
FeedCSV
FeedCloudflare
FeedCofense
FeedCognyteLuminar
FeedCyCognito
FeedCyjax
FeedCyrenThreatInDepth
FeedDHS
FeedDShield
FeedDomainTools
FeedElasticsearch
FeedFastly
FeedFeedly
FeedFeodoTracker
FeedFireEye
FeedGCPWhitelist
FeedGitHub
FeedGreyNoiseIndicator
FeedIntel471
FeedJSON
FeedLOLBAS
FeedMISP
FeedMISPThreatActors
FeedMajesticMillion
FeedMalwareBazaar
FeedMalwareDomainList
FeedMandiant
FeedMicrosoftIntune
FeedMitreAttack
FeedMitreAttackv2
```