### PR TITLE
Adopt 'platform' MP to content packs #5

### DIFF
--- a/Packs/CarbonBlackDefense/Integrations/CarbonBlackEndpointStandardEventCollector/CarbonBlackEndpointStandardEventCollector.yml
+++ b/Packs/CarbonBlackDefense/Integrations/CarbonBlackEndpointStandardEventCollector/CarbonBlackEndpointStandardEventCollector.yml
@@ -87,4 +87,5 @@ tests:
 - No tests (auto formatted)
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 6.10.0

--- a/Packs/CarbonBlackDefense/pack_metadata.json
+++ b/Packs/CarbonBlackDefense/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "defaultDataSource": "CarbonBlackEndpointStandardEventCollector"
+    "defaultDataSource": "CarbonBlackEndpointStandardEventCollector",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
+++ b/Packs/CarbonBlackEnterpriseEDR/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CarbonBlackProtect/pack_metadata.json
+++ b/Packs/CarbonBlackProtect/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Carbon_Black_Enterprise_Live_Response/pack_metadata.json
+++ b/Packs/Carbon_Black_Enterprise_Live_Response/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Carbon_Black_Enterprise_Response/pack_metadata.json
+++ b/Packs/Carbon_Black_Enterprise_Response/pack_metadata.json
@@ -21,6 +21,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Celonis/Integrations/CelonisEventCollector/CelonisEventCollector.yml
+++ b/Packs/Celonis/Integrations/CelonisEventCollector/CelonisEventCollector.yml
@@ -87,5 +87,6 @@ script:
 fromversion: 6.10.0
 marketplaces:
 - marketplacev2
+- platform
 tests:
 - No tests (auto formatted)

--- a/Packs/Celonis/pack_metadata.json
+++ b/Packs/Celonis/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Censys/pack_metadata.json
+++ b/Packs/Censys/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Centreon/pack_metadata.json
+++ b/Packs/Centreon/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CentrifyVault/pack_metadata.json
+++ b/Packs/CentrifyVault/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CheckPhish/pack_metadata.json
+++ b/Packs/CheckPhish/pack_metadata.json
@@ -18,6 +18,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CheckPointDome9/pack_metadata.json
+++ b/Packs/CheckPointDome9/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CheckPointHEC/pack_metadata.json
+++ b/Packs/CheckPointHEC/pack_metadata.json
@@ -24,7 +24,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "christiang@checkpoint.com"
@@ -33,5 +34,11 @@
         "chkp-christiang"
     ],
     "dependencies": {},
-    "displayedImages": []
+    "displayedImages": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CheckPointHarmonyEndpoint/pack_metadata.json
+++ b/Packs/CheckPointHarmonyEndpoint/pack_metadata.json
@@ -17,6 +17,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CheckPointNDR/pack_metadata.json
+++ b/Packs/CheckPointNDR/pack_metadata.json
@@ -20,7 +20,8 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "devEmail": [
         "maxn@checkpoint.com"
@@ -29,5 +30,11 @@
         "chkp-maxn"
     ],
     "dependencies": {},
-    "displayedImages": []
+    "displayedImages": [],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/CheckPointSandBlast/pack_metadata.json
+++ b/Packs/CheckPointSandBlast/pack_metadata.json
@@ -22,6 +22,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CheckpointFirewall/pack_metadata.json
+++ b/Packs/CheckpointFirewall/pack_metadata.json
@@ -19,6 +19,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Cherwell/pack_metadata.json
+++ b/Packs/Cherwell/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CimTrak-SystemIntegrityAssurance/pack_metadata.json
+++ b/Packs/CimTrak-SystemIntegrityAssurance/pack_metadata.json
@@ -18,6 +18,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CircleCI/pack_metadata.json
+++ b/Packs/CircleCI/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Cisco-umbrella-cloud-security/pack_metadata.json
+++ b/Packs/Cisco-umbrella-cloud-security/pack_metadata.json
@@ -15,7 +15,14 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
-    "certification": "certified"
+    "certification": "certified",
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
+    ]
 }

--- a/Packs/Cisco-umbrella-enforcement/pack_metadata.json
+++ b/Packs/Cisco-umbrella-enforcement/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Cisco-umbrella/pack_metadata.json
+++ b/Packs/Cisco-umbrella/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoAMP/pack_metadata.json
+++ b/Packs/CiscoAMP/pack_metadata.json
@@ -19,6 +19,13 @@
     "deprecated": true,
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoASA/pack_metadata.json
+++ b/Packs/CiscoASA/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoASR/pack_metadata.json
+++ b/Packs/CiscoASR/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoCatalyst/pack_metadata.json
+++ b/Packs/CiscoCatalyst/pack_metadata.json
@@ -16,6 +16,13 @@
         "Aironet"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoESAIronPortEmailAPI/pack_metadata.json
+++ b/Packs/CiscoESAIronPortEmailAPI/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoEmailSecurity/pack_metadata.json
+++ b/Packs/CiscoEmailSecurity/pack_metadata.json
@@ -16,6 +16,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoFirepower/pack_metadata.json
+++ b/Packs/CiscoFirepower/pack_metadata.json
@@ -15,6 +15,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoISR/pack_metadata.json
+++ b/Packs/CiscoISR/pack_metadata.json
@@ -20,6 +20,13 @@
         "integrated service router"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoNexus/pack_metadata.json
