### PR TITLE
Implement first iteration of fetch events in HashiCorp Terraform

### DIFF
--- a/Packs/HashiCorpTerraform/.secrets-ignore
+++ b/Packs/HashiCorpTerraform/.secrets-ignore
@@ -1,2 +1,3 @@
 https://app.terraform.io
 https://test_url.com
+https://developer.hashicorp.com

--- a/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/HashiCorpTerraform.yml
+++ b/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/HashiCorpTerraform.yml
@@ -1,6 +1,9 @@
 commonfields:
   id: HashicorpTerraform
   version: -1
+sectionOrder:
+- Connect
+- Collect
 configuration:
 - display: Server URL
   name: server_url
@@ -31,10 +34,28 @@ configuration:
   name: insecure
   type: 8
   required: false
+  section: Collect
+  advanced: true
 - display: Use system proxy settings
   name: proxy
   type: 8
   required: false
+  section: Collect
+  advanced: true
+- display: Fetch events
+  name: isFetchEvents
+  type: 8
+  required: false
+  section: Collect
+  hidden:
+  - xsoar
+- display: Maximum Number of Audit Events Per Fetch
+  name: max_fetch  # for fetch-events on XSIAM and PLATFORM
+  defaultvalue: 10000
+  type: 0
+  section: Collect
+  hidden:
+    - xsoar
 name: HashicorpTerraform
 display: HashiCorp Terraform
 category: IT Services
@@ -219,6 +240,23 @@ script:
     - contextPath: Terraform.Run.data.links.self
       description: Link to the Terraform run data.
       type: String
+  - name: terraform-get-events
+    description: Gets Terraform audit trail events. This command is supported in Cortex XSIAM only and is intended to be used for debugging purposes as it may result in duplicate events.
+    arguments:
+    - name: from_date
+      description: The start date for the audit trails as a relative time expression (e.g., '3 days ago') or an absolute time in ISO 8601 format (e.g., '2025-09-01T00:00:00Z').
+      defaultValue: "1 hour ago"
+    - name: limit
+      description: The maximum number of events to retrieve.
+      defaultValue: "10"
+    - name: should_push_events
+      description: If true, the command will push the events to the Cortex XSIAM dataset. Otherwise, it will only display them. 
+      auto: PREDEFINED
+      predefined:
+      - "true"
+      - "false"
+      defaultValue: "false"
+    outputs: []
   - name: terraform-run-action
     arguments:
     - name: run_id
@@ -621,7 +659,10 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/auth-utils:1.0.0.4578605
+  # Fetch events (XSIAM and PLATFORM only)
+  isfetchevents: true
+  isfetchevents:xsoar: false
 fromversion: 6.10.0
 tests:
 - No tests (auto formatted)

--- a/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/HashiCorpTerraform_description.md
+++ b/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/HashiCorpTerraform_description.md
@@ -1,10 +1,47 @@
 ## HashiCorp Terraform Help
 
+### How to Configure this Integration
 
