### PR TITLE
Add missing playbooks + integrations to XDR support (#40574)

### DIFF
--- a/Packs/CortexXDR/Integrations/XDR_iocs/XDR_iocs.yml
+++ b/Packs/CortexXDR/Integrations/XDR_iocs/XDR_iocs.yml
@@ -13,7 +13,7 @@ configuration:
   section: Connect
 - display: ''
   name: apikey_id_creds
-  type: 9
+  type: 9 
   displaypassword: API Key ID
   hiddenusername: true
   required: false


### PR DESCRIPTION
* Add missing playbooks + integrations to XDR support

* rn

* added more playbooks and packs

* update rn

* fix command-line analysis module

* docs: reverted release notes for Microsoft Exchange Online pack v1.6.16

* Bump pack from version PAN-OS to 2.5.8.

* Bump pack from version CommonPlaybooks to 2.7.11.

* fix: update image paths in Prisma Cloud playbook documentation to use relative paths

* chore: add RM116 ignore rule to multiple Prisma Cloud playbooks

* Bump pack from version PAN-OS to 2.6.1.

* feat: add section organization to Zoom IAM parameters and create Prisma Cloud remediation playbook docs

* chore: remove playbook images and update ignore rules for PAN-OS and PrismaCloud packs

* Bump pack from version MicrosoftExchangeOnline to 1.6.18.

* Bump pack from version PAN-OS to 2.6.2.

* Bump pack from version CommonPlaybooks to 2.7.12.

* chore: update Docker images to fastapi:0.116.1 and add EppDetectionSummaryEvent support for CrowdStrike

* feat: add Cortex Core IR integration to T1059 Command and Scripting Interpreter test in conf.json

* Bump pack from version PAN-OS to 2.6.3.

---------

Co-authored-by: Content Bot <bot@demisto.com>

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
