### PR TITLE
remove old supported modules from classifiers

### DIFF
--- a/Packs/AgariPhishingDefense/Classifiers/classifier-Agari_Phishing_Defense.json
+++ b/Packs/AgariPhishingDefense/Classifiers/classifier-Agari_Phishing_Defense.json
@@ -1,16 +1,20 @@
 {
- "name": "Agari Phishing Defense - Classifier",
- "type": "classification",
- "id": "Agari Phishing Defense",
- "description": "Classifies Agari Phishing Defense Incidents.",
- "defaultIncidentType": "Agari Phishing Defense Policy Event",
- "keyTypeMap": {
-  "Agari Phishing Defense Policy Event": "Agari Phishing Defense Policy Event"
- },
- "transformer": {
-  "complex": null,
-  "simple": ".=\"Agari Phishing Defense Policy Event\""
- },
- "version": -1,
- "fromVersion": "6.0.0"
+    "name": "Agari Phishing Defense - Classifier",
+    "type": "classification",
+    "id": "Agari Phishing Defense",
+    "description": "Classifies Agari Phishing Defense Incidents.",
+    "defaultIncidentType": "Agari Phishing Defense Policy Event",
+    "keyTypeMap": {
+        "Agari Phishing Defense Policy Event": "Agari Phishing Defense Policy Event"
+    },
+    "transformer": {
+        "complex": null,
+        "simple": ".=\"Agari Phishing Defense Policy Event\""
+    },
+    "version": -1,
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/AgariPhishingDefense/Classifiers/classifier-Agari_Phishing_Defense_-_Phishing_Alerts_-_Classifier.json
+++ b/Packs/AgariPhishingDefense/Classifiers/classifier-Agari_Phishing_Defense_-_Phishing_Alerts_-_Classifier.json
@@ -12,5 +12,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/AgariPhishingDefense/ReleaseNotes/1_1_22.md
+++ b/Packs/AgariPhishingDefense/ReleaseNotes/1_1_22.md
@@ -1,0 +1,10 @@
+
+#### Classifiers
+
+##### Agari Phishing Defense - Phishing Alerts - Classifier
+
+- Documentation and metadata improvements.
+
+##### Agari Phishing Defense - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/AgariPhishingDefense/pack_metadata.json
+++ b/Packs/AgariPhishingDefense/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Agari Phishing Defense",
     "description": "Use the Agari Phishing Defense integration to retrieve Policy Events as Incidents, retrieve messages and remediate suspected messages.",
     "support": "partner",
-    "currentVersion": "1.1.21",
+    "currentVersion": "1.1.22",
     "author": "Agari",
     "url": "https://www.agari.com/support/",
     "email": "support@agari.com",

--- a/Packs/Carbon_Black_Enterprise_Response/Classifiers/classifier-carbonblackedr.json
+++ b/Packs/Carbon_Black_Enterprise_Response/Classifiers/classifier-carbonblackedr.json
@@ -16,5 +16,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/Carbon_Black_Enterprise_Response/ReleaseNotes/2_1_56.md
+++ b/Packs/Carbon_Black_Enterprise_Response/ReleaseNotes/2_1_56.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Carbon Black EDR Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/Carbon_Black_Enterprise_Response/pack_metadata.json
+++ b/Packs/Carbon_Black_Enterprise_Response/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Carbon Black Enterprise Response",
     "description": "Query and respond with Carbon Black endpoint detection and response.",
     "support": "xsoar",
-    "currentVersion": "2.1.55",
+    "currentVersion": "2.1.56",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Code42/Classifiers/classifier-Code42-6.json
+++ b/Packs/Code42/Classifiers/classifier-Code42-6.json
@@ -9,5 +9,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.5.0"
+    "fromVersion": "6.5.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/Code42/ReleaseNotes/6_1_8.md
+++ b/Packs/Code42/ReleaseNotes/6_1_8.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Code42 - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/Code42/pack_metadata.json
+++ b/Packs/Code42/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Code42",
     "description": "The Code42 INCYDR integration accelerates insider threat incident response and remediation procedures for potential data exfiltration across computers, email, cloud and SaaS apps.",
     "support": "partner",
-    "currentVersion": "6.1.7",
+    "currentVersion": "6.1.8",
     "author": "Code42",
     "url": "https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Install_and_manage_the_Code42_app_for_Cortex_XSOAR",
     "email": "gethelp@code42.com",

--- a/Packs/CrowdStrikeFalcon/Classifiers/classifier-CrowdStrike_Falcon_Incident_Classifier.json
+++ b/Packs/CrowdStrikeFalcon/Classifiers/classifier-CrowdStrike_Falcon_Incident_Classifier.json
@@ -1,17 +1,17 @@
 {
-	"id": "CrowdStrike Falcon",
-	"name": "CrowdStrike Falcon Incident Classifier",
-	"type": "classification",
-	"description": "CrowdStrike Falcon Incident Classifier",
-	"version": -1,
-	"defaultIncidentType": "CrowdStrike Falcon Incident",
-	"keyTypeMap": {
+    "id": "CrowdStrike Falcon",
+    "name": "CrowdStrike Falcon Incident Classifier",
+    "type": "classification",
+    "description": "CrowdStrike Falcon Incident Classifier",
+    "version": -1,
+    "defaultIncidentType": "CrowdStrike Falcon Incident",
+    "keyTypeMap": {
         "CS Command And Scripting": "Crowdstrike Command And Scripting",
-		"detection": "CrowdStrike Falcon Detection",
-		"incident": "CrowdStrike Falcon Incident",
-		"IDP detection": "CrowdStrike Falcon IDP Detection",
-		"iom_configurations": "CrowdStrike Falcon IOM Event",
-		"ioa_events": "CrowdStrike Falcon IOA Event",
+        "detection": "CrowdStrike Falcon Detection",
+        "incident": "CrowdStrike Falcon Incident",
+        "IDP detection": "CrowdStrike Falcon IDP Detection",
+        "iom_configurations": "CrowdStrike Falcon IOM Event",
+        "ioa_events": "CrowdStrike Falcon IOA Event",
         "MOBILE detection": "CrowdStrike Falcon Mobile Detection",
         "On-Demand Scans detection": "CrowdStrike Falcon On-Demand Scans Detection",
         "OFP detection": "CrowdStrike Falcon OFP Detection",
@@ -20,31 +20,35 @@
         "ngsiem_incident": "CrowdStrike Falcon NGSIEM Incident",
         "ngsiem_automated_lead": "CrowdStrike Falcon NGSIEM Automated Lead",
         "ngsiem_case": "CrowdStrike Falcon NGSIEM Case"
-	},
-	"transformer": {
+    },
+    "transformer": {
         "complex": {
-			"filters": [],
-			"root": ".",
-			"transformers": [
-				{
-					"args": {
-						"conditions": {
-							"isContext": false,
-							"value": {
-								"simple": "[{\n    \"condition\": \"#{incident_type} == 'detection' and 'T1059' in #{technique_id}\",\n    \"return\": \"CS Command And Scripting\"\n  },\n{\n\"default\": #{incident_type}\n}\n]"
-							}
-						},
-						"flags": {
-							"isContext": false
-						}
-					},
-					"operator": "If-Elif"
-				}
-			]
-		}
-	},
+            "filters": [],
+            "root": ".",
+            "transformers": [
+                {
+                    "args": {
+                        "conditions": {
+                            "isContext": false,
+                            "value": {
+                                "simple": "[{\n    \"condition\": \"#{incident_type} == 'detection' and 'T1059' in #{technique_id}\",\n    \"return\": \"CS Command And Scripting\"\n  },\n{\n\"default\": #{incident_type}\n}\n]"
+                            }
+                        },
+                        "flags": {
+                            "isContext": false
+                        }
+                    },
+                    "operator": "If-Elif"
+                }
+            ]
+        }
+    },
     "fromVersion": "6.0.0",
     "marketplaces": [
         "xsoar"
+    ],
+    "supportedModules": [
+        "agentix",
+        "xsiam"
     ]
 }

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_8_4.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_8_4.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### CrowdStrike Falcon Incident Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.8.3",
+    "currentVersion": "2.8.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/F5Silverline/Classifiers/classifier-F5Silverline_Classifer.json
+++ b/Packs/F5Silverline/Classifiers/classifier-F5Silverline_Classifer.json
@@ -48,5 +48,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/F5Silverline/ReleaseNotes/1_0_39.md
+++ b/Packs/F5Silverline/ReleaseNotes/1_0_39.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### F5 Silverline Classifer
+
+- Documentation and metadata improvements.

