### PR TITLE
Fix/XSUP-54524/Add CIDR support for ThreatConnect

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -1311,6 +1311,8 @@ def tc_add_indicator_command(
     if indicator_type == "File":
         hash_type = args.get("hashType", "md5")
         payload[hash_type] = indicator
+    if indicator_type == "CIDR":
+        payload["Block"] = indicator
 
     url = "/api/v3/indicators"
     response = client.make_request(Method.POST, url, payload=json.dumps(payload))

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_15.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_15.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### ThreatConnect v3
+
+- Added support for CIDR indicators in the ***tc-add-indicator*** command.


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-54524)

## Description
According this [docs](https://docs.threatconnect.com/en/latest/rest_api/v3/indicators/indicators.html#cidr) we need to add the Block key to the payload.

## Must have
- [ ] Tests
- [ ] Documentation 
