### PR TITLE
CiscoThreat un-clickable URL

### DIFF
--- a/Packs/ThreatGrid/.secrets-ignore
+++ b/Packs/ThreatGrid/.secrets-ignore
@@ -1,3 +1,13 @@
 https://panacea.threatgrid.com
 http://example.com
+https://nested.com
+http://abc.com
+https://abc.com
+'https://b.com'
+'http://a.com'
+['http://a.com', 'https://b.com']
+http://1.com
 ['https://192.168.0.1', '192.168.0.1']
+http://...
+https://...
+www...

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
@@ -57,7 +57,6 @@ DEFAULT_MALICIOUS_THRESHOLD = 85
 DEFAULT_SUSPICIOUS_THRESHOLD = 50
 
 
-
 class Client(BaseClient):
     """API Client to communicate with ThreatGrid API."""
 
@@ -76,7 +75,7 @@ class Client(BaseClient):
     def _http_request(self, *args, **kwargs) -> Any:
         """Wrapper for _http_request to remove angle brackets from response"""
         return remove_angle_brackets_from_response(super()._http_request(*args, **kwargs))
-    
+
     def get_sample(
         self,
         sample_id: str | None = None,
@@ -122,14 +121,13 @@ class Client(BaseClient):
             url_suffix = f"{url_suffix}/{artifact}"
         else:
             resp_type = "json"
-            
+
         return self._http_request(
             "GET",
             urljoin(API_V2_PREFIX, url_suffix),
             params=params,
             resp_type=resp_type,
         )
-
 
     def analysis_sample(
         self,
@@ -504,6 +502,7 @@ def search_submission_command(
         outputs=submissions,
         raw_response=response,
     )
+
 
 def remove_angle_brackets_from_response(response):
     """
@@ -934,7 +933,7 @@ def get_sample_command(
         sha256=sha256,
         md5=md5,
     )
-    
+
     sample_details = response
     content_format = "json"
 

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
@@ -58,15 +58,6 @@ DEFAULT_SUSPICIOUS_THRESHOLD = 50
 
 
 
-def clean_response_urls(func):
-    """
-    Decorator to apply `remove_angle_brackets_from_urls` to the response of _http_request.
-    """
-    def wrapper(*args, **kwargs):
-        response = func(*args, **kwargs)
-        return remove_angle_brackets_from_response(response)
-    return wrapper
-
 class Client(BaseClient):
     """API Client to communicate with ThreatGrid API."""
 
@@ -81,11 +72,11 @@ class Client(BaseClient):
             headers=headers,
             proxy=proxy,
         )
-        
-        @clean_response_urls
-        def _http_request(self, *args, **kwargs):
-            return super()._http_request(*args, **kwargs)
 
+    def _http_request(self, *args, **kwargs) -> Any:
+        """Wrapper for _http_request to remove angle brackets from response"""
+        return remove_angle_brackets_from_response(super()._http_request(*args, **kwargs))
+    
     def get_sample(
         self,
         sample_id: str | None = None,

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
@@ -60,7 +60,7 @@ DEFAULT_SUSPICIOUS_THRESHOLD = 50
 
 def clean_response_urls(func):
     """
-    Decorator to apply `remove_angle_brackets_from_urls` to the response of a function (e.g., _http_request).
+    Decorator to apply `remove_angle_brackets_from_urls` to the response of _http_request.
     """
     def wrapper(*args, **kwargs):
         response = func(*args, **kwargs)

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.py
@@ -73,7 +73,7 @@ class Client(BaseClient):
         )
 
     def _http_request(self, *args, **kwargs) -> Any:
-        """Wrapper for _http_request to remove angle brackets from response"""
+        """Wrapper for _http_request that removes angle brackets from the response to prevent clickable URLs."""
         return remove_angle_brackets_from_response(super()._http_request(*args, **kwargs))
 
     def get_sample(

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.yml
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.yml
@@ -1418,7 +1418,7 @@ script:
     - contextPath: ThreatGrid.DomainAssociatedIp.ips
       description: The associated IP.
       type: String
-  dockerimage: demisto/python3:3.12.8.1983910
+  dockerimage: demisto/python3:3.12.8.3296088
 tests:
 - No tests (auto formatted)
 fromversion: 5.0.0

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.yml
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2.yml
@@ -2,6 +2,9 @@ commonfields:
   id: ThreatGridv2
   version: -1
 name: ThreatGridv2
+sectionOrder:
+- Connect
+- Collect
 display: Cisco Secure Malware Analytics (Threat Grid) v2
 category: Forensics & Malware Analysis
 description: Query and upload samples to Cisco threat grid.
@@ -11,12 +14,14 @@ configuration:
   defaultvalue: https://panacea.threatgrid.com
   type: 0
   required: true
+  section: Connect
 - displaypassword: API token
   name: credentials
   type: 9
   required: true
   hiddenusername: true
   display: ''
+  section: Connect
 - display: Source Reliability
   name: integrationReliability
   type: 15
@@ -31,14 +36,17 @@ configuration:
   - D - Not usually reliable
   - E - Unreliable
   - F - Reliability cannot be judged
+  section: Connect
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
   required: false
+  section: Connect
 - display: Use system proxy settings
   name: proxy
   type: 8
   required: false
+  section: Connect
 script:
   script: ''
   type: python
@@ -1410,7 +1418,7 @@ script:
     - contextPath: ThreatGrid.DomainAssociatedIp.ips
       description: The associated IP.
       type: String
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.8.1983910
 tests:
 - No tests (auto formatted)
 fromversion: 5.0.0

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2_test.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2_test.py
@@ -838,3 +838,59 @@ def test_upload_sample_method(
     mock_client.upload_sample(files=files, payload=payload)
     assert mock_func.call_args[1] == expected_call
     assert "Authorization" not in mock_client._headers if files else True
+    
+
+
+@pytest.mark.parametrize("input_data, expected_output", [
+    # --- Basic cases ---
+    ("Visit <http://example.com>", "Visit http://example.com"),
+    ("Secure: <https://secure.com>", "Secure: https://secure.com"),
+    ("Go to <www.site.com>", "Go to www.site.com"),
+
+    # --- No change cases ---
+    ("No brackets here", "No brackets here"),
+    ("<not-a-url>", "<not-a-url>"),
+
+    # --- Dict ---
+    (
+        {"url": "<https://abc.com>"},
+        {"url": "https://abc.com"}
+    ),
+
+    # --- List ---
+    (
+        ["<http://example.com>", "<https://example.com>", "safe"],
+        ["http://example.com", "https://example.com", "safe"]
+    ),
+
+    # --- Nested dict ---
+    (
+        {"data": {"link": "<http://abc.com>", "text": "clean"}},
+        {"data": {"link": "http://abc.com", "text": "clean"}}
+    ),
+
+    # --- Nested list ---
+    (
+        [{"url": "<http://1.com>"}, {"url": "<www.2.com>"}],
+        [{"url": "http://1.com"}, {"url": "www.2.com"}]
+    ),
+
+    # --- Deep nesting ---
+    (
+        {"outer": [{"inner": {"site": "<https://nested.com>"}}]},
+        {"outer": [{"inner": {"site": "https://nested.com"}}]}
+    ),
+])
+def test_remove_angle_brackets_from_urls(input_data, expected_output):
+    """
+    Given:
+        - A response input with different structures (string, list, dict) containing URLs wrapped in angle brackets.
+    When:
+        - Calling the `remove_angle_brackets_from_urls` function
+    Then:
+        - URLs like <http://...>, <https://...>, and <www...> should be unwrapped and returned without angle brackets
+        - All other strings and non-URL values should remain unchanged
+        - The function should work recursively for nested lists and dictionaries
+    """
+    from ThreatGridv2 import remove_angle_brackets_from_response
+    assert remove_angle_brackets_from_response(input_data) == expected_output

--- a/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2_test.py
+++ b/Packs/ThreatGrid/Integrations/ThreatGridv2/ThreatGridv2_test.py
@@ -892,5 +892,5 @@ def test_remove_angle_brackets_from_urls(input_data, expected_output):
         - All other strings and non-URL values should remain unchanged
         - The function should work recursively for nested lists and dictionaries
     """
-    from ThreatGridv2 import remove_angle_brackets_from_response
-    assert remove_angle_brackets_from_response(input_data) == expected_output
+    from ThreatGridv2 import remove_angle_brackets
+    assert remove_angle_brackets(input_data) == expected_output

--- a/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
+++ b/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### Cisco Secure Malware Analytics (Threat Grid) v2
+- Updated the Docker image to: *demisto/python3:3.12.8.1983910*.
 
-- Updated the ThreatGridv2 integration to defang URLs in command outputs so they are no longer clickable.
+- Updated the ThreatGridv2 integration to remove angle brackets from URLs in command outputs so they are no longer clickable.

--- a/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
+++ b/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cisco Secure Malware Analytics (Threat Grid) v2
+
+- Updated the ThreatGridv2 integration to defang URLs in command outputs so they are no longer clickable.

--- a/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
+++ b/Packs/ThreatGrid/ReleaseNotes/2_0_26.md
@@ -2,6 +2,6 @@
 #### Integrations
 
 ##### Cisco Secure Malware Analytics (Threat Grid) v2
-- Updated the Docker image to: *demisto/python3:3.12.8.1983910*.
+- Updated the Docker image to: *demisto/python3:3.12.8.3296088*.
 
-- Updated the ThreatGridv2 integration to remove angle brackets from URLs in command outputs so they are no longer clickable.
+- Updated the ThreatGridv2 integration to remove angle brackets from URLs in command outputs, ensuring they are no longer clickable.

--- a/Packs/ThreatGrid/pack_metadata.json
+++ b/Packs/ThreatGrid/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Secure Malware Analytics",
     "description": "Query and upload samples to Cisco threat grid.",
     "support": "xsoar",
-    "currentVersion": "2.0.25",
+    "currentVersion": "2.0.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-11055)

## Description
The URL in the command result were clickable due to angle brackets, removed angle brackets to make them un-clickable

## Must have
- [ ] Tests
- [ ] Documentation 
