### PR TITLE
Adopt 'platform' MP to content packs #31

### DIFF
--- a/Packs/Troubleshoot/pack_metadata.json
+++ b/Packs/Troubleshoot/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/TruSTAR/pack_metadata.json
+++ b/Packs/TruSTAR/pack_metadata.json
@@ -21,6 +21,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/TrustwaveFusion/pack_metadata.json
+++ b/Packs/TrustwaveFusion/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/TrustwaveSEG/pack_metadata.json
+++ b/Packs/TrustwaveSEG/pack_metadata.json
@@ -25,6 +25,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Tufin/pack_metadata.json
+++ b/Packs/Tufin/pack_metadata.json
@@ -29,6 +29,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Twilio/pack_metadata.json
+++ b/Packs/Twilio/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Twinwave/pack_metadata.json
+++ b/Packs/Twinwave/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Twitter/pack_metadata.json
+++ b/Packs/Twitter/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/TwitterIOCHunter-FullDailyFeed/pack_metadata.json
+++ b/Packs/TwitterIOCHunter-FullDailyFeed/pack_metadata.json
@@ -21,6 +21,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UBIRCH/pack_metadata.json
+++ b/Packs/UBIRCH/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/URLHaus/pack_metadata.json
+++ b/Packs/URLHaus/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/USTA/pack_metadata.json
+++ b/Packs/USTA/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/USTAv4/Integrations/FeedUstaThreatStream/FeedUstaThreatStream.yml
+++ b/Packs/USTAv4/Integrations/FeedUstaThreatStream/FeedUstaThreatStream.yml
@@ -247,5 +247,6 @@ description: This integration fetches indicators from the USTA Threat Stream fee
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/USTAv4/pack_metadata.json
+++ b/Packs/USTAv4/pack_metadata.json
@@ -36,11 +36,18 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "integration@prodaft.com"
     ],
     "githubUser": [],
-    "defaultDataSource": "USTA Account Takeover Prevention"
+    "defaultDataSource": "USTA Account Takeover Prevention",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/UltraMSG/pack_metadata.json
+++ b/Packs/UltraMSG/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "BarHalifa"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UncoverUnknownMalwareUsingSSDeep/pack_metadata.json
+++ b/Packs/UncoverUnknownMalwareUsingSSDeep/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UnifiVideoNVR/pack_metadata.json
+++ b/Packs/UnifiVideoNVR/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UnisysStealth/pack_metadata.json
+++ b/Packs/UnisysStealth/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Unit42Intel/pack_metadata.json
+++ b/Packs/Unit42Intel/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Unit42_Threat_Brief_-_Fighting_Ursa/pack_metadata.json
+++ b/Packs/Unit42_Threat_Brief_-_Fighting_Ursa/pack_metadata.json
@@ -27,6 +27,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UpdateEntriesBySearch/pack_metadata.json
+++ b/Packs/UpdateEntriesBySearch/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Uptycs/pack_metadata.json
+++ b/Packs/Uptycs/pack_metadata.json
@@ -20,6 +20,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/UrlScan/pack_metadata.json
+++ b/Packs/UrlScan/pack_metadata.json
@@ -22,6 +22,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VMRay/pack_metadata.json
+++ b/Packs/VMRay/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VMware/pack_metadata.json
+++ b/Packs/VMware/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VMwareESXi/pack_metadata.json
+++ b/Packs/VMwareESXi/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VMwareVCenter/pack_metadata.json
+++ b/Packs/VMwareVCenter/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VMwareWorkspaceONEUEM/pack_metadata.json
+++ b/Packs/VMwareWorkspaceONEUEM/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VaronisDataSecurityPlatform/pack_metadata.json
+++ b/Packs/VaronisDataSecurityPlatform/pack_metadata.json
@@ -23,7 +23,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "vkorenkov@varonis.com",
@@ -31,5 +32,11 @@
     ],
     "githubUser": [
         "vdobrotskyi-varonis"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VaronisSaaS/pack_metadata.json
+++ b/Packs/VaronisSaaS/pack_metadata.json
@@ -23,7 +23,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "vkorenkov@varonis.com",
@@ -31,5 +32,11 @@
     ],
     "githubUser": [
         "vdobrotskyi-varonis"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Vectra/pack_metadata.json
+++ b/Packs/Vectra/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VectraXDR/Integrations/VectraXDR/VectraXDR.yml
+++ b/Packs/VectraXDR/Integrations/VectraXDR/VectraXDR.yml
@@ -2184,4 +2184,5 @@ tests:
 marketplaces:
 - xsoar
 - marketplacev2
+- platform
 fromversion: 6.8.0

--- a/Packs/VectraXDR/pack_metadata.json
+++ b/Packs/VectraXDR/pack_metadata.json
@@ -37,8 +37,15 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector.yml
+++ b/Packs/Vectra_AI/Integrations/VectraAIEventCollector/VectraAIEventCollector.yml
@@ -60,6 +60,7 @@ script:
   dockerimage: demisto/python3:3.11.10.115186
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.10.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Vectra_AI/pack_metadata.json
+++ b/Packs/Vectra_AI/pack_metadata.json
@@ -25,7 +25,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "name": "Vectra AI",
     "support": "partner",
@@ -46,5 +47,11 @@
             "mandatory": true,
             "display_name": "Common Types"
         }
