### PR TITLE
Silent_pbs_fixes_portScan_and_Script_added_to_Registry

### DIFF
--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Script_file_added_to_startup-related_Registry_keys.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Script_file_added_to_startup-related_Registry_keys.yml
@@ -1758,6 +1758,24 @@ tasks:
     conditions:
     - label: Malicious
       condition:
+      - - operator: isNotEmpty
+          left:
+            value:
+              complex:
+                root: DBotScore
+                filters:
+                - - operator: containsGeneral
+                    left:
+                      value:
+                        simple: DBotScore.Indicator
+                      iscontext: true
+                    right:
+                      value:
+                        simple: ScriptSHA256
+                      iscontext: true
+                    ignorecase: true
+                accessor: Score
+            iscontext: true
       - - operator: isEqualNumber
           left:
             value:
@@ -2788,8 +2806,8 @@ tasks:
       id: e1b30cb3-e1fe-4ad0-8faa-40d2f52fec85
       version: -1
       name: Wildfire get verdict
-      description: Returns a verdict regarding multiple hashes, stored in a TXT file or given as a list.
-      script: '|||wildfire-get-verdicts'
+      description: Returns a verdict for a hash.
+      script: '|||wildfire-get-verdict'
       type: regular
       iscommand: true
       brand: ""
@@ -2797,7 +2815,7 @@ tasks:
       '#none#':
       - "143"
     scriptarguments:
-      hash_list:
+      hash:
         simple: ${ScriptSHA256}
     separatecontext: false
     continueonerrortype: ""
@@ -2811,7 +2829,7 @@ tasks:
     note: false
     timertriggers: []
     ignoreworker: false
-    skipunavailable: false
+    skipunavailable: true
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
@@ -2886,8 +2904,8 @@ tasks:
       id: b4fcf3b2-81ca-4068-8e9a-396b2c3336f4
       version: -1
       name: Wildfire get verdict
-      description: Returns a verdict regarding multiple hashes, stored in a TXT file or given as a list.
-      script: '|||wildfire-get-verdicts'
+      description: Returns a verdict for a hash.
+      script: '|||wildfire-get-verdict'
       type: regular
       iscommand: true
       brand: ""
@@ -2895,7 +2913,7 @@ tasks:
       '#none#':
       - "145"
     scriptarguments:
-      hash_list:
+      hash:
         simple: ${ScriptSHA256}
     separatecontext: false
     continueonerrortype: ""

--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Script_file_added_to_startup-related_Registry_keys.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Script_file_added_to_startup-related_Registry_keys.yml
@@ -147,6 +147,7 @@ tasks:
                       value:
                         simple: alert.cgosha256
                       iscontext: true
+                    ignorecase: true
                 accessor: Score
             iscontext: true
           right:
@@ -864,6 +865,7 @@ tasks:
                       value:
                         simple: alert.cgosha256
                       iscontext: true
+                    ignorecase: true
                 accessor: Score
             iscontext: true
           right:

--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
@@ -3450,7 +3450,9 @@ tasks:
           - operator: RemoveEmpty
             args:
               empty_values: {}
-              remove_keys: {}
+              remove_keys:
+                value:
+                  simple: "true"
           - operator: uniq
     separatecontext: false
     continueonerror: true

--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
@@ -565,6 +565,7 @@ tasks:
                       value:
                         simple: alert.cgosha256
                       iscontext: true
+                    ignorecase: true
                 accessor: Score
             iscontext: true
           right:
@@ -3446,6 +3447,10 @@ tasks:
                 value:
                   simple: alert.osparentsha256
                 iscontext: true
+          - operator: RemoveEmpty
+            args:
+              empty_values: {}
+              remove_keys: {}
           - operator: uniq
     separatecontext: false
     continueonerror: true

--- a/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
+++ b/Packs/CortexResponseAndRemediation/Playbooks/silent-playbook-Suspicious_Port_Scan.yml
@@ -137,31 +137,59 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isEqualNumber
+      - - operator: isNotEmpty
           left:
             value:
               complex:
-                root: Indicators
+                root: DBotScore
                 filters:
                 - - operator: containsGeneral
                     left:
                       value:
-                        simple: Indicators.Value
+                        simple: DBotScore.Indicator
+                      iscontext: true
+                    right:
+                      value:
+                        simple: alert.cgosha256
+                      iscontext: true
+                    ignorecase: true
+                  - operator: isEqualString
+                    left:
+                      value:
+                        simple: DBotScore.Indicator
+                      iscontext: true
+                    right:
+                      value:
+                        simple: alert.osparentsha256
+                      iscontext: true
+                accessor: Score
+            iscontext: true
+      - - operator: isEqualNumber
+          left:
+            value:
+              complex:
+                root: DBotScore
+                filters:
+                - - operator: containsGeneral
+                    left:
+                      value:
+                        simple: DBotScore.Indicator
+                      iscontext: true
+                    right:
+                      value:
+                        simple: alert.cgosha256
+                      iscontext: true
+                    ignorecase: true
+                  - operator: containsGeneral
+                    left:
+                      value:
+                        simple: DBotScore.Indicator
                       iscontext: true
                     right:
                       value:
                         simple: alert.osparentsha256
                       iscontext: true
                     ignorecase: true
-                  - operator: containsGeneral
-                    left:
-                      value:
-                        simple: Indicators.Value
-                      iscontext: true
-                    right:
-                      value:
-                        simple: alert.cgosha256
-                      iscontext: true
                 accessor: Score
             iscontext: true
           right:
@@ -1510,7 +1538,7 @@ tasks:
       '#default#':
       - "145"
       "yes":
-      - "152"
+      - "198"
     separatecontext: false
     conditions:
     - label: "yes"
