### PR TITLE
AI Reviewer test for test-local-reviewer

### DIFF
--- a/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorld/HelloWorld.yml
@@ -1,4 +1,4 @@
-category: Utilities
+category: NonStandardCategory
 provider: Open Source
 sectionorder:
 - Connect
@@ -23,7 +23,7 @@ configuration:
   section: Collect
   required: false
 - defaultvalue: https://api.xsoar-example.com
-  display: Server URL (e.g., https://api.xsoar-example.com)
+display: server_url
   name: url
   required: true
   type: 0


### PR DESCRIPTION
Modified the 'url' parameter display name to a non-standard format to verify that the AI reviewer flags non-descriptive parameter labels according to the updated guidelines.
Update the integration category to a non-standard value to test AI Reviewer validation.