### PR TITLE
SplunkPy mirror-in: remove duplications

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
+++ b/Packs/SplunkPy/Integrations/SplunkPy/SplunkPy.py
@@ -1842,11 +1842,20 @@ def get_modified_remote_data_command(
     Returns:
         SplunkGetModifiedRemoteDataResponse: The response containing the list of notables changed
     """
-    modified_notables_map = {}
-    entries: list[dict] = []
     remote_args = GetModifiedRemoteDataArgs(args)
-    demisto.debug(f"Original last_update before 1 minute reduction: {get_last_update_in_splunk_time(remote_args.last_update)}")
-    # Subtract 1 minute (60 seconds) to allow indexing
+
+    # Caching Mechanism for Handling Splunk Indexing Delays:
+    # 1. A 60-second buffer is subtracted from the last run time to create an overlapping query window.
+    #    This ensures we catch events that were indexed late by Splunk and missed in the previous run.
+    # 2. To prevent processing duplicate events from this overlap, we cache the unique key (notable_id:timestamp)
+    #    of every event processed in the current run.
+    # 3. This cache is stored in the integration context and loaded at the start of the next run.
+    # 4. Any fetched event whose key exists in the cache is skipped as a duplicate.
+    integration_context = get_integration_context()
+    processed_events_cache = set(integration_context.get('processed_events_cache', []))
+    demisto.debug(f"Loaded {len(processed_events_cache)} processed events from cache.")
+
+    # Build the query with the 60-second look-behind buffer.
     last_update_splunk_timestamp = get_last_update_in_splunk_time(remote_args.last_update) - SPLUNK_INDEXING_TIME
     incident_review_search = (
         "|`incident_review` "
@@ -1855,17 +1864,36 @@ def get_modified_remote_data_command(
         "| fields - _time,time "
         "| expandtoken"
     )
+
+    modified_notables_map = {}
+    entries: list[dict] = []
+    current_run_processed_events = set()
+
     demisto.debug(f"mirror-in: performing `incident_review` search with query: {incident_review_search}.")
     for item in results.JSONResultsReader(
         service.jobs.oneshot(query=incident_review_search, count=MIRROR_LIMIT, output_mode=OUTPUT_MODE_JSON)
     ):
         if handle_message(item):
             continue
+
         updated_notable = parse_notable(item, to_dict=True)
-        notable_id = updated_notable["rule_id"]  # in the `incident_review` macro - the ID are in the rule_id key
+        notable_id = updated_notable.get("rule_id")
+        last_modified = updated_notable.get("last_modified_timestamp")
 
+        if not notable_id or not last_modified:
+            continue
+
+        # Create a unique key for the event and check against the cache of previously processed events.
+        event_key = f"{notable_id}:{last_modified}"
+        if event_key in processed_events_cache:
+            demisto.debug(f"mirror-in: Skipping already processed event: {event_key}")
+            continue
+
+        # This is a new event. Add it to the map for processing and to the cache for the next run.
         modified_notables_map[notable_id] = updated_notable
+        current_run_processed_events.add(event_key)
 
+        # If the update contains a new comment, create a corresponding entry.
         if (comment := updated_notable.get("comment")) and COMMENT_MIRRORED_FROM_XSOAR not in comment:
             # comment, here in the `incident_review` macro results, hold only the updated comment
             # Creating a note
@@ -1879,6 +1907,10 @@ def get_modified_remote_data_command(
                     "Note": True,
                 }
             )
+
+    # Persist the cache of events processed in this run for the next iteration.
+    integration_context['processed_events_cache'] = list(current_run_processed_events)
+    set_integration_context(integration_context)
 
     if modified_notables_map:
         notable_ids_with_quotes = [f'"{notable_id}"' for notable_id in modified_notables_map]


### PR DESCRIPTION


## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-54482

## Description
This change addresses a mirroring issue where Splunk's indexing delays could cause duplicate events to be processed.

The solution implements a caching mechanism to track events that have already been processed:

A 60-second look-behind is used in the Splunk query to ensure late-indexed events are not missed.
To prevent duplicates from this overlapping query window, a unique key (notable_id:timestamp) for each processed event is stored in the integration context.
In subsequent runs, the integration checks this cache and skips any event that has already been processed, ensuring each notable is handled only once.

