### PR TITLE
CiscoUmbrellaReporting bugfix category filter

### DIFF
--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.py
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.py
@@ -334,7 +334,7 @@ def check_valid_indicator_value(indicator_type: str, indicator_value: str) -> bo
     if indicator_type == CATEGORIES_PARAM:
         categories = argToList(indicator_value)
         for category in categories:
-            if not category.isdigit():
+            if not category.lstrip('-').isdigit():
                 raise ValueError(f"Invalid input Error: Categories argument is not a valid list of integers: {indicator_value}")
 
     return True

--- a/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
+++ b/Packs/CiscoUmbrellaReporting/Integrations/CiscoUmbrellaReporting/CiscoUmbrellaReporting.yml
@@ -1546,7 +1546,7 @@ script:
     - contextPath: UmbrellaReporting.SignatureListSummary.signatures.id
       description: Signature ID.
       type: Number
-  dockerimage: demisto/python3:3.11.10.113941
+  dockerimage: demisto/python3:3.12.8.1983910
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_6.md
+++ b/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_6.md
@@ -3,4 +3,5 @@
 
 ##### Cisco Umbrella Reporting
 
-- Updated the Cisco Umbrella Reporting integration to %%UPDATE_CONTENT_ITEM_CHANGE_DESCRIPTION%%.
+- Fixed category validation to accept negative numbers
+- Updated the Docker image to: *demisto/python3:3.12.8.1983910.

--- a/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_6.md
+++ b/Packs/CiscoUmbrellaReporting/ReleaseNotes/1_1_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cisco Umbrella Reporting
+
+- Updated the Cisco Umbrella Reporting integration to %%UPDATE_CONTENT_ITEM_CHANGE_DESCRIPTION%%.

--- a/Packs/CiscoUmbrellaReporting/pack_metadata.json
+++ b/Packs/CiscoUmbrellaReporting/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Umbrella Reporting",
     "description": "Use Cisco Umbrella's Reporting to monitor your Umbrella integration and gain a better understanding of your Umbrella usage. Gain insights into request activity and blocked activity, determining which of your identities are generating blocked requests. Reports help build actionable intelligence in addressing security threats including changes in usage trends over time. The Umbrella Reporting v2 API provides visibility into your core network and security activities and Umbrella logs. This integration was integrated and tested with version 2 of Cisco-umbrella-reporting.",
     "support": "xsoar",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description

The validation of the categories which can be sent to the Cisco Umbrella API uses the python function isdigit() which returns only true for positive numbers. However, the Cisco Umbrella API accepts also negative numbers (to filter out categories explicitly)

So `[10, 34, 63]` is a valid list of categories but `[10, 34, -63]` is also valid. In the current version, the second argument throws a `ValueError()` although it is valid.

To be able to filter out categories explicitly, I added a `lstrip('-')` right before the `isdigit()` check which results in accepting strings of positive and also negative numbers.


## Must have
- [ ] Tests
- [ ] Documentation 
