### PR TITLE
QRadar_v3: Added sleep before initial check if query is complete.

### DIFF
--- a/Packs/QRadar/CONTRIBUTORS.json
+++ b/Packs/QRadar/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+    "Ryan McVicar"
+]

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -2311,8 +2311,6 @@ def poll_offense_events_with_retry(
     """
     for retry in range(max_retries):
         print_debug_msg(f"Polling for events for offense {offense_id}. Retry number {retry+1}/{max_retries}")
-        if retry == 0:
-            time.sleep(FETCH_INITIAL_SLEEP)
         events, status = poll_offense_events(client, search_id, should_get_events=True, offense_id=int(offense_id))
         if status == QueryStatus.SUCCESS.value:
             return events, ""
@@ -2356,6 +2354,7 @@ def enrich_offense_with_events(client: Client, offense: dict, fetch_mode: FetchM
         if search_id == QueryStatus.ERROR.value:
             failure_message = "Search for events was failed."
         else:
+            time.sleep(FETCH_INITIAL_SLEEP)
             events, failure_message = poll_offense_events_with_retry(client, search_id, int(offense_id))
         events_fetched = get_num_events(events)
         offense["events_fetched"] = events_fetched

--- a/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
+++ b/Packs/QRadar/Integrations/QRadar_v3/QRadar_v3.py
@@ -18,7 +18,7 @@ urllib3.disable_warnings()  # pylint: disable=no-member
 
 FAILURE_SLEEP = 20  # sleep between consecutive failures events fetch
 FETCH_SLEEP = arg_to_number(demisto.params().get("fetch_interval")) or 60  # sleep between fetches
-FETCH_INITIAL_SLEEP = 1 # sleep before the initial check to see if a query has completed.
+FETCH_INITIAL_SLEEP = 1  # sleep before the initial check to see if a query has completed.
 BATCH_SIZE = 100  # batch size used for offense ip enrichment
 OFF_ENRCH_LIMIT = BATCH_SIZE * 10  # max amount of IPs to enrich per offense
 MAX_WORKERS = 8  # max concurrent workers used for events enriching
@@ -2258,7 +2258,7 @@ def poll_offense_events(
         search_status_response = client.search_status_get(search_id)
         print_debug_msg(f"Got search status for {search_id}")
         query_status = search_status_response.get("status")
-        query_runtime = search_status_response.get("query_execution_time","N/A")
+        query_runtime = search_status_response.get("query_execution_time", "N/A")
         print_debug_msg(f"Search status for offense {offense_id} is {query_status}. Current time elapsed: {query_runtime}")
 
         if query_status in {"CANCELED", "ERROR"}:

--- a/Packs/QRadar/ReleaseNotes/2_5_21.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_21.md
@@ -3,4 +3,4 @@
 
 ##### IBM QRadar v3
 
-- Updated to add a sleep to address a problem where integration would wait >60 seconds for a search that was completed.
+- Fixed an issue where the integration would wait for over 60 seconds after a search had already completed.

--- a/Packs/QRadar/ReleaseNotes/2_5_21.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_21.md
@@ -3,5 +3,4 @@
 
 ##### IBM QRadar v3
 
-- Updated the Docker image to: *demisto/python3:3.12.8.3296088*.
 - Updated to add a sleep to address a problem where integration would wait >60 seconds for a search that was completed.

--- a/Packs/QRadar/ReleaseNotes/2_5_21.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_21.md
@@ -1,6 +1,7 @@
 
 #### Integrations
 
-##### QRadar v3
-Updated to add a sleep to address a problem where integration would wait >60 seconds for a search that was completed.
+##### IBM QRadar v3
 
+- Updated the Docker image to: *demisto/python3:3.12.8.3296088*.
+- Updated to add a sleep to address a problem where integration would wait >60 seconds for a search that was completed.

--- a/Packs/QRadar/ReleaseNotes/2_5_21.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_21.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### QRadar v3
+Updated to add a sleep to address a problem where integration would wait >60 seconds for a search that was completed.
+

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.5.20",
+    "currentVersion": "2.5.21",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Adds in an additional sleep, plus debug log line to address an issue where the integration checks for a search being completed ~5-10 milliseconds after starting it. 
In testing, this reduced the amount of time it took to ingest 36 Offenses from ~5 minutes, down to 1 minute. 

## Must have
- [x] Tests
- [x] Documentation 