+++ b/Packs/CiscoNexus/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoSMA/pack_metadata.json
+++ b/Packs/CiscoSMA/pack_metadata.json
@@ -21,6 +21,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoSpark/Integrations/CiscoWebexEventCollector/CiscoWebexEventCollector.yml
+++ b/Packs/CiscoSpark/Integrations/CiscoWebexEventCollector/CiscoWebexEventCollector.yml
@@ -155,7 +155,7 @@ script:
   script: ''
   subtype: python3
   type: python
-"marketplaces": ["marketplacev2"]
+"marketplaces": ["marketplacev2", "platform"]
 fromversion: 6.12.0
 tests:
 - No tests (auto formatted)

--- a/Packs/CiscoSpark/pack_metadata.json
+++ b/Packs/CiscoSpark/pack_metadata.json
@@ -17,6 +17,13 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoStealthwatch/pack_metadata.json
+++ b/Packs/CiscoStealthwatch/pack_metadata.json
@@ -21,6 +21,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoThousandEyes/Integrations/CiscoThousandEyes/CiscoThousandEyes.yml
+++ b/Packs/CiscoThousandEyes/Integrations/CiscoThousandEyes/CiscoThousandEyes.yml
@@ -76,6 +76,7 @@ script:
   type: python
 marketplaces:
 - marketplacev2
+- platform
 fromversion: 8.4.0
 tests:
 - No tests (auto formatted)

--- a/Packs/CiscoThousandEyes/pack_metadata.json
+++ b/Packs/CiscoThousandEyes/pack_metadata.json
@@ -19,6 +19,13 @@
         "Thousand Eyes"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoUmbrellaReporting/pack_metadata.json
+++ b/Packs/CiscoUmbrellaReporting/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoWSA/pack_metadata.json
+++ b/Packs/CiscoWSA/pack_metadata.json
@@ -15,6 +15,13 @@
     "githubUser": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CiscoWebExFeed/pack_metadata.json
+++ b/Packs/CiscoWebExFeed/pack_metadata.json
@@ -19,6 +19,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Cisco_Wireless_LAN_Controller/pack_metadata.json
+++ b/Packs/Cisco_Wireless_LAN_Controller/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CitrixADC/pack_metadata.json
+++ b/Packs/CitrixADC/pack_metadata.json
@@ -15,6 +15,13 @@
         "NetScaler"
     ],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Clarizen/pack_metadata.json
+++ b/Packs/Clarizen/pack_metadata.json
@@ -14,6 +14,13 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/Claroty/pack_metadata.json
+++ b/Packs/Claroty/pack_metadata.json
@@ -23,6 +23,13 @@
     "certification": "certified",
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ClarotyXDome/pack_metadata.json
+++ b/Packs/ClarotyXDome/pack_metadata.json
@@ -18,9 +18,16 @@
     ],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "tomlandes"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ClearswiftDLP/pack_metadata.json
+++ b/Packs/ClearswiftDLP/pack_metadata.json
@@ -13,6 +13,13 @@
     "useCases": [],
     "keywords": [],
     "marketplaces": [
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/ClickSend/pack_metadata.json
+++ b/Packs/ClickSend/pack_metadata.json
@@ -15,9 +15,16 @@
     "keywords": [],
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
     ],
     "githubUser": [
         "BarHalifa"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }

--- a/Packs/CloakedUrsaPhishingCampaign/pack_metadata.json
+++ b/Packs/CloakedUrsaPhishingCampaign/pack_metadata.json
@@ -28,6 +28,13 @@
     },
     "marketplaces": [
         "xsoar",
-        "marketplacev2"
+        "marketplacev2",
+        "platform"
+    ],
+    "supportedModules": [
+        "X1",
+        "X3",
+        "X5",
+        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION


Related: https://jira-dc.paloaltonetworks.com/browse/CIAC-12864

Updating the following packs before merging to `'platform-content-support-merge-gateway`:  
```
CarbonBlackDefense
CarbonBlackEnterpriseEDR
CarbonBlackProtect
Carbon_Black_Enterprise_Live_Response
Carbon_Black_Enterprise_Response
Celonis
Censys
Centreon
CentrifyVault
CheckPhish
CheckPointDome9
CheckPointHEC
CheckPointHarmonyEndpoint
CheckPointNDR
CheckPointSandBlast
CheckpointFirewall
Cherwell
CimTrak-SystemIntegrityAssurance
CircleCI
Cisco-umbrella
Cisco-umbrella-cloud-security
Cisco-umbrella-enforcement
CiscoAMP
CiscoASA
CiscoASR
CiscoCatalyst
CiscoESAIronPortEmailAPI
CiscoEmailSecurity
CiscoFirepower
CiscoISR
CiscoNexus
CiscoSMA
CiscoSpark
CiscoStealthwatch
CiscoThousandEyes
CiscoUmbrellaReporting
CiscoWSA
CiscoWebExFeed
Cisco_Wireless_LAN_Controller
CitrixADC
Clarizen
Claroty
ClarotyXDome
ClearswiftDLP
ClickSend
CloakedUrsaPhishingCampaign
```