### PR TITLE
Ms teams ring user in authcode

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -802,12 +802,13 @@ def get_refresh_token_from_auth_code_param() -> str:
     return ""
 
 
-def get_graph_access_token(auth_type: str = AUTH_TYPE) -> str:
+def get_graph_access_token(auth_type: str = '') -> str:
     """
     Retrieves Microsoft Graph API access token, either from cache or from Microsoft
     :param auth_type (str): Authentication type to use (Client credentials / Authorization code)
     :return: The Microsoft Graph API access token
     """
+    auth_type = auth_type or AUTH_TYPE # Default to integration configuration
     integration_context: dict = get_integration_context()
     if 'graph_access_token' in integration_context:
         # Migrate cached tokens to new format to avoid requiring reauthentication of existing instances

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -71,8 +71,7 @@ MISS_CONFIGURATION_ERROR_MESSAGE = (
 
 CLIENT_CREDENTIALS_FLOW = "Client Credentials"
 AUTHORIZATION_CODE_FLOW = "Authorization Code"
-AUTH_TYPE = (PARAMS.get('auth_type', CLIENT_CREDENTIALS_FLOW) if demisto.command() != 'microsoft-teams-ring-user'
-             else CLIENT_CREDENTIALS_FLOW)
+AUTH_TYPE = PARAMS.get("auth_type", CLIENT_CREDENTIALS_FLOW)
 
 AUTH_CODE: str = PARAMS.get("auth_code_creds", {}).get("password")
 REDIRECT_URI: str = PARAMS.get("redirect_uri", "")
@@ -801,29 +800,30 @@ def get_refresh_token_from_auth_code_param() -> str:
     return ""
 
 
-def get_graph_access_token() -> str:
+def get_graph_access_token(auth_type: str = AUTH_TYPE) -> str:
     """
     Retrieves Microsoft Graph API access token, either from cache or from Microsoft
+    :param auth_type (str): Authentication type to use (Client credentials / Authorization code)
     :return: The Microsoft Graph API access token
     """
     integration_context: dict = get_integration_context()
     if 'graph_access_token' in integration_context:
         # Migrate cached tokens to new format to avoid requiring reauthentication of existing instances
-        # This should happen at most once
+        # This should happen at most once, using the global AUTH_TYPE instead of the local argument
         token_params = {
             'graph_access_token': integration_context.pop('graph_access_token', ''),
             'current_refresh_token': integration_context.pop('current_refresh_token', ''),
             'graph_valid_until': integration_context.pop('graph_valid_until', ''),
         }
-        if PARAMS.get('auth_type', CLIENT_CREDENTIALS_FLOW) == CLIENT_CREDENTIALS_FLOW:
+        if AUTH_TYPE == CLIENT_CREDENTIALS_FLOW:
             integration_context['credentials_token_params'] = json.dumps(token_params)
         else:
             integration_context['authcode_token_params'] = json.dumps(token_params)
 
         set_integration_context(integration_context)
 
-    token_params = json.loads(integration_context.get('credentials_token_params', '') if AUTH_TYPE == CLIENT_CREDENTIALS_FLOW
-                              else integration_context.get('authcode_token_params', ''))
+    token_params = json.loads(integration_context.get('credentials_token_params', '{}') if auth_type == CLIENT_CREDENTIALS_FLOW
+                              else integration_context.get('authcode_token_params', '{}'))
 
     refresh_token = token_params.get('current_refresh_token', '')
     access_token: str = token_params.get('graph_access_token', '')
@@ -842,7 +842,7 @@ def get_graph_access_token() -> str:
         "scope": "https://graph.microsoft.com/.default",
         "client_secret": BOT_PASSWORD,
     }
-    if AUTH_TYPE == AUTHORIZATION_CODE_FLOW:
+    if auth_type == AUTHORIZATION_CODE_FLOW:
         if not AUTH_CODE:
             raise ValueError(
                 "No authorization code configured. Please use the !microsoft-teams-generate-login-url command"
@@ -883,7 +883,7 @@ def get_graph_access_token() -> str:
             'graph_access_token': access_token,
             'graph_valid_until': time_now + expires_in,
         }
-        if AUTH_TYPE == AUTHORIZATION_CODE_FLOW:
+        if auth_type == AUTHORIZATION_CODE_FLOW:
             integration_context['authcode_token_params'] = json.dumps(token_params)
         else:
             integration_context['credentials_token_params'] = json.dumps(token_params)
@@ -894,7 +894,8 @@ def get_graph_access_token() -> str:
         raise ValueError("Failed to get Graph access token")
 
 
-def http_request(method: str, url: str = "", json_: dict = None, api: str = "graph", params: dict | None = None) -> dict | list:
+def http_request(method: str, url: str = "", json_: dict = None, api: str = "graph", params: dict | None = None,
+                 auth_type: str = AUTH_TYPE) -> dict | list:
     """A wrapper for requests lib to send our requests and handle requests and responses better
     Headers to be sent in requests
 
@@ -904,11 +905,12 @@ def http_request(method: str, url: str = "", json_: dict = None, api: str = "gra
         json_ (dict): HTTP JSON body
         api (str): API to query (graph/bot)
         params (dict): Object of key-value URL query parameters
+        auth_type (str): Authentication type to use (Client credentials / Authorization code)
 
     Returns:
         Union[dict, list]: The response in list or dict format.
     """
