### PR TITLE
UnEscapeURLs: Fixed truncating URLs issue

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_21_6.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_21_6.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### UnEscapeURLs
+
+- Fixed an issue with Proofpoint v3/v4 URL decoding truncating URLs.

--- a/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.js
+++ b/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.js
@@ -75,8 +75,11 @@ function format_url(input) {
     // If proofpoint type v3
     if (v === 3 || v === 4) {
         var clean = input.substr(PROOFPOINT_PREFIXES[v - 1].length);
-        var closeIndex = clean.indexOf('__');
-        clean = clean.substr(0, closeIndex);
+        // The v3 URL ends with '__;' (double underscore + semicolon)
+        var closeIndex = clean.indexOf('__;');
+        if (closeIndex > -1) {
+            clean = clean.substr(0, closeIndex);
+        }
         var url_reg = /((http)s?:)(\/{1,2})(.*)/g;
         var clean_fixed = clean.replace(url_reg, '$1//$4');
         return clean_fixed;

--- a/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.yml
+++ b/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.yml
@@ -9,7 +9,7 @@ tags:
 comment: |-
   Extract URLs redirected by security tools like Proofpoint.
   Changes https://urldefense.proofpoint.com/v2/url?u=https-3A__example.com_something.html -> https://example.com/something.html
-  Also, un-escape URLs that are escaped for safety with formats like hxxps://www[.]demisto[.]com
+  Also, un-escape URLs that are escaped for safety with formats like hxxps://www[.]demisto[.]com.
 enabled: true
 args:
 - name: input

--- a/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.yml
+++ b/Packs/CommonScripts/Scripts/UnEscapeURLs/UnEscapeURLs.yml
@@ -13,7 +13,7 @@ comment: |-
 enabled: true
 args:
 - name: input
-  description: The URL(s) to process
+  description: The URL(s) to process.
   isArray: true
 scripttarget: 0
 runas: DBotWeakRole

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.21.5",
+    "currentVersion": "1.21.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-66981

## Description
Fixed an issue with Proofpoint v3/v4 URL decoding truncating URLs.