--- a/Packs/F5Silverline/pack_metadata.json
+++ b/Packs/F5Silverline/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "F5 Silverline",
     "description": "An integration with F5 Silverline to retrieve alerts and read/update IP lists.",
     "support": "xsoar",
-    "currentVersion": "1.0.38",
+    "currentVersion": "1.0.39",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FireEyeEX/Classifiers/classifier-FireEye_EX.json
+++ b/Packs/FireEyeEX/Classifiers/classifier-FireEye_EX.json
@@ -1,15 +1,19 @@
 {
-  "name": "FireEye Email Security - Classifier",
-  "type": "classification",
-  "id": "FireEye Email Security - Classifier",
-  "description": "Classifies FireEye Email Security Alerts.",
-  "keyTypeMap": {
-    "EMAIL_MPS": "FireEye EX Alert"
-  },
-  "transformer": {
-    "complex": null,
-    "simple": "product"
-  },
-  "version": -1,
-  "fromVersion": "6.0.0"
+    "name": "FireEye Email Security - Classifier",
+    "type": "classification",
+    "id": "FireEye Email Security - Classifier",
+    "description": "Classifies FireEye Email Security Alerts.",
+    "keyTypeMap": {
+        "EMAIL_MPS": "FireEye EX Alert"
+    },
+    "transformer": {
+        "complex": null,
+        "simple": "product"
+    },
+    "version": -1,
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/FireEyeEX/Classifiers/classifier-FireEye_Email_Security_-_Phishing_Alerts_-_Classifier.json
+++ b/Packs/FireEyeEX/Classifiers/classifier-FireEye_Email_Security_-_Phishing_Alerts_-_Classifier.json
@@ -11,5 +11,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/FireEyeEX/ReleaseNotes/2_0_38.md
+++ b/Packs/FireEyeEX/ReleaseNotes/2_0_38.md
@@ -1,0 +1,9 @@
+
+#### Classifiers
+
+##### FireEye Email Security - Classifier
+
+- Documentation and metadata improvements.
+##### FireEye Email Security - Phishing Alerts - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/FireEyeEX/pack_metadata.json
+++ b/Packs/FireEyeEX/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "FireEye Email Security series protects against breaches caused by advanced email attacks.",
     "support": "xsoar",
     "serverMinVersion": "6.0.0",
-    "currentVersion": "2.0.37",
+    "currentVersion": "2.0.38",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/FireEyeHX/Classifiers/classifier-FireEyeHX_Alert.json
+++ b/Packs/FireEyeHX/Classifiers/classifier-FireEyeHX_Alert.json
@@ -34,5 +34,9 @@
     },
     "type": "classification",
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/FireEyeHX/ReleaseNotes/2_4_2.md
+++ b/Packs/FireEyeHX/ReleaseNotes/2_4_2.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### FireEye HX Alert
+
+- Documentation and metadata improvements.

--- a/Packs/FireEyeHX/pack_metadata.json
+++ b/Packs/FireEyeHX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye HX",
     "description": "FireEye Endpoint Security is an integrated solution that detects and protects endpoints against known and unknown threats. The FireEye HX Cortex XSOAR integration provides access to information about endpoints, acquisitions, alerts, indicators, and containment. Customers can extract critical data and effectively operate the security operations automated playbooks.",
     "support": "xsoar",
-    "currentVersion": "2.4.1",
+    "currentVersion": "2.4.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/GenericSQL/Classifiers/classifier-GenericSQL_Classifier.json
+++ b/Packs/GenericSQL/Classifiers/classifier-GenericSQL_Classifier.json
@@ -17,10 +17,6 @@
     "fromVersion": "6.5.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/GenericSQL/ReleaseNotes/1_3_17.md
+++ b/Packs/GenericSQL/ReleaseNotes/1_3_17.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### GenericSQL Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/GenericSQL/pack_metadata.json
+++ b/Packs/GenericSQL/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Connect and execute sql queries in 5 Databases: MySQL, PostgreSQL, Microsoft SQL Server, Oracle and Teradata",
     "support": "xsoar",
     "serverMinVersion": "5.0.0",
