### PR TITLE
XSUP-67396 Fix bmc-itsm-work-order-update not actually updating work orders

### DIFF
--- a/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM.py
+++ b/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM.py
@@ -2609,7 +2609,7 @@ def task_update_command(client: Client, args: Dict[str, Any]) -> CommandResults:
         assigned_support_organization=assigned_support_organization,  # type: ignore[arg-type]
         assigned_support_group_name=assigned_support_group_name,  # type: ignore[arg-type]
         scedulded_start_date=scedulded_start_date.isoformat() if scedulded_start_date else None,  # type: ignore[arg-type]
-        schedulded_end_date=schedulded_end_date.isoformat if schedulded_end_date else None,  # type: ignore[arg-type]
+        schedulded_end_date=schedulded_end_date.isoformat() if schedulded_end_date else None,  # type: ignore[arg-type]
         customer_company=customer_company,  # type: ignore[arg-type]
         **additional_fields,
     )
@@ -3164,7 +3164,7 @@ def work_order_update_command(client: Client, args: Dict[str, Any]) -> CommandRe
         support_group_name=support_group,  # type: ignore[arg-type]
         location_company=location_company,  # type: ignore[arg-type]
         scedulded_start_date=scedulded_start_date.isoformat() if scedulded_start_date else None,  # type: ignore[arg-type]
-        schedulded_end_date=schedulded_end_date.isoformat if schedulded_end_date else None,  # type: ignore[arg-type]
+        schedulded_end_date=schedulded_end_date.isoformat() if schedulded_end_date else None,  # type: ignore[arg-type]
         **additional_fields,
     )
 
@@ -3340,7 +3340,7 @@ def extract_args_from_additional_fields_arg(additional_fields: str, field_name: 
         for each_field in fields:
             key, value = each_field.split(VALUE_DELIMITER)
             if value and value.strip() != "":
-                formatted_additional_fields[key.strip()] = value
+                formatted_additional_fields[key.strip()] = value.strip()
     except ValueError as error:
         raise ValueError(
             f'Please validate the format of the argument: {field_name}. For example: "fieldname1=value;fieldname2=value".  '

--- a/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM.py
+++ b/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM.py
@@ -1601,7 +1601,7 @@ class Client(BaseClient):
         data = {"values": properties}
         response = self._http_request(
             "PUT",
-            f"arsys/v1/entry/WOI:WorkOrder/{request_id}",
+            f"arsys/v1/entry/WOI:WorkOrderInterface/{request_id}",
             json_data=data,
             resp_type="text",
         )

--- a/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM_test.py
+++ b/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM_test.py
@@ -1360,7 +1360,7 @@ def test_work_order_update_command(request_id, command_arguments, expected_msg, 
     """
     from BmcITSM import work_order_update_command
 
-    url = f"{BASE_URL}/api/arsys/v1/entry/WOI:WorkOrder/{request_id}"
+    url = f"{BASE_URL}/api/arsys/v1/entry/WOI:WorkOrderInterface/{request_id}"
     requests_mock.put(url=url, text="")
 
     result = work_order_update_command(mock_client, command_arguments)

--- a/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM_test.py
+++ b/Packs/BmcITSM/Integrations/BmcITSM/BmcITSM_test.py
@@ -1590,3 +1590,43 @@ def test_worklog_attachment_get(
 
     result = worklog_attachment_get_command(mock_client, command_arguments)
     assert result[0].get("File") == file_name
+
+
+@pytest.mark.parametrize(
+    "additional_fields_input, expected_output",
+    [
+        pytest.param(
+            "ASGRP = Network Firewall",
+            {"ASGRP": "Network Firewall"},
+            id="strips whitespace from both key and value",
+        ),
+        pytest.param(
+            "key1=value1;key2=value2",
+            {"key1": "value1", "key2": "value2"},
+            id="multiple fields without extra whitespace",
+        ),
+        pytest.param(
+            " key1 = value1 ; key2 = value2 ",
+            {"key1": "value1", "key2": "value2"},
+            id="multiple fields with extra whitespace",
+        ),
+        pytest.param(
+            "",
+            {},
+            id="empty string returns empty dict",
+        ),
+    ],
+)
+def test_extract_args_from_additional_fields_arg(additional_fields_input, expected_output):
+    """
+    Given:
+        - An additional_fields string with key=value pairs potentially containing whitespace.
+    When:
+        - Calling extract_args_from_additional_fields_arg.
+    Then:
+        - Both keys and values should be stripped of leading/trailing whitespace.
+    """
+    from BmcITSM import extract_args_from_additional_fields_arg
+
+    result = extract_args_from_additional_fields_arg(additional_fields_input, "additional_fields")
+    assert result == expected_output

--- a/Packs/BmcITSM/ReleaseNotes/1_0_48.md
+++ b/Packs/BmcITSM/ReleaseNotes/1_0_48.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### BMC Helix ITSM
+
+- Fixed an issue where the ***bmc-itsm-work-order-update*** command reported success but did not actually update the work order in BMC, by correcting the API endpoint to use the WorkOrderInterface form.

--- a/Packs/BmcITSM/pack_metadata.json
+++ b/Packs/BmcITSM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "BMC Helix ITSM",
     "description": "BMC Helix ITSM allows customers to manage service requests, incidents, change requests, tasks, problem investigations, known errors and work order tickets.",
     "support": "xsoar",
-    "currentVersion": "1.0.47",
+    "currentVersion": "1.0.48",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-67396

## Description
Fixed an issue where the ***bmc-itsm-work-order-update*** command reported success but did not actually update the work order in BMC, by correcting the API endpoint to use the WorkOrderInterface form.
change endpoint from WOI:WorkOrder to WOI:WorkOrderInterface