### PR TITLE
[XSUP-50324] Add audit-comment option to pan-os-edit-rule documentation

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -2526,7 +2526,7 @@ Edits a policy rule.
 | **Argument Name** | **Description** | **Required** |
 |-------------------| --- | --- |
 | rulename          | Name of the rule to edit. | Required |
-| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag', 'source-user', 'service' or 'profile-setting'. | Required |
+| element_to_change | Parameter in the security rule to change. Can be 'source', 'destination', 'application', 'action', 'category', 'description', 'disabled', 'target', 'log-forwarding', 'tag', 'source-user', 'service', 'profile-setting' or 'audit-comment'. | Required |
 | element_value     | The new value for the parameter. | Required |
 | pre_post          | Pre-rule or post-rule (Panorama instances). | Optional |
 | behaviour         | Whether to replace, add, or remove the element_value from the current rule object value. | Optional |


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-50324)

## Description
Add audit-comment option to `pan-os-edit-rule` documentation