-    "currentVersion": "1.3.16",
+    "currentVersion": "1.3.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/GmailSingleUser/Classifiers/classifier-gmail-single-user.json
+++ b/Packs/GmailSingleUser/Classifiers/classifier-gmail-single-user.json
@@ -15,10 +15,6 @@
     "fromVersion": "6.0.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/GmailSingleUser/ReleaseNotes/1_4_17.md
+++ b/Packs/GmailSingleUser/ReleaseNotes/1_4_17.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Gmail Single User - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/GmailSingleUser/pack_metadata.json
+++ b/Packs/GmailSingleUser/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Gmail Single User",
     "description": "Gmail API using OAuth 2.0.",
     "support": "xsoar",
-    "currentVersion": "1.4.16",
+    "currentVersion": "1.4.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/IllusiveNetworks/Classifiers/classifier-IllusiveNetworks.json
+++ b/Packs/IllusiveNetworks/Classifiers/classifier-IllusiveNetworks.json
@@ -23,5 +23,9 @@
         "simple": ""
     },
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/IllusiveNetworks/ReleaseNotes/1_0_40.md
+++ b/Packs/IllusiveNetworks/ReleaseNotes/1_0_40.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Illusive Networks - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/IllusiveNetworks/pack_metadata.json
+++ b/Packs/IllusiveNetworks/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Illusive Networks",
     "description": "Enrich SOC incident triage and investigation data with valuable Illusive information and forensics, and manage the way Illusive deploys deceptions across the network.",
     "support": "partner",
-    "currentVersion": "1.0.39",
+    "currentVersion": "1.0.40",
     "author": "Illusive Networks",
     "url": "https://www.illusivenetworks.com",
     "email": "support@illusivenetworks.com",

--- a/Packs/MicrosoftExchangeOnPremise/Classifiers/classifier-EWS_v2.json
+++ b/Packs/MicrosoftExchangeOnPremise/Classifiers/classifier-EWS_v2.json
@@ -17,10 +17,6 @@
     "fromVersion": "6.0.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_2_22.md
+++ b/Packs/MicrosoftExchangeOnPremise/ReleaseNotes/2_2_22.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### EWS - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
+++ b/Packs/MicrosoftExchangeOnPremise/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Exchange On-Premise",
     "description": "Exchange Web Services",
     "support": "xsoar",
-    "currentVersion": "2.2.21",
+    "currentVersion": "2.2.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftGraphIdentityandAccess/Classifiers/classifier-Azure_Active_Directory_Identity_Protection_Classifier.json
+++ b/Packs/MicrosoftGraphIdentityandAccess/Classifiers/classifier-Azure_Active_Directory_Identity_Protection_Classifier.json
@@ -49,10 +49,6 @@
     "fromVersion": "6.2.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/MicrosoftGraphIdentityandAccess/ReleaseNotes/1_4_4.md
+++ b/Packs/MicrosoftGraphIdentityandAccess/ReleaseNotes/1_4_4.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Microsoft Graph Identity and Access Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
+++ b/Packs/MicrosoftGraphIdentityandAccess/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Identity and Access",
     "description": "Use this pack to manage roles and members in Microsoft.",
     "support": "xsoar",
-    "currentVersion": "1.4.3",
+    "currentVersion": "1.4.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftGraphMail/Classifiers/classifier-MicrosoftGraphListener.json
+++ b/Packs/MicrosoftGraphMail/Classifiers/classifier-MicrosoftGraphListener.json
@@ -14,9 +14,6 @@
     "fromVersion": "6.0.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security"
+        "xsiam"
     ]
 }

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_7_24.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_7_24.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Microsoft Graph Mail Single User - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph enables authorized access to a user’s Outlook mail data in personal or organizational accounts.",
     "support": "xsoar",
-    "currentVersion": "1.7.23",
+    "currentVersion": "1.7.24",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Okta/Classifiers/classifier-Okta_IAM.json
+++ b/Packs/Okta/Classifiers/classifier-Okta_IAM.json
@@ -20,10 +20,6 @@
     "fromVersion": "6.0.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/Okta/ReleaseNotes/3_3_37.md
+++ b/Packs/Okta/ReleaseNotes/3_3_37.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Okta IAM - App Sync (classifier)
+
+- Documentation and metadata improvements.

--- a/Packs/Okta/pack_metadata.json
+++ b/Packs/Okta/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Okta",
     "description": "Integration with Okta's cloud-based identity management service.",
     "support": "xsoar",
-    "currentVersion": "3.3.36",
+    "currentVersion": "3.3.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/PAN-OS/Classifiers/classifier-Panorama_Classifier.json
+++ b/Packs/PAN-OS/Classifiers/classifier-Panorama_Classifier.json
@@ -25,10 +25,6 @@
     "fromVersion": "6.5.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/PAN-OS/ReleaseNotes/2_6_28.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_28.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### Panorama Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. Use this pack to manage Prisma Access through Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "2.6.27",
+    "currentVersion": "2.6.28",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/PrismaCloud/Classifiers/classifier-Prisma_Cloud.json
+++ b/Packs/PrismaCloud/Classifiers/classifier-Prisma_Cloud.json
@@ -94,5 +94,9 @@
         "simple": "policy.name"
     },
     "version": -1,
