### PR TITLE
Adopt 'platform' MP to content packs #19

### DIFF
--- a/Packs/IronDefense/pack_metadata.json
+++ b/Packs/IronDefense/pack_metadata.json
@@ -16,6 +16,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IronPort/pack_metadata.json
+++ b/Packs/IronPort/pack_metadata.json
@@ -15,7 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "Phishing": {
@@ -23,5 +24,11 @@
             "name": "Phishing"
         }
     },
-    "itemPrefix": "CiscoESA"
+    "itemPrefix": "CiscoESA",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Ironscales/pack_metadata.json
+++ b/Packs/Ironscales/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IronscalesEventCollector/Integrations/IronscalesEventCollector/IronscalesEventCollector.yml
+++ b/Packs/IronscalesEventCollector/Integrations/IronscalesEventCollector/IronscalesEventCollector.yml
@@ -82,5 +82,6 @@ script:
 fromversion: 8.2.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/IronscalesEventCollector/pack_metadata.json
+++ b/Packs/IronscalesEventCollector/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "githubUser": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IsItPhishing/pack_metadata.json
+++ b/Packs/IsItPhishing/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IvantiConnectSecure/pack_metadata.json
+++ b/Packs/IvantiConnectSecure/pack_metadata.json
@@ -20,6 +20,13 @@
         "VPN"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IvantiCriticalVulnerabilities/pack_metadata.json
+++ b/Packs/IvantiCriticalVulnerabilities/pack_metadata.json
@@ -31,8 +31,6 @@
         "21887",
         "21888",
         "21893"
