### PR TITLE
Bugfix/XSUP-51673/missing-input-extract-indicators-generic-from-pdf-files

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -2480,6 +2480,7 @@ tasks:
       id: 54c92f03-3cc6-4742-b121-8694a35255b2
       version: -1
       name: Assert there are pdf files to extract from
+      description: Checks whether there are any PDF files to process
       type: condition
       iscommand: false
       brand: ""

--- a/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Extract_Indicators_From_File_-_Generic_v2_4_5.yml
@@ -31,10 +31,10 @@ starttaskid: "0"
 tasks:
   "0":
     id: "0"
-    taskid: 872fa459-b3f9-41a4-85ea-0aa06bc63d8b
+    taskid: 19112ab0-6176-49fc-83c5-b0d3b14eafe7
     type: start
     task:
-      id: 872fa459-b3f9-41a4-85ea-0aa06bc63d8b
+      id: 19112ab0-6176-49fc-83c5-b0d3b14eafe7
       version: -1
       name: ""
       iscommand: false
@@ -61,10 +61,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "1":
     id: "1"
-    taskid: 359dee17-14b5-4800-8429-16255df23121
+    taskid: 27e3a138-4521-475e-ab6e-d2fa5278a561
     type: condition
     task:
-      id: 359dee17-14b5-4800-8429-16255df23121
+      id: 27e3a138-4521-475e-ab6e-d2fa5278a561
       version: -1
       name: Is there a file?
       description: |
@@ -105,10 +105,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "3":
     id: "3"
-    taskid: 4c38c426-3444-4c6b-83dc-2ac1cda0aa3c
+    taskid: 463760b9-550a-4dea-8a06-42354107dc49
     type: title
     task:
-      id: 4c38c426-3444-4c6b-83dc-2ac1cda0aa3c
+      id: 463760b9-550a-4dea-8a06-42354107dc49
       version: -1
       name: Done
       type: title
@@ -121,7 +121,7 @@ tasks:
       {
         "position": {
           "x": 915,
-          "y": 1744
+          "y": 1826
         }
       }
     note: false
@@ -133,10 +133,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "4":
     id: "4"
-    taskid: 0aaef151-686c-4b5d-8632-cdd9dad3c501
+    taskid: 832f6312-844f-43ce-8c6b-ce6e3feb0ada
     type: title
     task:
-      id: 0aaef151-686c-4b5d-8632-cdd9dad3c501
+      id: 832f6312-844f-43ce-8c6b-ce6e3feb0ada
       version: -1
       name: Extract Indicators From Files
       type: title
@@ -171,10 +171,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "5":
     id: "5"
-    taskid: a8ed00fd-f07a-492a-8a9a-d2af590ab91d
+    taskid: 1f1bd979-a81c-4d02-8a7e-d039839c0f11
     type: condition
     task:
-      id: a8ed00fd-f07a-492a-8a9a-d2af590ab91d
+      id: 1f1bd979-a81c-4d02-8a7e-d039839c0f11
       version: -1
       name: Is there a text-based file?
       description: Checks if there is a text-based file in context. Skips MSG and EML files.
@@ -337,10 +337,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "6":
     id: "6"
-    taskid: e5274670-6c0c-4595-864f-0df9591c3f11
+    taskid: 1da99193-16fa-4afe-8c81-6181adf34b7a
     type: regular
     task:
-      id: e5274670-6c0c-4595-864f-0df9591c3f11
+      id: 1da99193-16fa-4afe-8c81-6181adf34b7a
       version: -1
       name: Extract indicators from text-based file
       description: Extracts indicators from text-based files.
@@ -488,10 +488,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 2c302a24-52da-4372-b33e-0bb513877c85
+    taskid: fe9aa9e7-8981-4594-b9a4-b7a4225a12fa
     type: condition
     task:
-      id: 2c302a24-52da-4372-b33e-0bb513877c85
+      id: fe9aa9e7-8981-4594-b9a4-b7a4225a12fa
       version: -1
       name: Is there a PDF file?
       description: Checks if there is a PDF file in context.
