### PR TITLE
Update documentation

### DIFF
--- a/Packs/CommonScripts/Scripts/DeleteContext/README.md
+++ b/Packs/CommonScripts/Scripts/DeleteContext/README.md
@@ -25,7 +25,7 @@ For more information, see the section about permissions here: For Cortex XSOAR 6
 | key | The key to delete from the context. |
 | all | Whether all context will be deleted. |
 | subplaybook | Whether the context key is inside of a sub-playbook. Use **auto** to delete either from the sub-playbook context (if the playbook is called as a sub-playbook) or from the global context (if the playbook is the top playbook). |
-| keysToKeep | The context keys to keep when deleting all context. Supports comma-separated values and nested objects. For example, "URL.Data" and "IP.Address". See *Usage Notes*. |
+| keysToKeep | The context keys to keep when deleting all other context. Supports comma-separated values and nested objects. For example, "URL.Data" and "IP.Address". See the **Usage Notes** for more information. |
 | index | The index to delete in case the 'key' argument was specified. |
 
 ## Outputs


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-54632](https://jira-dc.paloaltonetworks.com/browse/XSUP-54632)

## Description
Updated the DeleteContext documentation to clarify that when calling this script from another script with the keysToKeep parameter, return_results() must be used to ensure preserved context data is properly maintained.