### PR TITLE
Adopt 'platform' MP to content packs #15

### DIFF
--- a/Packs/FeedNVDv2/pack_metadata.json
+++ b/Packs/FeedNVDv2/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedORKL/pack_metadata.json
+++ b/Packs/FeedORKL/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedOffice365/pack_metadata.json
+++ b/Packs/FeedOffice365/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedOpenCTI/pack_metadata.json
+++ b/Packs/FeedOpenCTI/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedPlainText/pack_metadata.json
+++ b/Packs/FeedPlainText/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedPublicDNS/pack_metadata.json
+++ b/Packs/FeedPublicDNS/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedRSS/pack_metadata.json
+++ b/Packs/FeedRSS/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedRecordedFuture/pack_metadata.json
+++ b/Packs/FeedRecordedFuture/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
+++ b/Packs/FeedReversingLabsRansomwareAndRelatedToolsApp/pack_metadata.json
@@ -27,6 +27,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedSOCRadarThreatFeed/pack_metadata.json
+++ b/Packs/FeedSOCRadarThreatFeed/pack_metadata.json
@@ -33,6 +33,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedSpamhaus/pack_metadata.json
+++ b/Packs/FeedSpamhaus/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedTAXII/pack_metadata.json
+++ b/Packs/FeedTAXII/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedTalos/pack_metadata.json
+++ b/Packs/FeedTalos/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedThreatConnect/pack_metadata.json
+++ b/Packs/FeedThreatConnect/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedThreatFox/pack_metadata.json
+++ b/Packs/FeedThreatFox/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedThreatVault/pack_metadata.json
+++ b/Packs/FeedThreatVault/pack_metadata.json
@@ -10,8 +10,7 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": [
-    ],
+    "tags": [],
     "useCases": [
         "Threat Intelligence Management"
     ],
@@ -19,10 +18,16 @@
         "threatvault",
         "threat intelligence"
     ],
-    "dependencies": {
-    },
+    "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedTorExitAddresses/pack_metadata.json
+++ b/Packs/FeedTorExitAddresses/pack_metadata.json
@@ -20,6 +20,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedURLhaus/pack_metadata.json
+++ b/Packs/FeedURLhaus/pack_metadata.json
@@ -20,6 +20,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedUnit42/pack_metadata.json
+++ b/Packs/FeedUnit42/pack_metadata.json
@@ -27,6 +27,13 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedUnit42v2/pack_metadata.json
+++ b/Packs/FeedUnit42v2/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FeedZoom/pack_metadata.json
+++ b/Packs/FeedZoom/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Feedsslabusech/pack_metadata.json
+++ b/Packs/Feedsslabusech/pack_metadata.json
@@ -20,6 +20,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FidelisElevateNetwork/pack_metadata.json
+++ b/Packs/FidelisElevateNetwork/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FidelisEndpoint/pack_metadata.json
+++ b/Packs/FidelisEndpoint/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FileOrbis/pack_metadata.json
+++ b/Packs/FileOrbis/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FiltersAndTransformers/pack_metadata.json
+++ b/Packs/FiltersAndTransformers/pack_metadata.json
@@ -28,6 +28,5 @@
         "X3",
         "X5",
         "ENT_PLUS",
-        "identity_threat"
     ]
 }

--- a/Packs/FiltersAndTransformers/pack_metadata.json
+++ b/Packs/FiltersAndTransformers/pack_metadata.json
@@ -17,6 +17,17 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS",
+        "identity_threat"
     ]
 }

--- a/Packs/FireEye-Detection-on-Demand/pack_metadata.json
+++ b/Packs/FireEye-Detection-on-Demand/pack_metadata.json
@@ -30,6 +30,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireEyeCM/pack_metadata.json
+++ b/Packs/FireEyeCM/pack_metadata.json
@@ -28,6 +28,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireEyeCommonFields/pack_metadata.json
+++ b/Packs/FireEyeCommonFields/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireEyeETP/Integrations/FireEyeETPEventCollector/FireEyeETPEventCollector.yml
+++ b/Packs/FireEyeETP/Integrations/FireEyeETPEventCollector/FireEyeETPEventCollector.yml
@@ -89,5 +89,6 @@ script:
 fromversion: 8.2.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/FireEyeETP/pack_metadata.json
