### PR TITLE
Remove deprecated ruff UP038 check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,7 +355,6 @@ select = [
     "UP035", # deprecated-import
     "UP036", # outdated-version-block
     "UP037", # quoted-annotation
-    "UP038", # non-pep604-isinstance
 
     "W291", # trailing-whitespace
 


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://docs.astral.sh/ruff/rules/non-pep604-isinstance/


## Description
This removes a ruff check (UP038) which has been removed since ruff v0.13 (September 2025).
While pre-commit template does not utilize ruff v0.13+ yet, this change will help prepare for that.

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16610