### PR TITLE
Update `mimecast-update-block-sender-policy` command docs in Mimecast v2

### DIFF
--- a/Packs/Mimecast/Integrations/MimecastV2/MimecastV2.yml
+++ b/Packs/Mimecast/Integrations/MimecastV2/MimecastV2.yml
@@ -2572,7 +2572,7 @@ script:
       description: The receiver type.
       type: String
   - name: mimecast-update-block-sender-policy
-    description: Updates the specified policy.
+    description: "Updates an existing Blocked Senders policy. This command performs a full policy replacement at the API level. Arguments that are explicitly provided will overwrite the current policy values. Arguments that are left blank will be automatically preserved from the existing policy. To modify only specific fields, provide the policy_id and the fields to be changed — all other fields will remain unchanged. Note: Each policy supports a single sender value (fromValue). To block additional senders, separate policies should be created using the mimecast-create-block-sender-policy command."
     arguments:
     - description: The ID of the policy to update.
       name: policy_id

--- a/Packs/Mimecast/Integrations/MimecastV2/README.md
+++ b/Packs/Mimecast/Integrations/MimecastV2/README.md
@@ -2082,7 +2082,8 @@ Create a Blocked Sender Policy.
 ### mimecast-update-block-sender-policy
 
 ***
-Updates the specified policy.
+Updates an existing Blocked Senders policy. This command performs a full policy replacement at the API level. Arguments that are explicitly provided will overwrite the current policy values. Arguments that are left blank will be automatically preserved from the existing policy. To modify only specific fields, provide the `policy_id` and the fields to be changed — all other fields will remain unchanged.
+**Note**: Each policy supports a single sender value (`fromValue`). To block additional senders, separate policies should be created using the `mimecast-create-block-sender-policy` command.
 
 #### Base Command
 

--- a/Packs/Mimecast/ReleaseNotes/3_0_9.md
+++ b/Packs/Mimecast/ReleaseNotes/3_0_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Mimecast v2
+
+- Documentation and metadata improvements.

--- a/Packs/Mimecast/pack_metadata.json
+++ b/Packs/Mimecast/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mimecast",
     "description": "Mimecast unified email management offers cloud email services for email security, continuity and archiving emails.",
     "support": "xsoar",
-    "currentVersion": "3.0.8",
+    "currentVersion": "3.0.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-68400](https://jira-dc.paloaltonetworks.com/browse/XSUP-68400)
## Description
A documentation update to the `mimecast-update-block-sender-policy` command to clearly explain the full-replacement vs. field-preservation behavior.

