### PR TITLE
Adopt 'platform' MP to content packs #28

### DIFF
--- a/Packs/SailPointIdentityIQ/Playbooks/SailPoint_IdentityIQ_Disable_User_Account_Access.yml
+++ b/Packs/SailPointIdentityIQ/Playbooks/SailPoint_IdentityIQ_Disable_User_Account_Access.yml
@@ -1,7 +1,8 @@
 id: SailPoint IdentityIQ Disable User Account Access
 version: -1
 name: SailPoint IdentityIQ Disable User Account Access
-description: "Checks if the risk score of an identity exceeds a set threshold of 500 and disables the accounts."
+description: "Checks if the risk score of an identity exceeds a set threshold of 500\
+  \ and disables the accounts."
 starttaskid: "0"
 tasks:
   "0":
@@ -39,7 +40,8 @@ tasks:
       id: d619c184-12aa-405c-877f-2e97db01875d
       version: -1
       name: Get Identities By Incident Details Email
-      description: Search identities by search/filter parameters (id, email, risk & active) using IdentityIQ SCIM API's.
+      description: Search identities by search/filter parameters (id, email, risk
+        & active) using IdentityIQ SCIM API's.
       script: '|||identityiq-search-identities'
       type: regular
       iscommand: true
@@ -74,7 +76,9 @@ tasks:
       id: 31a79536-3538-4fcd-8692-9e344ccee781
       version: -1
       name: Get Account
-      description: Fetch accounts by search/filter parameters (id, display_name, last_refresh, native_identity, last_target_agg, identity_name & application_name) using IdentityIQ SCIM API's.
+      description: Fetch accounts by search/filter parameters (id, display_name, last_refresh,
+        native_identity, last_target_agg, identity_name & application_name) using
+        IdentityIQ SCIM API's.
       script: '|||identityiq-get-accounts'
       type: regular
       iscommand: true

--- a/Packs/SailPointIdentityIQ/Playbooks/SailPoint_IdentityIQ_Disable_User_Account_Access.yml
+++ b/Packs/SailPointIdentityIQ/Playbooks/SailPoint_IdentityIQ_Disable_User_Account_Access.yml
@@ -1,8 +1,7 @@
 id: SailPoint IdentityIQ Disable User Account Access
 version: -1
 name: SailPoint IdentityIQ Disable User Account Access
-description: "Checks if the risk score of an identity exceeds a set threshold of 500\
-  \ and disables the accounts."
+description: "Checks if the risk score of an identity exceeds a set threshold of 500 and disables the accounts."
 starttaskid: "0"
 tasks:
   "0":
@@ -40,8 +39,7 @@ tasks:
       id: d619c184-12aa-405c-877f-2e97db01875d
       version: -1
       name: Get Identities By Incident Details Email
-      description: Search identities by search/filter parameters (id, email, risk
-        & active) using IdentityIQ SCIM API's.
+      description: Search identities by search/filter parameters (id, email, risk & active) using IdentityIQ SCIM API's.
       script: '|||identityiq-search-identities'
       type: regular
       iscommand: true
@@ -76,9 +74,7 @@ tasks:
       id: 31a79536-3538-4fcd-8692-9e344ccee781
       version: -1
       name: Get Account
-      description: Fetch accounts by search/filter parameters (id, display_name, last_refresh,
-        native_identity, last_target_agg, identity_name & application_name) using
-        IdentityIQ SCIM API's.
+      description: Fetch accounts by search/filter parameters (id, display_name, last_refresh, native_identity, last_target_agg, identity_name & application_name) using IdentityIQ SCIM API's.
       script: '|||identityiq-get-accounts'
       type: regular
       iscommand: true
@@ -632,3 +628,8 @@ outputs: []
 fromversion: 6.0.0
 tests:
 - SailPointIdentityIQ-Test
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/SailPointIdentityIQ/pack_metadata.json
+++ b/Packs/SailPointIdentityIQ/pack_metadata.json
@@ -34,6 +34,15 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SailPointIdentityIQ/pack_metadata.json
+++ b/Packs/SailPointIdentityIQ/pack_metadata.json
@@ -38,7 +38,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "X1",
         "X3",

