### PR TITLE
Fix Monday EventCollector: IndexError on empty boards

### DIFF
--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.py
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.py
@@ -131,7 +131,11 @@ class ActivityLogsClient(BaseClient):
         """
         try:
             response = self.get_activity_logs_request(query, access_token)
-            logs = response["data"]["boards"][0].get("activity_logs", [])
+            boards = response.get("data", {}).get("boards", [])
+            if not boards:
+                demisto.debug(f"{ACTIVITY_LOG_DEBUG_PREFIX}No boards returned in check_empty_page.")
+                return True
+            logs = boards[0].get("activity_logs", [])
             return not logs
         except Exception as e:
             demisto.debug(f"{ACTIVITY_LOG_DEBUG_PREFIX}Error checking empty page: {str(e)}")
@@ -634,7 +638,15 @@ def get_activity_logs(last_run: dict, now_ms: int, limit: int, board_id: str, cl
         raise DemistoException(f"Exception during get activity logs. Exception is {e!s}")
 
     # Extract board logs from response
-    board_logs = response.get("data", {}).get("boards", [{}])[0].get("activity_logs", [])
+    data = response.get("data") or {}
+    boards = data.get("boards", [])
+    if not boards:
+        demisto.debug(
+            f"{ACTIVITY_LOG_DEBUG_PREFIX}No boards returned for board_id: {board_id}. "
+            "Verify the board ID exists and the OAuth token has permissions to access it."
+        )
+        return [], last_run
+    board_logs = boards[0].get("activity_logs", [])
     fetched_logs = extract_activity_log_data(board_logs)
     demisto.debug(f"{ACTIVITY_LOG_DEBUG_PREFIX}Successfully fetched {len(fetched_logs)} activity logs from board: {board_id}")
 
@@ -952,6 +964,9 @@ def initiate_activity_log_last_run(last_run: dict, board_ids_list: list[str]) ->
     Initialize last_run structure for multi-board activity logs fetching.
 
     Activity logs are fetched per board, and each board maintains its own separate state.
+    Ensures all configured board IDs have an entry in last_run, even if last_run already
+    contains data from previous fetches. This handles both first-time initialization and
+    cases where new board IDs are added to the configuration.
 
     Args:
         last_run (dict): Current last_run state from previous fetch execution
@@ -964,10 +979,12 @@ def initiate_activity_log_last_run(last_run: dict, board_ids_list: list[str]) ->
         Input: last_run={}, board_ids_list=["123", "456"]
         Output: {"123": {}, "456": {}}
 
+        Input: last_run={"123": {"last_timestamp": "..."}}, board_ids_list=["123", "456"]
+        Output: {"123": {"last_timestamp": "..."}, "456": {}}
+
     """
-    if not last_run:
-        for board_id in board_ids_list:
-            last_run[board_id] = {}
+    for board_id in board_ids_list:
+        last_run.setdefault(board_id, {})
     return last_run
 
 

