### PR TITLE
[FeedPlainText] Remove file types from indicator_type param

### DIFF
--- a/Packs/FeedPlainText/Integrations/FeedPlainText/FeedPlainText.yml
+++ b/Packs/FeedPlainText/Integrations/FeedPlainText/FeedPlainText.yml
@@ -40,9 +40,6 @@ configuration:
   - Email
   - URL
   - File
-  - File MD5
-  - File SHA256
-  - File SHA1
   - Account
   - CVE
   - Host

--- a/Packs/FeedPlainText/ReleaseNotes/1_1_36.md
+++ b/Packs/FeedPlainText/ReleaseNotes/1_1_36.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Plain Text Feed
+
+- Removed file types options from *Indicator Type* parameter as they are deprecated.

--- a/Packs/FeedPlainText/pack_metadata.json
+++ b/Packs/FeedPlainText/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Plain Text Feed",
     "description": "Fetches indicators from a plain text feed.",
     "support": "xsoar",
-    "currentVersion": "1.1.35",
+    "currentVersion": "1.1.36",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-50615)

## Description
Remove file types (File MD5, File SHA256, File SHA1) from `indicator_type` param.