### PR TITLE
Infoblox DNS Record API

### DIFF
--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
@@ -18,7 +18,7 @@ INTEGRATION_COMMAND_NAME = "infoblox"
 INTEGRATION_CONTEXT_NAME = "Infoblox"
 INTEGRATION_HOST_RECORDS_CONTEXT_NAME = "Host"
 INTEGRATION_NETWORK_INFO_CONTEXT_KEY = "NetworkInfo"
-INTEGRATION_DNS_ENTRIES_CONTEXT_KEY = "DNSEntries"
+INTEGRATION_DNS_ENTRIES_CONTEXT_KEY = "Records"
 INTEGRATION_AUTHORIZATION_EXCEPTION_MESSAGE = "Authorization error, check your credentials."
 
 # COMMON RAW RESULT KEYS
@@ -644,7 +644,7 @@ class InfoBloxNIOSClient(BaseClient):
 
         return self._http_request("GET", "network", params=request_params)
 
-    def get_dns_entries(
+    def get_record(
         self,
         name_search: str | None,
         ip4_search: str | None,
@@ -1641,9 +1641,9 @@ def get_network_info_command(client: InfoBloxNIOSClient, args: dict) -> tuple[st
     return hr, context, raw_response
 
 
-def get_dns_entries_command(client: InfoBloxNIOSClient, args: dict) -> tuple[str, dict, dict[str, Any]]:
+def get_record_command(client: InfoBloxNIOSClient, args: dict) -> tuple[str, dict, dict[str, Any]]:
     """
-    Get network information command.
+    Get DNS Records command.
 
     Args:
     - `client` (``InfoBloxNIOSClient``): Client object
@@ -1660,27 +1660,27 @@ def get_dns_entries_command(client: InfoBloxNIOSClient, args: dict) -> tuple[str
     max_results = arg_to_number(args.get("max_results", INTEGRATION_MAX_RESULTS_DEFAULT))
 
     record_types = list(record_type.lower().split(","))
-    dns_entries = []
+    records = []
     for record_type in record_types:
-        raw_response = client.get_dns_entries(
+        raw_response = client.get_record(
             name_search=name_search,
             ip4_search=ip4_search,
             ip6_search=ip6_search,
             record_type=record_type,
             max_results=max_results,
         )
-        dns_entries.extend(raw_response)
+        records.extend(raw_response)
 
     if "Error" in raw_response:
        msg = raw_response.get("text")
        raise DemistoException(f"Error retrieving host records: {msg}", res=raw_response)
 
-    if not dns_entries:
+    if not records:
         hr = "No dns entries found"
         context = {}
     else:
-        hr = tableToMarkdown("DNS entries", dns_entries)
-        context = {f"{INTEGRATION_CONTEXT_NAME}.{INTEGRATION_DNS_ENTRIES_CONTEXT_KEY}": dns_entries}
+        hr = tableToMarkdown("DNS entries", records)
+        context = {f"{INTEGRATION_CONTEXT_NAME}.{INTEGRATION_DNS_ENTRIES_CONTEXT_KEY}": records}
 
     return hr, context, raw_response
 
@@ -1725,7 +1725,7 @@ def main():  # pragma: no cover
         f"{INTEGRATION_COMMAND_NAME}-delete-rpz-rule": delete_rpz_rule_command,
         f"{INTEGRATION_COMMAND_NAME}-list-host-info": get_host_records_command,
         f"{INTEGRATION_COMMAND_NAME}-list-network-info": get_network_info_command,
-        f"{INTEGRATION_COMMAND_NAME}-list-dns-entries": get_dns_entries_command,
+        f"{INTEGRATION_COMMAND_NAME}-list-records": get_record_command,
     }
     try:
         if command in commands:

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.py
@@ -656,7 +656,10 @@ class InfoBloxNIOSClient(BaseClient):
         Get the network information.
 
         Args:
-        - `pattern` (``str | None``): Filter DNS Entries by Name.
+        - `name_search` (``str | None``): Filter DNS Entries by Name.
+        - `ip4_search` (``str | None``): Filter DNS Entries by IPv4.
+        - `ip6_search` (``str | None``): Filter DNS Entries by IPv6.
+        - `record_type` (``str | None``): Record Type to list e.g. "a", "aaaa", "cname"
         - `max_results` (``int``): maximum number of results to return, 0 for unlimited.
 
         Returns:
@@ -1655,8 +1658,6 @@ def get_dns_entries_command(client: InfoBloxNIOSClient, args: dict) -> tuple[str
     ip4_search = args.get("ip4_search")
     ip6_search = args.get("ip6_search")
     max_results = arg_to_number(args.get("max_results", INTEGRATION_MAX_RESULTS_DEFAULT))
-    # additional_return_fields = args.get("additional_return_fields", INTEGRATION_COMMON_RAW_RESULT_EXTENSION_ATTRIBUTES_KEY)
-    # extended_attributes = args.get(INTEGRATION_COMMON_RAW_RESULT_EXTENSION_ATTRIBUTES_KEY)
 
     record_types = list(record_type.lower().split(","))
     dns_entries = []
@@ -1666,22 +1667,19 @@ def get_dns_entries_command(client: InfoBloxNIOSClient, args: dict) -> tuple[str
             ip4_search=ip4_search,
             ip6_search=ip6_search,
             record_type=record_type,
-            #additional_return_fields=additional_return_fields,
-            #extended_attributes=extended_attributes,
             max_results=max_results,
         )
         dns_entries.extend(raw_response)
 
-    # if "Error" in raw_response:
-    #    msg = raw_response.get("text")
-    #    raise DemistoException(f"Error retrieving host records: {msg}", res=raw_response)
+    if "Error" in raw_response:
+       msg = raw_response.get("text")
+       raise DemistoException(f"Error retrieving host records: {msg}", res=raw_response)
 
     if not dns_entries:
         hr = "No dns entries found"
         context = {}
     else:
         hr = tableToMarkdown("DNS entries", dns_entries)
-        #hr = dns_entries
         context = {f"{INTEGRATION_CONTEXT_NAME}.{INTEGRATION_DNS_ENTRIES_CONTEXT_KEY}": dns_entries}
 
     return hr, context, raw_response

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
@@ -488,7 +488,7 @@ script:
       name: target
       required: true
     - description: The weight of the substitute rule of the SRV record. Can be 0 to 65535 (inclusive).
-      name: weight 
+      name: weight
       required: true
     description: Creates a substitute rule of a SRV record.
     name: infoblox-create-srv-substitute-record-rule
@@ -768,6 +768,42 @@ script:
       description: Comma-separated list of additional fields to return for each host, e.g., extattrs,aliases.
       required: false
       defaultValue: extattrs
+    outputs:
+    - contextPath: Infoblox.NetworkInfo.Reference
+      description: The network reference.
+      type: String
+    - contextPath: Infoblox.NetworkInfo.Name
+      description: The network name.
+      type: String
+    - contextPath: Infoblox.NetworkInfo.NetworkView
+      description: The network view name.
+      type: String
+    - contextPath: Infoblox.NetworkInfo.ExtendedAttributes
+      description: The network extended attributes.
+      type: Unknown
+    - contextPath: Infoblox.NetworkInfo.AdditionalFields
+      description: The additional fields for network.
+      type: Unknown
+  - name: infoblox-list-dns-entries
+    description: List DNS entries.
+    arguments:
+    - name: pattern
+      description: Search pattern for DNS entries.
+      required: false
+    - name: record_type
+      description: Coma seperated list of  Record types to load, e.g., 'A', 'MX'.
+      required: true
+      defaultValue: a,aaaa,cname
+    #- name: extattrs
+    #  description: Comma-separated key/value formatted filter for extended attributes, e.g., "Site=New York,OtherProp=MyValue".
+    #  required: false
+    - name: max_results
+      description: The maximum number of records to return. 0 for everything.
+      defaultValue: 50
+    #- name: additional_return_fields
+    #  description: Comma-separated list of additional fields to return for each host, e.g., extattrs,aliases.
+    #  required: false
+    #  defaultValue: extattrs
     outputs:
     - contextPath: Infoblox.NetworkInfo.Reference
       description: The network reference.

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
@@ -787,8 +787,14 @@ script:
   - name: infoblox-list-dns-entries
     description: List DNS entries.
     arguments:
-    - name: pattern
-      description: Search pattern for DNS entries.
+    - name: name_search
+      description: Search pattern for DNS Name entries.
+      required: false
+    - name: ip4_search
+      description: Search pattern for IPv4 DNS entries.
+      required: false
+    - name: ip6_search
+      description: Search pattern for IPv6 DNS entries.
       required: false
     - name: record_type
       description: Coma seperated list of  Record types to load, e.g., 'A', 'MX'.

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
@@ -784,17 +784,17 @@ script:
     - contextPath: Infoblox.NetworkInfo.AdditionalFields
       description: The additional fields for network.
       type: Unknown
-  - name: infoblox-list-dns-entries
-    description: List DNS entries.
+  - name: infoblox-list-records
+    description: List DNS records.
     arguments:
     - name: name_search
-      description: Search pattern for DNS Name entries.
+      description: Search pattern for DNS Name records.
       required: false
     - name: ip4_search
-      description: Search pattern for IPv4 DNS entries.
+      description: Search pattern for IPv4 DNS records.
       required: false
     - name: ip6_search
-      description: Search pattern for IPv6 DNS entries.
+      description: Search pattern for IPv6 DNS records.
       required: false
     - name: record_type
       description: Coma seperated list of  Record types to load, e.g., 'A', 'MX'.
@@ -804,22 +804,22 @@ script:
       description: The maximum number of records to return. 0 for everything.
       defaultValue: 50
     outputs:
-    - contextPath: Infoblox.DNSEntries._ref
+    - contextPath: Infoblox.Records._ref
       description: The network reference.
       type: String
-    - contextPath: Infoblox.DNSEntries.name
+    - contextPath: Infoblox.Records.name
       description: The network name.
       type: String
-    - contextPath: Infoblox.DNSEntries.ipv4addr
+    - contextPath: Infoblox.Records.ipv4addr
       description: IPv4 address
       type: String
-    - contextPath: Infoblox.DNSEntries.ipv6addr
+    - contextPath: Infoblox.Records.ipv6addr
       description: IPv6 address
       type: String
-    - contextPath: Infoblox.DNSEntries.canonical
+    - contextPath: Infoblox.Records.canonical
       description: CName of the Searched Address
       type: String
-    - contextPath: Infoblox.DNSEntries.view
+    - contextPath: Infoblox.Records.view
       description: Internal or External DNS Entry
       type: String
   dockerimage: demisto/python3:3.11.10.116949

--- a/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
+++ b/Packs/Infoblox/Integrations/Infoblox/Infoblox.yml
@@ -794,32 +794,28 @@ script:
       description: Coma seperated list of  Record types to load, e.g., 'A', 'MX'.
       required: true
       defaultValue: a,aaaa,cname
-    #- name: extattrs
-    #  description: Comma-separated key/value formatted filter for extended attributes, e.g., "Site=New York,OtherProp=MyValue".
-    #  required: false
     - name: max_results
       description: The maximum number of records to return. 0 for everything.
       defaultValue: 50
-    #- name: additional_return_fields
-    #  description: Comma-separated list of additional fields to return for each host, e.g., extattrs,aliases.
-    #  required: false
-    #  defaultValue: extattrs
     outputs:
-    - contextPath: Infoblox.NetworkInfo.Reference
+    - contextPath: Infoblox.DNSEntries._ref
       description: The network reference.
       type: String
-    - contextPath: Infoblox.NetworkInfo.Name
+    - contextPath: Infoblox.DNSEntries.name
       description: The network name.
       type: String
-    - contextPath: Infoblox.NetworkInfo.NetworkView
-      description: The network view name.
+    - contextPath: Infoblox.DNSEntries.ipv4addr
+      description: IPv4 address
       type: String
-    - contextPath: Infoblox.NetworkInfo.ExtendedAttributes
-      description: The network extended attributes.
-      type: Unknown
-    - contextPath: Infoblox.NetworkInfo.AdditionalFields
-      description: The additional fields for network.
-      type: Unknown
+    - contextPath: Infoblox.DNSEntries.ipv6addr
+      description: IPv6 address
+      type: String
+    - contextPath: Infoblox.DNSEntries.canonical
+      description: CName of the Searched Address
+      type: String
+    - contextPath: Infoblox.DNSEntries.view
+      description: Internal or External DNS Entry
+      type: String
   dockerimage: demisto/python3:3.11.10.116949
   runonce: false
   script: ''

--- a/Packs/Infoblox/Integrations/Infoblox/test_data/TestRecordsOperations/get_record.json
+++ b/Packs/Infoblox/Integrations/Infoblox/test_data/TestRecordsOperations/get_record.json
@@ -1,0 +1,20 @@
+[
+    {
+        "ipv4addr": "1.2.3.4",
+        "_ref": "record:a/KLJjuioasdjfklsdfiuighkj:test.contoso.org/external",
+        "name": "test.contoso.org",
+        "view": "external"
+    },
+    {
+        "_ref": "record:aaaa/gjkhdfjklghldfjkkljKJN:test2.contoso.org/external",
+        "name": "test2.contoso.org",
+        "view": "external",
+        "ipv6addr": "2a02:111:2222:33:444:555:666:7777"
+    },
+    {
+        "_ref": "record:cname/KJHkjIUhjkukhikjn:test3.contoso.org/external",
+        "name": "test3.contoso.org",
+        "view": "external",
+        "canonical": "test4.contoso.org"
+    }
+]

--- a/Packs/Infoblox/Integrations/Infoblox/test_data/TestRecordsOperations/get_record_with_args.json
+++ b/Packs/Infoblox/Integrations/Infoblox/test_data/TestRecordsOperations/get_record_with_args.json
@@ -1,0 +1,20 @@
+[
+    {
+        "ipv4addr": "1.2.3.4",
+        "_ref": "record:a/KLJjuioasdjfklsdfiuighkj:test.contoso.org/external",
+        "name": "test.contoso.org",
+        "view": "external"
+    },
+    {
+        "_ref": "record:aaaa/gjkhdfjklghldfjkkljKJN:test2.contoso.org/external",
+        "name": "test2.contoso.org",
+        "view": "external",
+        "ipv6addr": "2a02:111:2222:33:444:555:666:7777"
+    },
+    {
+        "_ref": "record:cname/KJHkjIUhjkukhikjn:test3.contoso.org/external",
+        "name": "test3.contoso.org",
+        "view": "external",
+        "canonical": "test4.contoso.org"
+    }
+]

--- a/Packs/Infoblox/ReleaseNotes/1_1_8.md
+++ b/Packs/Infoblox/ReleaseNotes/1_1_8.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Infoblox
+
+- Adding DNS Listing

--- a/Packs/Infoblox/pack_metadata.json
+++ b/Packs/Infoblox/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Infoblox NIOS",
     "description": "Infoblox is a comprehensive solution that consolidates DNS, DHCP, and IP address management into a single platform. It is designed to simplify network management by automating these critical functions and providing a centralized console for managing them.",
     "support": "xsoar",
-    "currentVersion": "1.1.7",
+    "currentVersion": "1.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
This addition to the infoblox integration is focused on loading DNS Records from an Infoblox appliance.
The idea being that XSOAR can pull information if needed from a DNS Server

## Must have
- [ ] Tests
- [ ] Documentation 
