### PR TITLE
remove old supported modules from event collectors

### DIFF
--- a/Packs/Akamai_SIEM/Integrations/Akamai_SIEM/Akamai_SIEM.yml
+++ b/Packs/Akamai_SIEM/Integrations/Akamai_SIEM/Akamai_SIEM.yml
@@ -282,3 +282,5 @@ script:
 tests:
 - Akamai_WAF_SIEM-Test
 fromversion: 5.0.0
+supportedModules:
+- xsiam

--- a/Packs/Akamai_SIEM/ReleaseNotes/1_2_19.md
+++ b/Packs/Akamai_SIEM/ReleaseNotes/1_2_19.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Akamai WAF SIEM
+
+- Documentation and metadata improvements.

--- a/Packs/Akamai_SIEM/pack_metadata.json
+++ b/Packs/Akamai_SIEM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Akamai WAF SIEM",
     "description": "Use the Akamai WAF SIEM integration to retrieve security events from Akamai Web Application Firewall (WAF) service.",
     "support": "xsoar",
-    "currentVersion": "1.2.18",
+    "currentVersion": "1.2.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Citrix/Integrations/CitrixCloudEventCollector/CitrixCloudEventCollector.yml
+++ b/Packs/Citrix/Integrations/CitrixCloudEventCollector/CitrixCloudEventCollector.yml
@@ -83,14 +83,4 @@ marketplaces:
 - platform
 fromversion: 6.8.0
 supportedModules:
-- cloud_posture
-- cloud
-- cloud_runtime_security
-- edr
-- cloud_appsec
-- asm
 - xsiam
-- exposure_management
-- agentix_xsiam
-- tim
-- email_security

--- a/Packs/Citrix/Integrations/CitrixDaasEventCollector/CitrixDaasEventCollector.yml
+++ b/Packs/Citrix/Integrations/CitrixDaasEventCollector/CitrixDaasEventCollector.yml
@@ -102,14 +102,4 @@ marketplaces:
 - platform
 fromversion: 6.8.0
 supportedModules:
-- cloud_posture
-- cloud
-- cloud_runtime_security
-- edr
-- cloud_appsec
-- asm
 - xsiam
-- exposure_management
-- agentix_xsiam
-- tim
-- email_security

--- a/Packs/Citrix/ReleaseNotes/1_0_6.md
+++ b/Packs/Citrix/ReleaseNotes/1_0_6.md
@@ -1,0 +1,10 @@
+
+#### Integrations
+
+##### Citrix Cloud
+
+- Documentation and metadata improvements.
+
+##### Citrix DaaS
+
+- Documentation and metadata improvements.

--- a/Packs/Citrix/pack_metadata.json
+++ b/Packs/Citrix/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Citrix",
     "description": "Citrix is a unified platform that provides management, monitoring, and delivery services for Citrix products and resources across cloud and on-premise environments. It centralizes administration, enhances visibility, and simplifies operational workflows.",
     "support": "xsoar",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Code42/Integrations/Code42EventCollector/Code42EventCollector.yml
+++ b/Packs/Code42/Integrations/Code42EventCollector/Code42EventCollector.yml
@@ -90,6 +90,3 @@ tests:
 - No tests (auto formatted)
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/Code42/ReleaseNotes/6_1_8.md
+++ b/Packs/Code42/ReleaseNotes/6_1_8.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Code42 Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/Code42/pack_metadata.json
+++ b/Packs/Code42/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Code42",
     "description": "The Code42 INCYDR integration accelerates insider threat incident response and remediation procedures for potential data exfiltration across computers, email, cloud and SaaS apps.",
     "support": "partner",
-    "currentVersion": "6.1.7",
+    "currentVersion": "6.1.8",
     "author": "Code42",
     "url": "https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Install_and_manage_the_Code42_app_for_Cortex_XSOAR",
     "email": "gethelp@code42.com",

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -192,9 +192,6 @@ configuration:
   - xsoar
   supportedModules:
   - "xsiam"
