### PR TITLE
Slack V3: adding logs for the mirror-investigation command

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -745,6 +745,7 @@ def mirror_investigation():
             "Mirroring is enabled, however long running is disabled. For mirrors to work correctly,"
             " long running must be enabled."
         )
+    demisto.debug(f"SlackV3 integration: This is the arguments for the mirror-investigation command: {demisto.args()}")
     mirror_type = demisto.args().get("type", "all")
     auto_close = demisto.args().get("autoclose", "true")
     mirror_direction = demisto.args().get("direction", "both")

--- a/Packs/Slack/ReleaseNotes/3_5_28.md
+++ b/Packs/Slack/ReleaseNotes/3_5_28.md
@@ -3,4 +3,4 @@
 
 ##### Slack v3
 
-- Improved implementation by adding some logs for the ***mirror-investigation*** command.
+- Added additional logs to improve the **mirror-investigation** command.

--- a/Packs/Slack/ReleaseNotes/3_5_28.md
+++ b/Packs/Slack/ReleaseNotes/3_5_28.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Slack v3
+
+- Improved implementation by adding some logs for the ***mirror-investigation*** command.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.5.27",
+    "currentVersion": "3.5.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-48610

## Description
Adding a debug log which shows the args in the mirror-investigation command.

## Must have
- [ ] Tests
- [ ] Documentation 
