### PR TITLE
docs: change pack and integration name from Venafi TLS Protect to Cyb…

### DIFF
--- a/Packs/Venafi/Integrations/Venafi/README.md
+++ b/Packs/Venafi/Integrations/Venafi/README.md
@@ -1,4 +1,4 @@
-Deprecated. use Venafi TLS Protect instead.
+Deprecated. use CyberArk Certificate Manager instead.
 
 This integration was integrated and tested with version 20.3.2.5263 of Venafi.
 

--- a/Packs/Venafi/Integrations/VenafiV2/README.md
+++ b/Packs/Venafi/Integrations/VenafiV2/README.md
@@ -1,9 +1,9 @@
 Retrieves information about certificates stored in Venafi.
 
-## Configure Venafi TLS Protect on Cortex XSOAR
+## Configure CyberArk Certificate Manager on Cortex XSOAR
 
 1. Navigate to **Settings** > **Integrations** > **Servers & Services**.
-2. Search for Venafi TLS Protect.
+2. Search for CyberArk Certificate Manager.
 3. Click **Add instance** to create and configure a new integration instance.
 
     | **Parameter** | **Required** |

--- a/Packs/Venafi/Integrations/VenafiV2/VenafiV2.yml
+++ b/Packs/Venafi/Integrations/VenafiV2/VenafiV2.yml
@@ -34,7 +34,7 @@ configuration:
   required: false
   section: Connect
 description: Retrieves information about certificates stored in Venafi.
-display: Venafi TLS Protect
+display: CyberArk Certificate Manager
 name: VenafiTLSProtect
 script:
   commands:

--- a/Packs/Venafi/README.md
+++ b/Packs/Venafi/README.md
@@ -3,7 +3,7 @@ The certificates you don’t know about can be dangerous to your organization’
 
 ## What does this pack do?
 
-The **Venafi** integration enables you to:
+The **CyberArk Certificate Manager** integration enables you to:
 
 - Get a list of all your certificates in Venafi.
 - Get the details of a single certificate in Venafi.

--- a/Packs/Venafi/ReleaseNotes/2_0_9.md
+++ b/Packs/Venafi/ReleaseNotes/2_0_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CyberArk Certificate Manager
+
+- Documentation and Metadata improvements.

--- a/Packs/Venafi/pack_metadata.json
+++ b/Packs/Venafi/pack_metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "CyberArk Certificate Manager",
+    "name": "CyberArk Certificate Manager Self-Hosted",
     "description": "Retrieves information about certificates stored in Venafi.",
     "support": "xsoar",
     "currentVersion": "2.0.9",

--- a/Packs/Venafi/pack_metadata.json
+++ b/Packs/Venafi/pack_metadata.json
@@ -1,8 +1,8 @@
 {
-    "name": "Venafi",
+    "name": "CyberArk Certificate Manager",
     "description": "Retrieves information about certificates stored in Venafi.",
     "support": "xsoar",
-    "currentVersion": "2.0.8",
+    "currentVersion": "2.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-14656

## Description
Rename "Venafi" pack name to "CyberArk Certificate Manager Self-Hosted"
Rename "Venafi TLS Protect" Integration name to "CyberArk Certificate Manager"
