### PR TITLE
Adopt 'platform' MP to content packs #21

### DIFF
--- a/Packs/McAfeeNSM/pack_metadata.json
+++ b/Packs/McAfeeNSM/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfeeWebGateway/pack_metadata.json
+++ b/Packs/McAfeeWebGateway/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee_Advanced_Threat_Defense/pack_metadata.json
+++ b/Packs/McAfee_Advanced_Threat_Defense/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee_DXL/pack_metadata.json
+++ b/Packs/McAfee_DXL/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee_ESM-v10/pack_metadata.json
+++ b/Packs/McAfee_ESM-v10/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/McAfee_ESM/pack_metadata.json
+++ b/Packs/McAfee_ESM/pack_metadata.json
@@ -21,6 +21,13 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicroFocusSMAX/pack_metadata.json
+++ b/Packs/MicroFocusSMAX/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Microsoft365Defender/pack_metadata.json
+++ b/Packs/Microsoft365Defender/pack_metadata.json
@@ -17,6 +17,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftADFS/pack_metadata.json
+++ b/Packs/MicrosoftADFS/pack_metadata.json
@@ -27,6 +27,13 @@
         }
     },
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftAdvancedThreatAnalytics/pack_metadata.json
+++ b/Packs/MicrosoftAdvancedThreatAnalytics/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftDefenderEventCollector/MicrosoftDefenderEventCollector.yml
+++ b/Packs/MicrosoftCloudAppSecurity/Integrations/MicrosoftDefenderEventCollector/MicrosoftDefenderEventCollector.yml
@@ -123,5 +123,6 @@ script:
 fromversion: 6.8.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No Tests

--- a/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
+++ b/Packs/MicrosoftCloudAppSecurity/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Microsoft Defender for Cloud Apps Event Collector"
+    "defaultDataSource": "Microsoft Defender for Cloud Apps Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/MicrosoftDHCP/pack_metadata.json
+++ b/Packs/MicrosoftDHCP/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftDNS/pack_metadata.json
+++ b/Packs/MicrosoftDNS/pack_metadata.json
@@ -19,6 +19,13 @@
         }
     },
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Playbooks/playbook-Microsoft_Defender_for_Endpoint_-_Malware_Detected.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Playbooks/playbook-Microsoft_Defender_for_Endpoint_-_Malware_Detected.yml
@@ -516,7 +516,7 @@ view: |-
 inputs: []
 outputs: []
 quiet: true
-marketplaces: ["marketplacev2"]
+marketplaces: ["marketplacev2", "platform"]
 tests:
 - No tests (auto formatted)
 fromversion: 6.6.0

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -15,7 +15,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "CommonScripts": {
@@ -66,5 +67,11 @@
         "CommonPlaybooks",
         "CommonTypes"
     ],
-    "defaultDataSource": "Microsoft Defender Advanced Threat Protection"
+    "defaultDataSource": "Microsoft Defender Advanced Threat Protection",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/MicrosoftDefenderforIdentity/pack_metadata.json
+++ b/Packs/MicrosoftDefenderforIdentity/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftECM/pack_metadata.json
+++ b/Packs/MicrosoftECM/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftEntraID/pack_metadata.json
+++ b/Packs/MicrosoftEntraID/pack_metadata.json
@@ -28,7 +28,8 @@
         "Activity Logs"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "AzureFirewall": {
@@ -47,5 +48,11 @@
             "mandatory": true,
             "display_name": "Azure App Service"
         }
-    }
+    },
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Get_Original_Email_-_EWS_v2.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Get_Original_Email_-_EWS_v2.yml
@@ -378,3 +378,8 @@ outputs:
 tests:
 - Get Original Email - EWS v2 - test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Process_Email_-_EWS.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Process_Email_-_EWS.yml
@@ -245,3 +245,8 @@ outputs:
   type: unknown
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Search_And_Delete_Emails_-_EWS.yml
+++ b/Packs/MicrosoftExchangeOnPremise/Playbooks/playbook-Search_And_Delete_Emails_-_EWS.yml
@@ -412,3 +412,8 @@ inputs:
 outputs: []
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
@@ -14,6 +14,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-Get_Mails_By_Folder_Paths.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-Get_Mails_By_Folder_Paths.yml
@@ -192,3 +192,8 @@ inputs:
 outputs: []
 tests:
 - Get EWS Folder Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-Search.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-Search.yml
@@ -981,3 +981,8 @@ fromversion: 5.5.0
 tests:
 - O365-SecurityAndCompliance-Test
 - O365-SecurityAndCompliance-ContextResults-Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAction-Delete.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAction-Delete.yml
@@ -484,3 +484,8 @@ version: -1
 fromversion: 5.5.0
 tests:
 - O365-SecurityAndCompliance-Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAction-Preview.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAction-Preview.yml
@@ -350,3 +350,8 @@ fromversion: 5.5.0
 tests:
 - O365-SecurityAndCompliance-Test
 - O365-SecurityAndCompliance-ContextResults-Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAndDelete.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-O365-SecurityAndCompliance-SearchAndDelete.yml
@@ -923,3 +923,8 @@ outputs: []
 tests:
 - O365-SecurityAndCompliance-Test
 fromversion: 5.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/Playbooks/playbook-Office_365_Search_and_Delete.yml
