### PR TITLE
Adopt 'platform' MP to content packs #20

### DIFF
--- a/Packs/Lokpath_Keylight/pack_metadata.json
+++ b/Packs/Lokpath_Keylight/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Looker/pack_metadata.json
+++ b/Packs/Looker/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Lost_Stolen_Device/pack_metadata.json
+++ b/Packs/Lost_Stolen_Device/pack_metadata.json
@@ -10,7 +10,9 @@
     "categories": [
         "IT Services"
     ],
-    "tags": ["Use Case"],
+    "tags": [
+        "Use Case"
+    ],
     "useCases": [
         "Compliance"
     ],
@@ -20,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Luminate/pack_metadata.json
+++ b/Packs/Luminate/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Lumu/pack_metadata.json
+++ b/Packs/Lumu/pack_metadata.json
@@ -20,7 +20,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "eparra@lumu.io"
@@ -30,5 +31,11 @@
         "Shellyber",
         "xsoar-bot",
         "content-bot"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MISP/pack_metadata.json
+++ b/Packs/MISP/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MITRECoA/Playbooks/playbook-CoA_-_T1204_-_User_Execution.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-CoA_-_T1204_-_User_Execution.yml
@@ -883,5 +883,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Collection.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Collection.yml
@@ -331,5 +331,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Command_and_Control.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Command_and_Control.yml
@@ -650,5 +650,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Credential_Access.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Credential_Access.yml
@@ -487,5 +487,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Defense_Evasion.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Defense_Evasion.yml
@@ -780,5 +780,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Discovery.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Discovery.yml
@@ -854,5 +854,6 @@ contentitemexportablefields:
     propagationLabels:
     - all
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Execution.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Execution.yml
@@ -731,5 +731,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Exfiltration.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Exfiltration.yml
@@ -618,5 +618,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Impact.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Courses_of_Action_-_Impact.yml
@@ -331,5 +331,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Apply_Security_Profile_to_Policy_Rule.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Apply_Security_Profile_to_Policy_Rule.yml
@@ -866,5 +866,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Block_all_unknown_and_unauthorized_applications.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Block_all_unknown_and_unauthorized_applications.yml
@@ -366,5 +366,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Anti-Spyware_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Anti-Spyware_Best_Practices_Profile.yml
@@ -1190,5 +1190,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Anti-Virus_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Anti-Virus_Best_Practices_Profile.yml
@@ -1168,5 +1168,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_File_Blocking_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_File_Blocking_Best_Practices_Profile.yml
@@ -1029,5 +1029,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_URL_Filtering_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_URL_Filtering_Best_Practices_Profile.yml
@@ -1190,5 +1190,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Vulnerability_Protection_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_Vulnerability_Protection_Best_Practices_Profile.yml
@@ -1190,5 +1190,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_WildFire_Best_Practices_Profile.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-PAN-OS_-_Enforce_WildFire_Best_Practices_Profile.yml
@@ -1268,5 +1268,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/Playbooks/playbook-Palo_Alto_Networks_BPA_-_Submit_Scan.yml
+++ b/Packs/MITRECoA/Playbooks/playbook-Palo_Alto_Networks_BPA_-_Submit_Scan.yml
@@ -419,5 +419,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/MITRECoA/pack_metadata.json
+++ b/Packs/MITRECoA/pack_metadata.json
@@ -66,6 +66,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MS-ISAC/pack_metadata.json
+++ b/Packs/MS-ISAC/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MacOS/pack_metadata.json
+++ b/Packs/MacOS/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MacVendors/pack_metadata.json
+++ b/Packs/MacVendors/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MailListener/pack_metadata.json
+++ b/Packs/MailListener/pack_metadata.json
@@ -16,6 +16,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MailListener_-_POP3/pack_metadata.json
+++ b/Packs/MailListener_-_POP3/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MailSenderNew/pack_metadata.json
+++ b/Packs/MailSenderNew/pack_metadata.json
@@ -16,6 +16,16 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MajorBreachesInvestigationandResponse/pack_metadata.json
+++ b/Packs/MajorBreachesInvestigationandResponse/pack_metadata.json
@@ -121,6 +121,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Maltiverse/pack_metadata.json
+++ b/Packs/Maltiverse/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Malware/pack_metadata.json
+++ b/Packs/Malware/pack_metadata.json
@@ -75,6 +75,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MalwareBazaar/pack_metadata.json
+++ b/Packs/MalwareBazaar/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Malwarebytes/pack_metadata.json
+++ b/Packs/Malwarebytes/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MalwationAIMA/pack_metadata.json
+++ b/Packs/MalwationAIMA/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Malwr/pack_metadata.json
+++ b/Packs/Malwr/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ManageEngine-ADAudit/pack_metadata.json
+++ b/Packs/ManageEngine-ADAudit/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ManageEngine-ADManager/pack_metadata.json
+++ b/Packs/ManageEngine-ADManager/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ManageEngine-ADSelfServicePlus/pack_metadata.json
+++ b/Packs/ManageEngine-ADSelfServicePlus/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ManageEngine_PAM360/pack_metadata.json
+++ b/Packs/ManageEngine_PAM360/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MandiantAdvantageAttackSurfaceManagement/pack_metadata.json
+++ b/Packs/MandiantAdvantageAttackSurfaceManagement/pack_metadata.json
@@ -14,12 +14,19 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "chrishultin"
     ],
     "itemPrefix": [
         "M-ASM"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
+++ b/Packs/MandiantAdvantageThreatIntelligence/pack_metadata.json
@@ -17,10 +17,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "chrishultin",
         "adamlevymandiant"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Mantis/pack_metadata.json
+++ b/Packs/Mantis/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Mattermost/pack_metadata.json
+++ b/Packs/Mattermost/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MaxMind_GeoIP2/pack_metadata.json
+++ b/Packs/MaxMind_GeoIP2/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee-MAR/pack_metadata.json
+++ b/Packs/McAfee-MAR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee-TIE/pack_metadata.json
+++ b/Packs/McAfee-TIE/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfeeDatabaseSecurity/pack_metadata.json
+++ b/Packs/McAfeeDatabaseSecurity/pack_metadata.json
@@ -16,6 +16,13 @@
         "Sentrigo"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
Lokpath_Keylight
Looker
Lost_Stolen_Device
Luminate
Lumu
MISP
MITRECoA
MS-ISAC
MacOS
MacVendors
MailListener
MailListener_-_POP3
MailSenderNew
MajorBreachesInvestigationandResponse
Maltiverse
Malware
MalwareBazaar
Malwarebytes
MalwationAIMA
Malwr
ManageEngine-ADAudit
ManageEngine-ADManager
ManageEngine-ADSelfServicePlus
ManageEngine_PAM360
MandiantAdvantageAttackSurfaceManagement
MandiantAdvantageThreatIntelligence
Mantis
Mattermost
MaxMind_GeoIP2
McAfee-MAR
McAfee-TIE
McAfeeDatabaseSecurity
```