### PR TITLE
Adopt 'platform' MP to content packs #24

### DIFF
--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Add_Anti-Spyware_Security_Profile_To_Rule.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Add_Anti-Spyware_Security_Profile_To_Rule.yml
@@ -1048,3 +1048,8 @@ outputs:
 tests:
 - PAN-OS - Add Anti-Spyware Security Profile To Rule - Test
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Configure_DNS_Sinkhole.yml
@@ -1959,3 +1959,8 @@ outputs: []
 tests:
 - No tests
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Extract_IPs_From_Traffic_Logs_To_Sinkhole.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Extract_IPs_From_Traffic_Logs_To_Sinkhole.yml
@@ -920,3 +920,8 @@ outputs:
 tests:
 - No tests
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Job_-_Add_Malicious_Domains_To_Sinkhole.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Job_-_Add_Malicious_Domains_To_Sinkhole.yml
@@ -1522,3 +1522,8 @@ quiet: true
 tests:
 - No tests (auto formatted)
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/PAN-OS_-_Job_-_Remove_Malicious_Domains_From_Sinkhole.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_-_Job_-_Remove_Malicious_Domains_From_Sinkhole.yml
@@ -506,3 +506,8 @@ quiet: true
 tests:
 - No tests (auto formatted)
 fromversion: 6.9.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/PAN-OS_Commit_Configuration_v2.yml
+++ b/Packs/PAN-OS/Playbooks/PAN-OS_Commit_Configuration_v2.yml
@@ -594,5 +594,10 @@ outputs:
 - contextPath: Panorama.Push.Details
   description: The job ID details.
 tests:
-  - no tests
+- no tests
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-NetOps_-_Firewall_Upgrade.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-NetOps_-_Firewall_Upgrade.yml
@@ -145,4 +145,9 @@ inputs:
   description: Target PAN-OS version to upgrade.
 outputs: []
 tests:
-  - No Tests
+- No Tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-NetOps_-_Firewall_Version_Content_Upgrade.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-NetOps_-_Firewall_Version_Content_Upgrade.yml
@@ -589,4 +589,9 @@ inputs:
   description: Target PAN-OS version to which to upgrade.
 outputs: []
 tests:
-  - No Tests
+- No Tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-NetOps_Panorama_coverage_by_CVE.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-NetOps_Panorama_coverage_by_CVE.yml
@@ -117,3 +117,8 @@ tests:
 - No tests (auto formatted)
 fromversion: 5.0.0
 description: Find if there is signature coverage for a specific CVE.
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-NetSec_-_Palo_Alto_Networks_DUG_-_Tag_User.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-NetSec_-_Palo_Alto_Networks_DUG_-_Tag_User.yml
@@ -262,4 +262,9 @@ inputs:
   description: Name of the list that contains VIP users who can only be blocked after manager approval.
 outputs: []
 tests:
-  - No test
+- No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Add_Domains_EDL_To_Anti-Spyware.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Add_Domains_EDL_To_Anti-Spyware.yml
@@ -485,3 +485,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.5.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Add_Static_Routes.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Add_Static_Routes.yml
@@ -497,4 +497,9 @@ inputs:
     PAN-OS. Specify Yes/No.
 outputs: []
 tests:
-  - No test
+- No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_Destination_Service.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_Destination_Service.yml
@@ -1117,3 +1117,8 @@ tests:
 fromversion: 5.0.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP.yml
@@ -515,3 +515,8 @@ tests:
 - PAN-OS - Block IP - Static Address Group Test
 - PAN-OS DAG Configuration Test
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Custom_Block_Rule.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Custom_Block_Rule.yml
@@ -474,3 +474,8 @@ inputs:
 outputs: []
 tests:
 - PAN-OS - Block IP - Custom Block Rule Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Static_Address_Group.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Static_Address_Group.yml
@@ -612,3 +612,8 @@ tests:
 - PAN-OS - Block IP - Static Address Group Test
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Static_Address_Group_6_10.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IP_-_Static_Address_Group_6_10.yml
@@ -625,3 +625,8 @@ outputs: []
 tests:
 - PAN-OS - Block IP - Static Address Group Test
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IPs_From_EDL_-_Custom_Block_Rule.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_IPs_From_EDL_-_Custom_Block_Rule.yml
@@ -508,3 +508,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_URL_-_Custom_URL_Category.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_URL_-_Custom_URL_Category.yml
@@ -850,3 +850,8 @@ tests:
 - PAN-OS - Block URL - Custom URL Category Test
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_URL_-_Custom_URL_Category_6_10.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Block_URL_-_Custom_URL_Category_6_10.yml
@@ -868,3 +868,8 @@ outputs: []
 tests:
 - PAN-OS - Block URL - Custom URL Category Test
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Create_Or_Edit_EDL_Rule.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Create_Or_Edit_EDL_Rule.yml
@@ -720,3 +720,8 @@ outputs: []
 tests:
 - No test
 
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Create_Or_Edit_Rule.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Create_Or_Edit_Rule.yml
@@ -528,3 +528,8 @@ outputs: []
 tests:
 - no test
 sourceplaybookid: PAN-OS - Create Or Edit Rule
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Delete_Static_Routes.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_-_Delete_Static_Routes.yml
@@ -299,4 +299,9 @@ inputs:
     PAN-OS. Specify Yes/No.
 outputs: []
 tests:
