### PR TITLE
Add 60-second timeout for Rasterize screenshot capture operations

### DIFF
--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -67,6 +67,7 @@ TAB_CLOSE_WAIT_TIME = 1
 DEFAULT_RETRIES_COUNT = 4
 DEFAULT_RETRY_WAIT_IN_SECONDS = 3
 PAGES_LIMITATION = 20
+SCREENSHOT_TIMEOUT = 60
 
 # chrome instance data keys
 INSTANCE_ID = "instance_id"
@@ -125,7 +126,7 @@ class RasterizeType(Enum):
 # region utility classes
 
 
-def excepthook_recv_loop(args):
+def excepthook_recv_loop(args: threading.ExceptHookArgs) -> None:
     """
     Suppressing exceptions that might happen after the tab was closed.
     """
@@ -225,7 +226,7 @@ class PychromeEventHandler:
             self.response_received = False
             # self.start_frame = None
         else:
-            demisto.debug(f"Frame started loading: {frameId}, no request_id")
+            demisto.debug(f"Frame started loading: {frameId}, no request_id, {self.tab.id=}, {self.path=}")
 
     def network_data_received(self, requestId, timestamp, dataLength, encodedDataLength):  # noqa: F841
         demisto.debug(f"PychromeEventHandler.network_data_received, {requestId=}, {self.tab.id=}, {self.path=}")
@@ -262,13 +263,13 @@ class PychromeEventHandler:
                 if self.path.lower().startswith("file://"):
                     frame_url = self.get_frame_tree_url()
                     if frame_url and frame_url.lower().startswith(CHROME_ERROR_URL):
-                        demisto.debug(f"Encountered chrome-error {frame_url=}, retrying...")
+                        demisto.debug(f"Encountered chrome-error {frame_url=}, {self.tab.id=}, {self.path=} retrying...")
                         self.retry_loading()
                     else:
-                        demisto.debug("PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event")
+                        demisto.debug(f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}")
                         self.tab_ready_event.set()
                 else:
-                    demisto.debug("PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event")
+                    demisto.debug(f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}")
                     self.tab_ready_event.set()
             except (pychrome.exceptions.RuntimeException, pychrome.exceptions.UserAbortException) as ex:
                 demisto.debug(f"page_frame_stopped_loading: Tab {self.tab.id=} for {self.path=} is stopping/stopped: {ex}")
@@ -287,7 +288,7 @@ class PychromeEventHandler:
         try:
             frame_tree_result = self.tab.Page.getFrameTree()
             frame_url = frame_tree_result.get("frameTree", {}).get("frame", {}).get("url", "")
-            demisto.debug(f"PychromeEventHandler.get_frame_tree_url, Frame URL: {frame_url}, Original path: {self.path}")
+            demisto.debug(f"PychromeEventHandler.get_frame_tree_url, Frame URL: {frame_url}, Original path: {self.path}, {self.tab.id}")
             return frame_url
         except (pychrome.exceptions.RuntimeException, pychrome.exceptions.UserAbortException) as ex:
             # The tab is already stopping or has been stopped
@@ -296,7 +297,7 @@ class PychromeEventHandler:
             )
             return ""
         except Exception as ex:
-            demisto.debug(f"Unexpected error getting frame tree URL: {ex}")
+            demisto.debug(f"Unexpected error getting frame tree URL for {self.tab.id=}, {self.path=}: {ex}")
             return ""
 
     def retry_loading(self):
