### PR TITLE
handle None keys in context

### DIFF
--- a/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
@@ -430,7 +430,7 @@ def add_playbook_metadata(data: dict, command: str):
     ctx_output: dict = demisto.callingContext or {}
 
     context = ctx_output.get("context") or {}
-    parent_entry = context.get("parentEntry") or {}
+    parent_entry = context.get("ParentEntry") or {}
     entry_task = parent_entry.get("entryTask") or {}
 
     incidents: list = context.get("Incidents", [])
@@ -475,7 +475,10 @@ def start_xql_query(client: CoreClient, args: Dict[str, Any]) -> str:
         }
     }
 
-    add_playbook_metadata(data, "start_xql_query")
+    try:
+        add_playbook_metadata(data, "start_xql_query")
+    except Exception as e:
+        demisto.error(f"Error adding playbook metadata: {str(e)}")
 
     time_frame = args.get("time_frame")
     if time_frame:

--- a/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
@@ -428,8 +428,12 @@ def convert_timeframe_string_to_json(time_to_convert: str) -> Dict[str, int]:
 
 def add_playbook_metadata(data: dict, command: str):
     ctx_output: dict = demisto.callingContext or {}
-    entry_task: dict = ctx_output.get("context", {}).get("ParentEntry", {}).get("entryTask", {})
-    incidents: list = ctx_output.get("context", {}).get("Incidents", [])
+
+    context = ctx_output.get("context") or {}
+    parent_entry = context.get("parentEntry") or {}
+    entry_task = parent_entry.get("entryTask") or {}
+
+    incidents: list = context.get("Incidents", [])
     playbook_id = incidents[0].get("playbookId", "") if incidents else ""
     playbook_name = entry_task.get("playbookName", "")
     task_name = entry_task.get("taskName", "")

--- a/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule_test.py
+++ b/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule_test.py
@@ -1074,18 +1074,27 @@ def test_add_playbook_metadata_complete_data(mocker):
     demisto.debug.assert_called_once()
 
 
-def test_add_playbook_metadata_missing_context(mocker):
+@pytest.mark.parametrize(
+    "callingContext",
+    [
+        (None),
+        ({"context": {"ParentEntry": None}}),
+        ({"context": {"ParentEntry": {"entryTask": None}}}),
+        ({"context": {"Incidents": None}}),
+    ],
+)
+def test_add_playbook_metadata_missing_context(mocker, callingContext):
     """
     Given:
-    - Missing calling context
+    - context is None or sub keys are None
 
     When:
     - Calling add_playbook_metadata function
 
     Then:
-    - Ensure the playbook metadata has default values for missing fields
+    - Ensure the playbook metadata has default values for missing fields and knows how to handle None.
     """
-    mocker.patch.object(demisto, "callingContext", None)
+    mocker.patch.object(demisto, "callingContext", callingContext)
     mocker.patch.object(demisto, "debug")
 
     data = {"request_data": {}}

--- a/Packs/Core/ReleaseNotes/3_3_4.md
+++ b/Packs/Core/ReleaseNotes/3_3_4.md
@@ -3,11 +3,11 @@
 
 ##### SearchIndicatorInEvents
 
-- Documentation and metadata improvements.
+- Fixed an issue with extracting metadata from playbooks.
 
 #### Integrations
 
 ##### XQL Query Engine
 
-- Documentation and metadata improvements.
+- Fixed an issue with extracting metadata from playbooks.
 

--- a/Packs/Core/ReleaseNotes/3_3_4.md
+++ b/Packs/Core/ReleaseNotes/3_3_4.md
@@ -1,0 +1,13 @@
+
+#### Scripts
+
+##### SearchIndicatorInEvents
+
+- Documentation and metadata improvements.
+
+#### Integrations
+
+##### XQL Query Engine
+
+- Documentation and metadata improvements.
+

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core - Investigation and Response",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.3.3",
+    "currentVersion": "3.3.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CortexXDR/ReleaseNotes/6_2_23.md
+++ b/Packs/CortexXDR/ReleaseNotes/6_2_23.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Cortex XDR - XQL Query Engine
+
+- Documentation and metadata improvements.

--- a/Packs/CortexXDR/ReleaseNotes/6_2_23.md
+++ b/Packs/CortexXDR/ReleaseNotes/6_2_23.md
@@ -3,4 +3,4 @@
 
 ##### Cortex XDR - XQL Query Engine
 
-- Documentation and metadata improvements.
+- Fixed an issue with extracting metadata from playbooks.

--- a/Packs/CortexXDR/pack_metadata.json
+++ b/Packs/CortexXDR/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex XDR by Palo Alto Networks",
     "description": "Automates Cortex XDR incident response, and includes custom Cortex XDR incident views and layouts to aid analyst investigations.",
     "support": "xsoar",
-    "currentVersion": "6.2.22",
+    "currentVersion": "6.2.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-51010)

## Description
Newly added add_playbook_metadata failed if context dict had sub keys which were None.