### PR TITLE
Fix wildfire upload url

### DIFF
--- a/Packs/Palo_Alto_Networks_WildFire/.secrets-ignore
+++ b/Packs/Palo_Alto_Networks_WildFire/.secrets-ignore
@@ -5,3 +5,4 @@ abcdef1234567890abcdef1234567890
 45.58.143.12
 1.0.1.0
 Palo Alto Networks
+https://www.paloaltonetworks.com

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2.py
@@ -24,7 +24,6 @@ FILE_TYPE_SUPPRESS_ERROR = PARAMS.get("suppress_file_type_error")
 RELIABILITY = PARAMS.get("integrationReliability", DBotScoreReliability.B) or DBotScoreReliability.B
 CREATE_RELATIONSHIPS = argToBoolean(PARAMS.get("create_relationships", "true"))
 DEFAULT_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
-MULTIPART_HEADERS = {"Content-Type": "multipart/form-data; boundary=upload_boundry"}
 WILDFIRE_REPORT_DT_FILE = (
     "WildFire.Report(val.SHA256 && val.SHA256 == obj.SHA256 || val.MD5 && val.MD5 == obj.MD5 || val.URL && val.URL == obj.URL)"
 )
@@ -447,38 +446,13 @@ def wildfire_upload_file_command(args) -> list:
 def wildfire_upload_file_url(upload):
     upload_file_url_uri = URL + URL_DICT["upload_file_url"]
 
-    body = f"""--upload_boundry
-Content-Disposition: form-data; name="apikey"
+    # The WildFire /submit/url endpoint requires multipart/form-data. Passing form
+    # fields as (None, value) tuples via `files=` makes `requests` build a compliant
+    # multipart body (auto-generated boundary, CRLF separators).
+    multipart_fields: dict = {key: (None, value) for key, value in BODY_DICT.items()}
+    multipart_fields["url"] = (None, upload)
 
-{TOKEN}
---upload_boundry
-Content-Disposition: form-data; name="url"
-
-{upload}
---upload_boundry--"""
-
-    body2 = f"""--upload_boundry
-Content-Disposition: form-data; name="apikey"
-
-{TOKEN}
---upload_boundry
-Content-Disposition: form-data; name="url"
-
-{upload}
---upload_boundry
-Content-Disposition: form-data; name="agent"
-
-{AGENT_VALUE}
---upload_boundry--"""
-
-    # check upload value
-    # body2 = 'apikey=' + TOKEN + '&url=' + upload + AGENT_VALUE
-
-    if AGENT_VALUE != "":
-        # we need to attach another form element of agent for this APIKEY
-        body = body2
-
-    result = http_request(upload_file_url_uri, "POST", headers=MULTIPART_HEADERS, body=body)
+    result = http_request(upload_file_url_uri, "POST", files=multipart_fields)
 
     upload_file_url_data = result["wildfire"]["upload-file-info"]
 
@@ -513,37 +487,13 @@ def wildfire_upload_file_url_command(args) -> list:
 def wildfire_upload_url(upload):
     upload_url_uri = URL + URL_DICT["upload_url"]
 
