### PR TITLE
Fix cbp-user-disable command

### DIFF
--- a/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
+++ b/Packs/CarbonBlackProtect/Integrations/CarbonBlackProtect/CarbonBlackProtect.py
@@ -2106,7 +2106,7 @@ def disable_user_command():
     user_id = args.get("user_id")
     payload = {"enabled": False}
 
-    user_data = http_request("PUT", f"/user/{user_id}", data=json.dumps(payload))
+    user_data = http_request("PUT", f"/user/{user_id}", data=payload)
 
     human_readable = tableToMarkdown("User Data", user_data, headers=[])
 

--- a/Packs/CarbonBlackProtect/ReleaseNotes/1_1_1.md
+++ b/Packs/CarbonBlackProtect/ReleaseNotes/1_1_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### VMware Carbon Black App Control v2
+
+Fixed an issue where an invalid HTTP request was sent as part of the ***cbp-user-disable*** command.

--- a/Packs/CarbonBlackProtect/pack_metadata.json
+++ b/Packs/CarbonBlackProtect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Carbon Black Enterprise Protection",
     "description": "Carbon Black Enterprise Protection is a next-generation endpoint threat prevention solution to deliver a portfolio of protection policies, real-time visibility across environments, and comprehensive compliance rule sets in a single platform.",
     "support": "xsoar",
-    "currentVersion": "1.1.0",
+    "currentVersion": "1.1.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-16395](https://jira-dc.paloaltonetworks.com/browse/CIAC-16395)

## Description
Fixed an issue where an invalid HTTP request was sent as part of the ***cbp-user-disable*** command.
The `data` argument in `http_request` should be a Python object (since it is serialized into a JSON by the internal logic of `requests.request`)
