### PR TITLE
Update docker for CommonServerPowerShell

### DIFF
--- a/Packs/Base/ReleaseNotes/1_39_43.md
+++ b/Packs/Base/ReleaseNotes/1_39_43.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### CommonServerPowerShell
+
+- Updated the Docker image to: *demisto/powershell:7.5.0.3759715*.
+

--- a/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.yml
+++ b/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.yml
@@ -10,7 +10,7 @@ tags:
 comment: Common code that will be merged into each PowerShell script/integration when it runs.
 system: true
 fromversion: 5.5.0
-dockerimage: demisto/powershell:7.4.6.117357
+dockerimage: devdemisto/powershell:7.6.0.4073794
 tests:
   - PowerShellCommon-Test
   - XsoarPowershellTesting-Test

--- a/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.yml
+++ b/Packs/Base/Scripts/CommonServerPowerShell/CommonServerPowerShell.yml
@@ -10,7 +10,7 @@ tags:
 comment: Common code that will be merged into each PowerShell script/integration when it runs.
 system: true
 fromversion: 5.5.0
-dockerimage: devdemisto/powershell:7.6.0.4073794
+dockerimage: demisto/powershell:7.5.0.3759715
 tests:
   - PowerShellCommon-Test
   - XsoarPowershellTesting-Test

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.39.42",
+    "currentVersion": "1.39.43",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Related Issues
fixes: link to the issue

## Description
##### CommonServerPowerShell

- Updated the Docker image to: *demisto/powershell:7.5.0.3759715*.

