### PR TITLE
Adopt 'platform' MP to content packs #23

### DIFF
--- a/Packs/Okta/Integrations/OktaEventCollector/OktaEventCollector.yml
+++ b/Packs/Okta/Integrations/OktaEventCollector/OktaEventCollector.yml
@@ -78,6 +78,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests

--- a/Packs/Okta/Playbooks/playbook-Allow_IP_-_Okta_Zone.yml
+++ b/Packs/Okta/Playbooks/playbook-Allow_IP_-_Okta_Zone.yml
@@ -1,11 +1,7 @@
 id: Allow IP - Okta Zone
 version: -1
 name: Allow IP - Okta Zone
-description: "Sync a list of IP addresses to the Okta Network Zone with the given\
-  \ ID. \nExisting IPs in the Okta Zone which are not in the input list will be removed\
-  \ and the indicator will be untagged in Cortex XSOAR.\nIDs can be retrieved  using !okta-list-zones.\
-  \ This playbook supports CIDR notation only (1.1.1.1/32) and not range notation\
-  \ (1.1.1.1-1.1.1.1)"
+description: "Sync a list of IP addresses to the Okta Network Zone with the given ID. \nExisting IPs in the Okta Zone which are not in the input list will be removed and the indicator will be untagged in Cortex XSOAR.\nIDs can be retrieved  using !okta-list-zones. This playbook supports CIDR notation only (1.1.1.1/32) and not range notation (1.1.1.1-1.1.1.1)"
 starttaskid: "0"
 tasks:
   "0":
@@ -427,8 +423,7 @@ tasks:
       id: f9a8dbfd-8968-4795-8d34-4126abb93cba
       version: -1
       name: List Sync - Any IPs to be added?
-      description: Check whether any IPs in the playbook input are not already in
-        the Okta Zone and need to be added during the list sync.
+      description: Check whether any IPs in the playbook input are not already in the Okta Zone and need to be added during the list sync.
       type: condition
       iscommand: false
       brand: ""
@@ -466,9 +461,7 @@ tasks:
       id: dd8d57c1-87b0-4ca2-826f-550a067a3792
       version: -1
       name: List Sync - Any IPs to be removed?
-      description: Check whether any IPs are in the Okta Zone that are not included
-        in the current playbook input and need to be removed during the
-        list sync.
+      description: Check whether any IPs are in the Okta Zone that are not included in the current playbook input and need to be removed during the list sync.
       type: condition
       iscommand: false
       brand: ""
@@ -729,3 +722,8 @@ outputs: []
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Okta/Playbooks/playbook-Allow_IP_-_Okta_Zone.yml
+++ b/Packs/Okta/Playbooks/playbook-Allow_IP_-_Okta_Zone.yml
@@ -1,7 +1,11 @@
 id: Allow IP - Okta Zone
 version: -1
 name: Allow IP - Okta Zone
-description: "Sync a list of IP addresses to the Okta Network Zone with the given ID. \nExisting IPs in the Okta Zone which are not in the input list will be removed and the indicator will be untagged in Cortex XSOAR.\nIDs can be retrieved  using !okta-list-zones. This playbook supports CIDR notation only (1.1.1.1/32) and not range notation (1.1.1.1-1.1.1.1)"
+description: "Sync a list of IP addresses to the Okta Network Zone with the given\
+  \ ID. \nExisting IPs in the Okta Zone which are not in the input list will be removed\
+  \ and the indicator will be untagged in Cortex XSOAR.\nIDs can be retrieved  using !okta-list-zones.\
+  \ This playbook supports CIDR notation only (1.1.1.1/32) and not range notation\
+  \ (1.1.1.1-1.1.1.1)"
 starttaskid: "0"
 tasks:
   "0":
@@ -423,7 +427,8 @@ tasks:
       id: f9a8dbfd-8968-4795-8d34-4126abb93cba
       version: -1
       name: List Sync - Any IPs to be added?
-      description: Check whether any IPs in the playbook input are not already in the Okta Zone and need to be added during the list sync.
+      description: Check whether any IPs in the playbook input are not already in
+        the Okta Zone and need to be added during the list sync.
       type: condition
       iscommand: false
       brand: ""
@@ -461,7 +466,9 @@ tasks:
       id: dd8d57c1-87b0-4ca2-826f-550a067a3792
       version: -1
       name: List Sync - Any IPs to be removed?
-      description: Check whether any IPs are in the Okta Zone that are not included in the current playbook input and need to be removed during the list sync.
+      description: Check whether any IPs are in the Okta Zone that are not included
+        in the current playbook input and need to be removed during the
+        list sync.
       type: condition
       iscommand: false
       brand: ""

--- a/Packs/Okta/Playbooks/playbook-Okta_-_User_Investigation.yml
+++ b/Packs/Okta/Playbooks/playbook-Okta_-_User_Investigation.yml
@@ -1749,3 +1749,8 @@ quiet: true
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Okta/pack_metadata.json
+++ b/Packs/Okta/pack_metadata.json
@@ -15,7 +15,18 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Okta Event Collector"
+    "defaultDataSource": "Okta Event Collector",
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Okta/pack_metadata.json
+++ b/Packs/Okta/pack_metadata.json
@@ -20,7 +20,6 @@
     ],
     "defaultDataSource": "Okta Event Collector",
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/OktaASA/Integrations/OktaASA/OktaASA.yml
+++ b/Packs/OktaASA/Integrations/OktaASA/OktaASA.yml
@@ -75,6 +75,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.3.0
 tests:
 - No tests (auto formatted)