@@ -307,14 +308,14 @@ class PychromeEventHandler:
         if it encounters a Chrome error page. It sets the tab_ready_event when successful.
         """
         for retry_count in range(1, DEFAULT_RETRIES_COUNT + 1):
-            demisto.debug(f"Retrying loading URL {self.path}. Attempt {retry_count}/{DEFAULT_RETRIES_COUNT}")
+            demisto.debug(f"Retrying loading URL {self.path}, {self.tab.id}. Attempt {retry_count}/{DEFAULT_RETRIES_COUNT}")
             try:
                 if self.navigation_timeout > 0:
                     self.tab.Page.navigate(url=self.path, _timeout=self.navigation_timeout)
                 else:
                     self.tab.Page.navigate(url=self.path)
             except Exception as e:
-                demisto.debug(f"Error during navigation attempt {retry_count}/{DEFAULT_RETRIES_COUNT}: {e}")
+                demisto.debug(f"Error during navigation to {self.tab.id=}, {self.path=} attempt {retry_count}/{DEFAULT_RETRIES_COUNT}: {e}")
 
             safe_sleep(DEFAULT_PAGE_LOAD_TIME / DEFAULT_RETRIES_COUNT + 1)
 
@@ -324,25 +325,26 @@ class PychromeEventHandler:
             if not frame_url:
                 demisto.debug(
                     f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Could not get frame URL. "
-                    f"Stopping after {DEFAULT_RETRIES_COUNT} retry attempts."
+                    f"Stopping after {DEFAULT_RETRIES_COUNT} retry attempts. "
+                    f"For {self.tab.id=}, {self.path=}"
                 )
                 self.tab_ready_event.set()
                 return
 
             if not frame_url.lower().startswith(CHROME_ERROR_URL):
-                demisto.debug(f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} successful.")
+                demisto.debug(f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} successful. {self.tab.id=}, {self.path=}")
                 self.tab_ready_event.set()
                 return
 
-            demisto.debug(f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error.")
+            demisto.debug(f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error. {self.tab.id=}, {self.path=}")
 
-        demisto.debug(f"Max retries ({DEFAULT_RETRIES_COUNT}) reached, could not load the page.")
+        demisto.debug(f"Max retries ({DEFAULT_RETRIES_COUNT}) reached, could not load the page. {self.tab.id=}, {self.path=}")
         # Ensure we always set the event to prevent hanging
         self.tab_ready_event.set()
 
     def network_request_will_be_sent(self, documentURL: str, **kwargs):
         """Triggered when a request is sent by the browser, catches mailto URLs."""
-        demisto.debug(f"PychromeEventHandler.network_request_will_be_sent, {documentURL=}")
+        demisto.debug(f"PychromeEventHandler.network_request_will_be_sent, {documentURL=}, {self.tab.id=}, {self.path=}")
 
         self.is_mailto = documentURL.lower().startswith("mailto:")
         self.is_private_network_url = is_private_network(documentURL)
@@ -352,7 +354,7 @@ class PychromeEventHandler:
 
         if any(value in request_url for value in BLOCKED_URLS):
             self.tab.Fetch.enable()
-            demisto.debug("Fetch events enabled.")
+            demisto.debug(f"Fetch events enabled. {self.tab.id=}, {self.path=}")
 
     def handle_request_paused(self, **kwargs):
         request_id = kwargs.get("requestId")
@@ -361,9 +363,9 @@ class PychromeEventHandler:
         # abort the request if the url inside blocked_urls param and its redirect request
         if any(value in request_url for value in BLOCKED_URLS) and not self.request_id:
             self.tab.Fetch.failRequest(requestId=request_id, errorReason="Aborted")
-            demisto.debug(f"Request paused: {request_url=} , {request_id=}")
+            demisto.debug(f"Request paused: {request_url=} , {request_id=}, {self.tab.id=}, {self.path=}")
             self.tab.Fetch.disable()
-            demisto.debug("Fetch events disabled.")
+            demisto.debug(f"Fetch events disabled. {self.tab.id=}, {self.path=}")
 
 
 # endregion
@@ -705,7 +707,7 @@ def chrome_manager_one_port() -> tuple[pychrome.Browser | None, str | None]:
     instance_id = demisto.callingContext.get("context", {}).get("IntegrationInstanceID", "None") or "None"
     chrome_options = demisto.params().get("chrome_options", "None")
     chrome_instances_contents = read_json_file(CHROME_INSTANCES_FILE_PATH)
-    demisto.debug(f" chrome_manager {chrome_instances_contents=} {chrome_options=} {instance_id=}")
+    demisto.debug(f"chrome_manager {chrome_instances_contents=} {chrome_options=} {instance_id=}")
     chrome_options_dict = {
         options[CHROME_INSTANCE_OPTIONS]: {"chrome_port": port} for port, options in chrome_instances_contents.items()
     }
@@ -771,30 +773,30 @@ def setup_tab_event(
     return tab_event_handler, tab_ready_event
 
 
-def navigate_to_path(browser, tab, path, wait_time, navigation_timeout) -> PychromeEventHandler:  # pragma: no cover
+def navigate_to_path(browser, tab: pychrome.Tab, path, wait_time, navigation_timeout) -> PychromeEventHandler:  # pragma: no cover
     tab_event_handler, tab_ready_event = setup_tab_event(browser, tab, path, navigation_timeout)
 
     try:
         demisto.info(f"Starting tab navigation to given path: {path} on {tab.id=}")
 
         allTimeSamplingProfile = tab.Memory.getAllTimeSamplingProfile()
-        demisto.debug(f"allTimeSamplingProfile before navigation {allTimeSamplingProfile=} on {tab.id=}")
+        demisto.debug(f"allTimeSamplingProfile before navigation {allTimeSamplingProfile=} on {tab.id=}, {path=}")
         heapUsage = tab.Runtime.getHeapUsage()
-        demisto.debug(f"heapUsage before navigation {heapUsage=} on {tab.id=}")
+        demisto.debug(f"heapUsage before navigation {heapUsage=} on {tab.id=}, {path=}")
 
         if navigation_timeout > 0:
             tab.Page.navigate(url=path, _timeout=navigation_timeout)
         else:
             tab.Page.navigate(url=path)
 
-        demisto.debug(f"Waiting for tab_ready_event on {tab.id=}")
+        demisto.debug(f"Waiting for tab_ready_event on {tab.id=}, {path=}")
         tab_ready_event.wait(navigation_timeout)
-        demisto.debug(f"After waiting for tab_ready_event on {tab.id=}")
+        demisto.debug(f"After waiting for tab_ready_event on {tab.id=}, {path=}")
 
         if wait_time > 0:
-            demisto.info(f"Sleeping before capturing screenshot, {wait_time=}, {tab.id=}")
+            demisto.info(f"Sleeping before capturing screenshot, {wait_time=}, {tab.id=}, {path=}")
         else:
-            demisto.debug(f"Not sleeping before capturing screenshot, {wait_time=}. {tab.id=}")
+            demisto.debug(f"Not sleeping before capturing screenshot, {wait_time=}. {tab.id=}, {path=}")
         time.sleep(wait_time)  # pylint: disable=E9003
         demisto.debug(f"Navigated to {path=} on {tab.id=}")
 
@@ -877,20 +879,20 @@ def screenshot_image(
     try:
         page_layout_metrics = tab.Page.getLayoutMetrics()
     except Exception as ex:
-        demisto.info(f"Failed to get tab LayoutMetrics due to {ex}")
+        demisto.info(f"Failed to get tab LayoutMetrics for {tab.id=} {path=} due to {ex}")
         raise ex
 
-    demisto.debug(f"{page_layout_metrics=} {tab.id=}.")
+    demisto.debug(f"{page_layout_metrics=} {tab.id=} {path=}.")
     css_content_size = page_layout_metrics["cssContentSize"]
     try:
         if full_screen:
             viewport = css_content_size
             viewport["scale"] = 1
-            screenshot_data = tab.Page.captureScreenshot(clip=viewport, captureBeyondViewport=True)["data"]
+            screenshot_data = tab.Page.captureScreenshot(clip=viewport, captureBeyondViewport=True, _timeout=SCREENSHOT_TIMEOUT)["data"]
         else:
-            screenshot_data = tab.Page.captureScreenshot()["data"]
+            screenshot_data = tab.Page.captureScreenshot(_timeout=SCREENSHOT_TIMEOUT)["data"]
     except Exception as ex:
-        demisto.info(f"Failed to capture screenshot due to {ex}, {tab.id=}")
+        demisto.info(f"Failed to capture screenshot due to {ex}, {tab.id=}, {path=}")
         raise ex
     # Make sure that the (asynchronous) screenshot data is available before continuing with execution
     screenshot_data, operation_time = backoff(screenshot_data)
@@ -900,24 +902,24 @@ def screenshot_image(
         demisto.info(f"Screenshot image of {path=} on {tab.id=}, not available after {operation_time} seconds.")
 
     allTimeSamplingProfile = tab.Memory.getAllTimeSamplingProfile()
-    demisto.debug(f"allTimeSamplingProfile after screenshot {allTimeSamplingProfile=} on {tab.id=}")
+    demisto.debug(f"allTimeSamplingProfile after screenshot {allTimeSamplingProfile=} on {tab.id=}, {path=}")
     heapUsage = tab.Runtime.getHeapUsage()
-    demisto.debug(f"heapUsage after screenshot {heapUsage=} on {tab.id=}")
+    demisto.debug(f"heapUsage after screenshot {heapUsage=} on {tab.id=}, {path=}")
 
     captured_image = base64.b64decode(screenshot_data)
     if not captured_image:
-        demisto.info(f"Empty snapshot, {screenshot_data=}, {tab.id=}")
+        demisto.info(f"Empty snapshot, {screenshot_data=}, {tab.id=}, {path=}")
     else:
-        demisto.info(f"Captured snapshot, {len(captured_image)=}, {tab.id=}")
+        demisto.info(f"Captured snapshot, {len(captured_image)=}, {tab.id=}, {path=}")
 
     # Page URL, if needed
     if include_url:
-        demisto.debug(f"Including URL in image for path: {path}, {tab.id=}")
+        demisto.debug(f"Including URL in image for path: {path}, {tab.id=}, {path=}")
         captured_image_object = Image.open(BytesIO(captured_image))
-        demisto.debug(f"Original image size: {captured_image_object.size}, {tab.id=}")
+        demisto.debug(f"Original image size: {captured_image_object.size}, {tab.id=}, {path=}")
 
         image_with_url = Image.new(captured_image_object.mode, (css_content_size["width"], css_content_size["height"] + 20))
-        demisto.debug(f"New image size with URL: {image_with_url.size}, {tab.id=}")
+        demisto.debug(f"New image size with URL: {image_with_url.size}, {tab.id=}, {path=}")
 
         image_with_url.paste(captured_image_object, (0, 20))
         ImageDraw.Draw(image_with_url).text((0, 0), path, fill=(255, 255, 255))
@@ -925,7 +927,7 @@ def screenshot_image(
         img_byte_arr = BytesIO()
         image_with_url.save(img_byte_arr, format="PNG")
         img_byte_arr = img_byte_arr.getvalue()
-        demisto.debug(f"Size of image with URL: {len(img_byte_arr)} bytes, {tab.id=}")
+        demisto.debug(f"Size of image with URL: {len(img_byte_arr)} bytes, {tab.id=}, {path=}")
 
         ret_value = img_byte_arr
     else:
@@ -934,26 +936,26 @@ def screenshot_image(
     # Page source, if needed
     response_body = ""
     if include_source:
-        demisto.debug(f"screenshot_image, include_source, waiting for request_id, {tab.id=}")
+        demisto.debug(f"screenshot_image, include_source, waiting for request_id, {tab.id=}, {path=}")
         request_id, request_id_operation_time = backoff(tab_event_handler.request_id)
         if request_id:
-            demisto.debug(f"request_id available after {request_id_operation_time} seconds, {tab.id=}.")
+            demisto.debug(f"request_id available after {request_id_operation_time} seconds, {tab.id=}, {path=}.")
         else:
-            demisto.info(f"request_id not available after {request_id_operation_time} seconds, {tab.id=}.")
-        demisto.debug(f"Got {request_id=} after {request_id_operation_time} seconds, {tab.id=}.")
+            demisto.info(f"request_id not available after {request_id_operation_time} seconds, {tab.id=}, {path=}.")
+        demisto.debug(f"Got {request_id=} after {request_id_operation_time} seconds, {tab.id=}, {path=}.")
 
         try:
             response_body = tab.Network.getResponseBody(requestId=request_id, _timeout=navigation_timeout)["body"]
-            demisto.debug(f"screenshot_image, {include_source=}, {response_body=}, {tab.id=}")
+            demisto.debug(f"screenshot_image, {include_source=}, {response_body=}, {tab.id=}, {path=}")
 
             response_body, operation_time = backoff(response_body)
             if response_body:
-                demisto.debug(f"Response Body available after {operation_time} seconds, {len(response_body)=}, {tab.id=}")
+                demisto.debug(f"Response Body available after {operation_time} seconds, {len(response_body)=}, {tab.id=}, {path=}")
             else:
-                demisto.info(f"Response Body not available after {operation_time} seconds, {tab.id=}.")
+                demisto.info(f"Response Body not available after {operation_time} seconds, {tab.id=}, {path=}.")
 
         except Exception as ex:  # This exception is raised when a non-existent URL is provided.
-            demisto.info(f"Exception when calling Network.getResponseBody with {request_id=}, {ex=}, {tab.id=}")
+            demisto.info(f"Exception when calling Network.getResponseBody with {request_id=}, {ex=}, {tab.id=}, {path=}")
             demisto.info(f"Failed to get URL body due to {ex}")
             response_body = "Failed to get URL body"
 
@@ -976,9 +978,9 @@ def screenshot_pdf(
     # Make sure that the (asynchronous) PDF data is available before continuing with execution
     pdf_data, operation_time = backoff(pdf_data)
     if pdf_data:
-        demisto.debug(f"PDF Data available after {operation_time} seconds, {tab.id=}.")
+        demisto.debug(f"PDF Data available after {operation_time} seconds, {tab.id=}, {path=}.")
     else:
-        demisto.info(f"PDF Data not available after {operation_time} seconds, {tab.id=}.")
+        demisto.info(f"PDF Data not available after {operation_time} seconds, {tab.id=}, {path=}.")
 
     ret_value = base64.b64decode(pdf_data)
     return ret_value, None
@@ -1227,7 +1229,7 @@ def perform_rasterize(
             executor.shutdown(wait=True)
             demisto.info(
                 f"perform_rasterize Finished {len(rasterization_threads)} rasterize operations,"
-                f"active tabs len: {len(browser.list_tab())}"
+                f"active tabs len: {len(browser.list_tab())}, {path=}"
             )
 
             chrome_instances_file_content: dict = read_json_file()  # CR fix name
@@ -1238,12 +1240,12 @@ def perform_rasterize(
 
             demisto.debug(
                 f"perform_rasterize checking if the chrome in port:{chrome_port} should be deleted:"
-                f"{rasterization_count=}, {MAX_RASTERIZATIONS_COUNT=}, {len(browser.list_tab())=}"
+                f"{rasterization_count=}, {MAX_RASTERIZATIONS_COUNT=}, {len(browser.list_tab())=}, {path=}"
             )
             if not chrome_port:
-                demisto.debug("perform_rasterize: the chrome port was not found")
+                demisto.debug(f"perform_rasterize: the chrome port was not found, {path=}")
             elif rasterization_count >= MAX_RASTERIZATIONS_COUNT:
-                demisto.info(f"perform_rasterize: terminating Chrome after {rasterization_count=} rasterization")
+                demisto.info(f"perform_rasterize: terminating Chrome after {rasterization_count=} rasterization, {path=}")
                 terminate_chrome(chrome_port=chrome_port)
             else:
                 increase_counter_chrome_instances_file(chrome_port=chrome_port)

--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -267,7 +267,8 @@ class PychromeEventHandler:
                         self.retry_loading()
                     else:
                         demisto.debug(
-                            f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}"
+                            "PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, "
+                            f" {self.tab.id=}, {self.path=}"
                         )
                         self.tab_ready_event.set()
                 else:
@@ -345,7 +346,8 @@ class PychromeEventHandler:
                 return
 
             demisto.debug(
-                f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error. {self.tab.id=}, {self.path=}"
+                "Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error. "
+                f"{self.tab.id=}, {self.path=}"
             )
 
         demisto.debug(f"Max retries ({DEFAULT_RETRIES_COUNT}) reached, could not load the page. {self.tab.id=}, {self.path=}")

--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -266,10 +266,14 @@ class PychromeEventHandler:
                         demisto.debug(f"Encountered chrome-error {frame_url=}, {self.tab.id=}, {self.path=} retrying...")
                         self.retry_loading()
                     else:
-                        demisto.debug(f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}")
+                        demisto.debug(
+                            f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}"
+                        )
                         self.tab_ready_event.set()
                 else:
-                    demisto.debug(f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}")
+                    demisto.debug(
+                        f"PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, {self.tab.id=}, {self.path=}"
+                    )
                     self.tab_ready_event.set()
             except (pychrome.exceptions.RuntimeException, pychrome.exceptions.UserAbortException) as ex:
                 demisto.debug(f"page_frame_stopped_loading: Tab {self.tab.id=} for {self.path=} is stopping/stopped: {ex}")
@@ -288,7 +292,9 @@ class PychromeEventHandler:
         try:
             frame_tree_result = self.tab.Page.getFrameTree()
             frame_url = frame_tree_result.get("frameTree", {}).get("frame", {}).get("url", "")
-            demisto.debug(f"PychromeEventHandler.get_frame_tree_url, Frame URL: {frame_url}, Original path: {self.path}, {self.tab.id}")
+            demisto.debug(
+                f"PychromeEventHandler.get_frame_tree_url, Frame URL: {frame_url}, Original path: {self.path}, {self.tab.id}"
+            )
             return frame_url
         except (pychrome.exceptions.RuntimeException, pychrome.exceptions.UserAbortException) as ex:
             # The tab is already stopping or has been stopped
@@ -315,7 +321,9 @@ class PychromeEventHandler:
                 else:
                     self.tab.Page.navigate(url=self.path)
             except Exception as e:
-                demisto.debug(f"Error during navigation to {self.tab.id=}, {self.path=} attempt {retry_count}/{DEFAULT_RETRIES_COUNT}: {e}")
+                demisto.debug(
+                    f"Error during navigation to {self.tab.id=}, {self.path=} attempt {retry_count}/{DEFAULT_RETRIES_COUNT}: {e}"
+                )
 
             safe_sleep(DEFAULT_PAGE_LOAD_TIME / DEFAULT_RETRIES_COUNT + 1)
 
@@ -336,7 +344,9 @@ class PychromeEventHandler:
                 self.tab_ready_event.set()
                 return
 
-            demisto.debug(f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error. {self.tab.id=}, {self.path=}")
+            demisto.debug(
+                f"Retry {retry_count}/{DEFAULT_RETRIES_COUNT} failed: Page still showing Chrome error. {self.tab.id=}, {self.path=}"
+            )
 
         demisto.debug(f"Max retries ({DEFAULT_RETRIES_COUNT}) reached, could not load the page. {self.tab.id=}, {self.path=}")
         # Ensure we always set the event to prevent hanging
@@ -888,7 +898,9 @@ def screenshot_image(
         if full_screen:
             viewport = css_content_size
             viewport["scale"] = 1
-            screenshot_data = tab.Page.captureScreenshot(clip=viewport, captureBeyondViewport=True, _timeout=SCREENSHOT_TIMEOUT)["data"]
+            screenshot_data = tab.Page.captureScreenshot(clip=viewport, captureBeyondViewport=True, _timeout=SCREENSHOT_TIMEOUT)[
+                "data"
+            ]
         else:
             screenshot_data = tab.Page.captureScreenshot(_timeout=SCREENSHOT_TIMEOUT)["data"]
     except Exception as ex:
@@ -950,7 +962,9 @@ def screenshot_image(
 
             response_body, operation_time = backoff(response_body)
             if response_body:
-                demisto.debug(f"Response Body available after {operation_time} seconds, {len(response_body)=}, {tab.id=}, {path=}")
+                demisto.debug(
+                    f"Response Body available after {operation_time} seconds, {len(response_body)=}, {tab.id=}, {path=}"
+                )
             else:
                 demisto.info(f"Response Body not available after {operation_time} seconds, {tab.id=}, {path=}.")
 

--- a/Packs/rasterize/Integrations/rasterize/rasterize.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize.py
@@ -268,7 +268,7 @@ class PychromeEventHandler:
                     else:
                         demisto.debug(
                             "PychromeEventHandler.page_frame_stopped_loading, setting tab_ready_event, "
-                            f" {self.tab.id=}, {self.path=}"
+                            f"{self.tab.id=}, {self.path=}"
                         )
                         self.tab_ready_event.set()
                 else:

--- a/Packs/rasterize/Integrations/rasterize/rasterize_test.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize_test.py
@@ -892,7 +892,7 @@ def test_remove_leading_zeros_from_ip_addresses(test_input: str, expected: str):
     assert remove_leading_zeros_from_ip_addresses(test_input) == expected
 
 
-def test_handle_request_paused(mocker):
+def test_handle_request_paused(mocker: MockerFixture):
     """
     Given:
         - cloudflare.com as BLOCKED_URLS parameter.
