### PR TITLE
Reintroduce earliest_occurrence_time_fieldname and latest_occurrence_…

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/README.md
+++ b/Packs/SplunkPy/Integrations/SplunkPy/README.md
@@ -112,6 +112,8 @@ Configured by the instance configuration fetch_limit (behind the scenes an query
 | Replace with Underscore in Incident Fields | Whether to replace special characters to underscore when parsing the raw data of the Notables, or not. | False |
 | Timezone of the Splunk server, in minutes. For example, if GMT is gmt +3, set timezone to +180. For UTC, set the timezone to 0. This is relevant only for fetching and mirroring notable events. It must be specified when mirroring is enabled. |  | False |
 | First fetch timestamp (&lt;number&gt; &lt;time unit&gt;, e.g., 12 hours, 7 days, 3 months, 1 year) | The amount of time to go back when performing the first fetch, or when creating a mapping using the Select Schema option. | False |
+| Earliest Occurence Time Fieldname | The name of the Splunk field whose value defines the query's earliest time to fetch. | False |
+| Latest Occurence Time Fieldname | The name of the Splunk field whose value defines the query's latest time to fetch. | False |
 | Extract Fields - CSV fields that will be parsed out of _raw notable events |  | False |
 | Event Type Field | Used only for mapping with the Select Schema option. The name of the field that contains the type of the event or alert. The default value is "source", which is a good option for notable events. However, you may choose any custom field. | False |
 | Use CIM Schemas for Mapping | If selected, when creating a mapper using the \`Select Schema\` feature \(supported from Cortex XSOAR V6.0\), the Splunk CIM field will be pulled. See https://docs.splunk.com/Documentation/CIM/4.18.0/User/Overview for more information. | False |

--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.yml
@@ -83,6 +83,18 @@ configuration:
   type: 0
   section: Collect
   required: false
+- defaultvalue: earliest_time
+  additionalinfo: The name of the Splunk field whose value defines the query's earliest time to fetch.
+  display: Earliest Occurence Time Fieldname 
+  name: earliest_occurrence_time_fieldname
+  required: false
+  type: 0
+- defaultvalue: latest_time
+  additionalinfo: The name of the Splunk field whose value defines the query's latest time to fetch.
+  display: Latest Occurence Time Fieldname
+  name: latest_occurrence_time_fieldname
+  required: false
+  type: 0
 - display: Extract Fields - CSV fields that will be parsed out of _raw notable events
   name: extractFields
   type: 12


### PR DESCRIPTION
…time_fieldname parameters in SplunkPy integration

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: n/a

## Description

In version 2.1.10 of the SplunkPy integration, the ability to customize the `earliest_fetch_time_fieldname` and `latest_fetch_time_fieldname` parameters in the oneshot fetch search was removed (#14365). These parameters are essential for dispatching the fetch search based on `index_earliest` and `index_latest` time filters, rather than the default `earliest_time` and `latest_time`.

Although the code for these parameters was reintroduced in version 2.3.0 (#16576), the corresponding parameters in the configuration file were not, making it impossible to set these values. The new parameter names are `earliest_occurrence_time_fieldname` and `latest_occurrence_time_fieldname`.

This pull request aims to reintroduce the `earliest_occurrence_time_fieldname` and `latest_occurrence_time_fieldname` parameters in the SplunkPy integration's configuration file (`SplunkPy.yml`) and ensure they are properly utilized in the code (`SplunkPy.py`).

By reintroducing these parameters, users can customize the oneshot fetch search based on specific time filters, enhancing the flexibility and usability of the SplunkPy integration.

## Must have
- [X] Tests
- [X] Documentation 