@@ -555,10 +555,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "9":
     id: "9"
-    taskid: b1b59f7d-7360-4392-829e-eb6d1fb39adf
+    taskid: b61b2d2d-526f-4d64-8bcc-46a45a3da866
     type: condition
     task:
-      id: b1b59f7d-7360-4392-829e-eb6d1fb39adf
+      id: b61b2d2d-526f-4d64-8bcc-46a45a3da866
       version: -1
       name: Is there a Word file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
@@ -792,10 +792,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "10":
     id: "10"
-    taskid: 0ecedf15-716d-48cd-8980-1812cb900663
+    taskid: 3e880c19-d946-4cca-8dd4-fabe023b5f27
     type: title
     task:
-      id: 0ecedf15-716d-48cd-8980-1812cb900663
+      id: 3e880c19-d946-4cca-8dd4-fabe023b5f27
       version: -1
       name: No File To Parse
       type: title
@@ -823,10 +823,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "11":
     id: "11"
-    taskid: 302236a9-6e02-4ca8-86ab-52e5a8c10b14
+    taskid: cce17910-c4c9-4c71-862c-9a55cbeca170
     type: regular
     task:
-      id: 302236a9-6e02-4ca8-86ab-52e5a8c10b14
+      id: cce17910-c4c9-4c71-862c-9a55cbeca170
       version: -1
       name: Extract indicators from Word file
       description: Extracts indicators from word files (DOC, DOCX).
@@ -1010,10 +1010,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "13":
     id: "13"
-    taskid: 61e4f247-0d0f-4a85-8f28-491314b03130
+    taskid: 13a4204e-43c3-4c7d-8331-5048057a0ab2
     type: condition
     task:
-      id: 61e4f247-0d0f-4a85-8f28-491314b03130
+      id: 13a4204e-43c3-4c7d-8331-5048057a0ab2
       version: -1
       name: Is Image OCR enabled?
       description: Checks whether there is an active instance of the Image OCR integration. enabled.
@@ -1061,10 +1061,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "14":
     id: "14"
-    taskid: b00731f6-af3b-4011-8be2-3680f778777e
+    taskid: 5fe1445f-0d84-48e8-84b5-265e777b594f
     type: regular
     task:
-      id: b00731f6-af3b-4011-8be2-3680f778777e
+      id: 5fe1445f-0d84-48e8-84b5-265e777b594f
       version: -1
       name: Extract text from images
       description: Extracts text from PNG, JPEG, and GIF image files, and uses auto-extract to get reputation for indicators.
@@ -1138,10 +1138,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "15":
     id: "15"
-    taskid: bebd1cad-b2c2-4a97-82c7-10d8e02c4d5a
+    taskid: a7ba5b59-d995-4fcd-8454-668c7047028c
     type: condition
     task:
-      id: bebd1cad-b2c2-4a97-82c7-10d8e02c4d5a
+      id: a7ba5b59-d995-4fcd-8454-668c7047028c
       version: -1
       name: Is there another supported document type?
       description: |-
@@ -1324,10 +1324,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "16":
     id: "16"
-    taskid: db39f917-db86-4591-861a-6a1f1220f5c2
+    taskid: 80811529-61cb-4b0c-8000-e31cd312fdda
     type: regular
     task:
-      id: db39f917-db86-4591-861a-6a1f1220f5c2
+      id: 80811529-61cb-4b0c-8000-e31cd312fdda
       version: -1
       name: Convert a document to PDF
       description: |-
@@ -1506,10 +1506,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "19":
     id: "19"
-    taskid: fbb64cc1-e15c-4dc9-b71d-5b65885d3549
+    taskid: 7f90c4cc-3035-4244-8785-360f594ddc62
     type: regular
     task:
