### PR TITLE
Added check if the endpoint starts with /platform in Core REST API

### DIFF
--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -74,10 +74,13 @@ getRequestURL = function (uri) {
     var requestUrl = serverURL;
 
     // only when using XSIAM or XSOAR >= 8.0 we will add the /xsoar suffix
-    // and only when it is not a /public_api endpoint.
+    // and only when it is not a /public_api or /platform endpoint.
     if (isHosted()) {
-        if ((!serverURL.endsWith('/xsoar')) && (!uri.startsWith('/public_api'))) {
-            requestUrl += '/xsoar'
+        var isPublicApi = uri.startsWith('/public_api');
+        var isPlatformApi = uri.startsWith('/platform');
+
+        if (!serverURL.endsWith('/xsoar') && !isPublicApi && !isPlatformApi) {
+            requestUrl += '/xsoar';
         }
     }
     if (params.use_tenant){
@@ -87,7 +90,7 @@ getRequestURL = function (uri) {
         requestUrl += '/';
     }
     requestUrl += uri;
-    return requestUrl
+    return requestUrl;
 }
 
 sendMultipart = function (uri, entryID, body) {

--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -78,8 +78,9 @@ getRequestURL = function (uri) {
     if (isHosted()) {
         const isPublicApi = uri.startsWith('/public_api');
         const isPlatformApi = uri.startsWith('/platform');
+        const isXsoar = serverURL.endsWith('/xsoar');
 
-        if (!serverURL.endsWith('/xsoar') && !isPublicApi && !isPlatformApi) {
+        if (!isXsoar && !isPublicApi && !isPlatformApi) {
             requestUrl += '/xsoar';
         }
     }

--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -76,8 +76,8 @@ getRequestURL = function (uri) {
     // only when using XSIAM or XSOAR >= 8.0 we will add the /xsoar suffix
     // and only when it is not a /public_api or /platform endpoint.
     if (isHosted()) {
-        var isPublicApi = uri.startsWith('/public_api');
-        var isPlatformApi = uri.startsWith('/platform');
+        const isPublicApi = uri.startsWith('/public_api');
+        const isPlatformApi = uri.startsWith('/platform');
 
         if (!serverURL.endsWith('/xsoar') && !isPublicApi && !isPlatformApi) {
             requestUrl += '/xsoar';


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
N/A - Couldn't find one at the moment. Can open one if needed.

## Description
Currently in XSIAM, if API the endpoint being called starts with /platform and the user is attempting to make the api call using the Core REST API integration (such as using the core-api-get command), the integration adds the /xsoar path into the URI, making the call invalid. Made changes to the `getRequestURL` function to include this additional check.

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16010