### PR TITLE
Add smtplib patch for utf-8 when login fails with encode error

### DIFF
--- a/Packs/MailSenderNew/Integrations/MailSenderNew/MailSenderNew.py
+++ b/Packs/MailSenderNew/Integrations/MailSenderNew/MailSenderNew.py
@@ -27,6 +27,50 @@ from itertools import zip_longest
 SERVER: Optional[smtplib.SMTP] = None
 UTF_8 = "utf-8"
 
+def support_utf8_patch():
+    """
+    Patches the SMTP class authentication methods to support utf-8 credentials.
+
+    smtplib currently only supports ascii characters in credentials.
+    This patch should be removed once support is added by smtplib. (https://github.com/python/cpython/issues/73936)
+    """
+    # Original lines left as comments for reference
+    def auth(self, mechanism, authobject, *, initial_response_ok=True):
+        mechanism = mechanism.upper()
+        initial_response = (authobject() if initial_response_ok else None)
+        if initial_response is not None:
+            #response = smtplib.encode_base64(initial_response.encode('ascii'), eol='')
+            response = smtplib.encode_base64(initial_response.encode('utf-8'), eol='')
+            (code, resp) = self.docmd("AUTH", mechanism + " " + response)
+            self._auth_challenge_count = 1
+        else:
+            (code, resp) = self.docmd("AUTH", mechanism)
+            self._auth_challenge_count = 0
+        while code == 334:
+            self._auth_challenge_count += 1
+            challenge = base64.decodebytes(resp)
+            response = smtplib.encode_base64(
+                #authobject(challenge).encode('ascii'), eol='')
+                authobject(challenge).encode('utf-8'), eol='')
+            (code, resp) = self.docmd(response)
+            if self._auth_challenge_count > smtplib._MAXCHALLENGE:
+                raise smtplib.SMTPException(
+                    "Server AUTH mechanism infinite loop. Last response: "
+                    + repr((code, resp))
+                )
+        if code in (235, 503):
+            return (code, resp)
+        raise smtplib.SMTPAuthenticationError(code, resp)
+
+    def auth_cram_md5(self, challenge=None):
+        if challenge is None:
+            return None
+        return self.user + " " + smtplib.hmac.HMAC(
+            #self.password.encode('ascii'), challenge, 'md5').hexdigest()
+            self.password.encode('utf-8'), challenge, 'md5').hexdigest()
+
+    SMTP.auth = auth
+    SMTP.auth_cram_md5 = auth_cram_md5
 
 def randomword(length):
     """
@@ -350,7 +394,14 @@ def main():
             SERVER.starttls()  # type: ignore
         user, password = get_user_pass()
         if user:
-            SERVER.login(user, password)  # type: ignore[union-attr]
+            try:
+                SERVER.login(user, password)  # type: ignore[union-attr]
+            except UnicodeEncodeError as e:
+                demisto.debug(f"Login failed with encode error: {e}\n"
+                              "Retrying using utf-8 patch")
+                support_utf8_patch()
+                SERVER.login(user, password)  # type: ignore[union-attr]
+
     except Exception as e:
         # also reset at the bottom finally
         swap_stderr(stderr_org)  # type: ignore[union-attr]

--- a/Packs/MailSenderNew/Integrations/MailSenderNew/MailSenderNew.yml
+++ b/Packs/MailSenderNew/Integrations/MailSenderNew/MailSenderNew.yml
@@ -109,7 +109,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.8.3296088
 tests:
 - Mail Sender (New) Test
 fromversion: 5.0.0

--- a/Packs/MailSenderNew/ReleaseNotes/1_0_31.md
+++ b/Packs/MailSenderNew/ReleaseNotes/1_0_31.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Mail Sender (New)
+
+- Fixed an issue causing authentication failure when using passwords with special ascii characters.

--- a/Packs/MailSenderNew/pack_metadata.json
+++ b/Packs/MailSenderNew/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mail Sender (New)",
     "description": "Send emails implemented in Python with embedded image support",
     "support": "xsoar",
-    "currentVersion": "1.0.30",
+    "currentVersion": "1.0.31",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-49289](https://jira-dc.paloaltonetworks.com/browse/XSUP-49289)

## Description
Patch smtplib's authentication methods to add utf-8 password support if normal login fails due to encode error.
This is an old open issue in the python repository (https://github.com/python/cpython/issues/73936)

## Must have
- [ ] Tests
- [ ] Documentation 
