### PR TITLE
Update Tenable.sc To python 3.12

### DIFF
--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py
@@ -133,10 +133,9 @@ class Client(BaseClient):
             try:
                 error = res.json()
             except Exception:
-                # type: ignore
                 raise DemistoException(
-                    f"Error: Got status code {res.status_code!s} with {url=} with"  # type: ignore
-                    f" body {res.content} with headers {res.headers!s}"
+                    f"Error: Got status code {res.status_code!s} with {url=} with"
+                    f" body {res.content} with headers {res.headers!s}"  # type: ignore[str-bytes-safe]
                 )
 
             raise DemistoException(f"Error: Got an error from TenableSC, code: {error['error_code']}, \
@@ -181,7 +180,7 @@ class Client(BaseClient):
 
         if res.status_code < 200 or res.status_code >= 300:
             raise DemistoException(f"Error: Got status code {res.status_code!s} with {url=} \
-                        with body {res.content} with headers {res.headers!s}")  # type: ignore
+                        with body {res.content} with headers {res.headers!s}")  # type: ignore[str-bytes-safe]
 
         self.cookie = res.cookies.get("TNS_SESSIONID", self.cookie)
         demisto.setIntegrationContext({"cookie": self.cookie})

--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
@@ -61,6 +61,7 @@ configuration:
   name: incidentFetchInterval
   required: false
   type: 19
+  section: Collect
 description: With Tenable.sc (formerly SecurityCenter) you get a real-time, continuous assessment of your security posture so you can find and fix vulnerabilities faster.
 display: Tenable.sc
 name: Tenable.sc

--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
@@ -2486,7 +2486,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.11.10.115186
+  dockerimage: demisto/python3:3.12.11.3982393
   runonce: false
 tests:
 - tenable-sc-test

--- a/Packs/Tenable_sc/ReleaseNotes/1_1_3.md
+++ b/Packs/Tenable_sc/ReleaseNotes/1_1_3.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Tenable.sc
+
+- Updated the Docker image to: *demisto/python3:3.12.11.3982393*.
+

--- a/Packs/Tenable_sc/pack_metadata.json
+++ b/Packs/Tenable_sc/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tenable.sc",
     "description": "With Tenable.sc (formerly SecurityCenter) you get a real-time, continuous assessment of your security posture so you can find and fix vulnerabilities faster.",
     "support": "xsoar",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: link to the issue

## Description
```
Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.py:139: error:(B If x =
b'abc' then f(B"{x}"(B or (B"{}"(B.format(x) produces (B"b'abc'"(B, not (B"abc"(B. If this is
desired behavior, use f(B"{x!r}"(B or (B"{!r}"(B.format(x). Otherwise, decode the bytes 
(B[str-bytes-safe](B
                        f" body {res.content} with headers {res.headers!s}...(B
                                ^~~~~~~~~~~~~(B
Found 1 error in 1 file (checked 359 source files)(B
```