### PR TITLE
MicrosoftTeamsAsk script - Improved docs

### DIFF
--- a/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/README.md
+++ b/Packs/MicrosoftTeams/Scripts/MicrosoftTeamsAsk/README.md
@@ -34,6 +34,7 @@ This script uses the following commands and scripts.
 There are no outputs for this script.
 
 ## Usage
+---
 
 The MicrosoftTeamsAsk script sends a message, such as operation approval or information retrieval, in a question format from Cortex XSOAR to Microsoft Teams. The message must have at least two options. For example, "yes" and "no".
 
@@ -45,3 +46,9 @@ After the question is answered in Microsoft Teams, the response is sent to the C
 If a team member responds "yes" the playbook continues running the "yes" branch.
 
 If a task ID is included in the script, and the task condition is met, the playbook closes as soon as a response is received.
+
+
+## Notes
+---
+
+* `MicrosoftTeamsAsk` will not work when run in the playbook debugger. This is because the debugger does not generate entitlements, since they must be tied to an investigation. Entitlements are needed to track the response.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-47328](https://jira-dc.paloaltonetworks.com/browse/XSUP-47328)

## Description
Added to the readme file a note explaining that the `MicrosoftTeamsAsk`script shouldn't been run from the debugger panel. 
Same reason as - `SlackAskV2` script - [slack-ask-v2](https://xsoar.pan.dev/docs/reference/scripts/slack-ask-v2).

## Must have
- [ ] Tests
- [x] Documentation 
