### PR TITLE
Xsup 55634 panorama fixes

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -6685,8 +6685,8 @@ def panorama_check_latest_dynamic_update_command(args: dict):
             {
                 "Update Type": update_type,
                 "Is Up To Date": "True" if data["IsUpToDate"] else "False",
-                "Latest Available Version": data["LatestAvailable"].get("version", "N/A"),  # type: ignore[union-attr]
-                "Currently Installed Version": data["CurrentlyInstalled"].get("version", "N/A"),  # type: ignore[union-attr]
+                "Latest Available Version": data["LatestAvailable"].get("version", "N/A"),  # type: ignore[attr-defined]
+                "Currently Installed Version": data["CurrentlyInstalled"].get("version", "N/A"),  # type: ignore[attr-defined]
             }
         )
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -6594,14 +6594,26 @@ def panorama_check_latest_dynamic_update_command(args: dict):
     target = args.get("target")
     outdated_item_count = 0
     outputs = {}
+    
+    if not VSYS and not target:
+        # When the VSYS param is not set it meams that this is a panorama instance -> user must specify a target FW 
+        raise DemistoException(
+                f"When running from a Panorama instance, you must specify the target argument. "
+                F"Set target to the serial number of the Panorama-managed firewall you want to check updates for."
+                )
 
     for update_type in DynamicUpdateType:
         # Call firewall API to check for the latest available update of each type
         result = panorama_check_latest_dynamic_update_content(update_type, target)
 
         if "result" in result["response"] and result["response"]["@status"] == "success":
-            versions = result["response"]["result"]["content-updates"]["entry"]
-
+            versions = result.get("response", {}).get("result", {}).get("content-updates", {}).get("entry",{})
+            if not versions: # firewall probably doesn't have any app/threat installed 
+                command_results = CommandResults(
+                    readable_output="No available updates (firewall probably doesn't have any app/threat installed).",
+                    )
+                return_results(command_results)
+                
             # Ensure versions is a list even if there's only one entry
             if not isinstance(versions, list):
                 versions = [versions]

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -6594,13 +6594,13 @@ def panorama_check_latest_dynamic_update_command(args: dict):
     target = args.get("target")
     outdated_item_count = 0
     outputs = {}
-    
+
     if not VSYS and not target:
-        # When the VSYS param is not set it meams that this is a panorama instance -> user must specify a target FW 
+        # When the VSYS param is not set it meams that this is a panorama instance -> user must specify a target FW
         raise DemistoException(
-                f"When running from a Panorama instance, you must specify the target argument. "
-                F"Set target to the serial number of the Panorama-managed firewall you want to check updates for."
-                )
+            f"When running from a Panorama instance, you must specify the target argument. "
+            f"Set target to the serial number of the Panorama-managed firewall you want to check updates for."
+        )
 
     for update_type in DynamicUpdateType:
         # Call firewall API to check for the latest available update of each type
@@ -6608,10 +6608,10 @@ def panorama_check_latest_dynamic_update_command(args: dict):
             result = panorama_check_latest_dynamic_update_content(update_type, target)
 
             if "result" in result["response"] and result["response"]["@status"] == "success":
-                versions = result.get("response", {}).get("result", {}).get("content-updates", {}).get("entry",[])
-                if not versions: # firewall probably doesn't have app/threat or Antivirus or WildFire or GP installed 
+                versions = result.get("response", {}).get("result", {}).get("content-updates", {}).get("entry", [])
+                if not versions:  # firewall probably doesn't have app/threat or Antivirus or WildFire or GP installed
                     demisto.debug(f"No available updates (Firewall probably doesn't have any {update_type.value} installed).")
-                    
+
                 # Ensure versions is a list even if there's only one entry
                 if not isinstance(versions, list):
                     versions = [versions]
@@ -6640,7 +6640,7 @@ def panorama_check_latest_dynamic_update_command(args: dict):
                 # Check if currently installed is the most recent available
                 is_up_to_date = False
                 if current_version and latest_version:
