### PR TITLE
update `fastapi` tag

### DIFF
--- a/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
+++ b/Packs/AWS-SNS-Listener/Integrations/AWSSNSListener/AWSSNSListener.yml
@@ -61,7 +61,7 @@ display: AWS-SNS-Listener
 name: AWS-SNS-Listener
 script:
   commands: []
-  dockerimage: demisto/fastapi:0.115.5.117397
+  dockerimage: demisto/fastapi:0.115.12.3243695
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/AWS-SNS-Listener/ReleaseNotes/1_0_10.md
+++ b/Packs/AWS-SNS-Listener/ReleaseNotes/1_0_10.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### AWS-SNS-Listener
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/AWS-SNS-Listener/pack_metadata.json
+++ b/Packs/AWS-SNS-Listener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS-SNS-Listener",
     "description": "A long running AWS SNS Listener service that can subscribe to an SNS topic and create incidents from the messages received.",
     "support": "xsoar",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/GenericWebhook/Integrations/GenericWebhook/GenericWebhook.yml
+++ b/Packs/GenericWebhook/Integrations/GenericWebhook/GenericWebhook.yml
@@ -57,7 +57,7 @@ display: Generic Webhook
 name: Generic Webhook
 script:
   commands: []
-  dockerimage: demisto/fastapi:0.115.9.2587379
+  dockerimage: demisto/fastapi:0.115.12.3243695
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/GenericWebhook/ReleaseNotes/1_1_9.md
+++ b/Packs/GenericWebhook/ReleaseNotes/1_1_9.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Generic Webhook
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/GenericWebhook/pack_metadata.json
+++ b/Packs/GenericWebhook/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Webhook",
     "description": "The Generic Webhook integration is used to create incidents on event triggers.",
     "support": "xsoar",
-    "currentVersion": "1.1.8",
+    "currentVersion": "1.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/GenericWebhook_FormData/Integrations/GenericWebhookFormData/GenericWebhookFormData.yml
+++ b/Packs/GenericWebhook_FormData/Integrations/GenericWebhookFormData/GenericWebhookFormData.yml
@@ -53,7 +53,7 @@ display: Generic Webhook (Form Data)
 name: Generic Webhook (Form Data)
 script:
   commands: []
-  dockerimage: demisto/fastapi:0.115.4.115067
+  dockerimage: demisto/fastapi:0.115.12.3243695
   longRunning: true
   longRunningPort: true
   script: '-'

--- a/Packs/GenericWebhook_FormData/ReleaseNotes/1_0_3.md
+++ b/Packs/GenericWebhook_FormData/ReleaseNotes/1_0_3.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Generic Webhook (Form Data)
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/GenericWebhook_FormData/pack_metadata.json
+++ b/Packs/GenericWebhook_FormData/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Webhook (Form Data)",
     "description": "A version of the Generic Webhook integration that accepts a form data body. Note: raw_json field is required.",
     "support": "community",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Alex Montminy",
     "url": "",
     "email": "",

--- a/Packs/GitLab/Integrations/GitLabEventCollector/GitLabEventCollector.yml
+++ b/Packs/GitLab/Integrations/GitLabEventCollector/GitLabEventCollector.yml
@@ -71,7 +71,7 @@ script:
       required: true
     description: Manual command to fetch events and display them.
     name: gitlab-get-events
-  dockerimage: demisto/fastapi:0.115.4.115067
+  dockerimage: demisto/fastapi:0.115.12.3243695
   isfetchevents: true
   subtype: python3
 marketplaces:

--- a/Packs/GitLab/ReleaseNotes/2_2_29.md
+++ b/Packs/GitLab/ReleaseNotes/2_2_29.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### GitLab Event Collector
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/GitLab/pack_metadata.json
+++ b/Packs/GitLab/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GitLab",
     "description": "Pack for handling gitlab operations",
     "support": "xsoar",
-    "currentVersion": "2.2.28",
+    "currentVersion": "2.2.29",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Okta/Integrations/OktaEventCollector/OktaEventCollector.yml
+++ b/Packs/Okta/Integrations/OktaEventCollector/OktaEventCollector.yml
@@ -73,7 +73,7 @@ script:
       required: false
     description: Manual command to fetch events and display them.
     name: okta-get-events
-  dockerimage: demisto/fastapi:0.115.5.117397
+  dockerimage: demisto/fastapi:0.115.12.3243695
   isfetchevents: true
   subtype: python3
 marketplaces:

--- a/Packs/Okta/ReleaseNotes/3_3_15.md
+++ b/Packs/Okta/ReleaseNotes/3_3_15.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Okta Event Collector
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/Okta/pack_metadata.json
+++ b/Packs/Okta/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Okta",
     "description": "Integration with Okta's cloud-based identity management service.",
     "support": "xsoar",
-    "currentVersion": "3.3.14",
+    "currentVersion": "3.3.15",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/PublishList/Integrations/PublishList/PublishList.yml
+++ b/Packs/PublishList/Integrations/PublishList/PublishList.yml
@@ -53,7 +53,7 @@ description: The Publish List integration is used to publish XSOAR lists for ext
 display: Publish List
 name: Publish List
 script:
-  dockerimage: demisto/fastapi:0.115.4.115067
+  dockerimage: demisto/fastapi:0.115.12.3243695
   longRunning: true
   longRunningPort: true
   script: ''

--- a/Packs/PublishList/ReleaseNotes/1_1_8.md
+++ b/Packs/PublishList/ReleaseNotes/1_1_8.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Publish List
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/PublishList/pack_metadata.json
+++ b/Packs/PublishList/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Publish List",
     "description": "The Publish List integration is used to publish XSOAR lists for external consumption.",
     "support": "community",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "landonc",
     "url": "",
     "email": "",

--- a/Packs/SimpleAPIProxy/Integrations/SimpleAPIProxy/SimpleAPIProxy.yml
+++ b/Packs/SimpleAPIProxy/Integrations/SimpleAPIProxy/SimpleAPIProxy.yml
@@ -69,7 +69,7 @@ description: Provide a simple API proxy to restrict privileges or minimize the a
 display: Simple API Proxy
 name: Simple API Proxy
 script:
-  dockerimage: demisto/fastapi:0.115.4.115067
+  dockerimage: demisto/fastapi:0.115.12.3243695
   longRunning: true
   longRunningPort: true
   runonce: true

--- a/Packs/SimpleAPIProxy/ReleaseNotes/1_0_8.md
+++ b/Packs/SimpleAPIProxy/ReleaseNotes/1_0_8.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Simple API Proxy
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/SimpleAPIProxy/pack_metadata.json
+++ b/Packs/SimpleAPIProxy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Simple API Proxy",
     "description": "This pack provides a simple API proxy to restrict privileges or minimize the amount of credentials issued at the API.",
     "support": "community",
-    "currentVersion": "1.0.7",
+    "currentVersion": "1.0.8",
     "author": "thimanshu474",
     "url": "",
     "email": "",

--- a/Packs/Zoom/Integrations/Zoom/Zoom.yml
+++ b/Packs/Zoom/Integrations/Zoom/Zoom.yml
@@ -1302,7 +1302,7 @@ script:
   runonce: false
   longRunning: true
   longRunningPort: true
-  dockerimage: demisto/fastapi:0.115.5.117397
+  dockerimage: demisto/fastapi:0.115.12.3243695
   script: "-"
   subtype: python3
   type: python

--- a/Packs/Zoom/ReleaseNotes/1_6_28.md
+++ b/Packs/Zoom/ReleaseNotes/1_6_28.md
@@ -1,0 +1,14 @@
+
+#### Integrations
+
+##### Zoom
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+
+
+#### Scripts
+
+##### ZoomAsk
+
+- Updated the Docker image to: *demisto/fastapi:0.115.12.3243695*.
+

--- a/Packs/Zoom/Scripts/ZoomAsk/ZoomAsk.yml
+++ b/Packs/Zoom/Scripts/ZoomAsk/ZoomAsk.yml
@@ -53,7 +53,7 @@ tags:
 - zoom
 timeout: '0'
 type: python
-dockerimage: demisto/fastapi:0.115.4.115067
+dockerimage: demisto/fastapi:0.115.12.3243695
 tests:
 - no test - Untestable
 dependson:

--- a/Packs/Zoom/pack_metadata.json
+++ b/Packs/Zoom/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zoom",
     "description": "Use the Zoom integration manage your Zoom users and meetings",
     "support": "xsoar",
-    "currentVersion": "1.6.27",
+    "currentVersion": "1.6.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Description
Update content items used `fastapi` docker image to use the latest tag `demisto/fastapi:0.115.12.3243695`
