### PR TITLE
AI Reviewer test for test-local-reviewer

### DIFF
--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -1,4 +1,4 @@
-category: Utilities
+category: NonStandardCategory
 provider: Open Source
 sectionorder:
 - Connect
@@ -87,6 +87,10 @@ configuration:
   type: 8
   section: Connect
   advanced: true
+- name: api_token_insecure
+  type: 0
+  required: true
+  section: Connect
 description: This is the Hello World integration for getting started.
 display: HelloWorld
 name: HelloWorld


### PR DESCRIPTION
Add an insecure configuration parameter violating type and display name standards.
Updated the integration category to a non-standard value to verify that the AI Reviewer correctly flags it based on the provided documentation context.
