### PR TITLE
Suspicious-port-scan-fix

### DIFF
--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
@@ -1444,7 +1444,7 @@ tasks:
     task:
       id: 4dfb8c0e-ca97-4263-a2c2-2e218f895d4a
       version: -1
-      name: Found suspicious of unique ports to connections?
+      name: Found suspicious ratio of unique ports to connections?
       description: Checks if a suspicious ratio of unique ports to connections is found.
       type: condition
       iscommand: false
@@ -1458,6 +1458,11 @@ tasks:
     conditions:
     - label: "yes"
       condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              simple: SuspiciousRatio
+            iscontext: true
       - - operator: InRange
           left:
             value:
@@ -3126,7 +3131,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 642,
+          "x": 640,
           "y": 3794
         }
       }
@@ -3298,7 +3303,7 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 644,
+          "x": 640,
           "y": 3646
         }
       }

--- a/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_66.md
+++ b/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_66.md
@@ -1,0 +1,1 @@
+## Documentation and metadata improvements.

--- a/Packs/CortexResponseAndRemediation/pack_metadata.json
+++ b/Packs/CortexResponseAndRemediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Response And Remediation",
     "description": "The Cortex Response & Remediation Pack delivers a powerful collection of automated playbooks designed to streamline incident response and remediation processes. Built to support an Autonomous SOC vision.",
     "support": "xsoar",
-    "currentVersion": "1.1.65",
+    "currentVersion": "1.1.66",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Added a condition during the investigation phase to check if the key SuspiciousRatio is not empty. This was added after the playbook failed during silent execution.

## Must have
- [ ] Tests
- [ ] Documentation 
