### PR TITLE
Xsup 64444/arcsight v79 no namespace support

### DIFF
--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -250,7 +250,7 @@ def login():
 
         if demisto.command() not in ["test-module", "fetch-incidents"]:
             # this is done to bypass setting integration context outside of the cli
-            demisto.setIntegrationContext({"auth_token": auth_token})
+            demisto.setIntegrationContext({"auth_token": auth_token, "is_v7_9": IS_V7_9})
         return auth_token
     except ValueError:
         return_error("Failed to login. Please check integration parameters")
@@ -1046,7 +1046,12 @@ def main():
     use_rest = demisto.params().get("use_rest", False)
 
     global AUTH_TOKEN
-    AUTH_TOKEN = demisto.getIntegrationContext().get("auth_token") or login()
+    integration_context = demisto.getIntegrationContext()
+    AUTH_TOKEN = integration_context.get("auth_token") or login()
+    
+    global IS_V7_9
+    # At this point, login() has already been called, and is_v7_9 is set within the login() function.
+    IS_V7_9 = integration_context.get("is_v7_9", False)
 
     use_detect_api = demisto.params().get("productVersion") == "7.4 and above"
 

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -1048,7 +1048,7 @@ def main():
     global AUTH_TOKEN
     integration_context = demisto.getIntegrationContext()
     AUTH_TOKEN = integration_context.get("auth_token") or login()
-    
+
     global IS_V7_9
     # At this point, login() has already been called, and is_v7_9 is set within the login() function.
     IS_V7_9 = integration_context.get("is_v7_9", False)

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -235,14 +235,23 @@ def login():
 
     try:
         res_json = parse_json_response(res)
-        if "log.loginResponse" in res_json and "log.return" in res_json.get("log.loginResponse"):
-            auth_token = res_json.get("log.loginResponse").get("log.return")
-            if demisto.command() not in ["test-module", "fetch-incidents"]:
-                # this is done to bypass setting integration context outside of the cli
-                demisto.setIntegrationContext({"auth_token": auth_token})
-            return auth_token
+        global IS_V7_9
+        # ArcSight 7.9+ (no namespaces)
+        if "loginResponse" in res_json and "return" in res_json.get("loginResponse", {}):
+            auth_token = res_json["loginResponse"]["return"]
+            IS_V7_9 = True
+        # Legacy ArcSight (with namespaces)
+        elif "log.loginResponse" in res_json and "log.return" in res_json.get("log.loginResponse", {}):
+            auth_token = res_json["log.loginResponse"]["log.return"]
+            IS_V7_9 = False
+        else:
+            return_error("Failed to login. Have not received token after login")
+            return None
 
-        return_error("Failed to login. Have not received token after login")
+        if demisto.command() not in ["test-module", "fetch-incidents"]:
+            # this is done to bypass setting integration context outside of the cli
+            demisto.setIntegrationContext({"auth_token": auth_token})
+        return auth_token
     except ValueError:
         return_error("Failed to login. Please check integration parameters")
 
@@ -311,13 +320,18 @@ def get_query_viewer_results(query_viewer_id):
     return_object = None
     res_json = parse_json_response(res)
 
-    if "qvs.getMatrixDataResponse" in res_json and "qvs.return" in res_json["qvs.getMatrixDataResponse"]:
-        # ArcSight ESM version 6.7 & 6.9 rest API supports qvs.getMatrixDataResponse
-        return_object = res_json.get("qvs.getMatrixDataResponse").get("qvs.return")
+    qvs_resp_key = _ns_key("qvs", "getMatrixDataResponse")
+    qvs_ret_key = _ns_key("qvs", "return")
+    que_resp_key = _ns_key("que", "getMatrixDataResponse")
+    que_ret_key = _ns_key("que", "return")
 
-    elif "que.getMatrixDataResponse" in res_json and "que.return" in res_json["que.getMatrixDataResponse"]:
+    if qvs_resp_key in res_json and qvs_ret_key in res_json[qvs_resp_key]:
+        # ArcSight ESM version 6.7 & 6.9 rest API supports qvs.getMatrixDataResponse
+        return_object = res_json[qvs_resp_key][qvs_ret_key]
+
+    elif que_resp_key in res_json and que_ret_key in res_json[que_resp_key]:
         # ArcSight ESM version 6.1 rest API supports que.getMatrixDataResponse
-        return_object = res_json.get("que.getMatrixDataResponse").get("que.return")
+        return_object = res_json[que_resp_key][que_ret_key]
 
     else:
         return_error("Invalid response structure. Open ticket to Demisto support and attach the logs")
@@ -485,8 +499,10 @@ def get_case(resource_id, fetch_base_events=False):
             return_error(f"Failed to get case. StatusCode: {res.status_code}")
 
     res_json = parse_json_response(res)
-    if "cas.getResourceByIdResponse" in res_json and "cas.return" in res_json.get("cas.getResourceByIdResponse"):
-        case = res_json.get("cas.getResourceByIdResponse").get("cas.return")
+    cas_resp_key = _ns_key("cas", "getResourceByIdResponse")
+    cas_ret_key = _ns_key("cas", "return")
+    if cas_resp_key in res_json and cas_ret_key in res_json.get(cas_resp_key, {}):
+        case = res_json[cas_resp_key][cas_ret_key]
 
         if case.get("eventIDs") and not isinstance(case["eventIDs"], list):
             # if eventIDs is single id then convert to list
@@ -538,7 +554,9 @@ def get_all_cases_command():
         return_error(f"Failed to get case list. StatusCode: {res.status_code}")
 
     res_json = parse_json_response(res)
-    contents = res_json.get("cas.findAllIdsResponse").get("cas.return")
+    cas_resp_key = _ns_key("cas", "findAllIdsResponse")
+    cas_ret_key = _ns_key("cas", "return")
+    contents = res_json.get(cas_resp_key, {}).get(cas_ret_key)
     human_readable = tableToMarkdown(name="All cases", headers="caseID", t=contents, removeNull=True)
     outputs = {"ArcSightESM.AllCaseIDs": contents}
     return_outputs(readable_output=human_readable, outputs=outputs, raw_response=contents)
@@ -583,11 +601,11 @@ def get_security_events(event_ids, last_date_range=None, ignore_empty=False):
     query_path = "www/manager-service/rest/SecurityEventService/getSecurityEvents"
     params = {"alt": "json"}
     json_ = {
-        "sev.getSecurityEvents": {
-            "sev.authToken": AUTH_TOKEN,
-            "sev.ids": event_ids,
-            "sev.startMillis": start_time,
-            "sev.endMillis": end_time,
+        _ns_key("sev", "getSecurityEvents"): {
+            _ns_key("sev", "authToken"): AUTH_TOKEN,
+            _ns_key("sev", "ids"): event_ids,
+            _ns_key("sev", "startMillis"): start_time,
+            _ns_key("sev", "endMillis"): end_time,
         }
     }
     res = send_request(query_path, json=json_, params=params)
@@ -600,8 +618,10 @@ def get_security_events(event_ids, last_date_range=None, ignore_empty=False):
         )
 
     res_json = parse_json_response(res)
