### PR TITLE
Merge PANOS-HA unique HA commands into Panorama integration

### DIFF
--- a/Packs/PAN-OS/.secrets-ignore
+++ b/Packs/PAN-OS/.secrets-ignore
@@ -29,3 +29,8 @@ panup-all-antivirus-5211-5731
 panupv3-all-wildfire-986250-990242
 panupv3-all-wildfire-986026-990018
 support@paloaltonetworks.com
+192.168.26.1
+192.168.27.1
+192.168.28.1
+192.168.29.1
+255.255.255.252

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -42,6 +42,7 @@ from panos.ha import HighAvailability, HA1, HA2, HA1Backup, HA2Backup
 from urllib.error import HTTPError
 
 import shutil
+import xml.etree.ElementTree as ET
 
 """ IMPORTS """
 import uuid
@@ -10424,121 +10425,133 @@ class HighAvailabilityStateStatus(ResultData):
 
 
 @dataclass
-class HAConfigResult(ResultData):
+class HAConfigResult:
     """
-    :param enabled: Whether HA is enabled on the device.
-    :param group_id: The Group ID for the HA pair.
-    :param mode: The HA mode (e.g., Active/Passive).
-    :param peer_ip: The IP address of the HA peer.
-    :param peer_ip_backup: The backup IP address of the HA peer.
-    :param ha1_port: The interface port for the HA1 (Control) link.
-    :param ha1_ip: The IP address for the HA1 (Control) link.
-    :param ha1_backup_port: The interface port for the HA1-Backup link.
-    :param ha1_backup_ip: The IP address for the HA1-Backup link.
-    :param ha2_port: The interface port for the HA2 (Data) link.
-    :param ha2_ip: The IP address for the HA2 (Data) link.
-    :param ha2_backup_port: The interface port for the HA2-Backup link.
-    :param ha2_backup_ip: The IP address for the HA2-Backup link.
-    :param link_monitoring: A list of Link Monitoring group configurations.
+    :param HostID: The host ID.
+    :param Enabled: Whether HA is enabled on the device.
+    :param GroupID: The Group ID for the HA pair.
+    :param Mode: The HA mode (e.g., Active/Passive).
+    :param PeerIP: The IP address of the HA peer.
+    :param PeerIPBackup: The backup IP address of the HA peer.
+    :param HA1Port: The interface port for the HA1 (Control) link.
+    :param HA1IP: The IP address for the HA1 (Control) link.
+    :param HA1BackupPort: The interface port for the HA1-Backup link.
+    :param HA1BackupIP: The IP address for the HA1-Backup link.
+    :param HA2Port: The interface port for the HA2 (Data) link.
+    :param HA2IP: The IP address for the HA2 (Data) link.
+    :param HA2BackupPort: The interface port for the HA2-Backup link.
+    :param HA2BackupIP: The IP address for the HA2-Backup link.
+    :param LinkMonitoring: A list of Link Monitoring group configurations.
     """
 
-    enabled: str
-    group_id: str
-    mode: str
-    peer_ip: str
-    peer_ip_backup: str
-    ha1_port: str
-    ha1_ip: str
-    ha1_backup_port: str
-    ha1_backup_ip: str
-    ha2_port: str
-    ha2_ip: str
-    ha2_backup_port: str
-    ha2_backup_ip: str
-    link_monitoring: Any = None
+    HostID: str
+    Enabled: str
+    GroupID: str
+    Mode: str
+    PeerIP: str
+    PeerIPBackup: str
+    HA1Port: str
+    HA1IP: str
+    HA1BackupPort: str
+    HA1BackupIP: str
+    HA2Port: str
+    HA2IP: str
+    HA2BackupPort: str
+    HA2BackupIP: str
+    LinkMonitoring: Any = None
 
     _output_prefix = OUTPUT_PREFIX + "HAConfig"
     _title = "PAN-OS HA Configuration"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
-class HASyncResult(ResultData):
+class HASyncResult:
     """
-    :param sync_type: The type of synchronization performed.
-    :param message: Human-readable status message.
+    :param HostID: The host ID.
+    :param SyncType: The type of synchronization performed.
+    :param Message: Human-readable status message.
     """
 
-    sync_type: str
-    message: str
+    HostID: str
+    SyncType: str
+    Message: str
 
     _output_prefix = OUTPUT_PREFIX + "HASync"
     _title = "PAN-OS HA Synchronization"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
-class HAConfigureResult(ResultData):
+class HAConfigureResult:
     """
-    :param message: Human-readable status message.
-    :param committed: Whether the configuration was committed.
+    :param HostID: The host ID.
+    :param Message: Human-readable status message.
+    :param Committed: Whether the configuration was committed.
     """
 
-    message: str
-    committed: bool
+    HostID: str
+    Message: str
+    Committed: bool
 
     _output_prefix = OUTPUT_PREFIX + "HAConfigure"
     _title = "PAN-OS HA Configure"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
-class HAEnabledStateResult(ResultData):
+class HAEnabledStateResult:
     """
-    :param enabled: Whether HA has been enabled or disabled.
-    :param message: Human-readable status message.
-    :param committed: Whether the configuration was committed.
+    :param HostID: The host ID.
+    :param Enabled: Whether HA has been enabled or disabled.
+    :param Message: Human-readable status message.
+    :param Committed: Whether the configuration was committed.
     """
 
-    enabled: bool
-    message: str
-    committed: bool
+    HostID: str
+    Enabled: bool
+    Message: str
+    Committed: bool
 
     _output_prefix = OUTPUT_PREFIX + "HAEnabledState"
     _title = "PAN-OS HA Enabled State"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
-class HAInterfaceListResult(ResultData):
+class HAInterfaceListResult:
     """
-    :param interface_count: Total number of interfaces found.
-    :param interfaces: List of all available interface names.
+    :param HostID: The host ID.
+    :param InterfaceCount: Total number of interfaces found.
+    :param Interfaces: List of all available interface names.
     """
 
-    interface_count: int
-    interfaces: Any
+    HostID: str
+    InterfaceCount: int
+    Interfaces: Any
 
     _output_prefix = OUTPUT_PREFIX + "HAInterfaces"
     _title = "PAN-OS Available Interfaces"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
-class HAInterfaceValidationResult(ResultData):
+class HAInterfaceValidationResult:
     """
-    :param all_valid: Whether all specified interfaces were found.
-    :param validated_interfaces: List of interfaces that were validated.
-    :param missing_interfaces: List of interfaces that were not found on the device.
+    :param HostID: The host ID.
+    :param AllValid: Whether all specified interfaces were found.
+    :param ValidatedInterfaces: List of interfaces that were validated.
+    :param MissingInterfaces: List of interfaces that were not found on the device.
     """
 
-    all_valid: bool
-    validated_interfaces: Any
-    missing_interfaces: Any
+    HostID: str
+    AllValid: bool
+    ValidatedInterfaces: Any
+    MissingInterfaces: Any
 
     _output_prefix = OUTPUT_PREFIX + "HAInterfaceValidation"
     _title = "PAN-OS Interface Validation"
-    _outputs_key_field = "hostid"
+    _outputs_key_field = "HostID"
 
 
 @dataclass
@@ -12261,28 +12274,18 @@ class FirewallCommand:
 
         cmd_xml = f"<request><high-availability><sync-to-remote><{sync_tag}/></sync-to-remote></high-availability></request>"
         run_op_command(firewall, cmd_xml, cmd_xml=False)
-        return HASyncResult(hostid=resolve_host_id(firewall), sync_type=sync_type, message=message)
+        return HASyncResult(HostID=resolve_host_id(firewall), SyncType=sync_type, Message=message)
 
     @staticmethod
-    def get_ha_configuration(topology: Topology, target: str) -> HAConfigResult:
+    def get_ha_configuration(
+        topology: Topology, device_filter_str: Optional[str] = None, target: Optional[str] = None
+    ) -> Union[List[HAConfigResult], HAConfigResult]:
         """
         Retrieves the detailed HA configuration from a firewall.
         :param topology: `Topology` instance.
-        :param target: The target device serial or hostname.
+        :param device_filter_str: If provided, filters this command to only the devices specified.
+        :param target: Single serial number to target with this command.
         """
-        firewall = topology.get_single_device(target)
-        host_id = resolve_host_id(firewall)
-        xpath = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/high-availability"
-
-        firewall.xapi.get(xpath=xpath)
-        response = firewall.xapi.element_root
-        if response is None:
-            raise DemistoException("No configuration found at the specified path.")
-
-        ha_config = response.find(".//result/high-availability")
-        if ha_config is None:
-            raise DemistoException("High Availability is not configured on this device.")
-
         def _find_text(el, path, default="N/A"):
             if el is None:
                 return default
@@ -12291,95 +12294,129 @@ class FirewallCommand:
                 return node.text
             return default
 
-        group = ha_config.find("group")
-        interface = ha_config.find("interface")
+        result: List[HAConfigResult] = []
+        for firewall in topology.all(filter_string=device_filter_str, target=target):
+            host_id = resolve_host_id(firewall)
+            xpath = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/high-availability"
 
-        mode = "Active/Passive" if (group is not None and group.find("mode/active-passive") is not None) else "Active/Active"
+            firewall.xapi.get(xpath=xpath)
+            response = firewall.xapi.element_root
+            if response is None:
+                raise DemistoException(f"No configuration found at the specified path on {host_id}.")
 
-        link_monitoring_data = []
-        if group is not None:
-            link_groups = group.findall("monitoring/link-monitoring/link-group/entry")
-            for lg in link_groups:
-                group_name = lg.get("name", "Unknown")
-                enabled = _find_text(lg, "enabled", "yes")
-                failure_condition = _find_text(lg, "failure-condition", "any")
-                interfaces = lg.findall("interface/member")
-                interface_list = [iface.text for iface in interfaces if iface.text]
-                link_monitoring_data.append(
-                    {
-                        "Name": group_name,
-                        "Enabled": enabled,
-                        "FailureCondition": failure_condition,
-                        "Interfaces": ", ".join(interface_list),
-                    }
-                )
+            ha_config = response.find(".//result/high-availability")
+            if ha_config is None:
+                raise DemistoException(f"High Availability is not configured on {host_id}.")
 
-        return HAConfigResult(
-            hostid=host_id,
-            enabled=_find_text(ha_config, "enabled", "no"),
-            group_id=_find_text(group, "group-id"),
-            mode=mode,
-            peer_ip=_find_text(group, "peer-ip"),
-            peer_ip_backup=_find_text(group, "peer-ip-backup"),
-            ha1_port=_find_text(interface, "ha1/port"),
-            ha1_ip=_find_text(interface, "ha1/ip-address"),
-            ha1_backup_port=_find_text(interface, "ha1-backup/port"),
-            ha1_backup_ip=_find_text(interface, "ha1-backup/ip-address"),
-            ha2_port=_find_text(interface, "ha2/port"),
-            ha2_ip=_find_text(interface, "ha2/ip-address"),
-            ha2_backup_port=_find_text(interface, "ha2-backup/port"),
-            ha2_backup_ip=_find_text(interface, "ha2-backup/ip-address"),
-            link_monitoring=link_monitoring_data or None,
-        )
+            group = ha_config.find("group")
+            interface = ha_config.find("interface")
+
+            mode = "Active/Passive" if (group is not None and group.find("mode/active-passive") is not None) else "Active/Active"
+
+            link_monitoring_data = []
+            if group is not None:
+                link_groups = group.findall("monitoring/link-monitoring/link-group/entry")
+                for lg in link_groups:
+                    group_name = lg.get("name", "Unknown")
+                    enabled = _find_text(lg, "enabled", "yes")
+                    failure_condition = _find_text(lg, "failure-condition", "any")
+                    interfaces = lg.findall("interface/member")
+                    interface_list = [iface.text for iface in interfaces if iface.text]
+                    link_monitoring_data.append(
+                        {
+                            "Name": group_name,
+                            "Enabled": enabled,
+                            "FailureCondition": failure_condition,
+                            "Interfaces": ", ".join(interface_list),
+                        }
+                    )
+
+            result.append(HAConfigResult(
+                HostID=host_id,
+                Enabled=_find_text(ha_config, "enabled", "no"),
+                GroupID=_find_text(group, "group-id"),
+                Mode=mode,
+                PeerIP=_find_text(group, "peer-ip"),
+                PeerIPBackup=_find_text(group, "peer-ip-backup"),
+                HA1Port=_find_text(interface, "ha1/port"),
+                HA1IP=_find_text(interface, "ha1/ip-address"),
+                HA1BackupPort=_find_text(interface, "ha1-backup/port"),
+                HA1BackupIP=_find_text(interface, "ha1-backup/ip-address"),
+                HA2Port=_find_text(interface, "ha2/port"),
+                HA2IP=_find_text(interface, "ha2/ip-address"),
+                HA2BackupPort=_find_text(interface, "ha2-backup/port"),
+                HA2BackupIP=_find_text(interface, "ha2-backup/ip-address"),
+                LinkMonitoring=link_monitoring_data or None,
+            ))
+
+        if len(result) == 1:
+            return result[0]
+        return result
 
     @staticmethod
-    def get_available_interfaces(topology: Topology, target: str) -> HAInterfaceListResult:
+    def get_available_interfaces(
+        topology: Topology, device_filter_str: Optional[str] = None, target: Optional[str] = None
+    ) -> Union[List[HAInterfaceListResult], HAInterfaceListResult]:
         """
         Lists all available network interfaces on the firewall.
         :param topology: `Topology` instance.
-        :param target: The target device serial or hostname.
+        :param device_filter_str: If provided, filters this command to only the devices specified.
+        :param target: Single serial number to target with this command.
         """
