### PR TITLE
Adopt 'platform' MP to content packs #16

### DIFF
--- a/Packs/FortiManager/pack_metadata.json
+++ b/Packs/FortiManager/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FortiSIEM/pack_metadata.json
+++ b/Packs/FortiSIEM/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "FortiSIEMV2"
+    "defaultDataSource": "FortiSIEMV2",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/FortiSandbox/pack_metadata.json
+++ b/Packs/FortiSandbox/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Fortimail/pack_metadata.json
+++ b/Packs/Fortimail/pack_metadata.json
@@ -18,7 +18,14 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "certification": "certified"
+    "certification": "certified",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/FortinetFortiwebVM/pack_metadata.json
+++ b/Packs/FortinetFortiwebVM/pack_metadata.json
@@ -17,6 +17,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ForwardXSOARAuditLogsToSplunkHEC/pack_metadata.json
+++ b/Packs/ForwardXSOARAuditLogsToSplunkHEC/pack_metadata.json
@@ -28,6 +28,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FraudWatch/pack_metadata.json
+++ b/Packs/FraudWatch/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FreeEnrichers/pack_metadata.json
+++ b/Packs/FreeEnrichers/pack_metadata.json
@@ -14,10 +14,8 @@
         "Free Enricher",
         "Plug & Enrich"
     ],
-    "itemPrefix": [
-    ],
-    "useCases": [
-    ],
+    "itemPrefix": [],
+    "useCases": [],
     "keywords": [
         "Feed"
     ],
@@ -74,130 +72,112 @@
             "mandatory": false,
             "display_name": "This Content Pack helps you run Whois commands as playbook tasks or real-time actions within Cortex XSOAR to obtain valuable domain metadata."
         },
-
         "AbuseDB": {
             "mandatory": false,
             "display_name": "Central repository to report and identify IP addresses that have been associated with malicious activity online. Check the Detailed Information section for more information on how to configure the integration."
         },
-
         "AlienVault_OTX": {
             "mandatory": false,
             "display_name": "Query Indicators of Compromise in AlienVault OTX."
         },
-
         "APIVoid": {
             "mandatory": false,
             "display_name": "APIVoid wraps up a number of services such as ipvoid & urlvoid"
         },
-
         "CheckPhish": {
             "mandatory": false,
             "display_name": "Check any URL to detect suspicious behavior."
         },
-
         "CrowdSec": {
             "mandatory": false,
             "display_name": "Enrich the data you have on your threats with the most advanced real-world CTI."
         },
-
         "GreyNoise": {
             "mandatory": false,
             "display_name": "GreyNoise is a threat intelligence service that collects and analyzes Internet-wide scan and attack traffic. With this integration, users can contextualize existing alerts, filter false-positives, identify compromised devices, and track emerging threats."
         },
-
         "HostIo": {
             "mandatory": false,
             "display_name": "Enrich domains using the host.io API."
         },
-
         "IP-API": {
             "mandatory": false,
             "display_name": "Integrate with the IP-API.com IP enrichment service."
         },
-
         "ipinfo": {
             "mandatory": false,
             "display_name": "Use the ipinfo.io API to get data about an IP address"
         },
-
-        "IPQualityScore" : {
+        "IPQualityScore": {
             "mandatory": false,
             "display_name": "Detect threats with real-time risk scoring by IPQS. Playbook analyzes IP addresses, email addresses, and domains or URLs for high risk behavior."
         },
-
         "Ipstack": {
             "mandatory": false,
             "display_name": "One of the leading IP to geolocation APIs and global IP database services."
         },
-
         "Lastline": {
             "mandatory": false,
             "display_name": "Use the Lastline v2 integration to provide threat analysts and incident response teams with the advanced malware isolation and inspection environment needed to safely execute advanced malware samples, and understand their behavior."
         },
-
         "Maltiverse": {
             "mandatory": false,
             "display_name": "Maltiverse helps you to analyze suspicious hashes, URLs, domains, and IP addresses."
         },
-
         "MalwareBazaar": {
             "mandatory": false,
             "display_name": "MalwareBazaar offers an API to download malware samples, comment malware samples, and obtain intel based on file hash, tag, signature, file type, etc."
         },
-
         "MandiantAdvantageThreatIntelligence": {
             "mandatory": false,
             "display_name": "Integrate your Mandiant Advantage Threat Intelligence data with Cortex XSOAR"
         },
-
         "MISP": {
             "mandatory": false,
             "display_name": "Malware information and threat sharing platform."
         },
-
         "PolySwarm": {
             "mandatory": false,
             "display_name": "Real-time threat intelligence from a crowdsourced network of security experts and antivirus companies."
         },
-
         "Pulsedive": {
             "mandatory": false,
             "display_name": "Leverage Pulsedive threat intelligence in Cortex XSOAR to enrich any domain, URL, or IP. Retrieve risk scores and factors, investigate contextual data, pivot on any data point, and investigate potential threats."
         },
-
         "Shodan": {
             "mandatory": false,
             "display_name": "A search engine used for searching Internet-connected devices"
         },
-
         "Synapse": {
             "mandatory": false,
             "display_name": "Vertex Synapse intelligence analysis framework."
         },
-
         "ThreatExchange": {
             "mandatory": false,
             "display_name": "Receive threat intelligence about applications, IP addresses, URLs and hashes, a service by Facebook"
         },
-
         "UrlScan": {
             "mandatory": false,
             "display_name": "urlscan.io Web Threat Intelligence"
         },
-
         "VirusTotal": {
             "mandatory": false,
             "display_name": "Analyze suspicious hashes, URLs, domains and IP addresses"
         },
-
         "CIRCL": {
             "mandatory": false,
             "display_name": "Searches for CVE information using [circl.lu](https://www.circl.lu/services/cve-search/)."
         }
-
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FreeFeeds/pack_metadata.json
+++ b/Packs/FreeFeeds/pack_metadata.json
@@ -168,6 +168,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FreshDesk/pack_metadata.json
+++ b/Packs/FreshDesk/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FreshworksFreshservice/pack_metadata.json
+++ b/Packs/FreshworksFreshservice/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/FullHunt/pack_metadata.json
+++ b/Packs/FullHunt/pack_metadata.json
@@ -19,9 +19,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "Sam0x90"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GCP-Enrichment-Remediation/pack_metadata.json
+++ b/Packs/GCP-Enrichment-Remediation/pack_metadata.json
@@ -15,7 +15,8 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
     "dependencies": {
         "GCP-IAM": {
@@ -40,5 +41,11 @@
         "CommonScripts",
         "GoogleCloudCompute",
         "GCP-IAM"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GCP-IAM/pack_metadata.json
+++ b/Packs/GCP-IAM/pack_metadata.json
@@ -18,6 +18,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GDPR/pack_metadata.json
+++ b/Packs/GDPR/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GLIMPS_Detect/pack_metadata.json
+++ b/Packs/GLIMPS_Detect/pack_metadata.json
@@ -21,12 +21,19 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "contact@glimps.re"
     ],
     "githubUser": [
         "tdidailler"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GLPI/pack_metadata.json
+++ b/Packs/GLPI/pack_metadata.json
@@ -14,7 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "support@secinfra.fr"
@@ -40,5 +41,11 @@
         "CoreAlertFields",
         "CommonTypes",
         "CommonScripts"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GRR/pack_metadata.json
+++ b/Packs/GRR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GSuiteAdmin/pack_metadata.json
+++ b/Packs/GSuiteAdmin/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GSuiteSecurityAlertCenter/pack_metadata.json
+++ b/Packs/GSuiteSecurityAlertCenter/pack_metadata.json
@@ -23,6 +23,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GZip/pack_metadata.json
+++ b/Packs/GZip/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "sharatpatil7"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gamma/pack_metadata.json
+++ b/Packs/Gamma/pack_metadata.json
@@ -41,6 +41,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gatewatcher-AionIQ/pack_metadata.json
+++ b/Packs/Gatewatcher-AionIQ/pack_metadata.json
@@ -14,13 +14,20 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "FabienMht",
         "CesarGW",
         "ThibaultReboul",
-	"clement-lyonnet"
+        "clement-lyonnet"
     ],
-    "defaultDataSource": "GCenter 103"
+    "defaultDataSource": "GCenter 103",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Gatewatcher-LIS/pack_metadata.json
+++ b/Packs/Gatewatcher-LIS/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "CesarGW",
         "Liolaeus"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gem/pack_metadata.json
+++ b/Packs/Gem/pack_metadata.json
@@ -75,7 +75,8 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "support@gem.security"
@@ -83,5 +84,11 @@
     "githubUser": [
         "dorkauf",
         "liormgem"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GenericAPIEventCollector/Integrations/GenericAPIEventCollector/GenericAPIEventCollector.yml
+++ b/Packs/GenericAPIEventCollector/Integrations/GenericAPIEventCollector/GenericAPIEventCollector.yml
@@ -251,5 +251,6 @@ script:
 fromversion: 6.8.0
 marketplaces:
   - marketplacev2
+  - platform
 tests:
   - No tests (auto formatted)

--- a/Packs/GenericAPIEventCollector/pack_metadata.json
+++ b/Packs/GenericAPIEventCollector/pack_metadata.json
@@ -17,7 +17,14 @@
     "price": 0,
     "dependencies": {},
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ],
     "defaultDataSource": "GenericAPIEventCollector"
 }

--- a/Packs/GenericSQL/pack_metadata.json
+++ b/Packs/GenericSQL/pack_metadata.json
@@ -18,6 +18,16 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GenericWebhook/pack_metadata.json
+++ b/Packs/GenericWebhook/pack_metadata.json
@@ -17,6 +17,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GenetecSecurityCenter/Integrations/GenetecSecurityCenterEventCollector/GenetecSecurityCenterEventCollector.yml
+++ b/Packs/GenetecSecurityCenter/Integrations/GenetecSecurityCenterEventCollector/GenetecSecurityCenterEventCollector.yml
@@ -65,6 +65,7 @@ script:
   isfetchevents: true
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GenetecSecurityCenter/pack_metadata.json
+++ b/Packs/GenetecSecurityCenter/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Genians/pack_metadata.json
+++ b/Packs/Genians/pack_metadata.json
@@ -17,6 +17,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GettingStartedWithXSOAR/pack_metadata.json
+++ b/Packs/GettingStartedWithXSOAR/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "This wizard is designed to provide a step-by-step walkthough on getting started with XSOAR",
     "support": "community",
     "videos": [
-    "https://www.youtube.com/watch?v=03TmGeAzvOQ"
+        "https://www.youtube.com/watch?v=03TmGeAzvOQ"
     ],
     "currentVersion": "1.0.0",
     "author": "Joe Cosgrove",
@@ -12,11 +12,20 @@
     "categories": [
         "Utilities"
     ],
-    "tags": ["Getting Started", "Simulation", "New", "Trending","Plug & Enrich"],
-    "useCases": ["Case Management"],
+    "tags": [
+        "Getting Started",
+        "Simulation",
+        "New",
+        "Trending",
+        "Plug & Enrich"
+    ],
+    "useCases": [
+        "Case Management"
+    ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "joecosgrove@paloaltonetworks.com"
@@ -130,5 +139,11 @@
         "CoreAlertFields",
         "CommonTypes",
         "CoreAlertFields"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GigamonThreatINSIGHT/pack_metadata.json
+++ b/Packs/GigamonThreatINSIGHT/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "apps@gigamon.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Giphy/pack_metadata.json
+++ b/Packs/Giphy/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GitGuardian/Integrations/GitGuardianEventCollector/GitGuardianEventCollector.yml
+++ b/Packs/GitGuardian/Integrations/GitGuardianEventCollector/GitGuardianEventCollector.yml
@@ -74,6 +74,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GitGuardian/pack_metadata.json
+++ b/Packs/GitGuardian/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
+++ b/Packs/GitHub/Integrations/GitHubEventCollector/GitHubEventCollector.yml
@@ -79,6 +79,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests

--- a/Packs/GitHub/pack_metadata.json
+++ b/Packs/GitHub/pack_metadata.json
@@ -21,7 +21,17 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Github Event Collector"
+    "defaultDataSource": "Github Event Collector",
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/GitLab/Integrations/GitLabEventCollector/GitLabEventCollector.yml
+++ b/Packs/GitLab/Integrations/GitLabEventCollector/GitLabEventCollector.yml
@@ -35,8 +35,7 @@ configuration:
   type: 0
   section: Collect
 - display: The maximum number of events per fetch for each event type
-  additionalinfo: Each fetch will bring the `limit` number of events for each type (audits, groups and projects) and each group/project ID.
-                  For example, if `limit` is set to 500 and groups/projects IDs are given as well, then the fetch will bring 500 audit events and 500 group/project events for each group/project ID.
+  additionalinfo: Each fetch will bring the `limit` number of events for each type (audits, groups and projects) and each group/project ID. For example, if `limit` is set to 500 and groups/projects IDs are given as well, then the fetch will bring 500 audit events and 500 group/project events for each group/project ID.
   name: limit
   type: 0
   defaultvalue: 500
@@ -77,6 +76,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests

--- a/Packs/GitLab/Playbooks/Gitlab_-_Guest_user_permission_change.yml
+++ b/Packs/GitLab/Playbooks/Gitlab_-_Guest_user_permission_change.yml
@@ -676,5 +676,5 @@ inputs:
 outputs: []
 tests:
 - No tests (auto formatted)
-marketplaces: ["marketplacev2"]
+marketplaces: ["marketplacev2", "platform"]
 fromversion: 6.6.0

--- a/Packs/GitLab/pack_metadata.json
+++ b/Packs/GitLab/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "marketplacev2",
-        "xsoar"
+        "xsoar",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GithubMaltrailFeed/pack_metadata.json
+++ b/Packs/GithubMaltrailFeed/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "asantamarina"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gmail/Playbooks/playbook-Get_Original_Email_-_Gmail_v2.yml
+++ b/Packs/Gmail/Playbooks/playbook-Get_Original_Email_-_Gmail_v2.yml
@@ -375,3 +375,8 @@ outputs:
 tests:
 - Get Original Email - Gmail v2 - test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling.yml
+++ b/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling.yml
@@ -301,3 +301,8 @@ outputs:
 tests:
 - No tests
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling.yml
+++ b/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling.yml
@@ -579,3 +579,8 @@ outputs:
 tests:
 - No tests
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Gmail/Playbooks/playbook-Search_And_Delete_Emails_-_Gmail.yml
+++ b/Packs/Gmail/Playbooks/playbook-Search_And_Delete_Emails_-_Gmail.yml
@@ -714,3 +714,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Gmail/pack_metadata.json
+++ b/Packs/Gmail/pack_metadata.json
@@ -17,6 +17,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GmailSingleUser/pack_metadata.json
+++ b/Packs/GmailSingleUser/pack_metadata.json
@@ -23,6 +23,16 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
FortiManager
FortiSIEM
FortiSandbox
Fortimail
FortinetFortiwebVM
ForwardXSOARAuditLogsToSplunkHEC
FraudWatch
FreeEnrichers
FreeFeeds
FreshDesk
FreshworksFreshservice
FullHunt
GCP-Enrichment-Remediation
GCP-IAM
GDPR
GLIMPS_Detect
GLPI
GRR
GSuiteAdmin
GSuiteSecurityAlertCenter
GZip
Gamma
Gatewatcher-AionIQ
Gatewatcher-LIS
Gem
GenericAPIEventCollector
GenericSQL
GenericWebhook
GenetecSecurityCenter
Genians
GettingStartedWithXSOAR
GigamonThreatINSIGHT
Giphy
GitGuardian
GitHub
GitLab
GithubMaltrailFeed
Gmail
GmailSingleUser
```