-                    is_up_to_date = current_version.get("version") == latest_version.get("version") 
+                    is_up_to_date = current_version.get("version") == latest_version.get("version")
 
                 context_prefix = DynamicUpdateContextPrefixMap.get(update_type)
 
@@ -6661,16 +6661,17 @@ def panorama_check_latest_dynamic_update_command(args: dict):
                 )
         except Exception as e:
             if "There is no Global Protext Gateway license on the box" in str(e):
-               outputs["GP"] = {
-                    "LatestAvailable": {"version": "An Error received from Panorama API: 'There is no Global Protect Gateway license on the box.'"},
+                outputs["GP"] = {
+                    "LatestAvailable": {
+                        "version": "An Error received from Panorama API: 'There is no Global Protect Gateway license on the box.'"
+                    },
                     "CurrentlyInstalled": {},
                     "IsUpToDate": False,
                 }
-               continue
+                continue
             else:
-               raise e
-           
-     
+                raise e
+
     outputs["ContentTypesOutOfDate"] = {"Count": outdated_item_count}
 
     # Create summary table for human-readable output

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -6868,7 +6868,7 @@ script:
   - arguments:
     - description: Serial number of the firewall on which to run the command. Use only for a Panorama instance.
       name: target
-    description: Checks for the latest available dynamic update versions and returns a list of latest available / currently installed content.
+    description: Checks for the latest available dynamic update versions and returns a list of latest available / currently installed content. When running from a Panorama instance, the 'target' argument must be specified.
     name: pan-os-check-dynamic-updates-status
     outputs:
     - contextPath: Panorama.DynamicUpdates.AntiVirus.CurrentlyInstalled.app-version
@@ -7247,7 +7247,7 @@ script:
       description: Version of the dynamic update package.
       type: String
   - arguments:
-    - description: Serial number of the firewall on which to run the command. Use only for a Panorama instance.
+    - description: Serial number of the firewall on which to run the command. Mandatory for Panorama instances.
       name: target
     - description: Job ID for a running download process. Used for status polling.
       name: job_id

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -10658,7 +10658,7 @@ script:
     - contextPath: Panorama.Certificate.devices_using_certificate
       type: Unknown
       description: List of devices using this certificate if it was pushed from Panorama.
-  dockerimage: demisto/pan-os-python:1.0.0.3545654
+  dockerimage: demisto/pan-os-python:1.0.0.4889421
   isfetch: true
   runonce: false
   script: ''

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8637,64 +8637,59 @@ class TestDynamicUpdateCommands:
 
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
-    
-    
+
     def test_panorama_check_latest_dynamic_update_panorama_instance(self):
         """
-            Given:
-                - A panorama instance (VSYS instance parameter is set to '').
-                - target argument is not specified (set to '').
-            
-            When:
-                - Calling the panorama_check_latest_dynamic_update_command.
-                
-            Then:
-                - Verify that an exception is raised askung the user to specify a target firewall
-                when running from a Panorama instance.
-            
+        Given:
+            - A panorama instance (VSYS instance parameter is set to '').
+            - target argument is not specified (set to '').
+
+        When:
+            - Calling the panorama_check_latest_dynamic_update_command.
+
+        Then:
+            - Verify that an exception is raised askung the user to specify a target firewall
+            when running from a Panorama instance.
+
         """
         from Panorama import panorama_check_latest_dynamic_update_command
-        
+
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
-        
+
         with pytest.raises(DemistoException) as e:
-            panorama_check_latest_dynamic_update_command({"target": ''})
-        
-        assert 'When running from a Panorama instance, you must specify the target argument.' in str(e.value)
-    
-    
+            panorama_check_latest_dynamic_update_command({"target": ""})
+
+        assert "When running from a Panorama instance, you must specify the target argument." in str(e.value)
+
     def test_panorama_check_latest_dynamic_update_command_empty_response(self, mocker):
         """
-            Tests the scenario were the response from the 'panorama_check_latest_dynamic_update_content' api call, includes no
-            entries - which means that the Firewall probably doesn't have any App/Threat or Antivirus, or Wildfire or GP 
-            installed.
-            
-            Given:
-                - a Panorama instance.
-                - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with no entries.
-          
-            When:
-                - Calling the panorama_check_latest_dynamic_update_command.
-                
-            Then:
-                - Verify that the outputs include no versions (all versions set to N/A).
-                - Verify that the expected debug log is created.
-            
+        Tests the scenario were the response from the 'panorama_check_latest_dynamic_update_content' api call, includes no
+        entries - which means that the Firewall probably doesn't have any App/Threat or Antivirus, or Wildfire or GP
+        installed.
+
+        Given:
+            - a Panorama instance.
+            - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with no entries.
+
+        When:
+            - Calling the panorama_check_latest_dynamic_update_command.
+
+        Then:
+            - Verify that the outputs include no versions (all versions set to N/A).
+            - Verify that the expected debug log is created.
+
         """
         from Panorama import panorama_check_latest_dynamic_update_command
-        
-        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content", return_value={"response": {
-        "@status": "success",
-        "result": {
-            "content-updates": {
-                "@last-updated-at": "2025/06/11 13:40:16 PDT",
-                "entry": [
-                ]
-            }
-        }
-    }
-})
-        
+
+        mocker.patch(
+            "Panorama.panorama_check_latest_dynamic_update_content",
+            return_value={
+                "response": {
+                    "@status": "success",
+                    "result": {"content-updates": {"@last-updated-at": "2025/06/11 13:40:16 PDT", "entry": []}},
+                }
+            },
+        )
 
         mock_return_results = mocker.patch("Panorama.return_results")
         mock_debug = mocker.patch.object(demisto, "debug")
