### PR TITLE
Update README.md

### DIFF
--- a/Packs/Infoblox/Integrations/Infoblox/README.md
+++ b/Packs/Infoblox/Integrations/Infoblox/README.md
@@ -25,7 +25,7 @@ You can execute these commands from the Cortex XSOAR CLI, as part of an automati
 
 1. [Get IP info: infoblox-get-ip](#infoblox-get-ip).
 2. [Searches IP related objects by a given IP: infoblox-search-related-objects-by-ip](#infoblox-search-related-objects-by-ip).
-3. [Lists all response policy rules that belong to the.g.,ven response policy zone: infoblox-list-response-policy-zone-rules](#infoblox-list-response-policy-zone-rules).
+3. [Lists all response policy rules that belong to the given response policy zone: infoblox-list-response-policy-zone-rules](#infoblox-list-response-policy-zone-rules).
 4. [List all response policy zones: infoblox-list-response-policy-zones](#infoblox-list-response-policy-zones).
 5. [Creates a response policy zone: infoblox-create-response-policy-zone](#infoblox-create-response-policy-zone).
 6. [Creates a response policy rule: infoblox-create-rpz-rule](#infoblox-create-rpz-rule).
@@ -174,7 +174,7 @@ Searches IP related objects by a given IP.
 
 * * *
 
-Lists all response policy rules that belong to the.g.,ven response policy zone.
+Lists all response policy rules that belong to the given response policy zone.
 
 ##### Base Command
 


### PR DESCRIPTION
corrected typo in infoblox-list-response-policy-zone-rules command section. Changed "the.g.,ven" to "the given"

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Corrected typo [here](https://xsoar.pan.dev/docs/reference/integrations/infoblox#infoblox-list-response-policy-zone-rules) (infoblox-list-response-policy-zone-rules command section). Change "the.g.,ven" to "the given".

## Must have
- [ ] Tests
- [x ] Documentation 