--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.py
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.py
@@ -131,7 +131,7 @@ class ActivityLogsClient(BaseClient):
         """
         try:
             response = self.get_activity_logs_request(query, access_token)
-            boards = response.get("data", {}).get("boards", [])
+            boards = (response.get("data") or {}).get("boards", [])
             if not boards:
                 demisto.debug(f"{ACTIVITY_LOG_DEBUG_PREFIX}No boards returned in check_empty_page.")
                 return True

--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.yml
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector.yml
@@ -104,7 +104,7 @@ script:
   - name: monday-auth-test
     description: Run this command to test the connectivity to Monday.
     arguments: []
-  dockerimage: demisto/python3:3.12.12.5490952
+  dockerimage: demisto/python3:3.12.13.8428455
   isfetchevents: true
   runonce: false
   script: '-'

--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector_test.py
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector_test.py
@@ -3,11 +3,14 @@ import ast
 from unittest.mock import MagicMock
 from MondayEventCollector import (
     get_audit_logs,
+    get_activity_logs,
     generate_log_hash,
     subtract_epsilon_from_timestamp,
     fetch_audit_logs,
     fetch_activity_logs,
+    initiate_activity_log_last_run,
     test_connection as monday_test_connection,
+    ActivityLogsClient,
 )
 import demistomock as demisto  # noqa: F401
 from CommonServerPython import *
@@ -796,3 +799,186 @@ class TestConnectionAndUtilities:
         timestamp = "2024-06-03T14:00:00.000Z"
         result = subtract_epsilon_from_timestamp(timestamp)
         assert result == "2024-06-03T13:59:59.999000Z"
+
+
+class TestInitiateActivityLogLastRun:
+    """Tests for initiate_activity_log_last_run to verify board ID initialization."""
+
+    def test_empty_last_run_initializes_all_boards(self):
+        """
+        Given:
+            - An empty last_run dict
+            - A list of board IDs ["123", "456"]
+        When:
+            initiate_activity_log_last_run is called
+        Then:
+            All board IDs should be initialized with empty dicts
+        """
+        last_run: dict[str, dict] = {}
+        board_ids = ["123", "456"]
+        result = initiate_activity_log_last_run(last_run, board_ids)
+        assert "123" in result
+        assert "456" in result
+        assert result["123"] == {}
+        assert result["456"] == {}
+
+    def test_existing_last_run_preserves_data_and_adds_new_boards(self):
+        """
+        Given:
+            - A last_run dict with existing board "123" containing state data
+            - A board_ids_list with both "123" (existing) and "456" (new)
+        When:
+            initiate_activity_log_last_run is called
+        Then:
+            - Existing board "123" state should be preserved
+            - New board "456" should be initialized with empty dict
+        """
+        last_run: dict = {"123": {"last_timestamp": "2024-06-03T14:25:47.000Z", "lower_bound_log_id": ["id1"]}}
+        board_ids = ["123", "456"]
+        result = initiate_activity_log_last_run(last_run, board_ids)
+        assert result["123"] == {"last_timestamp": "2024-06-03T14:25:47.000Z", "lower_bound_log_id": ["id1"]}
+        assert result["456"] == {}
+
+    def test_non_empty_last_run_with_all_boards_present(self):
+        """
+        Given:
+            - A last_run dict with all configured board IDs already present
+        When:
+            initiate_activity_log_last_run is called
+        Then:
+            No changes should be made, existing state preserved for all boards
+        """
+        last_run: dict = {
+            "123": {"last_timestamp": "2024-06-03T14:25:47.000Z"},
+            "456": {"last_timestamp": "2024-06-04T10:00:00.000Z"},
+        }
+        board_ids = ["123", "456"]
+        result = initiate_activity_log_last_run(last_run, board_ids)
+        assert result["123"] == {"last_timestamp": "2024-06-03T14:25:47.000Z"}
+        assert result["456"] == {"last_timestamp": "2024-06-04T10:00:00.000Z"}
+
+    def test_board_id_from_error_scenario(self):
+        """
+        Given:
+            - A last_run dict that is non-empty (has data from a previous fetch for board "5092890815")
+            - Board IDs list includes "1808515822" which is NOT in last_run (a previously observed missing-board-id scenario)
+        When:
+            initiate_activity_log_last_run is called
+        Then:
+            - The missing board "1808515822" should be initialized
+            - The existing board "5092890815" state should be preserved
+        """
+        last_run: dict = {"5092890815": {"last_timestamp": "2024-06-03T14:25:47.000Z"}}
+        board_ids = ["5092890815", "1808515822"]
+        result = initiate_activity_log_last_run(last_run, board_ids)
+        assert "1808515822" in result
+        assert result["1808515822"] == {}
+        assert result["5092890815"] == {"last_timestamp": "2024-06-03T14:25:47.000Z"}
+
+
+class TestEmptyBoardsResponse:
+    """Tests for handling empty boards response from Monday.com API (XSUP-65887)."""
+
+    def test_get_activity_logs_returns_empty_when_boards_list_is_empty(self, mocker):
+        """
+        Given:
+            - Monday.com API returns an empty boards list (e.g., invalid board ID or no permissions)
+        When:
+            get_activity_logs is called
+        Then:
+            It should return empty logs and unchanged last_run instead of raising IndexError
+        """
+        mocker.patch.object(demisto, "debug")
+        mocker.patch("MondayEventCollector.get_access_token", return_value="mock_access_token")
+
+        mock_client = MagicMock(spec=ActivityLogsClient)
+        mock_client.get_activity_logs_request.return_value = {"data": {"boards": []}}
+
+        last_run: dict = {}
+        now_ms = int(time.time() * 1000)
+
+        result_logs, result_last_run = get_activity_logs(
+            last_run=last_run, now_ms=now_ms, limit=10, board_id="invalid_board_id", client=mock_client
+        )
+
+        assert result_logs == []
+        assert result_last_run == last_run
+
+    def test_get_activity_logs_returns_empty_when_boards_key_missing(self, mocker):
+        """
+        Given:
+            - Monday.com API returns a response without the boards key
+        When:
+            get_activity_logs is called
+        Then:
+            It should return empty logs and unchanged last_run instead of raising IndexError
+        """
+        mocker.patch.object(demisto, "debug")
+        mocker.patch("MondayEventCollector.get_access_token", return_value="mock_access_token")
+
+        mock_client = MagicMock(spec=ActivityLogsClient)
+        mock_client.get_activity_logs_request.return_value = {"data": {}}
+
+        last_run: dict = {}
+        now_ms = int(time.time() * 1000)
+
+        result_logs, result_last_run = get_activity_logs(
+            last_run=last_run, now_ms=now_ms, limit=10, board_id="999", client=mock_client
+        )
+
+        assert result_logs == []
+        assert result_last_run == last_run
+
+    def test_check_empty_page_returns_true_when_boards_list_is_empty(self, mocker):
+        """
+        Given:
+            - Monday.com API returns an empty boards list during pagination check
+        When:
+            check_empty_page is called on an ActivityLogsClient
+        Then:
+            It should return True (treat as empty page) instead of raising IndexError
+        """
+        mocker.patch.object(demisto, "debug")
+
+        mock_client = MagicMock(spec=ActivityLogsClient)
+        mock_client.get_activity_logs_request.return_value = {"data": {"boards": []}}
+
+        # Call the actual method by using the real class method with the mock
+        client = ActivityLogsClient.__new__(ActivityLogsClient)
+        client.get_activity_logs_request = mock_client.get_activity_logs_request
+
+        result = client.check_empty_page("query", "token")
+        assert result is True
+
+    def test_test_connection_handles_empty_boards_gracefully(self, mocker):
+        """
+        Given:
+            - Activity logs configured with valid credentials but invalid board ID
+            - Monday.com API returns empty boards list
+        When:
+            test_connection (monday-auth-test) is called
+        Then:
+            It should not raise 'list index out of range' error
+        """
+        mock_params = {
+            "credentials": {"identifier": "client_id", "password": "client_secret"},
+            "auth_code": {"password": "auth_code"},
+            "activity_logs_url": "https://api.monday.com",
+            "board_ids": "invalid_board",
+            "audit_token": {"password": ""},
+            "audit_logs_url": "",
+            "proxy": False,
+            "insecure": False,
+        }
+        mocker.patch.object(demisto, "params", return_value=mock_params)
+        mocker.patch.object(demisto, "debug")
+        mocker.patch("MondayEventCollector.get_integration_context", return_value={"access_token": "mock_token"})
+        mocker.patch("MondayEventCollector.get_access_token", return_value="mock_token")
+
+        mock_http_request = mocker.patch("MondayEventCollector.BaseClient._http_request")
+        mock_http_request.return_value = {"data": {"boards": []}}
+
+        result = monday_test_connection()
+        # Should complete without IndexError - activity logs test returns empty (success path with 0 logs)
+        assert result is not None
+        assert "activity logs" in result.readable_output.lower()

--- a/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector_test.py
+++ b/Packs/Monday/Integrations/MondayEventCollector/MondayEventCollector_test.py
@@ -950,6 +950,27 @@ class TestEmptyBoardsResponse:
         result = client.check_empty_page("query", "token")
         assert result is True
 
+    def test_check_empty_page_returns_true_when_data_is_none(self, mocker):
+        """
+        Given:
+            - Monday.com API returns a response where the "data" field is explicitly None
+        When:
+            check_empty_page is called on an ActivityLogsClient
+        Then:
+            It should return True (treat as empty page) instead of raising AttributeError
+        """
+        mocker.patch.object(demisto, "debug")
+
+        mock_client = MagicMock(spec=ActivityLogsClient)
+        mock_client.get_activity_logs_request.return_value = {"data": None}
+
+        # Call the actual method by using the real class method with the mock
+        client = ActivityLogsClient.__new__(ActivityLogsClient)
+        client.get_activity_logs_request = mock_client.get_activity_logs_request
+
+        result = client.check_empty_page("query", "token")
+        assert result is True
+
     def test_test_connection_handles_empty_boards_gracefully(self, mocker):
         """
         Given:

--- a/Packs/Monday/ReleaseNotes/1_0_7.md
+++ b/Packs/Monday/ReleaseNotes/1_0_7.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Monday Event Collector
+
+- Fixed an issue where fetching activity logs would fail with a *KeyError* when multiple board IDs were configured, due to incomplete initialization of the per-board last_run state.
+- Fixed an issue where the `!monday-auth-test` command and activity log fetching would fail with *list index out of range* when the Monday.com API returned an empty boards response (e.g., invalid board ID or insufficient OAuth permissions).

--- a/Packs/Monday/ReleaseNotes/1_0_7.md
+++ b/Packs/Monday/ReleaseNotes/1_0_7.md
@@ -1,7 +1,7 @@
 
 #### Integrations
 
-##### Monday Event Collector
+##### MondayEventCollector
 
 - Fixed an issue where fetching activity logs would fail with a *KeyError* when multiple board IDs were configured, due to incomplete initialization of the per-board last_run state.
 - Fixed an issue where the `!monday-auth-test` command and activity log fetching would fail with *list index out of range* when the Monday.com API returned an empty boards response (e.g., invalid board ID or insufficient OAuth permissions).

--- a/Packs/Monday/ReleaseNotes/1_0_7.md
+++ b/Packs/Monday/ReleaseNotes/1_0_7.md
@@ -5,3 +5,4 @@
 
 - Fixed an issue where fetching activity logs would fail with a *KeyError* when multiple board IDs were configured, due to incomplete initialization of the per-board last_run state.
 - Fixed an issue where the `!monday-auth-test` command and activity log fetching would fail with *list index out of range* when the Monday.com API returned an empty boards response (e.g., invalid board ID or insufficient OAuth permissions).
+- Updated the Docker image to: *demisto/python3:3.12.13.8428455*.

--- a/Packs/Monday/pack_metadata.json
+++ b/Packs/Monday/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Monday",
     "description": "Integrates with Monday.com to collect activity logs and audit logs.",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "created": "2025-07-22T00:00:00Z",
@@ -13,7 +13,9 @@
         "IT"
     ],
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "Monday"
+    ],
     "marketplaces": [
         "marketplacev2",
         "platform"


### PR DESCRIPTION

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-68470

## Description
- Fixed an issue where fetching activity logs would fail with a *KeyError* when multiple board IDs were configured, due to incomplete initialization of the per-board last_run state.
- Fixed an issue where the `!monday-auth-test` command and activity log fetching would fail with *list index out of range* when the Monday.com API returned an empty boards response (e.g., invalid board ID or insufficient OAuth permissions).

## Must have
- [ ] Tests
- [ ] Documentation
