### PR TITLE
Bump Image OCR

### DIFF
--- a/Packs/ImageOCR/ReleaseNotes/1_1_38.md
+++ b/Packs/ImageOCR/ReleaseNotes/1_1_38.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Image OCR
+
+Locked dependencies of the pack to ensure stability for versioned core packs. No changes in this release.

--- a/Packs/ImageOCR/pack_metadata.json
+++ b/Packs/ImageOCR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Image OCR",
     "description": "Extracts text from images.",
     "support": "xsoar",
-    "currentVersion": "1.1.37",
+    "currentVersion": "1.1.38",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fix
```
The dependency ImageOCR/1.1.37 of the pack rasterize/2.1.0 in the rasterize.zip does not meet the conditions for ImageOCR/1.1.36 in the corepacks-8.10.0.json list.
```