### PR TITLE
Added Documentation For Rasterize Timeout Configuration Instructions

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/README.md
+++ b/Packs/rasterize/Integrations/rasterize/README.md
@@ -36,10 +36,10 @@ The default timeout is 5 minutes (300 seconds). If the rasterize command process
 
 In cases where you encounter timeout errors when processing many URLs, you can either:
 
-1. Split the URLs into smaller batches to process.
-2. Increase the timeout setting for the specific task in the playbook that runs the rasterize command.
+* Split the URLs into smaller batches to process.
+* Increase the timeout setting for the specific task in the playbook that runs the rasterize command.
 
-To increase the timeout, modify the task's configuration by accessing the task settings, clicking the **Advanced** section, and adjusting the **Execution timeout (seconds)** field to a higher value appropriate for the workload.
+To increase the timeout for a playbook task, modify the task's configuration by accessing the task settings, clicking the **Advanced** section, and adjusting the **Execution timeout (seconds)** field to a higher value appropriate for the workload.
 
 ## Commands
 

--- a/Packs/rasterize/Integrations/rasterize/README.md
+++ b/Packs/rasterize/Integrations/rasterize/README.md
@@ -30,6 +30,15 @@ If you want to set the language to en-US, use en-GB instead.
 * Rasterize Mode: It is possible to rasterize either via Chrome WebDriver or Chrome Headless CLI. WebDriver supports more options than Headless CLI. Such as support for the `offline` option in the `rasterize-emails` command. There are some urls that do not rasterize well with WebDriver and may succeed with Headless CLI. Thus, it is recommended to use the `WebDriver - Preferred` mode, which will use WebDriver as a start and fallback to Headless CLI if it fails.
 * Use system proxy settings: Select this checkbox to use the system's proxy settings. **Important**: this integration does not support proxies which require authentication.
 
+## Limitation
+
+The default timeout is 5 minutes (300 seconds). If the rasterize command processes a large number of URLs, or even a smaller number of URLs that take a long time to load, it can result in a timeout error. For example, 100 URLs each taking 5 seconds to open would total 500 seconds, exceeding the default timeout limit.
+
+In cases where you encounter timeout errors when processing many URLs, you can either:
+
+1. Split the URLs into smaller batches to process.
+2. Increase the timeout setting for the specific task in the playbook that runs the rasterize command.
+
 ## Commands
 
 You can execute these commands from the CLI, as part of an automation, or in a playbook.

--- a/Packs/rasterize/Integrations/rasterize/README.md
+++ b/Packs/rasterize/Integrations/rasterize/README.md
@@ -39,6 +39,8 @@ In cases where you encounter timeout errors when processing many URLs, you can e
 1. Split the URLs into smaller batches to process.
 2. Increase the timeout setting for the specific task in the playbook that runs the rasterize command.
 
+To increase the timeout, modify the task's configuration by accessing the task settings, clicking the **Advanced** section, and adjusting the **Execution timeout (seconds)** field to a higher value appropriate for the workload.
+
 ## Commands
 
 You can execute these commands from the CLI, as part of an automation, or in a playbook.

--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -216,11 +216,11 @@ class PychromeEventHandler:
         self.is_private_network_url = False
 
     def page_frame_started_loading(self, frameId):
-        demisto.debug(f"PychromeEventHandler.page_frame_started_loading, {frameId=}, {self.tab.id=}")
+        demisto.debug(f"PychromeEventHandler.page_frame_started_loading, {frameId=}, {self.tab.id=}, {self.path=}")
         self.start_frame = frameId
         if self.request_id:
             # We're in redirect
-            demisto.debug(f"Frame (reload) started loading: {frameId}, clearing {self.request_id=}, {self.tab.id=}")
+            demisto.debug(f"Frame (reload) started loading: {frameId}, clearing {self.request_id=}, {self.tab.id=}, {self.path=}")
             self.request_id = None
             self.response_received = False
             # self.start_frame = None

--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -216,11 +216,11 @@ class PychromeEventHandler:
         self.is_private_network_url = False
 
     def page_frame_started_loading(self, frameId):
-        demisto.debug(f"PychromeEventHandler.page_frame_started_loading, {frameId=}")
+        demisto.debug(f"PychromeEventHandler.page_frame_started_loading, {frameId=}, {self.tab.id=}")
         self.start_frame = frameId
         if self.request_id:
             # We're in redirect
-            demisto.debug(f"Frame (reload) started loading: {frameId}, clearing {self.request_id=}")
+            demisto.debug(f"Frame (reload) started loading: {frameId}, clearing {self.request_id=}, {self.tab.id=}")
             self.request_id = None
             self.response_received = False
             # self.start_frame = None
@@ -228,12 +228,12 @@ class PychromeEventHandler:
             demisto.debug(f"Frame started loading: {frameId}, no request_id")
 
     def network_data_received(self, requestId, timestamp, dataLength, encodedDataLength):  # noqa: F841
-        demisto.debug(f"PychromeEventHandler.network_data_received, {requestId=}")
+        demisto.debug(f"PychromeEventHandler.network_data_received, {requestId=}, {self.tab.id=}, {self.path=}")
         if requestId and not self.request_id:
-            demisto.debug(f"PychromeEventHandler.network_data_received, Using {requestId=}")
+            demisto.debug(f"PychromeEventHandler.network_data_received, Using {requestId=}, {self.tab.id=}, {self.path=}")
             self.request_id = requestId
         else:
-            demisto.debug(f"PychromeEventHandler.network_data_received, Not using {requestId=}")
+            demisto.debug(f"PychromeEventHandler.network_data_received, Not using {requestId=}, {self.tab.id=}, {self.path=}")
 
     def page_frame_stopped_loading(self, frameId):
         """

--- a/Packs/rasterize/ReleaseNotes/2_1_8.md
+++ b/Packs/rasterize/ReleaseNotes/2_1_8.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Rasterize
+
+Documentation and metadata improvements.

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "2.1.7",
+    "currentVersion": "2.1.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -912,7 +912,6 @@
             "scripts": [
                 "FindDuplicateEmailIncidents"
             ],
-            "integrations": "Rasterize",
             "timeout": 1000
         },
         {
@@ -4053,7 +4052,6 @@
             "scripts": [
                 "FindDuplicateEmailIncidents"
             ],
-            "integrations": "Rasterize",
             "has_api": false
         },
         {


### PR DESCRIPTION
## Related Issues
fixes: [link](https://jira-dc.paloaltonetworks.com/browse/CIAC-14105) to the issue

## Description

This PR improves the documentation in the Rasterize integration README.md by clarifying the instructions for increasing timeout settings when working with large numbers of URLs.