-    "fromVersion": "6.0.0"
+    "fromVersion": "6.0.0",
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/PrismaCloud/Classifiers/classifier-prismaCloud_app.json
+++ b/Packs/PrismaCloud/Classifiers/classifier-prismaCloud_app.json
@@ -1,120 +1,124 @@
 {
-  	"id": "prismaCloud_app",
+    "id": "prismaCloud_app",
     "name": "Prisma Cloud App - Classifier",
     "type": "classification",
     "description": "Classifies incoming Prisma Cloud events that are pushed into Cortex XSOAR through the Prisma Cloud App add-on.",
-	"fromVersion": "6.0.0",
-	"defaultIncidentType": "",
-	"keyTypeMap": {
-		"05befc8b-c78a-45e9-98dc-c7fbaef580e7": "AWS CloudTrail Misconfiguration",
-		"0d07ac51-fbfe-44fe-8edb-3314c9995ee0": "AWS CloudTrail Misconfiguration",
-		"10bc76ee-6f29-4c04-98bb-b9f8bafb0964": "GCP Compute Engine Misconfiguration",
-		"14d10ad2-51df-4b07-be69-e94951cc7067": "AWS EC2 Instance Misconfiguration",
-		"168bfaa0-8c1d-427e-bfa8-4d96d82e3d83": "AWS IAM Policy Misconfiguration",
-		"2378dbf4-b104-4bda-9b05-7417affbba3f": "AWS EC2 Instance Misconfiguration",
-		"2dbda57f-33d4-459a-97ae-dec7e81f9ec4": "AWS EC2 Instance Misconfiguration",
-		"31626ca9-f659-4d25-9d88-fa32262bbba7": "AWS IAM Policy Misconfiguration",
-		"36a5345a-230d-438e-a04c-a287a513e3dc": "AWS CloudTrail Misconfiguration",
-		"38e3d3cf-b694-46ec-8bd2-8f02194b5040": "AWS CloudTrail Misconfiguration",
-		"3b642d25-4534-487a-9399-c2622754ecb5": "AWS EC2 Instance Misconfiguration",
-		"519456f2-f9eb-407b-b32d-064f1ac7f0ca": "AWS EC2 Instance Misconfiguration",
-		"520308c5-57e3-4061-b9bf-1ce5325a2d61": "AWS EC2 Instance Misconfiguration",
-		"5599b97c-2965-4fd2-9370-927c368abd2d": "AWS EC2 Instance Misconfiguration",
-		"566686e8-0581-4df5-ae22-5a901ed37b58": "AWS EC2 Instance Misconfiguration",
-		"65daa6a0-e040-434e-aca3-9d5765c96e7c": "AWS EC2 Instance Misconfiguration",
-		"6eaf6455-1659-4c4b-bff5-c8c7b0fda201": "AWS EC2 Instance Misconfiguration",
-		"72b422c8-bef1-4842-a6c6-7230bf0b3492": "GCP Compute Engine Misconfiguration",
-		"760f2823-997e-495f-a538-5fb073c0ee78": "AWS EC2 Instance Misconfiguration",
-		"89cbc2f1-fcb0-48b9-be71-4cbe2d18a5f7": "AWS EC2 Instance Misconfiguration",
-		"8dd9e369-0c09-4477-97a2-ff0d50507fe2": "AWS EC2 Instance Misconfiguration",
-		"9a5813af-17a3-4058-be13-588ea00b4bfa": "AWS IAM Policy Misconfiguration",
-		"Prisma Cloud": "Prisma Cloud",
-		"a2107824-6ed5-4c67-9450-8b154bb1fd2b": "AWS IAM Policy Misconfiguration",
-		"a8dcc272-0b02-4534-8627-cf70ddd264c5": "AWS IAM Policy Misconfiguration",
-		"a9f1b983-f216-486e-b8ea-7259764fc420": "AWS EC2 Instance Misconfiguration",
-		"ab7f8eda-18ab-457c-b5d3-fd4f53c722bc": "AWS EC2 Instance Misconfiguration",
-		"ab8b6bb8-a730-4bdf-a4d5-080c01e97335": "AWS EC2 Instance Misconfiguration",
-		"b1acdeff-4959-4c14-8a5e-2adc1016a3d5": "AWS IAM Policy Misconfiguration",
-		"b82f90ce-ed8b-4b49-970c-2268b0a6c2e5": "AWS EC2 Instance Misconfiguration",
-		"c2074d5a-aa28-4dde-90c1-82f528cec55e": "AWS EC2 Instance Misconfiguration",
-		"cdcd663c-e9c9-4472-9779-e5f38751524a": "AWS EC2 Instance Misconfiguration",
-		"ee03a420-89d6-4745-a0ac-98878cb56cf4": "AWS EC2 Instance Misconfiguration",
-		"ef7c537b-72eb-42a7-bab7-cb2d22c76a0d": "AWS IAM Policy Misconfiguration",
-		"f53107a2-00b2-46fb-98a9-1f12262c7d44": "AWS IAM Policy Misconfiguration",
-		"fd4dae57-509e-4374-96d3-e136821fc3f3": "AWS IAM Policy Misconfiguration",
-                "6e125379-081e-4b06-a7ba-f04da2f0901a": "GCP Kubernetes Engine Misconfiguration",
-                "f57baa2a-6039-4a17-94e8-0be723bcdc75": "GCP Kubernetes Engine Misconfiguration",
-                "e1b70bb4-bb77-4326-93d5-5dd9c5170d3f": "GCP Kubernetes Engine Misconfiguration",
-                "6ddbfdfe-3936-43d0-8157-97a7899beae6": "GCP Kubernetes Engine Misconfiguration",
-                "53793c32-dd41-430f-bbea-2f002ddafe42": "GCP Kubernetes Engine Misconfiguration",
-                "ca4b4654-d36a-4b17-a055-9c5063fa2f41": "GCP Kubernetes Engine Misconfiguration",
-                "fe81b03a-c602-4b16-8ae9-973724c1adae": "GCP Kubernetes Engine Misconfiguration",
-                "a3688f2e-eb5b-4b8d-b26f-90d40f08fd84": "GCP Kubernetes Engine Misconfiguration",
-                "50d5ec3b-1710-4ff7-bb09-061c30deef96": "GCP Kubernetes Engine Misconfiguration",
-                "bee0893d-85fb-403f-9ba7-a5269a46d382": "GCP Kubernetes Engine Misconfiguration",
-		"be55c11a-981a-4f34-a2e7-81ce40d71aa5": "Azure AKS Misconfiguration",
-		"0429670c-5d2d-4d0f-ab33-59eb5e000305": "Azure AKS Misconfiguration",
-		"96b1b8e3-6936-434f-94ab-a154cd5967d9": "Azure SQL Misconfiguration",
-		"fa6fa903-8887-49dd-917f-91687df98dd1": "Azure SQL Misconfiguration",
-		"8f7eee48-dffb-4f18-9207-8ea48680b0e2": "Azure SQL Misconfiguration",
-		"c83a7b1d-ac74-475b-80fe-b1244daa1b27": "Azure SQL Misconfiguration",
-		"3beed53c-3f2d-47b6-bb6f-95da39ff0f26": "Azure Network Misconfiguration",
-		"a36a7170-d628-47fe-aab2-0e734702373d": "Azure Network Misconfiguration",
-		"0c620876-4549-46c4-a5b3-16e86e3cefe7": "Azure Network Misconfiguration",
-		"472e08a2-c741-43eb-a3ca-e2f5cd275cf7": "Azure Network Misconfiguration",
-		"f48eda6b-5d66-4d73-a62e-671de3844555": "Azure Network Misconfiguration",
-		"5826e50f-2f29-4444-9cad-3bb4e66ee3ca": "Azure Network Misconfiguration",
-		"5dbd0da1-cfa4-4bce-a753-56dade428bd4": "Azure Network Misconfiguration",
-		"4afdc071-53ca-4516-8a3c-d5c91345c409": "Azure Network Misconfiguration",
-		"500e9f2a-1063-4066-8eea-780efa90a0d7": "Azure Network Misconfiguration",
-		"a0791206-a669-4948-a845-cc735212013c": "Azure Network Misconfiguration",
-		"ac851899-1007-48c8-842f-dddb9a38c4ba": "Azure Network Misconfiguration",
-		"3aa12e75-d78b-4157-9eca-6049187a30d7": "Azure Network Misconfiguration",
-		"936dd3cb-a9cc-4a13-9a2c-ea5d40856072": "Azure Network Misconfiguration",
-		"91a53c5d-d629-45bb-9610-fbd2cb4c6f3c": "Azure Network Misconfiguration",
-		"840b4b1c-a50b-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
-		"0a3f1d49-4c05-47c4-98e2-3a42b822d05b": "Azure Network Misconfiguration",
-		"bc7929f8-fe70-48ec-8690-4288aa0b98ae": "Azure Network Misconfiguration",
-		"18e1dd76-9d0f-4cdb-96d4-9d01b5cd68dc": "Azure Network Misconfiguration",
-		"3784cdfd-dd25-4cf3-b506-ad77033ccc35": "Azure Network Misconfiguration",
-		"0546188d-6f21-449d-948e-677c285a5fcf": "Azure Network Misconfiguration",
-		"709b47cd-6b7a-4500-b99e-a58529a6c79e": "Azure Network Misconfiguration",
-		"d979e854-a50d-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
-		"543c6a0a-a50c-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
-		"7a506ab4-d0a2-48ee-a6f5-75a97f11397d": "Azure Storage Misconfiguration",
-		"bc4e467f-10fa-471e-aa9b-28981dc73e93": "Azure Storage Misconfiguration"
-	},
-	"transformer": {
-		"complex": {
-			"accessor": "policyId",
-			"filters": [],
-			"root": "policy",
-			"transformers": [
-				{
-					"args": {
-						"convertTo": {
-							"isContext": false,
-							"value": {
-								"complex": null,
-								"simple": "Prisma Cloud"
-							}
-						},
-						"except": {
-							"isContext": false,
-							"value": {
-								"complex": null,
-								"simple": "10bc76ee-6f29-4c04-98bb-b9f8bafb0964,72b422c8-bef1-4842-a6c6-7230bf0b3492,05befc8b-c78a-45e9-98dc-c7fbaef580e7,0d07ac51-fbfe-44fe-8edb-3314c9995ee0,36a5345a-230d-438e-a04c-a287a513e3dc,38e3d3cf-b694-46ec-8bd2-8f02194b5040,168bfaa0-8c1d-427e-bfa8-4d96d82e3d83,31626ca9-f659-4d25-9d88-fa32262bbba7,9a5813af-17a3-4058-be13-588ea00b4bfa,a2107824-6ed5-4c67-9450-8b154bb1fd2b,a8dcc272-0b02-4534-8627-cf70ddd264c5,b1acdeff-4959-4c14-8a5e-2adc1016a3d5,ef7c537b-72eb-42a7-bab7-cb2d22c76a0d,f53107a2-00b2-46fb-98a9-1f12262c7d44,fd4dae57-509e-4374-96d3-e136821fc3f3,14d10ad2-51df-4b07-be69-e94951cc7067,2378dbf4-b104-4bda-9b05-7417affbba3f,2dbda57f-33d4-459a-97ae-dec7e81f9ec4,3b642d25-4534-487a-9399-c2622754ecb5,519456f2-f9eb-407b-b32d-064f1ac7f0ca,520308c5-57e3-4061-b9bf-1ce5325a2d61,5599b97c-2965-4fd2-9370-927c368abd2d,566686e8-0581-4df5-ae22-5a901ed37b58,65daa6a0-e040-434e-aca3-9d5765c96e7c,6eaf6455-1659-4c4b-bff5-c8c7b0fda201,760f2823-997e-495f-a538-5fb073c0ee78,89cbc2f1-fcb0-48b9-be71-4cbe2d18a5f7,8dd9e369-0c09-4477-97a2-ff0d50507fe2,a9f1b983-f216-486e-b8ea-7259764fc420,ab7f8eda-18ab-457c-b5d3-fd4f53c722bc,ab8b6bb8-a730-4bdf-a4d5-080c01e97335,b82f90ce-ed8b-4b49-970c-2268b0a6c2e5,c2074d5a-aa28-4dde-90c1-82f528cec55e,cdcd663c-e9c9-4472-9779-e5f38751524a,ee03a420-89d6-4745-a0ac-98878cb56cf4,6e125379-081e-4b06-a7ba-f04da2f0901a,f57baa2a-6039-4a17-94e8-0be723bcdc75,e1b70bb4-bb77-4326-93d5-5dd9c5170d3f,6ddbfdfe-3936-43d0-8157-97a7899beae6,53793c32-dd41-430f-bbea-2f002ddafe42,ca4b4654-d36a-4b17-a055-9c5063fa2f41,fe81b03a-c602-4b16-8ae9-973724c1adae,a3688f2e-eb5b-4b8d-b26f-90d40f08fd84,50d5ec3b-1710-4ff7-bb09-061c30deef96,bee0893d-85fb-403f-9ba7-a5269a46d382,be55c11a-981a-4f34-a2e7-81ce40d71aa5,0429670c-5d2d-4d0f-ab33-59eb5e000305,96b1b8e3-6936-434f-94ab-a154cd5967d9,fa6fa903-8887-49dd-917f-91687df98dd1,8f7eee48-dffb-4f18-9207-8ea48680b0e,c83a7b1d-ac74-475b-80fe-b1244daa1b27,3beed53c-3f2d-47b6-bb6f-95da39ff0f26,a36a7170-d628-47fe-aab2-0e734702373d,0c620876-4549-46c4-a5b3-16e86e3cefe7,472e08a2-c741-43eb-a3ca-e2f5cd275cf7,f48eda6b-5d66-4d73-a62e-671de3844555,5826e50f-2f29-4444-9cad-3bb4e66ee3ca,5dbd0da1-cfa4-4bce-a753-56dade428bd4,4afdc071-53ca-4516-8a3c-d5c91345c409,500e9f2a-1063-4066-8eea-780efa90a0d7,a0791206-a669-4948-a845-cc735212013c,ac851899-1007-48c8-842f-dddb9a38c4ba,3aa12e75-d78b-4157-9eca-6049187a30d7,936dd3cb-a9cc-4a13-9a2c-ea5d40856072,91a53c5d-d629-45bb-9610-fbd2cb4c6f3c,840b4b1c-a50b-11e8-98d0-529269fb1459,0a3f1d49-4c05-47c4-98e2-3a42b822d05b,bc7929f8-fe70-48ec-8690-4288aa0b98ae,18e1dd76-9d0f-4cdb-96d4-9d01b5cd68dc,3784cdfd-dd25-4cf3-b506-ad77033ccc35,0546188d-6f21-449d-948e-677c285a5fcf,709b47cd-6b7a-4500-b99e-a58529a6c79e,d979e854-a50d-11e8-98d0-529269fb1459,543c6a0a-a50c-11e8-98d0-529269fb1459,7a506ab4-d0a2-48ee-a6f5-75a97f11397d,bc4e467f-10fa-471e-aa9b-28981dc73e93"
-							}
-						}
-					},
-					"operator": "ConvertAllExcept"
-				}
-			]
-		},
-		"simple": ""
-	},
+    "fromVersion": "6.0.0",
+    "defaultIncidentType": "",
+    "keyTypeMap": {
+        "05befc8b-c78a-45e9-98dc-c7fbaef580e7": "AWS CloudTrail Misconfiguration",
+        "0d07ac51-fbfe-44fe-8edb-3314c9995ee0": "AWS CloudTrail Misconfiguration",
+        "10bc76ee-6f29-4c04-98bb-b9f8bafb0964": "GCP Compute Engine Misconfiguration",
+        "14d10ad2-51df-4b07-be69-e94951cc7067": "AWS EC2 Instance Misconfiguration",
+        "168bfaa0-8c1d-427e-bfa8-4d96d82e3d83": "AWS IAM Policy Misconfiguration",
+        "2378dbf4-b104-4bda-9b05-7417affbba3f": "AWS EC2 Instance Misconfiguration",
+        "2dbda57f-33d4-459a-97ae-dec7e81f9ec4": "AWS EC2 Instance Misconfiguration",
+        "31626ca9-f659-4d25-9d88-fa32262bbba7": "AWS IAM Policy Misconfiguration",
+        "36a5345a-230d-438e-a04c-a287a513e3dc": "AWS CloudTrail Misconfiguration",
+        "38e3d3cf-b694-46ec-8bd2-8f02194b5040": "AWS CloudTrail Misconfiguration",
+        "3b642d25-4534-487a-9399-c2622754ecb5": "AWS EC2 Instance Misconfiguration",
+        "519456f2-f9eb-407b-b32d-064f1ac7f0ca": "AWS EC2 Instance Misconfiguration",
+        "520308c5-57e3-4061-b9bf-1ce5325a2d61": "AWS EC2 Instance Misconfiguration",
+        "5599b97c-2965-4fd2-9370-927c368abd2d": "AWS EC2 Instance Misconfiguration",
+        "566686e8-0581-4df5-ae22-5a901ed37b58": "AWS EC2 Instance Misconfiguration",
+        "65daa6a0-e040-434e-aca3-9d5765c96e7c": "AWS EC2 Instance Misconfiguration",
+        "6eaf6455-1659-4c4b-bff5-c8c7b0fda201": "AWS EC2 Instance Misconfiguration",
+        "72b422c8-bef1-4842-a6c6-7230bf0b3492": "GCP Compute Engine Misconfiguration",
+        "760f2823-997e-495f-a538-5fb073c0ee78": "AWS EC2 Instance Misconfiguration",
+        "89cbc2f1-fcb0-48b9-be71-4cbe2d18a5f7": "AWS EC2 Instance Misconfiguration",
+        "8dd9e369-0c09-4477-97a2-ff0d50507fe2": "AWS EC2 Instance Misconfiguration",
+        "9a5813af-17a3-4058-be13-588ea00b4bfa": "AWS IAM Policy Misconfiguration",
+        "Prisma Cloud": "Prisma Cloud",
+        "a2107824-6ed5-4c67-9450-8b154bb1fd2b": "AWS IAM Policy Misconfiguration",
+        "a8dcc272-0b02-4534-8627-cf70ddd264c5": "AWS IAM Policy Misconfiguration",
+        "a9f1b983-f216-486e-b8ea-7259764fc420": "AWS EC2 Instance Misconfiguration",
+        "ab7f8eda-18ab-457c-b5d3-fd4f53c722bc": "AWS EC2 Instance Misconfiguration",
+        "ab8b6bb8-a730-4bdf-a4d5-080c01e97335": "AWS EC2 Instance Misconfiguration",
+        "b1acdeff-4959-4c14-8a5e-2adc1016a3d5": "AWS IAM Policy Misconfiguration",
+        "b82f90ce-ed8b-4b49-970c-2268b0a6c2e5": "AWS EC2 Instance Misconfiguration",
+        "c2074d5a-aa28-4dde-90c1-82f528cec55e": "AWS EC2 Instance Misconfiguration",
+        "cdcd663c-e9c9-4472-9779-e5f38751524a": "AWS EC2 Instance Misconfiguration",
+        "ee03a420-89d6-4745-a0ac-98878cb56cf4": "AWS EC2 Instance Misconfiguration",
+        "ef7c537b-72eb-42a7-bab7-cb2d22c76a0d": "AWS IAM Policy Misconfiguration",
+        "f53107a2-00b2-46fb-98a9-1f12262c7d44": "AWS IAM Policy Misconfiguration",
+        "fd4dae57-509e-4374-96d3-e136821fc3f3": "AWS IAM Policy Misconfiguration",
+        "6e125379-081e-4b06-a7ba-f04da2f0901a": "GCP Kubernetes Engine Misconfiguration",
+        "f57baa2a-6039-4a17-94e8-0be723bcdc75": "GCP Kubernetes Engine Misconfiguration",
+        "e1b70bb4-bb77-4326-93d5-5dd9c5170d3f": "GCP Kubernetes Engine Misconfiguration",
+        "6ddbfdfe-3936-43d0-8157-97a7899beae6": "GCP Kubernetes Engine Misconfiguration",
+        "53793c32-dd41-430f-bbea-2f002ddafe42": "GCP Kubernetes Engine Misconfiguration",
+        "ca4b4654-d36a-4b17-a055-9c5063fa2f41": "GCP Kubernetes Engine Misconfiguration",
+        "fe81b03a-c602-4b16-8ae9-973724c1adae": "GCP Kubernetes Engine Misconfiguration",
+        "a3688f2e-eb5b-4b8d-b26f-90d40f08fd84": "GCP Kubernetes Engine Misconfiguration",
+        "50d5ec3b-1710-4ff7-bb09-061c30deef96": "GCP Kubernetes Engine Misconfiguration",
+        "bee0893d-85fb-403f-9ba7-a5269a46d382": "GCP Kubernetes Engine Misconfiguration",
+        "be55c11a-981a-4f34-a2e7-81ce40d71aa5": "Azure AKS Misconfiguration",
+        "0429670c-5d2d-4d0f-ab33-59eb5e000305": "Azure AKS Misconfiguration",
+        "96b1b8e3-6936-434f-94ab-a154cd5967d9": "Azure SQL Misconfiguration",
+        "fa6fa903-8887-49dd-917f-91687df98dd1": "Azure SQL Misconfiguration",
+        "8f7eee48-dffb-4f18-9207-8ea48680b0e2": "Azure SQL Misconfiguration",
+        "c83a7b1d-ac74-475b-80fe-b1244daa1b27": "Azure SQL Misconfiguration",
+        "3beed53c-3f2d-47b6-bb6f-95da39ff0f26": "Azure Network Misconfiguration",
+        "a36a7170-d628-47fe-aab2-0e734702373d": "Azure Network Misconfiguration",
+        "0c620876-4549-46c4-a5b3-16e86e3cefe7": "Azure Network Misconfiguration",
+        "472e08a2-c741-43eb-a3ca-e2f5cd275cf7": "Azure Network Misconfiguration",
+        "f48eda6b-5d66-4d73-a62e-671de3844555": "Azure Network Misconfiguration",
+        "5826e50f-2f29-4444-9cad-3bb4e66ee3ca": "Azure Network Misconfiguration",
+        "5dbd0da1-cfa4-4bce-a753-56dade428bd4": "Azure Network Misconfiguration",
+        "4afdc071-53ca-4516-8a3c-d5c91345c409": "Azure Network Misconfiguration",
+        "500e9f2a-1063-4066-8eea-780efa90a0d7": "Azure Network Misconfiguration",
+        "a0791206-a669-4948-a845-cc735212013c": "Azure Network Misconfiguration",
+        "ac851899-1007-48c8-842f-dddb9a38c4ba": "Azure Network Misconfiguration",
+        "3aa12e75-d78b-4157-9eca-6049187a30d7": "Azure Network Misconfiguration",
+        "936dd3cb-a9cc-4a13-9a2c-ea5d40856072": "Azure Network Misconfiguration",
+        "91a53c5d-d629-45bb-9610-fbd2cb4c6f3c": "Azure Network Misconfiguration",
+        "840b4b1c-a50b-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
+        "0a3f1d49-4c05-47c4-98e2-3a42b822d05b": "Azure Network Misconfiguration",
+        "bc7929f8-fe70-48ec-8690-4288aa0b98ae": "Azure Network Misconfiguration",
+        "18e1dd76-9d0f-4cdb-96d4-9d01b5cd68dc": "Azure Network Misconfiguration",
+        "3784cdfd-dd25-4cf3-b506-ad77033ccc35": "Azure Network Misconfiguration",
+        "0546188d-6f21-449d-948e-677c285a5fcf": "Azure Network Misconfiguration",
+        "709b47cd-6b7a-4500-b99e-a58529a6c79e": "Azure Network Misconfiguration",
+        "d979e854-a50d-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
+        "543c6a0a-a50c-11e8-98d0-529269fb1459": "Azure Network Misconfiguration",
+        "7a506ab4-d0a2-48ee-a6f5-75a97f11397d": "Azure Storage Misconfiguration",
+        "bc4e467f-10fa-471e-aa9b-28981dc73e93": "Azure Storage Misconfiguration"
+    },
+    "transformer": {
+        "complex": {
+            "accessor": "policyId",
+            "filters": [],
+            "root": "policy",
+            "transformers": [
+                {
+                    "args": {
+                        "convertTo": {
+                            "isContext": false,
+                            "value": {
+                                "complex": null,
+                                "simple": "Prisma Cloud"
+                            }
+                        },
+                        "except": {
+                            "isContext": false,
+                            "value": {
+                                "complex": null,
+                                "simple": "10bc76ee-6f29-4c04-98bb-b9f8bafb0964,72b422c8-bef1-4842-a6c6-7230bf0b3492,05befc8b-c78a-45e9-98dc-c7fbaef580e7,0d07ac51-fbfe-44fe-8edb-3314c9995ee0,36a5345a-230d-438e-a04c-a287a513e3dc,38e3d3cf-b694-46ec-8bd2-8f02194b5040,168bfaa0-8c1d-427e-bfa8-4d96d82e3d83,31626ca9-f659-4d25-9d88-fa32262bbba7,9a5813af-17a3-4058-be13-588ea00b4bfa,a2107824-6ed5-4c67-9450-8b154bb1fd2b,a8dcc272-0b02-4534-8627-cf70ddd264c5,b1acdeff-4959-4c14-8a5e-2adc1016a3d5,ef7c537b-72eb-42a7-bab7-cb2d22c76a0d,f53107a2-00b2-46fb-98a9-1f12262c7d44,fd4dae57-509e-4374-96d3-e136821fc3f3,14d10ad2-51df-4b07-be69-e94951cc7067,2378dbf4-b104-4bda-9b05-7417affbba3f,2dbda57f-33d4-459a-97ae-dec7e81f9ec4,3b642d25-4534-487a-9399-c2622754ecb5,519456f2-f9eb-407b-b32d-064f1ac7f0ca,520308c5-57e3-4061-b9bf-1ce5325a2d61,5599b97c-2965-4fd2-9370-927c368abd2d,566686e8-0581-4df5-ae22-5a901ed37b58,65daa6a0-e040-434e-aca3-9d5765c96e7c,6eaf6455-1659-4c4b-bff5-c8c7b0fda201,760f2823-997e-495f-a538-5fb073c0ee78,89cbc2f1-fcb0-48b9-be71-4cbe2d18a5f7,8dd9e369-0c09-4477-97a2-ff0d50507fe2,a9f1b983-f216-486e-b8ea-7259764fc420,ab7f8eda-18ab-457c-b5d3-fd4f53c722bc,ab8b6bb8-a730-4bdf-a4d5-080c01e97335,b82f90ce-ed8b-4b49-970c-2268b0a6c2e5,c2074d5a-aa28-4dde-90c1-82f528cec55e,cdcd663c-e9c9-4472-9779-e5f38751524a,ee03a420-89d6-4745-a0ac-98878cb56cf4,6e125379-081e-4b06-a7ba-f04da2f0901a,f57baa2a-6039-4a17-94e8-0be723bcdc75,e1b70bb4-bb77-4326-93d5-5dd9c5170d3f,6ddbfdfe-3936-43d0-8157-97a7899beae6,53793c32-dd41-430f-bbea-2f002ddafe42,ca4b4654-d36a-4b17-a055-9c5063fa2f41,fe81b03a-c602-4b16-8ae9-973724c1adae,a3688f2e-eb5b-4b8d-b26f-90d40f08fd84,50d5ec3b-1710-4ff7-bb09-061c30deef96,bee0893d-85fb-403f-9ba7-a5269a46d382,be55c11a-981a-4f34-a2e7-81ce40d71aa5,0429670c-5d2d-4d0f-ab33-59eb5e000305,96b1b8e3-6936-434f-94ab-a154cd5967d9,fa6fa903-8887-49dd-917f-91687df98dd1,8f7eee48-dffb-4f18-9207-8ea48680b0e,c83a7b1d-ac74-475b-80fe-b1244daa1b27,3beed53c-3f2d-47b6-bb6f-95da39ff0f26,a36a7170-d628-47fe-aab2-0e734702373d,0c620876-4549-46c4-a5b3-16e86e3cefe7,472e08a2-c741-43eb-a3ca-e2f5cd275cf7,f48eda6b-5d66-4d73-a62e-671de3844555,5826e50f-2f29-4444-9cad-3bb4e66ee3ca,5dbd0da1-cfa4-4bce-a753-56dade428bd4,4afdc071-53ca-4516-8a3c-d5c91345c409,500e9f2a-1063-4066-8eea-780efa90a0d7,a0791206-a669-4948-a845-cc735212013c,ac851899-1007-48c8-842f-dddb9a38c4ba,3aa12e75-d78b-4157-9eca-6049187a30d7,936dd3cb-a9cc-4a13-9a2c-ea5d40856072,91a53c5d-d629-45bb-9610-fbd2cb4c6f3c,840b4b1c-a50b-11e8-98d0-529269fb1459,0a3f1d49-4c05-47c4-98e2-3a42b822d05b,bc7929f8-fe70-48ec-8690-4288aa0b98ae,18e1dd76-9d0f-4cdb-96d4-9d01b5cd68dc,3784cdfd-dd25-4cf3-b506-ad77033ccc35,0546188d-6f21-449d-948e-677c285a5fcf,709b47cd-6b7a-4500-b99e-a58529a6c79e,d979e854-a50d-11e8-98d0-529269fb1459,543c6a0a-a50c-11e8-98d0-529269fb1459,7a506ab4-d0a2-48ee-a6f5-75a97f11397d,bc4e467f-10fa-471e-aa9b-28981dc73e93"
+                            }
+                        }
+                    },
+                    "operator": "ConvertAllExcept"
+                }
+            ]
+        },
+        "simple": ""
+    },
     "marketplaces": [
         "xsoar"
     ],
-	"version": -1
+    "version": -1,
+    "supportedModules": [
+        "agentix",
+        "xsiam"
+    ]
 }

