### PR TITLE
MS Teams add missing permission requirement to docs

### DIFF
--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams.py
@@ -129,6 +129,7 @@ class GraphPermissions(str, Enum):
     CHANNEL_CREATE = "Channel.Create"
     CHANNELMEMBER_READ_ALL = "ChannelMember.Read.All"
     CHANNELMEMBER_READWRITE_ALL = "ChannelMember.ReadWrite.All"
+    CHANNELMESSAGE_SEND = "ChannelMessage.Send"
     CHAT_READ = "Chat.Read"
     CHAT_READBASIC = "Chat.ReadBasic"
     CHAT_READWRITE = "Chat.ReadWrite"
@@ -144,65 +145,122 @@ class GraphPermissions(str, Enum):
 
 
 Perms = GraphPermissions  # alias for brevity
-COMMANDS_REQUIRED_PERMISSIONS: dict[str, list[GraphPermissions]] = {
-    # Note: at the moment, the required permission names between credentials and auth code are the same.
-    # Credentials require Application permissions while auth code requires delegated permissions
-    "send-notification": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
-    "teams-send-notification-quick-action": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
-    "mirror-investigation": [
-        Perms.GROUPMEMBER_READ_ALL,
-        Perms.CHANNEL_READBASIC_ALL,
-        Perms.CHANNEL_CREATE,
-        Perms.CHANNEL_DELETE_ALL,
-    ],
-    "close-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL, Perms.CHANNEL_DELETE_ALL],
-    "microsoft-teams-ring-user": [Perms.USER_READ_ALL, Perms.CALLS_INITIATE_ALL],
-    "microsoft-teams-add-user-to-channel": [
-        Perms.GROUPMEMBER_READ_ALL,
-        Perms.USER_READ_ALL,
-        Perms.CHANNEL_READBASIC_ALL,
-        Perms.CHANNELMEMBER_READWRITE_ALL,
-    ],
-    "add-user-to-channel": [
-        Perms.GROUPMEMBER_READ_ALL,
-        Perms.USER_READ_ALL,
-        Perms.CHANNEL_READBASIC_ALL,
-        Perms.CHANNELMEMBER_READWRITE_ALL,
-    ],
-    "microsoft-teams-create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
-    "create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
-    "microsoft-teams-create-meeting": [Perms.USER_READ_ALL, Perms.ONLINEMEETINGS_READWRITE],
-    "microsoft-teams-user-remove-from-channel": [
-        Perms.GROUPMEMBER_READ_ALL,
-        Perms.CHANNEL_READBASIC_ALL,
-        Perms.CHANNELMEMBER_READWRITE_ALL,
-    ],
-    "microsoft-teams-channel-user-list": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL, Perms.CHANNELMEMBER_READ_ALL],
-    "microsoft-teams-chat-create": [
-        Perms.USER_READ_ALL,
-        Perms.CHAT_CREATE,
-        Perms.APPCATALOG_READ_ALL,
-        Perms.TEAMSAPPINSTALLATION_READWRITESELFFORCHAT,
-    ],
-    "microsoft-teams-message-send-to-chat": [
-        Perms.USER_READ_ALL,
-        Perms.CHAT_CREATE,
-        Perms.CHATMESSAGE_SEND,
-        Perms.APPCATALOG_READ_ALL,
-        Perms.TEAMSAPPINSTALLATION_READWRITESELFFORCHAT,
-    ],
-    "microsoft-teams-chat-add-user": [Perms.CHAT_READBASIC, Perms.CHATMEMBER_READWRITE],
-    "microsoft-teams-chat-member-list": [Perms.USER_READ_ALL, Perms.CHAT_READBASIC],
-    "microsoft-teams-chat-list": [Perms.USER_READ_ALL, Perms.CHAT_READBASIC],
-    "microsoft-teams-chat-message-list": [Perms.USER_READ_ALL, Perms.CHAT_READ],
-    "microsoft-teams-chat-update": [Perms.USER_READ_ALL, Perms.CHAT_READWRITE],
-    "microsoft-teams-message-update": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
-    "microsoft-teams-integration-health": [],
-    "microsoft-teams-create-messaging-endpoint": [],
-    "microsoft-teams-generate-login-url": [],
-    "microsoft-teams-auth-test": [],
-    "microsoft-teams-auth-reset": [],
-    "microsoft-teams-token-permissions-list": [],
+COMMANDS_REQUIRED_PERMISSIONS: dict[str, dict[str, list[GraphPermissions]]] = {
+    AUTHORIZATION_CODE_FLOW: {
+        "send-notification": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL, Perms.CHANNELMESSAGE_SEND],
+        "teams-send-notification-quick-action": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMESSAGE_SEND
+        ],
+        "mirror-investigation": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNEL_CREATE,
+            Perms.CHANNEL_DELETE_ALL,
+        ],
+        "close-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL, Perms.CHANNEL_DELETE_ALL],
+        "microsoft-teams-ring-user": [],
+        "microsoft-teams-add-user-to-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.USER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "add-user-to-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.USER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL, Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "microsoft-teams-create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
+        "create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
+        "microsoft-teams-create-meeting": [Perms.USER_READ_ALL, Perms.ONLINEMEETINGS_READWRITE],
+        "microsoft-teams-user-remove-from-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "microsoft-teams-channel-user-list": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READ_ALL
+        ],
+        "microsoft-teams-chat-create": [
+            Perms.USER_READ_ALL,
+            Perms.CHAT_CREATE,
+            Perms.APPCATALOG_READ_ALL,
+            Perms.TEAMSAPPINSTALLATION_READWRITESELFFORCHAT,
+            ],
+        "microsoft-teams-message-send-to-chat": [
+            Perms.USER_READ_ALL,
+            Perms.CHAT_CREATE,
+            Perms.CHATMESSAGE_SEND,
+            Perms.APPCATALOG_READ_ALL,
+            Perms.TEAMSAPPINSTALLATION_READWRITESELFFORCHAT,
+            ],
+        "microsoft-teams-chat-add-user": [Perms.CHAT_READBASIC, Perms.CHATMEMBER_READWRITE],
+        "microsoft-teams-chat-member-list": [Perms.USER_READ_ALL, Perms.CHAT_READBASIC],
+        "microsoft-teams-chat-list": [Perms.USER_READ_ALL, Perms.CHAT_READBASIC],
+        "microsoft-teams-chat-message-list": [Perms.USER_READ_ALL, Perms.CHAT_READ],
+        "microsoft-teams-chat-update": [Perms.USER_READ_ALL, Perms.CHAT_READWRITE],
+        "microsoft-teams-message-update": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
+        "microsoft-teams-integration-health": [],
+        "microsoft-teams-create-messaging-endpoint": [],
+        "microsoft-teams-generate-login-url": [],
+        "microsoft-teams-auth-test": [],
+        "microsoft-teams-auth-reset": [],
+        "microsoft-teams-token-permissions-list": [],
+    },
+    CLIENT_CREDENTIALS_FLOW: {
+        "send-notification": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
+        "teams-send-notification-quick-action": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
+        "mirror-investigation": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNEL_CREATE,
+            Perms.CHANNEL_DELETE_ALL,
+        ],
+        "close-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL, Perms.CHANNEL_DELETE_ALL],
+        "microsoft-teams-ring-user": [Perms.USER_READ_ALL, Perms.CALLS_INITIATE_ALL],
+        "microsoft-teams-add-user-to-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.USER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "add-user-to-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.USER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL, Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "microsoft-teams-create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
+        "create-channel": [Perms.GROUPMEMBER_READ_ALL, Perms.USER_READ_ALL, Perms.CHANNEL_CREATE],
+        "microsoft-teams-create-meeting": [Perms.USER_READ_ALL, Perms.ONLINEMEETINGS_READWRITE],
+        "microsoft-teams-user-remove-from-channel": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READWRITE_ALL,
+        ],
+        "microsoft-teams-channel-user-list": [
+            Perms.GROUPMEMBER_READ_ALL,
+            Perms.CHANNEL_READBASIC_ALL,
+            Perms.CHANNELMEMBER_READ_ALL
+        ],
+        "microsoft-teams-chat-create": [],
+        "microsoft-teams-message-send-to-chat": [],
+        "microsoft-teams-chat-add-user": [],
+        "microsoft-teams-chat-member-list": [],
+        "microsoft-teams-chat-list": [],
+        "microsoft-teams-chat-message-list": [],
+        "microsoft-teams-chat-update": [],
+        "microsoft-teams-message-update": [Perms.GROUPMEMBER_READ_ALL, Perms.CHANNEL_READBASIC_ALL],
+        "microsoft-teams-integration-health": [],
+        "microsoft-teams-create-messaging-endpoint": [],
+        "microsoft-teams-generate-login-url": [],
+        "microsoft-teams-auth-test": [],
+        "microsoft-teams-auth-reset": [],
+        "microsoft-teams-token-permissions-list": [],
+    }
 }
 HIGHER_PERMISSIONS: dict[GraphPermissions, list[GraphPermissions]] = {
     # dict with some elevated permissions and some of the permissions they can replace
@@ -226,6 +284,7 @@ HIGHER_PERMISSIONS: dict[GraphPermissions, list[GraphPermissions]] = {
         Perms.CHANNEL_CREATE,
         Perms.CHANNEL_READBASIC_ALL,
         Perms.CHANNEL_DELETE_ALL,
+        Perms.CHANNELMESSAGE_SEND,
     ],
     Perms.CHANNELMEMBER_READWRITE_ALL: [Perms.CHANNELMEMBER_READ_ALL],
 }