-  - "edr"
-  - "cloud"
-  - "cloud_runtime_security"
 - display: Incident type
   name: incidentType
   type: 13

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_9_1.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_9_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Documentation and metadata improvements.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.9.0",
+    "currentVersion": "2.9.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Elasticsearch/Integrations/ElasticsearchEventCollector/ElasticsearchEventCollector.yml
+++ b/Packs/Elasticsearch/Integrations/ElasticsearchEventCollector/ElasticsearchEventCollector.yml
@@ -187,10 +187,4 @@ fromversion: 8.4.0
 tests:
 - No tests (auto formatted)
 supportedModules:
-- cloud_runtime_security
 - xsiam
-- edr
-- cloud
-- asm
-- cloud_posture
-- exposure_management

--- a/Packs/Elasticsearch/ReleaseNotes/1_4_4.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_4_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Elasticsearch Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.4.3",
+    "currentVersion": "1.4.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ExabeamSecurityOperationsPlatform/Integrations/ExabeamSecOpsPlatform/ExabeamSecOpsPlatform.yml
+++ b/Packs/ExabeamSecurityOperationsPlatform/Integrations/ExabeamSecOpsPlatform/ExabeamSecOpsPlatform.yml
@@ -679,3 +679,5 @@ fromversion: 6.10.0
 tests:
 - ExabeamSecurityOperationsPlatform-test
 defaultmapperin: "Exabeam Platform - Incoming Mapper"
+supportedModules:
+- xsiam

--- a/Packs/ExabeamSecurityOperationsPlatform/ReleaseNotes/1_3_3.md
+++ b/Packs/ExabeamSecurityOperationsPlatform/ReleaseNotes/1_3_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Exabeam Security Operations Platform
+
+- Documentation and metadata improvements.

--- a/Packs/ExabeamSecurityOperationsPlatform/pack_metadata.json
+++ b/Packs/ExabeamSecurityOperationsPlatform/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Exabeam Security Operations Platform",
     "description": " Exabeam Security Operations Platform ",
     "support": "xsoar",
-    "currentVersion": "1.3.2",
+    "currentVersion": "1.3.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ExtraHop/Integrations/ExtrahopRevealXEventCollector/ExtrahopRevealXEventCollector.yml
+++ b/Packs/ExtraHop/Integrations/ExtrahopRevealXEventCollector/ExtrahopRevealXEventCollector.yml
@@ -86,6 +86,3 @@ tests:
 - No tests (auto formatted)
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/ExtraHop/ReleaseNotes/2_3_11.md
+++ b/Packs/ExtraHop/ReleaseNotes/2_3_11.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### ExtraHop Reveal(x) Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/ExtraHop/pack_metadata.json
+++ b/Packs/ExtraHop/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ExtraHop Reveal(x)",
     "description": "Network detection and response. Complete visibility of network communications at enterprise scale, real-time threat detections backed by machine learning, and guided investigation workflows that simplify response.",
     "support": "partner",
-    "currentVersion": "2.3.10",
+    "currentVersion": "2.3.11",
     "author": "ExtraHop",
     "url": "https://customer.extrahop.com/s/",
     "email": "",

--- a/Packs/FireEyeHX/Integrations/FireEyeHXEventCollector/FireEyeHXEventCollector.yml
+++ b/Packs/FireEyeHX/Integrations/FireEyeHXEventCollector/FireEyeHXEventCollector.yml
@@ -68,6 +68,3 @@ marketplaces:
 fromversion: 6.8.0
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/FireEyeHX/ReleaseNotes/2_4_2.md
+++ b/Packs/FireEyeHX/ReleaseNotes/2_4_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### FireEye HX Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/FireEyeHX/pack_metadata.json
+++ b/Packs/FireEyeHX/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FireEye HX",
     "description": "FireEye Endpoint Security is an integrated solution that detects and protects endpoints against known and unknown threats. The FireEye HX Cortex XSOAR integration provides access to information about endpoints, acquisitions, alerts, indicators, and containment. Customers can extract critical data and effectively operate the security operations automated playbooks.",
     "support": "xsoar",
