### PR TITLE
Adopt 'platform' MP to content packs #27

### DIFF
--- a/Packs/RTIR/pack_metadata.json
+++ b/Packs/RTIR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RadwareCloudServices/pack_metadata.json
+++ b/Packs/RadwareCloudServices/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Radware Cloud Services",
-    "description": "Radware’s Cloud Security Services provides a range of fully managed, enterprise-grade cloud WAF and DDoS solutions to create a robust security network",
+    "description": "Radware\u2019s Cloud Security Services provides a range of fully managed, enterprise-grade cloud WAF and DDoS solutions to create a robust security network",
     "support": "xsoar",
     "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
@@ -11,8 +11,21 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["Radware", "WAF", "DDoS", "WAAP", "AppWall"],
+    "keywords": [
+        "Radware",
+        "WAF",
+        "DDoS",
+        "WAAP",
+        "AppWall"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RadwareCloudServices/pack_metadata.json
+++ b/Packs/RadwareCloudServices/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Radware Cloud Services",
-    "description": "Radware\u2019s Cloud Security Services provides a range of fully managed, enterprise-grade cloud WAF and DDoS solutions to create a robust security network",
+    "description": "Radware’s Cloud Security Services provides a range of fully managed, enterprise-grade cloud WAF and DDoS solutions to create a robust security network",
     "support": "xsoar",
     "currentVersion": "1.0.1",
     "author": "Cortex XSOAR",
@@ -11,13 +11,7 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [
-        "Radware",
-        "WAF",
-        "DDoS",
-        "WAAP",
-        "AppWall"
-    ],
+    "keywords": ["Radware", "WAF", "DDoS", "WAAP", "AppWall"],
     "marketplaces": [
         "marketplacev2",
         "platform"

--- a/Packs/Ransomware/pack_metadata.json
+++ b/Packs/Ransomware/pack_metadata.json
@@ -57,6 +57,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Rapid7AppSec/pack_metadata.json
+++ b/Packs/Rapid7AppSec/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Rapid7InsightVMCloud/pack_metadata.json
+++ b/Packs/Rapid7InsightVMCloud/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "thimanshu474"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Rapid7_InsightIDR/pack_metadata.json
+++ b/Packs/Rapid7_InsightIDR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Rapid7_Nexpose/pack_metadata.json
+++ b/Packs/Rapid7_Nexpose/pack_metadata.json
@@ -24,6 +24,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Reco/pack_metadata.json
+++ b/Packs/Reco/pack_metadata.json
@@ -28,7 +28,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "tags": []
+    "tags": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/RecordedFuture/Integrations/RecordedFutureEventCollector/RecordedFutureEventCollector.yml
+++ b/Packs/RecordedFuture/Integrations/RecordedFutureEventCollector/RecordedFutureEventCollector.yml
@@ -62,6 +62,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/RecordedFuture/pack_metadata.json
+++ b/Packs/RecordedFuture/pack_metadata.json
@@ -40,7 +40,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "RecordedFutureEventCollector"
+    "defaultDataSource": "RecordedFutureEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/RecordedFutureASI/pack_metadata.json
+++ b/Packs/RecordedFutureASI/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Recorded_Future/pack_metadata.json
+++ b/Packs/Recorded_Future/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Redmine/pack_metadata.json
+++ b/Packs/Redmine/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Remedy-On-Demand/pack_metadata.json
+++ b/Packs/Remedy-On-Demand/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Remedy_AR/pack_metadata.json
+++ b/Packs/Remedy_AR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RemoteAccess/pack_metadata.json
+++ b/Packs/RemoteAccess/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Resecurity/pack_metadata.json
+++ b/Packs/Resecurity/pack_metadata.json
@@ -18,7 +18,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Respond/pack_metadata.json
+++ b/Packs/Respond/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RetarusSecureEmailGateway/Integrations/RetarusSecureEmailGateway/RetarusSecureEmailGateway.yml
+++ b/Packs/RetarusSecureEmailGateway/Integrations/RetarusSecureEmailGateway/RetarusSecureEmailGateway.yml
@@ -56,6 +56,7 @@ script:
   longRunning: true
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.9.0
 tests:
 - No tests

--- a/Packs/RetarusSecureEmailGateway/pack_metadata.json
+++ b/Packs/RetarusSecureEmailGateway/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ReversingLabs_A1000/pack_metadata.json
+++ b/Packs/ReversingLabs_A1000/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ReversingLabs_TitaniumScale/pack_metadata.json
+++ b/Packs/ReversingLabs_TitaniumScale/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ReversingLabs_Titanium_Cloud/pack_metadata.json
+++ b/Packs/ReversingLabs_Titanium_Cloud/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RiskIQDigitalFootprint/pack_metadata.json
+++ b/Packs/RiskIQDigitalFootprint/pack_metadata.json
@@ -47,6 +47,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RiskSense/pack_metadata.json
+++ b/Packs/RiskSense/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RoksitDNSSecurity/pack_metadata.json
+++ b/Packs/RoksitDNSSecurity/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "asimsarpkurt"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RsaNetWitnessPacketsAndLogs/pack_metadata.json
+++ b/Packs/RsaNetWitnessPacketsAndLogs/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RsaNetwitnessSecurityAnalytics/pack_metadata.json
+++ b/Packs/RsaNetwitnessSecurityAnalytics/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RubrikPolaris/Scripts/RubrikSetIncidentSeverityUsingWorkLoadRiskLevel/RubrikSetIncidentSeverityUsingWorkLoadRiskLevel.yml
+++ b/Packs/RubrikPolaris/Scripts/RubrikSetIncidentSeverityUsingWorkLoadRiskLevel/RubrikSetIncidentSeverityUsingWorkLoadRiskLevel.yml
@@ -49,5 +49,6 @@ fromversion: 6.5.0
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/RubrikPolaris/Scripts/RubrikSonarSetIncidentSeverityUsingUserRiskLevel/RubrikSonarSetIncidentSeverityUsingUserRiskLevel.yml
+++ b/Packs/RubrikPolaris/Scripts/RubrikSonarSetIncidentSeverityUsingUserRiskLevel/RubrikSonarSetIncidentSeverityUsingUserRiskLevel.yml
@@ -25,3 +25,4 @@ fromversion: 6.5.0
 marketplaces:
 - xsoar
 - marketplacev2
+- platform

--- a/Packs/RubrikPolaris/pack_metadata.json
+++ b/Packs/RubrikPolaris/pack_metadata.json
@@ -27,6 +27,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/RunZero/Integrations/RunZeroEventCollector/RunZeroEventCollector.yml
+++ b/Packs/RunZero/Integrations/RunZeroEventCollector/RunZeroEventCollector.yml
@@ -82,6 +82,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/RunZero/pack_metadata.json
+++ b/Packs/RunZero/pack_metadata.json
@@ -16,6 +16,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Rundeck/pack_metadata.json
+++ b/Packs/Rundeck/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SANS/pack_metadata.json
+++ b/Packs/SANS/pack_metadata.json
@@ -61,6 +61,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SAP_IAM/pack_metadata.json
+++ b/Packs/SAP_IAM/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SCADAfence_CNM/pack_metadata.json
+++ b/Packs/SCADAfence_CNM/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SEKOIAIntelligenceCenter/pack_metadata.json
+++ b/Packs/SEKOIAIntelligenceCenter/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "team-integration@sekoia.io"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SMB/pack_metadata.json
+++ b/Packs/SMB/pack_metadata.json
@@ -15,6 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SMIME_Messaging/pack_metadata.json
+++ b/Packs/SMIME_Messaging/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SNDBOX/pack_metadata.json
+++ b/Packs/SNDBOX/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SOCRadar/pack_metadata.json
+++ b/Packs/SOCRadar/pack_metadata.json
@@ -43,6 +43,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SSLCertificates/pack_metadata.json
+++ b/Packs/SSLCertificates/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "TerminalFin"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SSLLabs/pack_metadata.json
+++ b/Packs/SSLLabs/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "edibleShell"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SafeBreach/pack_metadata.json
+++ b/Packs/SafeBreach/pack_metadata.json
@@ -25,6 +25,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SafeNet_Trusted_Access/Integrations/SafeNetTrustedAccessEventCollector/SafeNetTrustedAccessEventCollector.yml
+++ b/Packs/SafeNet_Trusted_Access/Integrations/SafeNetTrustedAccessEventCollector/SafeNetTrustedAccessEventCollector.yml
@@ -78,6 +78,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/SafeNet_Trusted_Access/pack_metadata.json
+++ b/Packs/SafeNet_Trusted_Access/pack_metadata.json
@@ -29,6 +29,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Safewalk/pack_metadata.json
+++ b/Packs/Safewalk/pack_metadata.json
@@ -14,7 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "SafewalkManagement"
+    "defaultDataSource": "SafewalkManagement",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
RTIR
RadwareCloudServices
Ransomware
Rapid7AppSec
Rapid7InsightVMCloud
Rapid7_InsightIDR
Rapid7_Nexpose
Reco
RecordedFuture
RecordedFutureASI
Recorded_Future
RedCanary
Redmine
Remedy-On-Demand
Remedy_AR
RemoteAccess
Resecurity
Respond
RetarusSecureEmailGateway
ReversingLabs_A1000
ReversingLabs_TitaniumScale
ReversingLabs_Titanium_Cloud
RiskIQDigitalFootprint
RiskSense
RoksitDNSSecurity
RsaNetWitnessPacketsAndLogs
RsaNetwitnessSecurityAnalytics
RubrikPolaris
RunZero
Rundeck
SANS
SAP_IAM
SCADAfence_CNM
SEKOIAIntelligenceCenter
SMB
SMIME_Messaging
SNDBOX
SOCRadar
SSLCertificates
SSLLabs
SafeBreach
SafeNet_Trusted_Access
Safewalk
```