@@ -8703,41 +8698,45 @@ class TestDynamicUpdateCommands:
 
         # Prepare results for comparison
         returned_commandresults: CommandResults = mock_return_results.call_args[0][0]
-        expected_returned_output = {'Content': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
-                                    'AntiVirus': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
-                                    'WildFire': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
-                                    'GP': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
-                                    'ContentTypesOutOfDate': {'Count': 4}}
-        expected_returned_readable = ('### Dynamic Update Status Summary\n|Update Type|Is Up To Date|Latest Available '
-                                      'Version|Currently Installed Version|\n|---|---|---|---|\n| Content | False | N/A | N/A |'
-                                      '\n| AntiVirus | False | N/A | N/A |\n| WildFire | False | N/A | N/A |\n| GP | False | N/A '
-                                      '| N/A |\n\n\n**Total Content Types Outdated: 4**')
-        
-        assert mock_debug.call_args[0][0] == ("No available updates "
-                                              "(Firewall probably doesn't have any global-protect-clientless-vpn installed).")
+        expected_returned_output = {
+            "Content": {"LatestAvailable": {}, "CurrentlyInstalled": {}, "IsUpToDate": False},
+            "AntiVirus": {"LatestAvailable": {}, "CurrentlyInstalled": {}, "IsUpToDate": False},
+            "WildFire": {"LatestAvailable": {}, "CurrentlyInstalled": {}, "IsUpToDate": False},
+            "GP": {"LatestAvailable": {}, "CurrentlyInstalled": {}, "IsUpToDate": False},
+            "ContentTypesOutOfDate": {"Count": 4},
+        }
+        expected_returned_readable = (
+            "### Dynamic Update Status Summary\n|Update Type|Is Up To Date|Latest Available "
+            "Version|Currently Installed Version|\n|---|---|---|---|\n| Content | False | N/A | N/A |"
+            "\n| AntiVirus | False | N/A | N/A |\n| WildFire | False | N/A | N/A |\n| GP | False | N/A "
+            "| N/A |\n\n\n**Total Content Types Outdated: 4**"
+        )
+
+        assert mock_debug.call_args[0][0] == (
+            "No available updates " "(Firewall probably doesn't have any global-protect-clientless-vpn installed)."
+        )
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
-        
-        
+
     def test_panorama_check_latest_dynamic_update_command_no_gp_license(self, mocker):
         """
-            Tests the scenario were there is no Global Protect license on the Firewall.
-            
-            Given:
-                - a Panorama instance.
-                - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with an exception regfarding the
-                GP missing license.
-          
-            When:
-                - Calling the panorama_check_latest_dynamic_update_command.
-                
-            Then:
-                - Verify that the outputs include the versions of the content, wildfire and antivirus, and the error message 
-                  egarding the gp missing license.
-                - Verify that the human readable output includes the versions of the versions of the content, wildfire and
-                  antivirus, and the error message regarding the gp missing license.  
+        Tests the scenario were there is no Global Protect license on the Firewall.
+
+        Given:
+            - a Panorama instance.
+            - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with an exception regfarding the
+            GP missing license.
+
+        When:
+            - Calling the panorama_check_latest_dynamic_update_command.
+
+        Then:
+            - Verify that the outputs include the versions of the content, wildfire and antivirus, and the error message
+              egarding the gp missing license.
+            - Verify that the human readable output includes the versions of the versions of the content, wildfire and
+              antivirus, and the error message regarding the gp missing license.
         """
