### PR TITLE
[Red Canary] Handle null file paths in detection timeline processing

### DIFF
--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.py
@@ -235,16 +235,16 @@ def process_timeline(detection_id):
                 }
                 files.append(
                     {
-                        "Name": os.path.basename(image.get("path", "")),
+                        "Name": os.path.basename(image.get("path") or ""),
                         "MD5": image.get("md5"),
                         "SHA256": image.get("sha256"),
                         "Path": image.get("path"),
-                        "Extension": os.path.splitext(image.get("path", ""))[-1],
+                        "Extension": os.path.splitext(image.get("path") or "")[-1],
                     }
                 )
                 processes.append(
                     {
-                        "Name": os.path.basename(image.get("path", "")),
+                        "Name": os.path.basename(image.get("path") or ""),
                         "Path": image.get("path"),
                         "MD5": image.get("md5"),
                         "SHA256": image.get("sha256"),

--- a/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
+++ b/Packs/RedCanary/Integrations/RedCanary/RedCanary.yml
@@ -72,7 +72,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/python3:3.12.11.4508456
   commands:
   - name: redcanary-acknowledge-detection
     arguments:

--- a/Packs/RedCanary/ReleaseNotes/1_1_28.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_28.md
@@ -3,4 +3,5 @@
 
 ##### Red Canary
 
-Fixed an issue where the *redcanary-get-detection* command failed when processing detections with null file paths.
+- Fixed an issue where the *redcanary-get-detection* command failed when processing detections with null file paths.
+- Updated the Docker image to: *demisto/python3:3.12.11.4508456*.

--- a/Packs/RedCanary/ReleaseNotes/1_1_28.md
+++ b/Packs/RedCanary/ReleaseNotes/1_1_28.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Red Canary
+
+Fixed an issue where the *redcanary-get-detection* command failed when processing detections with null file paths.

--- a/Packs/RedCanary/pack_metadata.json
+++ b/Packs/RedCanary/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Red Canary",
     "description": "Red Canary collects endpoint data using Carbon Black Response and CrowdStrike Falcon.  The collected data is standardized into a common schema which allows teams to detect, analyze and respond to security incidents.",
     "support": "xsoar",
-    "currentVersion": "1.1.27",
+    "currentVersion": "1.1.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-55227)

## Description
Fixed an issue where the *redcanary-get-detection* command failed when processing detections with null file paths.

## Must have
- [x] Tests
- [ ] Documentation 
