### PR TITLE
bug fix - set Microsoft Sentinel Classification Reason to empty if missing 

### DIFF
--- a/Packs/AzureSentinel/IncidentFields/incidentfield-Microsoft_Sentinel_Classification_Reason.json
+++ b/Packs/AzureSentinel/IncidentFields/incidentfield-Microsoft_Sentinel_Classification_Reason.json
@@ -12,6 +12,7 @@
     "neverSetAsRequired": false,
     "isReadOnly": false,
     "selectValues": [
+        "",
         "Inaccurate Data",
         "Incorrect Alert Logic"
     ],

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_71.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_71.md
@@ -1,0 +1,6 @@
+
+#### Incident Fields
+
+##### Microsoft Sentinel Classification Reason
+
+- Updated the Microsoft Sentinel Classification Reason incident field to default to None if missing rather than "Inaccurate Data".

--- a/Packs/AzureSentinel/ReleaseNotes/1_5_71.md
+++ b/Packs/AzureSentinel/ReleaseNotes/1_5_71.md
@@ -3,4 +3,4 @@
 
 ##### Microsoft Sentinel Classification Reason
 
-- Updated the Microsoft Sentinel Classification Reason incident field to default to None if missing rather than "Inaccurate Data".
+-  Fixed an issue where the *Microsoft Sentinel Classification Reason* incident field would default to "Inaccurate Data" in the case where the field is empty.

--- a/Packs/AzureSentinel/pack_metadata.json
+++ b/Packs/AzureSentinel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Sentinel",
     "description": "Microsoft Sentinel is a cloud-native security information and event manager (SIEM) platform that uses built-in AI to help analyze large volumes of data across an enterprise.",
     "support": "xsoar",
-    "currentVersion": "1.5.70",
+    "currentVersion": "1.5.71",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-55353?filter=-1

## Description
This pr resolves an issue where ms classification reason was set default to inaccurate data even when the field is actually missing. 
## Must have
- [ ] Tests
- [ ] Documentation 
