### PR TITLE
Fix tag merging in MalwareBazaar Feed

### DIFF
--- a/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.py
+++ b/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.py
@@ -15,6 +15,15 @@ def custom_mapping_function(mapping: Dict, indicator: Dict, attributes: Dict):
                     indicator["fields"][fields[0]][0].update({fields[1]: attributes.get(map_key)})
                 else:
                     indicator["fields"][fields[0]] = [{fields[1]: attributes.get(map_key)}]
+            elif mapping[map_key] == "tags":
+                # Merge API response tags with the existing feedTags to avoid overwriting
+                # the configured feedTags value set by the JSONFeedApiModule.
+                existing_tags: list = indicator["fields"].get("tags") or []
+                api_tags = attributes.get(map_key) or []
+                if isinstance(api_tags, list):
+                    # Use dict.fromkeys to deduplicate while preserving order
+                    indicator["fields"]["tags"] = list(dict.fromkeys(existing_tags + api_tags))
+                # If api_tags is not a list (unexpected), keep existing feedTags unchanged
             else:
                 indicator["fields"][mapping[map_key]] = attributes.get(map_key)
         if map_key == "url_download":

--- a/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.py
+++ b/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.py
@@ -21,9 +21,9 @@ def custom_mapping_function(mapping: Dict, indicator: Dict, attributes: Dict):
                 existing_tags: list = indicator["fields"].get("tags") or []
                 api_tags = attributes.get(map_key) or []
                 if isinstance(api_tags, list):
-                    # Use dict.fromkeys to deduplicate while preserving order
-                    indicator["fields"]["tags"] = list(dict.fromkeys(existing_tags + api_tags))
-                # If api_tags is not a list (unexpected), keep existing feedTags unchanged
+                    indicator["fields"]["tags"] = list(set(existing_tags + api_tags))  # Use set to remove duplicates
+                else:
+                    demisto.debug(f"{api_tags=} is not a list (unexpected), keeping existing feedTags unchanged.")
             else:
                 indicator["fields"][mapping[map_key]] = attributes.get(map_key)
         if map_key == "url_download":

--- a/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.yml
+++ b/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed.yml
@@ -130,7 +130,7 @@ script:
   script: '-'
   type: python
   subtype: python3
-  dockerimage: demisto/py3-tools:1.0.0.3205634
+  dockerimage: demisto/py3-tools:1.0.0.8544956
   feed: true
 fromversion: 6.0.0
 tests:

--- a/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed_test.py
+++ b/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed_test.py
@@ -239,6 +239,66 @@ def test_no_exception_thrown_when_no_auth_key_param(mocker):
     assert feed_main_mock.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "feed_tags, api_tags, expected_tags",
+    [
+        pytest.param(
+            ["source_mbazaar"],
+            ["SilverFox", "ValleyRAT", "zip"],
+            ["source_mbazaar", "SilverFox", "ValleyRAT", "zip"],
+            id="merges_feed_tags_with_api_tags",
+        ),
+        pytest.param(
+            ["source_mbazaar"],
+            None,
+            ["source_mbazaar"],
+            id="preserves_feed_tags_when_api_tags_is_none",
+        ),
+        pytest.param(
+            ["source_mbazaar"],
+            [],
+            ["source_mbazaar"],
+            id="preserves_feed_tags_when_api_tags_is_empty",
+        ),
+        pytest.param(
+            ["source_mbazaar", "SilverFox"],
+            ["SilverFox", "ValleyRAT"],
+            ["source_mbazaar", "SilverFox", "ValleyRAT"],
+            id="deduplicates_overlapping_tags",
+        ),
+    ],
+)
+def test_custom_mapping_function_tags_merge(feed_tags: list, api_tags: list | None, expected_tags: list):
+    """
+    Regression test for XSUP-68506:
+    The 'tags' mapping entry in MalwareBazaarFeed must MERGE the API response tags
+    with the existing feedTags (set by JSONFeedApiModule.handle_indicator) rather
+    than overwriting them.
+
+    Given
+    - An indicator whose fields["tags"] has already been populated with feedTags
+      by handle_indicator.
+    - A mapping that maps the API "tags" field to the indicator "tags" field.
+    - Attributes from the API response with various tag values (list, None, empty).
+
+    When
+    - custom_mapping_function is called.
+
+    Then
+    - The resulting indicator["fields"]["tags"] matches the expected merged/deduplicated list.
+    - The configured feedTags value is NOT lost.
+    """
+    from MalwareBazaarFeed import custom_mapping_function
+
+    mapping = {"tags": "tags"}
+    attributes = {"tags": api_tags}
+    indicator = {"fields": {"tags": feed_tags.copy()}, "value": "abc123"}
+
+    custom_mapping_function(mapping, indicator, attributes)
+
+    assert indicator["fields"]["tags"] == expected_tags
+
+
 def test_exceptions_handler_no_exception(mocker):
     """
     In the main function of the MalwareBazaar Feed we handle exceptions as follows:

--- a/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed_test.py
+++ b/Packs/FeedMalwareBazaar/Integrations/MalwareBazaarFeed/MalwareBazaarFeed_test.py
@@ -296,7 +296,7 @@ def test_custom_mapping_function_tags_merge(feed_tags: list, api_tags: list | No
 
     custom_mapping_function(mapping, indicator, attributes)
 
-    assert indicator["fields"]["tags"] == expected_tags
+    assert sorted(indicator["fields"]["tags"]) == sorted(expected_tags)
 
 
 def test_exceptions_handler_no_exception(mocker):

--- a/Packs/FeedMalwareBazaar/ReleaseNotes/1_0_53.md
+++ b/Packs/FeedMalwareBazaar/ReleaseNotes/1_0_53.md
@@ -2,4 +2,6 @@
 
 ##### MalwareBazaar Feed
 
-Fixed an issue where the configured *Tags* parameter was being overwritten by tags from the MalwareBazaar API response.
+- Fixed an issue where the configured *Tags* parameter was being overwritten by tags from the MalwareBazaar API response.
+
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.8544956*.

--- a/Packs/FeedMalwareBazaar/ReleaseNotes/1_0_53.md
+++ b/Packs/FeedMalwareBazaar/ReleaseNotes/1_0_53.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### MalwareBazaar Feed
+
+Fixed an issue where the configured *Tags* parameter was being overwritten by tags from the MalwareBazaar API response.

--- a/Packs/FeedMalwareBazaar/pack_metadata.json
+++ b/Packs/FeedMalwareBazaar/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MalwareBazaar Feed",
     "description": "MalwareBazaar is a project from abuse.ch with the goal of sharing malware samples with the infosec community, AV vendors and threat intelligence providers.",
     "support": "xsoar",
-    "currentVersion": "1.0.52",
+    "currentVersion": "1.0.53",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
 fixes: [XSUP-68506](https://jira-dc.paloaltonetworks.com/browse/XSUP-68506)

## Description
Fixed an issue where the configured *Tags* parameter was being overwritten by tags from the MalwareBazaar API response.