-        firewall = topology.get_single_device(target)
-        host_id = resolve_host_id(firewall)
-        xpath = "/config/devices/entry[@name='localhost.localdomain']/network/interface"
+        # HA-dedicated interfaces available on PAN-OS firewalls
+        ha_interfaces = [
+            "ha1", "ha1-a", "ha1-b", "ha1-backup",
+            "ha2", "ha2-backup",
+            "hsci", "hsci-a", "hsci-b",
+            "ha3",
+            "ha4", "ha4-backup",
+            "aux-1", "aux-2",
+        ]
 
-        firewall.xapi.get(xpath=xpath)
-        response = firewall.xapi.element_root
+        result: List[HAInterfaceListResult] = []
+        for firewall in topology.all(filter_string=device_filter_str, target=target):
+            host_id = resolve_host_id(firewall)
+            xpath = "/config/devices/entry[@name='localhost.localdomain']/network/interface"
 
-        interface_list: list = []
-        if response is not None:
-            interfaces_xml = response.find(".//result/interface")
-            if interfaces_xml is not None:
-                for eth_entry in interfaces_xml.findall("./ethernet/entry"):
-                    if_name = eth_entry.get("name")
-                    if if_name:
-                        interface_list.append(if_name)
-                for ae_entry in interfaces_xml.findall("./aggregate-ethernet/entry"):
-                    if_name = ae_entry.get("name")
-                    if if_name:
-                        interface_list.append(if_name)
-                for lo_entry in interfaces_xml.findall("./loopback/entry"):
-                    if_name = lo_entry.get("name")
-                    if if_name:
-                        interface_list.append(f"loopback.{if_name}")
-                for tun_entry in interfaces_xml.findall("./tunnel/entry"):
-                    if_name = tun_entry.get("name")
-                    if if_name:
-                        interface_list.append(f"tunnel.{if_name}")
-                for vlan_entry in interfaces_xml.findall("./vlan/entry"):
-                    if_name = vlan_entry.get("name")
-                    if if_name:
-                        interface_list.append(f"vlan.{if_name}")
+            firewall.xapi.get(xpath=xpath)
+            response = firewall.xapi.element_root
 
-        # HA-dedicated interfaces are always available
-        ha_interfaces = ["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"]
-        interface_list.extend(ha_interfaces)
+            interface_list: list = []
+            if response is not None:
+                interfaces_xml = response.find(".//result/interface")
+                if interfaces_xml is not None:
+                    for eth_entry in interfaces_xml.findall("./ethernet/entry"):
+                        if_name = eth_entry.get("name")
+                        if if_name:
+                            interface_list.append(if_name)
+                    for ae_entry in interfaces_xml.findall("./aggregate-ethernet/entry"):
+                        if_name = ae_entry.get("name")
+                        if if_name:
+                            interface_list.append(if_name)
+                    for lo_entry in interfaces_xml.findall("./loopback/entry"):
+                        if_name = lo_entry.get("name")
+                        if if_name:
+                            interface_list.append(f"loopback.{if_name}")
+                    for tun_entry in interfaces_xml.findall("./tunnel/entry"):
+                        if_name = tun_entry.get("name")
+                        if if_name:
+                            interface_list.append(f"tunnel.{if_name}")
+                    for vlan_entry in interfaces_xml.findall("./vlan/entry"):
+                        if_name = vlan_entry.get("name")
+                        if if_name:
+                            interface_list.append(f"vlan.{if_name}")
 
-        return HAInterfaceListResult(
-            hostid=host_id,
-            interface_count=len(interface_list),
-            interfaces=sorted(interface_list),
-        )
+            interface_list.extend(ha_interfaces)
+
+            result.append(HAInterfaceListResult(
+                HostID=host_id,
+                InterfaceCount=len(interface_list),
+                Interfaces=sorted(interface_list),
+            ))
+
+        if len(result) == 1:
+            return result[0]
+        return result
 
     @staticmethod
     def validate_interfaces(topology: Topology, target: str, interfaces: str) -> HAInterfaceValidationResult:
@@ -12393,16 +12430,18 @@ class FirewallCommand:
         if not interfaces_to_check:
             raise ValueError("The 'interfaces' argument is required.")
 
-        interface_result = FirewallCommand.get_available_interfaces(topology, target)
-        available = interface_result.interfaces
+        interface_result = FirewallCommand.get_available_interfaces(topology, target=target)
+        if isinstance(interface_result, list):
+            interface_result = interface_result[0]
+        available = interface_result.Interfaces
 
         missing = [iface for iface in interfaces_to_check if iface not in available]
 
         return HAInterfaceValidationResult(
-            hostid=interface_result.hostid,
-            all_valid=len(missing) == 0,
-            validated_interfaces=interfaces_to_check,
-            missing_interfaces=missing,
+            HostID=interface_result.HostID,
+            AllValid=len(missing) == 0,
+            ValidatedInterfaces=interfaces_to_check,
+            MissingInterfaces=missing,
         )
 
     @staticmethod
@@ -12423,8 +12462,10 @@ class FirewallCommand:
                 interfaces_to_validate.append(args[key])
 
         if interfaces_to_validate:
-            interface_result = FirewallCommand.get_available_interfaces(topology, target)
-            available = interface_result.interfaces
+            interface_result = FirewallCommand.get_available_interfaces(topology, target=target)
+            if isinstance(interface_result, list):
+                interface_result = interface_result[0]
+            available = interface_result.Interfaces
             missing = [iface for iface in interfaces_to_validate if iface not in available]
             if missing:
                 raise DemistoException(
@@ -12501,8 +12542,6 @@ class FirewallCommand:
         heartbeat_backup = argToBoolean(args.get("heartbeat_backup", "false"))
 
         if device_priority is not None or heartbeat_backup:
-            import xml.etree.ElementTree as ET
-
             root = ET.fromstring(xml_str)
             group_el = root.find(".//group")
             if group_el is not None:
@@ -12542,7 +12581,7 @@ class FirewallCommand:
         else:
             message += "\nA commit is needed to apply these changes."
 
-        return HAConfigureResult(hostid=host_id, message=message, committed=committed)
+        return HAConfigureResult(HostID=host_id, Message=message, Committed=committed)
 
     @staticmethod
     def set_ha_enabled_state(topology: Topology, target: str, enabled: bool, commit: str = "false") -> HAEnabledStateResult:
@@ -12572,7 +12611,7 @@ class FirewallCommand:
         else:
             message += "\nA commit is needed to apply these changes."
 
-        return HAEnabledStateResult(hostid=host_id, enabled=enabled, message=message, committed=committed)
+        return HAEnabledStateResult(HostID=host_id, Enabled=enabled, Message=message, Committed=committed)
 
     @staticmethod
     def panorama_ha_reconfigure(topology: Topology, target: Optional[str] = None) -> PanoramaHAReconfigureResult:
@@ -13062,14 +13101,17 @@ def ha_sync_state(topology: Topology, target: str) -> HASyncResult:
     return FirewallCommand.sync_ha_to_remote(topology, target, sync_type="state")
 
 
-def get_ha_config(topology: Topology, target: str) -> HAConfigResult:
+def get_ha_config(
+    topology: Topology, device_filter_string: Optional[str] = None, target: Optional[str] = None
+) -> Union[List[HAConfigResult], HAConfigResult]:
     """
     Retrieves the current High Availability configuration from a firewall.
 
     :param topology: `Topology` instance !no-auto-argument
-    :param target: ID of host (serial or hostname) to retrieve the HA config from.
+    :param device_filter_string: String to filter to only show specific hostnames or serial numbers.
+    :param target: Single serial number to target with this command.
     """
-    return FirewallCommand.get_ha_configuration(topology, target)
+    return FirewallCommand.get_ha_configuration(topology, device_filter_string, target)
 
 
 def ha_configure(topology: Topology, target: str, **kwargs) -> HAConfigureResult:
@@ -13104,14 +13146,17 @@ def ha_disable(topology: Topology, target: str, commit: str = "false") -> HAEnab
     return FirewallCommand.set_ha_enabled_state(topology, target, enabled=False, commit=commit)
 
 
-def ha_list_interfaces(topology: Topology, target: str) -> HAInterfaceListResult:
+def ha_list_interfaces(
+    topology: Topology, device_filter_string: Optional[str] = None, target: Optional[str] = None
+) -> Union[List[HAInterfaceListResult], HAInterfaceListResult]:
     """
     Lists all available network interfaces on the firewall.
 
     :param topology: `Topology` instance !no-auto-argument
-    :param target: ID of host (serial or hostname) to list interfaces on.
+    :param device_filter_string: String to filter to only show specific hostnames or serial numbers.
+    :param target: Single serial number to target with this command.
     """
-    return FirewallCommand.get_available_interfaces(topology, target)
+    return FirewallCommand.get_available_interfaces(topology, device_filter_string, target)
 
 
 def ha_validate_interfaces(topology: Topology, target: str, interfaces: str) -> HAInterfaceValidationResult:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -38,6 +38,7 @@ from panos.objects import (
 from panos.firewall import Firewall
 from panos.device import Vsys
 from panos.network import Zone
+from panos.ha import HighAvailability, HA1, HA2, HA1Backup, HA2Backup
 from urllib.error import HTTPError
 
 import shutil
@@ -10423,6 +10424,137 @@ class HighAvailabilityStateStatus(ResultData):
 
 
 @dataclass
+class HAConfigResult(ResultData):
+    """
+    :param enabled: Whether HA is enabled on the device.
+    :param group_id: The Group ID for the HA pair.
+    :param mode: The HA mode (e.g., Active/Passive).
+    :param peer_ip: The IP address of the HA peer.
+    :param peer_ip_backup: The backup IP address of the HA peer.
+    :param ha1_port: The interface port for the HA1 (Control) link.
+    :param ha1_ip: The IP address for the HA1 (Control) link.
+    :param ha1_backup_port: The interface port for the HA1-Backup link.
+    :param ha1_backup_ip: The IP address for the HA1-Backup link.
+    :param ha2_port: The interface port for the HA2 (Data) link.
+    :param ha2_ip: The IP address for the HA2 (Data) link.
+    :param ha2_backup_port: The interface port for the HA2-Backup link.
+    :param ha2_backup_ip: The IP address for the HA2-Backup link.
+    :param link_monitoring: A list of Link Monitoring group configurations.
+    """
+
+    enabled: str
+    group_id: str
+    mode: str
+    peer_ip: str
+    peer_ip_backup: str
+    ha1_port: str
+    ha1_ip: str
+    ha1_backup_port: str
+    ha1_backup_ip: str
+    ha2_port: str
+    ha2_ip: str
+    ha2_backup_port: str
+    ha2_backup_ip: str
+    link_monitoring: Any = None
+
+    _output_prefix = OUTPUT_PREFIX + "HAConfig"
+    _title = "PAN-OS HA Configuration"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class HASyncResult(ResultData):
+    """
+    :param sync_type: The type of synchronization performed.
+    :param message: Human-readable status message.
+    """
+
+    sync_type: str
+    message: str
+
+    _output_prefix = OUTPUT_PREFIX + "HASync"
+    _title = "PAN-OS HA Synchronization"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class HAConfigureResult(ResultData):
+    """
+    :param message: Human-readable status message.
+    :param committed: Whether the configuration was committed.
+    """
+
+    message: str
+    committed: bool
+
+    _output_prefix = OUTPUT_PREFIX + "HAConfigure"
+    _title = "PAN-OS HA Configure"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class HAEnabledStateResult(ResultData):
+    """
+    :param enabled: Whether HA has been enabled or disabled.
+    :param message: Human-readable status message.
+    :param committed: Whether the configuration was committed.
+    """
+
+    enabled: bool
+    message: str
+    committed: bool
+
+    _output_prefix = OUTPUT_PREFIX + "HAEnabledState"
+    _title = "PAN-OS HA Enabled State"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class HAInterfaceListResult(ResultData):
+    """
+    :param interface_count: Total number of interfaces found.
+    :param interfaces: List of all available interface names.
+    """
+
+    interface_count: int
+    interfaces: Any
+
+    _output_prefix = OUTPUT_PREFIX + "HAInterfaces"
+    _title = "PAN-OS Available Interfaces"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class HAInterfaceValidationResult(ResultData):
+    """
+    :param all_valid: Whether all specified interfaces were found.
+    :param validated_interfaces: List of interfaces that were validated.
+    :param missing_interfaces: List of interfaces that were not found on the device.
+    """
+
+    all_valid: bool
+    validated_interfaces: Any
+    missing_interfaces: Any
+
+    _output_prefix = OUTPUT_PREFIX + "HAInterfaceValidation"
+    _title = "PAN-OS Interface Validation"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
+class PanoramaHAReconfigureResult(ResultData):
+    """
+    :param message: Human-readable status message.
+    """
+
+    message: str
+
+    _output_prefix = OUTPUT_PREFIX + "PanoramaHAReconfigure"
+    _title = "PAN-OS Panorama HA Reconfigure"
+    _outputs_key_field = "hostid"
+
+
+@dataclass
 class DownloadSoftwareCommandResult:
     summary_data: List[GenericSoftwareStatus]
     result_data: None = None
@@ -12110,6 +12242,371 @@ class FirewallCommand:
         return HighAvailabilityStateStatus(hostid=resolve_host_id(firewall), state=state)
 
     @staticmethod
+    def sync_ha_to_remote(
+        topology: Topology, target: str, sync_type: str
+    ) -> HASyncResult:
+        """
+        Synchronizes configuration or state between HA peers.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        :param sync_type: Either 'config' (running-config) or 'state' (session table).
+        """
+        firewall = topology.get_single_device(target)
+        if sync_type == "config":
+            sync_tag = "running-config"
+            message = "Successfully initiated configuration synchronization."
+        elif sync_type == "state":
+            sync_tag = "state"
+            message = "Successfully initiated state (session) synchronization."
+        else:
+            raise ValueError("Invalid sync_type. Must be 'config' or 'state'.")
+
+        cmd_xml = f"<request><high-availability><sync-to-remote><{sync_tag}/></sync-to-remote></high-availability></request>"
+        run_op_command(firewall, cmd_xml, cmd_xml=False)
+        return HASyncResult(hostid=resolve_host_id(firewall), sync_type=sync_type, message=message)
+
+    @staticmethod
+    def get_ha_configuration(
+        topology: Topology, target: str
+    ) -> HAConfigResult:
+        """
+        Retrieves the detailed HA configuration from a firewall.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        """
+        firewall = topology.get_single_device(target)
+        host_id = resolve_host_id(firewall)
+        xpath = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/high-availability"
+
+        firewall.xapi.get(xpath=xpath)
+        response = firewall.xapi.element_root
+        if response is None:
+            raise DemistoException("No configuration found at the specified path.")
+
+        ha_config = response.find(".//result/high-availability")
+        if ha_config is None:
+            raise DemistoException("High Availability is not configured on this device.")
+
+        def _find_text(el, path, default="N/A"):
+            if el is None:
+                return default
+            node = el.find(path)
+            if node is not None and node.text is not None:
+                return node.text
+            return default
+
+        group = ha_config.find("group")
+        interface = ha_config.find("interface")
+
+        mode = "Active/Passive" if (group is not None and group.find("mode/active-passive") is not None) else "Active/Active"
+
+        link_monitoring_data = []
+        if group is not None:
+            link_groups = group.findall("monitoring/link-monitoring/link-group/entry")
+            for lg in link_groups:
+                group_name = lg.get("name", "Unknown")
+                enabled = _find_text(lg, "enabled", "yes")
+                failure_condition = _find_text(lg, "failure-condition", "any")
+                interfaces = lg.findall("interface/member")
+                interface_list = [iface.text for iface in interfaces if iface.text]
+                link_monitoring_data.append({
+                    "Name": group_name,
+                    "Enabled": enabled,
+                    "FailureCondition": failure_condition,
+                    "Interfaces": ", ".join(interface_list),
+                })
+
+        return HAConfigResult(
+            hostid=host_id,
+            enabled=_find_text(ha_config, "enabled", "no"),
+            group_id=_find_text(group, "group-id"),
+            mode=mode,
+            peer_ip=_find_text(group, "peer-ip"),
+            peer_ip_backup=_find_text(group, "peer-ip-backup"),
+            ha1_port=_find_text(interface, "ha1/port"),
+            ha1_ip=_find_text(interface, "ha1/ip-address"),
+            ha1_backup_port=_find_text(interface, "ha1-backup/port"),
+            ha1_backup_ip=_find_text(interface, "ha1-backup/ip-address"),
+            ha2_port=_find_text(interface, "ha2/port"),
+            ha2_ip=_find_text(interface, "ha2/ip-address"),
+            ha2_backup_port=_find_text(interface, "ha2-backup/port"),
+            ha2_backup_ip=_find_text(interface, "ha2-backup/ip-address"),
+            link_monitoring=link_monitoring_data or None,
+        )
+
+    @staticmethod
+    def get_available_interfaces(
+        topology: Topology, target: str
+    ) -> HAInterfaceListResult:
+        """
+        Lists all available network interfaces on the firewall.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        """
+        firewall = topology.get_single_device(target)
+        host_id = resolve_host_id(firewall)
+        xpath = "/config/devices/entry[@name='localhost.localdomain']/network/interface"
+
+        firewall.xapi.get(xpath=xpath)
+        response = firewall.xapi.element_root
+
+        interface_list: list = []
+        if response is not None:
+            interfaces_xml = response.find(".//result/interface")
+            if interfaces_xml is not None:
+                for eth_entry in interfaces_xml.findall("./ethernet/entry"):
+                    if_name = eth_entry.get("name")
+                    if if_name:
+                        interface_list.append(if_name)
+                for ae_entry in interfaces_xml.findall("./aggregate-ethernet/entry"):
+                    if_name = ae_entry.get("name")
+                    if if_name:
+                        interface_list.append(if_name)
+                for lo_entry in interfaces_xml.findall("./loopback/entry"):
+                    if_name = lo_entry.get("name")
+                    if if_name:
+                        interface_list.append(f"loopback.{if_name}")
+                for tun_entry in interfaces_xml.findall("./tunnel/entry"):
+                    if_name = tun_entry.get("name")
+                    if if_name:
+                        interface_list.append(f"tunnel.{if_name}")
+                for vlan_entry in interfaces_xml.findall("./vlan/entry"):
+                    if_name = vlan_entry.get("name")
+                    if if_name:
+                        interface_list.append(f"vlan.{if_name}")
+
+        # HA-dedicated interfaces are always available
+        ha_interfaces = ["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"]
+        interface_list.extend(ha_interfaces)
+
+        return HAInterfaceListResult(
+            hostid=host_id,
+            interface_count=len(interface_list),
+            interfaces=sorted(interface_list),
+        )
+
+    @staticmethod
+    def validate_interfaces(
+        topology: Topology, target: str, interfaces: str
+    ) -> HAInterfaceValidationResult:
+        """
+        Validates that specified interfaces exist on the firewall.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        :param interfaces: Comma-separated list of interface names to validate.
+        """
+        interfaces_to_check = argToList(interfaces)
+        if not interfaces_to_check:
+            raise ValueError("The 'interfaces' argument is required.")
+
+        interface_result = FirewallCommand.get_available_interfaces(topology, target)
+        available = interface_result.interfaces
+
+        missing = [iface for iface in interfaces_to_check if iface not in available]
+
+        return HAInterfaceValidationResult(
+            hostid=interface_result.hostid,
+            all_valid=len(missing) == 0,
+            validated_interfaces=interfaces_to_check,
+            missing_interfaces=missing,
+        )
+
+    @staticmethod
+    def configure_ha(
+        topology: Topology, target: str, args: dict
+    ) -> HAConfigureResult:
+        """
+        Configures HA setup on a firewall.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        :param args: Dictionary of HA configuration arguments.
+        """
+        firewall = topology.get_single_device(target)
+        host_id = resolve_host_id(firewall)
+
+        # Validate interfaces if any port arguments are provided
+        interfaces_to_validate = []
+        for key in ["ha1_port", "ha1_backup_port", "ha2_port", "ha2_backup_port"]:
+            if args.get(key):
+                interfaces_to_validate.append(args[key])
+
+        if interfaces_to_validate:
+            interface_result = FirewallCommand.get_available_interfaces(topology, target)
+            available = interface_result.interfaces
+            missing = [iface for iface in interfaces_to_validate if iface not in available]
+            if missing:
+                raise DemistoException(
+                    f"HA Configuration Failed: Interface(s) not found on {host_id}: {', '.join(missing)}. "
+                    "Use pan-os-platform-ha-list-interfaces to see available interfaces."
+                )
+
+        group_id = arg_to_number(args.get("group_id", "1"))
+        peer_ip = args.get("peer_ip")
+        peer_ip_backup = args.get("peer_ip_backup")
+        passive_link_state = args.get("passive_link_state", "auto")
+        device_priority = arg_to_number(args.get("device_priority", "100"))
+
+        state_sync = argToBoolean(args.get("state_sync", "false"))
+        ha2_keepalive = argToBoolean(args.get("ha2_keepalive", "false"))
+        ha2_keepalive_threshold = arg_to_number(args.get("ha2_keepalive_threshold", "10000"))
+        ha2_keepalive_action = args.get("ha2_keepalive_action", "log-only")
+
+        ha_config = HighAvailability(
+            enabled=True,
+            group_id=group_id,
+            peer_ip=peer_ip,
+            peer_ip_backup=peer_ip_backup,
+            mode="active-passive",
+            passive_link_state=passive_link_state,
+            config_sync=True,
+            state_sync=state_sync,
+            ha2_keepalive=ha2_keepalive,
+            ha2_keepalive_threshold=(ha2_keepalive_threshold if ha2_keepalive else None),
+            ha2_keepalive_action=(ha2_keepalive_action if ha2_keepalive else None),
+        )
+
+        # HA1 Interface
+        if all(args.get(k) for k in ["ha1_port", "ha1_ip_address", "ha1_netmask"]):
+            ha1 = HA1(
+                port=args["ha1_port"],
+                ip_address=args["ha1_ip_address"],
+                netmask=args["ha1_netmask"],
+                gateway=args.get("ha1_gateway"),
+            )
+            ha_config.add(ha1)
+
+        # HA1 Backup Interface
+        if all(args.get(k) for k in ["ha1_backup_port", "ha1_backup_ip_address", "ha1_backup_netmask"]):
+            ha1_backup = HA1Backup(
+                port=args["ha1_backup_port"],
+                ip_address=args["ha1_backup_ip_address"],
+                netmask=args["ha1_backup_netmask"],
+            )
+            ha_config.add(ha1_backup)
+
+        # HA2 Interface
+        if all(args.get(k) for k in ["ha2_port", "ha2_ip_address", "ha2_netmask"]):
+            ha2 = HA2(
+                port=args["ha2_port"],
+                ip_address=args["ha2_ip_address"],
+                netmask=args["ha2_netmask"],
+            )
+            ha_config.add(ha2)
+
+        # HA2 Backup Interface
+        if all(args.get(k) for k in ["ha2_backup_port", "ha2_backup_ip_address", "ha2_backup_netmask"]):
+            ha2_backup = HA2Backup(
+                port=args["ha2_backup_port"],
+                ip_address=args["ha2_backup_ip_address"],
+                netmask=args["ha2_backup_netmask"],
+            )
+            ha_config.add(ha2_backup)
+
+        firewall.add(ha_config)
+
+        # Generate XML and inject election settings
+        xml_str = ha_config.element_str()
+        heartbeat_backup = argToBoolean(args.get("heartbeat_backup", "false"))
+
+        if device_priority is not None or heartbeat_backup:
+            import xml.etree.ElementTree as ET
+            root = ET.fromstring(xml_str)
+            group_el = root.find(".//group")
+            if group_el is not None:
+                election = group_el.find("election-option")
+                if election is None:
+                    election = ET.SubElement(group_el, "election-option")
+
+                if device_priority is not None:
+                    priority_elem = election.find("device-priority")
+                    if priority_elem is None:
+                        priority_elem = ET.SubElement(election, "device-priority")
+                    priority_elem.text = str(device_priority)
+
+                if heartbeat_backup:
+                    hb_elem = election.find("heartbeat-backup")
+                    if hb_elem is None:
+                        hb_elem = ET.SubElement(election, "heartbeat-backup")
+                    hb_elem.text = "yes"
+
+                timers = election.find("timers")
+                if timers is None:
+                    timers = ET.SubElement(election, "timers")
+                    ET.SubElement(timers, "recommended")
+
+                xml_str = ET.tostring(root, encoding="unicode")
+
+        xpath = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/high-availability"
+        firewall.xapi.edit(xpath=xpath, element=xml_str)
+
+        message = "Configuration successfully applied to candidate config."
+        committed = False
+
+        if argToBoolean(args.get("commit", "false")):
+            commit_result = str(firewall.commit(sync=True))
+            message += f"\nCommit successful. Details: {commit_result}"
+            committed = True
+        else:
+            message += "\nA commit is needed to apply these changes."
+
+        return HAConfigureResult(hostid=host_id, message=message, committed=committed)
+
+    @staticmethod
+    def set_ha_enabled_state(
+        topology: Topology, target: str, enabled: bool, commit: str = "false"
+    ) -> HAEnabledStateResult:
+        """
+        Enables or disables HA on a firewall.
+        :param topology: `Topology` instance.
+        :param target: The target device serial or hostname.
+        :param enabled: Whether to enable or disable HA.
+        :param commit: Whether to commit the change.
+        """
+        firewall = topology.get_single_device(target)
+        host_id = resolve_host_id(firewall)
+
+        enabled_str = "yes" if enabled else "no"
+        xpath = "/config/devices/entry[@name='localhost.localdomain']/deviceconfig/high-availability/enabled"
+        element = f"<enabled>{enabled_str}</enabled>"
+        firewall.xapi.edit(xpath=xpath, element=element)
+
+        status_verb = "Enabled" if enabled else "Disabled"
+        message = f"'{status_verb}' setting successfully applied to candidate config."
+        committed = False
+
+        if argToBoolean(commit):
+            commit_result = str(firewall.commit(sync=True))
+            message += f"\nCommit successful. Details: {commit_result}"
+            committed = True
+        else:
+            message += "\nA commit is needed to apply these changes."
+
+        return HAEnabledStateResult(hostid=host_id, enabled=enabled, message=message, committed=committed)
+
+    @staticmethod
+    def panorama_ha_reconfigure(
+        topology: Topology, target: Optional[str] = None
+    ) -> PanoramaHAReconfigureResult:
+        """
+        Issues a revert to running HA state command to Panorama.
+        :param topology: `Topology` instance.
+        :param target: Optional target serial or hostname.
+        """
+        # Use Panorama object from topology
+        for panorama_device in topology.panorama_objects.values():
+            if target and resolve_host_id(panorama_device) != target:
+                continue
+            host_id = resolve_host_id(panorama_device)
+            ha_config_obj = HighAvailability()
+            panorama_device.add(ha_config_obj)
+            ha_config_obj.revert_to_running()
+            return PanoramaHAReconfigureResult(
+                hostid=host_id,
+                message=f"Successfully sent HA reconfiguration command to Panorama at {host_id}.",
+            )
+        raise DemistoException("No Panorama device found in topology.")
+
+    @staticmethod
     def get_routes(
         topology: Topology, device_filter_str: Optional[str] = None, target: Optional[str] = None
     ) -> ShowRoutingRouteCommandResult:
@@ -12554,6 +13051,99 @@ def update_ha_state(topology: Topology, target: str, state: str) -> HighAvailabi
     :param state: New state.
     """
     return FirewallCommand.change_status(topology, hostid=target, state=state)
+
+
+def ha_sync_config(topology: Topology, target: str) -> HASyncResult:
+    """
+    Forces the active firewall to synchronize its running configuration with the passive peer.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to synchronize config from.
+    """
+    return FirewallCommand.sync_ha_to_remote(topology, target, sync_type="config")
+
+
+def ha_sync_state(topology: Topology, target: str) -> HASyncResult:
+    """
+    Forces the active firewall to synchronize its state (session table) with the passive peer.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to synchronize state from.
+    """
+    return FirewallCommand.sync_ha_to_remote(topology, target, sync_type="state")
+
+
+def get_ha_config(topology: Topology, target: str) -> HAConfigResult:
+    """
+    Retrieves the current High Availability configuration from a firewall.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to retrieve the HA config from.
+    """
+    return FirewallCommand.get_ha_configuration(topology, target)
+
+
+def ha_configure(topology: Topology, target: str, **kwargs) -> HAConfigureResult:
+    """
+    Enables and configures a detailed High Availability setup on a firewall.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to configure HA on.
+    """
+    return FirewallCommand.configure_ha(topology, target, kwargs)
+
+
+def ha_enable(topology: Topology, target: str, commit: str = "false") -> HAEnabledStateResult:
+    """
+    Enables the HA functionality on a firewall from previous configuration.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to enable HA on.
+    :param commit: Whether to commit the change immediately.
+    """
+    return FirewallCommand.set_ha_enabled_state(topology, target, enabled=True, commit=commit)
+
+
+def ha_disable(topology: Topology, target: str, commit: str = "false") -> HAEnabledStateResult:
+    """
+    Disables the HA functionality on a firewall.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to disable HA on.
+    :param commit: Whether to commit the change immediately.
+    """
+    return FirewallCommand.set_ha_enabled_state(topology, target, enabled=False, commit=commit)
+
+
+def ha_list_interfaces(topology: Topology, target: str) -> HAInterfaceListResult:
+    """
+    Lists all available network interfaces on the firewall.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to list interfaces on.
+    """
+    return FirewallCommand.get_available_interfaces(topology, target)
+
+
+def ha_validate_interfaces(topology: Topology, target: str, interfaces: str) -> HAInterfaceValidationResult:
+    """
+    Validates that specified interfaces exist on the firewall before HA configuration.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: ID of host (serial or hostname) to validate interfaces on.
+    :param interfaces: Comma-separated list of interface names to validate.
+    """
+    return FirewallCommand.validate_interfaces(topology, target, interfaces)
+
+
+def panorama_ha_reconfigure(topology: Topology, target: Optional[str] = None) -> PanoramaHAReconfigureResult:
+    """
+    Issues a revert to running HA state command to a Panorama device.
+
+    :param topology: `Topology` instance !no-auto-argument
+    :param target: Optional ID of Panorama host (serial or hostname).
+    """
+    return FirewallCommand.panorama_ha_reconfigure(topology, target)
 
 
 def get_rule_hitcounts(
@@ -16857,6 +17447,78 @@ def main():  # pragma: no cover
                 dataclasses_to_command_results(
                     update_ha_state(topology, **demisto.args()),
                     empty_result_message="HA State either wasn't change or the device did not respond.",
+                )
+            )
+        elif command == "pan-os-platform-ha-sync-config":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_sync_config(topology, **demisto.args()),
+                    empty_result_message="HA sync config did not return a result.",
+                )
+            )
+        elif command == "pan-os-platform-ha-sync-state":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_sync_state(topology, **demisto.args()),
+                    empty_result_message="HA sync state did not return a result.",
+                )
+            )
+        elif command == "pan-os-platform-get-ha-config":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    get_ha_config(topology, **demisto.args()),
+                    empty_result_message="No HA configuration found.",
+                )
+            )
+        elif command == "pan-os-platform-ha-configure":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_configure(topology, **demisto.args()),
+                    empty_result_message="HA configuration did not return a result.",
+                )
+            )
+        elif command == "pan-os-platform-ha-enable":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_enable(topology, **demisto.args()),
+                    empty_result_message="HA enable did not return a result.",
+                )
+            )
+        elif command == "pan-os-platform-ha-disable":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_disable(topology, **demisto.args()),
+                    empty_result_message="HA disable did not return a result.",
+                )
+            )
+        elif command == "pan-os-platform-ha-list-interfaces":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_list_interfaces(topology, **demisto.args()),
+                    empty_result_message="No interfaces found.",
+                )
+            )
+        elif command == "pan-os-platform-ha-validate-interfaces":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    ha_validate_interfaces(topology, **demisto.args()),
+                    empty_result_message="Interface validation did not return a result.",
+                )
+            )
+        elif command == "pan-os-panorama-ha-reconfigure":
+            topology = get_topology()
+            return_results(
+                dataclasses_to_command_results(
+                    panorama_ha_reconfigure(topology, **demisto.args()),
+                    empty_result_message="Panorama HA reconfigure did not return a result.",
                 )
             )
         elif command == "pan-os-hygiene-check-log-forwarding":

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -42,7 +42,6 @@ from panos.ha import HighAvailability, HA1, HA2, HA1Backup, HA2Backup
 from urllib.error import HTTPError
 
 import shutil
-import xml.etree.ElementTree as ET
 
 """ IMPORTS """
 import uuid

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -12366,7 +12366,7 @@ class FirewallCommand:
         # HA-dedicated interfaces available on PAN-OS firewalls
         ha_interfaces = [
             "ha1", "ha1-a", "ha1-b", "ha1-backup",
-            "ha2", "ha2-backup",
+            "ha2", "ha2-a", "ha2-backup",
             "hsci", "hsci-a", "hsci-b",
             "ha3",
             "ha4", "ha4-backup",

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -12242,9 +12242,7 @@ class FirewallCommand:
         return HighAvailabilityStateStatus(hostid=resolve_host_id(firewall), state=state)
 
     @staticmethod
-    def sync_ha_to_remote(
-        topology: Topology, target: str, sync_type: str
-    ) -> HASyncResult:
+    def sync_ha_to_remote(topology: Topology, target: str, sync_type: str) -> HASyncResult:
         """
         Synchronizes configuration or state between HA peers.
         :param topology: `Topology` instance.
@@ -12266,9 +12264,7 @@ class FirewallCommand:
         return HASyncResult(hostid=resolve_host_id(firewall), sync_type=sync_type, message=message)
 
     @staticmethod
-    def get_ha_configuration(
-        topology: Topology, target: str
-    ) -> HAConfigResult:
+    def get_ha_configuration(topology: Topology, target: str) -> HAConfigResult:
         """
         Retrieves the detailed HA configuration from a firewall.
         :param topology: `Topology` instance.
@@ -12309,12 +12305,14 @@ class FirewallCommand:
                 failure_condition = _find_text(lg, "failure-condition", "any")
                 interfaces = lg.findall("interface/member")
                 interface_list = [iface.text for iface in interfaces if iface.text]
-                link_monitoring_data.append({
-                    "Name": group_name,
-                    "Enabled": enabled,
-                    "FailureCondition": failure_condition,
-                    "Interfaces": ", ".join(interface_list),
-                })
+                link_monitoring_data.append(
+                    {
+                        "Name": group_name,
+                        "Enabled": enabled,
+                        "FailureCondition": failure_condition,
+                        "Interfaces": ", ".join(interface_list),
+                    }
+                )
 
         return HAConfigResult(
             hostid=host_id,
@@ -12335,9 +12333,7 @@ class FirewallCommand:
         )
 
     @staticmethod
-    def get_available_interfaces(
-        topology: Topology, target: str
-    ) -> HAInterfaceListResult:
+    def get_available_interfaces(topology: Topology, target: str) -> HAInterfaceListResult:
         """
         Lists all available network interfaces on the firewall.
         :param topology: `Topology` instance.
@@ -12386,9 +12382,7 @@ class FirewallCommand:
         )
 
     @staticmethod
-    def validate_interfaces(
-        topology: Topology, target: str, interfaces: str
-    ) -> HAInterfaceValidationResult:
+    def validate_interfaces(topology: Topology, target: str, interfaces: str) -> HAInterfaceValidationResult:
         """
         Validates that specified interfaces exist on the firewall.
         :param topology: `Topology` instance.
@@ -12412,9 +12406,7 @@ class FirewallCommand:
         )
 
     @staticmethod
-    def configure_ha(
-        topology: Topology, target: str, args: dict
-    ) -> HAConfigureResult:
+    def configure_ha(topology: Topology, target: str, args: dict) -> HAConfigureResult:
         """
         Configures HA setup on a firewall.
         :param topology: `Topology` instance.
@@ -12510,6 +12502,7 @@ class FirewallCommand:
 
         if device_priority is not None or heartbeat_backup:
             import xml.etree.ElementTree as ET
+
             root = ET.fromstring(xml_str)
             group_el = root.find(".//group")
             if group_el is not None:
@@ -12552,9 +12545,7 @@ class FirewallCommand:
         return HAConfigureResult(hostid=host_id, message=message, committed=committed)
 
     @staticmethod
-    def set_ha_enabled_state(
-        topology: Topology, target: str, enabled: bool, commit: str = "false"
-    ) -> HAEnabledStateResult:
+    def set_ha_enabled_state(topology: Topology, target: str, enabled: bool, commit: str = "false") -> HAEnabledStateResult:
         """
         Enables or disables HA on a firewall.
         :param topology: `Topology` instance.
@@ -12584,9 +12575,7 @@ class FirewallCommand:
         return HAEnabledStateResult(hostid=host_id, enabled=enabled, message=message, committed=committed)
 
     @staticmethod
-    def panorama_ha_reconfigure(
-        topology: Topology, target: Optional[str] = None
-    ) -> PanoramaHAReconfigureResult:
+    def panorama_ha_reconfigure(topology: Topology, target: Optional[str] = None) -> PanoramaHAReconfigureResult:
         """
         Issues a revert to running HA state command to Panorama.
         :param topology: `Topology` instance.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -12286,6 +12286,7 @@ class FirewallCommand:
         :param device_filter_str: If provided, filters this command to only the devices specified.
         :param target: Single serial number to target with this command.
         """
+
         def _find_text(el, path, default="N/A"):
             if el is None:
                 return default
@@ -12331,23 +12332,25 @@ class FirewallCommand:
                         }
                     )
 
-            result.append(HAConfigResult(
-                HostID=host_id,
-                Enabled=_find_text(ha_config, "enabled", "no"),
-                GroupID=_find_text(group, "group-id"),
-                Mode=mode,
-                PeerIP=_find_text(group, "peer-ip"),
-                PeerIPBackup=_find_text(group, "peer-ip-backup"),
-                HA1Port=_find_text(interface, "ha1/port"),
-                HA1IP=_find_text(interface, "ha1/ip-address"),
-                HA1BackupPort=_find_text(interface, "ha1-backup/port"),
-                HA1BackupIP=_find_text(interface, "ha1-backup/ip-address"),
-                HA2Port=_find_text(interface, "ha2/port"),
-                HA2IP=_find_text(interface, "ha2/ip-address"),
-                HA2BackupPort=_find_text(interface, "ha2-backup/port"),
-                HA2BackupIP=_find_text(interface, "ha2-backup/ip-address"),
-                LinkMonitoring=link_monitoring_data or None,
-            ))
+            result.append(
+                HAConfigResult(
+                    HostID=host_id,
+                    Enabled=_find_text(ha_config, "enabled", "no"),
+                    GroupID=_find_text(group, "group-id"),
+                    Mode=mode,
+                    PeerIP=_find_text(group, "peer-ip"),
+                    PeerIPBackup=_find_text(group, "peer-ip-backup"),
+                    HA1Port=_find_text(interface, "ha1/port"),
+                    HA1IP=_find_text(interface, "ha1/ip-address"),
+                    HA1BackupPort=_find_text(interface, "ha1-backup/port"),
+                    HA1BackupIP=_find_text(interface, "ha1-backup/ip-address"),
+                    HA2Port=_find_text(interface, "ha2/port"),
+                    HA2IP=_find_text(interface, "ha2/ip-address"),
+                    HA2BackupPort=_find_text(interface, "ha2-backup/port"),
+                    HA2BackupIP=_find_text(interface, "ha2-backup/ip-address"),
+                    LinkMonitoring=link_monitoring_data or None,
+                )
+            )
 
         if len(result) == 1:
             return result[0]
@@ -12365,12 +12368,21 @@ class FirewallCommand:
         """
         # HA-dedicated interfaces available on PAN-OS firewalls
         ha_interfaces = [
-            "ha1", "ha1-a", "ha1-b", "ha1-backup",
-            "ha2", "ha2-a", "ha2-backup",
-            "hsci", "hsci-a", "hsci-b",
+            "ha1",
+            "ha1-a",
+            "ha1-b",
+            "ha1-backup",
+            "ha2",
+            "ha2-a",
+            "ha2-backup",
+            "hsci",
+            "hsci-a",
+            "hsci-b",
             "ha3",
-            "ha4", "ha4-backup",
-            "aux-1", "aux-2",
+            "ha4",
+            "ha4-backup",
+            "aux-1",
+            "aux-2",
         ]
 
         result: List[HAInterfaceListResult] = []
@@ -12408,11 +12420,13 @@ class FirewallCommand:
 
             interface_list.extend(ha_interfaces)
 
-            result.append(HAInterfaceListResult(
-                HostID=host_id,
-                InterfaceCount=len(interface_list),
-                Interfaces=sorted(interface_list),
-            ))
+            result.append(
+                HAInterfaceListResult(
+                    HostID=host_id,
+                    InterfaceCount=len(interface_list),
+                    Interfaces=sorted(interface_list),
+                )
+            )
 
         if len(result) == 1:
             return result[0]

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -8769,6 +8769,290 @@ script:
       description: The new HA state.
       type: String
   - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    description: Forces the active firewall to synchronize its running configuration with the passive peer.
+    name: pan-os-platform-ha-sync-config
+    outputs:
+    - contextPath: PANOS.HASync.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HASync.sync_type
+      description: The type of synchronization performed.
+      type: String
+    - contextPath: PANOS.HASync.message
+      description: Human-readable status message.
+      type: String
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    description: Forces the active firewall to synchronize its state (session table) with the passive peer.
+    name: pan-os-platform-ha-sync-state
+    outputs:
+    - contextPath: PANOS.HASync.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HASync.sync_type
+      description: The type of synchronization performed.
+      type: String
+    - contextPath: PANOS.HASync.message
+      description: Human-readable status message.
+      type: String
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    description: Retrieves the current High Availability configuration from a firewall.
+    name: pan-os-platform-get-ha-config
+    outputs:
+    - contextPath: PANOS.HAConfig.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAConfig.enabled
+      description: Whether HA is enabled on the device.
+      type: String
+    - contextPath: PANOS.HAConfig.group_id
+      description: The Group ID for the HA pair.
+      type: String
+    - contextPath: PANOS.HAConfig.mode
+      description: The HA mode (e.g., Active/Passive).
+      type: String
+    - contextPath: PANOS.HAConfig.peer_ip
+      description: The IP address of the HA peer.
+      type: String
+    - contextPath: PANOS.HAConfig.peer_ip_backup
+      description: The backup IP address of the HA peer.
+      type: String
+    - contextPath: PANOS.HAConfig.ha1_port
+      description: The interface port for the HA1 (Control) link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha1_ip
+      description: The IP address for the HA1 (Control) link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha1_backup_port
+      description: The interface port for the HA1-Backup link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha1_backup_ip
+      description: The IP address for the HA1-Backup link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha2_port
+      description: The interface port for the HA2 (Data) link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha2_ip
+      description: The IP address for the HA2 (Data) link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha2_backup_port
+      description: The interface port for the HA2-Backup link.
+      type: String
+    - contextPath: PANOS.HAConfig.ha2_backup_ip
+      description: The IP address for the HA2-Backup link.
+      type: String
+    - contextPath: PANOS.HAConfig.link_monitoring
+      description: A list of Link Monitoring group configurations.
+      type: Unknown
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    - description: The IP address of the peer firewall's primary HA1 control link.
+      name: peer_ip
+      required: true
+    - defaultValue: "1"
+      description: The HA Group ID (1-255).
+      name: group_id
+    - description: The IP address of the peer firewall's backup HA1 control link.
+      name: peer_ip_backup
+    - auto: PREDEFINED
+      defaultValue: auto
+      description: For Active/Passive mode, specifies the link state of the passive device.
+      name: passive_link_state
+      predefined:
+      - auto
+      - shutdown
+    - defaultValue: "100"
+      description: Device priority for HA election (0-255). Higher priority becomes active.
+      name: device_priority
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Enable backup heartbeat monitoring (recommended for production HA).
+      name: heartbeat_backup
+      predefined:
+      - "true"
+      - "false"
+    - description: The primary control link (HA1) interface port (e.g., ha1-a, ethernet1/1).
+      name: ha1_port
+    - description: The IP address for the primary control link (HA1) interface.
+      name: ha1_ip_address
+    - description: The netmask for the primary control link (HA1) interface.
+      name: ha1_netmask
+    - description: The gateway for the primary control link (HA1) interface.
+      name: ha1_gateway
+    - description: The backup control link (HA1-Backup) interface port.
+      name: ha1_backup_port
+    - description: The IP address for the backup control link (HA1-Backup) interface.
+      name: ha1_backup_ip_address
+    - description: The netmask for the backup control link (HA1-Backup) interface.
+      name: ha1_backup_netmask
+    - description: The primary data link (HA2) interface port for session synchronization.
+      name: ha2_port
+    - description: The IP address for the primary data link (HA2) interface.
+      name: ha2_ip_address
+    - description: The netmask for the primary data link (HA2) interface.
+      name: ha2_netmask
+    - description: The backup data link (HA2-Backup) interface port.
+      name: ha2_backup_port
+    - description: The IP address for the backup data link (HA2-Backup) interface.
+      name: ha2_backup_ip_address
+    - description: The netmask for the backup data link (HA2-Backup) interface.
+      name: ha2_backup_netmask
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Enable state (session) synchronization over the HA2 data link.
+      name: state_sync
+      predefined:
+      - "true"
+      - "false"
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Enable HA2 keep-alive monitoring to detect failures on the HA2 data link.
+      name: ha2_keepalive
+      predefined:
+      - "true"
+      - "false"
+    - defaultValue: "10000"
+      description: HA2 keep-alive threshold in milliseconds (5000-60000).
+      name: ha2_keepalive_threshold
+    - auto: PREDEFINED
+      defaultValue: log-only
+      description: Action to take when HA2 keep-alive fails.
+      name: ha2_keepalive_action
+      predefined:
+      - log-only
+      - log-and-reboot
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Commit the configuration change immediately.
+      name: commit
+      predefined:
+      - "true"
+      - "false"
+    description: Enables and configures a detailed High Availability setup on a firewall.
+    name: pan-os-platform-ha-configure
+    outputs:
+    - contextPath: PANOS.HAConfigure.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAConfigure.message
+      description: Human-readable status message.
+      type: String
+    - contextPath: PANOS.HAConfigure.committed
+      description: Whether the configuration was committed.
+      type: Boolean
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Set to true to automatically commit the configuration changes.
+      name: commit
+      predefined:
+      - "true"
+      - "false"
+    description: Enables the HA functionality on a firewall from previous configuration.
+    name: pan-os-platform-ha-enable
+    outputs:
+    - contextPath: PANOS.HAEnabledState.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAEnabledState.enabled
+      description: Whether HA has been enabled or disabled.
+      type: Boolean
+    - contextPath: PANOS.HAEnabledState.message
+      description: Human-readable status message.
+      type: String
+    - contextPath: PANOS.HAEnabledState.committed
+      description: Whether the configuration was committed.
+      type: Boolean
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    - auto: PREDEFINED
+      defaultValue: "false"
+      description: Set to true to automatically commit the configuration changes.
+      name: commit
+      predefined:
+      - "true"
+      - "false"
+    description: Disables the HA functionality on a firewall.
+    name: pan-os-platform-ha-disable
+    outputs:
+    - contextPath: PANOS.HAEnabledState.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAEnabledState.enabled
+      description: Whether HA has been enabled or disabled.
+      type: Boolean
+    - contextPath: PANOS.HAEnabledState.message
+      description: Human-readable status message.
+      type: String
+    - contextPath: PANOS.HAEnabledState.committed
+      description: Whether the configuration was committed.
+      type: Boolean
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    description: Lists all available network interfaces on the firewall.
+    name: pan-os-platform-ha-list-interfaces
+    outputs:
+    - contextPath: PANOS.HAInterfaces.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAInterfaces.interface_count
+      description: Total number of interfaces found.
+      type: Number
+    - contextPath: PANOS.HAInterfaces.interfaces
+      description: List of all available interface names.
+      type: Unknown
+  - arguments:
+    - description: The serial number, or IP address, of the target firewall.
+      name: target
+      required: true
+    - description: Comma-separated list of interface names to validate (e.g., ha1-a,ha2-a,ethernet1/1).
+      name: interfaces
+      required: true
+    description: Validates that specified interfaces exist on the firewall before HA configuration.
+    name: pan-os-platform-ha-validate-interfaces
+    outputs:
+    - contextPath: PANOS.HAInterfaceValidation.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.HAInterfaceValidation.all_valid
+      description: Whether all specified interfaces were found.
+      type: Boolean
+    - contextPath: PANOS.HAInterfaceValidation.validated_interfaces
+      description: List of interfaces that were validated.
+      type: Unknown
+    - contextPath: PANOS.HAInterfaceValidation.missing_interfaces
+      description: List of interfaces that were not found on the device.
+      type: Unknown
+  - arguments:
+    - description: The serial number, or IP address, of the target Panorama device.
+      name: target
+    description: Issues a revert to running HA state command to a Panorama device.
+    name: pan-os-panorama-ha-reconfigure
+    outputs:
+    - contextPath: PANOS.PanoramaHAReconfigure.hostid
+      description: The host ID.
+      type: String
+    - contextPath: PANOS.PanoramaHAReconfigure.message
+      description: Human-readable status message.
+      type: String
+  - arguments:
     - description: The string by which to filter so that only the given device is checked.
       name: device_filter_string
     description: Checks that at least one log forwarding profile is configured according to best practices.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -8775,13 +8775,13 @@ script:
     description: Forces the active firewall to synchronize its running configuration with the passive peer.
     name: pan-os-platform-ha-sync-config
     outputs:
-    - contextPath: PANOS.HASync.hostid
+    - contextPath: PANOS.HASync.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HASync.sync_type
+    - contextPath: PANOS.HASync.SyncType
       description: The type of synchronization performed.
       type: String
-    - contextPath: PANOS.HASync.message
+    - contextPath: PANOS.HASync.Message
       description: Human-readable status message.
       type: String
   - arguments:
@@ -8791,66 +8791,67 @@ script:
     description: Forces the active firewall to synchronize its state (session table) with the passive peer.
     name: pan-os-platform-ha-sync-state
     outputs:
-    - contextPath: PANOS.HASync.hostid
+    - contextPath: PANOS.HASync.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HASync.sync_type
+    - contextPath: PANOS.HASync.SyncType
       description: The type of synchronization performed.
       type: String
-    - contextPath: PANOS.HASync.message
+    - contextPath: PANOS.HASync.Message
       description: Human-readable status message.
       type: String
   - arguments:
+    - description: The string by which to filter the results to only show specific hostnames or serial numbers.
+      name: device_filter_string
     - description: The serial number, or IP address, of the target firewall.
       name: target
-      required: true
     description: Retrieves the current High Availability configuration from a firewall.
     name: pan-os-platform-get-ha-config
     outputs:
-    - contextPath: PANOS.HAConfig.hostid
+    - contextPath: PANOS.HAConfig.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAConfig.enabled
+    - contextPath: PANOS.HAConfig.Enabled
       description: Whether HA is enabled on the device.
       type: String
-    - contextPath: PANOS.HAConfig.group_id
+    - contextPath: PANOS.HAConfig.GroupID
       description: The Group ID for the HA pair.
       type: String
-    - contextPath: PANOS.HAConfig.mode
+    - contextPath: PANOS.HAConfig.Mode
       description: The HA mode (e.g., Active/Passive).
       type: String
-    - contextPath: PANOS.HAConfig.peer_ip
+    - contextPath: PANOS.HAConfig.PeerIP
       description: The IP address of the HA peer.
       type: String
-    - contextPath: PANOS.HAConfig.peer_ip_backup
+    - contextPath: PANOS.HAConfig.PeerIPBackup
       description: The backup IP address of the HA peer.
       type: String
-    - contextPath: PANOS.HAConfig.ha1_port
+    - contextPath: PANOS.HAConfig.HA1Port
       description: The interface port for the HA1 (Control) link.
       type: String
-    - contextPath: PANOS.HAConfig.ha1_ip
+    - contextPath: PANOS.HAConfig.HA1IP
       description: The IP address for the HA1 (Control) link.
       type: String
-    - contextPath: PANOS.HAConfig.ha1_backup_port
+    - contextPath: PANOS.HAConfig.HA1BackupPort
       description: The interface port for the HA1-Backup link.
       type: String
-    - contextPath: PANOS.HAConfig.ha1_backup_ip
+    - contextPath: PANOS.HAConfig.HA1BackupIP
       description: The IP address for the HA1-Backup link.
       type: String
-    - contextPath: PANOS.HAConfig.ha2_port
+    - contextPath: PANOS.HAConfig.HA2Port
       description: The interface port for the HA2 (Data) link.
       type: String
-    - contextPath: PANOS.HAConfig.ha2_ip
+    - contextPath: PANOS.HAConfig.HA2IP
       description: The IP address for the HA2 (Data) link.
       type: String
-    - contextPath: PANOS.HAConfig.ha2_backup_port
+    - contextPath: PANOS.HAConfig.HA2BackupPort
       description: The interface port for the HA2-Backup link.
       type: String
-    - contextPath: PANOS.HAConfig.ha2_backup_ip
+    - contextPath: PANOS.HAConfig.HA2BackupIP
       description: The IP address for the HA2-Backup link.
       type: String
-    - contextPath: PANOS.HAConfig.link_monitoring
-      description: A list of Link Monitoring group configurations.
+    - contextPath: PANOS.HAConfig.LinkMonitoring
+      description: A list of Link Monitoring group configurations (each with Name, Enabled, FailureCondition, Interfaces).
       type: Unknown
   - arguments:
     - description: The serial number, or IP address, of the target firewall.
@@ -8941,13 +8942,13 @@ script:
     description: Enables and configures a detailed High Availability setup on a firewall.
     name: pan-os-platform-ha-configure
     outputs:
-    - contextPath: PANOS.HAConfigure.hostid
+    - contextPath: PANOS.HAConfigure.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAConfigure.message
+    - contextPath: PANOS.HAConfigure.Message
       description: Human-readable status message.
       type: String
-    - contextPath: PANOS.HAConfigure.committed
+    - contextPath: PANOS.HAConfigure.Committed
       description: Whether the configuration was committed.
       type: Boolean
   - arguments:
@@ -8964,16 +8965,16 @@ script:
     description: Enables the HA functionality on a firewall from previous configuration.
     name: pan-os-platform-ha-enable
     outputs:
-    - contextPath: PANOS.HAEnabledState.hostid
+    - contextPath: PANOS.HAEnabledState.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAEnabledState.enabled
+    - contextPath: PANOS.HAEnabledState.Enabled
       description: Whether HA has been enabled or disabled.
       type: Boolean
-    - contextPath: PANOS.HAEnabledState.message
+    - contextPath: PANOS.HAEnabledState.Message
       description: Human-readable status message.
       type: String
-    - contextPath: PANOS.HAEnabledState.committed
+    - contextPath: PANOS.HAEnabledState.Committed
       description: Whether the configuration was committed.
       type: Boolean
   - arguments:
@@ -8990,32 +8991,33 @@ script:
     description: Disables the HA functionality on a firewall.
     name: pan-os-platform-ha-disable
     outputs:
-    - contextPath: PANOS.HAEnabledState.hostid
+    - contextPath: PANOS.HAEnabledState.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAEnabledState.enabled
+    - contextPath: PANOS.HAEnabledState.Enabled
       description: Whether HA has been enabled or disabled.
       type: Boolean
-    - contextPath: PANOS.HAEnabledState.message
+    - contextPath: PANOS.HAEnabledState.Message
       description: Human-readable status message.
       type: String
-    - contextPath: PANOS.HAEnabledState.committed
+    - contextPath: PANOS.HAEnabledState.Committed
       description: Whether the configuration was committed.
       type: Boolean
   - arguments:
+    - description: The string by which to filter the results to only show specific hostnames or serial numbers.
+      name: device_filter_string
     - description: The serial number, or IP address, of the target firewall.
       name: target
-      required: true
     description: Lists all available network interfaces on the firewall.
     name: pan-os-platform-ha-list-interfaces
     outputs:
-    - contextPath: PANOS.HAInterfaces.hostid
+    - contextPath: PANOS.HAInterfaces.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAInterfaces.interface_count
+    - contextPath: PANOS.HAInterfaces.InterfaceCount
       description: Total number of interfaces found.
       type: Number
-    - contextPath: PANOS.HAInterfaces.interfaces
+    - contextPath: PANOS.HAInterfaces.Interfaces
       description: List of all available interface names.
       type: Unknown
   - arguments:
@@ -9028,17 +9030,17 @@ script:
     description: Validates that specified interfaces exist on the firewall before HA configuration.
     name: pan-os-platform-ha-validate-interfaces
     outputs:
-    - contextPath: PANOS.HAInterfaceValidation.hostid
+    - contextPath: PANOS.HAInterfaceValidation.HostID
       description: The host ID.
       type: String
-    - contextPath: PANOS.HAInterfaceValidation.all_valid
+    - contextPath: PANOS.HAInterfaceValidation.AllValid
       description: Whether all specified interfaces were found.
       type: Boolean
-    - contextPath: PANOS.HAInterfaceValidation.validated_interfaces
-      description: List of interfaces that were validated.
+    - contextPath: PANOS.HAInterfaceValidation.ValidatedInterfaces
+      description: List of interface names that were validated.
       type: Unknown
-    - contextPath: PANOS.HAInterfaceValidation.missing_interfaces
-      description: List of interfaces that were not found on the device.
+    - contextPath: PANOS.HAInterfaceValidation.MissingInterfaces
+      description: List of interface names that were not found on the device.
       type: Unknown
   - arguments:
     - description: The serial number, or IP address, of the target Panorama device.

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -9507,9 +9507,9 @@ class TestHASyncToRemote:
         from Panorama import FirewallCommand
 
         result = FirewallCommand.sync_ha_to_remote(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "config")
-        assert result.sync_type == "config"
-        assert "configuration" in result.message.lower()
-        assert result.hostid == MOCK_FIREWALL_1_SERIAL
+        assert result.SyncType == "config"
+        assert "configuration" in result.Message.lower()
+        assert result.HostID == MOCK_FIREWALL_1_SERIAL
         patched_run_op_command.assert_called_once()
         call_args = patched_run_op_command.call_args
         assert "running-config" in call_args[0][1]
@@ -9519,9 +9519,9 @@ class TestHASyncToRemote:
         from Panorama import FirewallCommand
 
         result = FirewallCommand.sync_ha_to_remote(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "state")
-        assert result.sync_type == "state"
-        assert "state" in result.message.lower()
-        assert result.hostid == MOCK_FIREWALL_1_SERIAL
+        assert result.SyncType == "state"
+        assert "state" in result.Message.lower()
+        assert result.HostID == MOCK_FIREWALL_1_SERIAL
         patched_run_op_command.assert_called_once()
         call_args = patched_run_op_command.call_args
         assert "<state/>" in call_args[0][1]
@@ -9585,12 +9585,12 @@ class TestGetHAConfiguration:
         firewall.xapi.element_root = xml_element
 
         result = FirewallCommand.get_ha_configuration(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
-        assert result.enabled == "yes"
-        assert result.group_id == "1"
-        assert result.peer_ip == "192.168.1.2"
-        assert result.ha1_port == "ha1-a"
-        assert result.ha2_port == "ha2-a"
-        assert result.mode == "Active/Passive"
+        assert result.Enabled == "yes"
+        assert result.GroupID == "1"
+        assert result.PeerIP == "192.168.1.2"
+        assert result.HA1Port == "ha1-a"
+        assert result.HA2Port == "ha2-a"
+        assert result.Mode == "Active/Passive"
 
     def test_ha_not_configured(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9643,15 +9643,15 @@ class TestGetAvailableInterfaces:
         firewall.xapi.element_root = xml_element
 
         result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
-        assert "ethernet1/1" in result.interfaces
-        assert "ethernet1/2" in result.interfaces
-        assert "ae1" in result.interfaces
-        assert "loopback.1" in result.interfaces
-        assert "tunnel.1" in result.interfaces
-        assert "vlan.100" in result.interfaces
-        assert "ha1-a" in result.interfaces
-        assert "ha2-a" in result.interfaces
-        assert result.interface_count > 0
+        assert "ethernet1/1" in result.Interfaces
+        assert "ethernet1/2" in result.Interfaces
+        assert "ae1" in result.Interfaces
+        assert "loopback.1" in result.Interfaces
+        assert "tunnel.1" in result.Interfaces
+        assert "vlan.100" in result.Interfaces
+        assert "ha1-a" in result.Interfaces
+        assert "ha2-a" in result.Interfaces
+        assert result.InterfaceCount > 0
 
     def test_no_interfaces(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9667,8 +9667,8 @@ class TestGetAvailableInterfaces:
 
         result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
         # Still has HA dedicated interfaces
-        assert "ha1-a" in result.interfaces
-        assert result.interface_count == 5  # 5 HA interfaces
+        assert "ha1-a" in result.Interfaces
+        assert result.InterfaceCount == 5  # 5 HA interfaces
 
     def test_none_response(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9679,7 +9679,7 @@ class TestGetAvailableInterfaces:
 
         result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
         # Still has HA dedicated interfaces
-        assert result.interface_count == 5
+        assert result.InterfaceCount == 5
 
 
 class TestValidateInterfaces:
@@ -9690,28 +9690,28 @@ class TestValidateInterfaces:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=3,
-            interfaces=["ethernet1/1", "ha1-a", "ha2-a"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=3,
+            Interfaces=["ethernet1/1", "ha1-a", "ha2-a"],
         )
 
         result = FirewallCommand.validate_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha2-a")
-        assert result.all_valid is True
-        assert result.missing_interfaces == []
+        assert result.AllValid is True
+        assert result.MissingInterfaces == []
 
     @patch("Panorama.FirewallCommand.get_available_interfaces")
     def test_missing_interfaces(self, mock_get_interfaces, mock_firewall_topology):
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=2,
-            interfaces=["ethernet1/1", "ha1-a"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=2,
+            Interfaces=["ethernet1/1", "ha1-a"],
         )
 
         result = FirewallCommand.validate_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha3")
-        assert result.all_valid is False
-        assert "ha3" in result.missing_interfaces
+        assert result.AllValid is False
+        assert "ha3" in result.MissingInterfaces
 
     def test_empty_interfaces(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9732,8 +9732,8 @@ class TestSetHAEnabledState:
         result = FirewallCommand.set_ha_enabled_state(
             mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="false"
         )
-        assert result.enabled is True
-        assert "enabled" in result.message.lower()
+        assert result.Enabled is True
+        assert "enabled" in result.Message.lower()
         firewall.xapi.edit.assert_called_once()
         call_args = firewall.xapi.edit.call_args
         assert "<enabled>yes</enabled>" in call_args[1]["element"]
@@ -9747,8 +9747,8 @@ class TestSetHAEnabledState:
         result = FirewallCommand.set_ha_enabled_state(
             mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=False, commit="false"
         )
-        assert result.enabled is False
-        assert "disabled" in result.message.lower()
+        assert result.Enabled is False
+        assert "disabled" in result.Message.lower()
 
     def test_enable_with_commit(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9758,8 +9758,8 @@ class TestSetHAEnabledState:
         firewall.commit = MagicMock(return_value="Commit OK")
 
         result = FirewallCommand.set_ha_enabled_state(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="true")
-        assert result.committed is True
-        assert "commit" in result.message.lower()
+        assert result.Committed is True
+        assert "commit" in result.Message.lower()
         firewall.commit.assert_called_once_with(sync=True)
 
 
@@ -9771,9 +9771,9 @@ class TestConfigureHA:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=5,
-            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=5,
+            Interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
         )
         mock_ha_class = mocker.patch("Panorama.HighAvailability")
         mock_ha_instance = MagicMock()
@@ -9790,8 +9790,8 @@ class TestConfigureHA:
             "commit": "false",
         }
         result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
-        assert "candidate config" in result.message.lower()
-        assert result.committed is False
+        assert "candidate config" in result.Message.lower()
+        assert result.Committed is False
         firewall.xapi.edit.assert_called_once()
 
     @patch("Panorama.FirewallCommand.get_available_interfaces")
@@ -9799,9 +9799,9 @@ class TestConfigureHA:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=5,
-            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=5,
+            Interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
         )
         mock_ha_class = mocker.patch("Panorama.HighAvailability")
         mock_ha_instance = MagicMock()
@@ -9826,7 +9826,7 @@ class TestConfigureHA:
             "commit": "false",
         }
         result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
-        assert "candidate config" in result.message.lower()
+        assert "candidate config" in result.Message.lower()
         mock_ha1.assert_called_once()
         mock_ha2.assert_called_once()
 
@@ -9835,9 +9835,9 @@ class TestConfigureHA:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=5,
-            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=5,
+            Interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
         )
         mock_ha_class = mocker.patch("Panorama.HighAvailability")
         mock_ha_instance = MagicMock()
@@ -9853,8 +9853,8 @@ class TestConfigureHA:
             "commit": "true",
         }
         result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
-        assert "commit" in result.message.lower()
-        assert result.committed is True
+        assert "commit" in result.Message.lower()
+        assert result.Committed is True
         firewall.commit.assert_called_once_with(sync=True)
 
     @patch("Panorama.FirewallCommand.get_available_interfaces")
@@ -9862,9 +9862,9 @@ class TestConfigureHA:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=5,
-            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=5,
+            Interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
         )
 
         args = {
@@ -9879,9 +9879,9 @@ class TestConfigureHA:
         from Panorama import FirewallCommand, HAInterfaceListResult
 
         mock_get_interfaces.return_value = HAInterfaceListResult(
-            hostid=MOCK_FIREWALL_1_SERIAL,
-            interface_count=5,
-            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+            HostID=MOCK_FIREWALL_1_SERIAL,
+            InterfaceCount=5,
+            Interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
         )
         mock_ha_class = mocker.patch("Panorama.HighAvailability")
         mock_ha_instance = MagicMock()
@@ -9913,7 +9913,7 @@ class TestConfigureHA:
             "commit": "false",
         }
         result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
