### PR TITLE
CoreIR: fix quick action arg path

### DIFF
--- a/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
+++ b/Packs/Core/Integrations/CortexCoreIR/CortexCoreIR.yml
@@ -1756,8 +1756,9 @@ script:
       name: generic_file_path
       defaultValue: 'Issue initiator file'
       prettyname: File to retrieve
+      required: true
       prettypredefined:
-        Issue initiator file: ${issue.filepath}
+        Issue initiator file: ${issue.initiatorpath}
         Issue CGO file path: ${issue.cgopath}
     - description: For polling use.
       isArray: true

--- a/Packs/Core/ReleaseNotes/3_2_37.md
+++ b/Packs/Core/ReleaseNotes/3_2_37.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Investigation & Response
+
+- Documentation and metadata improvements.

--- a/Packs/Core/ReleaseNotes/3_2_37.md
+++ b/Packs/Core/ReleaseNotes/3_2_37.md
@@ -3,4 +3,4 @@
 
 ##### Investigation & Response
 
-- Documentation and metadata improvements.
+- Fixed the **Retrieve File** Quick Action. The ***File to retrieve*** argument is now displayed by default with the right paths from the issue context.

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.2.36",
+    "currentVersion": "3.2.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CRTX-170299

## Description
make the `generic_file_path` - REQUIRED and fix it's context paths
