### PR TITLE
Increasing interval timeout for Joe Security polling request.

### DIFF
--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
@@ -659,8 +659,9 @@ def url_submission(
     )
 
 
+# The interval timeout should be set between 30 and 60 seconds for optimal server usage.
 @polling_function(
-    name=demisto.command(), timeout=arg_to_number(demisto.args().get("timeout", 1200)), interval=10, requires_polling_arg=False
+    name=demisto.command(), timeout=arg_to_number(demisto.args().get("timeout", 1200)), interval=45, requires_polling_arg=False
 )
 def polling_submit_command(
     args: Dict[str, Any], client: Client, params: Dict[str, Any], exe_metrics: ExecutionMetrics

--- a/Packs/JoeSecurity/ReleaseNotes/1_1_28.md
+++ b/Packs/JoeSecurity/ReleaseNotes/1_1_28.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Joe Security v2
+
+Updated the polling request interval timeout to 45 seconds for optimal server performance.

--- a/Packs/JoeSecurity/pack_metadata.json
+++ b/Packs/JoeSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Joe Security",
     "description": "Sandbox Cloud",
     "support": "xsoar",
-    "currentVersion": "1.1.27",
+    "currentVersion": "1.1.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Description
Increased interval timeout for Joe Security polling request.

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-49295)