@@ -1533,98 +1561,6 @@ tasks:
         "position": {
           "x": 421,
           "y": 368
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
-    isoversize: false
-    isautoswitchedtoquietmode: false
-  "152":
-    id: "152"
-    taskid: ebd6be74-1abd-474e-8682-5592ff076ccc
-    type: regular
-    task:
-      id: ebd6be74-1abd-474e-8682-5592ff076ccc
-      version: -1
-      name: Create indicator
-      description: Create indicators to the Threat Intel database only if they are not registered. All submitted indicators will be associated with the parent incident. When using the script with many indicators, or when the Threat Intel Management database is highly populated, this script may have low performance issue.
-      scriptName: CreateNewIndicatorsOnly
-      type: regular
-      iscommand: false
-      brand: ""
-    nexttasks:
-      '#none#':
-      - "153"
-    scriptarguments:
-      indicator_values:
-        complex:
-          root: alert
-          accessor: cgosha256
-          transformers:
-          - operator: append
-            args:
-              item:
-                value:
-                  simple: alert.osparentsha256
-                iscontext: true
-          - operator: uniq
-      type:
-        simple: File
-    separatecontext: false
-    continueonerrortype: ""
-    view: |-
-      {
-        "position": {
-          "x": 421,
-          "y": 516
-        }
-      }
-    note: false
-    timertriggers: []
-    ignoreworker: false
-    skipunavailable: false
-    quietmode: 0
-    isoversize: false
-    isautoswitchedtoquietmode: false
-  "153":
-    id: "153"
-    taskid: dc02758c-0191-439d-b649-0ff4494965a0
-    type: regular
-    task:
-      id: dc02758c-0191-439d-b649-0ff4494965a0
-      version: -1
-      name: Check the processes reputation
-      description: commands.local.cmd.enrich.indicators
-      script: Builtin|||enrichIndicators
-      type: regular
-      iscommand: true
-      brand: Builtin
-    nexttasks:
-      '#none#':
-      - "2"
-    scriptarguments:
-      indicatorsValues:
-        complex:
-          root: alert
-          accessor: cgosha256
-          transformers:
-          - operator: append
-            args:
-              item:
-                value:
-                  simple: alert.osparentsha256
-                iscontext: true
-          - operator: uniq
-    separatecontext: false
-    continueonerrortype: ""
-    view: |-
-      {
-        "position": {
-          "x": 421,
-          "y": 670
         }
       }
     note: false
@@ -3482,6 +3418,52 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+  "198":
+    id: "198"
+    taskid: 6a395957-07ea-45ad-9c9c-17d96ad7ee73
+    type: regular
+    task:
+      id: 6a395957-07ea-45ad-9c9c-17d96ad7ee73
+      version: -1
+      name: Check the processes reputation
+      description: Checks the file reputation of the specified hash.
+      script: '|||file'
+      type: regular
+      iscommand: true
+      brand: ""
+    nexttasks:
+      '#none#':
+      - "2"
+    scriptarguments:
+      file:
+        complex:
+          root: alert
+          accessor: cgosha256
+          transformers:
+          - operator: append
+            args:
+              item:
+                value:
+                  simple: alert.osparentsha256
+                iscontext: true
+          - operator: uniq
+    separatecontext: false
+    continueonerror: true
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 421,
+          "y": 516
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: true
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -3492,7 +3474,7 @@ view: |-
       "147_165_#default#": 0.22,
       "149_163_yes": 0.48,
       "149_165_#default#": 0.11,
-      "151_152_yes": 0.43,
+      "151_198_yes": 0.48,
       "154_196_yes": 0.53,
       "160_1_#default#": 0.11,
       "166_159_#default#": 0.25,

--- a/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_73.md
+++ b/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_73.md
@@ -1,0 +1,3 @@
+## Cortex Response And Remediation
+
+- Improved documentation and metadata.

--- a/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_74.md
+++ b/Packs/CortexResponseAndRemediation/ReleaseNotes/1_1_74.md
@@ -1,0 +1,3 @@
+## Cortex Response And Remediation
+
+- Improved documentation and metadata.

--- a/Packs/CortexResponseAndRemediation/pack_metadata.json
+++ b/Packs/CortexResponseAndRemediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Response And Remediation",
     "description": "The Cortex Response & Remediation Pack delivers a powerful collection of automated playbooks designed to streamline incident response and remediation processes. Built to support an Autonomous SOC vision.",
     "support": "xsoar",
-    "currentVersion": "1.1.71",
+    "currentVersion": "1.1.73",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CortexResponseAndRemediation/pack_metadata.json
+++ b/Packs/CortexResponseAndRemediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Response And Remediation",
     "description": "The Cortex Response & Remediation Pack delivers a powerful collection of automated playbooks designed to streamline incident response and remediation processes. Built to support an Autonomous SOC vision.",
     "support": "xsoar",
-    "currentVersion": "1.1.72",
+    "currentVersion": "1.1.73",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/CortexResponseAndRemediation/pack_metadata.json
+++ b/Packs/CortexResponseAndRemediation/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex Response And Remediation",
     "description": "The Cortex Response & Remediation Pack delivers a powerful collection of automated playbooks designed to streamline incident response and remediation processes. Built to support an Autonomous SOC vision.",
     "support": "xsoar",
-    "currentVersion": "1.1.73",
+    "currentVersion": "1.1.74",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Suspicious port scan playbook:
change create indicator and enrich indicator to !file

Script file added to startup-related Registry keys playbook:
change command from 'wildfire-get-verdicts' to  'wildfire-get-verdict'.


## Must have
- [ ] Tests
- [ ] Documentation 