@@ -928,6 +987,16 @@ def http_request(method: str, url: str = "", json_: dict = None, api: str = "gra
             error: str = error_parser(response, api)
             if response.status_code == 403 and (detailed_error_message := insufficient_permissions_error_handler(auth_type)):
                 error = f"{detailed_error_message}\n\n(Error Message): {error}"
+
+            elif response.status_code == 401 and api == "bot":
+                error = f"""\
+Authorization error in call to the Microsoft Bot Framework, ensure the "Microsoft Teams" \
+channel was added to the bot in the Azure portal during setup.
+
+Refer to steps #13-14 of the "Creating the Demisto Bot using Microsoft Azure Portal" \
+section in the integration documentation for more information.
+
+(Error Message): {error}"""
 
             raise ValueError(f"Error code [{response.status_code}] in API call to Microsoft Teams:\n{error}")
 
@@ -3262,7 +3331,7 @@ def insufficient_permissions_error_handler(auth_type: str = AUTH_TYPE) -> str:
     error_message = []
     demisto.debug(f"Authentication type is: {auth_type}")
     missing_permissions = []
-    required_permissions_for_command: list = COMMANDS_REQUIRED_PERMISSIONS.get(command, [])
+    required_permissions_for_command: list = COMMANDS_REQUIRED_PERMISSIONS.get(auth_type, {}).get(command, [])
     permission_type = 'Application' if auth_type == CLIENT_CREDENTIALS_FLOW else 'Delegated'
     if not required_permissions_for_command:
         demisto.error(

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/MicrosoftTeams_test.py
@@ -2733,6 +2733,7 @@ def test_message_update(mocker, requests_mock):
                 Perms.CHANNEL_CREATE,
                 Perms.CHANNEL_READBASIC_ALL,
                 Perms.CHANNEL_DELETE_ALL,
+                Perms.CHANNELMESSAGE_SEND,
             },
         ),
         (
@@ -2767,16 +2768,17 @@ def test_expand_permissions_list(permissions, expected_out):
 
 
 @pytest.mark.parametrize(
-    "command, expected_missing",
+    "auth_type, command, expected_missing",
     [
-        ("microsoft-teams-create-channel", {Perms.CHANNEL_CREATE, Perms.GROUPMEMBER_READ_ALL}),
+        (CLIENT_CREDENTIALS_FLOW, "microsoft-teams-create-channel", {Perms.CHANNEL_CREATE, Perms.GROUPMEMBER_READ_ALL}),
         (
+            AUTHORIZATION_CODE_FLOW,
             "microsoft-teams-message-send-to-chat",
             {Perms.CHAT_CREATE, Perms.APPCATALOG_READ_ALL, Perms.TEAMSAPPINSTALLATION_READWRITESELFFORCHAT},
         ),
     ],
 )
-def test_insufficient_permissions_handler(mocker, command, expected_missing):
+def test_insufficient_permissions_handler(mocker, auth_type, command, expected_missing):
     """
     Given:
         - Microsoft Graph API returns a 403 Forbidden error due to insufficient permissions.
@@ -2794,13 +2796,16 @@ def test_insufficient_permissions_handler(mocker, command, expected_missing):
     mocker.patch("MicrosoftTeams.get_integration_context", return_value={
         CREDENTIALS_TOKEN_PARAMS: json.dumps({
             "graph_access_token": "mock_token"
+            }),
+        AUTHCODE_TOKEN_PARAMS: json.dumps({
+            "graph_access_token": "mock_token"
             })
     })
     missing_permissions_mock = mocker.patch(
         "MicrosoftTeams.create_missing_permissions_section", side_effect=create_missing_permissions_section
     )
 
-    error_msg = insufficient_permissions_error_handler()
+    error_msg = insufficient_permissions_error_handler(auth_type=auth_type)
 
     assert error_msg
     assert set(missing_permissions_mock.call_args[0][0]) == expected_missing
@@ -2829,7 +2834,8 @@ def test_commands_required_includes_all_commands():
         pytest.skip("yml file is unavailable for testing in this environment")
 
     for command in yml['script']['commands']:
-        assert command['name'] in COMMANDS_REQUIRED_PERMISSIONS
+        assert command['name'] in COMMANDS_REQUIRED_PERMISSIONS[AUTHORIZATION_CODE_FLOW]
+        assert command['name'] in COMMANDS_REQUIRED_PERMISSIONS[CLIENT_CREDENTIALS_FLOW]
 
 
 def test_get_one_on_one_chat_id(mocker, requests_mock):

--- a/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
+++ b/Packs/MicrosoftTeams/Integrations/MicrosoftTeams/README.md
@@ -183,7 +183,7 @@ Perform the following steps to add the needed permissions:
 2. Search for and click **Demisto Bot**.
 3. Click **API permissions > Add a permission > Microsoft Graph > Application permissions**.
 4. For each permission, search for the permission, select the checkbox, and click **Add permissions**.
-   **Application permissions required to use all credential flow supported commands:**
+    **Application permissions required to use all credential flow supported commands:**
 
     - `User.Read.All`
     - `GroupMember.Read.All`
@@ -210,7 +210,7 @@ Perform the following steps to add the needed permissions:
 2. Search for and click **Demisto Bot**.
 3. Click **API permissions** > **Add a permission** > **Microsoft Graph** > **Delegated permissions**.
 4. For each permission, search for the permission, select the checkbox, and click **Add permissions**.
-   **Delegated permissions required to use all auth code flow supported commands:**
+    **Delegated permissions required to use all auth code flow supported commands:**
 
     - `User.Read.All`
     - `GroupMember.Read.All`
@@ -218,6 +218,7 @@ Perform the following steps to add the needed permissions:
     - `ChannelMember.ReadWrite.All`
     - `Channel.Create`
     - `Channel.Delete.All`
+    - `ChannelMessage.Send`
     - `OnlineMeetings.ReadWrite.All`
     - `Chat.ReadWrite`
     - `AppCatalog.Read.All`
@@ -373,6 +374,8 @@ and picture to match the bot will make it appear to be from the same source.
 `GroupMember.Read.All` - *Application (Client Credentials) / Delegated (Authorization Code)*
 
 `Channel.ReadBasic.All` - *Application (Client Credentials) / Delegated (Authorization Code)*
+
+`ChannelMessage.Send` - *Delegated (Authorization Code) - Only needed for sending replies to messages*
 
 ##### Input
 

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_24.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_24.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Microsoft Teams
+
+- Improved error handling for cases where the **Microsoft Teams** Channel was not properly added to the bot app in the Azure Portal.
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftTeams/ReleaseNotes/1_5_24.md
+++ b/Packs/MicrosoftTeams/ReleaseNotes/1_5_24.md
@@ -3,5 +3,5 @@
 
 ##### Microsoft Teams
 
-- Improved error handling for cases where the **Microsoft Teams** Channel was not properly added to the bot app in the Azure Portal.
-- Documentation and metadata improvements.
+- Improved error handling for cases where the **Microsoft Teams** channel was not properly added to the bot app in the Azure Portal.
+- Added the **ChannelMessage.Send** permission to the documented permission requirements for ***send-notification***.

--- a/Packs/MicrosoftTeams/pack_metadata.json
+++ b/Packs/MicrosoftTeams/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Teams",
     "description": "Send messages and notifications to your team members.",
     "support": "xsoar",
-    "currentVersion": "1.5.23",
+    "currentVersion": "1.5.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Related: [CIAC-13241](https://jira-dc.paloaltonetworks.com/browse/CIAC-13241)

## Description
- Split the required permissions dictionary to differentiate client credentials and authorization code flow required permissions.
- Added ChannelMessage.Send permission to the required list for send-notification in Authorization code flow.
- Added a more detailed error message for cases of authorization error when trying to use the bot API

## Must have
- [ ] Tests
- [ ] Documentation 
