### PR TITLE
custom busy-wait for xdr-xql-generic-query

### DIFF
--- a/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
+++ b/Packs/ApiModules/Scripts/CoreXQLApiModule/CoreXQLApiModule.py
@@ -748,9 +748,20 @@ def get_xql_query_results_polling_command(client: CoreClient, args: dict) -> Uni
     interval_in_secs = int(args.get("interval_in_seconds", 30))
     timeout_in_secs = int(args.get("timeout_in_seconds", 600))
     max_fields = arg_to_number(args.get("max_fields", 20))
+    query_id = args.get('query_id', '')
+    is_polling = argToBoolean(args.get("is_polling", True))
     if max_fields is None:
         raise DemistoException("Please provide a valid number for max_fields argument.")
     outputs, file_data = get_xql_query_results(client, args)  # get query results with query_id
+    if not is_polling:
+        import time
+        while outputs.get('status') == 'PENDING':
+            demisto.debug(f'Query {query_id} status is still pending, polling again in {interval_in_secs} seconds')
+            # if status is still pending, call the command again after the interval
+            time.sleep(interval_in_secs)
+            outputs, file_data = get_xql_query_results(client, args)
+            if outputs.get('status') != 'PENDING':
+                break
     outputs.update({"query_name": args.get("query_name", "")})
     outputs_prefix = get_outputs_prefix(command_name)
     command_results = CommandResults(
@@ -769,7 +780,7 @@ def get_xql_query_results_polling_command(client: CoreClient, args: dict) -> Uni
             outputs["results"] = [json.loads(line) for line in data.split("\n") if len(line) > 0]
 
     # if status is pending, the command will be called again in the next run until success.
-    if outputs.get("status") == "PENDING":
+    if is_polling and outputs.get("status") == "PENDING":
         demisto.debug(f"Returned status 'PENDING' for {args.get('query_id', '')}.")
         scheduled_command = ScheduledCommand(
             command="xdr-xql-get-query-results",

--- a/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.yml
+++ b/Packs/CortexXDR/Integrations/XQLQueryingEngine/XQLQueryingEngine.yml
@@ -3,7 +3,7 @@ sectionorder:
 - Collect
 category: Endpoint
 commonfields:
-  id: Cortex XDR - XQL Query Engine
+  id: Cortex XDR - XQL Query Engine - No Polling
   version: -1
 configuration:
 - defaultvalue: https://example.com/
@@ -37,8 +37,8 @@ configuration:
   advanced: true
   required: false
 description: Cortex XDR - XQL Query Engine enables you to run XQL queries on your data sources.
-display: Cortex XDR - XQL Query Engine
-name: Cortex XDR - XQL Query Engine
+display: Cortex XDR - XQL Query Engine - No Polling
+name: Cortex XDR - XQL Query Engine - No Polling
 script:
   commands:
   - arguments:
@@ -70,6 +70,13 @@ script:
       - "true"
       - "false"
       defaultValue: "false"
+    - description: Whether to use polling for this command.
+      name: is_polling
+      auto: PREDEFINED
+      predefined:
+        - 'true'
+        - 'false'
+      defaultValue: 'true'
     description: |-
       Execute an XQL query and retrieve results of an executed XQL query API. The command will be executed every 10 seconds until results are retrieved or until a timeout error is raised.
       When more than 1000 results are retrieved, the command will return a compressed gzipped JSON format file,


### PR DESCRIPTION
This is not to be merged!
We created a custom integration using command:
`demisto-sdk unify -i /Users/jmizrahi/dev/demisto/content/Packs/CortexXDR/Integrations/XQLQueryingEngine -c "No Polling"`
