### PR TITLE
deprecated jq

### DIFF
--- a/Packs/CommunityCommonScripts/ReleaseNotes/1_4_0.md
+++ b/Packs/CommunityCommonScripts/ReleaseNotes/1_4_0.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### jq
+
+- Deprecated. Use JMESPath transformer from the FiltersAndTransformers pack instead.

--- a/Packs/CommunityCommonScripts/ReleaseNotes/1_4_0.md
+++ b/Packs/CommunityCommonScripts/ReleaseNotes/1_4_0.md
@@ -3,4 +3,4 @@
 
 ##### jq
 
-- Deprecated. Use JMESPath transformer from the FiltersAndTransformers pack instead.
+- Deprecated. Use JMESPath transformer from the Filters and Transformers content pack instead.

--- a/Packs/CommunityCommonScripts/Scripts/Jq/Jq.yml
+++ b/Packs/CommunityCommonScripts/Scripts/Jq/Jq.yml
@@ -1,11 +1,11 @@
 args:
-- description: JSON String
+- description: JSON String.
   name: value
   required: true
-- description: JQ compatible query
+- description: JQ compatible query.
   name: query
   required: true
-comment: "Run JQ Query. \n\nCheck these links:\n- https://stedolan.github.io/jq/manual/#Invokingjq\n- https://jqplay.org/"
+comment: "Deprecated. Use JMESPath transformer from the FiltersAndTransformers pack instead."
 commonfields:
   id: jq
   version: -1
@@ -20,7 +20,7 @@ name: jq
 outputs:
 - contextPath: jq.result
   type: unknown
-  description: Result of jq-query
+  description: Result of jq-query.
 runas: DBotWeakRole
 script: ''
 scripttarget: 0
@@ -30,4 +30,5 @@ tags:
 type: python
 fromversion: 6.1.0
 tests:
-- No tests (auto formatted)
+- No tests (deprecated)
+deprecated: true

--- a/Packs/CommunityCommonScripts/Scripts/Jq/Jq.yml
+++ b/Packs/CommunityCommonScripts/Scripts/Jq/Jq.yml
@@ -5,7 +5,7 @@ args:
 - description: JQ compatible query.
   name: query
   required: true
-comment: "Deprecated. Use JMESPath transformer from the FiltersAndTransformers pack instead."
+comment: "Deprecated. Use JMESPath transformer from the Filters and Transformers content pack instead."
 commonfields:
   id: jq
   version: -1

--- a/Packs/CommunityCommonScripts/pack_metadata.json
+++ b/Packs/CommunityCommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Community Common Scripts",
     "description": "A pack that contains community scripts",
     "support": "community",
-    "currentVersion": "1.3.23",
+    "currentVersion": "1.4.0",
     "author": "",
     "url": "https://live.paloaltonetworks.com/t5/cortex-xsoar-discussions/bd-p/Cortex_XSOAR_Discussions",
     "email": "",


### PR DESCRIPTION
Due to the lack of updates for the pyjq library over the last three years and its incompatibility with newer Python versions, we have deprecated this transformer. You can now use the official JMESPath transformer instead.