### PR TITLE
[Trellix_ePO] Remove MP xsoar

### DIFF
--- a/Packs/Trellix_ePO/pack_metadata.json
+++ b/Packs/Trellix_ePO/pack_metadata.json
@@ -20,7 +20,6 @@
         "trellix"
     ],
     "marketplaces": [
-        "xsoar",
         "marketplacev2",
         "platform"
     ],


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
As part of the effort https://github.com/demisto/content/pull/39268, the XSOAR marketplace was accidentally added to `Trellix_ePO`.

## Must have
- [ ] Tests
- [ ] Documentation 
