### PR TITLE
Decrease default limit netskope collectors

### DIFF
--- a/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.py
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.py
@@ -294,7 +294,7 @@ def test_module(client: Client, last_run: dict, max_fetch: int) -> str:
 
 
 def get_events_command(client: Client, args: dict[str, Any], last_run: dict, events: list) -> tuple[CommandResults, list]:
-    limit = arg_to_number(args.get("limit")) or MAX_EVENTS_PAGE_SIZE
+    limit = arg_to_number(args.get("limit")) or 10
     _ = get_all_events(client=client, last_run=last_run, limit=limit, all_event_types=events)
 
     for event in events:

--- a/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.yml
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.yml
@@ -75,7 +75,7 @@ script:
       defaultValue: 10
     description: Returns events extracted from SaaS traffic and or logs.
     name: netskope-get-events
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/python3:3.12.11.4508456
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.yml
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector/NetskopeEventCollector.yml
@@ -72,7 +72,7 @@ script:
       required: true
     - description: The maximum number of alerts to return (maximum value - 10000).
       name: limit
-      defaultValue: 10000
+      defaultValue: 10
     description: Returns events extracted from SaaS traffic and or logs.
     name: netskope-get-events
   dockerimage: demisto/python3:3.12.8.3296088

--- a/Packs/Netskope/Integrations/NetskopeEventCollector/README.md
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector/README.md
@@ -32,7 +32,7 @@ Returns events extracted from SaaS traffic and or logs.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| limit | The maximum number of alerts to return (maximum value - 10000). | Optional |
+| limit | The maximum number of alerts to return (default: 10, maximum value - 10000). | Optional |
 | should_push_events | Set this argument to True in order to create events, otherwise the command will only display them. | Optional |
 
 #### Context Output

--- a/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.py
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.py
@@ -591,7 +591,7 @@ async def handle_fetch_and_send_all_events(
 async def get_events_command_async(
     client: Client, args: dict[str, Any], last_run: dict, send_to_xsiam: bool = False
 ) -> CommandResults:
-    limit = arg_to_number(args.get("limit")) or MAX_EVENTS_PAGE_SIZE
+    limit = arg_to_number(args.get("limit")) or 10
     events, _ = await handle_fetch_and_send_all_events(client=client, last_run=last_run, limit=limit, send_to_xsiam=send_to_xsiam)
 
     for event in events:

--- a/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.yml
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.yml
@@ -72,7 +72,7 @@ script:
       required: true
     - description: The maximum number of alerts to return.
       name: limit
-      defaultValue: 10000
+      defaultValue: 10
     description: Returns events extracted from SaaS traffic and or logs.
     name: netskope-get-events
   dockerimage: demisto/auth-utils:1.0.0.3639076

--- a/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.yml
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector_v2/NetskopeEventCollector_v2.yml
@@ -75,7 +75,7 @@ script:
       defaultValue: 10
     description: Returns events extracted from SaaS traffic and or logs.
     name: netskope-get-events
-  dockerimage: demisto/auth-utils:1.0.0.3639076
+  dockerimage: demisto/auth-utils:1.0.0.4578605
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/Netskope/Integrations/NetskopeEventCollector_v2/README.md
+++ b/Packs/Netskope/Integrations/NetskopeEventCollector_v2/README.md
@@ -32,7 +32,7 @@ Returns events extracted from SaaS traffic and or logs.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| limit | The maximum number of alerts to return. | Optional |
+| limit | The maximum number of alerts to return (default: 10). | Optional |
 | should_push_events | Set this argument to True in order to create events, otherwise the command will only display them. | Optional |
 
 #### Context Output

--- a/Packs/Netskope/ReleaseNotes/4_1_1.md
+++ b/Packs/Netskope/ReleaseNotes/4_1_1.md
@@ -1,12 +1,12 @@
 
 #### Integrations
 
-##### Netskope Event Collector
-- Updated the Docker image to: *demisto/python3:3.12.11.4508456*.
-
-- Lower the default limit for the ***get-events*** command to prevent overloading the playground.
-
 ##### Netskope Event Collector v2
 - Updated the Docker image to: *demisto/auth-utils:1.0.0.4578605*.
 
 - Lower the default limit for the ***get-events*** command to prevent overloading the playground.  
+
+##### Netskope Event Collector
+- Updated the Docker image to: *demisto/python3:3.12.11.4508456*.
+
+- Lower the default limit for the ***get-events*** command to prevent overloading the playground.

--- a/Packs/Netskope/ReleaseNotes/4_1_1.md
+++ b/Packs/Netskope/ReleaseNotes/4_1_1.md
@@ -2,9 +2,11 @@
 #### Integrations
 
 ##### Netskope Event Collector
+- Updated the Docker image to: *demisto/python3:3.12.11.4508456*.
 
 - Lower the default limit for the ***get-events*** command to prevent overloading the playground.
 
 ##### Netskope Event Collector v2
+- Updated the Docker image to: *demisto/auth-utils:1.0.0.4578605*.
 
 - Lower the default limit for the ***get-events*** command to prevent overloading the playground.  

--- a/Packs/Netskope/ReleaseNotes/4_1_1.md
+++ b/Packs/Netskope/ReleaseNotes/4_1_1.md
@@ -1,0 +1,10 @@
+
+#### Integrations
+
+##### Netskope Event Collector
+
+- Lower the default limit for the ***get-events*** command to prevent overloading the playground.
+
+##### Netskope Event Collector v2
+
+- Lower the default limit for the ***get-events*** command to prevent overloading the playground.  

--- a/Packs/Netskope/pack_metadata.json
+++ b/Packs/Netskope/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Netskope",
     "description": "Cloud access security broker that enables to find, understand, and secure cloud apps.",
     "support": "xsoar",
-    "currentVersion": "4.1.0",
+    "currentVersion": "4.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
relates: https://jira-dc.paloaltonetworks.com/browse/XSUP-55598
## Description
Following a client complaint, this PR lowers the default limit for the get-events command. A client's playground froze after running the command without specifying a limit, due to the previously high default value.
## Must have
- [ ] Tests
- [ ] Documentation 
