### PR TITLE
Wiz content pack v2.0.4: surface resolutionReason and add defensive guards

### DIFF
--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -12,7 +12,7 @@ WIZ_API_LIMIT = 500  # limit number of returned records from the Wiz API
 MAX_NOTE_LENGTH = 1400  # Hard limit for issue note text length enforced by the Wiz API
 WIZ = "wiz"
 
-WIZ_VERSION = "1.5.0"
+WIZ_VERSION = "1.5.1"
 INTEGRATION_GUID = "8864e131-72db-4928-1293-e292f0ed699f"
 NOT_DEFINED = "Not Defined"
 
@@ -1810,7 +1810,7 @@ def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_B
     started = time.monotonic()
 
     response_json = checkAPIerrors(query, variables)
-    nodes = list(response_json.get("data", {}).get("issues", {}).get("nodes", []))
+    nodes = list(response_json.get("data", {}).get("issues", {}).get("nodes") or [])
 
     while response_json.get("data", {}).get("issues", {}).get("pageInfo", {}).get("hasNextPage"):
         if time.monotonic() - started > deadline_seconds:
@@ -1821,7 +1821,7 @@ def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_B
             break
         variables["after"] = response_json["data"]["issues"]["pageInfo"]["endCursor"]
         response_json = checkAPIerrors(query, variables)
-        page_nodes = response_json.get("data", {}).get("issues", {}).get("nodes", [])
+        page_nodes = response_json.get("data", {}).get("issues", {}).get("nodes") or []
         if page_nodes:
             nodes += page_nodes
 
@@ -2323,17 +2323,21 @@ def get_resources(
     if entity_type:
         variables["filterBy"]["type"] = [entity_type]
     if subscription_external_ids:
-        subscription_external_ids_formatted = [str(x) for x in re.split(r"[,\s]+", subscription_external_ids.strip())]
-        variables["filterBy"]["subscriptionExternalId"] = subscription_external_ids_formatted
+        subscription_external_ids_formatted = [str(x) for x in re.split(r"[,\s]+", subscription_external_ids.strip()) if x]
+        if subscription_external_ids_formatted:
+            variables["filterBy"]["subscriptionExternalId"] = subscription_external_ids_formatted
     if provider_unique_ids:
-        provider_unique_ids_formatted = [str(x) for x in re.split(r"[,\s]+", provider_unique_ids.strip())]
-        variables["filterBy"]["providerUniqueId"] = provider_unique_ids_formatted
+        provider_unique_ids_formatted = [str(x) for x in re.split(r"[,\s]+", provider_unique_ids.strip()) if x]
+        if provider_unique_ids_formatted:
+            variables["filterBy"]["providerUniqueId"] = provider_unique_ids_formatted
     if project_ids:
-        project_ids_formatted = [str(x) for x in re.split(r"[,\s]+", project_ids.strip())]
-        variables["filterBy"]["projectId"] = project_ids_formatted
+        project_ids_formatted = [str(x) for x in re.split(r"[,\s]+", project_ids.strip()) if x]
+        if project_ids_formatted:
+            variables["filterBy"]["projectId"] = project_ids_formatted
     if native_types:
-        native_types_formatted = [str(x) for x in re.split(r"[,\s]+", native_types.strip())]
-        variables["filterBy"]["nativeType"] = native_types_formatted
+        native_types_formatted = [str(x) for x in re.split(r"[,\s]+", native_types.strip()) if x]
+        if native_types_formatted:
+            variables["filterBy"]["nativeType"] = native_types_formatted
     if updated_at_before or updated_at_after:
         updated_at: Dict[str, str] = {}
         if updated_at_before:
@@ -2826,6 +2830,13 @@ def get_modified_remote_data_command(args):
         f"(last_update={last_update}, saved_cursor={saved_cursor}, limit={mirror_limit})"
     )
 
