### PR TITLE
Fix base DN verification timeout errors in large environments in Active Directory Query v2

### DIFF
--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
@@ -314,7 +314,7 @@ def base_dn_verified(base_dn: str) -> bool:
         return True
 
     except Exception as e:
-        demisto.error(f"Error during Base DN verification: {str(e)}")
+        demisto.error(f"Error during Base DN verification: {e}\n{traceback.format_exc()}")
         return False
 
 

--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
@@ -1827,7 +1827,7 @@ def main():
     server_ip = params.get("server_ip")
     username = params.get("credentials")["identifier"]
     password = params.get("credentials")["password"]
-    default_base_dn = params.get("base_dn")
+    default_base_dn = params.get("base_dn", "")
     secure_connection = params.get("secure_connection")
     ssl_version = params.get("ssl_version", "None")
     default_page_size = int(params.get("page_size"))
@@ -1839,6 +1839,7 @@ def main():
     create_if_not_exists = params.get("create-if-not-exists")
     mapper_in = params.get("mapper-in", DEFAULT_INCOMING_MAPPER)
     mapper_out = params.get("mapper-out", DEFAULT_OUTGOING_MAPPER)
+    verify_base_dn = params.get("verify_base_dn", True) or command == "test-module"
 
     if port:
         # port was configured, cast to int
@@ -1885,16 +1886,17 @@ def main():
 
         demisto.info(f"Established connection with AD LDAP server.\nLDAP Connection Details: {connection}")
 
-        if not base_dn_verified(default_base_dn):
-            message = (
-                f"Failed to verify the base DN configured for the instance.\n"
-                f"Last connection result: {json.dumps(connection.result)}\n"
-                f"Last error from LDAP server: {json.dumps(connection.last_error)}"
-            )
-            return_error(message)
-            return None
-
-        demisto.info(f'Verified base DN "{default_base_dn}"')
+        if verify_base_dn:
+            demisto.info(f'Starting to verify base DN "{default_base_dn}"')
+            if not base_dn_verified(default_base_dn):
+                message = (
+                    f"Failed to verify the base DN configured for the instance.\n"
+                    f"Last connection result: {json.dumps(connection.result)}\n"
+                    f"Last error from LDAP server: {json.dumps(connection.last_error)}"
+                )
+                return_error(message)
+                return None
+            demisto.info(f'Verified base DN "{default_base_dn}"')
 
         """ COMMAND EXECUTION """
 

--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.py
@@ -8,6 +8,7 @@ from ldap3 import (
     ALL_ATTRIBUTES,
     AUTO_BIND_NO_TLS,
     AUTO_BIND_TLS_BEFORE_BIND,
+    BASE,
     NTLM,
     SUBTREE,
     Connection,
@@ -282,14 +283,39 @@ def group_entry(group_object, custom_attributes):
     return group
 
 
-def base_dn_verified(base_dn):
-    # search AD with a simple query to test base DN is configured correctly
+def base_dn_verified(base_dn: str) -> bool:
+    """
+    Verifies the base DN is configured correctly.
+    Uses BASE scope, size limit of 1, and 'no attributes' OID for maximum performance.
+
+    This function performs an optimized LDAP search that only checks if the base DN entry itself exists,
+    rather than searching the entire directory tree. This reduces the complexity from O(n) to O(1).
+
+    Args:
+        base_dn: The base DN to verify (e.g., 'dc=example,dc=com')
+
+    Returns:
+        bool: True if the base DN is valid and accessible, False otherwise
+    """
+    assert connection is not None
     try:
-        search("(objectClass=*)", base_dn, size_limit=1)
+        # Optimized search with three performance improvements:
+        # 1. search_scope=BASE: Only looks at the DN itself (O(1) complexity)
+        # 2. size_limit=1: Safety guard to ensure only one record is processed
+        # 3. attributes=['1.1']: Special OID meaning 'return no attributes' (minimal data transfer)
+        success = connection.search(
+            search_base=base_dn, search_filter="(objectClass=*)", search_scope=BASE, size_limit=1, attributes=["1.1"]
+        )
+
+        if not success:
+            demisto.info(f"Base DN verification failed. Result: {connection.result}")
+            return False
+
+        return True
+
     except Exception as e:
-        demisto.info(str(e))
+        demisto.error(f"Error during Base DN verification: {str(e)}")
         return False
-    return True
 
 
 def generate_unique_cn(default_base_dn, cn):

--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query.yml
@@ -76,6 +76,13 @@ configuration:
   section: Connect
   advanced: true
   required: false
+- name: verify_base_dn
+  display: Verify base DN on every command
+  defaultvalue: 'true'
+  type: 8
+  required: false
+  section: Connect
+  advanced: true
 - additionalinfo: Used in the IAM commands.
   defaultvalue: User Profile - Active Directory (Incoming)
   display: Incoming Mapper

--- a/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query_test.py
+++ b/Packs/Active_Directory_Query/Integrations/Active_Directory_Query/Active_Directory_Query_test.py
@@ -1001,3 +1001,102 @@ def test_search_users_with_msDSUserAccountControlComputed(mocker):
         .get("PASSWORD_EXPIRED")
         is True
     )