-    "currentVersion": "2.4.1",
+    "currentVersion": "2.4.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Halcyon/Integrations/Halcyon/Halcyon.yml
+++ b/Packs/Halcyon/Integrations/Halcyon/Halcyon.yml
@@ -116,14 +116,4 @@ marketplaces:
 - marketplacev2
 - platform
 supportedModules:
-- cloud_posture
-- cloud
-- cloud_runtime_security
-- edr
-- cloud_appsec
-- asm
 - xsiam
-- exposure_management
-- agentix_xsiam
-- tim
-- email_security

--- a/Packs/Halcyon/ReleaseNotes/1_0_5.md
+++ b/Packs/Halcyon/ReleaseNotes/1_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Halcyon
+
+- Documentation and metadata improvements.

--- a/Packs/Halcyon/pack_metadata.json
+++ b/Packs/Halcyon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Halcyon",
     "description": "Halcyon is a device management platform that helps organizations monitor, control, and secure their network of devices. It provides centralized tools for overseeing hardware and software inventory, deploying updates, enforcing security policies, and ensuring compliance across device environments.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/HelloWorld/Integrations/HelloWorldV2/HelloWorldV2.yml
+++ b/Packs/HelloWorld/Integrations/HelloWorldV2/HelloWorldV2.yml
@@ -446,3 +446,5 @@ defaultmapperin: HelloWorld-mapper  # Incident field mapper (if "fetch-incidents
 fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- xsiam

--- a/Packs/HelloWorld/ReleaseNotes/4_0_4.md
+++ b/Packs/HelloWorld/ReleaseNotes/4_0_4.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Hello World v2
+
+- Documentation and metadata improvements.

--- a/Packs/HelloWorld/pack_metadata.json
+++ b/Packs/HelloWorld/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "HelloWorld",
     "description": "This is the Hello World integration for getting started.",
     "support": "community",
-    "currentVersion": "4.0.3",
+    "currentVersion": "4.0.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/Microsoft365DefenderEventCollector/Microsoft365DefenderEventCollector.yml
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/Integrations/Microsoft365DefenderEventCollector/Microsoft365DefenderEventCollector.yml
@@ -133,6 +133,3 @@ tests:
 deprecated: true
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_20_27.md
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/ReleaseNotes/1_20_27.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Defender for Endpoint Alerts (Deprecated)
+
+- Documentation and metadata improvements.

--- a/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
+++ b/Packs/MicrosoftDefenderAdvancedThreatProtection/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Defender for Endpoint",
     "description": "Microsoft Defender for Endpoint (previously Microsoft Defender Advanced Threat Protection (ATP)) is a unified platform for preventative protection, post-breach detection, automated investigation, and response.",
     "support": "xsoar",
-    "currentVersion": "1.20.26",
+    "currentVersion": "1.20.27",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Mimecast/Integrations/MimecastEventCollector/MimecastEventCollector.yml
+++ b/Packs/Mimecast/Integrations/MimecastEventCollector/MimecastEventCollector.yml
@@ -67,6 +67,3 @@ tests:
 - No tests
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/Mimecast/Integrations/MimecastEventCollectorV2/MimecastEventCollectorV2.yml
+++ b/Packs/Mimecast/Integrations/MimecastEventCollectorV2/MimecastEventCollectorV2.yml
@@ -106,6 +106,3 @@ tests:
 - No tests
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/Mimecast/ReleaseNotes/3_0_6.md
+++ b/Packs/Mimecast/ReleaseNotes/3_0_6.md
@@ -1,0 +1,10 @@
+
+#### Integrations
+
+##### Mimecast Event Collector (Deprecated)
+
+- Documentation and metadata improvements.
+
+##### Mimecast Event Collector v2
+
+- Documentation and metadata improvements.