-    }
+    },
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Veeam/pack_metadata.json
+++ b/Packs/Veeam/pack_metadata.json
@@ -14,8 +14,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "defaultDataSource": "VBR REST API",
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Venafi/pack_metadata.json
+++ b/Packs/Venafi/pack_metadata.json
@@ -16,6 +16,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VerifyIPv4Indicator/pack_metadata.json
+++ b/Packs/VerifyIPv4Indicator/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Verodin/pack_metadata.json
+++ b/Packs/Verodin/pack_metadata.json
@@ -10,11 +10,20 @@
     "categories": [
         "Data Enrichment & Threat Intelligence"
     ],
-    "tags": ["Breach Simulation"],
+    "tags": [
+        "Breach Simulation"
+    ],
     "useCases": [],
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VersaDirector/pack_metadata.json
+++ b/Packs/VersaDirector/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Vertica/pack_metadata.json
+++ b/Packs/Vertica/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Viper/pack_metadata.json
+++ b/Packs/Viper/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VirusTotal-Private_API/pack_metadata.json
+++ b/Packs/VirusTotal-Private_API/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VirusTotal/pack_metadata.json
+++ b/Packs/VirusTotal/pack_metadata.json
@@ -18,6 +18,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/VulnDB/pack_metadata.json
+++ b/Packs/VulnDB/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WALLIXBastion/pack_metadata.json
+++ b/Packs/WALLIXBastion/pack_metadata.json
@@ -28,6 +28,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WatchguardFirebox/pack_metadata.json
+++ b/Packs/WatchguardFirebox/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WebFileRepository/pack_metadata.json
+++ b/Packs/WebFileRepository/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "spearmin10"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WebScraper/pack_metadata.json
+++ b/Packs/WebScraper/pack_metadata.json
@@ -18,6 +18,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WhatIsMyBrowser/pack_metadata.json
+++ b/Packs/WhatIsMyBrowser/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
Troubleshoot
TruSTAR
TrustwaveFusion
TrustwaveSEG
Tufin
Twilio
Twinwave
Twitter
TwitterIOCHunter-FullDailyFeed
UBIRCH
URLHaus
USTA
USTAv4
UltraMSG
UncoverUnknownMalwareUsingSSDeep
UnifiVideoNVR
UnisysStealth
Unit42Intel
Unit42_Threat_Brief_-_Fighting_Ursa
UpdateEntriesBySearch
Uptycs
UrlScan
VMRay
VMware
VMwareESXi
VMwareVCenter
VMwareWorkspaceONEUEM
VaronisDataSecurityPlatform
VaronisSaaS
Vectra
VectraXDR
Vectra_AI
Veeam
Venafi
VerifyIPv4Indicator
Verodin
VersaDirector
Vertica
Viper
VirusTotal
VirusTotal-Private_API
VulnDB
WALLIXBastion
WatchguardFirebox
WebFileRepository
WebScraper
WhatIsMyBrowser
```