### PR TITLE
ews-message-trace-get from_ip, to_ip bug

### DIFF
--- a/Packs/MicrosoftExchangeOnline/.secrets-ignore
+++ b/Packs/MicrosoftExchangeOnline/.secrets-ignore
@@ -50,3 +50,7 @@ b'nUT26MNdeTzcQSwK679doIz5Avpv8Ps2H/aBkBamwRNOCJBkl7iCHyy+04yRj3ghikw3u/ufIFHi0s
 84f8a0dec6732c2341eeb7b05ebdbe919e7092bcaf6505fbd6cda495d89b55d6
 228d032fb728b3f86c49084b7d99ec37e913789415789084cd44fd94ea4647b7
 90daab88e6fac673e12acbbe28879d8d2b60fc2f524f1c2ff02fccb8e3e526a8
+Joe@Contoso.com
+kim@contoso.com
+legal@contoso.com
+manuel@contoso.com

--- a/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
@@ -988,7 +988,7 @@ class ExchangeOnlinePowershellV3Client
         #>
     }
 
-    [PSObject]GetMessageTrace([string[]]$sender_address, [string[]]$recipient_address, [string[]]$from_ip, [string[]]$to_ip, [string[]]$message_id,
+    [PSObject]GetMessageTrace([string[]]$sender_address, [string[]]$recipient_address, [string]$from_ip, [string]$to_ip, [string[]]$message_id,
         [string]$message_trace_id, [int32]$page, [int32]$page_size, [String]$start_date, [String]$end_date, [string]$status) {
         $response = ""
         try {
@@ -2208,10 +2208,8 @@ function GetMessageTraceCommand([ExchangeOnlinePowershellV3Client]$client, [hash
     # Parse arguments
     $sender_address = ArgToList $kwargs.sender_address
     $recipient_address = ArgToList $kwargs.recipient_address
-    $from_ip = ArgToList $kwargs.from_ip
-    $to_ip = ArgToList $kwargs.to_ip
 
-    $raw_response = $client.GetMessageTrace($sender_address, $recipient_address, $from_ip, $to_ip, $kwargs.message_id,
+    $raw_response = $client.GetMessageTrace($sender_address, $recipient_address, $kwargs.from_ip, $kwargs.to_ip, $kwargs.message_id,
         $kwargs.message_trace_id, $kwargs.page, $kwargs.page_size, $kwargs.start_date,
         $kwargs.end_date, $kwargs.status)
 

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
@@ -1,5 +1,5 @@
 #### Integrations
 
-##### EwsExtensionEXOPowershellV3
+##### EWS Extension Online Powershell v3
 
 - Fixed a bug in **ews-message-trace-get** command filtering results based on **from_ip** and **to_ip**

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
@@ -2,4 +2,4 @@
 
 ##### EWS Extension Online Powershell v3
 
-- Fixed a bug in **ews-message-trace-get** command filtering results based on **from_ip** and **to_ip**
+Fixed a bug where the ***ews-message-trace-get*** command would fail when filtering results based on the *from_ip* and *to_ip* arguments.

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_13.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### EwsExtensionEXOPowershellV3
+
+- Fixed a bug in **ews-message-trace-get** command filtering results based on **from_ip** and **to_ip**

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.6.12",
+    "currentVersion": "1.6.13",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Powershell EWS integration uses [Get-MessageTrace APIv1](https://learn.microsoft.com/en-us/powershell/module/exchange/get-messagetrace?view=exchange-ps). Based on documentation both FromIP and ToIP are String type values.
```
Get-MessageTrace
   [-FromIP <String>]
   [-ToIP <String>]
```
Demisto content integration written in PowerShell treats FromIP and ToIP as MultiValuedProperty, parsing input string with arguments from input to List instead on giving expected value of single IP to `Get-MessageTrace` resulting in runtime error.
```
Error: 
    Integration: EWS extension 
    Command: ews-message-trace-get 
    Arguments: { "from_ip": "0.0.0.0", "page": "1", "page_size": "100" }
Error: System.Management.Automation.ParameterBindingArgumentTransformationException: Cannot process argument transformation on parameter 'FromIP'. Cannot convert value to type System.String.
```

This change replaces List type with String type to allow filtering results based on IPs.

## Must have
- [x] Tests
- [x] Documentation 