--- a/Packs/Mimecast/pack_metadata.json
+++ b/Packs/Mimecast/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mimecast",
     "description": "Mimecast unified email management offers cloud email services for email security, continuity and archiving emails.",
     "support": "xsoar",
-    "currentVersion": "3.0.5",
+    "currentVersion": "3.0.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.yml
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.yml
@@ -116,3 +116,5 @@ marketplaces:
 fromversion: 8.3.0
 tests:
 - No tests (auto formatted)
+supportedModules:
+- xsiam

--- a/Packs/Monday/ReleaseNotes/1_0_5.md
+++ b/Packs/Monday/ReleaseNotes/1_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### MondayEventCollector
+
+- Documentation and metadata improvements.

--- a/Packs/Monday/pack_metadata.json
+++ b/Packs/Monday/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Monday",
     "description": "Integrates with Monday.com to collect activity logs and audit logs.",
     "support": "xsoar",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "created": "2025-07-22T00:00:00Z",

--- a/Packs/OracleCloudInfrastructure/Integrations/OracleCloudInfrastructureEventCollector/OracleCloudInfrastructureEventCollector.yml
+++ b/Packs/OracleCloudInfrastructure/Integrations/OracleCloudInfrastructureEventCollector/OracleCloudInfrastructureEventCollector.yml
@@ -115,4 +115,3 @@ tests:
 - No tests (auto formatted)
 supportedModules:
 - xsiam
-- cloud_posture

--- a/Packs/OracleCloudInfrastructure/ReleaseNotes/1_0_35.md
+++ b/Packs/OracleCloudInfrastructure/ReleaseNotes/1_0_35.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Oracle Cloud Infrastructure Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/OracleCloudInfrastructure/pack_metadata.json
+++ b/Packs/OracleCloudInfrastructure/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Oracle Cloud Infrastructure (OCI)",
     "description": "Oracle Cloud Infrastructure (OCI)",
     "support": "xsoar",
-    "currentVersion": "1.0.34",
+    "currentVersion": "1.0.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponseEventCollector/ProofpointThreatResponseEventCollector.yml
+++ b/Packs/ProofpointThreatResponse/Integrations/ProofpointThreatResponseEventCollector/ProofpointThreatResponseEventCollector.yml
@@ -143,6 +143,3 @@ tests:
 - No tests (auto formatted)
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/ProofpointThreatResponse/ReleaseNotes/2_0_34.md
+++ b/Packs/ProofpointThreatResponse/ReleaseNotes/2_0_34.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Proofpoint Threat Response Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/ProofpointThreatResponse/pack_metadata.json
+++ b/Packs/ProofpointThreatResponse/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Proofpoint Threat Response",
     "description": "Use the Proofpoint Threat Response integration to orchestrate and automate incident response.",
     "support": "xsoar",
-    "currentVersion": "2.0.33",
+    "currentVersion": "2.0.34",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/SailPointIdentityNow/Integrations/SailPointIdentityNowEventCollector/SailPointIdentityNowEventCollector.yml
+++ b/Packs/SailPointIdentityNow/Integrations/SailPointIdentityNowEventCollector/SailPointIdentityNowEventCollector.yml
@@ -85,4 +85,3 @@ tests:
 - No tests (auto formatted)
 supportedModules:
 - xsiam
-- edr

--- a/Packs/SailPointIdentityNow/ReleaseNotes/1_1_6.md
+++ b/Packs/SailPointIdentityNow/ReleaseNotes/1_1_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SailPoint IdentityNow Event Collector
+
+- Documentation and metadata improvements.

--- a/Packs/SailPointIdentityNow/pack_metadata.json
+++ b/Packs/SailPointIdentityNow/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SailPoint IdentityNow",
     "description": "SailPoint IdentityNow content pack enables XSOAR customers to utilize the deep, enriched contextual data in the SailPoint IdentityNow platform to better drive identity-aware security practices.",
     "support": "partner",