--- a/Packs/SailPointIdentityNow/Integrations/SailPointIdentityNowEventCollector/SailPointIdentityNowEventCollector.yml
+++ b/Packs/SailPointIdentityNow/Integrations/SailPointIdentityNowEventCollector/SailPointIdentityNowEventCollector.yml
@@ -69,6 +69,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/SailPointIdentityNow/pack_metadata.json
+++ b/Packs/SailPointIdentityNow/pack_metadata.json
@@ -42,7 +42,6 @@
         "platform"
     ],
     "supportedModules": [
-        "identity_threat",
         "C1",
         "X1",
         "X3",

--- a/Packs/SailPointIdentityNow/pack_metadata.json
+++ b/Packs/SailPointIdentityNow/pack_metadata.json
@@ -38,6 +38,15 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Salesforce/pack_metadata.json
+++ b/Packs/Salesforce/pack_metadata.json
@@ -19,7 +19,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Salesforce"
+    "defaultDataSource": "Salesforce",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SalesforceFusion/pack_metadata.json
+++ b/Packs/SalesforceFusion/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SalesforceIndicators/pack_metadata.json
+++ b/Packs/SalesforceIndicators/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SalesforceV2/pack_metadata.json
+++ b/Packs/SalesforceV2/pack_metadata.json
@@ -14,7 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SandBlastAppliance/pack_metadata.json
+++ b/Packs/SandBlastAppliance/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Sandblast/pack_metadata.json
+++ b/Packs/Sandblast/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ScheduleTaskAndPoll/pack_metadata.json
+++ b/Packs/ScheduleTaskAndPoll/pack_metadata.json
@@ -7,7 +7,9 @@
     "url": "",
     "email": "",
     "created": "2021-11-12T15:19:27Z",
-    "categories": ["Utilities"],
+    "categories": [
+        "Utilities"
+    ],
     "tags": [],
     "useCases": [],
     "keywords": [],
@@ -16,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ScreenshotMachine/pack_metadata.json
+++ b/Packs/ScreenshotMachine/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecBI/pack_metadata.json
+++ b/Packs/SecBI/pack_metadata.json
@@ -19,6 +19,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecneurXAnalysis/pack_metadata.json
+++ b/Packs/SecneurXAnalysis/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecneurXThreatFeeds/pack_metadata.json
+++ b/Packs/SecneurXThreatFeeds/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecureAuthIdentityPlatform/pack_metadata.json
+++ b/Packs/SecureAuthIdentityPlatform/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "SecureAuth Identity Platform",
-    "description": "The SecureAuth® Identity Platform is a flexible and adaptable identity and access management solution that helps organizations prevent the misuse of credentials and eliminate identity-related breaches.",
+    "description": "The SecureAuth\u00ae Identity Platform is a flexible and adaptable identity and access management solution that helps organizations prevent the misuse of credentials and eliminate identity-related breaches.",
     "support": "xsoar",
     "currentVersion": "1.0.0",
     "author": "Cortex XSOAR",
@@ -11,8 +11,22 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": ["Secure", "Auth", "SecureAuth", "IDP", "Identity Platform", "Identity"],
+    "keywords": [
+        "Secure",
+        "Auth",
+        "SecureAuth",
+        "IDP",
+        "Identity Platform",
+        "Identity"
+    ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecureAuthIdentityPlatform/pack_metadata.json
+++ b/Packs/SecureAuthIdentityPlatform/pack_metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "SecureAuth Identity Platform",
-    "description": "The SecureAuth\u00ae Identity Platform is a flexible and adaptable identity and access management solution that helps organizations prevent the misuse of credentials and eliminate identity-related breaches.",
+    "description": "The SecureAuth® Identity Platform is a flexible and adaptable identity and access management solution that helps organizations prevent the misuse of credentials and eliminate identity-related breaches.",
     "support": "xsoar",
     "currentVersion": "1.0.0",
     "author": "Cortex XSOAR",
@@ -11,14 +11,7 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [
-        "Secure",
-        "Auth",
-        "SecureAuth",
-        "IDP",
-        "Identity Platform",
-        "Identity"
-    ],
+    "keywords": ["Secure", "Auth", "SecureAuth", "IDP", "Identity Platform", "Identity"],
     "marketplaces": [
         "marketplacev2",
         "platform"

--- a/Packs/SecureWorks/pack_metadata.json
+++ b/Packs/SecureWorks/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Dell Secureworks"
+    "defaultDataSource": "Dell Secureworks",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SecurityAdvisor/pack_metadata.json
+++ b/Packs/SecurityAdvisor/pack_metadata.json
@@ -20,6 +20,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecurityIntelligenceServicesFeed/pack_metadata.json
+++ b/Packs/SecurityIntelligenceServicesFeed/pack_metadata.json
@@ -16,6 +16,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecurityScorecard/pack_metadata.json
+++ b/Packs/SecurityScorecard/pack_metadata.json
@@ -18,9 +18,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "hx0ar"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SecurityTrails/pack_metadata.json
+++ b/Packs/SecurityTrails/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Securonix/pack_metadata.json
+++ b/Packs/Securonix/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SekoiaXDR/pack_metadata.json
+++ b/Packs/SekoiaXDR/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "team-integration@sekoia.io"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SemperisDSP/pack_metadata.json
+++ b/Packs/SemperisDSP/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SendGrid/pack_metadata.json
+++ b/Packs/SendGrid/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOneEventCollector/SentinelOneEventCollector.yml
@@ -79,6 +79,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "SentinelOneEventCollector"
+    "defaultDataSource": "SentinelOneEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Sepio/pack_metadata.json
+++ b/Packs/Sepio/pack_metadata.json
@@ -23,6 +23,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ServiceDeskPlus/pack_metadata.json
+++ b/Packs/ServiceDeskPlus/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ServiceDeskPlus_On_Premise/pack_metadata.json
+++ b/Packs/ServiceDeskPlus_On_Premise/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.yml
@@ -128,7 +128,7 @@ script:
       isArray: false
       defaultValue: ""
     outputs: []
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.8.1983910
   isfetchevents: true
   runonce: false
   script: ''
@@ -137,5 +137,6 @@ script:
 fromversion: 8.4.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests

--- a/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.yml
+++ b/Packs/ServiceNow/Integrations/ServiceNowEventCollector/ServiceNowEventCollector.yml
@@ -128,7 +128,7 @@ script:
       isArray: false
       defaultValue: ""
     outputs: []
-  dockerimage: demisto/python3:3.12.8.1983910
+  dockerimage: demisto/python3:3.11.10.115186
   isfetchevents: true
   runonce: false
   script: ''

--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
@@ -3,13 +3,7 @@ version: -1
 contentitemexportablefields:
   contentitemfields: {}
 name: Create ServiceNow Ticket
-description: "Create ServiceNow Ticket allows you to open new tickets as a task from\
-  \ a parent playbook.\nWhen creating the ticket, you can decide to update based on\
-  \ on the ticket's state, which will wait for the ticket to resolve or close with\
-  \ StatePolling. \nAlternatively, you can select to mirror the ServiceNow ticket\
-  \ and incident fields. To apply either of these options, set the SyncTicket value\
-  \ in the playbook inputs to one of the following options: \n1. StatePolling\n2.\
-  \ Mirror\n3. Leave Blank to use none."
+description: "Create ServiceNow Ticket allows you to open new tickets as a task from a parent playbook.\nWhen creating the ticket, you can decide to update based on on the ticket's state, which will wait for the ticket to resolve or close with StatePolling. \nAlternatively, you can select to mirror the ServiceNow ticket and incident fields. To apply either of these options, set the SyncTicket value in the playbook inputs to one of the following options: \n1. StatePolling\n2. Mirror\n3. Leave Blank to use none."
 starttaskid: "0"
 tasks:
   "0":
@@ -459,8 +453,7 @@ inputs:
 - key: 'Severity '
   value: {}
   required: false
-  description: The severity of the new ticket. Leave empty for ServiceNow default
-    severity.
+  description: The severity of the new ticket. Leave empty for ServiceNow default severity.
   playbookInputQuery:
 - key: Comment
   value: {}
@@ -471,13 +464,7 @@ inputs:
   value:
     simple: Mirror
   required: false
-  description: "The value of the desired sync method with ServiceNow Ticket. You can\
-    \ choose one of the following options:\n1. StatePolling\n2. Mirror \n3. Blank\
-    \ for none \n\nGenericPolling polls for the state of the ticket and runs until\
-    \ the ticket state is either resolved or closed. \n\nMirror - You can use the\
-    \ Mirror option to perform a full sync with the ServiceNow Ticket. The ticket\
-    \ data is synced automatically between ServiceNow and Cortex XSOAR with the ServiceNow\
-    \ mirror feature.\nIf this option is selected, FieldPolling is true by default."
+  description: "The value of the desired sync method with ServiceNow Ticket. You can choose one of the following options:\n1. StatePolling\n2. Mirror \n3. Blank for none \n\nGenericPolling polls for the state of the ticket and runs until the ticket state is either resolved or closed. \n\nMirror - You can use the Mirror option to perform a full sync with the ServiceNow Ticket. The ticket data is synced automatically between ServiceNow and Cortex XSOAR with the ServiceNow mirror feature.\nIf this option is selected, FieldPolling is true by default."
   playbookInputQuery:
 - key: PollingInterval
   value: {}
@@ -494,13 +481,7 @@ inputs:
 - key: AdditionalPollingCommandName
   value: {}
   required: false
-  description: "In this use case, additional polling commands are relevant when using\
-    \ StatePolling, and there is more than one ServiceNow instance. It will specify\
-    \ the polling command to use a specific instance to run on. \nIf so, add \"Using\"\
-    \ to the value. \nThe playbook will then take the instance name as the instance\
-    \ to use.\"  the polling command to use a specific instance to run on. \nIf so,\
-    \ please add \"using\" to the value. \nThe playbook will then take the instance\
-    \ name as the instance to use."
+  description: "In this use case, additional polling commands are relevant when using StatePolling, and there is more than one ServiceNow instance. It will specify the polling command to use a specific instance to run on. \nIf so, add \"Using\" to the value. \nThe playbook will then take the instance name as the instance to use.\"  the polling command to use a specific instance to run on. \nIf so, please add \"using\" to the value. \nThe playbook will then take the instance name as the instance to use."
   playbookInputQuery:
 - key: InstanceName
   value:
@@ -513,8 +494,7 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "The mirror direction. It should be one of the following: \n1. In\n\
-    2. Out\n3. Both"
+  description: "The mirror direction. It should be one of the following: \n1. In\n2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorCommentTags
   value:
@@ -533,8 +513,7 @@ inputs:
 - key: TicketType
   value: {}
   required: false
-  description: The ServiceNow ticket type. Options are "incident", "problem", "change_request",
-    "sc_request", "sc_task", or "sc_req_item". Default is "incident".
+  description: The ServiceNow ticket type. Options are "incident", "problem", "change_request", "sc_request", "sc_task", or "sc_req_item". Default is "incident".
   playbookInputQuery:
 outputs:
 - contextPath: ServiceNow.Ticket.ID
@@ -580,3 +559,8 @@ tests:
 - Create ServiceNow Ticket and Mirror Test
 - Create ServiceNow Ticket and State Polling Test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Create_ServiceNow_Ticket.yml
@@ -3,7 +3,13 @@ version: -1
 contentitemexportablefields:
   contentitemfields: {}
 name: Create ServiceNow Ticket
-description: "Create ServiceNow Ticket allows you to open new tickets as a task from a parent playbook.\nWhen creating the ticket, you can decide to update based on on the ticket's state, which will wait for the ticket to resolve or close with StatePolling. \nAlternatively, you can select to mirror the ServiceNow ticket and incident fields. To apply either of these options, set the SyncTicket value in the playbook inputs to one of the following options: \n1. StatePolling\n2. Mirror\n3. Leave Blank to use none."
+description: "Create ServiceNow Ticket allows you to open new tickets as a task from\
+  \ a parent playbook.\nWhen creating the ticket, you can decide to update based on\
+  \ on the ticket's state, which will wait for the ticket to resolve or close with\
+  \ StatePolling. \nAlternatively, you can select to mirror the ServiceNow ticket\
+  \ and incident fields. To apply either of these options, set the SyncTicket value\
+  \ in the playbook inputs to one of the following options: \n1. StatePolling\n2.\
+  \ Mirror\n3. Leave Blank to use none."
 starttaskid: "0"
 tasks:
   "0":
@@ -453,7 +459,8 @@ inputs:
 - key: 'Severity '
   value: {}
   required: false
-  description: The severity of the new ticket. Leave empty for ServiceNow default severity.
+  description: The severity of the new ticket. Leave empty for ServiceNow default
+    severity.
   playbookInputQuery:
 - key: Comment
   value: {}
@@ -464,7 +471,13 @@ inputs:
   value:
     simple: Mirror
   required: false
-  description: "The value of the desired sync method with ServiceNow Ticket. You can choose one of the following options:\n1. StatePolling\n2. Mirror \n3. Blank for none \n\nGenericPolling polls for the state of the ticket and runs until the ticket state is either resolved or closed. \n\nMirror - You can use the Mirror option to perform a full sync with the ServiceNow Ticket. The ticket data is synced automatically between ServiceNow and Cortex XSOAR with the ServiceNow mirror feature.\nIf this option is selected, FieldPolling is true by default."
+  description: "The value of the desired sync method with ServiceNow Ticket. You can\
+    \ choose one of the following options:\n1. StatePolling\n2. Mirror \n3. Blank\
+    \ for none \n\nGenericPolling polls for the state of the ticket and runs until\
+    \ the ticket state is either resolved or closed. \n\nMirror - You can use the\
+    \ Mirror option to perform a full sync with the ServiceNow Ticket. The ticket\
+    \ data is synced automatically between ServiceNow and Cortex XSOAR with the ServiceNow\
+    \ mirror feature.\nIf this option is selected, FieldPolling is true by default."
   playbookInputQuery:
 - key: PollingInterval
   value: {}
@@ -481,7 +494,13 @@ inputs:
 - key: AdditionalPollingCommandName
   value: {}
   required: false
-  description: "In this use case, additional polling commands are relevant when using StatePolling, and there is more than one ServiceNow instance. It will specify the polling command to use a specific instance to run on. \nIf so, add \"Using\" to the value. \nThe playbook will then take the instance name as the instance to use.\"  the polling command to use a specific instance to run on. \nIf so, please add \"using\" to the value. \nThe playbook will then take the instance name as the instance to use."
+  description: "In this use case, additional polling commands are relevant when using\
+    \ StatePolling, and there is more than one ServiceNow instance. It will specify\
+    \ the polling command to use a specific instance to run on. \nIf so, add \"Using\"\
+    \ to the value. \nThe playbook will then take the instance name as the instance\
+    \ to use.\"  the polling command to use a specific instance to run on. \nIf so,\
+    \ please add \"using\" to the value. \nThe playbook will then take the instance\
+    \ name as the instance to use."
   playbookInputQuery:
 - key: InstanceName
   value:
@@ -494,7 +513,8 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "The mirror direction. It should be one of the following: \n1. In\n2. Out\n3. Both"
+  description: "The mirror direction. It should be one of the following: \n1. In\n\
+    2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorCommentTags
   value:
@@ -513,7 +533,8 @@ inputs:
 - key: TicketType
   value: {}
   required: false
-  description: The ServiceNow ticket type. Options are "incident", "problem", "change_request", "sc_request", "sc_task", or "sc_req_item". Default is "incident".
+  description: The ServiceNow ticket type. Options are "incident", "problem", "change_request",
+    "sc_request", "sc_task", or "sc_req_item". Default is "incident".
   playbookInputQuery:
 outputs:
 - contextPath: ServiceNow.Ticket.ID

--- a/Packs/ServiceNow/Playbooks/playbook-Mirror_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Mirror_ServiceNow_Ticket.yml
@@ -506,7 +506,8 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "Set the mirror direction, should be one of the following: \n1. In\n2. Out\n3. Both"
+  description: "Set the mirror direction, should be one of the following: \n1. In\n2. Out\n3.
+    Both"
   playbookInputQuery:
 - key: MirrorCommentTags
   value:

--- a/Packs/ServiceNow/Playbooks/playbook-Mirror_ServiceNow_Ticket.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-Mirror_ServiceNow_Ticket.yml
@@ -506,8 +506,7 @@ inputs:
   value:
     simple: Both
   required: false
-  description: "Set the mirror direction, should be one of the following: \n1. In\n2. Out\n3.
-    Both"
+  description: "Set the mirror direction, should be one of the following: \n1. In\n2. Out\n3. Both"
   playbookInputQuery:
 - key: MirrorCommentTags
   value:
@@ -541,3 +540,8 @@ outputs: []
 tests:
 - Create ServiceNow Ticket and Mirror Test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/ServiceNow/Playbooks/playbook-ServiceNow_-_Ticket_Management.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-ServiceNow_-_Ticket_Management.yml
@@ -843,6 +843,12 @@ outputs:
 tests:
 - No tests (auto formatted)
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/ServiceNow/Playbooks/playbook-ServiceNow_CMDB_Search.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-ServiceNow_CMDB_Search.yml
@@ -582,3 +582,8 @@ tests:
 fromversion: 6.0.0
 contentitemexportablefields:
   contentitemfields: {}
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/ServiceNow/Playbooks/playbook-ServiceNow_Ticket_State_Polling.yml
+++ b/Packs/ServiceNow/Playbooks/playbook-ServiceNow_Ticket_State_Polling.yml
@@ -265,3 +265,8 @@ outputs: []
 tests:
 - Create ServiceNow Ticket and State Polling Test
 fromversion: 6.0.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/ServiceNow/Scripts/ServiceNowTroubleshoot/ServiceNowTroubleshoot.yml
+++ b/Packs/ServiceNow/Scripts/ServiceNowTroubleshoot/ServiceNowTroubleshoot.yml
@@ -19,5 +19,6 @@ fromversion: 6.1.0
 marketplaces:
 - xsoar
 - marketplacev2
-tests: 
+- platform
+tests:
 - No tests

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -29,7 +29,6 @@
     ],
     "defaultDataSource": "ServiceNow v2",
     "supportedModules": [
-        "identity_threat",
         "C1",
         "C3",
         "X0",

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -24,7 +24,18 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
     ],
-    "defaultDataSource": "ServiceNow v2"
+    "defaultDataSource": "ServiceNow v2",
+    "supportedModules": [
+        "identity_threat",
+        "C1",
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ShadowIT/pack_metadata.json
+++ b/Packs/ShadowIT/pack_metadata.json
@@ -35,6 +35,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ShiftLeft/pack_metadata.json
+++ b/Packs/ShiftLeft/pack_metadata.json
@@ -24,6 +24,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ShiftManagement-AssignToNextShift/pack_metadata.json
+++ b/Packs/ShiftManagement-AssignToNextShift/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Shodan/pack_metadata.json
+++ b/Packs/Shodan/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Siemens_SiPass/pack_metadata.json
+++ b/Packs/Siemens_SiPass/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Sigma/pack_metadata.json
+++ b/Packs/Sigma/pack_metadata.json
@@ -16,7 +16,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "FeedMitreAttackv2": {
@@ -51,5 +52,11 @@
             "mandatory": false,
             "display_name": "Elasticsearch"
         }
-    }
+    },
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/SignalSciences/pack_metadata.json
+++ b/Packs/SignalSciences/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Signum/pack_metadata.json
+++ b/Packs/Signum/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "davistonehub"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Silverfort/pack_metadata.json
+++ b/Packs/Silverfort/pack_metadata.json
@@ -21,6 +21,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SimpleAPIProxy/pack_metadata.json
+++ b/Packs/SimpleAPIProxy/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SimpleSFTP/pack_metadata.json
+++ b/Packs/SimpleSFTP/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/SingleConnect/pack_metadata.json
+++ b/Packs/SingleConnect/pack_metadata.json
@@ -14,7 +14,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
SailPointIdentityIQ
SailPointIdentityNow
Salesforce
SalesforceFusion
SalesforceIndicators
SalesforceV2
SandBlastAppliance
Sandblast
ScheduleTaskAndPoll
ScreenshotMachine
SecBI
SecneurXAnalysis
SecneurXThreatFeeds
SecureAuthIdentityPlatform
SecureWorks
SecurityAdvisor
SecurityIntelligenceServicesFeed
SecurityScorecard
SecurityTrails
Securonix
SekoiaXDR
SemperisDSP
SendGrid
SentinelOne
Sepio
ServiceDeskPlus
ServiceDeskPlus_On_Premise
ServiceNow
ShadowIT
ShiftLeft
ShiftManagement-AssignToNextShift
Shodan
Siemens_SiPass
Sigma
SignalSciences
Signum
Silverfort
SimpleAPIProxy
SimpleSFTP
SingleConnect
```