+++ b/Packs/FireEyeETP/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "FireEye ETP Event Collector"
+    "defaultDataSource": "FireEye ETP Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/FireEyeEX/pack_metadata.json
+++ b/Packs/FireEyeEX/pack_metadata.json
@@ -21,6 +21,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireEyeHX/Integrations/FireEyeHXEventCollector/FireEyeHXEventCollector.yml
+++ b/Packs/FireEyeHX/Integrations/FireEyeHXEventCollector/FireEyeHXEventCollector.yml
@@ -63,4 +63,5 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0

--- a/Packs/FireEyeHX/pack_metadata.json
+++ b/Packs/FireEyeHX/pack_metadata.json
@@ -18,7 +18,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "FireEye HX Event Collector"
+    "defaultDataSource": "FireEye HX Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/FireEyeHelix/pack_metadata.json
+++ b/Packs/FireEyeHelix/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireEyeNX/pack_metadata.json
+++ b/Packs/FireEyeNX/pack_metadata.json
@@ -22,6 +22,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FireMonSecurityManager/pack_metadata.json
+++ b/Packs/FireMonSecurityManager/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Flashpoint/pack_metadata.json
+++ b/Packs/Flashpoint/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FlashpointFeed/pack_metadata.json
+++ b/Packs/FlashpointFeed/pack_metadata.json
@@ -23,6 +23,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Forcepoint/pack_metadata.json
+++ b/Packs/Forcepoint/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForcepointDLP/Integrations/ForcepointEventCollector/ForcepointEventCollector.yml
+++ b/Packs/ForcepointDLP/Integrations/ForcepointEventCollector/ForcepointEventCollector.yml
@@ -81,5 +81,6 @@ script:
 fromversion: 8.2.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/ForcepointDLP/pack_metadata.json
+++ b/Packs/ForcepointDLP/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForcepointEmailSecurity/pack_metadata.json
+++ b/Packs/ForcepointEmailSecurity/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForcepointSWG/pack_metadata.json
+++ b/Packs/ForcepointSWG/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForcepointSecurityManagementCenter/pack_metadata.json
+++ b/Packs/ForcepointSecurityManagementCenter/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Forescout/pack_metadata.json
+++ b/Packs/Forescout/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForescoutEyeInspect/pack_metadata.json
+++ b/Packs/ForescoutEyeInspect/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Fortanix-DSM/pack_metadata.json
+++ b/Packs/Fortanix-DSM/pack_metadata.json
@@ -40,6 +40,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FortiAuthenticator/pack_metadata.json
+++ b/Packs/FortiAuthenticator/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FortiGate/pack_metadata.json
+++ b/Packs/FortiGate/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
FeedNVDv2
FeedORKL
FeedOffice365
FeedOpenCTI
FeedPlainText
FeedPublicDNS
FeedRSS
FeedRecordedFuture
FeedReversingLabsRansomwareAndRelatedToolsApp
FeedSOCRadarThreatFeed
FeedSpamhaus
FeedTAXII
FeedTalos
FeedThreatConnect
FeedThreatFox
FeedThreatVault
FeedTorExitAddresses
FeedURLhaus
FeedUnit42
FeedUnit42v2
FeedZoom
Feedsslabusech
FidelisElevateNetwork
FidelisEndpoint
FileOrbis
FiltersAndTransformers
FireEye-Detection-on-Demand
FireEyeCM
FireEyeCommonFields
FireEyeETP
FireEyeEX
FireEyeHX
FireEyeHelix
FireEyeNX
FireMonSecurityManager
Flashpoint
FlashpointFeed
Forcepoint
ForcepointDLP
ForcepointEmailSecurity
ForcepointSWG
ForcepointSecurityManagementCenter
Forescout
ForescoutEyeInspect
Fortanix-DSM
FortiAuthenticator
FortiGate
```