-        assert "candidate config" in result.message.lower()
+        assert "candidate config" in result.Message.lower()
         mock_ha1_backup.assert_called_once()
         mock_ha2_backup.assert_called_once()
 

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -9668,7 +9668,7 @@ class TestGetAvailableInterfaces:
         result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
         # Still has HA dedicated interfaces
         assert "ha1-a" in result.Interfaces
-        assert result.InterfaceCount == 5  # 5 HA interfaces
+        assert result.InterfaceCount == 15  # 15 HA dedicated interfaces
 
     def test_none_response(self, mock_firewall_topology):
         from Panorama import FirewallCommand
@@ -9679,7 +9679,7 @@ class TestGetAvailableInterfaces:
 
         result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
         # Still has HA dedicated interfaces
-        assert result.InterfaceCount == 5
+        assert result.InterfaceCount == 15
 
 
 class TestValidateInterfaces:

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -9494,3 +9494,451 @@ def test_get_hitcounts_filters_param(unused_only, no_new_hits_since, expected_co
         if no_new_hits_since is not None:
             last_hit_dt = datetime.strptime(r.last_hit_timestamp, "%Y-%m-%dT%H:%M:%SZ")
             assert last_hit_dt <= no_new_hits_since
+
+
+"""Tests for HA commands ported from PANOS-HA integration"""
+
+
+class TestHASyncToRemote:
+    """Tests for FirewallCommand.sync_ha_to_remote"""
+
+    @patch("Panorama.run_op_command")
+    def test_sync_config(self, patched_run_op_command, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        result = FirewallCommand.sync_ha_to_remote(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "config")
+        assert result.sync_type == "config"
+        assert "configuration" in result.message.lower()
+        assert result.hostid == MOCK_FIREWALL_1_SERIAL
+        patched_run_op_command.assert_called_once()
+        call_args = patched_run_op_command.call_args
+        assert "running-config" in call_args[0][1]
+
+    @patch("Panorama.run_op_command")
+    def test_sync_state(self, patched_run_op_command, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        result = FirewallCommand.sync_ha_to_remote(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "state")
+        assert result.sync_type == "state"
+        assert "state" in result.message.lower()
+        assert result.hostid == MOCK_FIREWALL_1_SERIAL
+        patched_run_op_command.assert_called_once()
+        call_args = patched_run_op_command.call_args
+        assert "<state/>" in call_args[0][1]
+
+    def test_invalid_sync_type(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        with pytest.raises(ValueError, match="Invalid sync_type"):
+            FirewallCommand.sync_ha_to_remote(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "invalid")
+
+
+class TestGetHAConfiguration:
+    """Tests for FirewallCommand.get_ha_configuration"""
+
+    def test_ha_config_basic(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        xml_str = """<response status="success">
+            <result>
+                <high-availability>
+                    <enabled>yes</enabled>
+                    <group>
+                        <group-id>1</group-id>
+                        <mode>
+                            <active-passive>
+                                <passive-link-state>auto</passive-link-state>
+                            </active-passive>
+                        </mode>
+                        <peer-ip>192.168.1.2</peer-ip>
+                        <configuration-synchronization>
+                            <enabled>yes</enabled>
+                        </configuration-synchronization>
+                        <state-synchronization>
+                            <enabled>yes</enabled>
+                        </state-synchronization>
+                        <election-option>
+                            <device-priority>100</device-priority>
+                            <preemptive>yes</preemptive>
+                            <heartbeat-backup>no</heartbeat-backup>
+                        </election-option>
+                    </group>
+                    <interface>
+                        <ha1>
+                            <port>ha1-a</port>
+                            <ip-address>192.168.26.1</ip-address>
+                            <netmask>255.255.255.252</netmask>
+                        </ha1>
+                        <ha2>
+                            <port>ha2-a</port>
+                            <ip-address>192.168.27.1</ip-address>
+                            <netmask>255.255.255.252</netmask>
+                        </ha2>
+                    </interface>
+                </high-availability>
+            </result>
+        </response>"""
+        xml_element = ElementTree.fromstring(xml_str)
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.xapi.element_root = xml_element
+
+        result = FirewallCommand.get_ha_configuration(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
+        assert result.enabled == "yes"
+        assert result.group_id == "1"
+        assert result.peer_ip == "192.168.1.2"
+        assert result.ha1_port == "ha1-a"
+        assert result.ha2_port == "ha2-a"
+        assert result.mode == "Active/Passive"
+
+    def test_ha_not_configured(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        xml_str = """<response status="success">
+            <result/>
+        </response>"""
+        xml_element = ElementTree.fromstring(xml_str)
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.xapi.element_root = xml_element
+
+        with pytest.raises(DemistoException, match="not configured"):
+            FirewallCommand.get_ha_configuration(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
+
+
+class TestGetAvailableInterfaces:
+    """Tests for FirewallCommand.get_available_interfaces"""
+
+    def test_returns_all_interface_types(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        xml_str = """<response status="success">
+            <result>
+                <interface>
+                    <ethernet>
+                        <entry name="ethernet1/1"/>
+                        <entry name="ethernet1/2"/>
+                    </ethernet>
+                    <aggregate-ethernet>
+                        <entry name="ae1"/>
+                    </aggregate-ethernet>
+                    <loopback>
+                        <entry name="1"/>
+                    </loopback>
+                    <tunnel>
+                        <entry name="1"/>
+                    </tunnel>
+                    <vlan>
+                        <entry name="100"/>
+                    </vlan>
+                </interface>
+            </result>
+        </response>"""
+        xml_element = ElementTree.fromstring(xml_str)
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.xapi.element_root = xml_element
+
+        result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
+        assert "ethernet1/1" in result.interfaces
+        assert "ethernet1/2" in result.interfaces
+        assert "ae1" in result.interfaces
+        assert "loopback.1" in result.interfaces
+        assert "tunnel.1" in result.interfaces
+        assert "vlan.100" in result.interfaces
+        assert "ha1-a" in result.interfaces
+        assert "ha2-a" in result.interfaces
+        assert result.interface_count > 0
+
+    def test_no_interfaces(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        xml_str = """<response status="success">
+            <result/>
+        </response>"""
+        xml_element = ElementTree.fromstring(xml_str)
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.xapi.element_root = xml_element
+
+        result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
+        # Still has HA dedicated interfaces
+        assert "ha1-a" in result.interfaces
+        assert result.interface_count == 5  # 5 HA interfaces
+
+    def test_none_response(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.xapi.element_root = None
+
+        result = FirewallCommand.get_available_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL)
+        # Still has HA dedicated interfaces
+        assert result.interface_count == 5
+
+
+class TestValidateInterfaces:
+    """Tests for FirewallCommand.validate_interfaces"""
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_all_valid(self, mock_get_interfaces, mock_firewall_topology):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=3,
+            interfaces=["ethernet1/1", "ha1-a", "ha2-a"],
+        )
+
+        result = FirewallCommand.validate_interfaces(
+            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha2-a"
+        )
+        assert result.all_valid is True
+        assert result.missing_interfaces == []
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_missing_interfaces(self, mock_get_interfaces, mock_firewall_topology):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=2,
+            interfaces=["ethernet1/1", "ha1-a"],
+        )
+
+        result = FirewallCommand.validate_interfaces(
+            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha3"
+        )
+        assert result.all_valid is False
+        assert "ha3" in result.missing_interfaces
+
+    def test_empty_interfaces(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        with pytest.raises(ValueError, match="required"):
+            FirewallCommand.validate_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "")
+
+
+class TestSetHAEnabledState:
+    """Tests for FirewallCommand.set_ha_enabled_state"""
+
+    def test_enable_ha(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+
+        result = FirewallCommand.set_ha_enabled_state(
+            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="false"
+        )
+        assert result.enabled is True
+        assert "enabled" in result.message.lower()
+        firewall.xapi.edit.assert_called_once()
+        call_args = firewall.xapi.edit.call_args
+        assert "<enabled>yes</enabled>" in call_args[1]["element"]
+
+    def test_disable_ha(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+
+        result = FirewallCommand.set_ha_enabled_state(
+            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=False, commit="false"
+        )
+        assert result.enabled is False
+        assert "disabled" in result.message.lower()
+
+    def test_enable_with_commit(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.commit = MagicMock(return_value="Commit OK")
+
+        result = FirewallCommand.set_ha_enabled_state(
+            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="true"
+        )
+        assert result.committed is True
+        assert "commit" in result.message.lower()
+        firewall.commit.assert_called_once_with(sync=True)
+
+
+class TestConfigureHA:
+    """Tests for FirewallCommand.configure_ha"""
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_basic_config(self, mock_get_interfaces, mock_firewall_topology, mocker):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=5,
+            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+        )
+        mock_ha_class = mocker.patch("Panorama.HighAvailability")
+        mock_ha_instance = MagicMock()
+        mock_ha_instance.element_str.return_value = "<entry><group><group-id>1</group-id></group></entry>"
+        mock_ha_class.return_value = mock_ha_instance
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+
+        args = {
+            "peer_ip": "192.168.1.2",
+            "group_id": "1",
+            "device_priority": "100",
+            "commit": "false",
+        }
+        result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
+        assert "candidate config" in result.message.lower()
+        assert result.committed is False
+        firewall.xapi.edit.assert_called_once()
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_config_with_ha1_ha2(self, mock_get_interfaces, mock_firewall_topology, mocker):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=5,
+            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+        )
+        mock_ha_class = mocker.patch("Panorama.HighAvailability")
+        mock_ha_instance = MagicMock()
+        mock_ha_instance.element_str.return_value = "<entry><group><group-id>1</group-id></group></entry>"
+        mock_ha_class.return_value = mock_ha_instance
+        mock_ha1 = mocker.patch("Panorama.HA1")
+        mock_ha2 = mocker.patch("Panorama.HA2")
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+
+        args = {
+            "peer_ip": "192.168.1.2",
+            "group_id": "1",
+            "device_priority": "100",
+            "ha1_port": "ha1-a",
+            "ha1_ip_address": "192.168.26.1",
+            "ha1_netmask": "255.255.255.252",
+            "ha2_port": "ha2-a",
+            "ha2_ip_address": "192.168.27.1",
+            "ha2_netmask": "255.255.255.252",
+            "commit": "false",
+        }
+        result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
+        assert "candidate config" in result.message.lower()
+        mock_ha1.assert_called_once()
+        mock_ha2.assert_called_once()
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_config_with_commit(self, mock_get_interfaces, mock_firewall_topology, mocker):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=5,
+            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+        )
+        mock_ha_class = mocker.patch("Panorama.HighAvailability")
+        mock_ha_instance = MagicMock()
+        mock_ha_instance.element_str.return_value = "<entry><group><group-id>1</group-id></group></entry>"
+        mock_ha_class.return_value = mock_ha_instance
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+        firewall.commit = MagicMock(return_value="Commit OK")
+
+        args = {
+            "peer_ip": "192.168.1.2",
+            "commit": "true",
+        }
+        result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
+        assert "commit" in result.message.lower()
+        assert result.committed is True
+        firewall.commit.assert_called_once_with(sync=True)
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_config_missing_interface_fails(self, mock_get_interfaces, mock_firewall_topology):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=5,
+            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+        )
+
+        args = {
+            "peer_ip": "192.168.1.2",
+            "ha1_port": "ethernet99/99",
+        }
+        with pytest.raises(DemistoException, match="not found"):
+            FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
+
+    @patch("Panorama.FirewallCommand.get_available_interfaces")
+    def test_config_with_backup_interfaces(self, mock_get_interfaces, mock_firewall_topology, mocker):
+        from Panorama import FirewallCommand, HAInterfaceListResult
+
+        mock_get_interfaces.return_value = HAInterfaceListResult(
+            hostid=MOCK_FIREWALL_1_SERIAL,
+            interface_count=5,
+            interfaces=["ha1-a", "ha1-b", "ha2-a", "ha2-b", "ha3"],
+        )
+        mock_ha_class = mocker.patch("Panorama.HighAvailability")
+        mock_ha_instance = MagicMock()
+        mock_ha_instance.element_str.return_value = "<entry><group><group-id>1</group-id></group></entry>"
+        mock_ha_class.return_value = mock_ha_instance
+        mocker.patch("Panorama.HA1")
+        mocker.patch("Panorama.HA2")
+        mock_ha1_backup = mocker.patch("Panorama.HA1Backup")
+        mock_ha2_backup = mocker.patch("Panorama.HA2Backup")
+
+        firewall = list(mock_firewall_topology.firewall_objects.values())[0]
+        firewall.xapi = MagicMock()
+
+        args = {
+            "peer_ip": "192.168.1.2",
+            "ha1_port": "ha1-a",
+            "ha1_ip_address": "192.168.26.1",
+            "ha1_netmask": "255.255.255.252",
+            "ha1_backup_port": "ha1-b",
+            "ha1_backup_ip_address": "192.168.28.1",
+            "ha1_backup_netmask": "255.255.255.252",
+            "ha2_port": "ha2-a",
+            "ha2_ip_address": "192.168.27.1",
+            "ha2_netmask": "255.255.255.252",
+            "ha2_backup_port": "ha2-b",
+            "ha2_backup_ip_address": "192.168.29.1",
+            "ha2_backup_netmask": "255.255.255.252",
+            "heartbeat_backup": "true",
+            "commit": "false",
+        }
+        result = FirewallCommand.configure_ha(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, args)
+        assert "candidate config" in result.message.lower()
+        mock_ha1_backup.assert_called_once()
+        mock_ha2_backup.assert_called_once()
+
+
+class TestPanoramaHAReconfigure:
+    """Tests for FirewallCommand.panorama_ha_reconfigure"""
+
+    def test_panorama_reconfigure(self, mock_single_device_topology, mocker):
+        from Panorama import FirewallCommand
+
+        mock_ha = MagicMock()
+        mocker.patch("Panorama.HighAvailability", return_value=mock_ha)
+
+        result = FirewallCommand.panorama_ha_reconfigure(mock_single_device_topology)
+        assert "panorama" in result.message.lower()
+        mock_ha.revert_to_running.assert_called_once()
+
+    def test_no_panorama_device(self, mock_firewall_topology):
+        from Panorama import FirewallCommand
+
+        with pytest.raises(DemistoException, match="No Panorama device"):
+            FirewallCommand.panorama_ha_reconfigure(mock_firewall_topology)

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -9695,9 +9695,7 @@ class TestValidateInterfaces:
             interfaces=["ethernet1/1", "ha1-a", "ha2-a"],
         )
 
-        result = FirewallCommand.validate_interfaces(
-            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha2-a"
-        )
+        result = FirewallCommand.validate_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha2-a")
         assert result.all_valid is True
         assert result.missing_interfaces == []
 
@@ -9711,9 +9709,7 @@ class TestValidateInterfaces:
             interfaces=["ethernet1/1", "ha1-a"],
         )
 
-        result = FirewallCommand.validate_interfaces(
-            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha3"
-        )
+        result = FirewallCommand.validate_interfaces(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, "ha1-a,ha3")
         assert result.all_valid is False
         assert "ha3" in result.missing_interfaces
 
@@ -9761,9 +9757,7 @@ class TestSetHAEnabledState:
         firewall.xapi = MagicMock()
         firewall.commit = MagicMock(return_value="Commit OK")
 
-        result = FirewallCommand.set_ha_enabled_state(
-            mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="true"
-        )
+        result = FirewallCommand.set_ha_enabled_state(mock_firewall_topology, MOCK_FIREWALL_1_SERIAL, enabled=True, commit="true")
         assert result.committed is True
         assert "commit" in result.message.lower()
         firewall.commit.assert_called_once_with(sync=True)

--- a/Packs/PAN-OS/Integrations/Panorama/README.md
+++ b/Packs/PAN-OS/Integrations/Panorama/README.md
@@ -6331,6 +6331,256 @@ Get the HA state and associated details from the given device and any other deta
 >| true | 11111111111111 | HA Not enabled. |
 >| true | 192.168.1.145 | HA Not enabled. |
 
+### pan-os-platform-ha-sync-config
+
+***
+Forces the active firewall to synchronize its running configuration with the passive peer.
+
+#### Base Command
+
+`pan-os-platform-ha-sync-config`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HASync.HostID | String | The host ID. |
+| PANOS.HASync.SyncType | String | The type of synchronization performed. |
+| PANOS.HASync.Message | String | Human-readable status message. |
+
+### pan-os-platform-ha-sync-state
+
+***
+Forces the active firewall to synchronize its state (session table) with the passive peer.
+
+#### Base Command
+
+`pan-os-platform-ha-sync-state`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HASync.HostID | String | The host ID. |
+| PANOS.HASync.SyncType | String | The type of synchronization performed. |
+| PANOS.HASync.Message | String | Human-readable status message. |
+
+### pan-os-platform-get-ha-config
+
+***
+Retrieves the current High Availability configuration from a firewall.
+
+#### Base Command
+
+`pan-os-platform-get-ha-config`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| device_filter_string | The string by which to filter the results to only show specific hostnames or serial numbers. | Optional |
+| target | The serial number, or IP address, of the target firewall. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAConfig.HostID | String | The host ID. |
+| PANOS.HAConfig.Enabled | String | Whether HA is enabled on the device. |
+| PANOS.HAConfig.GroupID | String | The Group ID for the HA pair. |
+| PANOS.HAConfig.Mode | String | The HA mode (e.g., Active/Passive). |
+| PANOS.HAConfig.PeerIP | String | The IP address of the HA peer. |
+| PANOS.HAConfig.PeerIPBackup | String | The backup IP address of the HA peer. |
+| PANOS.HAConfig.HA1Port | String | The interface port for the HA1 (Control) link. |
+| PANOS.HAConfig.HA1IP | String | The IP address for the HA1 (Control) link. |
+| PANOS.HAConfig.HA1BackupPort | String | The interface port for the HA1-Backup link. |
+| PANOS.HAConfig.HA1BackupIP | String | The IP address for the HA1-Backup link. |
+| PANOS.HAConfig.HA2Port | String | The interface port for the HA2 (Data) link. |
+| PANOS.HAConfig.HA2IP | String | The IP address for the HA2 (Data) link. |
+| PANOS.HAConfig.HA2BackupPort | String | The interface port for the HA2-Backup link. |
+| PANOS.HAConfig.HA2BackupIP | String | The IP address for the HA2-Backup link. |
+| PANOS.HAConfig.LinkMonitoring | Unknown | A list of Link Monitoring group configurations (each with Name, Enabled, FailureCondition, Interfaces). |
+
+### pan-os-platform-ha-configure
+
+***
+Enables and configures a detailed High Availability setup on a firewall.
+
+#### Base Command
+
+`pan-os-platform-ha-configure`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+| peer_ip | The IP address of the peer firewall's primary HA1 control link. | Required |
+| group_id | The HA Group ID (1-255). Default is 1. | Optional |
+| peer_ip_backup | The IP address of the peer firewall's backup HA1 control link. | Optional |
+| passive_link_state | For Active/Passive mode, specifies the link state of the passive device. Possible values are: auto, shutdown. Default is auto. | Optional |
+| device_priority | Device priority for HA election (0-255). Higher priority becomes active. Default is 100. | Optional |
+| heartbeat_backup | Enable backup heartbeat monitoring (recommended for production HA). Possible values are: true, false. Default is false. | Optional |
+| ha1_port | The primary control link (HA1) interface port (e.g., ha1-a, ethernet1/1). | Optional |
+| ha1_ip_address | The IP address for the primary control link (HA1) interface. | Optional |
+| ha1_netmask | The netmask for the primary control link (HA1) interface. | Optional |
+| ha1_gateway | The gateway for the primary control link (HA1) interface. | Optional |
+| ha1_backup_port | The backup control link (HA1-Backup) interface port. | Optional |
+| ha1_backup_ip_address | The IP address for the backup control link (HA1-Backup) interface. | Optional |
+| ha1_backup_netmask | The netmask for the backup control link (HA1-Backup) interface. | Optional |
+| ha2_port | The primary data link (HA2) interface port for session synchronization. | Optional |
+| ha2_ip_address | The IP address for the primary data link (HA2) interface. | Optional |
+| ha2_netmask | The netmask for the primary data link (HA2) interface. | Optional |
+| ha2_backup_port | The backup data link (HA2-Backup) interface port. | Optional |
+| ha2_backup_ip_address | The IP address for the backup data link (HA2-Backup) interface. | Optional |
+| ha2_backup_netmask | The netmask for the backup data link (HA2-Backup) interface. | Optional |
+| state_sync | Enable state (session) synchronization over the HA2 data link. Possible values are: true, false. Default is false. | Optional |
+| ha2_keepalive | Enable HA2 keep-alive monitoring to detect failures on the HA2 data link. Possible values are: true, false. Default is false. | Optional |
+| ha2_keepalive_threshold | HA2 keep-alive threshold in milliseconds (5000-60000). Default is 10000. | Optional |
+| ha2_keepalive_action | Action to take when HA2 keep-alive fails. Possible values are: log-only, log-and-reboot. Default is log-only. | Optional |
+| commit | Commit the configuration change immediately. Possible values are: true, false. Default is false. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAConfigure.HostID | String | The host ID. |
+| PANOS.HAConfigure.Message | String | Human-readable status message. |
+| PANOS.HAConfigure.Committed | Boolean | Whether the configuration was committed. |
+
+### pan-os-platform-ha-enable
+
+***
+Enables the HA functionality on a firewall from previous configuration.
+
+#### Base Command
+
+`pan-os-platform-ha-enable`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+| commit | Set to true to automatically commit the configuration changes. Possible values are: true, false. Default is false. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAEnabledState.HostID | String | The host ID. |
+| PANOS.HAEnabledState.Enabled | Boolean | Whether HA has been enabled or disabled. |
+| PANOS.HAEnabledState.Message | String | Human-readable status message. |
+| PANOS.HAEnabledState.Committed | Boolean | Whether the configuration was committed. |
+
+### pan-os-platform-ha-disable
+
+***
+Disables the HA functionality on a firewall.
+
+#### Base Command
+
+`pan-os-platform-ha-disable`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+| commit | Set to true to automatically commit the configuration changes. Possible values are: true, false. Default is false. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAEnabledState.HostID | String | The host ID. |
+| PANOS.HAEnabledState.Enabled | Boolean | Whether HA has been enabled or disabled. |
+| PANOS.HAEnabledState.Message | String | Human-readable status message. |
+| PANOS.HAEnabledState.Committed | Boolean | Whether the configuration was committed. |
+
+### pan-os-platform-ha-list-interfaces
+
+***
+Lists all available network interfaces on the firewall.
+
+#### Base Command
+
+`pan-os-platform-ha-list-interfaces`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| device_filter_string | The string by which to filter the results to only show specific hostnames or serial numbers. | Optional |
+| target | The serial number, or IP address, of the target firewall. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAInterfaces.HostID | String | The host ID. |
+| PANOS.HAInterfaces.InterfaceCount | Number | Total number of interfaces found. |
+| PANOS.HAInterfaces.Interfaces | Unknown | List of all available interface names. |
+
+### pan-os-platform-ha-validate-interfaces
+
+***
+Validates that specified interfaces exist on the firewall before HA configuration.
+
+#### Base Command
+
+`pan-os-platform-ha-validate-interfaces`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target firewall. | Required |
+| interfaces | Comma-separated list of interface names to validate (e.g., ha1-a,ha2-a,ethernet1/1). | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.HAInterfaceValidation.HostID | String | The host ID. |
+| PANOS.HAInterfaceValidation.AllValid | Boolean | Whether all specified interfaces were found. |
+| PANOS.HAInterfaceValidation.ValidatedInterfaces | Unknown | List of interface names that were validated. |
+| PANOS.HAInterfaceValidation.MissingInterfaces | Unknown | List of interface names that were not found on the device. |
+
+### pan-os-panorama-ha-reconfigure
+
+***
+Issues a revert to running HA state command to a Panorama device.
+
+#### Base Command
+
+`pan-os-panorama-ha-reconfigure`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| target | The serial number, or IP address, of the target Panorama device. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| PANOS.PanoramaHAReconfigure.hostid | String | The host ID. |
+| PANOS.PanoramaHAReconfigure.message | String | Human-readable status message. |
+
 ### pan-os-platform-get-jobs
 
 ***

--- a/Packs/PAN-OS/ReleaseNotes/2_6_27.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_27.md
@@ -1,1 +1,15 @@
-- Documentation and metadata improvements.
+
+#### Integrations
+
+##### Panorama
+
+- Added 9 new High Availability (HA) commands for firewall management:
+  - **pan-os-platform-ha-sync-config** - Synchronize running configuration with HA passive peer.
+  - **pan-os-platform-ha-sync-state** - Synchronize state (session table) with HA passive peer.
+  - **pan-os-platform-get-ha-config** - Retrieve HA configuration from a firewall.
+  - **pan-os-platform-ha-configure** - Configure a detailed HA setup on a firewall.
+  - **pan-os-platform-ha-enable** - Enable HA functionality on a firewall.
+  - **pan-os-platform-ha-disable** - Disable HA functionality on a firewall.
+  - **pan-os-platform-ha-list-interfaces** - List all available network interfaces on a firewall.
+  - **pan-os-platform-ha-validate-interfaces** - Validate that interfaces exist before HA configuration.
+  - **pan-os-panorama-ha-reconfigure** - Issue a revert to running HA state command to Panorama.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16284

## Description

This PR ports the 9 unique HA management commands from the standalone PANOS-HA integration (PR #42980) into the existing Panorama (PAN-OS) integration, following the integration's existing code conventions and architecture.

**This branch is clean - based on upstream master with only Panorama changes. No PANOS-HA pack files are included.**

### New Commands Added

| Command | Description |
|---------|-------------|
| `pan-os-platform-ha-sync-config` | Sync running configuration to passive HA peer |
| `pan-os-platform-ha-sync-state` | Sync state (session table) to passive HA peer |
| `pan-os-platform-get-ha-config` | Retrieve full HA configuration from a firewall |
| `pan-os-platform-ha-configure` | Full HA setup (HA1/HA2 links, election settings, etc.) |
| `pan-os-platform-ha-enable` | Enable HA on a firewall |
| `pan-os-platform-ha-disable` | Disable HA on a firewall |
| `pan-os-platform-ha-list-interfaces` | List available network interfaces |
| `pan-os-platform-ha-validate-interfaces` | Validate interfaces exist before HA configuration |
| `pan-os-panorama-ha-reconfigure` | Panorama HA revert to running |

### Why merge instead of a separate pack?

As identified in the review of PR #42980, the PANOS-HA integration:
- Reimplements device connection logic already in Panorama
- Has 3 commands that directly duplicate existing Panorama commands (`get-ha-state`, `suspend-peer`, `make-peer-functional`)
- Lacks Panorama's topology awareness for managing device fleets

By merging the 9 unique commands into the existing Panorama integration, users get:
- Topology-aware HA management (target specific devices via serial/hostname)
- No duplicate connection configuration
- Consistent command naming (`pan-os-platform-*` prefix)
- Full compatibility with existing Panorama playbooks and workflows

### Changes

All changes are **purely additive** - zero existing code was modified:

- **Panorama.py**: Added HA imports, 7 new dataclasses, 9 new FirewallCommand static methods, 9 wrapper functions, 9 command dispatch entries in main()
- **Panorama.yml**: Added 9 new command definitions with arguments and outputs
- **Panorama_test.py**: Added 21 unit tests ported from PANOS-HA
- **.secrets-ignore**: Whitelisted test IP addresses/netmasks

### Validation

- All 374 Panorama tests pass (353 existing + 21 new)
- All 40 original PANOS-HA tests still pass
- `demisto-sdk validate` passes
- `demisto-sdk pre-commit` passes (pylint, mypy, pytest, xsoar-lint, secrets, etc.)

## Must have
- [X] Tests
- [X] Documentation
relates: link to the issue