-    if res_json.get("sev.getSecurityEventsResponse") and res_json.get("sev.getSecurityEventsResponse").get("sev.return"):
-        events = res_json.get("sev.getSecurityEventsResponse").get("sev.return")
+    sev_resp_key = _ns_key("sev", "getSecurityEventsResponse")
+    sev_ret_key = _ns_key("sev", "return")
+    if res_json.get(sev_resp_key) and res_json.get(sev_resp_key).get(sev_ret_key):
+        events = res_json[sev_resp_key][sev_ret_key]
         return events if isinstance(events, list) else [events]
 
     demisto.debug(res.text)
@@ -644,9 +664,9 @@ def update_case(case_id, stage, severity):
     query_path = "www/manager-service/rest/CaseService/update"
     params = {"alt": "json"}
     json_ = {
-        "cas.update": {
-            "cas.authToken": AUTH_TOKEN,
-            "cas.resource": case,
+        _ns_key("cas", "update"): {
+            _ns_key("cas", "authToken"): AUTH_TOKEN,
+            _ns_key("cas", "resource"): case,
         }
     }
     res = send_request(query_path, json=json_, params=params)
@@ -659,7 +679,9 @@ def update_case(case_id, stage, severity):
         )
 
     res_json = parse_json_response(res)
-    if "cas.updateResponse" in res_json and "cas.return" in res_json.get("cas.updateResponse"):
+    cas_upd_resp_key = _ns_key("cas", "updateResponse")
+    cas_upd_ret_key = _ns_key("cas", "return")
+    if cas_upd_resp_key in res_json and cas_upd_ret_key in res_json.get(cas_upd_resp_key, {}):
         return case
 
     return_error(f"Failed to update case, fail to parse response. Response Body: {res.text}")
@@ -696,8 +718,10 @@ def get_case_event_ids_command():
         return_error(f"Failed to get Event IDs with:\nStatus Code: {res.status_code}\nResponse: {res.text}")
 
     res_json = parse_json_response(res)
-    if "cas.getCaseEventIDsResponse" in res_json and "cas.return" in res_json.get("cas.getCaseEventIDsResponse"):
-        event_ids = res_json.get("cas.getCaseEventIDsResponse").get("cas.return")
+    cas_evt_resp_key = _ns_key("cas", "getCaseEventIDsResponse")
+    cas_evt_ret_key = _ns_key("cas", "return")
+    if cas_evt_resp_key in res_json and cas_evt_ret_key in res_json.get(cas_evt_resp_key, {}):
+        event_ids = res_json[cas_evt_resp_key][cas_evt_ret_key]
         if not isinstance(event_ids, list):
             event_ids = [event_ids]
 
@@ -717,7 +741,12 @@ def delete_case_command():
     case_id = demisto.args().get("caseId")
 
     query_path = "www/manager-service/rest/CaseService/deleteByUUID"
-    req_body = json.dumps({"cas.deleteByUUID": {"cas.authToken": AUTH_TOKEN, "cas.id": case_id}})
+    req_body = json.dumps({
+        _ns_key("cas", "deleteByUUID"): {
+            _ns_key("cas", "authToken"): AUTH_TOKEN,
+            _ns_key("cas", "id"): case_id,
+        }
+    })
     params = {"alt": "json"}
     res = send_request(query_path, params=params, body=req_body)
     if not res.ok:
@@ -740,9 +769,9 @@ def get_entries_command(use_rest, args):
         query_path = "www/manager-service/rest/ActiveListService/getEntries"
         params = {"alt": "json"}
         body = {
-            "act.getEntries": {
-                "act.authToken": AUTH_TOKEN,
-                "act.resourceId": resource_id,
+            _ns_key("act", "getEntries"): {
+                _ns_key("act", "authToken"): AUTH_TOKEN,
+                _ns_key("act", "resourceId"): resource_id,
             }
         }  # type: Union[str, Dict[str, Dict[str, Any]]]
         res = send_request(query_path, json=body, params=params)
@@ -760,7 +789,9 @@ def get_entries_command(use_rest, args):
 
     if use_rest:
         res_json = parse_json_response(res)
-        raw_entries = res_json.get("act.getEntriesResponse", {}).get("act.return", {})
+        act_resp_key = _ns_key("act", "getEntriesResponse")
+        act_ret_key = _ns_key("act", "return")
+        raw_entries = res_json.get(act_resp_key, {}).get(act_ret_key, {})
     else:
         res_json = json.loads(xml2json((res.text).encode("utf-8")))
         raw_entries = demisto.get(res_json, "Envelope.Body.getEntriesResponse.return")
@@ -811,9 +842,9 @@ def clear_entries_command(use_rest, args):
         query_path = "www/manager-service/rest/ActiveListService/clearEntries"
         params = {"alt": "json"}
         body = {
-            "act.clearEntries": {
-                "act.authToken": AUTH_TOKEN,
-                "act.resourceId": resource_id,
+            _ns_key("act", "clearEntries"): {
+                _ns_key("act", "authToken"): AUTH_TOKEN,
+                _ns_key("act", "resourceId"): resource_id,
             }
         }  # type: Union[str, Dict[str, Dict[str, Any]]]
         res = send_request(query_path, json=body, params=params)
@@ -919,8 +950,10 @@ def get_all_query_viewers_command():
         return_error(f"Failed to get query viewers:\nStatus Code: {res.status_code}\nResponse: {res.text}")
 
     res_json = parse_json_response(res)
-    if "qvs.findAllIdsResponse" in res_json and "qvs.return" in res_json.get("qvs.findAllIdsResponse"):
-        query_viewers = res_json.get("qvs.findAllIdsResponse").get("qvs.return")
+    qvs_resp_key = _ns_key("qvs", "findAllIdsResponse")
+    qvs_ret_key = _ns_key("qvs", "return")
+    if qvs_resp_key in res_json and qvs_ret_key in res_json.get(qvs_resp_key, {}):
+        query_viewers = res_json[qvs_resp_key][qvs_ret_key]
 
         contents = decode_arcsight_output(query_viewers)
         outputs = {"ArcSightESM.AllQueryViewers": contents}
@@ -978,6 +1011,18 @@ MAX_UNIQUE: int
 FETCH_CHUNK_SIZE: int
 BASE_URL: str
 VERIFY_CERTIFICATE: bool
+IS_V7_9: bool = False
+
+
+def _ns_key(prefix: str, key: str) -> str:
+    """Return the namespaced or plain key depending on the ArcSight version.
+
+    ArcSight ESM v7.9+ removed XML-style namespace prefixes from REST API keys.
+    This helper returns the correct key format based on auto-detection during login.
+    """
+    if IS_V7_9:
+        return key
+    return f"{prefix}.{key}"
 
 
 def main():

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -741,12 +741,14 @@ def delete_case_command():
     case_id = demisto.args().get("caseId")
 
     query_path = "www/manager-service/rest/CaseService/deleteByUUID"
-    req_body = json.dumps({
-        _ns_key("cas", "deleteByUUID"): {
-            _ns_key("cas", "authToken"): AUTH_TOKEN,
-            _ns_key("cas", "id"): case_id,
+    req_body = json.dumps(
+        {
+            _ns_key("cas", "deleteByUUID"): {
+                _ns_key("cas", "authToken"): AUTH_TOKEN,
+                _ns_key("cas", "id"): case_id,
+            }
         }
-    })
+    )
     params = {"alt": "json"}
     res = send_request(query_path, params=params, body=req_body)
     if not res.ok:

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.py
@@ -236,21 +236,29 @@ def login():
     try:
         res_json = parse_json_response(res)
         global IS_V7_9
-        # ArcSight 7.9+ (no namespaces)
+
         if "loginResponse" in res_json and "return" in res_json.get("loginResponse", {}):
+            demisto.debug("[login] Using ArcSight 7.9+ API (no namespaces)")
             auth_token = res_json["loginResponse"]["return"]
             IS_V7_9 = True
-        # Legacy ArcSight (with namespaces)
+
         elif "log.loginResponse" in res_json and "log.return" in res_json.get("log.loginResponse", {}):
+            demisto.debug("[login] Using Legacy ArcSight API (with namespaces)")
             auth_token = res_json["log.loginResponse"]["log.return"]
             IS_V7_9 = False
         else:
             return_error("Failed to login. Have not received token after login")
             return None
 
+        init_integration_context = demisto.getIntegrationContext()
+        init_integration_context["is_v7_9"] = IS_V7_9
+
         if demisto.command() not in ["test-module", "fetch-incidents"]:
             # this is done to bypass setting integration context outside of the cli
-            demisto.setIntegrationContext({"auth_token": auth_token, "is_v7_9": IS_V7_9})
+            init_integration_context["auth_token"] = auth_token
+
+        demisto.setIntegrationContext(init_integration_context)
+        demisto.debug(f"[login] Successfully logged in. Set IS_V7_9 to {IS_V7_9}")
         return auth_token
     except ValueError:
         return_error("Failed to login. Please check integration parameters")
@@ -1013,7 +1021,7 @@ MAX_UNIQUE: int
 FETCH_CHUNK_SIZE: int
 BASE_URL: str
 VERIFY_CERTIFICATE: bool
-IS_V7_9: bool = False
+IS_V7_9: bool
 
 
 def _ns_key(prefix: str, key: str) -> str:
@@ -1046,12 +1054,12 @@ def main():
     use_rest = demisto.params().get("use_rest", False)
 
     global AUTH_TOKEN
-    integration_context = demisto.getIntegrationContext()
-    AUTH_TOKEN = integration_context.get("auth_token") or login()
+    AUTH_TOKEN = demisto.getIntegrationContext().get("auth_token") or login()
 
     global IS_V7_9
-    # At this point, login() has already been called, and is_v7_9 is set within the login() function.
-    IS_V7_9 = integration_context.get("is_v7_9", False)
+    # Re-read integration context AFTER potential login() call, which updates is_v7_9 flag
+    IS_V7_9 = demisto.getIntegrationContext().get("is_v7_9", False)
+    demisto.debug(f"[main] IS_V7_9 set to {IS_V7_9}")
 
     use_detect_api = demisto.params().get("productVersion") == "7.4 and above"
 

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2.yml
@@ -384,7 +384,7 @@ script:
   runonce: false
   script: '-'
   subtype: python3
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/python3:3.12.12.7090913
   type: python
 tests:
 - ArcSight ESM v2 Test

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 import requests
 from ArcSightESMv2 import parse_json_response, repair_malformed_json
+import ArcSightESMv2
 import demistomock as demisto
 import pytest
 import requests_mock
@@ -33,6 +34,14 @@ test_data = [
     (True, "as-clear-entries", "https://server/www/manager-service/rest/ActiveListService/clearEntries?alt=json"),
     (False, "as-clear-entries", "https://server/www/manager-service/services/ActiveListService/"),
 ]
+
+
+@pytest.fixture(autouse=True)
+def reset_v79_flag():
+    """Reset IS_V7_9 to False before each test to ensure legacy mode by default."""
+    ArcSightESMv2.IS_V7_9 = False
+    yield
+    ArcSightESMv2.IS_V7_9 = False
 
 
 @pytest.mark.parametrize("use_rest, cmd_name, expected_rest_endpoint", test_data)
@@ -577,3 +586,337 @@ def test_unfixable_json_response():
     unfixable_response._content = b'{"key": "value"'  # Missing closing brace
     with pytest.raises(json.JSONDecodeError):
         parse_json_response(unfixable_response)
+
+
+# ===================== v7.9 No-Namespace Support Tests =====================
+
+
+def test_ns_key_helper():
+    """Test _ns_key() returns correct keys for both legacy and v7.9 modes.
+
+    Given:
+        - The _ns_key helper function
+
+    When:
+        - IS_V7_9 is False (legacy mode)
+        - IS_V7_9 is True (v7.9 mode)
+
+    Then:
+        - Legacy mode returns 'prefix.key'
+        - v7.9 mode returns just 'key'
+    """
+    ArcSightESMv2.IS_V7_9 = False
+    assert ArcSightESMv2._ns_key("cas", "return") == "cas.return"
+    assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "sev.getSecurityEvents"
+    assert ArcSightESMv2._ns_key("log", "loginResponse") == "log.loginResponse"
+
+    ArcSightESMv2.IS_V7_9 = True
+    assert ArcSightESMv2._ns_key("cas", "return") == "return"
+    assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "getSecurityEvents"
+    assert ArcSightESMv2._ns_key("log", "loginResponse") == "loginResponse"
+
+
+def test_login_v79_no_namespace(mocker, requests_mock):
+    """Verify login succeeds with v7.9 no-namespace response and sets IS_V7_9 = True.
+
+    Given:
+        - ArcSight ESM v7.9 login endpoint returns {"loginResponse": {"return": "token"}}
+
+    When:
+        - login() is called
+
+    Then:
+        - The auth token is returned
+        - IS_V7_9 is set to True
+    """
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+    mocker.patch.object(demisto, "setIntegrationContext")
+
+    requests_mock.post(
+        PARAMS["server"] + "/www/core-service/rest/LoginService/login",
+        json={"loginResponse": {"return": "v79_token"}},
+    )
+
+    ArcSightESMv2.IS_V7_9 = False
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    token = ArcSightESMv2.login()
+    assert token == "v79_token"
+    assert ArcSightESMv2.IS_V7_9 is True
+
+
+def test_login_legacy_namespace(mocker, requests_mock):
+    """Verify login succeeds with legacy namespaced response and sets IS_V7_9 = False.
+
+    Given:
+        - Legacy ArcSight ESM login endpoint returns {"log.loginResponse": {"log.return": "token"}}
+
+    When:
+        - login() is called
+
+    Then:
+        - The auth token is returned
+        - IS_V7_9 is set to False
+    """
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+    mocker.patch.object(demisto, "setIntegrationContext")
+
+    requests_mock.post(
+        PARAMS["server"] + "/www/core-service/rest/LoginService/login",
+        json={"log.loginResponse": {"log.return": "legacy_token"}},
+    )
+
+    ArcSightESMv2.IS_V7_9 = True  # Start as True to verify it gets set to False
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    token = ArcSightESMv2.login()
+    assert token == "legacy_token"
+    assert ArcSightESMv2.IS_V7_9 is False
+
+
+def test_get_case_v79(mocker, requests_mock):
+    """Verify get_case() works with v7.9 no-namespace response.
+
+    Given:
+        - ArcSight ESM v7.9 returns case data without namespace prefixes
+
+    When:
+        - get_case() is called
+
+    Then:
+        - The case data is correctly parsed from the no-namespace response
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    requests_mock.get(
+        PARAMS["server"] + "/www/manager-service/rest/CaseService/getResourceById",
+        json={
+            "getResourceByIdResponse": {
+                "return": {
+                    "name": "Test Case v79",
+                    "resourceid": "abc123",
+                    "createdTimestamp": 1629097454417,
+                }
+            }
+        },
+    )
+
+    case = ArcSightESMv2.get_case("abc123")
+    assert case["name"] == "Test Case v79"
+    assert case["resourceid"] == "abc123"
+
+
+def test_get_all_cases_v79(mocker, requests_mock):
+    """Verify get_all_cases_command() works with v7.9 no-namespace response.
+
+    Given:
+        - ArcSight ESM v7.9 returns case IDs without namespace prefixes
+
+    When:
+        - get_all_cases_command() is called
+
+    Then:
+        - The case IDs are correctly parsed
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "results")
+    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    requests_mock.get(
+        PARAMS["server"] + "/www/manager-service/rest/CaseService/findAllIds",
+        json={
+            "findAllIdsResponse": {
+                "return": ["case1", "case2", "case3"]
+            }
+        },
+    )
+
+    ArcSightESMv2.get_all_cases_command()
+    results = demisto.results.call_args[0][0]
+    cases = results["Contents"]
+    assert len(cases) == 3
+    assert cases[0] == "case1"
+
+
+def test_get_security_events_v79(mocker, requests_mock):
+    """Verify get_security_events() uses no-namespace keys in request and parses response correctly.
+
+    Given:
+        - ArcSight ESM v7.9 mode is active
+
+    When:
+        - get_security_events() is called
+
+    Then:
+        - Request body uses no-namespace keys
+        - Response is correctly parsed from no-namespace format
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    post_mock = requests_mock.post(
+        PARAMS["server"] + "/www/manager-service/rest/SecurityEventService/getSecurityEvents",
+        json={
+            "getSecurityEventsResponse": {
+                "return": [
+                    {"eventId": 12345, "name": "Test Event v79"}
+                ]
+            }
+        },
+    )
+
+    events = ArcSightESMv2.get_security_events(["12345"])
+    assert events is not None
+    assert len(events) == 1
+    assert events[0]["name"] == "Test Event v79"
+
+    # Verify request body uses no-namespace keys
+    request_body = post_mock.last_request.json()
+    assert "getSecurityEvents" in request_body
+    assert "authToken" in request_body["getSecurityEvents"]
+    assert "ids" in request_body["getSecurityEvents"]
+
+
+def test_get_query_viewer_results_v79(mocker, requests_mock):
+    """Verify get_query_viewer_results() works with v7.9 no-namespace response.
+
+    Given:
+        - ArcSight ESM v7.9 returns query viewer data without namespace prefixes
+
+    When:
+        - get_query_viewer_results() is called
+
+    Then:
+        - The data is correctly parsed
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    requests_mock.get(
+        PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/getMatrixData",
+        json={
+            "getMatrixDataResponse": {
+                "return": {
+                    "columnHeaders": ["ID", "Name"],
+                    "rows": [
+                        {
+                            "@xsi.type": "listWrapper",
+                            "value": [
+                                {"@xsi.type": "xs:string", "$": "id1"},
+                                {"@xsi.type": "xs:string", "$": "name1"},
+                            ],
+                        }
+                    ],
+                }
+            }
+        },
+    )
+
+    fields, results = ArcSightESMv2.get_query_viewer_results("test_qv_id")
+    assert fields == ["ID", "Name"]
+    assert len(results) == 1
+    assert results[0]["ID"] == "id1"
+    assert results[0]["Name"] == "name1"
+
+
+def test_get_case_event_ids_v79(mocker, requests_mock):
+    """Verify get_case_event_ids_command() works with v7.9 no-namespace response.
+
+    Given:
+        - ArcSight ESM v7.9 returns case event IDs without namespace prefixes
+
+    When:
+        - get_case_event_ids_command() is called
+
+    Then:
+        - The event IDs are correctly parsed
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "results")
+    mocker.patch.object(demisto, "command", return_value="as-get-case-event-ids")
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+    mocker.patch.object(demisto, "args", return_value={"caseId": "case1", "withCorrelatedEvents": "false"})
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    requests_mock.get(
+        PARAMS["server"] + "/www/manager-service/rest/CaseService/getCaseEventIDs",
+        json={
+            "getCaseEventIDsResponse": {
+                "return": [111, 222, 333]
+            }
+        },
+    )
+
+    ArcSightESMv2.get_case_event_ids_command()
+    results = demisto.results.call_args[0][0]
+    event_ids = results["Contents"]["getCaseEventIDsResponse"]["return"]
+    assert len(event_ids) == 3
+    assert event_ids[0] == 111
+
+
+def test_get_all_query_viewers_v79(mocker, requests_mock):
+    """Verify get_all_query_viewers_command() works with v7.9 no-namespace response.
+
+    Given:
+        - ArcSight ESM v7.9 returns query viewer IDs without namespace prefixes
+
+    When:
+        - get_all_query_viewers_command() is called
+
+    Then:
+        - The query viewer IDs are correctly parsed
+    """
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+    mocker.patch.object(demisto, "results")
+    mocker.patch.object(demisto, "command", return_value="as-get-all-query-viewers")
+    mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+    ArcSightESMv2.IS_V7_9 = True
+    ArcSightESMv2.AUTH_TOKEN = "token"
+    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+    ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+    requests_mock.post(
+        PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/findAllIds",
+        json={
+            "findAllIdsResponse": {
+                "return": ["qv1", "qv2", "qv3"]
+            }
+        },
+    )
+
+    ArcSightESMv2.get_all_query_viewers_command()
+    results = demisto.results.call_args[0][0]
+    output = results["Contents"]
+    assert len(output) == 3
+    assert output[0] == "qv1"

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -696,7 +696,8 @@ class TestV79VersionDetection:
             - login() is NOT called
         """
         mocker.patch.object(
-            demisto, "getIntegrationContext",
+            demisto,
+            "getIntegrationContext",
             return_value={"auth_token": "cached_token", "is_v7_9": True},
         )
         mocker.patch.object(demisto, "params", return_value=PARAMS)
@@ -726,7 +727,8 @@ class TestV79VersionDetection:
             - login() is NOT called
         """
         mocker.patch.object(
-            demisto, "getIntegrationContext",
+            demisto,
+            "getIntegrationContext",
             return_value={"auth_token": "cached_token", "is_v7_9": False},
         )
         mocker.patch.object(demisto, "params", return_value=PARAMS)
@@ -756,7 +758,8 @@ class TestV79VersionDetection:
             - login() is NOT called
         """
         mocker.patch.object(
-            demisto, "getIntegrationContext",
+            demisto,
+            "getIntegrationContext",
             return_value={"auth_token": "cached_token"},
         )
         mocker.patch.object(demisto, "params", return_value=PARAMS)

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -740,11 +740,7 @@ def test_get_all_cases_v79(mocker, requests_mock):
 
     requests_mock.get(
         PARAMS["server"] + "/www/manager-service/rest/CaseService/findAllIds",
-        json={
-            "findAllIdsResponse": {
-                "return": ["case1", "case2", "case3"]
-            }
-        },
+        json={"findAllIdsResponse": {"return": ["case1", "case2", "case3"]}},
     )
 
     ArcSightESMv2.get_all_cases_command()
@@ -777,13 +773,7 @@ def test_get_security_events_v79(mocker, requests_mock):
 
     post_mock = requests_mock.post(
         PARAMS["server"] + "/www/manager-service/rest/SecurityEventService/getSecurityEvents",
-        json={
-            "getSecurityEventsResponse": {
-                "return": [
-                    {"eventId": 12345, "name": "Test Event v79"}
-                ]
-            }
-        },
+        json={"getSecurityEventsResponse": {"return": [{"eventId": 12345, "name": "Test Event v79"}]}},
     )
 
     events = ArcSightESMv2.get_security_events(["12345"])
@@ -870,11 +860,7 @@ def test_get_case_event_ids_v79(mocker, requests_mock):
 
     requests_mock.get(
         PARAMS["server"] + "/www/manager-service/rest/CaseService/getCaseEventIDs",
-        json={
-            "getCaseEventIDsResponse": {
-                "return": [111, 222, 333]
-            }
-        },
+        json={"getCaseEventIDsResponse": {"return": [111, 222, 333]}},
     )
 
     ArcSightESMv2.get_case_event_ids_command()
@@ -908,11 +894,7 @@ def test_get_all_query_viewers_v79(mocker, requests_mock):
 
     requests_mock.post(
         PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/findAllIds",
-        json={
-            "findAllIdsResponse": {
-                "return": ["qv1", "qv2", "qv3"]
-            }
-        },
+        json={"findAllIdsResponse": {"return": ["qv1", "qv2", "qv3"]}},
     )
 
     ArcSightESMv2.get_all_query_viewers_command()

--- a/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
+++ b/Packs/ArcSightESM/Integrations/ArcSightESMv2/ArcSightESMv2_test.py
@@ -591,314 +591,403 @@ def test_unfixable_json_response():
 # ===================== v7.9 No-Namespace Support Tests =====================
 
 
-def test_ns_key_helper():
-    """Test _ns_key() returns correct keys for both legacy and v7.9 modes.
+class TestV79VersionDetection:
+    """Tests for ArcSight ESM v7.9 version detection, context persistence, and namespace handling."""
 
-    Given:
-        - The _ns_key helper function
+    def test_ns_key_helper(self):
+        """Test _ns_key() returns correct keys for both legacy and v7.9 modes.
 
-    When:
-        - IS_V7_9 is False (legacy mode)
-        - IS_V7_9 is True (v7.9 mode)
+        Given:
+            - The _ns_key helper function
 
-    Then:
-        - Legacy mode returns 'prefix.key'
-        - v7.9 mode returns just 'key'
-    """
-    ArcSightESMv2.IS_V7_9 = False
-    assert ArcSightESMv2._ns_key("cas", "return") == "cas.return"
-    assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "sev.getSecurityEvents"
-    assert ArcSightESMv2._ns_key("log", "loginResponse") == "log.loginResponse"
+        When:
+            - IS_V7_9 is False (legacy mode)
+            - IS_V7_9 is True (v7.9 mode)
 
-    ArcSightESMv2.IS_V7_9 = True
-    assert ArcSightESMv2._ns_key("cas", "return") == "return"
-    assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "getSecurityEvents"
-    assert ArcSightESMv2._ns_key("log", "loginResponse") == "loginResponse"
+        Then:
+            - Legacy mode returns 'prefix.key'
+            - v7.9 mode returns just 'key'
+        """
+        ArcSightESMv2.IS_V7_9 = False
+        assert ArcSightESMv2._ns_key("cas", "return") == "cas.return"
+        assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "sev.getSecurityEvents"
+        assert ArcSightESMv2._ns_key("log", "loginResponse") == "log.loginResponse"
 
+        ArcSightESMv2.IS_V7_9 = True
+        assert ArcSightESMv2._ns_key("cas", "return") == "return"
+        assert ArcSightESMv2._ns_key("sev", "getSecurityEvents") == "getSecurityEvents"
+        assert ArcSightESMv2._ns_key("log", "loginResponse") == "loginResponse"
 
-def test_login_v79_no_namespace(mocker, requests_mock):
-    """Verify login succeeds with v7.9 no-namespace response and sets IS_V7_9 = True.
+    def test_login_v79_no_namespace(self, mocker, requests_mock):
+        """Verify login succeeds with v7.9 no-namespace response and sets IS_V7_9 = True.
 
-    Given:
-        - ArcSight ESM v7.9 login endpoint returns {"loginResponse": {"return": "token"}}
+        Given:
+            - ArcSight ESM v7.9 login endpoint returns {"loginResponse": {"return": "token"}}
 
-    When:
-        - login() is called
+        When:
+            - login() is called
 
-    Then:
-        - The auth token is returned
-        - IS_V7_9 is set to True
-    """
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
-    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
-    mocker.patch.object(demisto, "setIntegrationContext")
+        Then:
+            - The auth token is returned
+            - IS_V7_9 is set to True
+            - Integration context is saved with is_v7_9=True
+        """
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+        mock_set_ctx = mocker.patch.object(demisto, "setIntegrationContext")
 
-    requests_mock.post(
-        PARAMS["server"] + "/www/core-service/rest/LoginService/login",
-        json={"loginResponse": {"return": "v79_token"}},
-    )
+        requests_mock.post(
+            PARAMS["server"] + "/www/core-service/rest/LoginService/login",
+            json={"loginResponse": {"return": "v79_token"}},
+        )
 
-    ArcSightESMv2.IS_V7_9 = False
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        ArcSightESMv2.IS_V7_9 = False
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    token = ArcSightESMv2.login()
-    assert token == "v79_token"
-    assert ArcSightESMv2.IS_V7_9 is True
+        token = ArcSightESMv2.login()
+        assert token == "v79_token"
+        assert ArcSightESMv2.IS_V7_9 is True
+        mock_set_ctx.assert_called_once_with({"auth_token": "v79_token", "is_v7_9": True})
 
+    def test_login_legacy_namespace(self, mocker, requests_mock):
+        """Verify login succeeds with legacy namespaced response and sets IS_V7_9 = False.
 
-def test_login_legacy_namespace(mocker, requests_mock):
-    """Verify login succeeds with legacy namespaced response and sets IS_V7_9 = False.
+        Given:
+            - Legacy ArcSight ESM login endpoint returns {"log.loginResponse": {"log.return": "token"}}
 
-    Given:
-        - Legacy ArcSight ESM login endpoint returns {"log.loginResponse": {"log.return": "token"}}
+        When:
+            - login() is called
 
-    When:
-        - login() is called
+        Then:
+            - The auth token is returned
+            - IS_V7_9 is set to False
+            - Integration context is saved with is_v7_9=False
+        """
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+        mock_set_ctx = mocker.patch.object(demisto, "setIntegrationContext")
 
-    Then:
-        - The auth token is returned
-        - IS_V7_9 is set to False
-    """
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
-    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
-    mocker.patch.object(demisto, "setIntegrationContext")
+        requests_mock.post(
+            PARAMS["server"] + "/www/core-service/rest/LoginService/login",
+            json={"log.loginResponse": {"log.return": "legacy_token"}},
+        )
 
-    requests_mock.post(
-        PARAMS["server"] + "/www/core-service/rest/LoginService/login",
-        json={"log.loginResponse": {"log.return": "legacy_token"}},
-    )
+        ArcSightESMv2.IS_V7_9 = True  # Start as True to verify it gets set to False
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    ArcSightESMv2.IS_V7_9 = True  # Start as True to verify it gets set to False
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        token = ArcSightESMv2.login()
+        assert token == "legacy_token"
+        assert ArcSightESMv2.IS_V7_9 is False
+        mock_set_ctx.assert_called_once_with({"auth_token": "legacy_token", "is_v7_9": False})
 
-    token = ArcSightESMv2.login()
-    assert token == "legacy_token"
-    assert ArcSightESMv2.IS_V7_9 is False
+    def test_main_loads_v79_from_context(self, mocker):
+        """Verify main() loads is_v7_9 from integration context when auth_token is cached.
 
+        Given:
+            - Integration context contains {"auth_token": "cached_token", "is_v7_9": True}
 
-def test_get_case_v79(mocker, requests_mock):
-    """Verify get_case() works with v7.9 no-namespace response.
+        When:
+            - main() is called (login is skipped because token is cached)
 
-    Given:
-        - ArcSight ESM v7.9 returns case data without namespace prefixes
+        Then:
+            - IS_V7_9 is set to True from integration context
+            - login() is NOT called
+        """
+        mocker.patch.object(
+            demisto, "getIntegrationContext",
+            return_value={"auth_token": "cached_token", "is_v7_9": True},
+        )
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "command", return_value="test-module")
+        mocker.patch.object(demisto, "results")
+        mock_login = mocker.patch.object(ArcSightESMv2, "login")
+        mocker.patch.object(ArcSightESMv2, "test")
 
-    When:
-        - get_case() is called
+        ArcSightESMv2.IS_V7_9 = False  # Start as False to verify it gets set from context
 
-    Then:
-        - The case data is correctly parsed from the no-namespace response
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
+        ArcSightESMv2.main()
 
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        assert ArcSightESMv2.IS_V7_9 is True
+        mock_login.assert_not_called()
 
-    requests_mock.get(
-        PARAMS["server"] + "/www/manager-service/rest/CaseService/getResourceById",
-        json={
-            "getResourceByIdResponse": {
-                "return": {
-                    "name": "Test Case v79",
-                    "resourceid": "abc123",
-                    "createdTimestamp": 1629097454417,
+    def test_main_loads_v79_false_from_context(self, mocker):
+        """Verify main() loads is_v7_9=False from integration context for legacy servers.
+
+        Given:
+            - Integration context contains {"auth_token": "cached_token", "is_v7_9": False}
+
+        When:
+            - main() is called (login is skipped because token is cached)
+
+        Then:
+            - IS_V7_9 remains False from integration context
+            - login() is NOT called
+        """
+        mocker.patch.object(
+            demisto, "getIntegrationContext",
+            return_value={"auth_token": "cached_token", "is_v7_9": False},
+        )
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "command", return_value="test-module")
+        mocker.patch.object(demisto, "results")
+        mock_login = mocker.patch.object(ArcSightESMv2, "login")
+        mocker.patch.object(ArcSightESMv2, "test")
+
+        ArcSightESMv2.IS_V7_9 = True  # Start as True to verify it gets set from context
+
+        ArcSightESMv2.main()
+
+        assert ArcSightESMv2.IS_V7_9 is False
+        mock_login.assert_not_called()
+
+    def test_main_defaults_v79_when_missing_from_context(self, mocker):
+        """Verify main() defaults is_v7_9 to False when key is missing from old integration context.
+
+        Given:
+            - Integration context contains {"auth_token": "cached_token"} (no is_v7_9 key)
+
+        When:
+            - main() is called (login is skipped because token is cached)
+
+        Then:
+            - IS_V7_9 defaults to False (legacy mode)
+            - login() is NOT called
+        """
+        mocker.patch.object(
+            demisto, "getIntegrationContext",
+            return_value={"auth_token": "cached_token"},
+        )
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "command", return_value="test-module")
+        mocker.patch.object(demisto, "results")
+        mock_login = mocker.patch.object(ArcSightESMv2, "login")
+        mocker.patch.object(ArcSightESMv2, "test")
+
+        ArcSightESMv2.IS_V7_9 = True  # Start as True to verify it defaults to False
+
+        ArcSightESMv2.main()
+
+        assert ArcSightESMv2.IS_V7_9 is False
+        mock_login.assert_not_called()
+
+    def test_get_case_v79(self, mocker, requests_mock):
+        """Verify get_case() works with v7.9 no-namespace response.
+
+        Given:
+            - ArcSight ESM v7.9 returns case data without namespace prefixes
+
+        When:
+            - get_case() is called
+
+        Then:
+            - The case data is correctly parsed from the no-namespace response
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
+
+        requests_mock.get(
+            PARAMS["server"] + "/www/manager-service/rest/CaseService/getResourceById",
+            json={
+                "getResourceByIdResponse": {
+                    "return": {
+                        "name": "Test Case v79",
+                        "resourceid": "abc123",
+                        "createdTimestamp": 1629097454417,
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
 
-    case = ArcSightESMv2.get_case("abc123")
-    assert case["name"] == "Test Case v79"
-    assert case["resourceid"] == "abc123"
+        case = ArcSightESMv2.get_case("abc123")
+        assert case["name"] == "Test Case v79"
+        assert case["resourceid"] == "abc123"
 
+    def test_get_all_cases_v79(self, mocker, requests_mock):
+        """Verify get_all_cases_command() works with v7.9 no-namespace response.
 
-def test_get_all_cases_v79(mocker, requests_mock):
-    """Verify get_all_cases_command() works with v7.9 no-namespace response.
+        Given:
+            - ArcSight ESM v7.9 returns case IDs without namespace prefixes
 
-    Given:
-        - ArcSight ESM v7.9 returns case IDs without namespace prefixes
+        When:
+            - get_all_cases_command() is called
 
-    When:
-        - get_all_cases_command() is called
+        Then:
+            - The case IDs are correctly parsed
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "results")
+        mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
 
-    Then:
-        - The case IDs are correctly parsed
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "results")
-    mocker.patch.object(demisto, "command", return_value="as-get-all-cases")
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        requests_mock.get(
+            PARAMS["server"] + "/www/manager-service/rest/CaseService/findAllIds",
+            json={"findAllIdsResponse": {"return": ["case1", "case2", "case3"]}},
+        )
 
-    requests_mock.get(
-        PARAMS["server"] + "/www/manager-service/rest/CaseService/findAllIds",
-        json={"findAllIdsResponse": {"return": ["case1", "case2", "case3"]}},
-    )
+        ArcSightESMv2.get_all_cases_command()
+        results = demisto.results.call_args[0][0]
+        cases = results["Contents"]
+        assert len(cases) == 3
+        assert cases[0] == "case1"
 
-    ArcSightESMv2.get_all_cases_command()
-    results = demisto.results.call_args[0][0]
-    cases = results["Contents"]
-    assert len(cases) == 3
-    assert cases[0] == "case1"
+    def test_get_security_events_v79(self, mocker, requests_mock):
+        """Verify get_security_events() uses no-namespace keys in request and parses response correctly.
 
+        Given:
+            - ArcSight ESM v7.9 mode is active
 
-def test_get_security_events_v79(mocker, requests_mock):
-    """Verify get_security_events() uses no-namespace keys in request and parses response correctly.
+        When:
+            - get_security_events() is called
 
-    Given:
-        - ArcSight ESM v7.9 mode is active
+        Then:
+            - Request body uses no-namespace keys
+            - Response is correctly parsed from no-namespace format
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
 
-    When:
-        - get_security_events() is called
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    Then:
-        - Request body uses no-namespace keys
-        - Response is correctly parsed from no-namespace format
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
+        post_mock = requests_mock.post(
+            PARAMS["server"] + "/www/manager-service/rest/SecurityEventService/getSecurityEvents",
+            json={"getSecurityEventsResponse": {"return": [{"eventId": 12345, "name": "Test Event v79"}]}},
+        )
 
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        events = ArcSightESMv2.get_security_events(["12345"])
+        assert events is not None
+        assert len(events) == 1
+        assert events[0]["name"] == "Test Event v79"
 
-    post_mock = requests_mock.post(
-        PARAMS["server"] + "/www/manager-service/rest/SecurityEventService/getSecurityEvents",
-        json={"getSecurityEventsResponse": {"return": [{"eventId": 12345, "name": "Test Event v79"}]}},
-    )
+        # Verify request body uses no-namespace keys
+        request_body = post_mock.last_request.json()
+        assert "getSecurityEvents" in request_body
+        assert "authToken" in request_body["getSecurityEvents"]
+        assert "ids" in request_body["getSecurityEvents"]
 
-    events = ArcSightESMv2.get_security_events(["12345"])
-    assert events is not None
-    assert len(events) == 1
-    assert events[0]["name"] == "Test Event v79"
+    def test_get_query_viewer_results_v79(self, mocker, requests_mock):
+        """Verify get_query_viewer_results() works with v7.9 no-namespace response.
 
-    # Verify request body uses no-namespace keys
-    request_body = post_mock.last_request.json()
-    assert "getSecurityEvents" in request_body
-    assert "authToken" in request_body["getSecurityEvents"]
-    assert "ids" in request_body["getSecurityEvents"]
+        Given:
+            - ArcSight ESM v7.9 returns query viewer data without namespace prefixes
 
+        When:
+            - get_query_viewer_results() is called
 
-def test_get_query_viewer_results_v79(mocker, requests_mock):
-    """Verify get_query_viewer_results() works with v7.9 no-namespace response.
+        Then:
+            - The data is correctly parsed
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
 
-    Given:
-        - ArcSight ESM v7.9 returns query viewer data without namespace prefixes
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    When:
-        - get_query_viewer_results() is called
-
-    Then:
-        - The data is correctly parsed
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
-
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
-
-    requests_mock.get(
-        PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/getMatrixData",
-        json={
-            "getMatrixDataResponse": {
-                "return": {
-                    "columnHeaders": ["ID", "Name"],
-                    "rows": [
-                        {
-                            "@xsi.type": "listWrapper",
-                            "value": [
-                                {"@xsi.type": "xs:string", "$": "id1"},
-                                {"@xsi.type": "xs:string", "$": "name1"},
-                            ],
-                        }
-                    ],
+        requests_mock.get(
+            PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/getMatrixData",
+            json={
+                "getMatrixDataResponse": {
+                    "return": {
+                        "columnHeaders": ["ID", "Name"],
+                        "rows": [
+                            {
+                                "@xsi.type": "listWrapper",
+                                "value": [
+                                    {"@xsi.type": "xs:string", "$": "id1"},
+                                    {"@xsi.type": "xs:string", "$": "name1"},
+                                ],
+                            }
+                        ],
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
 
-    fields, results = ArcSightESMv2.get_query_viewer_results("test_qv_id")
-    assert fields == ["ID", "Name"]
-    assert len(results) == 1
-    assert results[0]["ID"] == "id1"
-    assert results[0]["Name"] == "name1"
+        fields, results = ArcSightESMv2.get_query_viewer_results("test_qv_id")
+        assert fields == ["ID", "Name"]
+        assert len(results) == 1
+        assert results[0]["ID"] == "id1"
+        assert results[0]["Name"] == "name1"
 
+    def test_get_case_event_ids_v79(self, mocker, requests_mock):
+        """Verify get_case_event_ids_command() works with v7.9 no-namespace response.
 
-def test_get_case_event_ids_v79(mocker, requests_mock):
-    """Verify get_case_event_ids_command() works with v7.9 no-namespace response.
+        Given:
+            - ArcSight ESM v7.9 returns case event IDs without namespace prefixes
 
-    Given:
-        - ArcSight ESM v7.9 returns case event IDs without namespace prefixes
+        When:
+            - get_case_event_ids_command() is called
 
-    When:
-        - get_case_event_ids_command() is called
+        Then:
+            - The event IDs are correctly parsed
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "results")
+        mocker.patch.object(demisto, "command", return_value="as-get-case-event-ids")
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
+        mocker.patch.object(demisto, "args", return_value={"caseId": "case1", "withCorrelatedEvents": "false"})
 
-    Then:
-        - The event IDs are correctly parsed
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "results")
-    mocker.patch.object(demisto, "command", return_value="as-get-case-event-ids")
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
-    mocker.patch.object(demisto, "args", return_value={"caseId": "case1", "withCorrelatedEvents": "false"})
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
+        requests_mock.get(
+            PARAMS["server"] + "/www/manager-service/rest/CaseService/getCaseEventIDs",
+            json={"getCaseEventIDsResponse": {"return": [111, 222, 333]}},
+        )
 
-    requests_mock.get(
-        PARAMS["server"] + "/www/manager-service/rest/CaseService/getCaseEventIDs",
-        json={"getCaseEventIDsResponse": {"return": [111, 222, 333]}},
-    )
+        ArcSightESMv2.get_case_event_ids_command()
+        results = demisto.results.call_args[0][0]
+        event_ids = results["Contents"]["getCaseEventIDsResponse"]["return"]
+        assert len(event_ids) == 3
+        assert event_ids[0] == 111
 
-    ArcSightESMv2.get_case_event_ids_command()
-    results = demisto.results.call_args[0][0]
-    event_ids = results["Contents"]["getCaseEventIDsResponse"]["return"]
-    assert len(event_ids) == 3
-    assert event_ids[0] == 111
+    def test_get_all_query_viewers_v79(self, mocker, requests_mock):
+        """Verify get_all_query_viewers_command() works with v7.9 no-namespace response.
 
+        Given:
+            - ArcSight ESM v7.9 returns query viewer IDs without namespace prefixes
 
-def test_get_all_query_viewers_v79(mocker, requests_mock):
-    """Verify get_all_query_viewers_command() works with v7.9 no-namespace response.
+        When:
+            - get_all_query_viewers_command() is called
 
-    Given:
-        - ArcSight ESM v7.9 returns query viewer IDs without namespace prefixes
+        Then:
+            - The query viewer IDs are correctly parsed
+        """
+        mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
+        mocker.patch.object(demisto, "results")
+        mocker.patch.object(demisto, "command", return_value="as-get-all-query-viewers")
+        mocker.patch.object(demisto, "params", return_value=PARAMS)
 
-    When:
-        - get_all_query_viewers_command() is called
+        ArcSightESMv2.IS_V7_9 = True
+        ArcSightESMv2.AUTH_TOKEN = "token"
+        ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
+        ArcSightESMv2.VERIFY_CERTIFICATE = False
 
-    Then:
-        - The query viewer IDs are correctly parsed
-    """
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={"auth_token": "token"})
-    mocker.patch.object(demisto, "results")
-    mocker.patch.object(demisto, "command", return_value="as-get-all-query-viewers")
-    mocker.patch.object(demisto, "params", return_value=PARAMS)
+        requests_mock.post(
+            PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/findAllIds",
+            json={"findAllIdsResponse": {"return": ["qv1", "qv2", "qv3"]}},
+        )
 
-    ArcSightESMv2.IS_V7_9 = True
-    ArcSightESMv2.AUTH_TOKEN = "token"
-    ArcSightESMv2.BASE_URL = PARAMS["server"] + "/"
-    ArcSightESMv2.VERIFY_CERTIFICATE = False
-
-    requests_mock.post(
-        PARAMS["server"] + "/www/manager-service/rest/QueryViewerService/findAllIds",
-        json={"findAllIdsResponse": {"return": ["qv1", "qv2", "qv3"]}},
-    )
-
-    ArcSightESMv2.get_all_query_viewers_command()
-    results = demisto.results.call_args[0][0]
-    output = results["Contents"]
-    assert len(output) == 3
-    assert output[0] == "qv1"
+        ArcSightESMv2.get_all_query_viewers_command()
+        results = demisto.results.call_args[0][0]
+        output = results["Contents"]
+        assert len(output) == 3
+        assert output[0] == "qv1"

--- a/Packs/ArcSightESM/ReleaseNotes/1_3_0.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_3_0.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ArcSight ESM v2
+
+- Added support for ArcSight ESM v7.9, which removes XML namespace prefixes from REST API requests and responses.
+- The integration now auto-detects the ArcSight version during login and adapts all API calls accordingly.

--- a/Packs/ArcSightESM/ReleaseNotes/1_3_0.md
+++ b/Packs/ArcSightESM/ReleaseNotes/1_3_0.md
@@ -4,4 +4,5 @@
 ##### ArcSight ESM v2
 
 - Added support for ArcSight ESM v7.9, which removes XML namespace prefixes from REST API requests and responses.
-- The integration now auto-detects the ArcSight version during login and adapts all API calls accordingly.
+- Updated the integration to auto-detect the ArcSight version during login, which adapts all API calls accordingly.
+- Updated the Docker image to: *demisto/python3:3.12.12.7090913*.

--- a/Packs/ArcSightESM/pack_metadata.json
+++ b/Packs/ArcSightESM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ArcSight ESM",
     "description": "ArcSight ESM SIEM by Micro Focus (Formerly HPE Software).",
     "support": "xsoar",
-    "currentVersion": "1.2.8",
+    "currentVersion": "1.3.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-64444

## Description
Updated API logic to support ArcSight ESM 7.9 by removing legacy namespace prefixes (e.g., qvs., cas., log.) from both request payloads and response parsing.
This fix adds auto-detection of the ArcSight API format during login and uses a _ns_key() helper to dynamically resolve the correct request/response keys across the integration.