### PR TITLE
Update documentation for agentixCommands and searchIndicators

### DIFF
--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -750,25 +750,25 @@ def agentixCommands(command, args):
             - "rateMessage": Rate a specific message in the conversation
         args (dict): Command arguments. The structure depends on the command:
             - For "sendToConversation": {
-                "channel_id": str (required),
-                "thread_id": str (required),
-                "message": str (required),
-                "username": str (required),
-                "agent_id": str (optional, required on second call)
+                    "channel_id": str (required),
+                    "thread_id": str (required),
+                    "message": str (required),
+                    "username": str (required),
+                    "agent_id": str (optional, required on second call)
               }
             - For "resetConversation": {
-                "channel_id": str (required),
-                "thread_id": str (required),
-                "username": str (required)
+                    "channel_id": str (required),
+                    "thread_id": str (required),
+                    "username": str (required)
               }
             - For "rateMessage": {
-                "channel_id": str (required),
-                "thread_id": str (required),
-                "message_id": str (required),
-                "username": str (required),
-                "is_liked": bool (required),
-                "improvement_suggestion": str (required if is_liked=false),
-                "issues": list[str] (required if is_liked=false)
+                    "channel_id": str (required),
+                    "thread_id": str (required),
+                    "message_id": str (required),
+                    "username": str (required),
+                    "is_liked": bool (required),
+                    "improvement_suggestion": str (required if is_liked=false),
+                    "issues": list[str] (required if is_liked=false)
               }
 
     Returns:

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -785,74 +785,101 @@ def agentixCommands(command, args):
 
     Examples:
         Success - First call (agent selection):
-        >>> demisto.agentixCommands("sendToConversation", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "message": "Hello",
-        ...     "username": "user@example.com"
-        ... })
-        {"agents": [{"id": "agent-uuid-1", "name": "Security Agent"}, {"id": "agent-uuid-2", "name": "IT Agent"}]}
-        
+
+        ```
+        demisto.agentixCommands("sendToConversation", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "message": "Hello",
+            "username": "user@example.com"
+        })
+        # Returns: {"agents": [{"id": "agent-uuid-1", "name": "Security Agent"}, {"id": "agent-uuid-2", "name": "IT Agent"}]}
+        ```
+
         Success - Second call (with agent):
-        >>> demisto.agentixCommands("sendToConversation", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "message": "Hello",
-        ...     "username": "user@example.com",
-        ...     "agent_id": "agent-uuid-1"
-        ... })
-        {"success": true}
-        
+
+        ```
+        demisto.agentixCommands("sendToConversation", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "message": "Hello",
+            "username": "user@example.com",
+            "agent_id": "agent-uuid-1"
+        })
+        # Returns: {"success": true}
+        ```
+
         Success - Reset conversation:
-        >>> demisto.agentixCommands("resetConversation", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "username": "user@example.com"
-        ... })
-        {"success": true}
-        
+
+        ```
+        demisto.agentixCommands("resetConversation", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "username": "user@example.com"
+        })
+        # Returns: {"success": true}
+        ```
+
         Success - Rate message positively:
-        >>> demisto.agentixCommands("rateMessage", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "message_id": "M789",
-        ...     "username": "user@example.com",
-        ...     "is_liked": true
-        ... })
-        {"success": true}
-        
+
+        ```
+        demisto.agentixCommands("rateMessage", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "message_id": "M789",
+            "username": "user@example.com",
+            "is_liked": true
+        })
+        # Returns: {"success": true}
+        ```
+
         Success - Rate message negatively:
-        >>> demisto.agentixCommands("rateMessage", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "message_id": "M789",
-        ...     "username": "user@example.com",
-        ...     "is_liked": false,
-        ...     "improvement_suggestion": "Response was too generic",
-        ...     "issues": ["Inaccurate", "Not helpful"]
-        ... })
-        {"success": true}
-        
+
+        ```
+        demisto.agentixCommands("rateMessage", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "message_id": "M789",
+            "username": "user@example.com",
+            "is_liked": false,
+            "improvement_suggestion": "Response was too generic",
+            "issues": ["Inaccurate", "Not helpful"]
+        })
+        # Returns: {"success": true}
+        ```
+
         Failure - User not found:
-        >>> demisto.agentixCommands("sendToConversation", {...})
-        {"success": false, "error": "User not found in system", "error_code": 103102}
-        
+
+        ```
+        demisto.agentixCommands("sendToConversation", {...})
+        # Returns: {"success": false, "error": "User not found in system", "error_code": 103102}
+        ```
+
         Failure - Permission denied:
-        >>> demisto.agentixCommands("sendToConversation", {...})
-        {"success": false, "error": "User lacks required Cortex Assistant permissions", "error_code": 103103}
-        
+
+        ```
+        demisto.agentixCommands("sendToConversation", {...})
+        # Returns: {"success": false, "error": "User lacks required Cortex Assistant permissions", "error_code": 103103}
+        ```
+
         Failure - Conversation not found:
-        >>> demisto.agentixCommands("rateMessage", {...})
-        {"success": false, "error": "Conversation not found", "error_code": 103201}
-        
+
+        ```
+        demisto.agentixCommands("rateMessage", {...})
+        # Returns: {"success": false, "error": "Conversation not found", "error_code": 103201}
+        ```
+
         Failure - Wrong user:
-        >>> demisto.agentixCommands("sendToConversation", {
-        ...     "channel_id": "C123",
-        ...     "thread_id": "T456",
-        ...     "message": "Hello",
-        ...     "username": "different-user@example.com"
-        ... })
-        {"success": false, "error": "This conversation belongs to another user", "error_code": 103204}
+
+        ```
+        demisto.agentixCommands("sendToConversation", {
+            "channel_id": "C123",
+            "thread_id": "T456",
+            "message": "Hello",
+            "username": "different-user@example.com"
+        })
+        # Returns: {"success": false, "error": "This conversation belongs to another user", "error_code": 103204}
+        ```
 
     Note:
         This is a mock implementation for testing purposes. In production, this function
@@ -1231,7 +1258,7 @@ def searchIndicators(
     searchAfter after the demisto.executeCommand.
     When you run a search for the query type:IP, the return value includes searchAfter
     ```
-    >>> demisto.executeCommand(searchIndicators, "query": 'type:IP', "size" :1000})
+    demisto.executeCommand(searchIndicators, "query": 'type:IP', "size" :1000})
     {
         "iocs": [],
         "searchAfter": [1596106239679, dd7aa6abfcb3adf793922618005b2ad5],
@@ -1240,12 +1267,12 @@ def searchIndicators(
     ```
     You can then use the returned value of searchAfter to iterate over all batches.
     ```
-    >>> res = demisto.executeCommand("searchIndicators", {"query" : 'type:IP', "size" : 1000})
-    >>> search_after_title = 'searchAfter'
-    >>> while search_after_title in res and res[search_after_title] is not None:
-    >>>     demisto.results(res)
-    >>>     res = demisto.executeCommand("searchIndicators",
-    >>>                                 {"query" : 'type:IP', "size" : 1000, "searchAfter" : res[search_after_title]})
+    res = demisto.executeCommand("searchIndicators", {"query" : 'type:IP', "size" : 1000})
+    search_after_title = 'searchAfter'
+    while search_after_title in res and res[search_after_title] is not None:
+        demisto.results(res)
+        res = demisto.executeCommand("searchIndicators",
+                                    {"query" : 'type:IP', "size" : 1000, "searchAfter" : res[search_after_title]})
     ```
     """
     return {}
@@ -1383,7 +1410,7 @@ def searchRelationships(args):
 
     Example (partial results):
     ```
-    >>> demisto.searchRelationships({"entities": ["8.8.8.8", "google.com"], "size": 2})
+    demisto.searchRelationships({"entities": ["8.8.8.8", "google.com"], "size": 2})
         {
         "total": 2,
         "data": [

--- a/Tests/demistomock/demistomock.py
+++ b/Tests/demistomock/demistomock.py
@@ -749,19 +749,19 @@ def agentixCommands(command, args):
             - "resetConversation": Reset/clear the current conversation
             - "rateMessage": Rate a specific message in the conversation
         args (dict): Command arguments. The structure depends on the command:
-            - For "sendToConversation": {
+            - For "sendToConversation":
                     "channel_id": str (required),
                     "thread_id": str (required),
                     "message": str (required),
                     "username": str (required),
                     "agent_id": str (optional, required on second call)
-              }
-            - For "resetConversation": {
+              
+            - For "resetConversation":
                     "channel_id": str (required),
                     "thread_id": str (required),
                     "username": str (required)
-              }
-            - For "rateMessage": {
+            
+            - For "rateMessage":
                     "channel_id": str (required),
                     "thread_id": str (required),
                     "message_id": str (required),
@@ -769,7 +769,7 @@ def agentixCommands(command, args):
                     "is_liked": bool (required),
                     "improvement_suggestion": str (required if is_liked=false),
                     "issues": list[str] (required if is_liked=false)
-              }
+            
 
     Returns:
         dict: Command execution response object with the following structure:


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
 [CRTX-238825](https://jira-dc.paloaltonetworks.com/browse/CRTX-238825)

## Description
Fix docstring rendering in `demistomock.agentixCommands`

Replace Python doctest-style examples (>>> / ... continuation markers) with backtick-fenced code blocks in the agentixCommands docstring. The doctest syntax was rendering poorly in `xsoar.pan.dev` - continuation ... markers were displayed as literal content, breaking readability.

<img width="844" height="532" alt="image" src="https://github.com/user-attachments/assets/105cc3d0-c5a8-4974-b8ac-febb1d26d0f6" />

or existing blocks: 
<img width="864" height="258" alt="image" src="https://github.com/user-attachments/assets/94a36ecc-7137-4be1-a275-f4646727cb0f" />

while classic code-block syntax renders properly.
