### PR TITLE
Add rawJSON to fetched indicator object in Feed MISP Threat Actors

### DIFF
--- a/Packs/FeedMISPThreatActors/CONTRIBUTORS.json
+++ b/Packs/FeedMISPThreatActors/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+  "Timothy Roberts"
+]

--- a/Packs/FeedMISPThreatActors/Integrations/FeedMISPThreatActors/FeedMISPThreatActors.py
+++ b/Packs/FeedMISPThreatActors/Integrations/FeedMISPThreatActors/FeedMISPThreatActors.py
@@ -477,6 +477,7 @@ def fetch_indicators_command(client: Client, feed_tags: str, tlp_color: str) -> 
         indicator = {
             "value": value,
             "type": "Threat Actor",
+            "rawJSON": threat_actor,
             "fields": {
                 "description": threat_actor.get("description", ""),
                 "trafficlightprotocol": tlp_color,

--- a/Packs/FeedMISPThreatActors/ReleaseNotes/1_0_2.md
+++ b/Packs/FeedMISPThreatActors/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Feed MISP Threat Actors
+
+- Added rawJSON to fetched indicator object to enable custom mapping.

--- a/Packs/FeedMISPThreatActors/pack_metadata.json
+++ b/Packs/FeedMISPThreatActors/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP Threat Actors",
     "description": "This pack downloads and parses the MISP threat actor galaxy into XSOAR TIM.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Added rawJSON to fetched indicator object in Feed MISP Threat Actors to enable custom mapping.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: N/A

## Description
Currently unable to build a custom mapper for this Feed Integration due to the rawJSON not being returned. This causes no data to be returned in the Classifier/Mapper editors when you pull from this instance. The simple addition of `'rawJSON': threat_actor` to the returned indicators object from `fetch_indicators_command` allows the Classifier/Mapper editors to actually fetch data to build the mapper off of.

## Must have
- [x ] Tests
- [ x] Documentation 
