### PR TITLE
Improve documentation of execute_polling_command function

### DIFF
--- a/Packs/Base/ReleaseNotes/1_41_6.md
+++ b/Packs/Base/ReleaseNotes/1_41_6.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CommonServerPython
+
+Documentation and metadata improvements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -12717,7 +12717,8 @@ def execute_polling_command(
     default_polling_timeout=600,
 ):
     r"""
-    Continuously executes a specified command until the command indicates polling is done or a
+    **Only for use in special circumstances where polling is not supported. Avoid using otherwise!**
+    Continuously executes a specified command and sleeps until the command indicates polling is done or a
     timeout is reached.
     :param command_name: The name of the initial Demisto command to execute.
     :type command_name: ``str``

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.41.5",
+    "currentVersion": "1.41.6",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-13967)

## Description
Improve documentation of the `execute_polling_command` function in CommonServerPython to clarify that it should not be used under normal circumstances. 
