### PR TITLE
Adopt 'platform' MP to content packs #25

### DIFF
--- a/Packs/PassiveTotal/pack_metadata.json
+++ b/Packs/PassiveTotal/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PasswordResetViaChatbot/pack_metadata.json
+++ b/Packs/PasswordResetViaChatbot/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PcapAnalysis/pack_metadata.json
+++ b/Packs/PcapAnalysis/pack_metadata.json
@@ -208,6 +208,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Pcysys/pack_metadata.json
+++ b/Packs/Pcysys/pack_metadata.json
@@ -17,6 +17,13 @@
     "authorImage": "content/Packs/Pcysys/Integrations/Pcysys/Pcysys_image.png",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PenfieldAI/pack_metadata.json
+++ b/Packs/PenfieldAI/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PerceptionPoint/pack_metadata.json
+++ b/Packs/PerceptionPoint/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Perch/pack_metadata.json
+++ b/Packs/Perch/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PerimeterX/pack_metadata.json
+++ b/Packs/PerimeterX/pack_metadata.json
@@ -16,6 +16,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PhishAI/pack_metadata.json
+++ b/Packs/PhishAI/pack_metadata.json
@@ -20,6 +20,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PhishLabs/pack_metadata.json
+++ b/Packs/PhishLabs/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "PhishLabs IOC"
+    "defaultDataSource": "PhishLabs IOC",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/PhishTank/pack_metadata.json
+++ b/Packs/PhishTank/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PhishUp/IncidentTypes/incidenttype-PhishUp.json
+++ b/Packs/PhishUp/IncidentTypes/incidenttype-PhishUp.json
@@ -709,6 +709,7 @@
     "fromVersion": "6.0.0",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ]
 }

--- a/Packs/PhishUp/Playbooks/PhishUp_Mail_Scanner.yml
+++ b/Packs/PhishUp/Playbooks/PhishUp_Mail_Scanner.yml
@@ -805,5 +805,6 @@ tests:
 - No tests (auto formatted)
 fromversion: 6.0.0
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform

--- a/Packs/PhishUp/pack_metadata.json
+++ b/Packs/PhishUp/pack_metadata.json
@@ -40,6 +40,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Phishing/Layouts/layoutscontainer-Phishing_Layout_XSIAM.json
+++ b/Packs/Phishing/Layouts/layoutscontainer-Phishing_Layout_XSIAM.json
@@ -911,7 +911,8 @@
     "system": false,
     "version": -1,
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "fromVersion": "6.10.0"
 }

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -236,6 +236,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PhishingAlerts/pack_metadata.json
+++ b/Packs/PhishingAlerts/pack_metadata.json
@@ -21,6 +21,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PiHole/pack_metadata.json
+++ b/Packs/PiHole/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PicusAutomation/pack_metadata.json
+++ b/Packs/PicusAutomation/pack_metadata.json
@@ -27,6 +27,13 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PicusNGAutomation/pack_metadata.json
+++ b/Packs/PicusNGAutomation/pack_metadata.json
@@ -16,7 +16,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/PingCastle/pack_metadata.json
+++ b/Packs/PingCastle/pack_metadata.json
@@ -19,6 +19,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PingIdentity/pack_metadata.json
+++ b/Packs/PingIdentity/pack_metadata.json
@@ -40,7 +40,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/PingIdentity/pack_metadata.json
+++ b/Packs/PingIdentity/pack_metadata.json
@@ -36,6 +36,17 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Pipl/pack_metadata.json
+++ b/Packs/Pipl/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PolarSecurity/pack_metadata.json
+++ b/Packs/PolarSecurity/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "macoirc"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PolySwarm/pack_metadata.json
+++ b/Packs/PolySwarm/pack_metadata.json
@@ -22,6 +22,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Polygon/pack_metadata.json
+++ b/Packs/Polygon/pack_metadata.json
@@ -21,6 +21,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PopularCybersecurityNews/pack_metadata.json
+++ b/Packs/PopularCybersecurityNews/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PortScan/pack_metadata.json
+++ b/Packs/PortScan/pack_metadata.json
@@ -65,6 +65,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Portnox/pack_metadata.json
+++ b/Packs/Portnox/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PostmarkSpamcheck/pack_metadata.json
+++ b/Packs/PostmarkSpamcheck/pack_metadata.json
@@ -14,12 +14,19 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "soar-engineering@nviso.eu"
     ],
     "githubUser": [
         "wstinkens"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PowershellPayloadResponse/pack_metadata.json
+++ b/Packs/PowershellPayloadResponse/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PowershellRemoting/pack_metadata.json
+++ b/Packs/PowershellRemoting/pack_metadata.json
@@ -22,6 +22,13 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Preempt/pack_metadata.json
+++ b/Packs/Preempt/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_-_Connection_Health_Check.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_-_Connection_Health_Check.yml
@@ -349,3 +349,8 @@ outputs: []
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_-__Logout_User.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_-__Logout_User.yml
@@ -151,3 +151,8 @@ outputs: []
 fromversion: 5.0.0
 tests:
 - No tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_Whitelist_Egress_IPs_on_SaaS_Services.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_Access_Whitelist_Egress_IPs_on_SaaS_Services.yml
@@ -486,3 +486,8 @@ outputs: []
 fromversion: 5.5.0
 tests:
 - No tests
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Add_IPs_to_Static_Address_Group.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Add_IPs_to_Static_Address_Group.yml
@@ -587,3 +587,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Block_IP.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Block_IP.yml
@@ -728,3 +728,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Block_URL.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Block_URL.yml
@@ -737,3 +737,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_Address_Object.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_Address_Object.yml
@@ -496,3 +496,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_a_security_pre-rule_for_EDL.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_a_security_pre-rule_for_EDL.yml
@@ -634,3 +634,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_or_Edit_EDL_object.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_or_Edit_EDL_object.yml
@@ -652,3 +652,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_or_Edit_Security_Policy_Rule.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Create_or_Edit_Security_Policy_Rule.yml
@@ -767,3 +767,8 @@ outputs:
 tests:
 - No tests (auto formatted)
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Quarantine_Host_With_Active_Threat.yml
+++ b/Packs/PrismaAccess/Playbooks/playbook-Prisma_SASE_-_Quarantine_Host_With_Active_Threat.yml
@@ -426,3 +426,8 @@ outputs: []
 tests:
 - No tests (auto formatted)
 fromversion: 6.10.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/PrismaAccess/pack_metadata.json
+++ b/Packs/PrismaAccess/pack_metadata.json
@@ -30,7 +30,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/PrismaAccess/pack_metadata.json
+++ b/Packs/PrismaAccess/pack_metadata.json
@@ -26,6 +26,17 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PrismaCloud/Layouts/layoutscontainer-Prisma_Cloud_-_Network_Incident_Layout.json
+++ b/Packs/PrismaCloud/Layouts/layoutscontainer-Prisma_Cloud_-_Network_Incident_Layout.json
@@ -843,7 +843,10 @@
     "name": "Prisma Cloud - Network API and Anomaly Incident Layout",
     "system": false,
     "version": -1,
-    "marketplaces": ["marketplacev2"],
+    "marketplaces": [
+        "marketplacev2",
+        "platform"
+    ],
     "fromVersion": "6.10.0",
     "description": ""
 }

--- a/Packs/PrismaCloud/Layouts/layoutscontainer-Prisma_Cloud_V2.json
+++ b/Packs/PrismaCloud/Layouts/layoutscontainer-Prisma_Cloud_V2.json
@@ -564,7 +564,8 @@
         ]
     },
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "group": "incident",
     "id": "Prisma Cloud V2",

--- a/Packs/PrismaCloud/Playbooks/playbook-Prisma_Cloud_-_Network__API_and_Anomaly_Incidents.yml
+++ b/Packs/PrismaCloud/Playbooks/playbook-Prisma_Cloud_-_Network__API_and_Anomaly_Incidents.yml
@@ -1942,5 +1942,5 @@ outputSections:
 outputs: []
 tests:
 - No tests (auto formatted)
-marketplaces: ["marketplacev2"]
+marketplaces: ["marketplacev2", "platform"]
 fromversion: 6.10.0

--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -82,7 +82,14 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
-    "hybrid": true
+    "hybrid": true,
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
PassiveTotal
PasswordResetViaChatbot
PcapAnalysis
Pcysys
PenfieldAI
PerceptionPoint
Perch
PerimeterX
PhishAI
PhishLabs
PhishTank
PhishUp
Phishing
PhishingAlerts
PiHole
PicusAutomation
PicusNGAutomation
PingCastle
PingIdentity
Pipl
PolarSecurity
PolySwarm
Polygon
PopularCybersecurityNews
PortScan
Portnox
PostmarkSpamcheck
PowershellPayloadResponse
PowershellRemoting
Preempt
PrismaAccess
PrismaCloud
```