### PR TITLE
Remove CheckPointFirewall_v2 integration from the default brands value in block-external-ip

### DIFF
--- a/Packs/AggregatedScripts/ReleaseNotes/1_1_16.md
+++ b/Packs/AggregatedScripts/ReleaseNotes/1_1_16.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### block-external-ip
+
+- Fixed an issue where running the **block-external-ip** script also triggered the unsupported integration CheckPointFirewall_v2, causing an error.

--- a/Packs/AggregatedScripts/Scripts/BlockExternalIp/BlockExternalIp.py
+++ b/Packs/AggregatedScripts/Scripts/BlockExternalIp/BlockExternalIp.py
@@ -798,7 +798,7 @@ def main():  # pragma: no cover
         brands_to_run = argToList(
             args.get(
                 "brands",
-                "Palo Alto Networks - Prisma SASE,Panorama,CheckPointFirewall_v2,FortiGate,F5Silverline,Cisco ASA,Zscaler",
+                "Palo Alto Networks - Prisma SASE,Panorama,FortiGate,F5Silverline,Cisco ASA,Zscaler",
             )
         )
         modules = demisto.getModules()

--- a/Packs/AggregatedScripts/pack_metadata.json
+++ b/Packs/AggregatedScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Aggregated Scripts",
     "description": "A pack containing all aggregated scripts.",
     "support": "xsoar",
-    "currentVersion": "1.1.15",
+    "currentVersion": "1.1.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Description
Remove CheckPointFirewall_v2 integration from the default brands value in block-external-ip.
Following this [PR](https://github.com/demisto/content/commit/a5d89b09df9eb9af678bdb8366ab71174c547c2a), the default value was removed from the YML so the script would instead use the default defined in the main function. However, the `CheckPointFirewall_v2` value was mistakenly left behind.
It was decided that this integration will not be supported for now (see [original ticket](https://jira-dc.paloaltonetworks.com/browse/CIAC-12409)), and there is a dedicated [ticket](https://jira-dc.paloaltonetworks.com/browse/CIAC-13370) planned for it.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/CIAC-14837)

## Must have
- [ ] Tests
- [ ] Documentation 
