### PR TITLE
URL Enrichment - Generic v2: increase timeout to 600 seconds

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-URL_Enrichment_-_Generic_v2.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-URL_Enrichment_-_Generic_v2.yml
@@ -197,6 +197,8 @@ tasks:
           root: inputs.URL
           transformers:
           - operator: uniq
+      execution-timeout:
+        simple: "600"
     reputationcalc: 1
     separatecontext: false
     view: |-
@@ -629,16 +631,16 @@ outputs:
 - contextPath: URL.Malicious.Description
   description: For malicious URLs, the reason that the vendor made the decision.
 - contextPath: DBotScore.Indicator
-  description: The indicator
+  description: The indicator.
   type: string
 - contextPath: DBotScore.Type
-  description: The indicator's type
+  description: The indicator's type.
   type: string
 - contextPath: DBotScore.Vendor
-  description: The reputation vendor
+  description: The reputation vendor.
   type: string
 - contextPath: DBotScore.Score
-  description: The reputation score
+  description: The reputation score.
   type: number
 - contextPath: DBotScore.Reliability
   description: Reliability of the source providing the intelligence data.

--- a/Packs/CommonPlaybooks/Playbooks/playbook-URL_Enrichment_-_Generic_v2_README.md
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-URL_Enrichment_-_Generic_v2_README.md
@@ -6,6 +6,10 @@ URL enrichment includes:
 * Providing of URL screenshots.
 * URL Reputation using !url.
 
+## Limitation
+
+The "Get URL screenshot" task has a timeout of 10 minutes when using the Rasterize integration. This allows processing a large number of URLs. If the task still fails due to timeout because the Rasterize command is processing too many URLs, the timeout value of the task needs to be increased.
+
 ## Dependencies
 
 This playbook uses the following sub-playbooks, integrations, and scripts.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_7_4.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_7_4.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### URL Enrichment - Generic v2
+
+Increased the timeout of the ***Get URL screenshot*** task in the URL Enrichment - Generic v2 playbook from 5 minutes to 10 minutes. This enhancement allows the playbook to process a larger number of URLs without timing out.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.7.3",
+    "currentVersion": "2.7.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: link to the issue

## Description
Increasing the timeout of the "Get URL screenshot" task from 300 seconds (5 minutes) to 600 seconds (10 minutes)

These changes allow the playbook to process a larger number of URLs without timing out, as documented in both the README.