### PR TITLE
Adopt 'platform' MP to content packs #33

### DIFF
--- a/Packs/cisco-ise/pack_metadata.json
+++ b/Packs/cisco-ise/pack_metadata.json
@@ -20,6 +20,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/cisco-meraki/pack_metadata.json
+++ b/Packs/cisco-meraki/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/cyberark_AIM/pack_metadata.json
+++ b/Packs/cyberark_AIM/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/dnstwist/pack_metadata.json
+++ b/Packs/dnstwist/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/epo/pack_metadata.json
+++ b/Packs/epo/pack_metadata.json
@@ -22,6 +22,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/fireeye/pack_metadata.json
+++ b/Packs/fireeye/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/iDefense/pack_metadata.json
+++ b/Packs/iDefense/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/illuminate/pack_metadata.json
+++ b/Packs/illuminate/pack_metadata.json
@@ -16,6 +16,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ipinfo/pack_metadata.json
+++ b/Packs/ipinfo/pack_metadata.json
@@ -17,6 +17,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/isight/pack_metadata.json
+++ b/Packs/isight/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/jamf/pack_metadata.json
+++ b/Packs/jamf/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/knowbe4Phisher/pack_metadata.json
+++ b/Packs/knowbe4Phisher/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/mcafeeDam/pack_metadata.json
+++ b/Packs/mcafeeDam/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/mnemonicMDR/pack_metadata.json
+++ b/Packs/mnemonicMDR/pack_metadata.json
@@ -23,6 +23,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/nessus/pack_metadata.json
+++ b/Packs/nessus/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/opswat-metadefender/pack_metadata.json
+++ b/Packs/opswat-metadefender/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -18,6 +18,13 @@
     "marketplaces": [
         "xsoar",
         "marketplacev2",
-        "xpanse"
+        "xpanse",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -16,6 +16,13 @@
     "dependencies": {},
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/remedy_SR/pack_metadata.json
+++ b/Packs/remedy_SR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/sampleSiem/pack_metadata.json
+++ b/Packs/sampleSiem/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/trendMicroDsm/pack_metadata.json
+++ b/Packs/trendMicroDsm/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CitrixADC
cisco-ise
cisco-meraki
cyberark_AIM
dnstwist
epo
fireeye
iDefense
illuminate
ipinfo
isight
jamf
knowbe4Phisher
mcafeeDam
mnemonicMDR
nessus
opswat-metadefender
qualys
rasterize
remedy_SR
sampleSiem
trendMicroDsm
```