@@ -909,6 +909,7 @@ def test_handle_request_paused(mocker):
     mock_fetch.disable = MagicMock()
     mock_fail_request = mocker.patch.object(mock_fetch, "failRequest", new_callable=MagicMock)
     mock_tab.Fetch = mock_fetch
+    mock_tab.id =  "mock_tab_id"
     tab_event_handler = PychromeEventHandler(None, mock_tab, None, "", 0)
 
     tab_event_handler.handle_request_paused(**kwargs)

--- a/Packs/rasterize/Integrations/rasterize/rasterize_test.py
+++ b/Packs/rasterize/Integrations/rasterize/rasterize_test.py
@@ -909,7 +909,7 @@ def test_handle_request_paused(mocker: MockerFixture):
     mock_fetch.disable = MagicMock()
     mock_fail_request = mocker.patch.object(mock_fetch, "failRequest", new_callable=MagicMock)
     mock_tab.Fetch = mock_fetch
-    mock_tab.id =  "mock_tab_id"
+    mock_tab.id = "mock_tab_id"
     tab_event_handler = PychromeEventHandler(None, mock_tab, None, "", 0)
 
     tab_event_handler.handle_request_paused(**kwargs)

--- a/Packs/rasterize/ReleaseNotes/2_1_9.md
+++ b/Packs/rasterize/ReleaseNotes/2_1_9.md
@@ -3,4 +3,4 @@
 
 ##### Rasterize
 
-Added a 60-second timeout for screenshot capture operations in ***rasterize*** commands to prevent hanging operations and improve reliability.
+Added a 60-second timeout for screenshot capture operations in ***rasterize*** commands to prevent hanging operations.

--- a/Packs/rasterize/ReleaseNotes/2_1_9.md
+++ b/Packs/rasterize/ReleaseNotes/2_1_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Rasterize
+
+Added a 60-second timeout for screenshot capture operations in ***rasterize*** commands to prevent hanging operations and improve reliability.

--- a/Packs/rasterize/pack_metadata.json
+++ b/Packs/rasterize/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rasterize",
     "description": "Converts URLs, PDF files, and emails to an image file or PDF file.",
     "support": "xsoar",
-    "currentVersion": "2.1.8",
+    "currentVersion": "2.1.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixed: [link](https://jira-dc.paloaltonetworks.com/browse/XSUP-46913) to the issue

## Description
Added a 60-second timeout for screenshot capture operations in ***rasterize*** commands to prevent hanging operations.

