### PR TITLE
Adding interval_in_seconds argument in polling command for Joe security

### DIFF
--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
@@ -661,7 +661,8 @@ def url_submission(
 
 # The interval timeout should be set between 30 and 60 seconds for optimal server usage.
 @polling_function(
-    name=demisto.command(), timeout=arg_to_number(demisto.args().get("timeout", 1200)), interval=45, requires_polling_arg=False
+    name=demisto.command(), timeout=arg_to_number(demisto.args().get("timeout", 1200)),
+    interval=demisto.args().get("interval_in_seconds", 45), requires_polling_arg=False
 )
 def polling_submit_command(
     args: Dict[str, Any], client: Client, params: Dict[str, Any], exe_metrics: ExecutionMetrics

--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.py
@@ -661,8 +661,10 @@ def url_submission(
 
 # The interval timeout should be set between 30 and 60 seconds for optimal server usage.
 @polling_function(
-    name=demisto.command(), timeout=arg_to_number(demisto.args().get("timeout", 1200)),
-    interval=demisto.args().get("interval_in_seconds", 45), requires_polling_arg=False
+    name=demisto.command(),
+    timeout=arg_to_number(demisto.args().get("timeout", 1200)),
+    interval=arg_to_number(demisto.args().get("interval_in_seconds", 45)),
+    requires_polling_arg=False,
 )
 def polling_submit_command(
     args: Dict[str, Any], client: Client, params: Dict[str, Any], exe_metrics: ExecutionMetrics

--- a/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.yml
+++ b/Packs/JoeSecurity/Integrations/JoeSecurityV2/JoeSecurityV2.yml
@@ -782,6 +782,9 @@ script:
     - name: timeout
       description: The timeout for the polling in seconds.
       defaultValue: "1200"
+    - name: interval_in_seconds
+      description: The timeout for the interval in seconds.
+      defaultValue: "45"
     - name: hide_polling_output
       description: Hide polling output.
       deprecated: true

--- a/Packs/JoeSecurity/ReleaseNotes/1_1_29.md
+++ b/Packs/JoeSecurity/ReleaseNotes/1_1_29.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Joe Security v2
+
+- Added the *interval_in_seconds* argument in the **joe-submit-sample** command.

--- a/Packs/JoeSecurity/pack_metadata.json
+++ b/Packs/JoeSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Joe Security",
     "description": "Sandbox Cloud",
     "support": "xsoar",
-    "currentVersion": "1.1.28",
+    "currentVersion": "1.1.29",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Adding interval_in_seconds argument in polling command for Joe security

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-49870)

## Must have
- [ ] Tests
- [ ] Documentation 
