### PR TITLE
XSUP-55405 as-search-events command doesn't display all entries in context data

### DIFF
--- a/Packs/ArcSightLogger/Integrations/ArcSightLogger/ArcSightLogger.js
+++ b/Packs/ArcSightLogger/Integrations/ArcSightLogger/ArcSightLogger.js
@@ -88,7 +88,7 @@ function getSearchEvents(userSessionId) {
     var context = events;
     entry.HumanReadable = tableToMarkdown(title, events);
     entry.EntryContext = {};
-    entry.EntryContext['ArcSightLogger.Events(val.rowId === obj.rowId)'] = context;
+    entry.EntryContext[`ArcSightLogger.Events(val.${args.key} === obj.${args.key})`] = context;
     return entry;
 }
 

--- a/Packs/ArcSightLogger/Integrations/ArcSightLogger/ArcSightLogger.yml
+++ b/Packs/ArcSightLogger/Integrations/ArcSightLogger/ArcSightLogger.yml
@@ -110,6 +110,8 @@ script:
       description: The sort direction based on event time. forward/backward (default is forward).
     - name: fields
       description: comma separated list of fields in the order to show. If not specified, all fields will be used
+    - name: key
+      description: Unique key for context ID.
     description: Start a new search, wait until the search status is complete and then return the events. This command combine 3 commands - as-search, as-status, as-events
   - name: as-status
     arguments:


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-55405

## Description
Add an argument to as-search-events command that allow the user to provide the unique key for the context

## Must have
- [ ] Tests
- [ ] Documentation 
