### PR TITLE
Only perform Basic Auth if not Header Auth

### DIFF
--- a/Packs/GenericAPICall/Integrations/GenericAPICall/GenericAPICall.py
+++ b/Packs/GenericAPICall/Integrations/GenericAPICall/GenericAPICall.py
@@ -257,6 +257,7 @@ def main():
         params = demisto.params()
         results = ""
         auth: Optional[tuple[str, str]] = None
+        apikey_in_header = argToBoolean(params.get("apikey_in_header", False))
         base_url = params.get("base_url", "")
         is_auth = params.get("is_auth", True)
         creds = params.get("credentials", "")
@@ -266,7 +267,7 @@ def main():
         command = demisto.command()
 
         if command == "generic-api-call":
-            if is_auth:
+            if is_auth and not apikey_in_header:
                 # Credential object - API Key or HTTP Basic Auth
                 if "credentials" in creds and creds["credentials"]["name"]:
                     auth = (creds["credentials"]["user"], creds["credentials"]["password"])

--- a/Packs/GenericAPICall/Integrations/GenericAPICall/GenericAPICall.yml
+++ b/Packs/GenericAPICall/Integrations/GenericAPICall/GenericAPICall.yml
@@ -179,7 +179,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/python3:3.12.11.4508456
+  dockerimage: demisto/python3:3.12.13.8428455
 fromversion: 5.5.0
 tests:
 - No tests (auto formatted)

--- a/Packs/GenericAPICall/ReleaseNotes/1_0_4.md
+++ b/Packs/GenericAPICall/ReleaseNotes/1_0_4.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### GenericAPICall
+
+- When using Header Auth the integration no longer sends Basic Auth credentials with the request.
+- Updated the Docker image to: *demisto/python3:3.12.13.8428455*.
+

--- a/Packs/GenericAPICall/pack_metadata.json
+++ b/Packs/GenericAPICall/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic API Call",
     "description": "Content pack to enable execution of generic API calls to a variety of endpoints outside the scope of other integrations",
     "support": "community",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "Josh Levine",
     "url": "",
     "email": "xsoar@cantreach.me",


### PR DESCRIPTION
When performing Header Auth the integration would also send the credentials as Basic Auth, so both authentication methods were being used at the same time. Update the integration so that when Header Auth is performed, the credentials do not get sent as Basic Auth in addition.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example relates: link to the issue

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation
