### PR TITLE
Adopt 'platform' MP to content packs #32

### DIFF
--- a/Packs/WhisperGateCVE-2021-32648/pack_metadata.json
+++ b/Packs/WhisperGateCVE-2021-32648/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Whois/pack_metadata.json
+++ b/Packs/Whois/pack_metadata.json
@@ -33,6 +33,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WinRM/pack_metadata.json
+++ b/Packs/WinRM/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WindowsDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/WindowsDefenderAdvancedThreatProtection/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WindowsForensics/pack_metadata.json
+++ b/Packs/WindowsForensics/pack_metadata.json
@@ -32,6 +32,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WithSecure/Integrations/WithSecureEventCollector/WithSecureEventCollector.yml
+++ b/Packs/WithSecure/Integrations/WithSecureEventCollector/WithSecureEventCollector.yml
@@ -60,5 +60,6 @@ script:
 fromversion: 6.8.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests

--- a/Packs/WithSecure/pack_metadata.json
+++ b/Packs/WithSecure/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -26,6 +26,13 @@
     "githubUser": "ariel-wiz",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WolkenITSM/pack_metadata.json
+++ b/Packs/WolkenITSM/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/WootCloud/pack_metadata.json
+++ b/Packs/WootCloud/pack_metadata.json
@@ -20,6 +20,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Wordpress/pack_metadata.json
+++ b/Packs/Wordpress/pack_metadata.json
@@ -14,10 +14,17 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "aburt@paloaltonetworks.com"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Workday/Integrations/WorkdayEventCollector/WorkdayEventCollector.yml
+++ b/Packs/Workday/Integrations/WorkdayEventCollector/WorkdayEventCollector.yml
@@ -113,3 +113,4 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform

--- a/Packs/Workday/Integrations/WorkdaySignOnEventCollector/WorkdaySignOnEventCollector.yml
+++ b/Packs/Workday/Integrations/WorkdaySignOnEventCollector/WorkdaySignOnEventCollector.yml
@@ -116,3 +116,4 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform

--- a/Packs/Workday/pack_metadata.json
+++ b/Packs/Workday/pack_metadata.json
@@ -15,7 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Workday Event Collector"
+    "defaultDataSource": "Workday Event Collector",
+    "supportedModules": [
+        "identity_threat",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Workday/pack_metadata.json
+++ b/Packs/Workday/pack_metadata.json
@@ -20,7 +20,6 @@
     ],
     "defaultDataSource": "Workday Event Collector",
     "supportedModules": [
-        "identity_threat",
         "X1",
         "X3",
         "X5",

--- a/Packs/X509Certificate/pack_metadata.json
+++ b/Packs/X509Certificate/pack_metadata.json
@@ -29,6 +29,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XDRBestPracticeAssessment/pack_metadata.json
+++ b/Packs/XDRBestPracticeAssessment/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XForceExchange/pack_metadata.json
+++ b/Packs/XForceExchange/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XMCO/pack_metadata.json
+++ b/Packs/XMCO/pack_metadata.json
@@ -14,7 +14,8 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "factory@xmco.fr",
@@ -22,5 +23,11 @@
     ],
     "githubUser": [
         "pal-xmco"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XMCyber/pack_metadata.json
+++ b/Packs/XMCyber/pack_metadata.json
@@ -22,6 +22,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XMatters/pack_metadata.json
+++ b/Packs/XMatters/pack_metadata.json
@@ -28,6 +28,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XQLDSHelper/pack_metadata.json
+++ b/Packs/XQLDSHelper/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "spearmin10"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_GDPR/pack_metadata.json
+++ b/Packs/XSIAMCompliance_GDPR/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_HIPAA/pack_metadata.json
+++ b/Packs/XSIAMCompliance_HIPAA/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_ISO_27001/pack_metadata.json
+++ b/Packs/XSIAMCompliance_ISO_27001/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_NIST_800_171/pack_metadata.json
+++ b/Packs/XSIAMCompliance_NIST_800_171/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_NIST_800_53/pack_metadata.json
+++ b/Packs/XSIAMCompliance_NIST_800_53/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_NIST_CSF/pack_metadata.json
+++ b/Packs/XSIAMCompliance_NIST_CSF/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_PCI_DSS/pack_metadata.json
+++ b/Packs/XSIAMCompliance_PCI_DSS/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSIAMCompliance_SOX/pack_metadata.json
+++ b/Packs/XSIAMCompliance_SOX/pack_metadata.json
@@ -20,6 +20,13 @@
         "compliance"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSOARContentUpdateNotifications/pack_metadata.json
+++ b/Packs/XSOARContentUpdateNotifications/pack_metadata.json
@@ -22,12 +22,19 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {
         "ContentInstallation": {
             "mandatory": false,
             "display_name": "Content Installation"
         }
-    }
+    },
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/XSOARFileManagement/pack_metadata.json
+++ b/Packs/XSOARFileManagement/pack_metadata.json
@@ -17,9 +17,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "Winultimatum"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSOARLabUpdates/pack_metadata.json
+++ b/Packs/XSOARLabUpdates/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/XSOARStorage/pack_metadata.json
+++ b/Packs/XSOARStorage/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Xsoar_Utils/pack_metadata.json
+++ b/Packs/Xsoar_Utils/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Yara/pack_metadata.json
+++ b/Packs/Yara/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Zabbix/pack_metadata.json
+++ b/Packs/Zabbix/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Zafran/pack_metadata.json
+++ b/Packs/Zafran/pack_metadata.json
@@ -31,7 +31,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "githubUser": []
+    "githubUser": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Zendesk/Playbooks/playbook-Zendesk_-_Ticket_Management.yml
+++ b/Packs/Zendesk/Playbooks/playbook-Zendesk_-_Ticket_Management.yml
@@ -825,6 +825,12 @@ outputs:
 tests:
 - No tests (auto formatted)
 marketplaces:
