### PR TITLE
Fix Cisco AMP endpoint command

### DIFF
--- a/Packs/AMP/CONTRIBUTORS.json
+++ b/Packs/AMP/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+  "Maximilian Lehrbaum"
+]

--- a/Packs/AMP/Integrations/AMPv2/AMPv2.py
+++ b/Packs/AMP/Integrations/AMPv2/AMPv2.py
@@ -2979,7 +2979,7 @@ def endpoint_command(client: Client, args: dict[str, Any]) -> List[CommandResult
         for endpoint_ip in endpoint_ips:
             response = client.computer_list_request(internal_ip=endpoint_ip)
 
-        responses.append(response)
+            responses.append(response)
 
     else:
         responses.append(client.computer_list_request(hostnames=endpoint_hostnames))

--- a/Packs/AMP/Integrations/AMPv2/AMPv2.yml
+++ b/Packs/AMP/Integrations/AMPv2/AMPv2.yml
@@ -1769,7 +1769,7 @@ script:
     - contextPath: DBotScore.Score
       description: The actual score.
       type: Number
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.8.3296088
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/AMP/ReleaseNotes/2_1_9.md
+++ b/Packs/AMP/ReleaseNotes/2_1_9.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Cisco AMP v2
+
+- Updated the Docker image to: *demisto/python3:3.12.8.3296088*.
+- Fixed the endpoint command to correctly handle multiple IP addresses.

--- a/Packs/AMP/pack_metadata.json
+++ b/Packs/AMP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco AMP",
     "description": "Uses CISCO AMP Endpoint",
     "support": "xsoar",
-    "currentVersion": "2.1.8",
+    "currentVersion": "2.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CiscoAMP/Integrations/CiscoAMP/CiscoAMP.py
+++ b/Packs/CiscoAMP/Integrations/CiscoAMP/CiscoAMP.py
@@ -3006,7 +3006,7 @@ def endpoint_command(client: Client, args: Dict[str, Any]) -> List[CommandResult
         for endpoint_ip in endpoint_ips:
             response = client.computer_list_request(internal_ip=endpoint_ip)
 
-        responses.append(response)
+            responses.append(response)
 
     else:
         responses.append(client.computer_list_request(hostnames=endpoint_hostnames))

--- a/Packs/CiscoAMP/ReleaseNotes/1_0_2.md
+++ b/Packs/CiscoAMP/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cisco AMP (Deprecated)
+
+- Fixed the endpoint command to correctly handle multiple IPs.

--- a/Packs/CiscoAMP/pack_metadata.json
+++ b/Packs/CiscoAMP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco AMP (Deprecated)",
     "description": "Deprecated. Use the AMP pack instead.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixing an error in the endpoint command implementation for Cisco AMP. When the IP argument is used with multiple values, only the last response is returned.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

## Description
I fix a simple mistake in the implementation for the AMPv2 integration. Where not all results for the endpoint command with IP addresses are correctly collected. I also fixed it in the outdated Pack because it is where the mistake originated from.

## Must have
- [ ] Tests
- [ ] Documentation 