-      id: fbb64cc1-e15c-4dc9-b71d-5b65885d3549
+      id: 7f90c4cc-3035-4244-8785-360f594ddc62
       version: -1
       name: Set ExtractedURLsFromFiles
       description: |-
@@ -1537,7 +1537,7 @@ tasks:
       {
         "position": {
           "x": 915,
-          "y": 1608
+          "y": 1690
         }
       }
     note: false
@@ -1549,10 +1549,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "20":
     id: "20"
-    taskid: 7f7c2617-8a16-46bc-8141-96f650642272
+    taskid: 7ce286a8-d86f-42f4-8e36-426f4753740c
     type: playbook
     task:
-      id: 7f7c2617-8a16-46bc-8141-96f650642272
+      id: 7ce286a8-d86f-42f4-8e36-426f4753740c
       version: -1
       name: Microsoft Office File Enrichment - Oletools
       description: |-
@@ -1604,10 +1604,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "21":
     id: "21"
-    taskid: 6bead496-6144-44a8-8973-6e43547abcf3
+    taskid: 6515f21b-9e06-4b53-8b76-4ade7d43e829
     type: condition
     task:
-      id: 6bead496-6144-44a8-8973-6e43547abcf3
+      id: 6515f21b-9e06-4b53-8b76-4ade7d43e829
       version: -1
       name: Is there an image file?
       description: |-
@@ -1689,10 +1689,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "22":
     id: "22"
-    taskid: 1b7979ee-7c46-429d-84ae-f0af5678b192
+    taskid: 23e84751-1ddc-46b8-85dd-043b3252e940
     type: regular
     task:
-      id: 1b7979ee-7c46-429d-84ae-f0af5678b192
+      id: 23e84751-1ddc-46b8-85dd-043b3252e940
       version: -1
       name: Extract indicators from docx file
       description: Extracts indicators from word files (DOC, DOCX).
@@ -1757,10 +1757,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "23":
     id: "23"
-    taskid: 86766e4e-e9f9-4df3-8dc9-13646c82d2fa
+    taskid: 07993c36-28e2-46b3-8816-e580ba1ae505
     type: condition
     task:
-      id: 86766e4e-e9f9-4df3-8dc9-13646c82d2fa
+      id: 07993c36-28e2-46b3-8816-e580ba1ae505
       version: -1
       name: Is there a Word docx file?
       description: Checks if there is a Word file (DOC, DOCX) in context.
@@ -1832,10 +1832,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "24":
     id: "24"
-    taskid: 5c6cf188-f1e8-45ea-9d0b-41bcae9be38f
+    taskid: e80f3f02-7c8b-4cde-8456-79145e049569
     type: regular
     task:
-      id: 5c6cf188-f1e8-45ea-9d0b-41bcae9be38f
+      id: e80f3f02-7c8b-4cde-8456-79145e049569
       version: -1
       name: Extract Text from QR Code
       description: Extracts the text from a QR code. The output of this script includes the output of the script "extractIndicators" run on the text extracted from the QR code.
@@ -1898,7 +1898,7 @@ tasks:
       {
         "position": {
           "x": 1606,
-          "y": 1418
+          "y": 1540
         }
       }
     note: false
@@ -1910,10 +1910,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "25":
     id: "25"
-    taskid: 6a981b49-f471-48e1-9b3b-a084646c1cdd
+    taskid: 1c5f93e5-dd4c-46bf-8f76-ae594a83a90d
     type: regular
     task:
-      id: 6a981b49-f471-48e1-9b3b-a084646c1cdd
+      id: 1c5f93e5-dd4c-46bf-8f76-ae594a83a90d
       version: -1
       name: Convert PDF to Image
       description: Converts a PDF file to an image file.
@@ -1949,7 +1949,7 @@ tasks:
       {
         "position": {
           "x": 1606,
-          "y": 1282
+          "y": 1404
         }
       }
     note: false
@@ -1961,10 +1961,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "26":
     id: "26"