--- a/Packs/OktaASA/pack_metadata.json
+++ b/Packs/OktaASA/pack_metadata.json
@@ -11,6 +11,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OktaAuth0/Integrations/OktaAuth0EventCollector/OktaAuth0EventCollector.yml
+++ b/Packs/OktaAuth0/Integrations/OktaAuth0EventCollector/OktaAuth0EventCollector.yml
@@ -64,6 +64,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.2.0
 tests:
 - No tests (auto formatted)

--- a/Packs/OktaAuth0/pack_metadata.json
+++ b/Packs/OktaAuth0/pack_metadata.json
@@ -17,7 +17,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/OktaAuth0/pack_metadata.json
+++ b/Packs/OktaAuth0/pack_metadata.json
@@ -13,6 +13,14 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OktaOAG/pack_metadata.json
+++ b/Packs/OktaOAG/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Oletools/pack_metadata.json
+++ b/Packs/Oletools/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Ollama/pack_metadata.json
+++ b/Packs/Ollama/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "rfortress-pan"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OnboardingIntegration/pack_metadata.json
+++ b/Packs/OnboardingIntegration/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OneLogin/Integrations/OneLoginEventCollector/OneLoginEventCollector.yml
+++ b/Packs/OneLogin/Integrations/OneLoginEventCollector/OneLoginEventCollector.yml
@@ -66,6 +66,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/OneLogin/pack_metadata.json
+++ b/Packs/OneLogin/pack_metadata.json
@@ -17,7 +17,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/OneLogin/pack_metadata.json
+++ b/Packs/OneLogin/pack_metadata.json
@@ -13,6 +13,14 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OnePassword/Integrations/OnePassword/OnePassword.yml
+++ b/Packs/OnePassword/Integrations/OnePassword/OnePassword.yml
@@ -107,6 +107,7 @@ script:
   dockerimage: demisto/python3:3.12.8.1983910
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/OnePassword/pack_metadata.json
+++ b/Packs/OnePassword/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenAI/pack_metadata.json
+++ b/Packs/OpenAI/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenCTI/pack_metadata.json
+++ b/Packs/OpenCTI/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenCVE/pack_metadata.json
+++ b/Packs/OpenCVE/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenLDAP/pack_metadata.json
+++ b/Packs/OpenLDAP/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenPhish/pack_metadata.json
+++ b/Packs/OpenPhish/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OpenSourceVulnerabilities/pack_metadata.json
+++ b/Packs/OpenSourceVulnerabilities/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "anagrawal@paloaltonetworks.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/OpsGenie/pack_metadata.json
+++ b/Packs/OpsGenie/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Opsgeniev2/pack_metadata.json
+++ b/Packs/Opsgeniev2/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Oracle/pack_metadata.json
+++ b/Packs/Oracle/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OracleCloudInfrastructure/Integrations/OracleCloudInfrastructureEventCollector/OracleCloudInfrastructureEventCollector.yml
+++ b/Packs/OracleCloudInfrastructure/Integrations/OracleCloudInfrastructureEventCollector/OracleCloudInfrastructureEventCollector.yml
@@ -86,6 +86,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.10.0
 tests:
 - No tests (auto formatted)

--- a/Packs/OracleCloudInfrastructure/pack_metadata.json
+++ b/Packs/OracleCloudInfrastructure/pack_metadata.json
@@ -17,7 +17,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/OracleCloudInfrastructure/pack_metadata.json
+++ b/Packs/OracleCloudInfrastructure/pack_metadata.json
@@ -13,6 +13,14 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/OracleCloudInfrastructureFeed/pack_metadata.json
+++ b/Packs/OracleCloudInfrastructureFeed/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "rgleza"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Oracle_IAM/pack_metadata.json
+++ b/Packs/Oracle_IAM/pack_metadata.json
@@ -14,6 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Oracle_IAM/pack_metadata.json
+++ b/Packs/Oracle_IAM/pack_metadata.json
@@ -18,7 +18,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/Orca/Integrations/OrcaEventCollector/OrcaEventCollector.yml
+++ b/Packs/Orca/Integrations/OrcaEventCollector/OrcaEventCollector.yml
@@ -63,5 +63,6 @@ fromversion: '6.8.0'
 supportlevelheader: xsoar
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/Orca/pack_metadata.json
+++ b/Packs/Orca/pack_metadata.json
@@ -21,7 +21,6 @@
     ],
     "defaultDataSource": "Orca Event Collector",
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/Orca/pack_metadata.json
+++ b/Packs/Orca/pack_metadata.json
@@ -16,7 +16,15 @@
     "githubUser": "edenorca",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Orca Event Collector"
+    "defaultDataSource": "Orca Event Collector",
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
Okta
OktaASA
OktaAuth0
OktaOAG
Oletools
Ollama
OnboardingIntegration
OneLogin
OnePassword
OpenAI
OpenCTI
OpenCVE
OpenLDAP
OpenPhish
OpenSourceVulnerabilities
OpsGenie
Opsgeniev2
Oracle
OracleCloudInfrastructure
OracleCloudInfrastructureFeed
Oracle_IAM
Orca
```