### PR TITLE
Jira run query fix endpoint selection

### DIFF
--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -268,6 +268,7 @@ class JiraBaseClient(BaseClient, metaclass=ABCMeta):
             url_suffix = f"rest/api/{self.api_version}/search"
         else:
             url_suffix = f"rest/api/{self.api_version}/search/jql"
+
         query_params |= {"expand": "renderedFields,transitions,names", "fields": ["*all"]}
         return self.http_request(method="GET", url_suffix=url_suffix, params=query_params)
 

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -2079,6 +2079,9 @@ def issue_query_command(client: JiraBaseClient, args: Dict[str, str]) -> list[Co
     max_results = arg_to_number(args.get("max_results", DEFAULT_PAGE_SIZE)) or DEFAULT_PAGE_SIZE
     headers = args.get("headers", "")
     specific_fields = argToList(args.get("fields", ""))
+    
+    if client.api_version == "2" and next_page_token:
+        raise DemistoException("The next_page_token argument is not supported for Jira OnPrem instances.")
 
     query_params = create_query_params(
         jql_query=jql_query, start_at=start_at, max_results=max_results, next_page_token=next_page_token

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -248,13 +248,12 @@ class JiraBaseClient(BaseClient, metaclass=ABCMeta):
         """
 
     # Query Requests
-    def run_query(self, query_params: Dict[str, Any], use_old_endpoint: bool = False) -> Dict[str, Any]:
+    def run_query(self, query_params: Dict[str, Any]) -> Dict[str, Any]:
         """This method is in charge of running a JQL (Jira Query Language), and retrieving its results.
 
         Args:
             query_params (Dict[str, Any]): The query parameters, which will hold the query string itself,
             and any pagination data (using startAt and maxResults, as required by the API)
-            use_old_endpoint (bool, optional): Whether to use the old deprecated endpoint for backwards compatibility.
 
         Returns:
             Dict[str, Any]: The query results, which will hold the issues acquired from the query.
@@ -264,7 +263,11 @@ class JiraBaseClient(BaseClient, metaclass=ABCMeta):
         # content in HTML format, using a 3rd party package, rather than complex format.
         # We also supply the fields: *all to return all the fields from an issue (specifically the field that holds
         # data about the attachments in the issue), otherwise, it won't get returned in the query.
-        url_suffix = f"rest/api/{self.api_version}/search" if use_old_endpoint else f"rest/api/{self.api_version}/search/jql"
+        if self.api_version == "2" or "startAt" in query_params:
+            # Use old endpoint for backwards compatibility and for on-prem instances
+            url_suffix = f"rest/api/{self.api_version}/search"
+        else:
+            url_suffix = f"rest/api/{self.api_version}/search/jql"
         query_params |= {"expand": "renderedFields,transitions,names", "fields": ["*all"]}
         return self.http_request(method="GET", url_suffix=url_suffix, params=query_params)
 
@@ -1511,20 +1514,23 @@ def create_query_params(
         Dict[str, Any]: The query parameters to be sent when issuing a query request to the API.
     """
     max_results = max_results or DEFAULT_PAGE_SIZE
-    demisto.debug(f"Querying with: {jql_query}\nnext_page_token: {next_page_token}\nmax_results: {max_results}\n")
-    if start_at and not next_page_token:
-        # Old endpoint call, kept for backwards compatibility
-        return {
-            "jql": jql_query,
-            "startAt": start_at,
-            "maxResults": max_results,
-        }
-
-    return {
+    demisto.debug(
+        f"Querying with: {jql_query}\n"
+        f"next_page_token: {next_page_token}\n"
+        f"max_results: {max_results}\n"
+        f"startAt: {start_at}"
+    )
+    query = {
         "jql": jql_query,
-        "nextPageToken": next_page_token,
         "maxResults": max_results,
     }
+    if next_page_token:
+        query["nextPageToken"] = next_page_token
+    elif start_at:
+        # Old endpoint call, kept for backwards compatibility and on-prem
+        query["startAt"] = start_at
+
+    return query
 
 
 def get_issue_fields_id_to_name_mapping(client: JiraBaseClient) -> Dict[str, str]:
@@ -2074,16 +2080,12 @@ def issue_query_command(client: JiraBaseClient, args: Dict[str, str]) -> list[Co
     headers = args.get("headers", "")
     specific_fields = argToList(args.get("fields", ""))
 
-    if start_at and not next_page_token:
-        # Backward compatibility, use the old endpoint if start_at is being used for pagination
-        query_params = create_query_params(jql_query=jql_query, start_at=start_at, max_results=max_results)
-        use_old_endpoint = True
-    else:
-        query_params = create_query_params(jql_query=jql_query, next_page_token=next_page_token, max_results=max_results)
-        use_old_endpoint = False
+    query_params = create_query_params(
+        jql_query=jql_query, start_at=start_at, max_results=max_results, next_page_token=next_page_token
+    )
 
     try:
-        res = client.run_query(query_params=query_params, use_old_endpoint=use_old_endpoint)
+        res = client.run_query(query_params=query_params)
 
     except DemistoException as e:
         if start_at and "Error in API call [410]" in str(e):

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.py
@@ -2079,7 +2079,7 @@ def issue_query_command(client: JiraBaseClient, args: Dict[str, str]) -> list[Co
     max_results = arg_to_number(args.get("max_results", DEFAULT_PAGE_SIZE)) or DEFAULT_PAGE_SIZE
     headers = args.get("headers", "")
     specific_fields = argToList(args.get("fields", ""))
-    
+
     if client.api_version == "2" and next_page_token:
         raise DemistoException("The next_page_token argument is not supported for Jira OnPrem instances.")
 

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.yml
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.yml
@@ -325,7 +325,7 @@ script:
       required: true
     - description: The token for the next page of the query (if such exists). Not supported for Jira OnPrem.
       name: next_page_token
-    - description: The index (integer) of the first issue to return (0-based). For Jira CLoud - Please use next_page_token.
+    - description: The index (integer) of the first issue to return (0-based). For Jira Cloud - Please use next_page_token.
       name: start_at
     - description: Deprecated. Please use start_at.
       name: startAt

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.yml
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.yml
@@ -323,11 +323,10 @@ script:
       description: The JQL query string.
       name: query
       required: true
-    - description: The token for the next page of the query (if such exists).
+    - description: The token for the next page of the query (if such exists). Not supported for Jira OnPrem.
       name: next_page_token
-    - description: The index (integer) of the first issue to return (0-based). Deprecated, Please use next_page_token.
+    - description: The index (integer) of the first issue to return (0-based). For Jira CLoud - Please use next_page_token.
       name: start_at
-      deprecated: true
     - description: Deprecated. Please use start_at.
       name: startAt
       hidden: true

--- a/Packs/Jira/Integrations/JiraV3/JiraV3.yml
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3.yml
@@ -323,7 +323,7 @@ script:
       description: The JQL query string.
       name: query
       required: true
-    - description: The token for the next page of the query (if such exists). Not supported for Jira OnPrem.
+    - description: The token for the next page of the query (if such exists). Not supported for Jira On-prem.
       name: next_page_token
     - description: The index (integer) of the first issue to return (0-based). For Jira Cloud - Please use next_page_token.
       name: start_at

--- a/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
@@ -194,7 +194,7 @@ CREATE_ISSUE_QUERY_CASES = [
         "some_jql_string",
         None,
         None,
-        {"jql": "some_jql_string", "nextPageToken": "", "maxResults": 50},
+        {"jql": "some_jql_string", "maxResults": 50},
     ),
     (
         "some_jql_string",

--- a/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
@@ -46,7 +46,7 @@ def jira_cloud_client_mock() -> JiraCloudClient:
         client_secret="dummy_secret",
         callback_url="dummy_url",
         cloud_id="dummy_cloud_id",
-        server_url="dummy_server_url",
+        server_url="https://dummy_server_url",
         username="",
         api_key="",
         pat="",
@@ -60,7 +60,7 @@ def jira_onprem_client_mock() -> JiraOnPremClient:
         client_id="dummy_client_id",
         client_secret="dummy_secret",
         callback_url="dummy_url",
-        server_url="dummy_server_url",
+        server_url="https://dummy_server_url",
         username="",
         api_key="",
         pat="",
@@ -195,27 +195,37 @@ CREATE_ISSUE_QUERY_CASES = [
         None,
         None,
         {"jql": "some_jql_string", "maxResults": 50},
+        "",
     ),
     (
         "some_jql_string",
         12,
         None,
         {"jql": "some_jql_string", "startAt": 12, "maxResults": 50},
+        "",
     ),
     (
         "some_jql_string",
         1,
         80,
         {"jql": "some_jql_string", "startAt": 1, "maxResults": 80},
+        "",
+    ),
+    (
+        "some_jql_string",
+        5,
+        80,
+        {"jql": "some_jql_string", "nextPageToken": "dummy_page_token", "maxResults": 80},
+        "dummy_page_token",
     ),
 ]
 
 
-@pytest.mark.parametrize("jql, start_at, max_results, expected_query_params", CREATE_ISSUE_QUERY_CASES)
-def test_create_query_params(jql, start_at, max_results, expected_query_params):
+@pytest.mark.parametrize("jql, start_at, max_results, expected_query_params, next_page_token", CREATE_ISSUE_QUERY_CASES)
+def test_create_query_params(jql, start_at, max_results, expected_query_params, next_page_token):
     from JiraV3 import create_query_params
 
-    query_params = create_query_params(jql_query=jql, start_at=start_at, max_results=max_results)
+    query_params = create_query_params(jql_query=jql, start_at=start_at, max_results=max_results, next_page_token=next_page_token)
     assert query_params == expected_query_params
 
 
@@ -1946,10 +1956,11 @@ class TestJiraIssueQueryField:
             assert expected_command_result["EntryContext"] == command_result.to_context()["EntryContext"]
             assert expected_command_result["HumanReadable"] == command_result.to_context()["HumanReadable"]
 
-    def test_issue_query_command_uses_new_endpoint(self, requests_mock):
+
+    def test_issue_query_command_uses_new_endpoint_for_cloud(self, mocker, requests_mock):
         """
         Given:
-            - A Jira client
+            - A Cloud Jira client
         When
             - When calling the jira-issue-query
         Then
@@ -1957,10 +1968,11 @@ class TestJiraIssueQueryField:
         """
         from JiraV3 import issue_query_command
 
-        client = jira_base_client_mock(username="user", api_key="key")
+        client = jira_cloud_client_mock()
+        mocker.patch.object(client, "get_headers_with_access_token", return_value={})
         issue_query_raw_response = util_load_json("test_data/get_issue_query_test/raw_response.json")
         expected_command_results = util_load_json("test_data/get_issue_query_test/parsed_result.json")
-        requests_mock.get("https://dummy_url/rest/api/999/search/jql", json=issue_query_raw_response)
+        requests_mock.get("https://dummy_server_url/dummy_cloud_id/rest/api/3/search/jql", json=issue_query_raw_response)
 
         command_results = issue_query_command(client=client, args={"fields": "watches,rank"})
         command_results = command_results if isinstance(command_results, list) else [command_results]
@@ -1968,7 +1980,30 @@ class TestJiraIssueQueryField:
             assert expected_command_result["EntryContext"] == command_result.to_context()["EntryContext"]
             assert expected_command_result["HumanReadable"] == command_result.to_context()["HumanReadable"]
 
-    def test_issue_query_command_with_start_at(self, requests_mock):
+    def test_issue_query_command_uses_old_endpoint_for_onprem(self, mocker, requests_mock):
+        """
+        Given:
+            - An on-prem Jira client
+        When
+            - When calling the jira-issue-query
+        Then
+            - Validate that the old endpoint is used and the command returns the expected output.
+        """
+        from JiraV3 import issue_query_command
+
+        client = jira_onprem_client_mock()
+        mocker.patch.object(client, "get_headers_with_access_token", return_value={})
+        issue_query_raw_response = util_load_json("test_data/get_issue_query_test/raw_response.json")
+        expected_command_results = util_load_json("test_data/get_issue_query_test/parsed_result.json")
+        requests_mock.get("https://dummy_server_url/rest/api/2/search", json=issue_query_raw_response)
+
+        command_results = issue_query_command(client=client, args={"fields": "watches,rank"})
+        command_results = command_results if isinstance(command_results, list) else [command_results]
+        for expected_command_result, command_result in zip(expected_command_results, command_results):
+            assert expected_command_result["EntryContext"] == command_result.to_context()["EntryContext"]
+            assert expected_command_result["HumanReadable"] == command_result.to_context()["HumanReadable"]
+
+    def test_issue_query_command_with_start_at(self, mocker, requests_mock):
         """
         Given:
             - A Jira client
@@ -1979,10 +2014,11 @@ class TestJiraIssueQueryField:
         """
         from JiraV3 import issue_query_command
 
-        client = jira_base_client_mock(username="user", api_key="key")
+        client = jira_cloud_client_mock()
+        mocker.patch.object(client, "get_headers_with_access_token", return_value={})
         issue_query_raw_response = util_load_json("test_data/get_issue_query_test/raw_response.json")
         expected_command_results = util_load_json("test_data/get_issue_query_test/parsed_result.json")
-        requests_mock.get("https://dummy_url/rest/api/999/search", json=issue_query_raw_response)
+        requests_mock.get("https://dummy_server_url/dummy_cloud_id/rest/api/3/search", json=issue_query_raw_response)
 
         command_results = issue_query_command(client=client, args={"start_at": "10", "fields": "watches,rank"})
         command_results = command_results if isinstance(command_results, list) else [command_results]

--- a/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
+++ b/Packs/Jira/Integrations/JiraV3/JiraV3_test.py
@@ -1956,7 +1956,6 @@ class TestJiraIssueQueryField:
             assert expected_command_result["EntryContext"] == command_result.to_context()["EntryContext"]
             assert expected_command_result["HumanReadable"] == command_result.to_context()["HumanReadable"]
 
-
     def test_issue_query_command_uses_new_endpoint_for_cloud(self, mocker, requests_mock):
         """
         Given:

--- a/Packs/Jira/ReleaseNotes/3_3_8.md
+++ b/Packs/Jira/ReleaseNotes/3_3_8.md
@@ -3,5 +3,5 @@
 
 ##### Atlassian Jira v3
 
-- Fixed a bug where Jira On-prem Jira instances used an invalid endpoint for issue queries.
+- Fixed a bug where On-prem Jira instances used an invalid endpoint for issue queries.
 - Removed the deprecation of the *start_at* argument in the **jira-issue-query** command.

--- a/Packs/Jira/ReleaseNotes/3_3_8.md
+++ b/Packs/Jira/ReleaseNotes/3_3_8.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Atlassian Jira v3
+
+- Fixed a bug where OnPrem Jira instances were using an invalid endpoint for issue queries.
+- Removed the deprecation of the *start_at* argument in the **jira-issue-query** command.

--- a/Packs/Jira/ReleaseNotes/3_3_8.md
+++ b/Packs/Jira/ReleaseNotes/3_3_8.md
@@ -3,5 +3,5 @@
 
 ##### Atlassian Jira v3
 
-- Fixed a bug where OnPrem Jira instances were using an invalid endpoint for issue queries.
+- Fixed a bug where Jira On-prem Jira instances used an invalid endpoint for issue queries.
 - Removed the deprecation of the *start_at* argument in the **jira-issue-query** command.

--- a/Packs/Jira/pack_metadata.json
+++ b/Packs/Jira/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Jira",
     "description": "Use the Jira integration to manage issues and create Cortex XSOAR incidents from Jira projects.",
     "support": "xsoar",
-    "currentVersion": "3.3.7",
+    "currentVersion": "3.3.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-55543](https://jira-dc.paloaltonetworks.com/browse/XSUP-55543)

## Description
Change issue queries to only use the new endpoint for Jira Cloud environments, as it is not available in the onPrem API.

## Must have
- [ ] Tests
- [ ] Documentation 
