### PR TITLE
Fix error handling when loading signature in sendEmailReply script

### DIFF
--- a/Packs/EmailCommunication/ReleaseNotes/2_0_46.md
+++ b/Packs/EmailCommunication/ReleaseNotes/2_0_46.md
@@ -3,4 +3,4 @@
 
 ##### SendEmailReply
 
-Fixed an issue where the script would fail in the **XSOAR - Email Communication Signature** list could not be loaded.
+Fixed an issue where the script would fail if the **XSOAR - Email Communication Signature** list could not be loaded.

--- a/Packs/EmailCommunication/ReleaseNotes/2_0_46.md
+++ b/Packs/EmailCommunication/ReleaseNotes/2_0_46.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### SendEmailReply
+
+Fixed an issue where the script would fail in the **XSOAR - Email Communication Signature** list could not be loaded.

--- a/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply.py
+++ b/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply.py
@@ -139,8 +139,9 @@ def append_email_signature(html_body: str) -> str:
     )
     if not is_succeed:
         # If not is_succeed, email_signature_result is an error message
+        error_message = email_signature_result
         demisto.debug(
-            f"Error occurred while trying to load the `{list_name}` list. No signature added to email. Error: {email_signature_result}."
+            f"Error occurred while trying to load the `{list_name}` list. No signature added to email. Error: {error_message}."
         )
         return html_body
 

--- a/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply.py
+++ b/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply.py
@@ -138,9 +138,9 @@ def append_email_signature(html_body: str) -> str:
         "getList", {"listName": list_name}, extract_contents=False, fail_on_error=False
     )
     if not is_succeed:
-        error_message = get_error(email_signature_result)
+        # If not is_succeed, email_signature_result is an error message
         demisto.debug(
-            f"Error occurred while trying to load the `{list_name}` list. No signature added to email. Error: {error_message}."
+            f"Error occurred while trying to load the `{list_name}` list. No signature added to email. Error: {email_signature_result}."
         )
         return html_body
 

--- a/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply_test.py
+++ b/Packs/EmailCommunication/Scripts/SendEmailReply/SendEmailReply_test.py
@@ -64,8 +64,8 @@ def test_append_email_signature_fails(mocker):
     """
     from SendEmailReply import append_email_signature
 
-    get_list_error_response = False, util_load_json("test_data/getList_signature_error.json")
-    mocker.patch("SendEmailReply.execute_command", return_value=get_list_error_response)
+    get_list_error_response = util_load_json("test_data/getList_signature_error.json")
+    mocker.patch.object(demisto, "executeCommand", return_value=get_list_error_response)
     debug_mocker = mocker.patch.object(demisto, "debug")
     html_body = append_email_signature("<html><body>Simple HTML message.\r\n</body></html>")
     debug_mocker_call_args = debug_mocker.call_args

--- a/Packs/EmailCommunication/pack_metadata.json
+++ b/Packs/EmailCommunication/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Email Communication",
     "description": "Do you have to send multiple emails to end users? This content pack helps you streamline the process and automate updates, notifications and more.\n",
     "support": "xsoar",
-    "currentVersion": "2.0.45",
+    "currentVersion": "2.0.46",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "videos": [


### PR DESCRIPTION
## Related Issues
relates: [link to issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-53433)

## Description
Fixed an issue where the script would fail in the **XSOAR - Email Communication Signature** list could not be loaded.

If running `execute_command` with `fail_on_error` == `False`, the `error_message` is already extracted (if `is_error`).
<img height="500" alt="Screenshot 2025-08-17 at 11 39 31" src="https://github.com/user-attachments/assets/14efb735-9dde-43c6-9914-08a5874c0aec" />


