### PR TITLE
Cortex attack surface management remove supported modules

### DIFF
--- a/Packs/CortexAttackSurfaceManagement/pack_metadata.json
+++ b/Packs/CortexAttackSurfaceManagement/pack_metadata.json
@@ -121,14 +121,5 @@
         "Jira",
         "Tenable_io",
         "Venafi"
-    ],
-    "supportedModules": [
-        "C1",
-        "C3",
-        "X0",
-        "X1",
-        "X3",
-        "X5",
-        "ENT_PLUS"
     ]
 }


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
A followup of [this](https://github.com/demisto/content/pull/39758) PR as Cortex attack surface was [removed](https://jira-dc.paloaltonetworks.com/browse/CRTX-168369) from the platform bucket it shouldn't have the supported modules.

## Must have
- [ ] Tests
- [ ] Documentation 
