### PR TITLE
Bugfix/XSUP-52806-wrong-filter-causing-unsupported-type-in-Enrichment-for-verdict

### DIFF
--- a/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict.yml
+++ b/Packs/CommonPlaybooks/Playbooks/playbook-Enrichment_for_Verdict.yml
@@ -37,6 +37,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "8":
     id: "8"
     taskid: cf7fbd3d-5b7f-4b20-8196-e356bc3aaf46
@@ -79,6 +80,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "9":
     id: "9"
     taskid: b3cad615-be42-4953-8f72-010f572ef0fd
@@ -192,6 +194,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "16":
     id: "16"
     taskid: 5a797f7b-e0f2-46de-85c1-0d2165ce20a9
@@ -251,6 +254,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "17":
     id: "17"
     taskid: 955d7432-cc8b-45d6-89c9-1ab23df18f9e
@@ -303,6 +307,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "18":
     id: "18"
     taskid: 0f1e5698-ef4e-4235-8788-8393074064f4
@@ -355,6 +360,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "19":
     id: "19"
     taskid: 1aee9e4c-cf41-4bb4-8a63-960caf6fb8f4
@@ -414,6 +420,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "20":
     id: "20"
     taskid: 5563f2a4-486e-4f81-8643-177d0e8b5771
@@ -435,13 +442,13 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isNotEqualString
+      - - operator: greaterThanOrEqual
           left:
             value:
               complex:
                 root: DBotScore
                 filters:
-                - - operator: isEqualString
+                - - operator: inList
                     left:
                       value:
                         simple: DBotScore.Indicator
@@ -454,7 +461,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "1"
+              simple: "2"
       - - operator: isExists
           left:
             value:
@@ -474,6 +481,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "25":
     id: "25"
     taskid: afcbc012-2435-4010-8296-9371a006f70b
@@ -501,6 +509,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "26":
     id: "26"
     taskid: 6449a627-0408-4675-84d4-0d982602cfd2
@@ -542,6 +551,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "27":
     id: "27"
     taskid: c7d07b53-36ad-4c6e-8677-ad4e7af2db77
@@ -596,6 +606,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "28":
     id: "28"
     taskid: 7836c6c3-382f-4b12-87c7-2c913506c7dc
@@ -617,13 +628,13 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isNotEqualString
+      - - operator: greaterThanOrEqual
           left:
             value:
               complex:
                 root: DBotScore
                 filters:
-                - - operator: isEqualString
+                - - operator: inList
                     left:
                       value:
                         simple: DBotScore.Indicator
@@ -636,7 +647,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "1"
+              simple: "2"
       - - operator: isExists
           left:
             value:
@@ -656,6 +667,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "29":
     id: "29"
     taskid: cbb20744-6ea2-4151-8575-3bbac0b2962e
@@ -692,6 +704,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "31":
     id: "31"
     taskid: 75caed90-bf85-43b3-86f3-417962547da8
@@ -728,6 +741,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "33":
     id: "33"
     taskid: f8752cf3-0514-4ab3-8c9a-3d863f727dc8
@@ -764,6 +778,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "35":
     id: "35"
     taskid: 94003992-1ec4-4053-80cc-3afb14bf2843
@@ -802,6 +817,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "36":
     id: "36"
     taskid: 4ca36cfe-ae11-4c3b-8f9e-92aea2eec70d
@@ -836,6 +852,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "37":
     id: "37"
     taskid: 55674d1e-079e-4675-8d61-14369fe12222
@@ -866,6 +883,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "41":
     id: "41"
     taskid: b4647d4e-c996-4f29-8948-f23c392d7733
@@ -919,6 +937,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "43":
     id: "43"
     taskid: 30038490-f60a-4a8a-8edd-06bd7af8e182
@@ -966,6 +985,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "44":
     id: "44"
     taskid: a7f19866-af4a-4e16-899f-5bbfbeae9f65
@@ -1009,6 +1029,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "45":
     id: "45"
     taskid: c90ceb83-b4c8-488f-8c01-d452b2360c9f
@@ -1030,13 +1051,13 @@ tasks:
     conditions:
     - label: "yes"
       condition:
-      - - operator: isNotEqualString
+      - - operator: greaterThanOrEqual
           left:
             value:
               complex:
                 root: DBotScore
                 filters:
-                - - operator: isEqualString
+                - - operator: inList
                     left:
                       value:
                         simple: DBotScore.Indicator
@@ -1049,7 +1070,7 @@ tasks:
             iscontext: true
           right:
             value:
-              simple: "1"
+              simple: "2"
       - - operator: isExists
           left:
             value:
@@ -1069,6 +1090,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "46":
     id: "46"
     taskid: 079c1a82-0c4f-4824-8578-8785da3dc423
@@ -1105,6 +1127,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "48":
     id: "48"
     taskid: b3f5772e-2d82-4c85-86e5-c49de7849da4
@@ -1177,6 +1200,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "51":
     id: "51"
     taskid: 13580bdc-aa7d-488b-8c01-91a4511454b8
@@ -1207,6 +1231,7 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+    continueonerrortype: ""
   "52":
     id: "52"
     taskid: 13d55c21-5ddb-47d4-8c25-ff3b969e5532
@@ -1518,7 +1543,7 @@ outputs:
 - contextPath: WildFire.Verdicts.VerdictDescription
   description: Description of the file verdict.
 - contextPath: DomainVerdict
-  description: Domain verdict
+  description: Domain verdict.
   type: unknown
 - contextPath: Core.AnalyticsPrevalence.Ip.value
   description: Whether the IP address is prevalent or not.

--- a/Packs/CommonPlaybooks/ReleaseNotes/2_7_8.md
+++ b/Packs/CommonPlaybooks/ReleaseNotes/2_7_8.md
@@ -1,0 +1,6 @@
+
+#### Playbooks
+
+##### Enrichment for Verdict
+
+- Fixed incorrect type comparison in Enrichment for Verdict playbook input filter that caused unsupported type errors when processing verdicts.

--- a/Packs/CommonPlaybooks/pack_metadata.json
+++ b/Packs/CommonPlaybooks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Playbooks",
     "description": "Frequently used playbooks pack.",
     "support": "xsoar",
-    "currentVersion": "2.7.7",
+    "currentVersion": "2.7.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA 

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.** -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-52806)

## Description
Fixed incorrect type comparison in Enrichment for Verdict playbook input filter that caused unsupported type errors when processing verdicts.