-    "currentVersion": "1.1.5",
+    "currentVersion": "1.1.6",
     "author": "SailPoint",
     "url": "https://support.sailpoint.com/hc/en-us/requests/new",
     "email": "support.idplusa@sailpoint.com",

--- a/Packs/Salesforce/Integrations/SalesForceEventCollector/SalesForceEventCollector.yml
+++ b/Packs/Salesforce/Integrations/SalesForceEventCollector/SalesForceEventCollector.yml
@@ -82,6 +82,3 @@ tests:
 - No tests
 supportedModules:
 - xsiam
-- edr
-- cloud
-- cloud_runtime_security

--- a/Packs/Salesforce/ReleaseNotes/2_1_18.md
+++ b/Packs/Salesforce/ReleaseNotes/2_1_18.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Salesforce Event Collector (Deprecated)
+
+- Documentation and metadata improvements.

--- a/Packs/Salesforce/pack_metadata.json
+++ b/Packs/Salesforce/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Salesforce",
     "description": "CRM Services",
     "support": "xsoar",
-    "currentVersion": "2.1.17",
+    "currentVersion": "2.1.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Shodan/Integrations/Shodan_v2/Shodan_v2.yml
+++ b/Packs/Shodan/Integrations/Shodan_v2/Shodan_v2.yml
@@ -505,9 +505,3 @@ tests:
 fromversion: 5.0.0
 supportedModules:
 - xsiam
-- edr
-- cloud
-- asm
-- cloud_runtime_security
-- cloud_posture
-- exposure_management

--- a/Packs/Shodan/ReleaseNotes/1_2_9.md
+++ b/Packs/Shodan/ReleaseNotes/1_2_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Shodan v2
+
+- Documentation and metadata improvements.

--- a/Packs/Shodan/pack_metadata.json
+++ b/Packs/Shodan/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Shodan",
     "description": "A search engine used for searching Internet-connected devices",
     "support": "xsoar",
-    "currentVersion": "1.2.8",
+    "currentVersion": "1.2.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/TwilioSendGrid/Integrations/TwilioSendGrid/TwilioSendGrid.yml
+++ b/Packs/TwilioSendGrid/Integrations/TwilioSendGrid/TwilioSendGrid.yml
@@ -85,14 +85,4 @@ marketplaces:
 tests:
 - No tests
 supportedModules:
-- cloud_posture
-- cloud
-- cloud_runtime_security
-- edr
-- cloud_appsec
-- asm
 - xsiam
-- exposure_management
-- agentix_xsiam
-- tim
-- email_security

--- a/Packs/TwilioSendGrid/ReleaseNotes/1_0_3.md
+++ b/Packs/TwilioSendGrid/ReleaseNotes/1_0_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Twilio SendGrid
+
+- Documentation and metadata improvements.

--- a/Packs/TwilioSendGrid/pack_metadata.json
+++ b/Packs/TwilioSendGrid/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Twilio SendGrid",
     "description": "Twilio SendGrid is a cloud-based email platform designed to help businesses send and manage both transactional and marketing emails reliably and at scale.",
     "support": "xsoar",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [CIAC-15886](https://jira-dc.paloaltonetworks.com/browse/CIAC-15886)

## Description
remove old supported modules from event collectors
the old supported modules
cloud_posture cloud cloud_runtime_security edr xsoar asm tim cloud_appsec exposure_management email_security agentix

`MATCH (c:Integration)-[:IN_PACK]->(p:Pack) 
WHERE c.is_fetch_events = true 
AND ANY(m IN c.supportedModules WHERE m IN ["cloud_posture", "cloud", "cloud_runtime_security", "edr", "xsoar", "asm", "tim", "cloud_appsec", "exposure_management", "email_security", "agentix"]) 
RETURN c.name AS classifier_name, c.supportedModules AS supported_modules 
ORDER BY c.name`



## Must have
- [ ] Tests
- [ ] Documentation
