### PR TITLE
Fix/xsup 67864/threat connect ip command missing details and wrong HR hearder

### DIFF
--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -229,7 +229,7 @@ def detection_to_incident(threatconnect_data: dict, threatconnect_date: str) -> 
     return incident
 
 
-def get_indicator_reputation(client: Client, args_type: str, type_name: str, args: dict) -> None:  # pragma: no cover
+def get_indicator_reputation(client: Client, args_type: str, type_name: str, args: dict) -> None:
     owners_query = create_or_query(args.get("owners", ""), "ownerName")
     query = create_or_query(args.get(args_type), "summary")  # type: ignore
     rating_threshold = args.get("ratingThreshold", "")

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3.py
@@ -230,7 +230,7 @@ def detection_to_incident(threatconnect_data: dict, threatconnect_date: str) -> 
 
 
 def get_indicator_reputation(client: Client, args_type: str, type_name: str, args: dict) -> None:  # pragma: no cover
-    owners_query = create_or_query(args.get("owners", demisto.params().get("defaultOrg")), "ownerName")
+    owners_query = create_or_query(args.get("owners", ""), "ownerName")
     query = create_or_query(args.get(args_type), "summary")  # type: ignore
     rating_threshold = args.get("ratingThreshold", "")
     confidence_threshold = args.get("confidenceThreshold", "")
@@ -257,7 +257,7 @@ def get_indicator_reputation(client: Client, args_type: str, type_name: str, arg
             "Contents": indicators,
             "ReadableContentsFormat": formats["markdown"],
             "HumanReadable": tableToMarkdown(
-                f"ThreatConnect URL Reputation for: {args.get(args_type)}",
+                f"ThreatConnect {type_name} Reputation for: {args.get(args_type)}",
                 human_readable,
                 headerTransform=pascalToSpace,
                 removeNull=True,

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3_test.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3_test.py
@@ -678,3 +678,74 @@ def test_tc_add_file_indicator_with_hash_type_command(mocker):
     # Verifying if the client.make_request method was called with the expected arguments
     call_args = json.loads(res.call_args[1]["payload"])
     assert call_args["sha256"] == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+@pytest.mark.parametrize(
+    "args, expected_owner_in_url",
+    [
+        # No owners arg and no defaultOrg — should query all owners (no ownerName filter in TQL)
+        ({}, False),
+        # Explicit owners arg — should filter by that owner
+        ({"owners": "MyOrg"}, True),
+    ],
+)
+def test_get_indicator_reputation_owner_filter(mocker, args, expected_owner_in_url):
+    """
+    Given:
+        - get_indicator_reputation is called with or without an explicit 'owners' argument
+        - The defaultOrg integration parameter is set to 'DefaultOrg'
+    When:
+        - Running a reputation command (e.g. !ip)
+    Then:
+        - When no 'owners' arg is provided, the TQL query must NOT contain an ownerName filter
+          (all accessible owners are queried, consistent with tc-get-indicator behavior)
+        - When an explicit 'owners' arg is provided, the TQL query must contain that ownerName filter
+    """
+    import urllib.parse
+
+    mocker.patch.object(demisto, "params", return_value={"defaultOrg": "DefaultOrg", "rating": "3", "confidence": "3"})
+    mock_request = mocker.patch.object(Client, "make_request", return_value={"data": []})
+    mocker.patch("ThreatConnectV3.return_results")
+
+    args = {**args, "ip": "1.2.3.4"}
+    get_indicator_reputation(client, "ip", "Address", args)
+
+    called_url = mock_request.call_args[0][1]
+    tql_encoded = called_url.split("tql=")[1].split("&")[0]
+    tql_decoded = urllib.parse.unquote(tql_encoded)
+
+    if expected_owner_in_url:
+        assert "ownerName" in tql_decoded
+        assert "MyOrg" in tql_decoded
+    else:
+        assert "ownerName" not in tql_decoded
+        assert "DefaultOrg" not in tql_decoded
+
+
+@pytest.mark.parametrize(
+    "args_type, type_name, indicator_value, expected_header_fragment",
+    [
+        ("ip", "Address", "1.2.3.4", "ThreatConnect Address Reputation for: 1.2.3.4"),
+        ("url", "URL", "http://example.com", "ThreatConnect URL Reputation for: http://example.com"),
+        ("domain", "Host", "example.com", "ThreatConnect Host Reputation for: example.com"),
+        ("file", "File", "d41d8cd98f00b204e9800998ecf8427e", "ThreatConnect File Reputation for: d41d8cd98f00b204e9800998ecf8427e"),
+    ],
+)
+def test_get_indicator_reputation_header(mocker, args_type, type_name, indicator_value, expected_header_fragment):
+    """
+    Given:
+        - get_indicator_reputation is called for different indicator types
+    When:
+        - Running !ip, !url, !domain, or !file reputation commands
+    Then:
+        - The human-readable table title must reflect the actual indicator type, not a hardcoded 'URL Reputation'
+    """
+    mocker.patch.object(demisto, "params", return_value={"defaultOrg": "DefaultOrg", "rating": "3", "confidence": "3"})
+    mocker.patch.object(Client, "make_request", return_value={"data": []})
+    return_results_mock = mocker.patch("ThreatConnectV3.return_results")
+
+    args = {args_type: indicator_value}
+    get_indicator_reputation(client, args_type, type_name, args)
+
+    returned_entry = return_results_mock.call_args[0][0]
+    assert expected_header_fragment in returned_entry["HumanReadable"]

--- a/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3_test.py
+++ b/Packs/ThreatConnect/Integrations/ThreatConnectV3/ThreatConnectV3_test.py
@@ -728,7 +728,12 @@ def test_get_indicator_reputation_owner_filter(mocker, args, expected_owner_in_u
         ("ip", "Address", "1.2.3.4", "ThreatConnect Address Reputation for: 1.2.3.4"),
         ("url", "URL", "http://example.com", "ThreatConnect URL Reputation for: http://example.com"),
         ("domain", "Host", "example.com", "ThreatConnect Host Reputation for: example.com"),
-        ("file", "File", "d41d8cd98f00b204e9800998ecf8427e", "ThreatConnect File Reputation for: d41d8cd98f00b204e9800998ecf8427e"),
+        (
+            "file",
+            "File",
+            "d41d8cd98f00b204e9800998ecf8427e",
+            "ThreatConnect File Reputation for: d41d8cd98f00b204e9800998ecf8427e",
+        ),
     ],
 )
 def test_get_indicator_reputation_header(mocker, args_type, type_name, indicator_value, expected_header_fragment):

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_21.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_21.md
@@ -2,5 +2,5 @@
 
 ##### ThreatConnect v3
 
-- Fixed an issue where the ***ip***, ***url***, ***domain***, and ***file*** reputation commands returned no results when the **Default Organization** parameter was configured, because the owner filter was incorrectly applied. The commands now query all accessible owners, consistent with the ***tc-get-indicator*** command behavior.
-- Fixed an issue where the ***ip***, ***domain***, and ***file*** reputation commands displayed an incorrect **ThreatConnect URL Reputation** header. The header now correctly reflects the indicator type being queried.
+- Fixed an issue where the ***ip***, ***url***, ***domain***, and ***file*** reputation commands returned no results when the **Default Organization** parameter was configured.
+- Fixed an issue where the ***ip***, ***domain***, and ***file*** reputation commands displayed an incorrect **ThreatConnect URL Reputation** header.

--- a/Packs/ThreatConnect/ReleaseNotes/3_1_21.md
+++ b/Packs/ThreatConnect/ReleaseNotes/3_1_21.md
@@ -1,0 +1,6 @@
+#### Integrations
+
+##### ThreatConnect v3
+
+- Fixed an issue where the ***ip***, ***url***, ***domain***, and ***file*** reputation commands returned no results when the **Default Organization** parameter was configured, because the owner filter was incorrectly applied. The commands now query all accessible owners, consistent with the ***tc-get-indicator*** command behavior.
+- Fixed an issue where the ***ip***, ***domain***, and ***file*** reputation commands displayed an incorrect **ThreatConnect URL Reputation** header. The header now correctly reflects the indicator type being queried.

--- a/Packs/ThreatConnect/pack_metadata.json
+++ b/Packs/ThreatConnect/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatConnect",
     "description": "Threat intelligence platform.",
     "support": "xsoar",
-    "currentVersion": "3.1.20",
+    "currentVersion": "3.1.21",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-67864

## Description
Fixed !ip/!url/!domain/!file returning no results when Default Organization is configured — owner filter was incorrectly applied to read queries, restricting results to a single org instead of all accessible sources.
Fixed incorrect "ThreatConnect URL Reputation" header shown for all indicator types — header now reflects the actual indicator type being queried.

## Must have
- [ ] Tests
- [ ] Documentation
