### PR TITLE
Adopt 'platform' MP to content packs #17

### DIFF
--- a/Packs/GoogleApigee/Integrations/GoogleApigeeEventCollector/GoogleApigeeEventCollector.yml
+++ b/Packs/GoogleApigee/Integrations/GoogleApigeeEventCollector/GoogleApigeeEventCollector.yml
@@ -80,6 +80,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GoogleApigee/pack_metadata.json
+++ b/Packs/GoogleApigee/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleBigQuery/pack_metadata.json
+++ b/Packs/GoogleBigQuery/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCalendar/pack_metadata.json
+++ b/Packs/GoogleCalendar/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleChatViaWebhook/pack_metadata.json
+++ b/Packs/GoogleChatViaWebhook/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "edibleShell"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleChrome/pack_metadata.json
+++ b/Packs/GoogleChrome/pack_metadata.json
@@ -20,6 +20,13 @@
         "browser"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleChronicleBackstory/pack_metadata.json
+++ b/Packs/GoogleChronicleBackstory/pack_metadata.json
@@ -354,6 +354,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudCompute/pack_metadata.json
+++ b/Packs/GoogleCloudCompute/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudFunctions/pack_metadata.json
+++ b/Packs/GoogleCloudFunctions/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudLogging/pack_metadata.json
+++ b/Packs/GoogleCloudLogging/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudSCC/pack_metadata.json
+++ b/Packs/GoogleCloudSCC/pack_metadata.json
@@ -22,6 +22,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudStorage/pack_metadata.json
+++ b/Packs/GoogleCloudStorage/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleCloudTranslate/pack_metadata.json
+++ b/Packs/GoogleCloudTranslate/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleDocs/pack_metadata.json
+++ b/Packs/GoogleDocs/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleDorking/pack_metadata.json
+++ b/Packs/GoogleDorking/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleDrive/pack_metadata.json
+++ b/Packs/GoogleDrive/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleKeyManagementService/pack_metadata.json
+++ b/Packs/GoogleKeyManagementService/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleKubernetesEngine/pack_metadata.json
+++ b/Packs/GoogleKubernetesEngine/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleMaps/pack_metadata.json
+++ b/Packs/GoogleMaps/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GooglePubSub/pack_metadata.json
+++ b/Packs/GooglePubSub/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleResourceManager/pack_metadata.json
+++ b/Packs/GoogleResourceManager/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleSafeBrowsing/pack_metadata.json
+++ b/Packs/GoogleSafeBrowsing/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleSheets/pack_metadata.json
+++ b/Packs/GoogleSheets/pack_metadata.json
@@ -14,6 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleThreatIntelligence/pack_metadata.json
+++ b/Packs/GoogleThreatIntelligence/pack_metadata.json
@@ -16,6 +16,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleVault/pack_metadata.json
+++ b/Packs/GoogleVault/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleVertexAI/pack_metadata.json
+++ b/Packs/GoogleVertexAI/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "sepaprivate"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GoogleVisionAPI/pack_metadata.json
+++ b/Packs/GoogleVisionAPI/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gophish/pack_metadata.json
+++ b/Packs/Gophish/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Grafana/pack_metadata.json
+++ b/Packs/Grafana/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GraphQL/pack_metadata.json
+++ b/Packs/GraphQL/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Graylog/pack_metadata.json
+++ b/Packs/Graylog/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GreatHorn/pack_metadata.json
+++ b/Packs/GreatHorn/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GreyNoise/pack_metadata.json
+++ b/Packs/GreyNoise/pack_metadata.json
@@ -22,6 +22,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GroupIB_ThreatIntelligenceAttribution/pack_metadata.json
+++ b/Packs/GroupIB_ThreatIntelligenceAttribution/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GsuiteAuditor/pack_metadata.json
+++ b/Packs/GsuiteAuditor/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/GuardiCore/pack_metadata.json
+++ b/Packs/GuardiCore/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Guidance_Encase_Endpoint/pack_metadata.json
+++ b/Packs/Guidance_Encase_Endpoint/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Gurucul/pack_metadata.json
+++ b/Packs/Gurucul/pack_metadata.json
@@ -29,6 +29,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HIPAA-BreachNotification/pack_metadata.json
+++ b/Packs/HIPAA-BreachNotification/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HPEArubaCentral/Integrations/HPEArubaCentralEventCollector/HPEArubaCentralEventCollector.yml
+++ b/Packs/HPEArubaCentral/Integrations/HPEArubaCentralEventCollector/HPEArubaCentralEventCollector.yml
@@ -99,6 +99,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/HPEArubaCentral/pack_metadata.json
+++ b/Packs/HPEArubaCentral/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HPEArubaClearPass/pack_metadata.json
+++ b/Packs/HPEArubaClearPass/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HPESwitch/pack_metadata.json
+++ b/Packs/HPESwitch/pack_metadata.json
@@ -20,6 +20,13 @@
         "Hewlett Packard Enterprise"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HPE_Service_Manager/pack_metadata.json
+++ b/Packs/HPE_Service_Manager/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HYASInsight/pack_metadata.json
+++ b/Packs/HYASInsight/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HYASProtect/pack_metadata.json
+++ b/Packs/HYASProtect/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HackerOne/pack_metadata.json
+++ b/Packs/HackerOne/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Hackuity/pack_metadata.json
+++ b/Packs/Hackuity/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HashiCorp-Vault/pack_metadata.json
+++ b/Packs/HashiCorp-Vault/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/HashiCorpTerraform/pack_metadata.json
+++ b/Packs/HashiCorpTerraform/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
GoogleApigee
GoogleBigQuery
GoogleCalendar
GoogleChatViaWebhook
GoogleChrome
GoogleChronicleBackstory
GoogleCloudCompute
GoogleCloudFunctions
GoogleCloudLogging
GoogleCloudSCC
GoogleCloudStorage
GoogleCloudTranslate
GoogleDocs
GoogleDorking
GoogleDrive
GoogleKeyManagementService
GoogleKubernetesEngine
GoogleMaps
GooglePubSub
GoogleResourceManager
GoogleSafeBrowsing
GoogleSheets
GoogleThreatIntelligence
GoogleVault
GoogleVertexAI
GoogleVisionAPI
Gophish
Grafana
GraphQL
Graylog
GreatHorn
GreyNoise
GroupIB_ThreatIntelligenceAttribution
GsuiteAuditor
GuardiCore
Guidance_Encase_Endpoint
Gurucul
HIPAA-BreachNotification
HPEArubaCentral
HPEArubaClearPass
HPESwitch
HPE_Service_Manager
HYASInsight
HYASProtect
HackerOne
Hackuity
HashiCorp-Vault
HashiCorpTerraform
```