-    taskid: 4fb08fe7-5b0b-48ef-8d70-8cc00cb5c6c8
+    taskid: 53db3653-4ebd-46c3-84e2-2a029bb9561c
     type: condition
     task:
-      id: 4fb08fe7-5b0b-48ef-8d70-8cc00cb5c6c8
+      id: 53db3653-4ebd-46c3-84e2-2a029bb9561c
       version: -1
       name: Is there a PPTX/XSLX file?
       description: Checks if there is a PowerPoint or Excel file (PPTX/XSLX) in context.
@@ -2054,10 +2054,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "27":
     id: "27"
-    taskid: 213aae05-47d1-4361-8a40-a5f58b03d241
+    taskid: 629dd9a1-1eb5-42f1-8846-faf65be915f9
     type: regular
     task:
-      id: 213aae05-47d1-4361-8a40-a5f58b03d241
+      id: 629dd9a1-1eb5-42f1-8846-faf65be915f9
       version: -1
       name: Extract Hyper-Links from Office Files
       description: 'Extracts hyperlinks from Office files. Supported file types are: xlsx, docx, pptx.'
@@ -2140,10 +2140,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "28":
     id: "28"
-    taskid: ff1834e4-8544-4395-86e4-81f108cf6920
+    taskid: 8cae1b0c-df86-4070-83bc-2108b2fb3281
     type: condition
     task:
-      id: ff1834e4-8544-4395-86e4-81f108cf6920
+      id: 8cae1b0c-df86-4070-83bc-2108b2fb3281
       version: -1
       name: Does ReadQRCode support the image?
       type: condition
@@ -2200,10 +2200,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "29":
     id: "29"
-    taskid: 4e00d382-41da-410c-b7dd-e856e2f60023
+    taskid: f3ab8c1c-f06f-4e23-8fb8-92d02cbee65a
     type: regular
     task:
-      id: 4e00d382-41da-410c-b7dd-e856e2f60023
+      id: f3ab8c1c-f06f-4e23-8fb8-92d02cbee65a
       version: -1
       name: Check validity of PDF files
       description: Returns wether a PDF is both valid and encrypted.
@@ -2262,10 +2262,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "30":
     id: "30"
-    taskid: 449b1e01-91c0-4853-a8fe-008500281d54
+    taskid: 544e230f-6df0-46c2-8d9d-e4535594f5b4
     type: condition
     task:
-      id: 449b1e01-91c0-4853-a8fe-008500281d54
+      id: 544e230f-6df0-46c2-8d9d-e4535594f5b4
       version: -1
       name: Any readable PDF files?
       description: Checks if there are valid, non-encrypted PDFs.
@@ -2322,10 +2322,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "31":
     id: "31"
-    taskid: 3b75e6ba-be07-4108-9c6b-69e6dc9479aa
+    taskid: 5ff6052a-4a53-49d0-8471-508a5e27af03
     type: regular
     task:
-      id: 3b75e6ba-be07-4108-9c6b-69e6dc9479aa
+      id: 5ff6052a-4a53-49d0-8471-508a5e27af03
       version: -1
       name: Extract indicators from PDF files
       description: Load a PDF file's content and metadata into context.
@@ -2359,7 +2359,7 @@ tasks:
       {
         "position": {
           "x": 1606,
-          "y": 1143
+          "y": 1275
         }
       }
     note: false
@@ -2371,10 +2371,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "32":
     id: "32"
-    taskid: 48a9949e-eefc-4718-a81e-fbbf1c29609f
+    taskid: 5b9ddd9d-143f-47fc-8cf8-0249889f1532
     type: regular
     task:
-      id: 48a9949e-eefc-4718-a81e-fbbf1c29609f
+      id: 5b9ddd9d-143f-47fc-8cf8-0249889f1532
       version: -1
       name: Save converted PDFs separately
       description: "Set a value in context under the key you entered. If no value is entered, the script doesn't do anything.\n\nThis automation runs using the default Limited User role, unless you explicitly change the permissions.\nFor more information, see the section about permissions here:\n- For Cortex XSOAR 6 see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/6.x/Cortex-XSOAR-Playbook-Design-Guide/Automations \n- For Cortex XSOAR 8 Cloud see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8/Cortex-XSOAR-Cloud-Documentation/Create-a-script\n- For Cortex XSOAR 8.7 On-prem see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8.7/Cortex-XSOAR-On-prem-Documentation/Create-a-script"
