### PR TITLE
Fix core-api-download for endpoints without Content-Disposition header in Core REST API

### DIFF
--- a/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
+++ b/Packs/DemistoRESTAPI/Integrations/CoreRESTAPI/CoreRESTAPI.js
@@ -631,11 +631,17 @@ switch (command) {
         var filename = res.Path;
         if (args.filename) {
             filename = args.filename;
-        } else {
+            logDebug('core-api-download: Using user-provided filename: ' + filename);
+        } else if (res.Headers && res.Headers['Content-Disposition'] && res.Headers['Content-Disposition'][0]) {
             var disposition = res.Headers['Content-Disposition'][0].split('=');
             if (disposition.length === 2) {
                 filename = disposition[1];
+                logDebug('core-api-download: Extracted filename from Content-Disposition header: ' + filename);
+            } else {
+                logDebug('core-api-download: Content-Disposition header exists but could not parse filename. Using fallback: ' + filename);
             }
+        } else {
+            logDebug('core-api-download: No Content-Disposition header found. Using fallback filename: ' + filename);
         }
         var desc = args.description || '';
         return ({Type: entryTypes.file, FileID: res.Path, File: filename, Contents: desc});

--- a/Packs/DemistoRESTAPI/ReleaseNotes/1_3_96.md
+++ b/Packs/DemistoRESTAPI/ReleaseNotes/1_3_96.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Core REST API
+
+Fixed an issue where the ***core-api-download*** command failed with a TypeError when the response did not include the `Content-Disposition` header.

--- a/Packs/DemistoRESTAPI/pack_metadata.json
+++ b/Packs/DemistoRESTAPI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cortex REST API",
     "description": "Use Demisto REST APIs",
     "support": "xsoar",
-    "currentVersion": "1.3.95",
+    "currentVersion": "1.3.96",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-65613](https://jira-dc.paloaltonetworks.com/browse/XSUP-65613)

## Description
Fixed an issue where the ***core-api-download*** command failed with a TypeError when the response did not include the `Content-Disposition` header.

