### PR TITLE
[Slack V3] Improve error logging with full traceback instead of basic exception message

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -59,7 +59,7 @@ APP_TOKEN: str
 PROXY_URL: Optional[str]
 PROXIES: dict
 DEDICATED_CHANNEL: str
-ASYNC_CLIENT: slack_sdk.web.async_client.AsyncWebClient
+ASYNC_CLIENT: AsyncWebClient
 CLIENT: slack_sdk.WebClient
 USER_CLIENT: slack_sdk.WebClient
 ALLOW_INCIDENTS: bool
@@ -1597,9 +1597,9 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
             if len(actions) > 0:
                 channel = data.get("channel", {}).get("id", "")
                 entitlement_json = actions[0].get("value")
-                entitlement_string = json.loads(entitlement_json)
                 if entitlement_json is None:
                     return
+                entitlement_string = json.loads(entitlement_json)
                 if actions[0].get("action_id") == "xsoar-button-submit":
                     demisto.debug("Handling a SlackBlockBuilder response.")
                     if state:
@@ -1653,8 +1653,8 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
             await process_mirror(channel, text, user)
         reset_listener_health()
         return
-    except Exception as e:
-        await handle_listen_error(f"Error occurred while listening to Slack: {e}")
+    except Exception:
+        await handle_listen_error(f"Error occurred while listening to Slack:\n{traceback.format_exc()}")
 
 
 async def get_user_by_id_async(client: AsyncWebClient, user_id: str) -> dict:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.yml
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.yml
@@ -526,7 +526,7 @@ script:
     - contextPath: Slack.Thread.ID
       description: The Slack thread ID.
       type: String
-  dockerimage: demisto/slackv3:1.0.0.3638862
+  dockerimage: demisto/slackv3:1.0.0.4127314
   longRunning: true
   runonce: false
   script: '-'

--- a/Packs/Slack/ReleaseNotes/3_5_27.md
+++ b/Packs/Slack/ReleaseNotes/3_5_27.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Slack v3
+
+- Fixed an issue where the script failed to provide detailed error information during Slack event listening and could encounter null pointer exceptions when processing entitlement data.
+- Updated the Docker image to: *demisto/slackv3:1.0.0.4127314*.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.5.26",
+    "currentVersion": "3.5.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-53362)

## Description
Fixed an issue where the script failed to provide detailed error information during Slack event listening and could encounter null pointer exceptions when processing entitlement data.

## Must have
- [ ] Tests
- [ ] Documentation 