-    body = f"""--upload_boundry
-Content-Disposition: form-data; name="apikey"
+    # The WildFire /submit/link endpoint requires multipart/form-data. Passing form
+    # fields as (None, value) tuples via `files=` makes `requests` build a compliant
+    # multipart body (auto-generated boundary, CRLF separators).
+    multipart_fields: dict = {key: (None, value) for key, value in BODY_DICT.items()}
+    multipart_fields["link"] = (None, upload)
 
-{TOKEN}
---upload_boundry
-Content-Disposition: form-data; name="link"
-
-{upload}
---upload_boundry--"""
-
-    body2 = f"""--upload_boundry
-Content-Disposition: form-data; name="apikey"
-
-{TOKEN}
---upload_boundry
-Content-Disposition: form-data; name="link"
-
-{upload}
---upload_boundry
-Content-Disposition: form-data; name="agent"
-
-{AGENT_VALUE}
---upload_boundry--"""
-
-    # koby test
-    # body2 = 'apikey=' + TOKEN + '&url=' + upload + AGENT_VALUE
-
-    if AGENT_VALUE != "":
-        body = body2
-
-    result = http_request(upload_url_uri, "POST", headers=MULTIPART_HEADERS, body=body)
+    result = http_request(upload_url_uri, "POST", files=multipart_fields)
 
     upload_url_data = result["wildfire"]["submit-link-info"]
 

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/Palo_Alto_Networks_WildFire_v2_test.py
@@ -876,3 +876,46 @@ def test_wildfire_upload_file_uses_basename(mocker, input_name, expected_basenam
     copy_call_args = mock_copy.call_args[0]
     assert copy_call_args[1] == expected_basename
     assert os.path.basename(copy_call_args[1]) == copy_call_args[1]
+
+
+@pytest.mark.parametrize(
+    "func_name, url_dict_key, link_field, response_key",
+    [
+        ("wildfire_upload_url", "upload_url", "link", "submit-link-info"),
+        ("wildfire_upload_file_url", "upload_file_url", "url", "upload-file-info"),
+    ],
+)
+def test_url_upload_uses_files_arg_for_multipart(mocker, func_name, url_dict_key, link_field, response_key):
+    """
+    Given:
+        - wildfire_upload_url or wildfire_upload_file_url is invoked with a URL.
+    When:
+        - The integration constructs the HTTP request to the WildFire API.
+    Then:
+        - http_request is called with `files=` (so `requests` builds a compliant
+          multipart/form-data body), and not with a manual `body=`/`headers=`.
+    """
+    import Palo_Alto_Networks_WildFire_v2 as wf
+
+    mocker.patch.object(wf, "URL", "https://wildfire.example.com/publicapi")
+    mocker.patch.object(wf, "URL_DICT", {url_dict_key: f"/{url_dict_key.replace('_', '/')}"})
+    mocker.patch.object(wf, "BODY_DICT", {"apikey": "test-api-key", "agent": "xdr"})
+    mock_http = mocker.patch.object(
+        wf,
+        "http_request",
+        return_value={"wildfire": {response_key: {"md5": "m", "sha256": "s", "url": "https://example.com"}}},
+    )
+
+    func = getattr(wf, func_name)
+    func("https://example.com")
+
+    # Must use files= so requests builds RFC-compliant multipart/form-data.
+    args, kwargs = mock_http.call_args
+    assert "files" in kwargs, "Must pass files= so requests builds RFC-compliant multipart"
+    files = kwargs["files"]
+    assert files["apikey"] == (None, "test-api-key")
+    assert files["agent"] == (None, "xdr")
+    assert files[link_field] == (None, "https://example.com")
+    # Defensive: ensure no hand-rolled body string snuck back in.
+    assert kwargs.get("body") is None
+    assert kwargs.get("headers") is None

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
@@ -503,12 +503,6 @@ Returns a verdict regarding multiple hashes, stored in a TXT file or given as li
 | DBotScore.Vendor | string | Vendor used to calculate the score. |
 | DBotScore.Score | number | The actual score. |
 
-#### Command Example
-
-``````
-
-#### Human Readable Output
-
 ### wildfire-upload-url
 
 ***

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/README.md
@@ -420,11 +420,11 @@ Retrieves results for a file hash using WildFire.
 
 #### Command Example
 
-```!wildfire-report url=https://www.XSOAR.com```
+```!wildfire-report url=https://www.paloaltonetworks.com```
 
 #### Human Readable Output
 
->### Wildfire URL report for https://www.XSOAR.com
+>### Wildfire URL report for https://www.paloaltonetworks.com
 >
 >|sha256|type|verdict|
 >|---|---|---|
@@ -600,7 +600,7 @@ Notice: Submitting indicators using this command might make the indicator data p
 
 #### Command Example
 
-```!wildfire-upload-url upload=https://www.XSOAR.com```
+```!wildfire-upload-url upload=https://www.paloaltonetworks.com```
 
 #### Human Readable Output
 
@@ -608,7 +608,7 @@ Notice: Submitting indicators using this command might make the indicator data p
 >
 >|MD5|SHA256|Status|URL|
 >|---|---|---|---|
->| 67632f32e6af123aa8ffd1fe8765a783 | c51a8231d1be07a2545ac99e86a25c5d68f88380b7ebf7ac91501661e6d678bb | Pending | https://www.XSOAR.com |
+>| 67632f32e6af123aa8ffd1fe8765a783 | c51a8231d1be07a2545ac99e86a25c5d68f88380b7ebf7ac91501661e6d678bb | Pending | https://www.paloaltonetworks.com |
 
 ### wildfire-get-sample
 

--- a/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/command_examples.txt
+++ b/Packs/Palo_Alto_Networks_WildFire/Integrations/Palo_Alto_Networks_WildFire_v2/command_examples.txt
@@ -1,4 +1,4 @@
-!wildfire-upload upload=<entry_id>
+!wildfire-upload upload='<entry_id>'
 !wildfire-upload-file-url upload=http://www.software995.net/bin/pdf995s.exe
 !wildfire-upload-url upload=https://www.demisto.com
 !wildfire-report url=https://www.demisto.com

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_79.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_79.md
@@ -1,5 +1,5 @@
 #### Integrations
 
-##### WildFire v2
+##### Palo Alto Networks WildFire v2
 
 Fixed an issue where the ***wildfire-upload-url*** and ***wildfire-upload-file-url*** commands could fail with the error `Request Failed with status: 420 Reason is: Insufficient arguments` in some network environments.

--- a/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_79.md
+++ b/Packs/Palo_Alto_Networks_WildFire/ReleaseNotes/2_1_79.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### WildFire v2
+
+Fixed an issue where the ***wildfire-upload-url*** and ***wildfire-upload-file-url*** commands could fail with the error `Request Failed with status: 420 Reason is: Insufficient arguments` in some network environments.

--- a/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_WildFire/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "WildFire by Palo Alto Networks",
     "description": "Perform malware dynamic analysis",
     "support": "xsoar",
-    "currentVersion": "2.1.78",
+    "currentVersion": "2.1.79",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[XSUP-64888](https://jira-dc.paloaltonetworks.com/browse/XSUP-64888)

## Description

Replaces a hand-rolled multipart/form-data body in `wildfire_upload_url` and `wildfire_upload_file_url` with a properly-encoded body built by the requests library. The previous body used LF line separators and a static boundary, which caused HTTP 420 "Insufficient arguments" failures in environments where outbound traffic passes through HTTP-aware security devices (proxies, TLS inspection, WAFs) that strictly validate multipart MIME formatting.

### Before this fix
<img width="1568" height="675" alt="image" src="https://github.com/user-attachments/assets/1677ddec-59dc-4aef-bbda-b603fbb7f2ae" />

### After
<img width="1564" height="905" alt="image" src="https://github.com/user-attachments/assets/5a139257-b2bd-426d-add6-d85af11c78d6" />
