### PR TITLE
ServiceNowv2 - get-modified-remote-data fix

### DIFF
--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -11,7 +11,7 @@ from CommonServerPython import *  # noqa: F401
 
 urllib3.disable_warnings()
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 DEFAULT_FETCH_TIME = "10 minutes"
 MAX_RETRY = 9
@@ -3499,7 +3499,12 @@ def get_modified_remote_data_command(
 ) -> GetModifiedRemoteDataResponse:
     remote_args = GetModifiedRemoteDataArgs(args)
     parsed_date = dateparser.parse(remote_args.last_update, settings={"TIMEZONE": "UTC"})
-    assert parsed_date is not None, f"could not parse {remote_args.last_update}"
+    if parsed_date is None:
+        demisto.debug(
+            f"Could not parse lastUpdate='{remote_args.last_update}', "
+            f"falling back to epoch (1970-01-01 00:00:00)"
+        )
+        parsed_date = datetime(1970, 1, 1, tzinfo=timezone.utc)
     last_update = parsed_date.strftime(DATE_FORMAT)
 
     demisto.debug(f"Running get-modified-remote-data command. Last update is: {last_update}")

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2.py
@@ -11,7 +11,7 @@ from CommonServerPython import *  # noqa: F401
 
 urllib3.disable_warnings()
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 DEFAULT_FETCH_TIME = "10 minutes"
 MAX_RETRY = 9
@@ -3500,11 +3500,8 @@ def get_modified_remote_data_command(
     remote_args = GetModifiedRemoteDataArgs(args)
     parsed_date = dateparser.parse(remote_args.last_update, settings={"TIMEZONE": "UTC"})
     if parsed_date is None:
-        demisto.debug(
-            f"Could not parse lastUpdate='{remote_args.last_update}', "
-            f"falling back to epoch (1970-01-01 00:00:00)"
-        )
-        parsed_date = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        demisto.debug(f"Could not parse lastUpdate='{remote_args.last_update}', falling back to epoch (1970-01-01 00:00:00)")
+        parsed_date = datetime(1970, 1, 1, tzinfo=UTC)
     last_update = parsed_date.strftime(DATE_FORMAT)
 
     demisto.debug(f"Running get-modified-remote-data command. Last update is: {last_update}")

--- a/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
+++ b/Packs/ServiceNow/Integrations/ServiceNowv2/ServiceNowv2_test.py
@@ -2527,6 +2527,45 @@ def test_get_modified_remote_data(requests_mock, mocker, api_response):
     )
 
 
+def test_get_modified_remote_data_unparseable_last_update(requests_mock, mocker):
+    """
+    Given:
+        - lastUpdate is "0" (uninitialized dbotMirrorLastSync sent by XSOAR)
+
+    When:
+        - Running get-modified-remote-data
+
+    Then:
+        - The command does not raise an error and falls back to epoch time (1970-01-01 00:00:00)
+    """
+    mocker.patch.object(demisto, "debug")
+    url = "https://test.service-now.com/api/now/v2/"
+    client = Client(
+        url,
+        "sc_server_url",
+        "cr_server_url",
+        "username",
+        "password",
+        "verify",
+        "fetch_time",
+        "sysparm_query",
+        "sysparm_limit",
+        "timestamp_field",
+        "ticket_type",
+        "get_attachments",
+        "incident_name",
+    )
+    params = {
+        "sysparm_limit": "100",
+        "sysparm_offset": "0",
+        "sysparm_query": "sys_updated_on>1970-01-01 00:00:00",
+        "sysparm_fields": "sys_id",
+    }
+    requests_mock.request("GET", f"{url}table/ticket_type?{urlencode(params)}", json={"result": []})
+    result = get_modified_remote_data_command(client, {"lastUpdate": "0"})
+    assert result.modified_incident_ids == []
+
+
 @pytest.mark.parametrize(
     "sys_created_on, expected",
     [

--- a/Packs/ServiceNow/ReleaseNotes/2_9_4.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_9_4.md
@@ -3,5 +3,4 @@
 
 ##### ServiceNow v2
 
-- Fixed an issue where the ***get-modified-remote-data*** command failed when `lastUpdate` could not be parsed. The command now falls back to epoch time in such cases.
-
+- Fixed an issue where the ***get-modified-remote-data*** command could fail on its first run due to an unparseable *lastUpdate* argument value, preventing incoming mirroring from ever succeeding.

--- a/Packs/ServiceNow/ReleaseNotes/2_9_4.md
+++ b/Packs/ServiceNow/ReleaseNotes/2_9_4.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### ServiceNow v2
+
+- Fixed an issue where the ***get-modified-remote-data*** command failed when `lastUpdate` could not be parsed. The command now falls back to epoch time in such cases.
+

--- a/Packs/ServiceNow/pack_metadata.json
+++ b/Packs/ServiceNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ServiceNow",
     "description": "Use The ServiceNow IT Service Management (ITSM) solution to modernize the way you manage and deliver services to your users.",
     "support": "xsoar",
-    "currentVersion": "2.9.3",
+    "currentVersion": "2.9.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-65604

## Description
- Fixed an issue where the ***get-modified-remote-data*** command failed when `lastUpdate` could not be parsed. The command now falls back to epoch time in such cases.

## Must have
- [x] Tests
- [x] Documentation
