### PR TITLE
Ip-update_docs_gmail_search_all_mailboxes

### DIFF
--- a/Packs/Gmail/Integrations/Gmail/Gmail.yml
+++ b/Packs/Gmail/Integrations/Gmail/Gmail.yml
@@ -545,7 +545,7 @@ script:
       name: search_from
     - description: Used to track search progress.
       name: search_to
-    description: Searches the Gmail records for all Google users. (For more than 2500 accounts, use with the `Search all mailboxes - Gmail with polling` playbook).
+    description: Searches the Gmail records for all Google users. (This command handles up to 2,500 email accounts).
     polling: true
     name: gmail-search-all-mailboxes
     outputs:

--- a/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling.yml
+++ b/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling.yml
@@ -300,6 +300,7 @@ outputs:
   description: All headers of a specific mail (list).
 tests:
 - No tests
+deprecated: true
 fromversion: 6.5.0
 supportedModules:
 - X1

--- a/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling_README.md
+++ b/Packs/Gmail/Playbooks/playbook-Search-all-mailboxes_with_polling_README.md
@@ -1,3 +1,4 @@
+NOTE: This playbook is deprecated.
 This playbook searches Gmail records for all Google users. It is intended for large companies with over 2500 Google users.
 
 ## Dependencies

--- a/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling.yml
+++ b/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling.yml
@@ -578,6 +578,7 @@ outputs:
   type: String
 tests:
 - No tests
+deprecated: true
 fromversion: 6.5.0
 supportedModules:
 - X1

--- a/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling_README.md
+++ b/Packs/Gmail/Playbooks/playbook-Search-in-mailboxes_Loop_with_polling_README.md
@@ -1,3 +1,4 @@
+NOTE: This playbook is deprecated.
 This playbook should only run as a sub-playbook for the Search-all-mailboxes - Gmail playbook, it should not run alone.
 
 ## Dependencies

--- a/Packs/Gmail/ReleaseNotes/1_3_33.md
+++ b/Packs/Gmail/ReleaseNotes/1_3_33.md
@@ -1,0 +1,15 @@
+
+#### Integrations
+
+##### Gmail
+
+- Updated the documentation for the ***gmail-search-all-mailboxes*** command to clarify that the command supports searching across up to 2,500 email accounts.
+
+#### Playbooks
+
+##### Search all mailboxes - Gmail with polling
+
+- Deprecated the playbook.
+##### Search in mailboxes Gmail (Loop) with polling
+
+- Deprecated the playbook.

--- a/Packs/Gmail/pack_metadata.json
+++ b/Packs/Gmail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Gmail",
     "description": "Gmail API and user management (This integration replaces the Gmail functionality in the GoogleApps API and G Suite integration).",
     "support": "xsoar",
-    "currentVersion": "1.3.32",
+    "currentVersion": "1.3.33",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Updated the documentation for the ***gmail-search-all-mailboxes*** command to clarify that the command supports searching across up to 2,500 email accounts.
apply Search all mailboxes - Gmail with polling playbook to Deprecated

## Must have
- [ ] Tests
- [ ] Documentation 
