### PR TITLE
Adopt 'platform' MP to content packs #26

### DIFF
--- a/Packs/PrismaCloudCompute/Layouts/layoutscontainer-Prisma_Cloud_Compute_Audit_Layout_v3_XSIAM.json
+++ b/Packs/PrismaCloudCompute/Layouts/layoutscontainer-Prisma_Cloud_Compute_Audit_Layout_v3_XSIAM.json
@@ -937,5 +937,8 @@
     "version": -1,
     "fromVersion": "6.10.0",
     "description": "",
-    "marketplaces": ["marketplacev2"]
+    "marketplaces": [
+        "marketplacev2",
+        "platform"
+    ]
 }

--- a/Packs/PrismaCloudCompute/Layouts/layoutscontainer-Prisma_Cloud_Compute_Compliance_v2_XSIAM.json
+++ b/Packs/PrismaCloudCompute/Layouts/layoutscontainer-Prisma_Cloud_Compute_Compliance_v2_XSIAM.json
@@ -903,7 +903,8 @@
     "system": false,
     "version": -1,
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "fromVersion": "6.10.0",
     "description": ""

--- a/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Container_Enrichment_Loop_XSOAR8_XSIAM.yml
+++ b/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Container_Enrichment_Loop_XSOAR8_XSIAM.yml
@@ -786,3 +786,4 @@ fromversion: 8.0.0
 marketplaces:
 - xsoar_saas
 - marketplacev2
+- platform

--- a/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Host_Enrichment_Loop_XSOAR8_XSIAM.yml
+++ b/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Host_Enrichment_Loop_XSOAR8_XSIAM.yml
@@ -814,3 +814,4 @@ fromversion: 8.0.0
 marketplaces:
 - xsoar_saas
 - marketplacev2
+- platform

--- a/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Image_Enrichment_Loop_XSOAR8_XSIAM.yml
+++ b/Packs/PrismaCloudCompute/Playbooks/Prisma_Cloud_Compute_-_Compliance_Alert_Image_Enrichment_Loop_XSOAR8_XSIAM.yml
@@ -830,3 +830,4 @@ fromversion: 8.0.0
 marketplaces:
 - xsoar_saas
 - marketplacev2
+- platform

--- a/Packs/PrismaCloudCompute/pack_metadata.json
+++ b/Packs/PrismaCloudCompute/pack_metadata.json
@@ -30,6 +30,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PrismaSaasSecurity/Integrations/SaasSecurityEventCollector/SaasSecurityEventCollector.yml
+++ b/Packs/PrismaSaasSecurity/Integrations/SaasSecurityEventCollector/SaasSecurityEventCollector.yml
@@ -162,4 +162,5 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0

--- a/Packs/PrismaSaasSecurity/pack_metadata.json
+++ b/Packs/PrismaSaasSecurity/pack_metadata.json
@@ -20,7 +20,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "SaaS Security Event Collector"
+    "defaultDataSource": "SaaS Security Event Collector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ProofpointCasb/pack_metadata.json
+++ b/Packs/ProofpointCasb/pack_metadata.json
@@ -20,6 +20,13 @@
         "cloud security"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.yml
+++ b/Packs/ProofpointEmailSecurity/Integrations/ProofpointEmailSecurityEventCollector/ProofpointEmailSecurityEventCollector.yml
@@ -55,6 +55,7 @@ script:
   subtype: python3
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.9.0
 tests:
 - No tests

--- a/Packs/ProofpointEmailSecurity/pack_metadata.json
+++ b/Packs/ProofpointEmailSecurity/pack_metadata.json
@@ -20,6 +20,13 @@
         "PoD"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointIsolation/Integrations/ProofpointIsolationEventCollector/ProofpointIsolationEventCollector.yml
+++ b/Packs/ProofpointIsolation/Integrations/ProofpointIsolationEventCollector/ProofpointIsolationEventCollector.yml
@@ -75,5 +75,6 @@ script:
 fromversion: 6.10.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/ProofpointIsolation/pack_metadata.json
+++ b/Packs/ProofpointIsolation/pack_metadata.json
@@ -17,6 +17,13 @@
         "RBI"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointObserveIT/pack_metadata.json
+++ b/Packs/ProofpointObserveIT/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointServerProtection/pack_metadata.json
+++ b/Packs/ProofpointServerProtection/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointTAP/pack_metadata.json
+++ b/Packs/ProofpointTAP/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointThreatProtection/pack_metadata.json
+++ b/Packs/ProofpointThreatProtection/pack_metadata.json
@@ -18,9 +18,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "randomizerxd"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponseEventCollector/ProofpointThreatResponseEventCollector.yml
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponseEventCollector/ProofpointThreatResponseEventCollector.yml
@@ -136,6 +136,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "ProofpointThreatResponseEventCollector"
+    "defaultDataSource": "ProofpointThreatResponseEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ProtectWise/pack_metadata.json
+++ b/Packs/ProtectWise/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/PublishList/pack_metadata.json
+++ b/Packs/PublishList/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Pulsedive/pack_metadata.json
+++ b/Packs/Pulsedive/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Pwned/pack_metadata.json
+++ b/Packs/Pwned/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QRCodeReader/pack_metadata.json
+++ b/Packs/QRCodeReader/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QRadar/Playbooks/playbook-Access_Investigation_-_QRadar.yml
+++ b/Packs/QRadar/Playbooks/playbook-Access_Investigation_-_QRadar.yml
@@ -541,5 +541,10 @@ view: |-
 inputs: []
 outputs: []
 tests:
