### PR TITLE
XSUP-54700 Active Directory Query v2 Integration Error When Disable Account

### DIFF
--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
@@ -1341,7 +1341,9 @@ def restore_user(default_base_dn: str, page_size: int) -> int:
     attributes = list(set(DEFAULT_PERSON_ATTRIBUTES))
 
     entries = search_with_paging(query, default_base_dn, attributes=attributes, size_limit=0, page_size=page_size)
+    demisto.log(f"Active Directory restore_user {entries=}")
     if entries.get("flat"):
+        demisto.log(f"Active Directory restore_user flat={entries.get('flat')}")
         return entries.get("flat")[0].get("userAccountControl")[0]
     return 0
 


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-54700

## Description
fix for Error When run ad-disable-account

## Must have
- [ ] Tests
- [ ] Documentation 