-    access_token = get_graph_access_token() if api == "graph" else get_bot_access_token()  # Bot Framework API
+    access_token = get_graph_access_token(auth_type) if api == "graph" else get_bot_access_token()  # Bot Framework API
 
     headers: dict = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json", "Accept": "application/json"}
     try:
@@ -924,7 +926,7 @@ def http_request(method: str, url: str = "", json_: dict = None, api: str = "gra
 
         if not response.ok:
             error: str = error_parser(response, api)
-            if response.status_code == 403 and (detailed_error_message := insufficient_permissions_error_handler()):
+            if response.status_code == 403 and (detailed_error_message := insufficient_permissions_error_handler(auth_type)):
                 error = f"{detailed_error_message}\n\n(Error Message): {error}"
 
             raise ValueError(f"Error code [{response.status_code}] in API call to Microsoft Teams:\n{error}")
@@ -1182,7 +1184,7 @@ def get_chat_id_and_type(chat: str, create_dm_chat: bool = True) -> tuple[str, s
     return chat_id, chat_type
 
 
-def get_user(user: str) -> list:
+def get_user(user: str, auth_type: str = AUTH_TYPE) -> list:
     """Retrieves the AAD ID of requested user and the userType
 
     Args:
@@ -1197,7 +1199,7 @@ def get_user(user: str) -> list:
         "$filter": f"displayName eq '{user}' or mail eq '{user}' or userPrincipalName eq '{user}'",
         "$select": "id, userType",
     }
-    users = cast(dict[Any, Any], http_request("GET", url, params=params))
+    users = cast(dict[Any, Any], http_request("GET", url, params=params, auth_type=auth_type))
     return users.get("value", [])
 
 
@@ -2803,7 +2805,8 @@ def messages() -> Response:
 
 
 def ring_user_request(call_request_data):
-    return http_request(method="POST", url=f"{GRAPH_BASE_URL}/v1.0/communications/calls", json_=call_request_data)
+    return http_request(method="POST", url=f"{GRAPH_BASE_URL}/v1.0/communications/calls", json_=call_request_data,
+                        auth_type=CLIENT_CREDENTIALS_FLOW)
 
 
 def ring_user():
@@ -2823,7 +2826,7 @@ def ring_user():
         raise ValueError(MISS_CONFIGURATION_ERROR_MESSAGE)
     # get user to call name and id
     username_to_call = demisto.args().get("username")
-    user: list = get_user(username_to_call)
+    user: list = get_user(username_to_call, auth_type=CLIENT_CREDENTIALS_FLOW)
     if not (user and user[0].get("id")):
         raise ValueError(f"User {username_to_call} was not found")
 
@@ -3162,7 +3165,6 @@ def auth_type_switch_handling():
     Handling cases where the user switches the auth type in the integration instance (from the client credentials flow to the
     auth code flow and vice versa), by auto-resetting the Graph API authorization in the integration context.
     """
-    auth_type = PARAMS.get('auth_type', CLIENT_CREDENTIALS_FLOW)
     integration_context = get_integration_context()
     current_auth_type = integration_context.get("current_auth_type", "")
     if current_auth_type:
@@ -3171,22 +3173,22 @@ def auth_type_switch_handling():
         # current_auth_type is not set - First run of the integration instance
         demisto.debug(
             f"This is the first run of the integration instance.\n"
-            f"Setting the current_auth_type in the integration context to {auth_type}."
+            f"Setting the current_auth_type in the integration context to {AUTH_TYPE}."
         )
-        integration_context["current_auth_type"] = auth_type
+        integration_context["current_auth_type"] = AUTH_TYPE
         set_integration_context(integration_context)
-        current_auth_type = auth_type
+        current_auth_type = AUTH_TYPE
 
-    if current_auth_type != auth_type:
+    if current_auth_type != AUTH_TYPE:
         # First run after the user switched the authentication type
         demisto.debug(
-            f"The user switched the instance authentication type from {current_auth_type} to {auth_type}.\n"
+            f"The user switched the instance authentication type from {current_auth_type} to {AUTH_TYPE}.\n"
             f"Resetting the integration context."
         )
         reset_graph_auth()
         integration_context = get_integration_context()
-        demisto.debug(f"Setting the current_auth_type in the integration context to {auth_type}.")
-        integration_context["current_auth_type"] = auth_type
+        demisto.debug(f"Setting the current_auth_type in the integration context to {AUTH_TYPE}.")
+        integration_context["current_auth_type"] = AUTH_TYPE
         set_integration_context(integration_context)
 
 
@@ -3208,12 +3210,13 @@ def expand_permission_list(permissions: list[str]) -> set[str]:
     return expanded_permissions
 
 
-def create_missing_permissions_section(missing_permissions: list[str], permission_type: str) -> str:
+def create_missing_permissions_section(missing_permissions: list[str], permission_type: str, auth_type: str = AUTH_TYPE) -> str:
     """
     Generates a detailed error message for the missing permissions.
 
     :param missing_permissions: List of missing permissions
     :param permission_type: The type of permissions ('Application' or 'Delegated')
+    :param auth_type (str): Authentication type used in the request (Client credentials / Authorization code)
     :return: Error message string
     """
     error_message = f"""\
@@ -3227,7 +3230,7 @@ and grant admin consent.
 Once done, reset your token using the "!microsoft-teams-auth-reset" command.
 """
 
-    if AUTH_TYPE == AUTHORIZATION_CODE_FLOW:
+    if auth_type == AUTHORIZATION_CODE_FLOW:
         error_message += 'Then, generate a new auth code using "!microsoft-teams-generate-login-url".\n'
 
     error_message += (
@@ -3238,19 +3241,20 @@ Once done, reset your token using the "!microsoft-teams-auth-reset" command.
     return error_message
 
 
-def insufficient_permissions_error_handler() -> str:
+def insufficient_permissions_error_handler(auth_type: str = AUTH_TYPE) -> str:
     """
     Retrieve the known permission requirements for the failed command and give a detailed error message
     indicating the missing permissions and how to resolve the issue.
 
+    :param auth_type (str): Authentication type used in the request (Client credentials / Authorization code)
     :return: Error message string with instructions regarding the missing permissions
     """
     command: str = demisto.command()
     error_message = []
-    demisto.debug(f"Authentication type is: {AUTH_TYPE}")
+    demisto.debug(f"Authentication type is: {auth_type}")
     missing_permissions = []
     required_permissions_for_command: list = COMMANDS_REQUIRED_PERMISSIONS.get(command, [])
-    permission_type = "Application" if AUTH_TYPE == CLIENT_CREDENTIALS_FLOW else "Delegated"
+    permission_type = 'Application' if auth_type == CLIENT_CREDENTIALS_FLOW else 'Delegated'
     if not required_permissions_for_command:
         demisto.error(
             "Got an insufficient permissions error from Microsoft Graph. "
@@ -3260,8 +3264,8 @@ def insufficient_permissions_error_handler() -> str:
 
     # Get current token permissions
     integration_context: dict = get_integration_context()
-    token_params = (integration_context.get('credentials_token_params', {}) if AUTH_TYPE == CLIENT_CREDENTIALS_FLOW
-                    else integration_context.get('authcode_token_params', {}))
+    token_params = json.loads(integration_context.get('credentials_token_params', '{}') if auth_type == CLIENT_CREDENTIALS_FLOW
+                              else integration_context.get('authcode_token_params', '{}'))
     graph_access_token: str = token_params.get('graph_access_token', '')
     if not graph_access_token:
         demisto.error(
@@ -3277,7 +3281,7 @@ def insufficient_permissions_error_handler() -> str:
     ]
 
     # Start building the error message
-    error_message.append(f"The {command} command using the {AUTH_TYPE} Flow, requires the following API permissions:")
+    error_message.append(f"The {command} command using the {auth_type} Flow, requires the following API permissions:")
 
     error_message.append(f'{permission_type} - {", ".join(required_permissions_for_command)}\n')
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_description.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_description.md
@@ -18,7 +18,7 @@ There are two different authentication methods for [self-deployed configuration]
 - [Client Credentials flow](https://xsoar.pan.dev/docs/reference/integrations/microsoft-teams#client-credentials-flow)
 - [Authorization Code flow](https://xsoar.pan.dev/docs/reference/integrations/microsoft-teams#authorization-code-flow)
 
-In order to use ***microsoft-teams-ring-user***, you must use the **Client Credentials flow**.
+***microsoft-teams-ring-user*** always uses **Client Credentials flow**. If **Authorization Code flow** is configured, the integration will seemlessly authenticate using **Client Credentials** when the command is called. This should have no effect on other commands.
 
 In order to use the following commands, you must use the **Authorization Code flow**:
   - ***microsoft-teams-chat-create***

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_description.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_description.md
@@ -18,7 +18,7 @@ There are two different authentication methods for [self-deployed configuration]
 - [Client Credentials flow](https://xsoar.pan.dev/docs/reference/integrations/microsoft-teams#client-credentials-flow)
 - [Authorization Code flow](https://xsoar.pan.dev/docs/reference/integrations/microsoft-teams#authorization-code-flow)
 
-***microsoft-teams-ring-user*** always uses **Client Credentials flow**. If **Authorization Code flow** is configured, the integration will seemlessly authenticate using **Client Credentials** when the command is called. This should have no effect on other commands.
+***microsoft-teams-ring-user*** always uses **Client Credentials flow**. If **Authorization Code flow** is configured. The integration will authenticate using **Client Credentials** when the command is called. This should have no effect on other commands.
 
 In order to use the following commands, you must use the **Authorization Code flow**:
   - ***microsoft-teams-chat-create***

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -301,7 +301,7 @@ def test_mirror_investigation(mocker, requests_mock):
     assert demisto.setIntegrationContext.call_count == 3
     set_integration_context = demisto.setIntegrationContext.call_args[0]
     assert len(set_integration_context) == 1
-    set_integration_context[0].pop("authcode_token_params")
+    set_integration_context[0].pop("credentials_token_params")
     set_integration_context[0].pop("bot_access_token")
     set_integration_context[0].pop("bot_valid_until")
     assert set_integration_context[0] == expected_integration_context
@@ -2789,7 +2789,7 @@ def test_insufficient_permissions_handler(mocker, command, expected_missing):
     mocker.patch.object(demisto, "command", return_value=command)
     mocker.patch("MicrosoftTeams.get_token_permissions", return_value=mock_permissions)
     mocker.patch("MicrosoftTeams.get_integration_context", return_value={
-        "authcode_token_params": json.dumps({
+        "credentials_token_params": json.dumps({
             "graph_access_token": "mock_token"
             })
     })
@@ -2957,7 +2957,8 @@ def test_ring_user_in_auth_code(mocker, requests_mock):
         f'{GRAPH_BASE_URL}/v1.0/communications/calls',
         json={},
     )
+    integration_context.pop('credentials_token_params')
 
     ring_user()
 
-    assert requests_mock.request_history[1].headers['Authorization'] == f'Bearer {mock_credentials_token}'
+    assert requests_mock.last_request.headers['Authorization'] == f'Bearer {mock_credentials_token}'

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -115,6 +115,8 @@ integration_context: dict = {
 
 CLIENT_CREDENTIALS_FLOW = "Client Credentials"
 AUTHORIZATION_CODE_FLOW = "Authorization Code"
+CREDENTIALS_TOKEN_PARAMS = 'credentials_token_params'
+AUTHCODE_TOKEN_PARAMS = 'authcode_token_params'
 ONEONONE_CHAT_ID = "19:09ddc990-3821-4ceb-8019-24d39998f93e_48d31887-5fad-4d73-a9f5-3c356e68a038@unq.gbl.spaces"
 GROUP_CHAT_ID = "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
 
@@ -301,7 +303,7 @@ def test_mirror_investigation(mocker, requests_mock):
     assert demisto.setIntegrationContext.call_count == 3
     set_integration_context = demisto.setIntegrationContext.call_args[0]
     assert len(set_integration_context) == 1
-    set_integration_context[0].pop("credentials_token_params")
+    set_integration_context[0].pop(CREDENTIALS_TOKEN_PARAMS)
     set_integration_context[0].pop("bot_access_token")
     set_integration_context[0].pop("bot_valid_until")
     assert set_integration_context[0] == expected_integration_context
@@ -2580,7 +2582,7 @@ def test_switch_auth_type_to_client_credentials(mocker):
         "MicrosoftTeams.get_integration_context",
         return_value={
             "current_auth_type": "Authorization Code",
-            "authcode_token_params": json.dumps({
+            AUTHCODE_TOKEN_PARAMS: json.dumps({
                 "current_refresh_token": "test_refresh_token",
                 "graph_access_token": "test_graph_token",
                 "graph_valid_until": "test_valid_until"}),
@@ -2595,8 +2597,8 @@ def test_switch_auth_type_to_client_credentials(mocker):
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
         "current_auth_type": "Client Credentials",
-        "authcode_token_params": "{}",
-        "credentials_token_params": "{}",
+        AUTHCODE_TOKEN_PARAMS: "{}",
+        CREDENTIALS_TOKEN_PARAMS: "{}",
     }
     assert "Setting the current_auth_type in the integration context to Client Credentials" in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
@@ -2625,7 +2627,7 @@ def test_switch_auth_type_to_authorization_code_flow(mocker):
         "MicrosoftTeams.get_integration_context",
         return_value={
             "current_auth_type": "Client Credentials",
-            "authcode_token_params": json.dumps({
+            AUTHCODE_TOKEN_PARAMS: json.dumps({
                 "current_refresh_token": "test_refresh_token",
                 "graph_access_token": "test_graph_token",
                 "graph_valid_until": "test_valid_until"}),
@@ -2640,8 +2642,8 @@ def test_switch_auth_type_to_authorization_code_flow(mocker):
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
         "current_auth_type": "Authorization Code",
-        "authcode_token_params": "{}",
-        "credentials_token_params": "{}",
+        AUTHCODE_TOKEN_PARAMS: "{}",
+        CREDENTIALS_TOKEN_PARAMS: "{}",
     }
     assert "Setting the current_auth_type in the integration context to Authorization Code" in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
@@ -2789,7 +2791,7 @@ def test_insufficient_permissions_handler(mocker, command, expected_missing):
     mocker.patch.object(demisto, "command", return_value=command)
     mocker.patch("MicrosoftTeams.get_token_permissions", return_value=mock_permissions)
     mocker.patch("MicrosoftTeams.get_integration_context", return_value={
-        "credentials_token_params": json.dumps({
+        CREDENTIALS_TOKEN_PARAMS: json.dumps({
             "graph_access_token": "mock_token"
             })
     })
@@ -2957,7 +2959,7 @@ def test_ring_user_in_auth_code(mocker, requests_mock):
         f'{GRAPH_BASE_URL}/v1.0/communications/calls',
         json={},
     )
-    integration_context.pop('credentials_token_params')
+    integration_context.pop(CREDENTIALS_TOKEN_PARAMS)
 
     ring_user()
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -271,16 +271,20 @@ def test_mirror_investigation(mocker, requests_mock):
         }
     )
     expected_integration_context: dict = {
-        'bot_name': 'DemistoBot',
-        'tenant_id': tenant_id,
-        'service_url': service_url,
-        'teams': json.dumps([{
-            'mirrored_channels': updated_mirrored_channels,
-            'team_id': team_id,
-            'team_aad_id': team_aad_id,
-            'team_members': team_members,
-            'team_name': 'The-A-Team'
-        }])
+        "bot_name": "DemistoBot",
+        "tenant_id": tenant_id,
+        "service_url": service_url,
+        "teams": json.dumps(
+            [
+                {
+                    "mirrored_channels": updated_mirrored_channels,
+                    "team_id": team_id,
+                    "team_aad_id": team_aad_id,
+                    "team_members": team_members,
+                    "team_name": "The-A-Team",
+                }
+            ]
+        ),
     }
     assert requests_mock.request_history[1].json() == {
         "displayName": "incident-2",
@@ -297,9 +301,9 @@ def test_mirror_investigation(mocker, requests_mock):
     assert demisto.setIntegrationContext.call_count == 3
     set_integration_context = demisto.setIntegrationContext.call_args[0]
     assert len(set_integration_context) == 1
-    set_integration_context[0].pop('authcode_token_params')
-    set_integration_context[0].pop('bot_access_token')
-    set_integration_context[0].pop('bot_valid_until')
+    set_integration_context[0].pop("authcode_token_params")
+    set_integration_context[0].pop("bot_access_token")
+    set_integration_context[0].pop("bot_valid_until")
     assert set_integration_context[0] == expected_integration_context
     results = demisto.results.call_args[0]
     assert len(results) == 1
@@ -2571,23 +2575,30 @@ def test_switch_auth_type_to_client_credentials(mocker):
         - Verify that the debug logs are as expected.
     """
     from MicrosoftTeams import auth_type_switch_handling
-    mocker.patch('MicrosoftTeams.get_integration_context', return_value={'current_auth_type': 'Authorization Code',
-                                                                         'authcode_token_params': json.dumps({
-                                                                             'current_refresh_token': 'test_refresh_token',
-                                                                             'graph_access_token': 'test_graph_token',
-                                                                             'graph_valid_until': 'test_valid_until'})
-                                                                         })
-    set_integration_context_mocker = mocker.patch('MicrosoftTeams.set_integration_context', return_value={})
-    debug_log_mocker = mocker.patch.object(demisto, 'debug')
-    mocker.patch('MicrosoftTeams.AUTH_TYPE', new='Client Credentials')
+
+    mocker.patch(
+        "MicrosoftTeams.get_integration_context",
+        return_value={
+            "current_auth_type": "Authorization Code",
+            "authcode_token_params": json.dumps({
+                "current_refresh_token": "test_refresh_token",
+                "graph_access_token": "test_graph_token",
+                "graph_valid_until": "test_valid_until"}),
+        },
+    )
+    set_integration_context_mocker = mocker.patch("MicrosoftTeams.set_integration_context", return_value={})
+    debug_log_mocker = mocker.patch.object(demisto, "debug")
+    mocker.patch("MicrosoftTeams.AUTH_TYPE", new="Client Credentials")
 
     auth_type_switch_handling()
 
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
-        'current_auth_type': 'Client Credentials', 'authcode_token_params': '{}',
-        'credentials_token_params': '{}'}
-    assert 'Setting the current_auth_type in the integration context to Client Credentials' in debug_log_mocker.call_args[0][0]
+        "current_auth_type": "Client Credentials",
+        "authcode_token_params": "{}",
+        "credentials_token_params": "{}",
+    }
+    assert "Setting the current_auth_type in the integration context to Client Credentials" in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
 
 
@@ -2609,23 +2620,30 @@ def test_switch_auth_type_to_authorization_code_flow(mocker):
         - Verify that the debug logs are as expected.
     """
     from MicrosoftTeams import auth_type_switch_handling
-    mocker.patch('MicrosoftTeams.get_integration_context', return_value={'current_auth_type': 'Client Credentials',
-                                                                         'authcode_token_params': json.dumps({
-                                                                             'current_refresh_token': 'test_refresh_token',
-                                                                             'graph_access_token': 'test_graph_token',
-                                                                             'graph_valid_until': 'test_valid_until'})
-                                                                         })
-    set_integration_context_mocker = mocker.patch('MicrosoftTeams.set_integration_context', return_value={})
-    debug_log_mocker = mocker.patch.object(demisto, 'debug')
-    mocker.patch('MicrosoftTeams.AUTH_TYPE', new='Authorization Code')
+
+    mocker.patch(
+        "MicrosoftTeams.get_integration_context",
+        return_value={
+            "current_auth_type": "Client Credentials",
+            "authcode_token_params": json.dumps({
+                "current_refresh_token": "test_refresh_token",
+                "graph_access_token": "test_graph_token",
+                "graph_valid_until": "test_valid_until"}),
+        },
+    )
+    set_integration_context_mocker = mocker.patch("MicrosoftTeams.set_integration_context", return_value={})
+    debug_log_mocker = mocker.patch.object(demisto, "debug")
+    mocker.patch("MicrosoftTeams.AUTH_TYPE", new="Authorization Code")
 
     auth_type_switch_handling()
 
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
-        'current_auth_type': 'Authorization Code', 'authcode_token_params': '{}',
-        'credentials_token_params': '{}'}
-    assert 'Setting the current_auth_type in the integration context to Authorization Code' in debug_log_mocker.call_args[0][0]
+        "current_auth_type": "Authorization Code",
+        "authcode_token_params": "{}",
+        "credentials_token_params": "{}",
+    }
+    assert "Setting the current_auth_type in the integration context to Authorization Code" in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
 
 
@@ -2768,15 +2786,16 @@ def test_insufficient_permissions_handler(mocker, command, expected_missing):
 
     mock_permissions = [Perms.USER_READ_ALL.value, Perms.CHATMESSAGE_SEND.value]
 
-    mocker.patch.object(demisto, 'command', return_value=command)
-    mocker.patch('MicrosoftTeams.get_token_permissions', return_value=mock_permissions)
-    mocker.patch('MicrosoftTeams.get_integration_context', return_value={
-        'authcode_token_params': json.dumps({
-            'graph_access_token': 'mock_token'
-        })
+    mocker.patch.object(demisto, "command", return_value=command)
+    mocker.patch("MicrosoftTeams.get_token_permissions", return_value=mock_permissions)
+    mocker.patch("MicrosoftTeams.get_integration_context", return_value={
+        "authcode_token_params": json.dumps({
+            "graph_access_token": "mock_token"
+            })
     })
-    missing_permissions_mock = mocker.patch('MicrosoftTeams.create_missing_permissions_section',
-                                            side_effect=create_missing_permissions_section)
+    missing_permissions_mock = mocker.patch(
+        "MicrosoftTeams.create_missing_permissions_section", side_effect=create_missing_permissions_section
+    )
 
     error_msg = insufficient_permissions_error_handler()
 

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -271,21 +271,16 @@ def test_mirror_investigation(mocker, requests_mock):
         }
     )
     expected_integration_context: dict = {
-        "bot_name": "DemistoBot",
-        "current_refresh_token": "",
-        "tenant_id": tenant_id,
-        "service_url": service_url,
-        "teams": json.dumps(
-            [
-                {
-                    "mirrored_channels": updated_mirrored_channels,
-                    "team_id": team_id,
-                    "team_aad_id": team_aad_id,
-                    "team_members": team_members,
-                    "team_name": "The-A-Team",
-                }
-            ]
-        ),
+        'bot_name': 'DemistoBot',
+        'tenant_id': tenant_id,
+        'service_url': service_url,
+        'teams': json.dumps([{
+            'mirrored_channels': updated_mirrored_channels,
+            'team_id': team_id,
+            'team_aad_id': team_aad_id,
+            'team_members': team_members,
+            'team_name': 'The-A-Team'
+        }])
     }
     assert requests_mock.request_history[1].json() == {
         "displayName": "incident-2",
@@ -302,10 +297,9 @@ def test_mirror_investigation(mocker, requests_mock):
     assert demisto.setIntegrationContext.call_count == 3
     set_integration_context = demisto.setIntegrationContext.call_args[0]
     assert len(set_integration_context) == 1
-    set_integration_context[0].pop("graph_access_token")
-    set_integration_context[0].pop("graph_valid_until")
-    set_integration_context[0].pop("bot_access_token")
-    set_integration_context[0].pop("bot_valid_until")
+    set_integration_context[0].pop('authcode_token_params')
+    set_integration_context[0].pop('bot_access_token')
+    set_integration_context[0].pop('bot_valid_until')
     assert set_integration_context[0] == expected_integration_context
     results = demisto.results.call_args[0]
     assert len(results) == 1
@@ -2577,30 +2571,23 @@ def test_switch_auth_type_to_client_credentials(mocker):
         - Verify that the debug logs are as expected.
     """
     from MicrosoftTeams import auth_type_switch_handling
-
-    mocker.patch(
-        "MicrosoftTeams.get_integration_context",
-        return_value={
-            "current_auth_type": "Authorization Code",
-            "current_refresh_token": "test_refresh_token",
-            "graph_access_token": "test_graph_token",
-            "graph_valid_until": "test_valid_until",
-        },
-    )
-    set_integration_context_mocker = mocker.patch("MicrosoftTeams.set_integration_context", return_value={})
-    debug_log_mocker = mocker.patch.object(demisto, "debug")
-    mocker.patch("MicrosoftTeams.AUTH_TYPE", new="Client Credentials")
+    mocker.patch('MicrosoftTeams.get_integration_context', return_value={'current_auth_type': 'Authorization Code',
+                                                                         'authcode_token_params': json.dumps({
+                                                                             'current_refresh_token': 'test_refresh_token',
+                                                                             'graph_access_token': 'test_graph_token',
+                                                                             'graph_valid_until': 'test_valid_until'})
+                                                                         })
+    set_integration_context_mocker = mocker.patch('MicrosoftTeams.set_integration_context', return_value={})
+    debug_log_mocker = mocker.patch.object(demisto, 'debug')
+    mocker.patch('MicrosoftTeams.AUTH_TYPE', new='Client Credentials')
 
     auth_type_switch_handling()
 
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
-        "current_auth_type": "Client Credentials",
-        "current_refresh_token": "",
-        "graph_access_token": "",
-        "graph_valid_until": "",
-    }
-    assert "Setting the current_auth_type in the integration context to Client Credentials" in debug_log_mocker.call_args[0][0]
+        'current_auth_type': 'Client Credentials', 'authcode_token_params': '{}',
+        'credentials_token_params': '{}'}
+    assert 'Setting the current_auth_type in the integration context to Client Credentials' in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
 
 
@@ -2622,30 +2609,23 @@ def test_switch_auth_type_to_authorization_code_flow(mocker):
         - Verify that the debug logs are as expected.
     """
     from MicrosoftTeams import auth_type_switch_handling
-
-    mocker.patch(
-        "MicrosoftTeams.get_integration_context",
-        return_value={
-            "current_auth_type": "Client Credentials",
-            "current_refresh_token": "test_refresh_token",
-            "graph_access_token": "test_graph_token",
-            "graph_valid_until": "test_valid_until",
-        },
-    )
-    set_integration_context_mocker = mocker.patch("MicrosoftTeams.set_integration_context", return_value={})
-    debug_log_mocker = mocker.patch.object(demisto, "debug")
-    mocker.patch("MicrosoftTeams.AUTH_TYPE", new="Authorization Code")
+    mocker.patch('MicrosoftTeams.get_integration_context', return_value={'current_auth_type': 'Client Credentials',
+                                                                         'authcode_token_params': json.dumps({
+                                                                             'current_refresh_token': 'test_refresh_token',
+                                                                             'graph_access_token': 'test_graph_token',
+                                                                             'graph_valid_until': 'test_valid_until'})
+                                                                         })
+    set_integration_context_mocker = mocker.patch('MicrosoftTeams.set_integration_context', return_value={})
+    debug_log_mocker = mocker.patch.object(demisto, 'debug')
+    mocker.patch('MicrosoftTeams.AUTH_TYPE', new='Authorization Code')
 
     auth_type_switch_handling()
 
     assert set_integration_context_mocker.call_count == 2
     assert set_integration_context_mocker.call_args[0][0] == {
-        "current_auth_type": "Authorization Code",
-        "current_refresh_token": "",
-        "graph_access_token": "",
-        "graph_valid_until": "",
-    }
-    assert "Setting the current_auth_type in the integration context to Authorization Code" in debug_log_mocker.call_args[0][0]
+        'current_auth_type': 'Authorization Code', 'authcode_token_params': '{}',
+        'credentials_token_params': '{}'}
+    assert 'Setting the current_auth_type in the integration context to Authorization Code' in debug_log_mocker.call_args[0][0]
     assert debug_log_mocker.call_count == 4
 
 
@@ -2788,12 +2768,15 @@ def test_insufficient_permissions_handler(mocker, command, expected_missing):
 
     mock_permissions = [Perms.USER_READ_ALL.value, Perms.CHATMESSAGE_SEND.value]
 
-    mocker.patch.object(demisto, "command", return_value=command)
-    mocker.patch("MicrosoftTeams.get_token_permissions", return_value=mock_permissions)
-    mocker.patch("MicrosoftTeams.get_integration_context", return_value={"graph_access_token": "mock_token"})
-    missing_permissions_mock = mocker.patch(
-        "MicrosoftTeams.create_missing_permissions_section", side_effect=create_missing_permissions_section
-    )
+    mocker.patch.object(demisto, 'command', return_value=command)
+    mocker.patch('MicrosoftTeams.get_token_permissions', return_value=mock_permissions)
+    mocker.patch('MicrosoftTeams.get_integration_context', return_value={
+        'authcode_token_params': json.dumps({
+            'graph_access_token': 'mock_token'
+        })
+    })
+    missing_permissions_mock = mocker.patch('MicrosoftTeams.create_missing_permissions_section',
+                                            side_effect=create_missing_permissions_section)
 
     error_msg = insufficient_permissions_error_handler()
 
@@ -2923,3 +2906,39 @@ def test_get_chat_id_and_type_not_found_no_chat_creation_permission(mocker, requ
         get_chat_id_and_type(chat_name, create_dm_chat=False)
 
     assert str(e.value) == f'Could not find chat: {chat_name}'
+
+
+def test_ring_user_in_auth_code(mocker, requests_mock):
+    """
+    Given:
+      - Authentication type is set to authorization code.
+    When:
+      - Calling the ring-user command.
+    Then:
+      - Ring user is called with a token obtained from client credentials instead of auth code.
+    """
+    from MicrosoftTeams import ring_user
+
+    mocker.patch('MicrosoftTeams.AUTH_TYPE', new=AUTHORIZATION_CODE_FLOW)
+    mocker.patch.object(demisto, 'args', return_value={'username': 'test_user'})
+    mocker.patch('MicrosoftTeams.get_user', return_value=[{'id': 'test_user_id', 'userType': 'Member'}])
+
+    mock_credentials_token = 'credentials_token'
+
+    requests_mock.post(
+        f'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token',
+        json={
+            'access_token': mock_credentials_token
+        },
+        status_code=200,
+        additional_matcher=lambda request: 'grant_type=client_credentials' in request.text,
+    )
+
+    requests_mock.post(
+        f'{GRAPH_BASE_URL}/v1.0/communications/calls',
+        json={},
+    )
+
+    ring_user()
+
+    assert requests_mock.request_history[1].headers['Authorization'] == f'Bearer {mock_credentials_token}'

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -154,7 +154,7 @@ Before you can create an instance of the Microsoft Teams integration in Cortex X
 9. Navigate to **Settings -> Configuration** on the left bar, and fill in the **Messaging Endpoint**.
 
     - To get the correct messaging endpoint based on the server URL, the server version, and the instance configurations, use the `microsoft-teams-create-messaging-endpoint`command.
-**Note:** Using this command requires an active integration instance. This step can be done after completing the [instance configuration](#configure-microsoft-teams-on-cortex-xsoar) section.
+    **Note:** Using this command requires an active integration instance. This step can be done after completing the [instance configuration](#configure-microsoft-teams-on-cortex-xsoar) section.
 
 10. Store the **Microsoft App ID** value for the next steps, and navigate to **Manage** next to it.
 11. Click **New Client Secret**, fill in the **Description** and **Expires** fields as desired. Then click **Add**.
@@ -201,7 +201,7 @@ Perform the following steps to add the needed permissions:
 
 #### Authorization Code Flow
 
-Note: The [microsoft-teams-ring-user](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0&tabs=http) command is only supported when using the `Client Credentials flow` due to a limitation in Microsoft's permissions system.
+Note: The [microsoft-teams-ring-user](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0&tabs=http) command requires authenticating with `Client Credentials` due to a limitation in Microsoft's permissions system. (Calling this command will perform the authentication seemlessly)
 
 Executing commands when using an authorization code requires **Delegated Permissions**.
 Perform the following steps to add the needed permissions:
@@ -222,6 +222,10 @@ Perform the following steps to add the needed permissions:
     - `Chat.ReadWrite`
     - `AppCatalog.Read.All`
     - `TeamsAppInstallation.ReadWriteSelfForChat`
+
+    **Application permissions:** (For `microsoft-teams-ring-user`)
+    - `User.Read.All`
+    - `Calls.Initiate.All`
 
     Alternatively, check each relevant command section below for the minimum permissions it requires.
 
@@ -338,7 +342,7 @@ For more detailed instructions, refer to the [Configuring the instance with the 
 ## Known Limitations
 ---
 - In some cases, you might encounter a problem, where no communication is created between Teams and the messaging endpoint, when adding a bot to the team. You can work around this problem by adding any member to the team the bot was added to. It will trigger a communication and solve the issue.
-- The [microsoft-teams-ring-user](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0&tabs=http) command is only supported when using the `Client Credentials flow` due to a limitation in Microsoft's permissions system. 
+- The [microsoft-teams-ring-user](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0&tabs=http) command requires using the `Client Credentials` authentication due to a limitation in Microsoft's permissions system. As such, when using `Authorization Code flow` and calling this command, the integration will internally authenticate using the `Client Credentials flow`.
 - In addition, the chat commands are only supported when using the `Authorization Code flow`.
 - Posting a message or adaptive card to a private/shared channel is currently not supported in the ***send-notification*** command. Thus, also the ***mirror_investigation*** command does not support private/shared channels. For more information, see [Microsoft General known issues and limitations](https://learn.microsoft.com/en-us/connectors/teams/#general-known-issues-and-limitations).
 - In case of multiple chats/users sharing the same name, the first one will be taken.
@@ -503,7 +507,7 @@ There is no context output for this command.
 
 ### microsoft-teams-ring-user
 ***
-Rings a user's Teams account. Note: This is a ring only! no media will play in case the generated call is answered. To use this make sure your Bot has the following permissions - Calls.Initiate.All and Calls.InitiateGroupCall.All
+Rings a user's Teams account. Note: This is a ring only! no media will play in case the generated call is answered.
 
 
 ##### Base Command

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
@@ -3,4 +3,4 @@
 
 ##### Microsoft Teams
 
-- ***ms-teams-ring-user*** is now enabled while using the **Authorization Code** authentication type.
+Updated the ***ms-teams-ring-user*** command to be enabled while using the **Authorization Code** authentication type.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Teams
+
+- ***ms-teams-ring-user*** is now enabled while using the **Authorization Code** authentication type.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_22.md
@@ -3,4 +3,4 @@
 
 ##### Microsoft Teams
 
-Updated the ***ms-teams-ring-user*** command to be enabled while using the **Authorization Code** authentication type.
+Added the ability to use the ***microsoft-teams-ring-user*** command while using the **Authorization Code** authentication flow, by using **Client Credentials** authentication in the background.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.5.21",
+    "currentVersion": "1.5.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-13091](https://jira-dc.paloaltonetworks.com/browse/CIAC-13091)

## Description
Allow calling ms-teams-ring-user when the integration is configured to use authorization code.
Done by authenticating with 'Client Credentials' for ring-user while caching both token types separately.

## Must have
- [ ] Tests
- [ ] Documentation 
