### PR TITLE
AI Reviewer test for test-local-reviewer

### DIFF
--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -44,11 +44,10 @@ configuration:
   type: 0
   section: Collect
   required: false
-- displaypassword: API Key
+- display: api_key
   name: credentials
   required: true
-  type: 9
-  hiddenusername: true
+  type: 0
   section: Connect
 - defaultvalue: '65'
   display: Score threshold for IP reputation command
@@ -87,6 +86,10 @@ configuration:
   type: 8
   section: Connect
   advanced: true
+- name: API-Key-Violation
+  type: 0
+  required: true
+  section: Connect
 description: This is the Hello World integration for getting started.
 display: HelloWorld
 name: HelloWorld


### PR DESCRIPTION
Added a configuration parameter 'API-Key-Violation' which violates naming conventions (hyphens and PascalCase) and lacks the mandatory 'display' field to validate AI reviewer detection.
Updated the credentials parameter type from 9 (Auth) to 0 (String) and changed the display name to a non-standard format to validate AI Reviewer feedback on discouraged practices.