+
+
+def test_base_dn_verified_success(mocker):
+    """
+    Given:
+        A valid base DN and a successful LDAP connection.
+    When:
+        Running the 'base_dn_verified' function.
+    Then:
+        Verify that the function returns True and uses BASE scope with optimized parameters.
+    """
+    import Active_Directory_Query
+    from ldap3 import BASE
+
+    search_args = []
+    search_kwargs = {}
+
+    class ConnectionMocker:
+        result = {"description": "success"}
+
+        def search(self, *args, **kwargs):
+            nonlocal search_args, search_kwargs
+            search_args = args
+            search_kwargs = kwargs
+            return True
+
+    Active_Directory_Query.connection = ConnectionMocker()
+    mocker.patch.object(demisto, "info")
+
+    result = Active_Directory_Query.base_dn_verified("dc=example,dc=com")
+
+    # Verify the function returns True
+    assert result is True
+
+    # Verify the search was called with optimized parameters
+    assert search_kwargs.get("search_base") == "dc=example,dc=com"
+    assert search_kwargs.get("search_filter") == "(objectClass=*)"
+    assert search_kwargs.get("search_scope") == BASE  # Verify BASE scope is used
+    assert search_kwargs.get("size_limit") == 1  # Verify size limit is 1
+    assert search_kwargs.get("attributes") == ["1.1"]  # Verify no attributes are fetched
+
+
+def test_base_dn_verified_failure(mocker):
+    """
+    Given:
+        An invalid base DN that causes the LDAP search to fail.
+    When:
+        Running the 'base_dn_verified' function.
+    Then:
+        Verify that the function returns False and logs the failure.
+    """
+    import Active_Directory_Query
+
+    class ConnectionMocker:
+        result = {"description": "noSuchObject"}
+
+        def search(self, *args, **kwargs):
+            return False
+
+    Active_Directory_Query.connection = ConnectionMocker()
+    info_mock = mocker.patch.object(demisto, "info")
+
+    result = Active_Directory_Query.base_dn_verified("dc=invalid,dc=com")
+
+    # Verify the function returns False
+    assert result is False
+
+    # Verify that the failure was logged
+    assert info_mock.call_count == 1
+    assert "Base DN verification failed" in info_mock.call_args[0][0]
+
+
+def test_base_dn_verified_exception(mocker):
+    """
+    Given:
+        A base DN that causes an exception during LDAP search.
+    When:
+        Running the 'base_dn_verified' function.
+    Then:
+        Verify that the function returns False and logs the error.
+    """
+    import Active_Directory_Query
+
+    class ConnectionMocker:
+        def search(self, *args, **kwargs):
+            raise Exception("Connection timeout")
+
+    Active_Directory_Query.connection = ConnectionMocker()
+    error_mock = mocker.patch.object(demisto, "error")
+
+    result = Active_Directory_Query.base_dn_verified("dc=example,dc=com")
+
+    # Verify the function returns False
+    assert result is False
+
+    # Verify that the error was logged
+    assert error_mock.call_count == 1
+    assert "Error during Base DN verification" in error_mock.call_args[0][0]
+    assert "Connection timeout" in error_mock.call_args[0][0]

--- a/Packs/Active_Directory_Query/ReleaseNotes/1_6_74.md
+++ b/Packs/Active_Directory_Query/ReleaseNotes/1_6_74.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Active Directory Query v2
+
+- Fixed an issue where the base DN verification performed on every command execution caused timeout errors in large Active Directory environments by optimizing the LDAP search to use BASE scope instead of SUBTREE scope.

--- a/Packs/Active_Directory_Query/ReleaseNotes/1_7_0.md
+++ b/Packs/Active_Directory_Query/ReleaseNotes/1_7_0.md
@@ -3,3 +3,4 @@
 ##### Active Directory Query v2
 
 - Fixed an issue where the base DN verification performed on every command execution caused timeout errors in large Active Directory environments by optimizing the LDAP search to use BASE scope instead of SUBTREE scope.
+- Added support for the *Verify base DN on every command* configuration parameter to allow users to disable the base DN verification if needed.

--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Active Directory Query",
     "description": "Active Directory Query integration enables you to access and manage Active Directory objects (users, contacts, and computers).",
     "support": "xsoar",
-    "currentVersion": "1.6.73",
+    "currentVersion": "1.6.74",
     "author": "Cortex XSOAR",
     "url": "",
     "email": "",

--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Active Directory Query",
     "description": "Active Directory Query integration enables you to access and manage Active Directory objects (users, contacts, and computers).",
     "support": "xsoar",
-    "currentVersion": "1.6.74",
+    "currentVersion": "1.7.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Active_Directory_Query/pack_metadata.json
+++ b/Packs/Active_Directory_Query/pack_metadata.json
@@ -4,7 +4,7 @@
     "support": "xsoar",
     "currentVersion": "1.6.74",
     "author": "Cortex XSOAR",
-    "url": "",
+    "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",
     "created": "2020-03-09T14:47:00Z",
     "categories": [


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-67739](https://jira-dc.paloaltonetworks.com/browse/XSUP-67739)

## Description
- Fixed an issue where the base DN verification performed on every command execution caused timeout errors in large Active Directory environments by optimizing the LDAP search to use BASE scope instead of SUBTREE scope.
- Added support for the *Verify base DN on every command* configuration parameter to allow users to disable the base DN verification if needed.