+    # Empty cursor would send {"after": ""} to GraphQL, which the Wiz API
+    # rejects as an invalid datetime. Short-circuit to an empty result so
+    # XSOAR will retry on the next mirror cycle once lastUpdate is populated.
+    if not cursor:
+        demisto.debug("get_modified_remote_data: empty cursor (no last_update and no saved_cursor); returning []")
+        return GetModifiedRemoteDataResponse([])
+
     variables = {
         "first": mirror_limit,
         "filterBy": {"statusChangedAt": {"after": cursor}},
@@ -3026,8 +3037,8 @@ def _handle_outgoing_entries(remote_id, entries):
     """
     comment_tag = demisto.params().get(WizMirrorParam.COMMENT_TAG, "comments")
     for entry in entries:
-        contents = entry.get("contents", "")
-        if not contents:
+        contents = entry.get("contents") or ""
+        if not contents.strip():
             continue
         entry_tags = entry.get("tags") or []
         if comment_tag not in entry_tags:

--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -2270,6 +2270,11 @@ def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit):
     return issues
 
 
+def _split_csv_to_list(value):
+    """Split a comma/whitespace-separated string into a list of non-empty string tokens."""
+    return [str(x) for x in re.split(r"[,\s]+", value.strip()) if x]
+
+
 def get_resources(
     search,
     entity_type,
@@ -2324,21 +2329,21 @@ def get_resources(
     if entity_type:
         variables["filterBy"]["type"] = [entity_type]
     if subscription_external_ids:
-        subscription_external_ids_formatted = [str(x) for x in re.split(r"[,\s]+", subscription_external_ids.strip()) if x]
-        if subscription_external_ids_formatted:
-            variables["filterBy"]["subscriptionExternalId"] = subscription_external_ids_formatted
+        formatted = _split_csv_to_list(subscription_external_ids)
+        if formatted:
+            variables["filterBy"]["subscriptionExternalId"] = formatted
     if provider_unique_ids:
-        provider_unique_ids_formatted = [str(x) for x in re.split(r"[,\s]+", provider_unique_ids.strip()) if x]
-        if provider_unique_ids_formatted:
-            variables["filterBy"]["providerUniqueId"] = provider_unique_ids_formatted
+        formatted = _split_csv_to_list(provider_unique_ids)
+        if formatted:
+            variables["filterBy"]["providerUniqueId"] = formatted
     if project_ids:
-        project_ids_formatted = [str(x) for x in re.split(r"[,\s]+", project_ids.strip()) if x]
-        if project_ids_formatted:
-            variables["filterBy"]["projectId"] = project_ids_formatted
+        formatted = _split_csv_to_list(project_ids)
+        if formatted:
+            variables["filterBy"]["projectId"] = formatted
     if native_types:
-        native_types_formatted = [str(x) for x in re.split(r"[,\s]+", native_types.strip()) if x]
-        if native_types_formatted:
-            variables["filterBy"]["nativeType"] = native_types_formatted
+        formatted = _split_csv_to_list(native_types)
+        if formatted:
+            variables["filterBy"]["nativeType"] = formatted
     if updated_at_before or updated_at_after:
         updated_at: Dict[str, str] = {}
         if updated_at_before:
@@ -2831,9 +2836,6 @@ def get_modified_remote_data_command(args):
         f"(last_update={last_update}, saved_cursor={saved_cursor}, limit={mirror_limit})"
     )
 
-    # Empty cursor would send {"after": ""} to GraphQL, which the Wiz API
-    # rejects as an invalid datetime. Short-circuit to an empty result so
-    # XSOAR will retry on the next mirror cycle once lastUpdate is populated.
     if not cursor:
         demisto.debug("get_modified_remote_data: empty cursor (no last_update and no saved_cursor); returning []")
         return GetModifiedRemoteDataResponse([])

--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -151,6 +151,7 @@ query IssuesTable(
         }
       }
       status
+      resolutionReason
       severity
       entitySnapshot {
         id

--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -2275,6 +2275,15 @@ def _split_csv_to_list(value):
     return [str(x) for x in re.split(r"[,\s]+", value.strip()) if x]
 
 
+def _add_csv_filter(filter_by, arg, key):
+    """Add a CSV-parsed filter to a `filterBy` dict, only if `arg` yields any non-empty tokens."""
+    if not arg:
+        return
+    formatted = _split_csv_to_list(arg)
+    if formatted:
+        filter_by[key] = formatted
+
+
 def get_resources(
     search,
     entity_type,
@@ -2328,18 +2337,10 @@ def get_resources(
         variables["filterBy"]["search"] = search
     if entity_type:
         variables["filterBy"]["type"] = [entity_type]
-    csv_filters = [
-        (subscription_external_ids, "subscriptionExternalId"),
-        (provider_unique_ids, "providerUniqueId"),
-        (project_ids, "projectId"),
-        (native_types, "nativeType"),
-    ]
-    for arg, filter_key in csv_filters:
-        if not arg:
-            continue
-        formatted = _split_csv_to_list(arg)
-        if formatted:
-            variables["filterBy"][filter_key] = formatted
+    _add_csv_filter(variables["filterBy"], subscription_external_ids, "subscriptionExternalId")
+    _add_csv_filter(variables["filterBy"], provider_unique_ids, "providerUniqueId")
+    _add_csv_filter(variables["filterBy"], project_ids, "projectId")
+    _add_csv_filter(variables["filterBy"], native_types, "nativeType")
     if updated_at_before or updated_at_after:
         updated_at: Dict[str, str] = {}
         if updated_at_before:

--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -2328,22 +2328,18 @@ def get_resources(
         variables["filterBy"]["search"] = search
     if entity_type:
         variables["filterBy"]["type"] = [entity_type]
-    if subscription_external_ids:
-        formatted = _split_csv_to_list(subscription_external_ids)
+    csv_filters = [
+        (subscription_external_ids, "subscriptionExternalId"),
+        (provider_unique_ids, "providerUniqueId"),
+        (project_ids, "projectId"),
+        (native_types, "nativeType"),
+    ]
+    for arg, filter_key in csv_filters:
+        if not arg:
+            continue
+        formatted = _split_csv_to_list(arg)
         if formatted:
-            variables["filterBy"]["subscriptionExternalId"] = formatted
-    if provider_unique_ids:
-        formatted = _split_csv_to_list(provider_unique_ids)
-        if formatted:
-            variables["filterBy"]["providerUniqueId"] = formatted
-    if project_ids:
-        formatted = _split_csv_to_list(project_ids)
-        if formatted:
-            variables["filterBy"]["projectId"] = formatted
-    if native_types:
-        formatted = _split_csv_to_list(native_types)
-        if formatted:
-            variables["filterBy"]["nativeType"] = formatted
+            variables["filterBy"][filter_key] = formatted
     if updated_at_before or updated_at_after:
         updated_at: Dict[str, str] = {}
         if updated_at_before:

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -163,7 +163,7 @@ _resolved_issue_response = {
 
 @patch("Wiz.checkAPIerrors", return_value=_resolved_issue_response)
 def test_get_issue_surfaces_resolution_reason(checkAPIerrors):
-    """WZ-111555: wiz-get-issue must surface resolutionReason for resolved/rejected issues."""
+    """wiz-get-issue must surface resolutionReason for resolved/rejected issues."""
     from Wiz import get_issue
 
     res = get_issue("11111111-2222-3333-4444-555555555555")

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -2735,6 +2735,25 @@ def test_get_modified_remote_data_uses_slim_query(mock_check_api, _get_ctx, _set
 @patch("Wiz.demisto.setIntegrationContext")
 @patch("Wiz.demisto.getIntegrationContext", return_value={})
 @patch("Wiz.checkAPIerrors")
+def test_get_modified_remote_data_empty_cursor_short_circuits(mock_check_api, _get_ctx, _set_ctx):
+    """First mirror cycle (no lastUpdate, no saved cursor) must short-circuit
+    to an empty response without calling checkAPIerrors.
+
+    The Wiz API rejects {"after": ""} as an invalid datetime, so issuing the
+    query with an empty cursor would crash the mirror cycle. The short-circuit
+    lets XSOAR retry on the next cycle once lastUpdate is populated."""
+    from Wiz import get_modified_remote_data_command
+
+    with patch.object(demisto, "params", return_value={WizMirrorParam.LIMIT: "50"}):
+        result = get_modified_remote_data_command({"lastUpdate": ""})
+
+    assert mock_check_api.call_count == 0
+    assert result.modified_incident_ids == []
+
+
+@patch("Wiz.demisto.setIntegrationContext")
+@patch("Wiz.demisto.getIntegrationContext", return_value={})
+@patch("Wiz.checkAPIerrors")
 def test_get_modified_remote_data_single_page_only(mock_check_api, _get_ctx, _set_ctx):
     """Mirror must do exactly ONE GraphQL call per cycle, even when hasNextPage=True.
     The unbounded pagination loop in _fetch_all_issue_nodes is what blew the timeout —

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -141,6 +141,38 @@ def test_get_issue(checkAPIerrors):
     assert res == result_response
 
 
+_resolved_issue_response = {
+    "data": {
+        "issues": {
+            "nodes": [
+                {
+                    "id": "11111111-2222-3333-4444-555555555555",
+                    "type": "THREAT_DETECTION",
+                    "createdAt": "2022-01-02T15:46:34Z",
+                    "updatedAt": "2022-01-10T09:15:00Z",
+                    "status": "RESOLVED",
+                    "resolutionReason": "FALSE_POSITIVE",
+                    "severity": "HIGH",
+                }
+            ],
+            "pageInfo": {"hasNextPage": False, "endCursor": ""},
+        }
+    }
+}
+
+
+@patch("Wiz.checkAPIerrors", return_value=_resolved_issue_response)
+def test_get_issue_surfaces_resolution_reason(checkAPIerrors):
+    """WZ-111555: wiz-get-issue must surface resolutionReason for resolved/rejected issues."""
+    from Wiz import get_issue
+
+    res = get_issue("11111111-2222-3333-4444-555555555555")
+
+    assert isinstance(res, list) and len(res) == 1
+    assert res[0]["status"] == "RESOLVED"
+    assert res[0]["resolutionReason"] == "FALSE_POSITIVE"
+
+
 test_get_resource_response = {
     "data": {
         "cloudResources": {

--- a/Packs/Wiz/Integrations/WizDefend/WizDefend_description.md
+++ b/Packs/Wiz/Integrations/WizDefend/WizDefend_description.md
@@ -10,8 +10,14 @@ This section explains how to fully configure the instance of Wiz Defend Integrat
   - On the New Integration page
       - For **Name** —Enter a meaningful name.
       - For **Scope** —Set the Project's scope.
-  - Click **Add Integration**. A new service account is created.
+  - Click **Add Integration**. A new service account is created with the scopes this integration needs.
   - Copy and save the **client ID**, **client secret**, **API Endpoint URL** and **Authenticate API URL** for the next steps.
+- **Alternative: manual Service Account creation.** If you prefer to create the Service Account directly from [Settings > Service Accounts ↗](https://app.wiz.io/settings/service-accounts) instead of through the Integrations page, scope the permissions as follows:
+    - **Detections** > `read:detections`
+    - **Cloud Events** > `read:cloud_events_cloud`, `read:cloud_events_sensor`
+    - **Issues** > `read:threat_issues`
+    - **Issues** > `write:threat_issue_status`
+    - **Issues** > `write:threat_issue_comments`
 - In the Cortex XSOAR Integration instance configuration window:
     - Check **Fetches incidents** radio button
     - Choose **Wiz Classifier** as your classifier

--- a/Packs/Wiz/ReleaseNotes/2_0_4.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_4.md
@@ -2,6 +2,7 @@
 
 ## Wiz
 
+- Added **resolutionReason** field to **wiz-get-issue** (and **wiz-get-issues** / **fetch-incidents**) output so analysts can see why a Wiz issue was resolved or rejected without making a second API call. (WZ-111555)
 - Documented manual Service Account scope requirements for **Wiz Defend** integration setup.
 - Defensive guard for **wiz-get-resources**: empty/whitespace items in `subscription_external_ids`, `provider_unique_ids`, `project_ids`, and `native_types` arguments are now filtered out, and empty resulting lists are no longer sent to the GraphQL filter.
 - Defensive guard for **fetch-incidents** pagination: `_fetch_all_issue_nodes` now tolerates `null` `nodes` returned by the API (previously assumed missing-key only).

--- a/Packs/Wiz/ReleaseNotes/2_0_4.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_4.md
@@ -2,10 +2,10 @@
 
 ## Wiz
 
-- Added **resolutionReason** field to **wiz-get-issue** (and **wiz-get-issues** / **fetch-incidents**) output so analysts can see why a Wiz issue was resolved or rejected without making a second API call. (WZ-111555)
+- Added **resolutionReason** field to **wiz-get-issue**, **wiz-get-issues**, and fetched incidents so analysts can see why an Issue was resolved or rejected without making a second API call.
 - Documented manual Service Account scope requirements for **Wiz Defend** integration setup.
-- Defensive guard for **wiz-get-resources**: empty/whitespace items in `subscription_external_ids`, `provider_unique_ids`, `project_ids`, and `native_types` arguments are now filtered out, and empty resulting lists are no longer sent to the GraphQL filter.
-- Defensive guard for **fetch-incidents** pagination: `_fetch_all_issue_nodes` now tolerates `null` `nodes` returned by the API (previously assumed missing-key only).
-- Defensive guard for outgoing mirror entries: war-room entries with whitespace-only contents are now skipped silently instead of triggering a downstream API error.
-- Fixed mirror cycle crash on first install: `get-modified-remote-data` short-circuits to an empty result when no `last_update` and no saved cursor are available, instead of sending an invalid empty-string `after` to the Wiz API.
+- Improved **wiz-get-resources** input handling: empty or whitespace-only values in `subscription_external_ids`, `provider_unique_ids`, `project_ids`, and `native_types` are now filtered out, preventing invalid filter requests to the Wiz API.
+- Improved Issue fetch resilience to tolerate empty pagination responses from the Wiz API.
+- Outgoing mirror comments: entries with whitespace-only content are now skipped, preventing empty notes on Wiz Issues.
+- Fixed a mirror cycle error on first install when no last update timestamp was available; the integration now waits for the next cycle instead of sending an invalid timestamp to the Wiz API.
 </~PLATFORM>

--- a/Packs/Wiz/ReleaseNotes/2_0_4.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_4.md
@@ -1,0 +1,10 @@
+<~PLATFORM>
+
+## Wiz
+
+- Documented manual Service Account scope requirements for **Wiz Defend** integration setup.
+- Defensive guard for **wiz-get-resources**: empty/whitespace items in `subscription_external_ids`, `provider_unique_ids`, `project_ids`, and `native_types` arguments are now filtered out, and empty resulting lists are no longer sent to the GraphQL filter.
+- Defensive guard for **fetch-incidents** pagination: `_fetch_all_issue_nodes` now tolerates `null` `nodes` returned by the API (previously assumed missing-key only).
+- Defensive guard for outgoing mirror entries: war-room entries with whitespace-only contents are now skipped silently instead of triggering a downstream API error.
+- Fixed mirror cycle crash on first install: `get-modified-remote-data` short-circuits to an empty result when no `last_update` and no saved cursor are available, instead of sending an invalid empty-string `after` to the Wiz API.
+</~PLATFORM>

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Wiz",
     "description": "Integrate with Wiz for bidirectional Issue management, Detections investigation, and fetching of resource information. \n",
     "support": "partner",
-    "currentVersion": "2.0.3",
+    "currentVersion": "2.0.4",
     "author": "Wiz Inc.",
     "url": "https://wiz.io/",
     "email": "support@wiz.io",


### PR DESCRIPTION
## Motivation
v2.0.4 is a small, targeted release on top of v2.0.3 (#43959). Two themes:
1. Analysts triaging closed Wiz Issues need to see the **resolution reason** (FALSE_POSITIVE / DETECTION_EXPIRED / WONT_FIX / etc.) without making a second API call.
2. Defensive guards for corner cases discovered after v2.0.3 shipped (empty filter args, `null` API responses, whitespace-only mirror entries, fresh-install mirror cycle).

Plus a documentation cleanup for the WizDefend integration setup flow.

## Changes

| Area | Change |
|---|---|
| `Wiz.py` :: `PULL_ISSUES_QUERY` | Add `resolutionReason` to the Issue node selection — flows through `wiz-get-issue`, `wiz-get-issues`, and `fetch-incidents` |
| `Wiz.py` :: `get_resources` | Filter empty/whitespace items out of `subscription_external_ids`, `provider_unique_ids`, `project_ids`, `native_types`; skip the GraphQL filter entirely when the resulting list is empty (avoids 400 from the Wiz API) |
| `Wiz.py` :: `_fetch_all_issue_nodes` | Tolerate `null` returns from `nodes` (`nodes or []` instead of `nodes, []`) |
| `Wiz.py` :: `_handle_outgoing_entries` | Skip whitespace-only war-room entries via `.strip()` (previously only fully empty contents were skipped) |
| `Wiz.py` :: `get_modified_remote_data_command` | Short-circuit to empty `GetModifiedRemoteDataResponse` when cursor is empty (no `last_update`, no saved cursor) — fixes mirror-cycle crash on first install before `lastUpdate` is populated |
| `WizDefend_description.md` | Document manual Service Account scope alternative (Detections, Cloud Events, Threat Issues read/write scopes) |
| `pack_metadata.json` | `currentVersion` 2.0.3 → 2.0.4 |
| `Wiz.py` :: `WIZ_VERSION` | "1.5.0" → "1.5.1" |
| `ReleaseNotes/2_0_4.md` | Customer-facing release notes |

## Test plan
- [x] `pytest Packs/Wiz/Integrations/Wiz/Wiz_test.py` — 241 passed, 0 failed (added `test_get_issue_surfaces_resolution_reason` and `test_get_modified_remote_data_empty_cursor_short_circuits`)
- [x] `demisto-sdk validate -i Packs/Wiz` — all validations passed
- [x] `demisto-sdk upload -i Packs/Wiz -z --override-existing` — SUCCESSFUL UPLOADS, pack version 2.0.4
- [x] Code-integrity diff: deployed XSOAR `Wiz.py` matches local source (only SDK-stripped imports differ)
- [x] Live `wiz-get-issues severity=CRITICAL limit=1 using=Wiz_prod` returns `resolutionReason=DETECTION_EXPIRED` for a `RESOLVED THREAT_DETECTION` issue
- [x] Production `integration-instance.log` confirms `pack version = 2.0.4` is the running version, mirror cursor advancing cycle-to-cycle, Wiz API 200 responses, no errors
relates: link to the issue