+++ b/Packs/MicrosoftExchangeOnline/Playbooks/playbook-Office_365_Search_and_Delete.yml
@@ -369,3 +369,8 @@ inputs:
 outputs: []
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -14,6 +14,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftExchangeServer/pack_metadata.json
+++ b/Packs/MicrosoftExchangeServer/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphAPI/pack_metadata.json
+++ b/Packs/MicrosoftGraphAPI/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/MicrosoftGraphAPI/pack_metadata.json
+++ b/Packs/MicrosoftGraphAPI/pack_metadata.json
@@ -15,6 +15,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphApplications/pack_metadata.json
+++ b/Packs/MicrosoftGraphApplications/pack_metadata.json
@@ -14,6 +14,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphCalendar/pack_metadata.json
+++ b/Packs/MicrosoftGraphCalendar/pack_metadata.json
@@ -15,6 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphDeviceManagement/pack_metadata.json
+++ b/Packs/MicrosoftGraphDeviceManagement/pack_metadata.json
@@ -15,6 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphFiles/pack_metadata.json
+++ b/Packs/MicrosoftGraphFiles/pack_metadata.json
@@ -15,6 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphGroups/pack_metadata.json
+++ b/Packs/MicrosoftGraphGroups/pack_metadata.json
@@ -15,6 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphGroups/pack_metadata.json
+++ b/Packs/MicrosoftGraphGroups/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C3",
         "X0",
         "X1",

--- a/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
+++ b/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
@@ -15,6 +15,17 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
+++ b/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/MicrosoftGraphMail/Playbooks/playbook-Get_Original_Email_-_Microsoft_Graph_Mail.yml
+++ b/Packs/MicrosoftGraphMail/Playbooks/playbook-Get_Original_Email_-_Microsoft_Graph_Mail.yml
@@ -411,3 +411,8 @@ outputs:
 tests:
 - Get Original Email - Microsoft Graph Mail - test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -16,7 +16,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "MicrosoftGraphMail"
+    "defaultDataSource": "MicrosoftGraphMail",
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/MicrosoftGraphSearch/pack_metadata.json
+++ b/Packs/MicrosoftGraphSearch/pack_metadata.json
@@ -15,9 +15,18 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "randomizerxd"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphSecurity/pack_metadata.json
+++ b/Packs/MicrosoftGraphSecurity/pack_metadata.json
@@ -15,6 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphSecurity/pack_metadata.json
+++ b/Packs/MicrosoftGraphSecurity/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C3",
         "X0",
         "X1",

--- a/Packs/MicrosoftGraphTeams/pack_metadata.json
+++ b/Packs/MicrosoftGraphTeams/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "MicrosoftGraphTeams",
-    "description": "O365 Teams (Using Graph API) gives you authorized access to a user\u2019s Teams enabling you to facilitate communication through teams as that user, or read conversations and/or messages of that user.",
+    "description": "O365 Teams (Using Graph API) gives you authorized access to a user’s Teams enabling you to facilitate communication through teams as that user, or read conversations and/or messages of that user.",
     "support": "community",
     "currentVersion": "1.1.11",
     "author": "Joachim Bockland",

--- a/Packs/MicrosoftGraphTeams/pack_metadata.json
+++ b/Packs/MicrosoftGraphTeams/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "MicrosoftGraphTeams",
-    "description": "O365 Teams (Using Graph API) gives you authorized access to a user’s Teams enabling you to facilitate communication through teams as that user, or read conversations and/or messages of that user.",
+    "description": "O365 Teams (Using Graph API) gives you authorized access to a user\u2019s Teams enabling you to facilitate communication through teams as that user, or read conversations and/or messages of that user.",
     "support": "community",
     "currentVersion": "1.1.11",
     "author": "Joachim Bockland",
@@ -15,9 +15,19 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "invent0r"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphUser/pack_metadata.json
+++ b/Packs/MicrosoftGraphUser/pack_metadata.json
@@ -16,6 +16,17 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftGraphUser/pack_metadata.json
+++ b/Packs/MicrosoftGraphUser/pack_metadata.json
@@ -20,7 +20,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/MicrosoftIISWebServer/pack_metadata.json
+++ b/Packs/MicrosoftIISWebServer/pack_metadata.json
@@ -18,6 +18,13 @@
         "Internet Information Services"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftIntune/pack_metadata.json
+++ b/Packs/MicrosoftIntune/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftManagementActivity/pack_metadata.json
+++ b/Packs/MicrosoftManagementActivity/pack_metadata.json
@@ -19,7 +19,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/MicrosoftManagementActivity/pack_metadata.json
+++ b/Packs/MicrosoftManagementActivity/pack_metadata.json
@@ -15,6 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftNPS/pack_metadata.json
+++ b/Packs/MicrosoftNPS/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -15,6 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/MicrosoftWSUS/pack_metadata.json
+++ b/Packs/MicrosoftWSUS/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
McAfeeNSM
McAfeeWebGateway
McAfee_Advanced_Threat_Defense
McAfee_DXL
McAfee_ESM
McAfee_ESM-v10
MicroFocusSMAX
Microsoft365Defender
MicrosoftADFS
MicrosoftAdvancedThreatAnalytics
MicrosoftCloudAppSecurity
MicrosoftDHCP
MicrosoftDNS
MicrosoftDefenderAdvancedThreatProtection
MicrosoftDefenderforIdentity
MicrosoftECM
MicrosoftEntraID
MicrosoftExchangeOnPremise
MicrosoftExchangeOnline
MicrosoftExchangeServer
MicrosoftGraphAPI
MicrosoftGraphApplications
MicrosoftGraphCalendar
MicrosoftGraphDeviceManagement
MicrosoftGraphFiles
MicrosoftGraphGroups
MicrosoftGraphIdentityandAccess
MicrosoftGraphMail
MicrosoftGraphSearch
MicrosoftGraphSecurity
MicrosoftGraphTeams
MicrosoftGraphUser
MicrosoftIISWebServer
MicrosoftIntune
MicrosoftManagementActivity
MicrosoftNPS
MicrosoftTeams
MicrosoftWSUS
```