### PR TITLE
EWS v3: Remove tmpEXO directories on session disconnect

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
+++ b/Packs/MicrosoftExchangeOnline/Integrations/EwsExtensionEXOPowershellV3/EwsExtensionEXOPowershellV3.ps1
@@ -228,6 +228,8 @@ class ExchangeOnlinePowershellV3Client
     DisconnectSession()
     {
         Disconnect-ExchangeOnline -Confirm:$false -WarningAction:SilentlyContinue 6>$null | Out-Null
+        # Remove any lingering tmpEXO_ directories to prevent filling the disk
+        Remove-Item -Path "/tmp/tmpEXO_*" -Recurse -Force
     }
     [PSObject]
     GetEXOCASMailbox(

--- a/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_22.md
+++ b/Packs/MicrosoftExchangeOnline/ReleaseNotes/1_6_22.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### EWS Extension Online Powershell v3
+
+- Added deletion of temporary tmpEXO directories on session disconnect to avoid filling up Docker partition.

--- a/Packs/MicrosoftExchangeOnline/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange Online",
     "description": "Exchange Online and Office 365 (mail)",
     "support": "xsoar",
-    "currentVersion": "1.6.21",
+    "currentVersion": "1.6.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
EWS Extension Online Powershell v3 -integration fills Docker partition/container disk up with temp files/dirs; it seems to be a known issue with Microsoft (Exchange) Powershell -modules, see e.g. https://support.oneidentity.com/identity-manager/kb/4266842/temp-files-created-by-powershell-scripts-are-not-being-removed or https://www.reddit.com/r/PowerShell/comments/wf723a/tmpexo_folders_in_tmp/. This PR adds deletion of these to the session disconnect which fixes the problem.

## Must have
- [ ] Tests
- [ ] Documentation 
