### PR TITLE
Fix: unhide email security search and delete command for playbook use

### DIFF
--- a/Packs/MicrosoftExchangeOnline/Integrations/SecurityAndComplianceV2/SecurityAndComplianceV2.yml
+++ b/Packs/MicrosoftExchangeOnline/Integrations/SecurityAndComplianceV2/SecurityAndComplianceV2.yml
@@ -1223,7 +1223,6 @@ script:
     name: o365-sc-case-hold-policy-set
   - name: o365-sc-email-security-search-and-delete-email-office-365-quick-action
     prettyname: "[Email Security] Search And Delete Email - Office 365"
-    hidden: true
     quickaction: true
     polling: true
     description: Deletes an email for all recipients.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A

## Description
This PR unhides the command o365-sc-email-security-search-and-delete-email-office-365-quick-action in the SecurityAndComplianceV2 integration YAML.

Removed hidden: true to allow this command to be used in standard Playbooks and Automations (previously limited to Quick Actions).

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc-proxy.xdr.pan.local/browse/CIAC-15598