### PR TITLE
fixed wrong url in unzip file tpb

### DIFF
--- a/Packs/CommonScripts/TestPlaybooks/playbook-UnzipFile-Test.yml
+++ b/Packs/CommonScripts/TestPlaybooks/playbook-UnzipFile-Test.yml
@@ -58,7 +58,7 @@ tasks:
         simple: "yes"
       unsecure: {}
       url:
-        simple: https://github.com/demisto/content/raw/master/Packs/CommonScripts/Scripts/UnzipFile/data_test/fix_unzip.png.zip
+        simple: https://github.com/demisto/content/raw/master/Packs/CommonScripts/Scripts/UnzipFile/test_data/fix_unzip.png.zip
       username: {}
     separatecontext: false
     view: |-


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-13446

## Description
fixed an issue where the unzipFile-test tpb failed due to changing a folder name in the UnZip script folder.

## Must have
- [ ] Tests
- [ ] Documentation 