-**Note:**
-There are 3 different types of tokens - Organization, User, Team
-A customer should use a User or Team token that has admin level access to the workspace.
-For details, see [HashiCorp API Tokens](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens).
+- The *API Token* can be generated using the instructions below.
+- The *Default Workspace ID* can be taken from *Projects & workspaces* within the selected organization.
+- The *Default Organization Name* can be taken from the organizations listed in [organizations](https://app.terraform.io/app/organizations).
 
-- *Default Workspace ID* can be taken from *Projects & workspaces* within the selected organization.
-- *Default Organization Name* can be taken from the organizations listed in [organizations](https://app.terraform.io/app/organizations).
+---
+
+### How to Generate an API Token
+
+1. Log in with a HashiCorp Cloud Platform account.
+
+2. Click **Tokens** in the sidebar to create, manage, and revoke API tokens. HCP Terraform has multiple types of tokens:
+
+   - Organization tokens
+   - Team tokens
+   - User tokens
+   - Audit trail tokens
+   - Agent tokens
+
+   Most commands require a **User** or **Team** token that has admin level access to the workspace.
+
+   Fetching audit trail events requires an **Audit trail** or **Organization** token.
+
+   For additional details, refer to the integration documentation and [HashiCorp Terraform API Tokens](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens).
+
+3. Click **Create an API token**. The Create API token box appears.
+
+4. Enter a Description that explains what the token is for and click **Create API token**.
+
+5. (Optional) Enter the token's expiration date or time, or create a token that never expires.
+
+6. Copy the token from the box and save it in a secure location. Use it to configure an instance of this integration.
+
+---
+
+### How to Fetch Access Audit Trail Events
+
+#### Feature Entitlements
+
+The organization should have the `audit-logging` entitlement to fetch access audit trail events. Refer to [HashiCorp Terraform Feature Entitlements](https://developer.hashicorp.com/terraform/cloud-docs/api-docs#feature-entitlements).
+
+#### Rate Limits
+
+The HashiCorp Terraform API can return up to 1,000 access audit trail events per request and supports up to 30 requests per second. If the *Maximum Number of Audit Events Per Fetch* is set too high, the integration instance may encounter HTTP 429 "Too Many Requests" errors. Refer to [HashiCorp Terraform API Rate Limits](https://developer.hashicorp.com/terraform/enterprise/api-docs#rate-limits).

--- a/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/README.md
+++ b/Packs/HashiCorpTerraform/Integrations/HashiCorpTerraform/README.md
@@ -11,6 +11,8 @@ This integration was integrated and tested with version v1.4.4 of HashicorpTerra
 | Default Workspace ID | There is an option to override with an input parameter. If not provided, some commands should require the workspace ID. | False |
 | Trust any certificate (not secure) |  | False |
 | Use system proxy settings |  | False |
+| Fetch events | | False |
+| Maximum Number of Audit Events Per Fetch | Default is 10000. | False |
 
 ## Commands
 
@@ -25,6 +27,10 @@ List runs in a workspace.
 #### Base Command
 
 `terraform-runs-list`
+
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
 
 #### Input
 
@@ -321,6 +327,10 @@ Perform an action on a Terraform run. The available actions are: apply, cancel, 
 
 `terraform-run-action`
 
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -349,6 +359,10 @@ Get the plan JSON file or the plan meta data.
 #### Base Command
 
 `terraform-plan-get`
+
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
 
 #### Input
 
@@ -479,6 +493,10 @@ List the policies for an organization or get a specific policy.
 
 `terraform-policies-list`
 
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -589,6 +607,10 @@ List the policy sets for an organization or get a specific policy set.
 #### Base Command
 
 `terraform-policy-set-list`
+
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
 
 #### Input
 
@@ -721,6 +743,10 @@ List the policy checks for a Terraform run.
 
 `terraform-policies-checks-list`
 
+#### Permissions
+
+This command requires a **User** or **Team** token that has admin level access to the workspace. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
+
 #### Input
 
 | **Argument Name** | **Description** | **Required** |
@@ -763,3 +789,42 @@ List the policy checks for a Terraform run.
 >### Terraform Policy Checks
 >
 >**No entries.**
+
+### terraform-get-events
+
+***
+Gets Terraform audit trail events. This command is supported in Cortex XSIAM only and is intended to be used for debugging purposes as it may result in duplicate events.
+
+#### Base Command
+
+`terraform-get-events`
+
+#### Permissions
+
+This command requires the `audit-logging` feature entitlement for the organization as well as an **Audit trail** or **Organization** token. Refer to [HashiCorp Terraform API Token Access Levels](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#access-levels).
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| from_date | The start date for the audit trails as a relative time expression (e.g., '3 days ago') or an absolute time in ISO 8601 format (e.g., '2025-09-01T00:00:00Z'). Default is 1 hour ago. | Optional |
+| limit | The maximum number of events to retrieve. Default is 10. | Optional |
+| should_push_events | If true, the command will push the events to the Cortex XSIAM dataset. Otherwise, it will only display them. Default is false. | Optional |
+
+#### Context Output
+
+There is no context output for this command.
+
+#### Command example
+
+```!terraform-get-events limit=2```
+
+#### Human Readable Output
+
+>### Terraform Audit Trail Events
+>
+>
+>| timestamp| id | version | type | auth | request |
+>| --- | --- | --- | --- | --- | --- |
+>| 2025-09-21T11:24:26.541Z | ae66e491-aaaa-457c-8445-9c908ee726aa | 0 | Resource | {"accessor_id": "user-xxxxxxxxxxxx", "description": "example-userA"} | {"id": "4df584d4-7e2a-aaaa-6cc0-4adbefa020e6"} |
+>| 2025-09-21T11:24:26.541Z | ae66e491-bbbb-457c-8445-9c908ee726bb | 0 | Resource | {"accessor_id": "user-yyyyyyyyyyyy", "description": "example-userB"} | {"id": "4df584d4-7e2a-bbbb-6cc0-4adbefa020e6"} |

--- a/Packs/HashiCorpTerraform/ReleaseNotes/1_1_0.md
+++ b/Packs/HashiCorpTerraform/ReleaseNotes/1_1_0.md
@@ -1,0 +1,15 @@
+
+#### Integrations
+
+##### HashiCorp Terraform
+
+<~XSIAM>
+
+- Added support for **Maximum Number of Audit Events Per Fetch** parameter.
+- Added support for **Fetch events** parameter.
+- Added support for **terraform-get-events** command that gets audit trail events using the HashiCorp Terraform API.
+
+<~/XSIAM>
+
+- Updated the Docker image to: *demisto/auth-utils:1.0.0.4578605*.
+- Minor code and documentation improvements.

--- a/Packs/HashiCorpTerraform/pack_metadata.json
+++ b/Packs/HashiCorpTerraform/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HashiCorp Terraform",
     "description": "Hashicorp Terraform provide infrastructure automation to provision and manage resources in any cloud or data center with Terraform.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.1.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-14311)

## Description
- Added support for **Maximum Number of Audit Events Per Fetch** parameter.
- Added support for **Fetch events** parameter.
- Added support for **terraform-get-events** command that gets audit trail events using the HashiCorp Terraform API.
- Updated the Docker image to: *demisto/auth-utils:1.0.0.4578605*.
- Minor code and documentation improvements.

## TO DO ‼️
- [ ] Tests
- [x] Documentation 
