### PR TITLE
DBOTFindSimilarAlerts unable to handle alerts with a list containing 1 element

### DIFF
--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -478,7 +478,7 @@ class Model:
                     skip_reason = FIELD_SKIP_REASON_FALSY_VALUE.format(field=field, val=val)
                 elif valid_types and not isinstance(val, valid_types):
                     skip_reason = FIELD_SKIP_REASON_INVALID_TYPE.format(field=field, valid=valid_types, type=type(val))
-                elif len(val) < 2:
+                elif isinstance(val, str) and len(val) < 2:
                     skip_reason = FIELD_SKIP_REASON_TOO_SHORT.format(field=field, val=val, len=len(val))
                 elif isinstance(val, list) and all(not x for x in val):
                     skip_reason = FIELD_SKIP_REASON_LIST_OF_FALSY_VALS.format(field=field, val=val)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This pull request fixes a small issue on XSIAM, where almost all alert fields that has been provided in the "similarTextFields" argument are skipped(see screenshot below). 
The problem seem to stem from the length check not handling datatype, as all of the fields that have been skipped are lists with only one element.

![image](https://github.com/user-attachments/assets/dab2f585-b5b2-4919-ab8b-837840688006)

This was fixed in a copied script that, where an additional check for the fields datatype is added.
I must admit I am not quite sure what ramifications this has, but this does work on when testing locally:
![image](https://github.com/user-attachments/assets/2001522f-118a-40b1-9337-45bd13efee83)

It might be beneficial to perform the check on each of elements in the lists, but I think someone with more knowledge of the inner workings of this script should make that decision.
## Must have
- [ ] Tests
- [ ] Documentation 
