### PR TITLE
Fix Exabeam nightly test failure after CSP look-back limit change

### DIFF
--- a/Packs/Exabeam/Integrations/Exabeam/test_data/response_incidents.py
+++ b/Packs/Exabeam/Integrations/Exabeam/test_data/response_incidents.py
@@ -475,13 +475,15 @@ EXPECTED_LAST_RUN_FOR_LOOK_BACK = {
         "limit": 5,
         "time": "2022-12-22T09:59:05.001000",
         "found_incident_ids": {
+            "SOC-402": "",
             "SOC-403": "",
         },
     },
     "second_fetch": {
-        "limit": 3,
+        "limit": 5,
         "time": "2022-12-22T10:00:05.000000",
         "found_incident_ids": {
+            "SOC-402": "",
             "SOC-403": "",
         },
     },


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: CIAC-1234

## Description

this [pr](https://github.com/demisto/content/pull/43746) updated create_updated_last_run_object so that when no new incidents are found (len(incidents)==0) and look_back > 0, the next fetch limit uses new_limit (accumulated found IDs + fetch limit)
instead of always resetting to fetch_limit. 
The Exabeam test expectations were never updated to reflect this.

## Must have
- [ ] Tests
- [ ] Documentation
