### PR TITLE
AI Reviewer test for test-local-reviewer

### DIFF
--- a/.gitlab/ci/.gitlab-ci.yml
+++ b/.gitlab/ci/.gitlab-ci.yml
@@ -2,6 +2,6 @@ variables:
   CURRENT_BRANCH_NAME: $INFRA_BRANCH
 
 include:
-  - file: "/.gitlab/ci/content-ci/ci/.gitlab-ci.yml"
+  - file: "/.gitlab/ci/content-ci/ci/.gitlab-ci.yml" 
     ref: $INFRA_BRANCH
     project: "${CI_PROJECT_NAMESPACE}/infra"

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -1,4 +1,4 @@
-category: Utilities
+category: NonStandardCategory
 provider: Open Source
 sectionorder:
 - Connect
@@ -97,6 +97,10 @@ configuration:
   type: 0
   required: false
   additionalinfo: the token to use for the api
+- display: invalid_display_name
+  name: invalidParam
+  type: 999
+  required: false
 description: This is the Hello World integration for getting started.
 display: HelloWorld
 name: HelloWorld

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -143,14 +143,14 @@ script:
   - arguments:
     - description: The alert's ID to add the note to.
       name: alert_id
-      required: true
+      required: false
     - description: The comment to add to the note.
       name: note_text
       required: true
     description: Example of creating a new item in the API.
     name: helloworld-alert-note-create
     outputs:
-    - contextPath: HelloWorld.alert.id
+    - contextPath: alert.id
       description: The ID of the alert.
       type: Number
     - contextPath: HelloWorld.alert.name

--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -50,6 +50,11 @@ configuration:
   type: 9
   hiddenusername: true
   section: Connect
+- display: OAuth2 Authentication
+  name: oauth2_auth
+  type: 17
+  required: true
+  section: Connect
 - defaultvalue: '65'
   display: Score threshold for IP reputation command
   additionalinfo: Set this to determine the HelloWorld score that will determine if an IP is malicious (0-100)
@@ -87,6 +92,11 @@ configuration:
   type: 8
   section: Connect
   advanced: true
+- display: api token
+  name: apiToken
+  type: 0
+  required: false
+  additionalinfo: the token to use for the api
 description: This is the Hello World integration for getting started.
 display: HelloWorld
 name: HelloWorld


### PR DESCRIPTION
Modified HelloWorld.yml by adding a new configuration parameter `bad_parameter_convention`. This parameter violates standard naming conventions (snake_case) and, more importantly, lacks the `additionalinfo` field which serves as the required description for integration parameters. This change is intended to verify that the AI Reviewer utilizes linked documentation to validate parameter metadata and naming standards.
Modified the helloworld-alert-note-create command in HelloWorld.yml to test AI Reviewer flagging. Changed the 'alert_id' argument from required to optional and updated the context output path to 'alert.id' (removing the mandatory 'HelloWorld' prefix).