-  - xsoar
-  - marketplacev2
+- xsoar
+- marketplacev2
+- platform
 fromversion: 6.8.0
+supportedModules:
+- X1
+- X3
+- X5
+- ENT_PLUS

--- a/Packs/Zendesk/pack_metadata.json
+++ b/Packs/Zendesk/pack_metadata.json
@@ -15,6 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "C3",
+        "X0",
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ZeroFox/pack_metadata.json
+++ b/Packs/ZeroFox/pack_metadata.json
@@ -15,8 +15,15 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "dependencies": {},
-    "displayedImages": []
+    "displayedImages": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ZeroNetworksSegment/Integrations/ZeroNetworksSegmentEventCollector/ZeroNetworksSegmentEventCollector.yml
+++ b/Packs/ZeroNetworksSegment/Integrations/ZeroNetworksSegmentEventCollector/ZeroNetworksSegmentEventCollector.yml
@@ -95,3 +95,4 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform

--- a/Packs/ZeroNetworksSegment/pack_metadata.json
+++ b/Packs/ZeroNetworksSegment/pack_metadata.json
@@ -21,6 +21,13 @@
         "zeronetworks"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ZeroTrustAnalyticsPlatform/pack_metadata.json
+++ b/Packs/ZeroTrustAnalyticsPlatform/pack_metadata.json
@@ -43,6 +43,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Zerohack_XDR/pack_metadata.json
+++ b/Packs/Zerohack_XDR/pack_metadata.json
@@ -37,6 +37,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Zimperium/pack_metadata.json
+++ b/Packs/Zimperium/pack_metadata.json
@@ -17,7 +17,14 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "Zimperium v2"
+    "defaultDataSource": "Zimperium v2",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Zoom/Integrations/ZoomEventCollector/ZoomEventCollector.yml
+++ b/Packs/Zoom/Integrations/ZoomEventCollector/ZoomEventCollector.yml
@@ -60,13 +60,14 @@ script:
       defaultValue: 300
     description: Gets events from Zoom.
     name: zoom-get-events
-  dockerimage: demisto/auth-utils:1.0.0.116930
+  dockerimage: demisto/auth-utils:1.0.0.2025089
   isfetchevents: true
   script: '-'
   subtype: python3
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)

--- a/Packs/Zoom/pack_metadata.json
+++ b/Packs/Zoom/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "ZoomEventCollector"
+    "defaultDataSource": "ZoomEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/ZoomMail/pack_metadata.json
+++ b/Packs/ZoomMail/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ZscalerZPA/pack_metadata.json
+++ b/Packs/ZscalerZPA/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
WhisperGateCVE-2021-32648
Whois
WinRM
WindowsDefenderAdvancedThreatProtection
WindowsForensics
WithSecure
Wiz
WolkenITSM
WootCloud
Wordpress
Workday
X509Certificate
XDRBestPracticeAssessment
XForceExchange
XMCO
XMCyber
XMatters
XQLDSHelper
XSIAMCompliance_GDPR
XSIAMCompliance_HIPAA
XSIAMCompliance_ISO_27001
XSIAMCompliance_NIST_800_171
XSIAMCompliance_NIST_800_53
XSIAMCompliance_NIST_CSF
XSIAMCompliance_PCI_DSS
XSIAMCompliance_SOX
XSOARContentUpdateNotifications
XSOARFileManagement
XSOARLabUpdates
XSOARStorage
Xsoar_Utils
Yara
Zabbix
Zafran
Zendesk
ZeroFox
ZeroNetworksSegment
ZeroTrustAnalyticsPlatform
Zerohack_XDR
Zimperium
Zoom
ZoomMail
Zscaler
ZscalerZPA
```