--- a/Packs/PrismaCloud/ReleaseNotes/4_4_19.md
+++ b/Packs/PrismaCloud/ReleaseNotes/4_4_19.md
@@ -1,0 +1,9 @@
+
+#### Classifiers
+
+##### Prisma Cloud App - Classifier
+
+- Documentation and metadata improvements.
+##### Prisma Cloud - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/PrismaCloud/pack_metadata.json
+++ b/Packs/PrismaCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Prisma Cloud by Palo Alto Networks",
     "description": "Automate and unify security incident response across your cloud environments, while still giving a degree of control to dedicated cloud teams.",
     "support": "xsoar",
-    "currentVersion": "4.4.18",
+    "currentVersion": "4.4.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/QRadar/Classifiers/classifier-QRadar.json
+++ b/Packs/QRadar/Classifiers/classifier-QRadar.json
@@ -16,10 +16,6 @@
     "fromVersion": "6.0.0",
     "supportedModules": [
         "agentix",
-        "xsiam",
-        "edr",
-        "cloud",
-        "cloud_runtime_security",
-        "cloud_posture"
+        "xsiam"
     ]
 }

--- a/Packs/QRadar/ReleaseNotes/2_5_39.md
+++ b/Packs/QRadar/ReleaseNotes/2_5_39.md
@@ -1,0 +1,6 @@
+
+#### Classifiers
+
+##### QRadar - Classifier
+
+- Documentation and metadata improvements.

--- a/Packs/QRadar/pack_metadata.json
+++ b/Packs/QRadar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "IBM QRadar",
     "description": "Fetch offenses as incidents and search QRadar",
     "support": "xsoar",
-    "currentVersion": "2.5.38",
+    "currentVersion": "2.5.39",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-15886](https://jira-dc.paloaltonetworks.com/browse/CIAC-15886)

## Description
remove old supported modules from classifiers
the old supported modules 
cloud_posture cloud cloud_runtime_security edr xsoar asm tim cloud_appsec exposure_management

`MATCH (c:Classifier) 
WHERE ANY(
    m IN c.supportedModules WHERE m IN ["cloud_posture", "cloud", "cloud_runtime_security", "edr", "xsoar", "asm", "tim", "cloud_appsec", "exposure_management"]
    ) RETURN c.name AS classifier_name, c.supportedModules AS supported_modules ORDER BY c.name`

## Must have
- [x] Tests
- [x] Documentation
