### PR TITLE
Ewso365 get attachment output parsing fix

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.py
@@ -1827,11 +1827,11 @@ def sub_main():  # pragma: no cover
             "ews-expand-group": get_expanded_group,
             "ews-mark-items-as-read": mark_item_as_read,
             "ews-delete-attachment": delete_attachments_for_message,
+            "ews-get-attachment": fetch_attachments_for_message,
         }
 
         # commands that may return multiple results or non-note result
         special_output_commands = {
-            "ews-get-attachment": fetch_attachments_for_message,
             "ews-get-items-as-eml": get_item_as_eml,
             "reply-mail": reply_mail,
         }

--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.yml
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365.yml
@@ -996,7 +996,7 @@ script:
   - description: Run this command if for some reason you need to rerun the authentication process.
     name: ews-auth-reset
     arguments: []
-  dockerimage: demisto/py3ews:5.5.0.118099
+  dockerimage: demisto/py3ews:5.5.1.2816493
   isfetch: true
   script: ''
   subtype: python3

--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
@@ -29,7 +29,6 @@ from EWSO365 import (
     handle_transient_files,
     parse_incident_from_item,
     parse_item_as_dict,
-    fetch_attachments_for_message,
 )
 from exchangelib import EWSDate, EWSDateTime, EWSTimeZone, FileAttachment
 from exchangelib.attachments import AttachmentId, ItemAttachment
@@ -715,7 +714,7 @@ def test_parse_incident_from_item_with_eml_attachment_header_integrity(mocker):
     # sent to "fileResult", original headers from content with matched casing, with additional header
     expected_data = (
         "MIME-Version: 1.0\r\n"
-        "Message-ID:  <message-test-idRANDOMVALUES@testing.com>\r\n"
+        "Message-ID: <message-test-idRANDOMVALUES@testing.com>\r\n"
         "X-FAKE-Header: HVALue\r\n"
         "X-Who-header: whovALUE\r\n"
         "DATE: 2023-12-16T12:04:45\r\n"
@@ -873,7 +872,7 @@ def test_get_item_as_eml(subject, expected_file_name, mocker):
     ]
     expected_data = (
         "MIME-Version: 1.0\r\n"
-        "Message-ID:  <message-test-idRANDOMVALUES@testing.com>\r\n"
+        "Message-ID: <message-test-idRANDOMVALUES@testing.com>\r\n"
         "X-FAKE-Header: HVALue\r\n"
         "X-Who-header: whovALUE\r\n"
         "DATE: 2023-12-16T12:04:45\r\n"

--- a/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EWSO365/EWSO365_test.py
@@ -1145,6 +1145,15 @@ def test_handle_attached_email_with_incorrect_from_header_fixes_malformed_header
     assert result["From"] == "Task One Test <info@test.com>"
 
 def test_fetch_attachments_for_message_output(mocker):
+    """
+    Given:
+        - The command and args are set for the ews-get-attachment command.
+    When:
+        - Calling the main function
+    Then:
+        - Attachments are fetched and parsed as expected.
+        - The output is returned in the correct format.
+    """
     from EWSO365 import main
     from EWSApiModule import CustomDomainOAuth2Credentials
     from CommonServerPython import CommandResults

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_6.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_6.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### EWS O365
+
+- Updated the Docker image to: *demisto/py3ews:5.5.1.2816493*.
+- Fixed issue with the ***ews-get-attachment*** command's output format.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.6.5",
+    "currentVersion": "1.6.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-49874](https://jira-dc.paloaltonetworks.com/browse/XSUP-49874)

## Description
Fix ews-get-attachment output returning a CommandResults object to the war room.

## Must have
- [ ] Tests
- [ ] Documentation 