-  - No test
+- No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_DAG_Configuration.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_DAG_Configuration.yml
@@ -482,3 +482,8 @@ outputs: []
 tests:
 - PAN-OS DAG Configuration Test
 sourceplaybookid: PAN-OS DAG Configuration
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_DAG_Configuration_6_10.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_DAG_Configuration_6_10.yml
@@ -542,3 +542,8 @@ outputs: []
 tests:
 - PAN-OS DAG Configuration Test
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_Log_Forwarding_Setup_And_Maintenance.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_Log_Forwarding_Setup_And_Maintenance.yml
@@ -420,3 +420,8 @@ inputs:
 outputs: []
 tests:
 - No Tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-PAN-OS_Query_Logs_For_Indicators_6_2.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-PAN-OS_Query_Logs_For_Indicators_6_2.yml
@@ -894,3 +894,8 @@ outputs:
 tests:
 - PAN-OS Query Logs For Indicators Test
 fromversion: 6.2.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-Pan-OS_Commit_Configuration.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-Pan-OS_Commit_Configuration.yml
@@ -825,3 +825,8 @@ outputs:
 tests:
 - No tests (deprecated)
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs_6_2.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-Panorama_Query_Logs_6_2.yml
@@ -437,3 +437,8 @@ outputs:
 tests:
 - Panorama Query Logs - Test
 fromversion: 6.2.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/Playbooks/playbook-palo_alto_panorama_test_content_update.yml
+++ b/Packs/PAN-OS/Playbooks/playbook-palo_alto_panorama_test_content_update.yml
@@ -386,3 +386,8 @@ tests:
 - PAN-OS DAG Configuration Test
 - Panorama Query Logs - Test
 - PAN-OS - Block IP - Custom Block Rule Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -37,6 +37,16 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PANOSPolicyOptimizer/pack_metadata.json
+++ b/Packs/PANOSPolicyOptimizer/pack_metadata.json
@@ -30,6 +30,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PANWComprehensiveInvestigation/pack_metadata.json
+++ b/Packs/PANWComprehensiveInvestigation/pack_metadata.json
@@ -69,6 +69,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PATHelpdeskAdvanced/pack_metadata.json
+++ b/Packs/PATHelpdeskAdvanced/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PICUS/pack_metadata.json
+++ b/Packs/PICUS/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PacketMail/pack_metadata.json
+++ b/Packs/PacketMail/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Packetsled/pack_metadata.json
+++ b/Packs/Packetsled/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PagerDuty/pack_metadata.json
+++ b/Packs/PagerDuty/pack_metadata.json
@@ -15,6 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworksAIOps/pack_metadata.json
+++ b/Packs/PaloAltoNetworksAIOps/pack_metadata.json
@@ -14,6 +14,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworksAutomaticSLR_Community/pack_metadata.json
+++ b/Packs/PaloAltoNetworksAutomaticSLR_Community/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworks_IoT/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_IoT/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworks_IoT3rdParty/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_IoT3rdParty/pack_metadata.json
@@ -41,6 +41,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_-_Block_Domain_-_External_Dynamic_List.yml
+++ b/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_-_Block_Domain_-_External_Dynamic_List.yml
@@ -484,3 +484,8 @@ inputs:
 outputs: []
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_-_Block_IP_and_URL_-_External_Dynamic_List_v2.yml
+++ b/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_-_Block_IP_and_URL_-_External_Dynamic_List_v2.yml
@@ -813,3 +813,8 @@ outputs: []
 sourceplaybookid: PAN-OS - Block IP and URL - External Dynamic List
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_EDL_Setup_v3.yml
+++ b/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/Playbooks/playbook-PAN-OS_EDL_Setup_v3.yml
@@ -712,3 +712,8 @@ outputs:
 sourceplaybookid: PAN-OS EDL Setup v2
 tests:
 - PAN-OS EDL Setup v3 Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_PAN_OS_EDL_Management/pack_metadata.json
@@ -19,6 +19,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworks_SecurityAdvisories/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_SecurityAdvisories/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PaloAltoNetworks_Threat_Vault/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_Threat_Vault/pack_metadata.json
@@ -28,6 +28,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
@@ -16,10 +16,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "itemPrefix": [
         "PAN",
         "DLP"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
PAN-OS
PANOSPolicyOptimizer
PANWComprehensiveInvestigation
PATHelpdeskAdvanced
PICUS
PacketMail
Packetsled
PagerDuty
PaloAltoNetworksAIOps
PaloAltoNetworksAutomaticSLR_Community
PaloAltoNetworks_IoT
PaloAltoNetworks_IoT3rdParty
PaloAltoNetworks_PAN_OS_EDL_Management
PaloAltoNetworks_SecurityAdvisories
PaloAltoNetworks_Threat_Vault
Palo_Alto_Networks_Enterprise_DLP
Palo_Alto_Networks_WildFire
```