-  - No test
+- No test
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar-GetOffenseCorrelationsV2.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar-GetOffenseCorrelationsV2.yml
@@ -870,3 +870,8 @@ outputs:
   description: The log's protocol name
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadarCorrelationLog.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadarCorrelationLog.yml
@@ -287,3 +287,8 @@ outputs:
 fromversion: 5.0.0
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadarFullSearch.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadarFullSearch.yml
@@ -456,3 +456,8 @@ deprecated: true
 contentitemexportablefields:
   contentitemfields: {}
 system: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_-_Get_Offense_Logs.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_-_Get_Offense_Logs.yml
@@ -871,3 +871,8 @@ fromversion: 6.0.0
 contentitemexportablefields:
   contentitemfields: {}
 system: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_Build_Query_and_Search.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_Build_Query_and_Search.yml
@@ -482,3 +482,8 @@ tests:
 fromversion: 6.2.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_Generic.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_Generic.yml
@@ -2042,3 +2042,8 @@ outputs: []
 tests:
 - No test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_Get_Hunting_Results.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_Get_Hunting_Results.yml
@@ -795,3 +795,8 @@ outputs:
 tests:
 - no test
 fromversion: 6.2.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_Indicator_Hunting.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_Indicator_Hunting.yml
@@ -3440,3 +3440,8 @@ outputs:
 tests:
 - No test - Deprecated playbook
 deprecated: true
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-QRadar_Indicator_Hunting_V2.yml
+++ b/Packs/QRadar/Playbooks/playbook-QRadar_Indicator_Hunting_V2.yml
@@ -3078,3 +3078,8 @@ tests:
 - QRadar_v3-test
 - QRadar Indicator Hunting Test
 fromversion: 5.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Bad_Hash_Indicators.yml
+++ b/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Bad_Hash_Indicators.yml
@@ -955,3 +955,8 @@ outputs: []
 quiet: true
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Domain_Indicators.yml
+++ b/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Domain_Indicators.yml
@@ -903,3 +903,8 @@ outputs: []
 quiet: true
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_IP_Indicators.yml
+++ b/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_IP_Indicators.yml
@@ -761,3 +761,8 @@ outputs: []
 quiet: true
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Url_Indicators.yml
+++ b/Packs/QRadar/Playbooks/playbook-TIM_-_QRadar_Add_Url_Indicators.yml
@@ -903,3 +903,8 @@ outputs: []
 quiet: true
 tests:
 - No test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -44,7 +44,17 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "QRadar v3"
+    "defaultDataSource": "QRadar v3",
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/QSS/pack_metadata.json
+++ b/Packs/QSS/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Qintel/pack_metadata.json
+++ b/Packs/Qintel/pack_metadata.json
@@ -28,6 +28,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QualysFIM/pack_metadata.json
+++ b/Packs/QualysFIM/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QueryAI/pack_metadata.json
+++ b/Packs/QueryAI/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "QueryAI",
-    "description": "Query.AI is a decentralized data access and analysis technology that simplifies security investigations across disparate platforms without data duplication.",
+    "description": "Query.AI\u00a0is a decentralized data access and analysis technology that simplifies security investigations across disparate platforms without data duplication.",
     "support": "partner",
     "currentVersion": "1.0.13",
     "author": "Query.AI",
@@ -23,6 +23,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QuestKace/pack_metadata.json
+++ b/Packs/QuestKace/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/QutteraWebsiteMalwareScanner/pack_metadata.json
+++ b/Packs/QutteraWebsiteMalwareScanner/pack_metadata.json
@@ -25,6 +25,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RSANetWitnessEndpoint/pack_metadata.json
+++ b/Packs/RSANetWitnessEndpoint/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RSANetWitness_v11_1/pack_metadata.json
+++ b/Packs/RSANetWitness_v11_1/pack_metadata.json
@@ -24,7 +24,14 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "itemPrefix": "RSA"
+    "itemPrefix": "RSA",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/RSASecureID/pack_metadata.json
+++ b/Packs/RSASecureID/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RSS/pack_metadata.json
+++ b/Packs/RSS/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RSTCloud/pack_metadata.json
+++ b/Packs/RSTCloud/pack_metadata.json
@@ -45,6 +45,13 @@
     "displayedImages": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
PrismaCloudCompute
PrismaSaasSecurity
ProofpointCasb
ProofpointEmailSecurity
ProofpointIsolation
ProofpointObserveIT
ProofpointServerProtection
ProofpointTAP
ProofpointThreatProtection
ProofpointThreatResponse
ProtectWise
PublishList
Pulsedive
Pwned
QRCodeReader
QRadar
QSS
Qintel
QualysFIM
QueryAI
QuestKace
QutteraWebsiteMalwareScanner
RSANetWitnessEndpoint
RSANetWitness_v11_1
RSASecureID
RSS
RSTCloud
```