### PR TITLE
feat: add Web Link field to ThreatConnect group list output

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -845,6 +845,7 @@ def list_groups(
         "AssociatedIndicators",
         "AssociatedGroups",
         "securityLabels",
+        "Web Link",
     ]
 
     for group in response.get("data"):
@@ -860,6 +861,7 @@ def list_groups(
                 "AssociatedIndicators": group.get("associatedIndicators"),
                 "AssociatedGroups": group.get("associatedGroups"),
                 "securityLabels": group.get("securityLabels"),
+                "Web Link": group.get("webLink", ""),
             }
         )
     context = {"TC.Groups(val.ID && val.ID === obj.ID)": content}

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.yml
@@ -2984,7 +2984,7 @@ script:
     - contextPath: TC.AttributeType.TC.AttributeType.validationRule.version
       description: The attribute type validation rule version.
       type: string
-  dockerimage: demisto/python3:3.12.11.4417419
+  dockerimage: demisto/python3:3.12.11.4819260
   isfetch: true
   script: ''
   subtype: python3

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_16.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_16.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ThreatConnect v3
+
+- Updated the Docker image to: *demisto/python3:3.12.11.4819260*.
+- Added the Web Link field to the Group object.

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "3.1.15",
+    "currentVersion": "3.1.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-55760)

## Description
Added "Web Link" to field to list group command output.