-   
+
         from Panorama import panorama_check_latest_dynamic_update_command
 
         # Side-effect function to return the proper NGFW API response for the requested dynamic update type
@@ -8766,8 +8765,9 @@ class TestDynamicUpdateCommands:
 
         # Prepare results for comparison
         returned_commandresults: CommandResults = mock_return_results.call_args[0][0]
-        expected_returned_output = load_json("test_data/pan-os-check-latest-dynamic-update-status_expected-returned-outputs-no-gp"
-                                             "-license.json")
+        expected_returned_output = load_json(
+            "test_data/pan-os-check-latest-dynamic-update-status_expected-returned-outputs-no-gp" "-license.json"
+        )
         expected_returned_readable = (
             "### Dynamic Update Status Summary\n|Update Type|Is Up To Date|Latest Available "
             "Version|Currently Installed Version|\n|---|---|---|---|\n| Content | True | 8987-9481 | 8987-9481 |\n| "
@@ -8779,9 +8779,6 @@ class TestDynamicUpdateCommands:
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
 
-    
-    
-            
     @pytest.mark.parametrize(
         "update_phase, job_id, api_response_payload",
         [

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8638,7 +8638,7 @@ class TestDynamicUpdateCommands:
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
 
-    def test_panorama_check_latest_dynamic_update_panorama_instance(self):
+    def test_panorama_check_latest_dynamic_update_panorama_instance(self, mocker):
         """
         Given:
             - A panorama instance (VSYS instance parameter is set to '').
@@ -8655,6 +8655,8 @@ class TestDynamicUpdateCommands:
         from Panorama import panorama_check_latest_dynamic_update_command
 
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
+        
+        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content")
 
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8655,8 +8655,8 @@ class TestDynamicUpdateCommands:
         from Panorama import panorama_check_latest_dynamic_update_command
 
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
-        
-        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content")
+
+        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content", return_value={})
 
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8638,7 +8638,7 @@ class TestDynamicUpdateCommands:
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
 
-    def test_panorama_check_latest_dynamic_update_panorama_instance(self, mocker):
+    def test_panorama_check_latest_dynamic_update_panorama_instance(self):
         """
         Given:
             - A panorama instance (VSYS instance parameter is set to '').
@@ -8656,11 +8656,9 @@ class TestDynamicUpdateCommands:
 
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
 
-        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content", return_value={})
-
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})
-            assert "When running from a Panorama instance, you must specify the target argument." in str(e.value)
+        assert "When running from a Panorama instance, you must specify the target argument." in str(e.value)
 
     def test_panorama_check_latest_dynamic_update_command_empty_response(self, mocker):
         """

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8657,7 +8657,6 @@ class TestDynamicUpdateCommands:
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
 
         mocker.patch("Panorama.VSYS", "")
-        #Panorama.VSYS = None  # this a Panorama instance
 
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8623,7 +8623,7 @@ class TestDynamicUpdateCommands:
 
         mock_return_results = mocker.patch("Panorama.return_results")
 
-        panorama_check_latest_dynamic_update_command({"args": {"target": "1337"}})
+        panorama_check_latest_dynamic_update_command({"target": "1337"})
 
         # Prepare results for comparison
         returned_commandresults: CommandResults = mock_return_results.call_args[0][0]
@@ -8637,7 +8637,151 @@ class TestDynamicUpdateCommands:
 
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
+    
+    
+    def test_panorama_check_latest_dynamic_update_panorama_instance(self):
+        """
+            Given:
+                - A panorama instance (VSYS instance parameter is set to '').
+                - target argument is not specified (set to '').
+            
+            When:
+                - Calling the panorama_check_latest_dynamic_update_command.
+                
+            Then:
+                - Verify that an exception is raised askung the user to specify a target firewall
+                when running from a Panorama instance.
+            
+        """
+        from Panorama import panorama_check_latest_dynamic_update_command
+        
+        # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
+        
+        with pytest.raises(DemistoException) as e:
+            panorama_check_latest_dynamic_update_command({"target": ''})
+        
+        assert 'When running from a Panorama instance, you must specify the target argument.' in str(e.value)
+    
+    
+    def test_panorama_check_latest_dynamic_update_command_empty_response(self, mocker):
+        """
+            Tests the scenario were the response from the 'panorama_check_latest_dynamic_update_content' api call, includes no
+            entries - which means that the Firewall probably doesn't have any App/Threat or Antivirus, or Wildfire or GP 
+            installed.
+            
+            Given:
+                - a Panorama instance.
+                - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with no entries.
+          
+            When:
+                - Calling the panorama_check_latest_dynamic_update_command.
+                
+            Then:
+                - Verify that the outputs include no versions (all versions set to N/A).
+                - Verify that the expected debug log is created.
+            
+        """
+        from Panorama import panorama_check_latest_dynamic_update_command
+        
+        mocker.patch("Panorama.panorama_check_latest_dynamic_update_content", return_value={"response": {
+        "@status": "success",
+        "result": {
+            "content-updates": {
+                "@last-updated-at": "2025/06/11 13:40:16 PDT",
+                "entry": [
+                ]
+            }
+        }
+    }
+})
+        
 
+        mock_return_results = mocker.patch("Panorama.return_results")
+        mock_debug = mocker.patch.object(demisto, "debug")
+
+        panorama_check_latest_dynamic_update_command({"target": "1337"})
+
+        # Prepare results for comparison
+        returned_commandresults: CommandResults = mock_return_results.call_args[0][0]
+        expected_returned_output = {'Content': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
+                                    'AntiVirus': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
+                                    'WildFire': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
+                                    'GP': {'LatestAvailable': {}, 'CurrentlyInstalled': {}, 'IsUpToDate': False},
+                                    'ContentTypesOutOfDate': {'Count': 4}}
+        expected_returned_readable = ('### Dynamic Update Status Summary\n|Update Type|Is Up To Date|Latest Available '
+                                      'Version|Currently Installed Version|\n|---|---|---|---|\n| Content | False | N/A | N/A |'
+                                      '\n| AntiVirus | False | N/A | N/A |\n| WildFire | False | N/A | N/A |\n| GP | False | N/A '
+                                      '| N/A |\n\n\n**Total Content Types Outdated: 4**')
+        
+        assert mock_debug.call_args[0][0] == ("No available updates "
+                                              "(Firewall probably doesn't have any global-protect-clientless-vpn installed).")
+        assert returned_commandresults.outputs == expected_returned_output
+        assert returned_commandresults.readable_output == expected_returned_readable
+        
+        
+    def test_panorama_check_latest_dynamic_update_command_no_gp_license(self, mocker):
+        """
+            Tests the scenario were there is no Global Protect license on the Firewall.
+            
+            Given:
+                - a Panorama instance.
+                - Mock response for the 'panorama_check_latest_dynamic_update_content' api call, with an exception regfarding the
+                GP missing license.
+          
+            When:
+                - Calling the panorama_check_latest_dynamic_update_command.
+                
+            Then:
+                - Verify that the outputs include the versions of the content, wildfire and antivirus, and the error message 
+                  egarding the gp missing license.
+                - Verify that the human readable output includes the versions of the versions of the content, wildfire and
+                  antivirus, and the error message regarding the gp missing license.  
+        """
+   
+        from Panorama import panorama_check_latest_dynamic_update_command
+
+        # Side-effect function to return the proper NGFW API response for the requested dynamic update type
+        def side_effect_function(update_type, target):
+            if update_type.name == "APP_THREAT":
+                return load_json("test_data/pan-os-check-latest-dynamic-update-status_apiresponse_app-threat.json")
+
+            elif update_type.name == "ANTIVIRUS":
+                return load_json("test_data/pan-os-check-latest-dynamic-update-status_apiresponse_antivirus.json")
+
+            elif update_type.name == "WILDFIRE":
+                return load_json("test_data/pan-os-check-latest-dynamic-update-status_apiresponse_wildfire.json")
+
+            elif update_type.name == "GP":
+                raise Exception("There is no Global Protext Gateway license on the box")
+
+            else:
+                return None
+
+        mock_api_call = mocker.patch("Panorama.panorama_check_latest_dynamic_update_content")
+        mock_api_call.side_effect = side_effect_function
+
+        mock_return_results = mocker.patch("Panorama.return_results")
+
+        panorama_check_latest_dynamic_update_command({"target": "1337"})
+
+        # Prepare results for comparison
+        returned_commandresults: CommandResults = mock_return_results.call_args[0][0]
+        expected_returned_output = load_json("test_data/pan-os-check-latest-dynamic-update-status_expected-returned-outputs-no-gp"
+                                             "-license.json")
+        expected_returned_readable = (
+            "### Dynamic Update Status Summary\n|Update Type|Is Up To Date|Latest Available "
+            "Version|Currently Installed Version|\n|---|---|---|---|\n| Content | True | 8987-9481 | 8987-9481 |\n| "
+            "AntiVirus | False | 5212-5732 | 5211-5731 |\n| WildFire | False | 986250-990242 | 986026-990018 |\n| GP | "
+            "False | An Error received from Panorama API: 'There is no Global Protect Gateway license on the box.' |"
+            " N/A |\n\n\n**Total Content Types Outdated: 2**"
+        )
+
+        assert returned_commandresults.outputs == expected_returned_output
+        assert returned_commandresults.readable_output == expected_returned_readable
+
+    
+    
+            
     @pytest.mark.parametrize(
         "update_phase, job_id, api_response_payload",
         [

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8660,8 +8660,7 @@ class TestDynamicUpdateCommands:
 
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})
-
-        assert "When running from a Panorama instance, you must specify the target argument." in str(e.value)
+            assert "When running from a Panorama instance, you must specify the target argument." in str(e.value)
 
     def test_panorama_check_latest_dynamic_update_command_empty_response(self, mocker):
         """

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -8638,7 +8638,7 @@ class TestDynamicUpdateCommands:
         assert returned_commandresults.outputs == expected_returned_output
         assert returned_commandresults.readable_output == expected_returned_readable
 
-    def test_panorama_check_latest_dynamic_update_panorama_instance(self):
+    def test_panorama_check_latest_dynamic_update_panorama_instance(self, mocker):
         """
         Given:
             - A panorama instance (VSYS instance parameter is set to '').
@@ -8655,6 +8655,9 @@ class TestDynamicUpdateCommands:
         from Panorama import panorama_check_latest_dynamic_update_command
 
         # VSYS global variable is set to '' by default, which means we are simulating a run from a Panorama instance.
+
+        mocker.patch("Panorama.VSYS", "")
+        #Panorama.VSYS = None  # this a Panorama instance
 
         with pytest.raises(DemistoException) as e:
             panorama_check_latest_dynamic_update_command({"target": ""})

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -9904,7 +9904,7 @@ When running from a Panorama instance, the `target` argument must be specified.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| target | Serial number of the firewall on which to run the command. Mandatory for a Panorama instance. | Optional |
+| target | Serial number of the firewall on which to run the command. Mandatory for Panorama instances. | Optional |
 
 #### Context Output
 

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -9894,6 +9894,7 @@ Gathers the name, expiration date, and expiration status of certificates configu
 
 ***
 Checks for the latest available dynamic update versions and returns a list of latest available / currently installed content.
+When running from a Panorama instance, the `target` argument must be specified.
 
 #### Base Command
 
@@ -9903,7 +9904,7 @@ Checks for the latest available dynamic update versions and returns a list of la
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| target | Serial number of the firewall on which to run the command. Use only for a Panorama instance. | Optional |
+| target | Serial number of the firewall on which to run the command. Mandatory for a Panorama instance. | Optional |
 
 #### Context Output
 

--- a/Packs/PAN-OS/Integrations/Panorama/test_data/pan-os-check-latest-dynamic-update-status_expected-returned-outputs-no-gp-license.json
+++ b/Packs/PAN-OS/Integrations/Panorama/test_data/pan-os-check-latest-dynamic-update-status_expected-returned-outputs-no-gp-license.json
@@ -1,0 +1,122 @@
+{
+    "Content": {
+        "LatestAvailable": {
+            "version": "8987-9481",
+            "app-version": "8987-9481",
+            "filename": "panupv2-all-contents-8987-9481",
+            "size": "109",
+            "size-kb": "112260",
+            "released-on": "2025/06/10 16:26:28 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "yes",
+            "current": "no",
+            "previous": "no",
+            "installing": "yes",
+            "features": "Apps, Threats",
+            "update-type": "Full",
+            "feature-desc": "Unknown",
+            "sha256": "fake-sha256-hash"
+        },
+        "CurrentlyInstalled": {
+            "version": "8987-9481",
+            "app-version": "8987-9481",
+            "filename": "panupv2-all-contents-8987-9481",
+            "size": "109",
+            "size-kb": "112260",
+            "released-on": "2025/06/10 16:26:28 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "yes",
+            "current": "no",
+            "previous": "no",
+            "installing": "yes",
+            "features": "Apps, Threats",
+            "update-type": "Full",
+            "feature-desc": "Unknown",
+            "sha256": "fake-sha256-hash"
+        },
+        "IsUpToDate": true
+    },
+    "AntiVirus": {
+        "LatestAvailable": {
+            "version": "5212-5732",
+            "app-version": "5212-5732",
+            "filename": "panup-all-antivirus-5212-5732",
+            "size": "102",
+            "size-kb": "104745",
+            "released-on": "2025/06/11 04:00:51 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "no",
+            "current": "no",
+            "previous": "no",
+            "installing": "no",
+            "features": "virus",
+            "update-type": "Full",
+            "feature-desc": "Unknown",
+            "sha256": "fake-sha256-hash"
+        },
+        "CurrentlyInstalled": {
+            "version": "5211-5731",
+            "app-version": "5211-5731",
+            "filename": "panup-all-antivirus-5211-5731",
+            "size": "102",
+            "size-kb": "104547",
+            "released-on": "2025/06/10 04:01:55 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "yes",
+            "current": "yes",
+            "previous": "no",
+            "installing": "no",
+            "features": "virus",
+            "update-type": "Full",
+            "feature-desc": "Unknown",
+            "sha256": "fake-sha256-hash"
+        },
+        "IsUpToDate": false
+    },
+    "WildFire": {
+        "LatestAvailable": {
+            "version": "986250-990242",
+            "app-version": "986250-990242",
+            "filename": "panupv3-all-wildfire-986250-990242",
+            "size": "9",
+            "size-kb": "9290",
+            "released-on": "2025/06/11 13:37:03 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "no",
+            "current": "no",
+            "previous": "no",
+            "installing": "no",
+            "features": "wildfire",
+            "update-type": "Full",
+            "feature-desc": "PAN-OS 10.0 and later",
+            "sha256": "fake-sha256-hash"
+        },
+        "CurrentlyInstalled": {
+            "version": "986026-990018",
+            "app-version": "986026-990018",
+            "filename": "panupv3-all-wildfire-986026-990018",
+            "size": "9",
+            "size-kb": "9307",
+            "released-on": "2025/06/10 18:56:52 PDT",
+            "release-notes": "https://fake-release-note-link",
+            "downloaded": "yes",
+            "current": "yes",
+            "previous": "no",
+            "installing": "no",
+            "features": "wildfire",
+            "update-type": "Full",
+            "feature-desc": "PAN-OS 10.0 and later",
+            "sha256": "fake-sha256-hash"
+        },
+        "IsUpToDate": false
+    },
+    "GP": {
+        "LatestAvailable": {"version": "An Error received from Panorama API: 'There is no Global Protect Gateway license on the box.'"},
+        "CurrentlyInstalled": {
+        },
+        "IsUpToDate": false
+    },
+    "ContentTypesOutOfDate": {
+        "Count": 2
+    }
+}

--- a/Packs/PAN-OS/ReleaseNotes/2_6_9.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_9.md
@@ -5,4 +5,5 @@
 
 - Fixed an issue where the ***pan-os-check-dynamic-updates-status*** command was failing when there was no Global Protect license on the Firewall.
 - Fixed an issue where the ***pan-os-check-dynamic-updates-status*** command was failing when there was no App/Threat or GP or Antivirus or Wildfire installed on the Firewall.
-- Added a validation for the ***pan-os-check-dynamic-updates-status*** command that makes sure that the *target* argument is specified when running from a Panorama instance.
+- Added a validation for the ***pan-os-check-dynamic-updates-status*** command that verifies that the *target* argument is specified when running from a Panorama instance.
+- Updated the Docker image to: *demisto/pan-os-python:1.0.0.4889421*.

--- a/Packs/PAN-OS/ReleaseNotes/2_6_9.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_9.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### Palo Alto Networks PAN-OS
+
+- Fixed an issue where the ***pan-os-check-dynamic-updates-status*** command was failing when there was no Global Protect license on the Firewall.
+- Fixed an issue where the ***pan-os-check-dynamic-updates-status*** command was failing when there was no App/Threat or GP or Antivirus or Wildfire installed on the Firewall.
+- Added a validation for the ***pan-os-check-dynamic-updates-status*** command that makes sure that the *target* argument is specified when running from a Panorama instance.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. Use this pack to manage Prisma Access through Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "2.6.8",
+    "currentVersion": "2.6.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-55634](https://jira-dc.paloaltonetworks.com/browse/XSUP-55634).

## Description
Fixes several issues in the `pan-os-check-dynamic-updates-status` command: 
1. Handles a scenario where the user runs the command from a Panorama instance without specifying a `target` argument. 
2. Handles a scenario where the checked Firewall doesn't contain any installations on it (instead of failing, we wrapped it with a suitable message). 
3. Handles an error message which received when there is no GP license on the Firewall. 

## Must have
- [x] Tests
- [x] Documentation 