-
-
     ],
     "dependencies": {
         "MajorBreachesInvestigationandResponse": {
@@ -42,6 +40,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IvantiHeat/pack_metadata.json
+++ b/Packs/IvantiHeat/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/IvantiPulseSecureVTM/pack_metadata.json
+++ b/Packs/IvantiPulseSecureVTM/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JARM/pack_metadata.json
+++ b/Packs/JARM/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JSONSampleIncidentGenerator/pack_metadata.json
+++ b/Packs/JSONSampleIncidentGenerator/pack_metadata.json
@@ -17,6 +17,15 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JWT/pack_metadata.json
+++ b/Packs/JWT/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Ja3er/pack_metadata.json
+++ b/Packs/Ja3er/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JamfProtect/Integrations/JamfProtectEventCollector/JamfProtectEventCollector.yml
+++ b/Packs/JamfProtect/Integrations/JamfProtectEventCollector/JamfProtectEventCollector.yml
@@ -104,6 +104,7 @@ script:
   dockerimage: demisto/python3:3.12.8.1983910
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.9.0
 tests:
 - No tests (auto formatted)

--- a/Packs/JamfProtect/pack_metadata.json
+++ b/Packs/JamfProtect/pack_metadata.json
@@ -14,6 +14,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Jask/pack_metadata.json
+++ b/Packs/Jask/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Jira/Integrations/JiraEventCollector/JiraEventCollector.yml
+++ b/Packs/Jira/Integrations/JiraEventCollector/JiraEventCollector.yml
@@ -1,4 +1,7 @@
 category: Analytics & SIEM
+sectionOrder:
+- Connect
+- Collect
 commonfields:
   id: Jira Event Collector
   version: -1
@@ -51,9 +54,10 @@ script:
   isfetchevents: true
   type: python
   subtype: python3
-  dockerimage: demisto/py3-tools:1.0.0.114656
+  dockerimage: demisto/py3-tools:1.0.0.2072021
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Jira/Playbooks/playbook-Create_Jira_Issue.yml
+++ b/Packs/Jira/Playbooks/playbook-Create_Jira_Issue.yml
@@ -564,3 +564,8 @@ outputs: []
 tests:
 - No test.
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Jira/Playbooks/playbook-Jira_Ticket_State_Polling.yml
+++ b/Packs/Jira/Playbooks/playbook-Jira_Ticket_State_Polling.yml
@@ -243,8 +243,7 @@ inputs:
 - key: Timeout
   value: {}
   required: true
-  description: Amount of time to poll before declaring a timeout and resuming the
-    playbook (in minutes).
+  description: Amount of time to poll before declaring a timeout and resuming the playbook (in minutes).
   playbookInputQuery:
 - key: InstanceName
   value: {}
@@ -256,12 +255,14 @@ inputs:
 - key: AdditionalPollingCommandName
   value: {}
   required: false
-  description: "Additional polling commands are relevant when using StatePolling,\
-    \ and there is more than one Jira instance. It will specify the polling command\
-    \ to use a specific instance to run on. \nWhen implemented, add \"Using\" to the value.\
-    \ \nThe polling command will then take the instance name as the instance to use. "
+  description: "Additional polling commands are relevant when using StatePolling, and there is more than one Jira instance. It will specify the polling command to use a specific instance to run on. \nWhen implemented, add \"Using\" to the value. \nThe polling command will then take the instance name as the instance to use. "
   playbookInputQuery:
 outputs: []
 tests:
 - No test.
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Jira/Playbooks/playbook-Mirror_Jira_Ticket.yml
+++ b/Packs/Jira/Playbooks/playbook-Mirror_Jira_Ticket.yml
@@ -3,8 +3,7 @@ version: -1
 contentitemexportablefields:
   contentitemfields: {}
 name: Mirror Jira Ticket
-description: Mirror Jira Ticket is designed to serve as a sub-playbook, which enables
-  ticket mirroring with Jira.
+description: Mirror Jira Ticket is designed to serve as a sub-playbook, which enables ticket mirroring with Jira.
 starttaskid: "0"
 tasks:
   "0":
@@ -218,8 +217,7 @@ inputs:
 - key: MirrorDirection
   value: {}
   required: false
-  description: "Set the mirror direction to one of the following values: \n1. In\n\
-    2. Out\n3. Both"
+  description: "Set the mirror direction to one of the following values: \n1. In\n2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorTags
   value: {}
@@ -252,3 +250,8 @@ outputs: []
 tests:
 - No test.
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -24,7 +24,6 @@
     ],
     "defaultDataSource": "Jira Event Collector",
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -19,7 +19,18 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
-    "defaultDataSource": "Jira Event Collector"
+    "defaultDataSource": "Jira Event Collector",
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/JoeSecurity/pack_metadata.json
+++ b/Packs/JoeSecurity/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JsonWhoIs/pack_metadata.json
+++ b/Packs/JsonWhoIs/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/JuniperSRX/pack_metadata.json
+++ b/Packs/JuniperSRX/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/KELARaDark/pack_metadata.json
+++ b/Packs/KELARaDark/pack_metadata.json
@@ -29,6 +29,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Kafka/pack_metadata.json
+++ b/Packs/Kafka/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/KasperskySecurityCenter/pack_metadata.json
+++ b/Packs/KasperskySecurityCenter/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/KeeperSecretsManager/pack_metadata.json
+++ b/Packs/KeeperSecretsManager/pack_metadata.json
@@ -26,7 +26,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/KeeperSecurity/Integrations/KeeperSecurity/KeeperSecurity.yml
+++ b/Packs/KeeperSecurity/Integrations/KeeperSecurity/KeeperSecurity.yml
@@ -61,5 +61,6 @@ script:
 fromversion: 6.8.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/KeeperSecurity/pack_metadata.json
+++ b/Packs/KeeperSecurity/pack_metadata.json
@@ -19,6 +19,13 @@
         "secret"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Kenna/pack_metadata.json
+++ b/Packs/Kenna/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Keyfactor/pack_metadata.json
+++ b/Packs/Keyfactor/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "davistonehub"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Kiteworks/pack_metadata.json
+++ b/Packs/Kiteworks/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/KnowBe4KMSAT/pack_metadata.json
+++ b/Packs/KnowBe4KMSAT/pack_metadata.json
@@ -27,8 +27,15 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [],
-    "hidden": true
+    "hidden": true,
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/KnowBe4_KMSAT/Integrations/KnowBe4KMSATEventCollector/KnowBe4KMSATEventCollector.yml
+++ b/Packs/KnowBe4_KMSAT/Integrations/KnowBe4KMSATEventCollector/KnowBe4KMSATEventCollector.yml
@@ -128,3 +128,4 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform

--- a/Packs/KnowBe4_KMSAT/pack_metadata.json
+++ b/Packs/KnowBe4_KMSAT/pack_metadata.json
@@ -27,7 +27,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Koodous/pack_metadata.json
+++ b/Packs/Koodous/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Kubernetes/pack_metadata.json
+++ b/Packs/Kubernetes/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LINENotify/pack_metadata.json
+++ b/Packs/LINENotify/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LSASSCredentialDumping/pack_metadata.json
+++ b/Packs/LSASSCredentialDumping/pack_metadata.json
@@ -7,12 +7,25 @@
     "url": "",
     "email": "",
     "created": "2020-12-18T18:06:49Z",
-    "categories": ["Utilities"],
-    "tags": ["Use Case"],
-    "useCases": ["Identity and Access Management"],
+    "categories": [
+        "Utilities"
+    ],
+    "tags": [
+        "Use Case"
+    ],
+    "useCases": [
+        "Identity and Access Management"
+    ],
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Lacework/pack_metadata.json
+++ b/Packs/Lacework/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Lansweeper/pack_metadata.json
+++ b/Packs/Lansweeper/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Lastline/pack_metadata.json
+++ b/Packs/Lastline/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Linkshadow/pack_metadata.json
+++ b/Packs/Linkshadow/pack_metadata.json
@@ -19,6 +19,13 @@
     "githubUser": "Devika-LS",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LinuxEventsCollection/pack_metadata.json
+++ b/Packs/LinuxEventsCollection/pack_metadata.json
@@ -18,6 +18,13 @@
         "linux"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LogPoint_SIEM_Integration/pack_metadata.json
+++ b/Packs/LogPoint_SIEM_Integration/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LogRhythmRest/pack_metadata.json
+++ b/Packs/LogRhythmRest/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/LogsignSiem/pack_metadata.json
+++ b/Packs/LogsignSiem/pack_metadata.json
@@ -26,6 +26,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Logzio/pack_metadata.json
+++ b/Packs/Logzio/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
IronDefense
IronPort
Ironscales
IronscalesEventCollector
IsItPhishing
IvantiConnectSecure
IvantiCriticalVulnerabilities
IvantiHeat
IvantiPulseSecureVTM
JARM
JSONSampleIncidentGenerator
JWT
Ja3er
JamfProtect
Jask
Jira
JoeSecurity
JsonWhoIs
JuniperSRX
KELARaDark
Kafka
KasperskySecurityCenter
KeeperSecretsManager
KeeperSecurity
Kenna
Keyfactor
Kiteworks
KnowBe4KMSAT
KnowBe4_KMSAT
Koodous
Kubernetes
LINENotify
LSASSCredentialDumping
Lacework
Lansweeper
Lastline
Linkshadow
LinuxEventsCollection
LogPoint_SIEM_Integration
LogRhythmRest
LogsignSiem
Logzio
```