### PR TITLE
MISPv3 - Command contributions - misp-get-warninglist(s), misp-change-warninglist, misp-add-sighting

### DIFF
--- a/Packs/MISP/CONTRIBUTORS.json
+++ b/Packs/MISP/CONTRIBUTORS.json
@@ -1,4 +1,5 @@
 [
     "Martin Ohl",
-    "nikstuckenbrock"
+    "nikstuckenbrock",
+    "Charon De Beukelaer"
 ]

--- a/Packs/MISP/Integrations/MISPV3/MISPV3.py
+++ b/Packs/MISP/Integrations/MISPV3/MISPV3.py
@@ -252,6 +252,11 @@ ATTRIBUTE_FIELDS = [
 ]
 
 
+WARNINGLIST_HEADERS = ["ID", "Name", "Type", "Description", "Version", "Enabled", "Default", "Category", "Attributes"]
+WARNINGLIST_ENTRY_HEADERS = ["ID", "Value", "Comment"]
+WARNINGLIST_TYPE_HEADERS = ["ID", "Type"]
+
+
 def extract_error(error: list) -> list[dict]:
     """
     Extracting errors raised by PYMISP into readable response, for more information and examples
@@ -1465,18 +1470,30 @@ def add_sighting(demisto_args: dict):
     """Adds sighting to MISP attribute"""
     attribute_id = demisto_args.get("id")
     attribute_uuid = demisto_args.get("uuid")
+    attribute_value = demisto_args.get("value")
+    sighting_source = demisto_args.get("source")
     sighting_type = demisto_args["type"]  # mandatory arg
     att_id = attribute_id or attribute_uuid
-    if not att_id:
-        raise DemistoException("ID or UUID not specified")
-    sighting_args = {"id": attribute_id, "uuid": attribute_uuid, "type": SIGHTING_TYPE_NAME_TO_ID[sighting_type]}
+    if not (att_id or attribute_value):
+        raise DemistoException("ID, UUID or value not specified")
+    sighting_args = {
+        "id": attribute_id,
+        "uuid": attribute_uuid,
+        "type": SIGHTING_TYPE_NAME_TO_ID[sighting_type],
+        "source": sighting_source,
+        "value": attribute_value,
+    }
     sigh_obj = MISPSighting()
     sigh_obj.from_dict(**sighting_args)
-    response = PYMISP.add_sighting(sigh_obj, att_id)
+
+    if attribute_value:
+        response = PYMISP.add_sighting(sigh_obj)
+    else:
+        response = PYMISP.add_sighting(sigh_obj, att_id)
     if response.get("message"):
         raise DemistoException(f"An error was occurred: {response.get('message')}")
     elif response.get("Sighting"):
-        human_readable = f"Sighting '{sighting_type}' has been successfully added to attribute {att_id}"
+        human_readable = f"Sighting '{sighting_type}' has been successfully added to attribute {attribute_value or att_id}"
         return CommandResults(readable_output=human_readable)
     raise DemistoException(f"An error was occurred: {json.dumps(response)}")
 
@@ -1871,6 +1888,196 @@ def warninglist_command(demisto_args: dict) -> CommandResults:
     )
 
 
+def get_warninglists_command(demisto_args: dict) -> CommandResults:
+    """
+    Gets warninglists from MISP
+    Args:
+        demisto_args: dict of arguments.
+
+    Returns:
+        CommandResults.
+    """
+    try:
+        logging.log(logging.DEBUG, f"{demisto.command()} Sending request to get warninglists")
+        if response := PYMISP.warninglists():
+            warninglists_output = []
+            for item in response:
+                # Ensure item is a dict and has the 'Warninglist' key
+                if warninglist := item.get("Warninglist") if isinstance(item, dict) else None:
+                    res = {
+                        "ID": warninglist.get("id"),
+                        "Name": warninglist.get("name"),
+                        "Type": warninglist.get("type"),
+                        "Description": warninglist.get("description"),
+                        "Version": warninglist.get("version"),
+                        "Enabled": warninglist.get("enabled"),
+                        "Default": warninglist.get("default"),
+                        "Category": warninglist.get("category"),
+                    }
+                    valid_attributes = warninglist.get("valid_attributes")
+                    if valid_attributes and isinstance(valid_attributes, str):
+                        res["Attributes"] = valid_attributes.split(",")
+
+                    warninglists_output.append(res)
+
+            human_readable = tableToMarkdown(
+                "MISP Warninglists", warninglists_output, headers=WARNINGLIST_HEADERS, removeNull=True
+            )
+
+            return CommandResults(
+                outputs_prefix="MISP.Warninglist",
+                outputs_key_field=["ID"],
+                outputs=warninglists_output,
+                readable_output=human_readable,
+                raw_response=response,
+            )
+        else:
+            return CommandResults(
+                outputs_prefix="MISP.Warninglist",
+                outputs_key_field=["ID"],
+                outputs=[],
+                readable_output="No warninglists found in MISP",
+                raw_response=[],
+            )
+    except Exception as e:
+        raise DemistoException(f"Error in `{demisto.command()}` command: {e}")
+
+
+def get_warninglist_command(demisto_args: dict) -> CommandResults:
+    """
+    Returns the values of a specific MISP warninglist based on ID
+    """
+    warninglist_id = demisto_args["id"]
+
+    try:
+        logging.log(logging.DEBUG, f"{demisto.command()} Sending request to get warninglist {warninglist_id}")
+        response = PYMISP.get_warninglist(warninglist_id)
+
+        warninglist_output = {}
+        if entity := response.get("Warninglist", {}):
+            warninglist_attributes = [f"{t['type']}" for t in (entity.get("WarninglistType"))]
+            warninglist_output = {
+                "ID": entity["id"],
+                "Name": entity["name"],
+                "Type": entity["type"],
+                "Description": entity["description"],
+                "Version": entity["version"],
+                "Enabled": entity["enabled"],
+                "Default": entity["default"],
+                "Category": entity["category"],
+                "Attributes": warninglist_attributes,
+            }
+            # Parse valid attributes from the "valid_attributes" field if present
+            warninglist_output["Entries"] = [
+                {
+                    "ID": entry["id"],
+                    "Value": entry.get("value"),
+                    "WarninglistID": entry.get("warninglist_id"),
+                    "Comment": entry.get("comment"),
+                }
+                for entry in (entity["WarninglistEntry"])
+            ]
+
+        human_readable = tableToMarkdown("MISP Warninglist", warninglist_output, headers=WARNINGLIST_HEADERS, removeNull=True)
+        human_readable += tableToMarkdown(
+            "Entries in MISP Warninglist",
+            warninglist_output["Entries"],
+            headers=WARNINGLIST_ENTRY_HEADERS,
+            removeNull=True,
+        )
+
+        return CommandResults(
+            outputs=warninglist_output,
+            outputs_prefix="MISP.Warninglist",
+            outputs_key_field=["ID"],
+            readable_output=human_readable,
+            raw_response=response,
+        )
+    except Exception as e:
+        raise DemistoException(f"Error in `{demisto.command()}` command: {e}")
+
+
+def change_warninglist_command(demisto_args: dict) -> CommandResults:
+    """
+    Appends new values to supplied warninglist
+    """
+    warninglist_id = demisto_args["id"]
+    warninglist_name = demisto_args.get("name")
+    warninglist_type = demisto_args.get("type")
+    warninglist_description = demisto_args.get("description")
+    warninglist_enabled = demisto_args.get("enabled")
+    warninglist_default = demisto_args.get("default")
+    warninglist_category = demisto_args.get("category")
+    warninglist_values = argToList(demisto_args.get("values"))
+    warninglist_types = argToList(demisto_args.get("types"))
+
+    data = {}
+    if warninglist_name:
+        data["name"] = warninglist_name
+    if warninglist_type:
+        data["type"] = warninglist_type
+    if warninglist_description:
+        data["description"] = warninglist_description
+    if warninglist_enabled:
+        data["enabled"] = warninglist_enabled
+    if warninglist_default:
+        data["default"] = warninglist_default
+    if warninglist_category:
+        data["category"] = warninglist_category
+    if warninglist_values:
+        for value in warninglist_values:
+            value_dict = {"value": value}
+            warninglist_values[warninglist_values.index(value)] = value_dict
+        data["WarninglistEntry"] = warninglist_values
+    if warninglist_types:
+        data["matching_attributes"] = warninglist_types
+    try:
+        logging.log(logging.DEBUG, f"{demisto.command()} Sending request to edit warninglist {warninglist_id}: {data}")
+        response = PYMISP._prepare_request("POST", f"warninglists/edit/{warninglist_id}", data=data)
+        logging.log(logging.DEBUG, f"{demisto.command()}Status {response.status_code}: warninglists/edit/{warninglist_id}")
+        response = response.json()
+        warninglist_output = {}
+        if entity := response.get("Warninglist", {}):  # type: ignore[attr-defined]
+            warninglist_output = {
+                "ID": entity["id"],
+                "Name": entity["name"],
+                "Type": entity["type"],
+                "Description": entity["description"],
+                "Version": entity["version"],
+                "Enabled": entity["enabled"],
+                "Default": entity["default"],
+                "Category": entity["category"],
+            }
+            warninglist_output["Attributes"] = [f"{t['type']}" for t in (response.get("WarninglistType"))]  # type: ignore[attr-defined]
+            warninglist_output["Entries"] = [
+                {
+                    "ID": entry.get("id"),
+                    "Value": entry.get("value"),
+                    "WarninglistID": entry.get("warninglist_id"),
+                    "Comment": entry.get("comment"),
+                }
+                for entry in (response["WarninglistEntry"])  # type: ignore[index]
+            ]
+
+        human_readable = tableToMarkdown("MISP Warninglist", warninglist_output, headers=WARNINGLIST_HEADERS, removeNull=True)
+        human_readable += tableToMarkdown(
+            "Entries in MISP Warninglist",
+            warninglist_output["Entries"],
+            headers=WARNINGLIST_ENTRY_HEADERS,
+            removeNull=True,
+        )
+        return CommandResults(
+            readable_output=human_readable,
+            outputs_prefix="MISP.Warninglist",
+            outputs_key_field="ID",
+            outputs=warninglist_output,
+            raw_response=response,
+        )
+
+    except Exception as e:
+        raise DemistoException(f"Error in `{demisto.command()}` command: {e}")
+
+
 def main():
     params = demisto.params()
     malicious_tag_ids = argToList(params.get("malicious_tag_ids"))
@@ -2013,6 +2220,12 @@ def main():
             return_results(set_event_attributes_command(args))
         elif command == "misp-check-warninglist":
             return_results(warninglist_command(args))
+        elif command == "misp-get-warninglists":
+            return_results(get_warninglists_command(args))
+        elif command == "misp-get-warninglist":
+            return_results(get_warninglist_command(args))
+        elif command == "misp-change-warninglist":
+            return_results(change_warninglist_command(args))
         elif command == "misp-add-user":
             return_results(add_user_to_misp(args))
         elif command == "misp-get-organization-info":

--- a/Packs/MISP/Integrations/MISPV3/MISPV3.yml
+++ b/Packs/MISP/Integrations/MISPV3/MISPV3.yml
@@ -1668,10 +1668,14 @@ script:
       - false_positive
       - expiration
       required: true
-    - description: ID of attribute to add sighting to (Must be filled if UUID is empty). Can be retrieved from the misp-search commands.
+    - description: ID of attribute to add sighting to (Must be filled if UUID or value is empty). Can be retrieved from the misp-search commands.
       name: id
-    - description: UUID of the attribute to add sighting to (Must be filled if ID is empty). Can be retrieved from the misp-search commands.
+    - description: UUID of the attribute to add sighting to (Must be filled if ID or value is empty). Can be retrieved from the misp-search commands.
       name: uuid
+    - description: Value of the attribute to add sighting to. (Must be filled if ID or UUID is empty). Adds sighting to all attributes with this value. Takes precedence over (UU)ID. Can be retrieved from the misp-search commands.
+      name: value
+    - description: Sighting source.
+      name: source
     description: Add sighting to an attribute.
     name: misp-add-sighting
   - arguments:
@@ -2733,7 +2737,131 @@ script:
     - contextPath: MISP.Role.role_name
       description: MISP role name.
       type: string
-  dockerimage: demisto/pymisp2:2.5.10.3545364
+  - arguments:
+    - description: ID of the warninglist.
+      name: id
+      required: true
+    description: Get a specific warninglist by its ID.
+    name: misp-get-warninglist
+    outputs:
+    - contextPath: MISP.Warninglist.ID
+      description: The ID of the warninglist.
+      type: number
+    - contextPath: MISP.Warninglist.Name
+      description: The warninglist's name.
+      type: string
+    - contextPath: MISP.Warninglist.Type
+      description: MISP warninglist type.
+      type: string
+    - contextPath: MISP.Warninglist.Description
+      description: Description of the warninglist.
+      type: string
+    - contextPath: MISP.Warninglist.Version
+      description: The warninglist version number.
+      type: number
+    - contextPath: MISP.Warninglist.Enabled
+      description: Whether the warninglist is enabled.
+      type: boolean
+    - contextPath: MISP.Warninglist.Default
+      description: Whether the warninglist is set as default.
+      type: boolean
+    - contextPath: MISP.Warninglist.Category
+      description: The category of the MISP warninglist.
+      type: string
+    - contextPath: MISP.Warninglist.Entries
+      description: The warninglist entries.
+      type: dict
+    - contextPath: MISP.Warninglist.Attributes
+      description: The attribute types for this warninglist.
+      type: dict
+  - arguments: []
+    description: Gets all warninglists from MISP
+    name: misp-get-warninglists
+    outputs:
+    - contextPath: MISP.Warninglist.ID
+      description: The ID of the warninglist.
+      type: number
+    - contextPath: MISP.Warninglist.Name
+      description: The warninglist's name.
+      type: string
+    - contextPath: MISP.Warninglist.Type
+      description: MISP warninglist type.
+      type: string
+    - contextPath: MISP.Warninglist.Description
+      description: Description of the warninglist.
+      type: string
+    - contextPath: MISP.Warninglist.Version
+      description: The warninglist version number.
+      type: number
+    - contextPath: MISP.Warninglist.Enabled
+      description: Whether the warninglist is enabled.
+      type: boolean
+    - contextPath: MISP.Warninglist.Default
+      description: Whether the warninglist is set as default.
+      type: boolean
+    - contextPath: MISP.Warninglist.Entries
+      description: The warninglist entries.
+      type: dict
+    - contextPath: MISP.Warninglist.Attributes
+      description: The attribute types for this warninglist.
+      type: dict
+  - arguments:
+    - name: id
+      description: ID of the warninglist to update.
+      required: true
+      type: number
+    - name: name
+      description: Updated name of the warninglist.
+    - name: type
+      description: Updated type of the warninglist.
+    - name: description
+      description: Updated description of the warninglist.
+    - name: enabled
+      description: Whether the warninglist is enabled.
+      type: boolean
+    - name: version
+      description: Updated version number of the warninglist.
+    - name: default
+      description: Whether the warninglist is set as default.
+      type: boolean
+    - name: values
+      description: Updated values of the warninglist.
+    - name: types
+      description: Updated valid attribute types for the warninglist.
+    description: Changes a warninglist in MISP.
+    name: misp-change-warninglist
+    outputs:
+    - contextPath: MISP.Warninglist.ID
+      description: The ID of the warninglist to be changed.
+      type: number
+    - contextPath: MISP.Warninglist.Name
+      description: The updated warninglist name.
+      type: string
+    - contextPath: MISP.Warninglist.Type
+      description: The updated warninglist type.
+      type: string
+    - contextPath: MISP.Warninglist.Description
+      description: The updated description of the warninglist.
+      type: string
+    - contextPath: MISP.Warninglist.Version
+      description: The updated warninglist version number.
+      type: number
+    - contextPath: MISP.Warninglist.Enabled
+      description: Whether the warninglist is enabled.
+      type: boolean
+    - contextPath: MISP.Warninglist.Default
+      description: Whether the warninglist is set as default.
+      type: boolean
+    - contextPath: MISP.Warninglist.Category
+      description: The updated category of the warninglist.
+      type: string
+    - contextPath: MISP.Warninglist.Entries
+      description: The warninglist entries.
+      type: dict
+    - contextPath: MISP.Warninglist.Attributes
+      description: The attribute types for this warninglist.
+      type: string
+  dockerimage: demisto/pymisp2:2.5.10.3725488
   runonce: false
   script: ''
   subtype: python3

--- a/Packs/MISP/Integrations/MISPV3/MISPV3_test.py
+++ b/Packs/MISP/Integrations/MISPV3/MISPV3_test.py
@@ -1118,3 +1118,138 @@ def test_get_indicator_results(
     assert "my_custom_list" in result.readable_output
     assert isinstance(result.indicator, Common.IP)
     assert result.indicator.dbot_score.score == Common.DBotScore.GOOD
+
+
+@pytest.mark.parametrize(
+    "demisto_args",
+    [
+        ({"id": "1"}),
+    ],
+)
+def test_get_warninglist(demisto_args: dict, mocker):
+    """
+    Given:
+    - A MISP Warninglist (json).
+
+    When:
+    - Running misp-get-warninglist command.
+
+    Then:
+    - Ensure that the output is valid and was parsed correctly.
+    """
+    mock_misp(mocker)
+    from MISPV3 import get_warninglist_command
+
+    warninglist_response = util_load_json("test_data/get_warninglist_response.json")
+    with open("test_data/get_warninglist_outputs.md", encoding="utf-8") as f:
+        warninglist_readable_output = f.read()
+    warninglist_outputs = util_load_json("test_data/get_warninglist_outputs.json")
+    mocker.patch("pymisp.ExpandedPyMISP.get_warninglist", return_value=warninglist_response)
+    result = get_warninglist_command(demisto_args)
+
+    assert result.readable_output == warninglist_readable_output
+    assert result.outputs_prefix == "MISP.Warninglist"
+    assert result.outputs == warninglist_outputs
+
+
+def test_get_warninglists(mocker):
+    """
+    Given:
+    - A collection of MISP Warninglists (json).
+
+    When:
+    - Running misp-get-warninglists command.
+
+    Then:
+    - Ensure that the output is valid and was parsed correctly.
+    """
+    mock_misp(mocker)
+    from MISPV3 import get_warninglists_command
+
+    # Load the expected outputs and use them as the mock response
+    warninglists_response_data = util_load_json("test_data/get_warninglists_response.json")
+    with open("test_data/get_warninglists_outputs.md", encoding="utf-8") as f:
+        warninglists_readable_output = f.read()
+    warninglists_outputs = util_load_json("test_data/get_warninglists_outputs.json")
+
+    # Mock the PYMISP.warninglists method to return the expected warninglists response data
+    MISPV3 = __import__("MISPV3")
+    MISPV3.PYMISP.warninglists = mocker.Mock(return_value=warninglists_response_data)
+    demisto_args = {}
+    result = get_warninglists_command(demisto_args)
+    assert result.readable_output == warninglists_readable_output
+    assert result.outputs_prefix == "MISP.Warninglist"
+    assert result.outputs == warninglists_outputs
+
+
+@pytest.mark.parametrize(
+    "demisto_args",
+    [
+        ({"id": "1", "values": ["8.8.8.8", "9.9.9.9"]}),
+    ],
+)
+def test_change_warninglist_entries(demisto_args: dict, mocker):
+    """
+    Given:
+    - A changed MISP Warninglist (json).
+
+    When:
+    - Running misp-change-warninglists command.
+
+    Then:
+    - Ensure that the output is valid and was parsed correctly.
+    """
+    mock_misp(mocker)
+    from MISPV3 import change_warninglist_command
+    import pymisp
+
+    # Load the expected outputs and use them as the mock response
+    warninglists_response_data = util_load_json("test_data/change_warninglist_entries_response.json")
+    with open("test_data/change_warninglist_entries_outputs.md", encoding="utf-8") as f:
+        warninglists_readable_output = f.read()
+    warninglists_outputs = util_load_json("test_data/change_warninglist_entries_outputs.json")
+
+    # Mock the PYMISP._prepare_request method to return a Response-like object with a .json() method
+    from requests.models import Response
+
+    class MockResponse(Response):
+        def json(self):
+            return warninglists_response_data
+
+    mocker.patch.object(pymisp.api.PyMISP, "_prepare_request", return_value=MockResponse())
+    result = change_warninglist_command(demisto_args)
+    assert result.readable_output == warninglists_readable_output
+    assert result.outputs_prefix == "MISP.Warninglist"
+    assert result.outputs == warninglists_outputs
+
+
+@pytest.mark.parametrize(
+    "demisto_args",
+    [
+        ({"id": "1", "values": ["8.8.8.8", "9.9.9.9"]}),
+    ],
+)
+def test_change_warninglist_details(demisto_args: dict, mocker):
+    mock_misp(mocker)
+    from MISPV3 import change_warninglist_command
+    import pymisp
+
+    # Load the expected outputs and use them as the mock response
+    warninglist_response_data = util_load_json("test_data/change_warninglist_details_response.json")
+    with open("test_data/change_warninglist_details_outputs.md", encoding="utf-8") as f:
+        warninglist_readable_output = f.read()
+    warninglist_outputs = util_load_json("test_data/change_warninglist_details_outputs.json")
+
+    # Mock the PYMISP._prepare_request method to return a Response-like object with a .json() method
+    from requests.models import Response
+
+    class MockResponse(Response):
+        def json(self):
+            return warninglist_response_data
+
+    # Mock the PYMISP.warninglists method to return the expected warninglists response data
+    mocker.patch.object(pymisp.api.PyMISP, "_prepare_request", return_value=MockResponse())
+    result = change_warninglist_command(demisto_args)
+    assert result.readable_output == warninglist_readable_output
+    assert result.outputs_prefix == "MISP.Warninglist"
+    assert result.outputs == warninglist_outputs

--- a/Packs/MISP/Integrations/MISPV3/README.md
+++ b/Packs/MISP/Integrations/MISPV3/README.md
@@ -2871,8 +2871,10 @@ Add sighting to an attribute.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | type | Type of sighting to add. Possible values: "sighting", "false_positive", and "expiration". Possible values are: sighting, false_positive, expiration. | Required |
-| id | ID of attribute to add sighting to (Must be filled if UUID is empty). Can be retrieved from the misp-search commands. | Optional |
-| uuid | UUID of the attribute to add sighting to (Must be filled if ID is empty). Can be retrieved from the misp-search commands. | Optional |
+| id | ID of attribute to add sighting to (Must be filled if UUID or value is empty). Can be retrieved from the misp-search commands. | Optional |
+| uuid | UUID of the attribute to add sighting to (Must be filled if ID or value is empty). Can be retrieved from the misp-search commands. | Optional |
+| value | Value of the attribute to add sighting to. (Must be filled if ID or UUID is empty). Adds sighting to all attributes with this value. Takes precedence over (UU)ID. Can be retrieved from the misp-search commands. | Optional |
+| source | Sighting source. | Optional |
 
 #### Context Output
 
@@ -4348,3 +4350,223 @@ Display role names and role ids.
 >|id|name|
 >|---|---|
 >| 1 | rolename |
+
+### misp-get-warninglists
+
+***
+Gets all warninglists from MISP
+
+#### Base Command
+
+`misp-get-warninglists`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MISP.Warninglist.ID | number | The ID of the warninglist. |
+| MISP.Warninglist.Name | string | The warninglist's name. |
+| MISP.Warninglist.Type | string | MISP warninglist type. |
+| MISP.Warninglist.Description | string | Description of the warninglist. |
+| MISP.Warninglist.Version | number | The warninglist version number. |
+| MISP.Warninglist.Enabled | boolean | Whether the warninglist is enabled. |
+| MISP.Warninglist.Default | boolean | Whether the warninglist is set as default. |
+| MISP.Warninglist.Entries | dict | The warninglist entries. |
+| MISP.Warninglist.Attributes | dict | The valid attribute types for this warninglist. |
+
+#### Command Example
+
+```!misp-get-warninglists```
+
+#### Human Readable Output
+
+>### MISP
+>
+>|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+>|---|---|---|---|---|---|---|---|---|---|
+>| 1 | List | string | An example list | 1 | true | true | false_positive | hostname |
+>| 2 | Another list | cidr | An example of another list | 42 | false | false | false_positive | url |
+
+### misp-change-warninglist
+
+***
+Changes a warninglist in MISP.
+This command only changes the values supplied through the parameters of this command (in a non idempotent way).
+
+#### Base Command
+
+`misp-change-warninglist`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| id | ID of the warninglist to update. | Required |
+| name | Updated name of the warninglist. | Optional |
+| type | Updated type of the warninglist. | Optional |
+| description | Updated description of the warninglist. | Optional |
+| version | Updated version number of the warninglist. | Optional |
+| default | Whether the warninglist should be set as default. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MISP.Warninglist.ID | number | The ID of the warninglist. |
+| MISP.Warninglist.Name | string | The warninglist's name. |
+| MISP.Warninglist.Type | string | MISP warninglist type. |
+| MISP.Warninglist.Description | string | Description of the warninglist. |
+| MISP.Warninglist.Version | number | The warninglist version number. |
+| MISP.Warninglist.Enabled | boolean | Whether the warninglist is enabled. |
+| MISP.Warninglist.Default | boolean | Whether the warninglist is set as default. |
+| MISP.Warninglist.Category | string | The category of the MISP warninglist. |
+| MISP.Warninglist.Entries | dict | The warninglist entries. |
+| MISP.Warninglist.Attributes | dict | The valid attribute types for this warninglist. |
+
+#### Command Example
+
+```!misp-change-warninglist id=1234 name="Changed list name" values="1.2.3.4,5.6.7.8" types="ip-src,ip-dst"```
+
+```json
+{
+    "MISP": {
+        "Warninglist": [ 
+            {
+                "ID": 1234,
+                "Name": "Changed list name",
+                "Type": "string",
+                "Description": "The entries in this list have been changed",
+                "Version": 42,
+                "Enabled": false,
+                "Default": false,
+                "Category": "false_positive",
+                "Attributes": [
+                    "ip-src",
+                    "ip-dst"
+                ],
+                "Entries": [
+                    {
+                        "Comment": null,
+                        "ID": null,
+                        "Value": "1.2.3.4",
+                        "WarninglistID": null
+                    },
+                    {
+                        "Comment": null,
+                        "ID": null,
+                        "Value": "5.6.7.8",
+                        "WarninglistID": null
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+#### Human Readable Output
+>
+>### MISP Warninglist
+>
+>|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+>|---|---|---|---|---|---|---|---|
+>| 1234 | Changed list name | string | An example of an existing description | 1 | true | true | false_positive | ip-src, ip-dst |
+
+>### Entries in MISP Warninglist
+>
+>|Value|
+>|---|
+>| 1.2.3.4 |
+>| 5.6.7.8 |
+
+### misp-get-warninglist
+
+***
+Get a specific warninglist by its ID.
+
+#### Base Command
+
+`misp-get-warninglist`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| id | ID of the warninglist. | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MISP.Warninglist.ID | number | The ID of the warninglist. |
+| MISP.Warninglist.Name | string | The warninglist's name. |
+| MISP.Warninglist.Type | string | MISP warninglist type. |
+| MISP.Warninglist.Description | string | Description of the warninglist. |
+| MISP.Warninglist.Version | number | The warninglist version number. |
+| MISP.Warninglist.Enabled | boolean | Whether the warninglist is enabled. |
+| MISP.Warninglist.Default | boolean | Whether the warninglist is set as default. |
+| MISP.Warninglist.Category | string | The category of the MISP warninglist. |
+| MISP.Warninglist.Entries | unknown | The warninglist entries. |
+| MISP.Warninglist.Attributes | unknown | The valid attribute types for this warninglist. |
+
+#### Command Example
+
+```!misp-get-warninglist id=1234```
+
+#### Context Example
+
+```json
+{
+    "MISP": {
+        "Warninglist": [ 
+            {
+                "ID": 1234,
+                "Name": "Hello XSOAR!",
+                "Type": "string",
+                "Description": "The Quick Brown Fox Jumped Over The Lazy Dog",
+                "Version": 1,
+                "Enabled": false,
+                "Default": false,
+                "Category": "false_positive",
+                "Attributes": [
+                    "attrib1",
+                    "attrib2"
+                ],
+                "Entries": [
+                    {
+                        "ID": 12345,
+                        "Value": "test",
+                        "WarninglistID": 1,
+                        "Comment": null
+                    },
+                    {
+                        "ID": 56789,
+                        "Value": "another-test",
+                        "WarninglistID": 1,
+                        "Comment": null
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+#### Human Readable Output
+
+>### MISP Warninglist
+>
+>|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+>|---|---|---|---|---|---|---|---|
+>| 1234 | Example List Name | string | An example of a warninglist in MISP | 1 | true | true | false_positive | hostname |
+>
+>### Entries in MISP Warninglist
+>
+>|ID|Value|Description|
+>|---|---|---|
+>|123| hostname.example.local | An example of a hostname |

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_outputs.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_outputs.json
@@ -1,0 +1,29 @@
+{
+    "ID": 1,
+    "Name": "Hello, this world has changed!",
+    "Type": "string",
+    "Description": "Changed yet agaaaaaaaaaaaain!",
+    "Version": 42,
+    "Enabled": true,
+    "Default": true,
+    "Category": "false_positive",
+    "Attributes": [
+        "md5",
+        "sha1",
+        "sha256"
+    ],
+    "Entries": [
+        {
+            "Comment": null,
+            "ID": 123,
+            "Value": "8.8.8.8",
+            "WarninglistID": 1
+        },
+        {
+            "Comment": null,
+            "ID": 456,
+            "Value": "www.example.com",
+            "WarninglistID": 1
+        }
+    ]
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_outputs.md
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_outputs.md
@@ -1,0 +1,9 @@
+### MISP Warninglist
+|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+|---|---|---|---|---|---|---|---|---|
+| 1 | Hello, this world has changed! | string | Changed yet agaaaaaaaaaaaain! | 42 | true | true | false_positive | md5,<br>sha1,<br>sha256 |
+### Entries in MISP Warninglist
+|ID|Value|
+|---|---|
+| 123 | 8.8.8.8 |
+| 456 | www.example.com |

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_response.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_details_response.json
@@ -1,0 +1,42 @@
+{
+    "Warninglist": {
+        "id": 1,
+        "name": "Hello, this world has changed!",
+        "type": "string",
+        "description": "Changed yet agaaaaaaaaaaaain!",
+        "version": 42,
+        "enabled": true,
+        "default": true,
+        "category": "false_positive",
+        "matching_attributes": [
+            "md5",
+            "sha1",
+            "sha256"
+        ]
+    },
+    "WarninglistEntry": [
+        {
+            "id": 123,
+            "value": "8.8.8.8",
+            "warninglist_id": 1,
+            "comment": null
+        },
+        {
+            "id": 456,
+            "value": "www.example.com",
+            "warninglist_id": 1,
+            "comment": null
+        }
+    ],
+    "WarninglistType": [
+        {
+            "type": "md5"
+        },
+        {
+            "type": "sha1"
+        },
+        {
+            "type": "sha256"
+        }
+    ]
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_outputs.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_outputs.json
@@ -1,0 +1,28 @@
+{
+    "ID": 1,
+    "Name": "Hello, this world has changed!",
+    "Type": "string",
+    "Description": "The entries in this list have been changed",
+    "Version": 42,
+    "Enabled": false,
+    "Default": false,
+    "Category": "false_positive",
+    "Attributes": [
+        "ip-src",
+        "ip-dst"
+    ],
+    "Entries": [
+        {
+            "Comment": null,
+            "ID": null,
+            "Value": "8.8.8.8",
+            "WarninglistID": null
+        },
+        {
+            "Comment": null,
+            "ID": null,
+            "Value": "9.9.9.9",
+            "WarninglistID": null
+        }
+    ]
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_outputs.md
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_outputs.md
@@ -1,0 +1,9 @@
+### MISP Warninglist
+|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+|---|---|---|---|---|---|---|---|---|
+| 1 | Hello, this world has changed! | string | The entries in this list have been changed | 42 | false | false | false_positive | ip-src,<br>ip-dst |
+### Entries in MISP Warninglist
+|Value|
+|---|
+| 8.8.8.8 |
+| 9.9.9.9 |

--- a/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_response.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/change_warninglist_entries_response.json
@@ -1,0 +1,38 @@
+{
+    "Warninglist": {
+        "id": 1,
+        "name": "Hello, this world has changed!",
+        "type": "string",
+        "description": "The entries in this list have been changed",
+        "version": 42,
+        "enabled": false,
+        "default": false,
+        "category": "false_positive",
+        "matching_attributes": [
+            "ip-src",
+            "ip-dst"
+        ]
+    },
+    "WarninglistEntry": [
+        {
+            "value": "8.8.8.8",
+            "comment": null
+        },
+        {
+            "value": "9.9.9.9",
+            "comment": null
+        }
+    ],
+    "WarninglistType": [
+        {
+            "id": 123,
+            "type": "ip-src",
+            "warninglist_id": 1
+        },
+        {
+            "id": 456,
+            "type": "ip-dst",
+            "warninglist_id": 1
+        }
+    ]
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_outputs.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_outputs.json
@@ -1,0 +1,28 @@
+{
+    "ID": 1,
+    "Name": "Hello XSOAR!",
+    "Type": "string",
+    "Description": "The Quick Brown Fox Jumped Over The Lazy Dog",
+    "Version": 1,
+    "Enabled": false,
+    "Default": false,
+    "Category": "false_positive",
+    "Attributes": [
+        "attrib1",
+        "attrib2"
+    ],
+    "Entries": [
+        {
+            "ID": 12345,
+            "Value": "test",
+            "WarninglistID": 1,
+            "Comment": null
+        },
+        {
+            "ID": 56789,
+            "Value": "another-test",
+            "WarninglistID": 1,
+            "Comment": null
+        }
+    ]
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_outputs.md
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_outputs.md
@@ -1,0 +1,9 @@
+### MISP Warninglist
+|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+|---|---|---|---|---|---|---|---|---|
+| 1 | Hello XSOAR! | string | The Quick Brown Fox Jumped Over The Lazy Dog | 1 | false | false | false_positive | attrib1,<br>attrib2 |
+### Entries in MISP Warninglist
+|ID|Value|
+|---|---|
+| 12345 | test |
+| 56789 | another-test |

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_response.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglist_response.json
@@ -1,0 +1,38 @@
+{
+    "Warninglist": {
+        "id": 1,
+        "name": "Hello XSOAR!",
+        "type": "string",
+        "description": "The Quick Brown Fox Jumped Over The Lazy Dog",
+        "version": 1,
+        "enabled": false,
+        "default": false,
+        "category": "false_positive",
+        "WarninglistEntry": [
+            {
+                "id": 12345,
+                "value": "test",
+                "warninglist_id": 1,
+                "comment": null
+            },
+            {
+                "id": 56789,
+                "value": "another-test",
+                "warninglist_id": 1,
+                "comment": null
+            }
+        ],
+        "WarninglistType": [
+            {
+                "id": 2468,
+                "type": "attrib1",
+                "warninglist_id": 1
+            },
+            {
+                "id": 8642,
+                "type": "attrib2",
+                "warninglist_id": 1
+            }
+        ]
+    }
+}

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_outputs.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_outputs.json
@@ -1,0 +1,30 @@
+[
+    {
+        "ID": 1,
+        "Name": "Hello XSOAR!",
+        "Type": "string",
+        "Description": "The Quick Brown Fox Jumped Over The Lazy Dog",
+        "Version": 1,
+        "Enabled": false,
+        "Default": false,
+        "Category": "false_positive",
+        "Attributes": [
+            "attrib1",
+            "attrib2"
+        ]
+    },
+    {
+        "ID": 2,
+        "Name": "Warninglist2",
+        "Type": "string",
+        "Description": "Description2",
+        "Version": 42,
+        "Enabled": true,
+        "Default": true,
+        "Category": "false_positive",
+        "Attributes": [
+            "attrib1",
+            "attrib2"
+        ]
+    }
+]

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_outputs.md
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_outputs.md
@@ -1,0 +1,5 @@
+### MISP Warninglists
+|ID|Name|Type|Description|Version|Enabled|Default|Category|Attributes|
+|---|---|---|---|---|---|---|---|---|
+| 1 | Hello XSOAR! | string | The Quick Brown Fox Jumped Over The Lazy Dog | 1 | false | false | false_positive | attrib1,<br>attrib2 |
+| 2 | Warninglist2 | string | Description2 | 42 | true | true | false_positive | attrib1,<br>attrib2 |

--- a/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_response.json
+++ b/Packs/MISP/Integrations/MISPV3/test_data/get_warninglists_response.json
@@ -1,0 +1,30 @@
+[
+    {
+        "Warninglist": {
+            "id": 1,
+            "name": "Hello XSOAR!",
+            "type": "string",
+            "description": "The Quick Brown Fox Jumped Over The Lazy Dog",
+            "version": 1,
+            "enabled": false,
+            "default": false,
+            "category": "false_positive",
+            "warninglist_entry_count": 2,
+            "valid_attributes": "attrib1,attrib2"
+        }
+    },
+    {
+        "Warninglist": {
+            "id": 2,
+            "name": "Warninglist2",
+            "type": "string",
+            "description": "Description2",
+            "version": 42,
+            "enabled": true,
+            "default": true,
+            "category": "false_positive",
+            "warninglist_entry_count": 2,
+            "valid_attributes": "attrib1,attrib2"
+        }
+    }
+]

--- a/Packs/MISP/ReleaseNotes/2_2_0.md
+++ b/Packs/MISP/ReleaseNotes/2_2_0.md
@@ -1,0 +1,11 @@
+
+#### Integrations
+
+##### MISP v3
+
+- Added support for **misp-get-warninglists** command that gets all warninglists from MISP.
+- Added support for **misp-get-warninglist** command that get a specific warninglist by it's ID.
+- Added support for **misp-change-warninglist** command that changes a warninglist in MISP.
+- Added support for *source* argument in the **misp-add-sighting** command.
+- Added support for *value* argument in the **misp-add-sighting** command.
+- Updated the Docker image to: *demisto/pymisp2:2.5.10.3725488*.

--- a/Packs/MISP/pack_metadata.json
+++ b/Packs/MISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP",
     "description": "Malware information and threat sharing platform.",
     "support": "xsoar",
-    "currentVersion": "2.1.54",
+    "currentVersion": "2.2.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Note:
Due to issues with the _license/cla_  github action and not being able to consolidate commits to my Github accoutn, this PR has been made to consolidate the authors [on the PR I originally opened](https://github.com/demisto/content/pull/40550).
Verified with @merit-maita that this is OK

## (Original) Description
This PR adds the following new commands to the MISPv3 integration:

- misp-get-warninglist
- misp-get-warninglists
- misp-change-warninglist

And adds functionality to the following command as well:
- misp-add-sighting

### Contributions
#### Commands
##### misp-get-warninglist (new)
This newly added command returns a warninglist from MISP by ID
https://www.misp-project.org/openapi/#tag/Warninglists/operation/getWarninglistById

##### misp-get-warninglists (new)
This newly added command returns a collection of warninglists from MISP
https://www.misp-project.org/openapi/#tag/Warninglists/operation/getWarninglists

##### misp-change-warninglist (new)
This newly added command provides an interface to MISP to change the values, entry values and attributes of a warning list.
[Uses the (currently undocumented) API endpoint](https://github.com/search?q=org%3AMISP+warninglists%2Fedit&type=code) `warninglists/edit`

##### misp-add-sighting (changed)
Changed the add-sighting command to include value and sighting source parameters

## Must have
- [x] Tests
- [x] Documentation 