@@ -2384,7 +2384,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "31"
+      - "34"
     scriptarguments:
       key:
         simple: AdditionalPDFs
@@ -2422,10 +2422,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "33":
     id: "33"
-    taskid: 0b9fdb0b-fe2b-4ebe-9bc9-1cf25c15a577
+    taskid: 82c30ea3-4fbc-42dc-852b-0bda54ef1315
     type: regular
     task:
-      id: 0b9fdb0b-fe2b-4ebe-9bc9-1cf25c15a577
+      id: 82c30ea3-4fbc-42dc-852b-0bda54ef1315
       version: -1
       name: Save valid PDFs separately
       description: "Set a value in context under the key you entered. If no value is entered, the script doesn't do anything.\n\nThis automation runs using the default Limited User role, unless you explicitly change the permissions.\nFor more information, see the section about permissions here:\n- For Cortex XSOAR 6 see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/6.x/Cortex-XSOAR-Playbook-Design-Guide/Automations \n- For Cortex XSOAR 8 Cloud see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8/Cortex-XSOAR-Cloud-Documentation/Create-a-script\n- For Cortex XSOAR 8.7 On-prem see https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8.7/Cortex-XSOAR-On-prem-Documentation/Create-a-script"
@@ -2435,7 +2435,7 @@ tasks:
       brand: ""
     nexttasks:
       '#none#':
-      - "31"
+      - "34"
     scriptarguments:
       key:
         simple: ValidPDFEntryIDs
@@ -2461,8 +2461,57 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 1311,
-          "y": 1007
+          "x": 1320,
+          "y": 1013
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+  "34":
+    id: "34"
+    taskid: 54c92f03-3cc6-4742-b121-8694a35255b2
+    type: condition
+    task:
+      id: 54c92f03-3cc6-4742-b121-8694a35255b2
+      version: -1
+      name: Assert there are pdf files to extract from
+      type: condition
+      iscommand: false
+      brand: ""
+    nexttasks:
+      '#default#':
+      - "19"
+      "yes":
+      - "31"
+    separatecontext: false
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              complex:
+                root: ValidPDFEntryIDs
+                transformers:
+                - operator: AppendIfNotEmpty
+                  args:
+                    item:
+                      value:
+                        simple: AdditionalPDFs
+                      iscontext: true
+                    raw: {}
+            iscontext: true
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 1606,
+          "y": 1149
         }
       }
     note: false
@@ -2483,6 +2532,7 @@ view: |-
       "23_10_#default#": 0.14,
       "23_22_yes": 0.43,
       "28_24_yes": 0.88,
+      "34_19_#default#": 0.42,
       "5_10_#default#": 0.33,
       "5_6_yes": 0.36,
       "7_10_#default#": 0.1,
@@ -2491,7 +2541,7 @@ view: |-
     },
     "paper": {
       "dimensions": {
-        "height": 1814,
+        "height": 1896,
         "width": 4165,
         "x": -975,
         "y": -10

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_7_3.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_7_3.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Extract Indicators From File - Generic v2
+
+- Updated the Extract Indicators From File - Generic v2 playbook to assert there are pdf files to extract indicators from - if not, the playbook will now exit gracefully.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.7.2",
+    "currentVersion": "2.7.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA 
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.** -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-51673)

## Description
Fixed a bug where the extract indicators from pdf files is failing when there are only converted pdf files but the conversion failed so there are actually no pdf files to extract from.
Fix is to add a conditional task righ before the extraction to assert there are pdf files to extract from.

## Must have
- [x] Tests
- [x] Documentation 
