### PR TITLE
Ediscovery get status operation new command

### DIFF
--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -681,7 +681,7 @@ def get_status_of_operation(client: MsGraphClient, res: Response | None = None, 
         The full operation response dict, or {'status': 'success'} if no Location header is present.
     """
     location = location_url or (res.headers.get("Location") if res else "")
-    if not location: # if no location is returned then the custodian is already in this state/theres no data sources
+    if not location:  # if no location is returned then the custodian is already in this state/theres no data sources
         demisto.debug("No Location header or URL provided, returning default success status.")
         return {"status": "success"}
 
@@ -1456,21 +1456,26 @@ def list_ediscovery_non_custodial_data_source_command(client: MsGraphClient, arg
     return ediscovery_source_command_results(source_list, DataSourceType["NON_CUSTODIAL"], raw_res)
 
 
-def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_action: HoldAction):
-    demisto.debug(f"{hold_action.value=}")
-    res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
-    location = res.headers.get("Location", "")
-    demisto.debug(f"update_hold_ediscovery_custodian response Location header: {location}")
-    operation = get_status_of_operation(client, res)
-    status = operation.get("status", "success")
+def build_operation_results(outputs_prefix: str, title: str, status: str, location: str) -> CommandResults:
+    """
+    Build a CommandResults object for an eDiscovery operation that returns a Status and LocationURL.
 
+    Args:
+        outputs_prefix: The context output prefix (e.g., 'MsGraph.eDiscoveryHoldOperation').
+        title: The human-readable table title.
+        status: The operation status string.
+        location: The Location URL from the response headers.
+
+    Returns:
+        A CommandResults object with the operation status and location URL.
+    """
     outputs = {
         "Status": status,
         "LocationURL": location,
     }
 
     hr = tableToMarkdown(
-        f"{hold_action.value.capitalize()} Hold Results",
+        title,
         outputs,
         headers=["Status", "LocationURL"],
         headerTransform=lambda h: "Location URL" if h == "LocationURL" else h,
@@ -1478,9 +1483,26 @@ def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_a
     )
 
     return CommandResults(
-        outputs_prefix="MsGraph.eDiscoveryHoldOperation",
+        outputs_prefix=outputs_prefix,
+        outputs_key_field="LocationURL",
         outputs=outputs,
         readable_output=hr,
+    )
+
+
+def update_hold_ediscovery_custodian_command(client: MsGraphClient, args: dict, hold_action: HoldAction):
+    demisto.debug(f"{hold_action.value=}")
+    res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
+    location = res.headers.get("Location", "")
+    demisto.debug(f"update_hold_ediscovery_custodian response Location header: {location}")
+    operation = get_status_of_operation(client, res)
+    status = operation.get("status", "success")
+
+    return build_operation_results(
+        outputs_prefix="MsGraph.eDiscoveryHoldOperation",
+        title=f"{hold_action.value.capitalize()} Hold Results",
+        status=status,
+        location=location,
     )
 
 
@@ -1511,7 +1533,7 @@ def delete_ediscovery_search_command(client: MsGraphClient, args):
     return CommandResults(readable_output=f'eDiscovery search {args.get("search_id")} was deleted successfully.')
 
 
-def purge_ediscovery_data_command(client: MsGraphClient, args):
+def purge_ediscovery_data_command(client: MsGraphClient, args: dict):
     resp = client.purge_ediscovery_data(
         args.get("case_id"), args.get("search_id"), args.get("purge_type"), args.get("purge_areas")
     )
@@ -1520,23 +1542,11 @@ def purge_ediscovery_data_command(client: MsGraphClient, args):
     operation_status = get_status_of_operation(client, resp)
     status = operation_status.get("status", "success")
 
-    outputs = {
-        "Status": status,
-        "LocationURL": location,
-    }
-
-    hr = tableToMarkdown(
-        "eDiscovery Purge Data Results",
-        outputs,
-        headers=["Status", "LocationURL"],
-        headerTransform=lambda h: "Location URL" if h == "LocationURL" else h,
-        removeNull=True,
-    )
-
-    return CommandResults(
+    return build_operation_results(
         outputs_prefix="MsGraph.eDiscoveryPurge",
-        outputs=outputs,
-        readable_output=hr,
+        title="eDiscovery Purge Data Results",
+        status=status,
+        location=location,
     )
 
 
@@ -1553,6 +1563,8 @@ def get_operation_status_command(client: MsGraphClient, args: dict) -> CommandRe
         CommandResults with the operation status details.
     """
     location_url: str = args.get("location_url", "")
+    if not location_url:
+        raise DemistoException("The 'location_url' argument is required.")
     resp = get_status_of_operation(client, location_url=location_url)
 
     outputs = {

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -1490,7 +1490,7 @@ def build_operation_results(outputs_prefix: str, title: str, status: str, locati
     )
 
 
-def update_hold_ediscovery_custodian_command(client: MsGraphClient, args: dict, hold_action: HoldAction):
+def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_action: HoldAction):
     demisto.debug(f"{hold_action.value=}")
     res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
     location = res.headers.get("Location", "")
@@ -1533,7 +1533,7 @@ def delete_ediscovery_search_command(client: MsGraphClient, args):
     return CommandResults(readable_output=f'eDiscovery search {args.get("search_id")} was deleted successfully.')
 
 
-def purge_ediscovery_data_command(client: MsGraphClient, args: dict):
+def purge_ediscovery_data_command(client: MsGraphClient, args):
     resp = client.purge_ediscovery_data(
         args.get("case_id"), args.get("search_id"), args.get("purge_type"), args.get("purge_areas")
     )

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -681,7 +681,7 @@ def get_status_of_operation(client: MsGraphClient, res: Response | None = None, 
         The full operation response dict, or {'status': 'success'} if no Location header is present.
     """
     location = location_url or (res.headers.get("Location") if res else "")
-    if not location:
+    if not location: # if no location is returned then the custodian is already in this state/theres no data sources
         demisto.debug("No Location header or URL provided, returning default success status.")
         return {"status": "success"}
 
@@ -1459,8 +1459,8 @@ def list_ediscovery_non_custodial_data_source_command(client: MsGraphClient, arg
 def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_action: HoldAction):
     demisto.debug(f"{hold_action.value=}")
     res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
-    operation = get_status_of_operation(client, res)
-    status = operation.get("status", "success")
+    operation_status = get_status_of_operation(client, res)
+    status = operation_status.get("status", "success")
     return CommandResults(readable_output=f"{hold_action.value.capitalize()} hold status is {status}.")
 
 
@@ -1497,8 +1497,8 @@ def purge_ediscovery_data_command(client: MsGraphClient, args):
     )
     location = resp.headers.get("Location", "")
     demisto.debug(f"purge_ediscovery_data response Location header: {location}")
-    operation = get_status_of_operation(client, resp)
-    status = operation.get("status", "success")
+    operation_status = get_status_of_operation(client, resp)
+    status = operation_status.get("status", "success")
 
     outputs = {
         "Status": status,
@@ -1533,9 +1533,6 @@ def get_operation_status_command(client: MsGraphClient, args: dict) -> CommandRe
         CommandResults with the operation status details.
     """
     location_url: str = args.get("location_url", "")
-    if not location_url:
-        raise DemistoException("The 'location_url' argument is required.")
-
     resp = get_status_of_operation(client, location_url=location_url)
 
     outputs = {

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -2559,7 +2559,7 @@ def main():
         "msg-list-ediscovery-case-hold-policy": list_ediscovery_case_hold_policy_command,
         "msg-list-case-operation": list_case_operation_command,
         "msg-export-result-ediscovery-data": export_result_ediscovery_data_command,
-        "msg-get-operation-status": get_operation_status_command,
+        "msg-ediscovery-get-operation-status": get_operation_status_command,
     }
     command = demisto.command()
     LOG(f"Command being called is {command}")

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -660,25 +660,35 @@ class MsGraphClient:
 """ HELPER FUNCTIONS """
 
 
-def get_status_of_operation(client: MsGraphClient, res: Response) -> str:
+def get_status_of_operation(client: MsGraphClient, res: Response | None = None, location_url: str = "") -> dict:
     """
-    Some responses from MSG where an action is called return a url in the headers that we can use to retrieve the status
+    Retrieve the status of a long-running eDiscovery operation.
+
+    Some Microsoft Graph eDiscovery action responses (e.g., purgeData, applyHold, removeHold)
+    return a Location header pointing to the created caseOperation resource.
+    This function fetches that URL and returns the full operation response.
+
+    Can be called with either a Response object (extracts the Location header) or a direct location_url string.
+
+    See: https://learn.microsoft.com/en-us/graph/api/security-caseoperation-get
+
     Args:
-        client: Microsoft
-        GraphClient
-        res: the response from the api
+        client: MsGraphClient instance.
+        res: The HTTP response from an eDiscovery action. The Location header is extracted from it.
+        location_url: A direct Location URL pointing to the operation resource.
 
     Returns:
-        The status
+        The full operation response dict, or {'status': 'success'} if no Location header is present.
     """
-    location = res.headers.get("Location")
-    status = "success"  # if no location is returned then the custodian is already in this state/theres no data sources
-    if location:
-        location = "security" + location.split("/security")[1]  # chop off the baseurl
-        resp = client.get(location)
-        demisto.debug(f"response from location get: {resp}")
-        status = resp.get("status")
-    return status
+    location = location_url or (res.headers.get("Location") if res else "")
+    if not location:
+        demisto.debug("No Location header or URL provided, returning default success status.")
+        return {"status": "success"}
+
+    location = "security" + location.split("/security")[1]  # chop off the baseurl
+    resp = client.get(location)
+    demisto.debug(f"response from location get: {resp}")
+    return resp
 
 
 def create_search_alerts_filters(args, is_fetch=False):
@@ -1449,7 +1459,8 @@ def list_ediscovery_non_custodial_data_source_command(client: MsGraphClient, arg
 def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_action: HoldAction):
     demisto.debug(f"{hold_action.value=}")
     res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
-    status = get_status_of_operation(client, res)
+    operation = get_status_of_operation(client, res)
+    status = operation.get("status", "success")
     return CommandResults(readable_output=f"{hold_action.value.capitalize()} hold status is {status}.")
 
 
@@ -1484,8 +1495,72 @@ def purge_ediscovery_data_command(client: MsGraphClient, args):
     resp = client.purge_ediscovery_data(
         args.get("case_id"), args.get("search_id"), args.get("purge_type"), args.get("purge_areas")
     )
-    status = get_status_of_operation(client, resp)
-    return CommandResults(readable_output=f"eDiscovery purge status is {status}.")
+    location = resp.headers.get("Location", "")
+    demisto.debug(f"purge_ediscovery_data response Location header: {location}")
+    operation = get_status_of_operation(client, resp)
+    status = operation.get("status", "success")
+
+    outputs = {
+        "Status": status,
+        "LocationURL": location,
+    }
+
+    hr = tableToMarkdown(
+        "eDiscovery Purge Data Results",
+        outputs,
+        headers=["Status", "LocationURL"],
+        headerTransform=lambda h: "Location URL" if h == "LocationURL" else h,
+        removeNull=True,
+    )
+
+    return CommandResults(
+        outputs_prefix="MsGraph.eDiscoveryPurge",
+        outputs=outputs,
+        readable_output=hr,
+    )
+
+
+def get_operation_status_command(client: MsGraphClient, args: dict) -> CommandResults:
+    """
+    Retrieve the status of a long-running eDiscovery operation using the Location URL.
+    Wraps the get_status_of_operation function as a user-facing command.
+
+    Args:
+        client: MsGraphClient instance.
+        args: Command arguments containing 'location_url'.
+
+    Returns:
+        CommandResults with the operation status details.
+    """
+    location_url: str = args.get("location_url", "")
+    if not location_url:
+        raise DemistoException("The 'location_url' argument is required.")
+
+    resp = get_status_of_operation(client, location_url=location_url)
+
+    outputs = {
+        "Id": resp.get("id"),
+        "Action": resp.get("action"),
+        "Status": resp.get("status"),
+        "PercentProgress": resp.get("percentProgress"),
+        "CreatedDateTime": resp.get("createdDateTime"),
+        "CompletedDateTime": resp.get("completedDateTime"),
+    }
+
+    hr = tableToMarkdown(
+        "eDiscovery Operation Status",
+        outputs,
+        headers=["Id", "Action", "Status", "PercentProgress", "CreatedDateTime", "CompletedDateTime"],
+        removeNull=True,
+    )
+
+    return CommandResults(
+        outputs_prefix="MsGraph.eDiscoveryOperation",
+        outputs_key_field="Id",
+        outputs=outputs,
+        readable_output=hr,
+        raw_response=resp,
+    )
 
 
 def run_estimate_statistics_command(client: MsGraphClient, args) -> CommandResults:
@@ -2467,6 +2542,7 @@ def main():
         "msg-list-ediscovery-case-hold-policy": list_ediscovery_case_hold_policy_command,
         "msg-list-case-operation": list_case_operation_command,
         "msg-export-result-ediscovery-data": export_result_ediscovery_data_command,
+        "msg-get-operation-status": get_operation_status_command,
     }
     command = demisto.command()
     LOG(f"Command being called is {command}")

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.py
@@ -1459,9 +1459,29 @@ def list_ediscovery_non_custodial_data_source_command(client: MsGraphClient, arg
 def update_hold_ediscovery_custodian_command(client: MsGraphClient, args, hold_action: HoldAction):
     demisto.debug(f"{hold_action.value=}")
     res = client.update_hold_ediscovery_custodian(args.get("case_id"), args.get("custodian_id"), hold_action)
-    operation_status = get_status_of_operation(client, res)
-    status = operation_status.get("status", "success")
-    return CommandResults(readable_output=f"{hold_action.value.capitalize()} hold status is {status}.")
+    location = res.headers.get("Location", "")
+    demisto.debug(f"update_hold_ediscovery_custodian response Location header: {location}")
+    operation = get_status_of_operation(client, res)
+    status = operation.get("status", "success")
+
+    outputs = {
+        "Status": status,
+        "LocationURL": location,
+    }
+
+    hr = tableToMarkdown(
+        f"{hold_action.value.capitalize()} Hold Results",
+        outputs,
+        headers=["Status", "LocationURL"],
+        headerTransform=lambda h: "Location URL" if h == "LocationURL" else h,
+        removeNull=True,
+    )
+
+    return CommandResults(
+        outputs_prefix="MsGraph.eDiscoveryHoldOperation",
+        outputs=outputs,
+        readable_output=hr,
+    )
 
 
 def apply_hold_ediscovery_custodian_command(client: MsGraphClient, args):

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
@@ -1389,7 +1389,7 @@ script:
       description: 'The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed.'
       type: String
     - contextPath: MsGraph.eDiscoveryHoldOperation.LocationURL
-      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status.
       type: String
   - arguments:
     - description: The ID of the eDiscovery case.
@@ -1408,7 +1408,7 @@ script:
       description: 'The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed.'
       type: String
     - contextPath: MsGraph.eDiscoveryHoldOperation.LocationURL
-      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status.
       type: String
   - arguments:
     - description: The ID of the eDiscovery case.
@@ -1721,7 +1721,7 @@ script:
       description: 'The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed.'
       type: String
     - contextPath: MsGraph.eDiscoveryPurge.LocationURL
-      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status.
       type: String
   - arguments:
     - description: The Location URL returned in the response headers of an eDiscovery action (e.g., purge, hold). This URL points to the operation resource in Microsoft Graph and is used to retrieve the current status of the operation.
@@ -1733,7 +1733,7 @@ script:
 
       The Location URL is returned in the response headers when an eDiscovery action is initiated and can be used to poll for the operation status until it completes.
     execution: false
-    name: msg-get-operation-status
+    name: msg-ediscovery-get-operation-status
     outputs:
     - contextPath: MsGraph.eDiscoveryOperation.Id
       description: The ID of the operation.
@@ -1748,10 +1748,10 @@ script:
       description: The progress of the operation as a percentage.
       type: Number
     - contextPath: MsGraph.eDiscoveryOperation.CreatedDateTime
-      description: The date and time the operation was created.
+      description: 'The date and time the operation was created. Format: ISO 8601 UTC, e.g., 2026-05-14T09:19:54.721164Z.'
       type: Date
     - contextPath: MsGraph.eDiscoveryOperation.CompletedDateTime
-      description: The date and time the operation was completed.
+      description: 'The date and time the operation was completed. Format: ISO 8601 UTC, e.g., 2026-05-14T09:21:24.6853071Z.'
       type: Date
   - arguments:
     - description: The email address of the user who received the email.

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
@@ -1713,8 +1713,7 @@ script:
       Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
       Private channels - Message posts, replies, and attachments shared in a private Teams channel.
       Shared channels - Message posts, replies, and attachments shared in a shared Teams channel.
-
-      Note: This request purges a maximum of 100 items per location only. When purgeType is set to either recoverable or permanentlyDelete and purgeAreas is set to teamsMessages, the Teams messages are permanently deleted.
+      This request purges a maximum of 100 items per mailbox only.
     execution: false
     name: msg-purge-ediscovery-data
     outputs:

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
@@ -1384,6 +1384,13 @@ script:
       partial - The custodian is in a mixed state where some sources are on hold and some not on hold or error state.
     execution: false
     name: msg-apply-hold-ediscovery-custodian
+    outputs:
+    - contextPath: MsGraph.eDiscoveryHoldOperation.Status
+      description: 'The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed.'
+      type: String
+    - contextPath: MsGraph.eDiscoveryHoldOperation.LocationURL
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      type: String
   - arguments:
     - description: The ID of the eDiscovery case.
       isArray: false
@@ -1396,6 +1403,13 @@ script:
     description: Start the process of removing a hold from eDiscovery custodians.
     execution: false
     name: msg-remove-hold-ediscovery-custodian
+    outputs:
+    - contextPath: MsGraph.eDiscoveryHoldOperation.Status
+      description: 'The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed.'
+      type: String
+    - contextPath: MsGraph.eDiscoveryHoldOperation.LocationURL
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      type: String
   - arguments:
     - description: The ID of the eDiscovery case.
       isArray: false

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
@@ -1701,6 +1701,43 @@ script:
       Shared channels - Message posts, replies, and attachments shared in a shared Teams channel.
     execution: false
     name: msg-purge-ediscovery-data
+    outputs:
+    - contextPath: MsGraph.eDiscoveryPurge.Status
+      description: 'The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed.'
+      type: String
+    - contextPath: MsGraph.eDiscoveryPurge.LocationURL
+      description: The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status.
+      type: String
+  - arguments:
+    - description: The Location URL returned in the response headers of an eDiscovery action (e.g., purge, hold). This URL points to the operation resource in Microsoft Graph and is used to retrieve the current status of the operation.
+      isArray: false
+      name: location_url
+      required: true
+    description: |-
+      Retrieve the status of a long-running eDiscovery operation using the Location URL returned by action commands such as msg-purge-ediscovery-data or msg-apply-hold-ediscovery-custodian.
+
+      The Location URL is returned in the response headers when an eDiscovery action is initiated and can be used to poll for the operation status until it completes.
+    execution: false
+    name: msg-get-operation-status
+    outputs:
+    - contextPath: MsGraph.eDiscoveryOperation.Id
+      description: The ID of the operation.
+      type: String
+    - contextPath: MsGraph.eDiscoveryOperation.Action
+      description: 'The type of action the operation represents. Possible values include: purgeData, holdUpdate, estimateStatistics, contentExport, and others.'
+      type: String
+    - contextPath: MsGraph.eDiscoveryOperation.Status
+      description: 'The status of the operation. Possible values are: notStarted, running, succeeded, failed, skipped, unknownFutureValue.'
+      type: String
+    - contextPath: MsGraph.eDiscoveryOperation.PercentProgress
+      description: The progress of the operation as a percentage.
+      type: Number
+    - contextPath: MsGraph.eDiscoveryOperation.CreatedDateTime
+      description: The date and time the operation was created.
+      type: Date
+    - contextPath: MsGraph.eDiscoveryOperation.CompletedDateTime
+      description: The date and time the operation was completed.
+      type: Date
   - arguments:
     - description: The email address of the user who received the email.
       isArray: false

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity.yml
@@ -1699,6 +1699,8 @@ script:
       Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
       Private channels - Message posts, replies, and attachments shared in a private Teams channel.
       Shared channels - Message posts, replies, and attachments shared in a shared Teams channel.
+
+      Note: This request purges a maximum of 100 items per location only. When purgeType is set to either recoverable or permanentlyDelete and purgeAreas is set to teamsMessages, the Teams messages are permanently deleted.
     execution: false
     name: msg-purge-ediscovery-data
     outputs:

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_description.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_description.md
@@ -33,7 +33,6 @@ If you previously had an API V1 configured based on the credentials obtained fro
 1. The ***eDiscovery*** and ***Threat Assessment*** commands are only supported when using the `Authorization Code flow` with `Delegated (work or school account)` permission type.
 2. When using `Authorization Code flow`, the connection should be tested using the ***!msg-auth-test*** command.
 3. When using the `Authorization Code flow` for this integration, you should log in as an administrator or a user with administrative privileges (`Security Reader` or `Security Administrator`) after running the ***msg-generate-login-url*** command and the login window appears. For more information, see [here](https://learn.microsoft.com/en-us/graph/security-authorization).
-4. For eDiscovery commands that operate within a specific case, the calling user must be a member of that eDiscovery case or be assigned the **eDiscovery Administrator** role. An **eDiscovery Manager** can only view and manage the eDiscovery cases they create or are a member of. For more information, see [Assign eDiscovery permissions](https://learn.microsoft.com/en-us/purview/ediscovery-assign-permissions).
 
 ### Authentication Based on Azure Managed Identities
 ##### Note: This option is relevant only if the integration is running on Azure VM.

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_description.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_description.md
@@ -33,6 +33,7 @@ If you previously had an API V1 configured based on the credentials obtained fro
 1. The ***eDiscovery*** and ***Threat Assessment*** commands are only supported when using the `Authorization Code flow` with `Delegated (work or school account)` permission type.
 2. When using `Authorization Code flow`, the connection should be tested using the ***!msg-auth-test*** command.
 3. When using the `Authorization Code flow` for this integration, you should log in as an administrator or a user with administrative privileges (`Security Reader` or `Security Administrator`) after running the ***msg-generate-login-url*** command and the login window appears. For more information, see [here](https://learn.microsoft.com/en-us/graph/security-authorization).
+4. For eDiscovery commands that operate within a specific case, the calling user must be a member of that eDiscovery case or be assigned the **eDiscovery Administrator** role. An **eDiscovery Manager** can only view and manage the eDiscovery cases they create or are a member of. For more information, see [Assign eDiscovery permissions](https://learn.microsoft.com/en-us/purview/ediscovery-assign-permissions).
 
 ### Authentication Based on Azure Managed Identities
 ##### Note: This option is relevant only if the integration is running on Azure VM.

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
@@ -38,6 +38,8 @@ from MicrosoftGraphSecurity import (
     list_threat_assessment_requests_command,
     main,
     purge_ediscovery_data_command,
+    get_operation_status_command,
+    get_status_of_operation,
     release_ediscovery_custodian_command,
     reopen_ediscovery_case_command,
     search_alerts_command,
@@ -569,7 +571,32 @@ def test_test_auth_code_command(mocker, command_to_check):
 
 def test_purge_ediscovery_data_command(mocker):
     mocker.patch.object(client_mocker, "purge_ediscovery_data", return_value=SimpleNamespace(headers={}))
-    assert purge_ediscovery_data_command(client_mocker, {}).readable_output == "eDiscovery purge status is success."
+    result = purge_ediscovery_data_command(client_mocker, {})
+    assert result.outputs_prefix == "MsGraph.eDiscoveryPurge"
+    assert result.outputs["Status"] == "success"
+    assert "success" in result.readable_output
+
+
+def test_purge_ediscovery_data_command_with_location(mocker):
+    """
+    Given:
+        A purge response with a Location header.
+    When:
+        Calling purge_ediscovery_data_command.
+    Then:
+        The Location URL is included in the readable output and context outputs.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op456"
+    mocker.patch.object(
+        client_mocker, "purge_ediscovery_data", return_value=SimpleNamespace(headers={"Location": location_url})
+    )
+    mocker.patch.object(client_mocker, "get", return_value={"status": "running", "id": "op456", "action": "purgeData"})
+    result = purge_ediscovery_data_command(client_mocker, {})
+    assert result.outputs_prefix == "MsGraph.eDiscoveryPurge"
+    assert result.outputs["Status"] == "running"
+    assert result.outputs["LocationURL"] == location_url
+    assert "running" in result.readable_output
+    assert location_url in result.readable_output
 
 
 def test_list_ediscovery_non_custodial_data_source_command_empty_output(mocker):
@@ -1288,3 +1315,133 @@ def test_download_operation_export_file_errors(mocker, mock_attrs, expected_erro
         _download_operation_export_file(client_mocker, operation)
 
     assert expected_error_msg in str(e.value)
+
+
+# ==============================
+# get_status_of_operation tests
+# ==============================
+
+
+def test_get_status_of_operation_no_location():
+    """
+    Given:
+        A response with no Location header.
+    When:
+        Calling get_status_of_operation.
+    Then:
+        Returns {'status': 'success'}.
+    """
+    resp = SimpleNamespace(headers={})
+    result = get_status_of_operation(client_mocker, resp)
+    assert result == {"status": "success"}
+
+
+def test_get_status_of_operation_with_location(mocker):
+    """
+    Given:
+        A response with a Location header pointing to an operation.
+    When:
+        Calling get_status_of_operation.
+    Then:
+        Returns the full operation response dict.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op456"
+    mock_response = {"id": "op456", "action": "purgeData", "status": "succeeded", "percentProgress": 100}
+    mocker.patch.object(client_mocker, "get", return_value=mock_response)
+
+    resp = SimpleNamespace(headers={"Location": location_url})
+    result = get_status_of_operation(client_mocker, resp)
+    assert result == mock_response
+
+
+def test_get_status_of_operation_with_location_url(mocker):
+    """
+    Given:
+        A direct location_url string (no Response object).
+    When:
+        Calling get_status_of_operation with location_url parameter.
+    Then:
+        Returns the full operation response dict.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op456"
+    mock_response = {"id": "op456", "action": "purgeData", "status": "running", "percentProgress": 50}
+    mocker.patch.object(client_mocker, "get", return_value=mock_response)
+
+    result = get_status_of_operation(client_mocker, location_url=location_url)
+    assert result == mock_response
+
+
+# ==============================
+# get_operation_status_command tests
+# ==============================
+
+
+def test_get_operation_status_command_missing_url():
+    """
+    Given:
+        No location_url argument.
+    When:
+        Calling get_operation_status_command.
+    Then:
+        Raises DemistoException.
+    """
+    with pytest.raises(DemistoException, match="location_url"):
+        get_operation_status_command(client_mocker, {})
+
+
+def test_get_operation_status_command_success(mocker):
+    """
+    Given:
+        A valid location_url argument.
+    When:
+        Calling get_operation_status_command.
+    Then:
+        Returns CommandResults with the operation status details.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op456"
+    mock_response = {
+        "id": "op456",
+        "action": "purgeData",
+        "status": "succeeded",
+        "percentProgress": 100,
+        "createdDateTime": "2026-05-14T07:00:00Z",
+        "completedDateTime": "2026-05-14T07:05:00Z",
+    }
+    mocker.patch.object(client_mocker, "get", return_value=mock_response)
+
+    result = get_operation_status_command(client_mocker, {"location_url": location_url})
+
+    assert isinstance(result, CommandResults)
+    assert result.outputs_prefix == "MsGraph.eDiscoveryOperation"
+    assert result.outputs["Id"] == "op456"
+    assert result.outputs["Action"] == "purgeData"
+    assert result.outputs["Status"] == "succeeded"
+    assert result.outputs["PercentProgress"] == 100
+    assert "succeeded" in result.readable_output
+
+
+def test_get_operation_status_command_running(mocker):
+    """
+    Given:
+        A location_url for an operation that is still running.
+    When:
+        Calling get_operation_status_command.
+    Then:
+        Returns CommandResults with status 'running'.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op789"
+    mock_response = {
+        "id": "op789",
+        "action": "purgeData",
+        "status": "running",
+        "percentProgress": 45,
+        "createdDateTime": "2026-05-14T07:00:00Z",
+        "completedDateTime": None,
+    }
+    mocker.patch.object(client_mocker, "get", return_value=mock_response)
+
+    result = get_operation_status_command(client_mocker, {"location_url": location_url})
+
+    assert result.outputs["Status"] == "running"
+    assert result.outputs["PercentProgress"] == 45
+    assert result.outputs["CompletedDateTime"] is None

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
@@ -56,6 +56,9 @@ from MicrosoftGraphSecurity import (
     _extract_filename_from_headers,
     _download_operation_export_file,
     export_result_ediscovery_data_command,
+    apply_hold_ediscovery_custodian_command,
+    remove_hold_ediscovery_custodian_command,
+    HoldAction,
 )
 
 client_mocker = MsGraphClient(
@@ -1445,3 +1448,68 @@ def test_get_operation_status_command_running(mocker):
     assert result.outputs["Status"] == "running"
     assert result.outputs["PercentProgress"] == 45
     assert result.outputs["CompletedDateTime"] is None
+
+
+# ==============================
+# update_hold_ediscovery_custodian_command tests
+# ==============================
+
+
+def test_apply_hold_ediscovery_custodian_command_no_location(mocker):
+    """
+    Given:
+        A hold response with no Location header.
+    When:
+        Calling apply_hold_ediscovery_custodian_command.
+    Then:
+        Returns CommandResults with status 'success' and context outputs.
+    """
+    mocker.patch.object(
+        client_mocker, "update_hold_ediscovery_custodian", return_value=SimpleNamespace(headers={})
+    )
+    result = apply_hold_ediscovery_custodian_command(client_mocker, {"case_id": "case1", "custodian_id": "cust1"})
+    assert result.outputs_prefix == "MsGraph.eDiscoveryHoldOperation"
+    assert result.outputs["Status"] == "success"
+    assert "success" in result.readable_output
+
+
+def test_apply_hold_ediscovery_custodian_command_with_location(mocker):
+    """
+    Given:
+        A hold response with a Location header.
+    When:
+        Calling apply_hold_ediscovery_custodian_command.
+    Then:
+        Returns CommandResults with the operation status and Location URL in context and table.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case1/operations/op123"
+    mocker.patch.object(
+        client_mocker, "update_hold_ediscovery_custodian", return_value=SimpleNamespace(headers={"Location": location_url})
+    )
+    mocker.patch.object(client_mocker, "get", return_value={"status": "running", "id": "op123", "action": "holdUpdate"})
+    result = apply_hold_ediscovery_custodian_command(client_mocker, {"case_id": "case1", "custodian_id": "cust1"})
+    assert result.outputs_prefix == "MsGraph.eDiscoveryHoldOperation"
+    assert result.outputs["Status"] == "running"
+    assert result.outputs["LocationURL"] == location_url
+    assert "running" in result.readable_output
+    assert location_url in result.readable_output
+
+
+def test_remove_hold_ediscovery_custodian_command(mocker):
+    """
+    Given:
+        A remove hold response with a Location header.
+    When:
+        Calling remove_hold_ediscovery_custodian_command.
+    Then:
+        Returns CommandResults with the operation status and Location URL.
+    """
+    location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case1/operations/op456"
+    mocker.patch.object(
+        client_mocker, "update_hold_ediscovery_custodian", return_value=SimpleNamespace(headers={"Location": location_url})
+    )
+    mocker.patch.object(client_mocker, "get", return_value={"status": "succeeded", "id": "op456", "action": "holdUpdate"})
+    result = remove_hold_ediscovery_custodian_command(client_mocker, {"case_id": "case1", "custodian_id": "cust1"})
+    assert result.outputs_prefix == "MsGraph.eDiscoveryHoldOperation"
+    assert result.outputs["Status"] == "succeeded"
+    assert result.outputs["LocationURL"] == location_url

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
@@ -58,7 +58,6 @@ from MicrosoftGraphSecurity import (
     export_result_ediscovery_data_command,
     apply_hold_ediscovery_custodian_command,
     remove_hold_ediscovery_custodian_command,
-    HoldAction,
 )
 
 client_mocker = MsGraphClient(
@@ -590,9 +589,7 @@ def test_purge_ediscovery_data_command_with_location(mocker):
         The Location URL is included in the readable output and context outputs.
     """
     location_url = "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case123/operations/op456"
-    mocker.patch.object(
-        client_mocker, "purge_ediscovery_data", return_value=SimpleNamespace(headers={"Location": location_url})
-    )
+    mocker.patch.object(client_mocker, "purge_ediscovery_data", return_value=SimpleNamespace(headers={"Location": location_url}))
     mocker.patch.object(client_mocker, "get", return_value={"status": "running", "id": "op456", "action": "purgeData"})
     result = purge_ediscovery_data_command(client_mocker, {})
     assert result.outputs_prefix == "MsGraph.eDiscoveryPurge"
@@ -1464,9 +1461,7 @@ def test_apply_hold_ediscovery_custodian_command_no_location(mocker):
     Then:
         Returns CommandResults with status 'success' and context outputs.
     """
-    mocker.patch.object(
-        client_mocker, "update_hold_ediscovery_custodian", return_value=SimpleNamespace(headers={})
-    )
+    mocker.patch.object(client_mocker, "update_hold_ediscovery_custodian", return_value=SimpleNamespace(headers={}))
     result = apply_hold_ediscovery_custodian_command(client_mocker, {"case_id": "case1", "custodian_id": "cust1"})
     assert result.outputs_prefix == "MsGraph.eDiscoveryHoldOperation"
     assert result.outputs["Status"] == "success"

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/MicrosoftGraphSecurity_test.py
@@ -58,6 +58,7 @@ from MicrosoftGraphSecurity import (
     export_result_ediscovery_data_command,
     apply_hold_ediscovery_custodian_command,
     remove_hold_ediscovery_custodian_command,
+    build_operation_results,
 )
 
 client_mocker = MsGraphClient(
@@ -1315,6 +1316,54 @@ def test_download_operation_export_file_errors(mocker, mock_attrs, expected_erro
         _download_operation_export_file(client_mocker, operation)
 
     assert expected_error_msg in str(e.value)
+
+
+# ==============================
+# build_operation_results tests
+# ==============================
+
+
+def test_build_operation_results_with_location():
+    """
+    Given:
+        A status and a Location URL.
+    When:
+        Calling build_operation_results.
+    Then:
+        Returns CommandResults with correct outputs_prefix, outputs_key_field, and outputs.
+    """
+    result = build_operation_results(
+        outputs_prefix="MsGraph.eDiscoveryPurge",
+        title="eDiscovery Purge Data Results",
+        status="running",
+        location="https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case1/operations/op1",
+    )
+    assert result.outputs_prefix == "MsGraph.eDiscoveryPurge"
+    assert result.outputs_key_field == "LocationURL"
+    assert result.outputs["Status"] == "running"
+    assert result.outputs["LocationURL"] == "https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/case1/operations/op1"
+    assert "running" in result.readable_output
+    assert "Location URL" in result.readable_output
+
+
+def test_build_operation_results_without_location():
+    """
+    Given:
+        A status with no Location URL (empty string).
+    When:
+        Calling build_operation_results.
+    Then:
+        Returns CommandResults with Status only; LocationURL is empty but present in outputs.
+    """
+    result = build_operation_results(
+        outputs_prefix="MsGraph.eDiscoveryHoldOperation",
+        title="Apply Hold Results",
+        status="success",
+        location="",
+    )
+    assert result.outputs["Status"] == "success"
+    assert result.outputs["LocationURL"] == ""
+    assert "success" in result.readable_output
 
 
 # ==============================

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -1225,11 +1225,6 @@ partial - The custodian is in a mixed state where some sources are on hold and s
 ### msg-remove-hold-ediscovery-custodian
 
 ***
-Start the process of removing hold from eDiscovery custodians.
-
-### msg-remove-hold-ediscovery-custodian
-
-***
 Start the process of removing a hold from eDiscovery custodians.
 
 #### Base Command
@@ -1249,6 +1244,11 @@ Start the process of removing a hold from eDiscovery custodians.
 | --- | --- | --- |
 | MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. | 
 | MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
+
+### msg-create-ediscovery-non-custodial-data-source
+
+***
+Create a new eDiscoveryNoncustodialDataSource object.
 
 #### Base Command
 
@@ -1575,16 +1575,6 @@ You can collect and purge the following categories of Teams content:
 Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called conversations.
 Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called 1:N chats or group conversations.
 Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
-### msg-purge-ediscovery-data
-
-***
-Deletes mailbox items in Exchange or messages in Microsoft Teams that are included in an eDiscovery search.
-
-You can collect and purge the following categories of Teams content:
-
-Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called conversations.
-Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called 1:N chats or group conversations.
-Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
 Private channels - Message posts, replies, and attachments shared in a private Teams channel.
 Shared channels - Message posts, replies, and attachments shared in a shared Teams channel.
 
@@ -1610,6 +1600,17 @@ Note: This request purges a maximum of 100 items per location only. When purgeTy
 | MsGraph.eDiscoveryPurge.Status | String | The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed. | 
 | MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
 
+
+### msg-delete-ediscovery-search
+
+***
+Delete an eDiscoverySearch object.
+
+#### Base Command
+
+`msg-delete-ediscovery-search`
+
+#### Input
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -2731,3 +2731,32 @@ Update the properties of an ediscoveryHoldPolicy object.
 #### Context Output
 
 There is no context output for this command.
+
+### msg-get-operation-status
+
+***
+Retrieve the status of a long-running eDiscovery operation using the Location URL returned by action commands such as msg-purge-ediscovery-data or msg-apply-hold-ediscovery-custodian.
+
+The Location URL is returned in the response headers when an eDiscovery action is initiated and can be used to poll for the operation status until it completes.
+
+#### Base Command
+
+`msg-get-operation-status`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| location_url | The Location URL returned in the response headers of an eDiscovery action (e.g., purge, hold). This URL points to the operation resource in Microsoft Graph and is used to retrieve the current status of the operation. | Required | 
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MsGraph.eDiscoveryOperation.Id | String | The ID of the operation. | 
+| MsGraph.eDiscoveryOperation.Action | String | The type of action the operation represents. Possible values include: purgeData, holdUpdate, estimateStatistics, contentExport, and others. | 
+| MsGraph.eDiscoveryOperation.Status | String | The status of the operation. Possible values are: notStarted, running, succeeded, failed, skipped, unknownFutureValue. | 
+| MsGraph.eDiscoveryOperation.PercentProgress | Number | The progress of the operation as a percentage. | 
+| MsGraph.eDiscoveryOperation.CreatedDateTime | Date | The date and time the operation was created. | 
+| MsGraph.eDiscoveryOperation.CompletedDateTime | Date | The date and time the operation was completed. | 
+

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -1220,7 +1220,7 @@ partial - The custodian is in a mixed state where some sources are on hold and s
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. |
-| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. |
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status. |
 
 #### Command example
 
@@ -1254,7 +1254,7 @@ Start the process of removing a hold from eDiscovery custodians.
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. |
-| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. |
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status. |
 
 #### Command example
 
@@ -1620,7 +1620,7 @@ Note: This request purges a maximum of 100 items per location only. When purgeTy
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
 | MsGraph.eDiscoveryPurge.Status | String | The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed. | 
-| MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
+| MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status. | 
 
 
 ### msg-delete-ediscovery-search
@@ -2751,7 +2751,7 @@ Update the properties of an ediscoveryHoldPolicy object.
 #### Context Output
 
 There is no context output for this command.
-### msg-get-operation-status
+### msg-ediscovery-get-operation-status
 
 ***
 Retrieve the status of a long-running eDiscovery operation using the Location URL returned by action commands such as msg-purge-ediscovery-data or msg-apply-hold-ediscovery-custodian.
@@ -2760,7 +2760,7 @@ The Location URL is returned in the response headers when an eDiscovery action i
 
 #### Base Command
 
-`msg-get-operation-status`
+`msg-ediscovery-get-operation-status`
 
 #### Input
 

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -47,6 +47,8 @@ For more information, see: https://github.com/microsoftgraph/security-api-soluti
 3. eDiscovery.Download.Read - Delegated (Required for the msg-list-case-operation, download_file=True command)
 More information about defining this permission can be found [here](https://learn.microsoft.com/en-us/graph/api/security-caseoperation-get?view=graph-rest-1.0&tabs=http).
 
+> **Note:** In addition to the API permissions above, the calling user must be a member of the eDiscovery case or be assigned the **eDiscovery Administrator** role. An **eDiscovery Manager** can only view and manage the eDiscovery cases they create or are a member of. For more information, see [Assign eDiscovery permissions](https://learn.microsoft.com/en-us/purview/ediscovery-assign-permissions).
+
 **Threat Assessment**:
 
 1. Mail.Read.Shared - Delegated
@@ -1195,12 +1197,12 @@ Get a list of the siteSource objects associated with an eDiscoveryCustodian. Use
 
 ***
 Start the process of applying hold on eDiscovery custodians.
-Available return statuses:
+Available return statuses: 
 notApplied - The custodian is not on hold (all sources in it are not on hold).
 applied - The custodian is on hold (all sources are on hold).
-applying - The custodian is in applying hold state (applyHold operation triggered).
+applying - The custodian is in applying the hold state (applyHold operation triggered).
 removing - The custodian is in removing the hold state(removeHold operation triggered).
-partial - The custodian is in mixed state where some sources are on hold and some not on hold or error state.
+partial - The custodian is in a mixed state where some sources are on hold and some not on hold or error state.
 
 #### Base Command
 
@@ -1210,25 +1212,25 @@ partial - The custodian is in mixed state where some sources are on hold and som
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required |
-| custodian_id | A comma-seperated list of custodians ids to apply a hold to. | Required |
+| case_id | The ID of the eDiscovery case. | Required | 
+| custodian_id | A comma-separated list of custodians IDs to apply a hold to. | Required | 
 
 #### Context Output
 
-There is no context output for this command.
-
-#### Command example
-
-```!msg-apply-hold-ediscovery-custodian custodian_id=09f05c43ffc54ff88cf5c5e89699375d,0af7ca2b84bc4cff930d5d301cc4caf3 case_id=84abfff1-dd69-4559-8f4e-8225e0d505c5```
-
-#### Human Readable Output
-
->Apply hold status is running.
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. | 
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
 
 ### msg-remove-hold-ediscovery-custodian
 
 ***
 Start the process of removing hold from eDiscovery custodians.
+
+### msg-remove-hold-ediscovery-custodian
+
+***
+Start the process of removing a hold from eDiscovery custodians.
 
 #### Base Command
 
@@ -1238,25 +1240,15 @@ Start the process of removing hold from eDiscovery custodians.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required |
-| custodian_id | A comma-seperated list of custodians ids to remove a hold from. | Required |
+| case_id | The ID of the eDiscovery case. | Required | 
+| custodian_id | A comma-separated list of custodians IDs to remove a hold from. | Required | 
 
 #### Context Output
 
-There is no context output for this command.
-
-#### Command example
-
-```!msg-remove-hold-ediscovery-custodian custodian_id=09f05c43ffc54ff88cf5c5e89699375d,0af7ca2b84bc4cff930d5d301cc4caf3 case_id=84abfff1-dd69-4559-8f4e-8225e0d505c5```
-
-#### Human Readable Output
-
->Remove hold status is running.
-
-### msg-create-ediscovery-non-custodial-data-source
-
-***
-Create a new eDiscoveryNoncustodialDataSource object.
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. | 
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
 
 #### Base Command
 
@@ -1583,8 +1575,20 @@ You can collect and purge the following categories of Teams content:
 Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called conversations.
 Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called 1:N chats or group conversations.
 Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+### msg-purge-ediscovery-data
+
+***
+Deletes mailbox items in Exchange or messages in Microsoft Teams that are included in an eDiscovery search.
+
+You can collect and purge the following categories of Teams content:
+
+Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called conversations.
+Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called 1:N chats or group conversations.
+Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
 Private channels - Message posts, replies, and attachments shared in a private Teams channel.
 Shared channels - Message posts, replies, and attachments shared in a shared Teams channel.
+
+Note: This request purges a maximum of 100 items per location only. When purgeType is set to either recoverable or permanentlyDelete and purgeAreas is set to teamsMessages, the Teams messages are permanently deleted.
 
 #### Base Command
 
@@ -1594,25 +1598,18 @@ Shared channels - Message posts, replies, and attachments shared in a shared Tea
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required |
-| search_id | The ID of the eDiscovery search. | Required |
-| purge_type | Whether the action is soft delete or hard delete. Possible values are: permanentlyDelete, recoverable. | Optional |
-| purge_areas | Define the locations to be in scope of the purge action. Possible values are: teamsMessages, mailboxes. | Optional |
+| case_id | The ID of the eDiscovery case. | Required | 
+| search_id | The ID of the eDiscovery search. | Required | 
+| purge_type | Whether the action is soft delete or hard delete. Possible values are: permanentlyDelete, recoverable. | Optional | 
+| purge_areas | Define the locations to be in scope of the purge action. Possible values are: teamsMessages, mailboxes. | Optional | 
 
 #### Context Output
 
-There is no context output for this command.
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| MsGraph.eDiscoveryPurge.Status | String | The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed. | 
+| MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
 
-### msg-delete-ediscovery-search
-
-***
-Delete an eDiscoverySearch object.
-
-#### Base Command
-
-`msg-delete-ediscovery-search`
-
-#### Input
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
@@ -2731,7 +2728,6 @@ Update the properties of an ediscoveryHoldPolicy object.
 #### Context Output
 
 There is no context output for this command.
-
 ### msg-get-operation-status
 
 ***

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -1219,8 +1219,19 @@ partial - The custodian is in a mixed state where some sources are on hold and s
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. | 
-| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
+| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. |
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. |
+
+#### Command example
+
+```!msg-apply-hold-ediscovery-custodian custodian_id=a1b1345673d4,b2c1234565f6c3d4e5 case_id=f71234c4-1234-1234-1234-321fedcba987```
+
+#### Human Readable Output
+
+>### Apply Hold Results
+>|Status|Location URL|
+>|---|---|
+>| running | https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/f7e6d5c4-b3a2-1098-7654-321fedcba987/operations/a1b2c3d4-e5f6-7890-abcd-ef1234567890 |
 
 ### msg-remove-hold-ediscovery-custodian
 
@@ -1242,8 +1253,19 @@ Start the process of removing a hold from eDiscovery custodians.
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. | 
-| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. | 
+| MsGraph.eDiscoveryHoldOperation.Status | String | The status of the hold operation. Possible values are: success, notStarted, running, succeeded, failed. |
+| MsGraph.eDiscoveryHoldOperation.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-get-operation-status command to poll for the operation status. |
+
+#### Command example
+
+```!msg-remove-hold-ediscovery-custodian custodian_id=a1b25412345a1b2c3d4,b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5 case_id=f73tgr5c4-1234-1234-1234-321fedcba987```
+
+#### Human Readable Output
+
+>### Remove Hold Results
+>|Status|Location URL|
+>|---|---|
+>| running | https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/f7e6d5c4-b3a2-1098-7654-321fedcba987/operations/b2c3d4e5-f6a1-2345-bcde-f67890123456 |
 
 ### msg-create-ediscovery-non-custodial-data-source
 

--- a/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
+++ b/Packs/MicrosoftGraphSecurity/Integrations/MicrosoftGraphSecurity/README.md
@@ -1197,7 +1197,7 @@ Get a list of the siteSource objects associated with an eDiscoveryCustodian. Use
 
 ***
 Start the process of applying hold on eDiscovery custodians.
-Available return statuses: 
+Available return statuses:
 notApplied - The custodian is not on hold (all sources in it are not on hold).
 applied - The custodian is on hold (all sources are on hold).
 applying - The custodian is in applying the hold state (applyHold operation triggered).
@@ -1212,8 +1212,8 @@ partial - The custodian is in a mixed state where some sources are on hold and s
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required | 
-| custodian_id | A comma-separated list of custodians IDs to apply a hold to. | Required | 
+| case_id | The ID of the eDiscovery case. | Required |
+| custodian_id | A comma-separated list of custodians IDs to apply a hold to. | Required |
 
 #### Context Output
 
@@ -1229,6 +1229,7 @@ partial - The custodian is in a mixed state where some sources are on hold and s
 #### Human Readable Output
 
 >### Apply Hold Results
+>
 >|Status|Location URL|
 >|---|---|
 >| running | https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/f7e6d5c4-b3a2-1098-7654-321fedcba987/operations/a1b2c3d4-e5f6-7890-abcd-ef1234567890 |
@@ -1246,8 +1247,8 @@ Start the process of removing a hold from eDiscovery custodians.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required | 
-| custodian_id | A comma-separated list of custodians IDs to remove a hold from. | Required | 
+| case_id | The ID of the eDiscovery case. | Required |
+| custodian_id | A comma-separated list of custodians IDs to remove a hold from. | Required |
 
 #### Context Output
 
@@ -1263,6 +1264,7 @@ Start the process of removing a hold from eDiscovery custodians.
 #### Human Readable Output
 
 >### Remove Hold Results
+>
 >|Status|Location URL|
 >|---|---|
 >| running | https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/f7e6d5c4-b3a2-1098-7654-321fedcba987/operations/b2c3d4e5-f6a1-2345-bcde-f67890123456 |
@@ -1610,18 +1612,17 @@ Note: This request purges a maximum of 100 items per location only. When purgeTy
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| case_id | The ID of the eDiscovery case. | Required | 
-| search_id | The ID of the eDiscovery search. | Required | 
-| purge_type | Whether the action is soft delete or hard delete. Possible values are: permanentlyDelete, recoverable. | Optional | 
-| purge_areas | Define the locations to be in scope of the purge action. Possible values are: teamsMessages, mailboxes. | Optional | 
+| case_id | The ID of the eDiscovery case. | Required |
+| search_id | The ID of the eDiscovery search. | Required |
+| purge_type | Whether the action is soft delete or hard delete. Possible values are: permanentlyDelete, recoverable. | Optional |
+| purge_areas | Define the locations to be in scope of the purge action. Possible values are: teamsMessages, mailboxes. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| MsGraph.eDiscoveryPurge.Status | String | The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed. | 
-| MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status. | 
-
+| MsGraph.eDiscoveryPurge.Status | String | The status of the purge operation. Possible values are: success, notStarted, running, succeeded, failed. |
+| MsGraph.eDiscoveryPurge.LocationURL | String | The Location URL returned in the response headers, pointing to the operation resource. Use this URL with the msg-ediscovery-get-operation-status command to poll for the operation status. |
 
 ### msg-delete-ediscovery-search
 
@@ -2751,6 +2752,7 @@ Update the properties of an ediscoveryHoldPolicy object.
 #### Context Output
 
 There is no context output for this command.
+
 ### msg-ediscovery-get-operation-status
 
 ***
@@ -2766,16 +2768,15 @@ The Location URL is returned in the response headers when an eDiscovery action i
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| location_url | The Location URL returned in the response headers of an eDiscovery action (e.g., purge, hold). This URL points to the operation resource in Microsoft Graph and is used to retrieve the current status of the operation. | Required | 
+| location_url | The Location URL returned in the response headers of an eDiscovery action (e.g., purge, hold). This URL points to the operation resource in Microsoft Graph and is used to retrieve the current status of the operation. | Required |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| MsGraph.eDiscoveryOperation.Id | String | The ID of the operation. | 
-| MsGraph.eDiscoveryOperation.Action | String | The type of action the operation represents. Possible values include: purgeData, holdUpdate, estimateStatistics, contentExport, and others. | 
-| MsGraph.eDiscoveryOperation.Status | String | The status of the operation. Possible values are: notStarted, running, succeeded, failed, skipped, unknownFutureValue. | 
-| MsGraph.eDiscoveryOperation.PercentProgress | Number | The progress of the operation as a percentage. | 
-| MsGraph.eDiscoveryOperation.CreatedDateTime | Date | The date and time the operation was created. | 
-| MsGraph.eDiscoveryOperation.CompletedDateTime | Date | The date and time the operation was completed. | 
-
+| MsGraph.eDiscoveryOperation.Id | String | The ID of the operation. |
+| MsGraph.eDiscoveryOperation.Action | String | The type of action the operation represents. Possible values include: purgeData, holdUpdate, estimateStatistics, contentExport, and others. |
+| MsGraph.eDiscoveryOperation.Status | String | The status of the operation. Possible values are: notStarted, running, succeeded, failed, skipped, unknownFutureValue. |
+| MsGraph.eDiscoveryOperation.PercentProgress | Number | The progress of the operation as a percentage. |
+| MsGraph.eDiscoveryOperation.CreatedDateTime | Date | The date and time the operation was created. |
+| MsGraph.eDiscoveryOperation.CompletedDateTime | Date | The date and time the operation was completed. |

--- a/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_4_1.md
+++ b/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_4_1.md
@@ -3,4 +3,4 @@
 
 ##### Microsoft Graph Security
 
-- Added the ***msg-get-operation-status*** command to check the status of long-running eDiscovery operations.
+- Added the ***msg-ediscovery-get-operation-status*** command to check the status of long-running eDiscovery operations.

--- a/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_4_1.md
+++ b/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_4_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Graph Security
+
+- Added the ***msg-get-operation-status*** command to check the status of long-running eDiscovery operations.

--- a/Packs/MicrosoftGraphSecurity/pack_metadata.json
+++ b/Packs/MicrosoftGraphSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Security",
     "description": "Unified gateway to security insights - all from a unified Microsoft Graph\n  Security API.",
     "support": "xsoar",
-    "currentVersion": "2.4.0",
+    "currentVersion": "2.4.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Added the ***msg-get-operation-status*** command to check the status of long-running eDiscovery operations.

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: [link to the issue]([CRTX-249720](https://jira-dc.paloaltonetworks.com/browse/CRTX-249720))

## Must have
- [x] Tests
- [x] Documentation
