### PR TITLE
FreshworksFreshservice: hide mirroring params on unsupported platforms

### DIFF
--- a/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/FreshworksFreshservice.yml
+++ b/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/FreshworksFreshservice.yml
@@ -132,6 +132,9 @@ configuration:
   type: 15
   required: false
   section: Collect
+  hidden:
+  - marketplacev2
+  - platform
 - display: Incident type
   name: incidentType
   type: 13
@@ -144,6 +147,9 @@ configuration:
   type: 8
   required: false
   section: Collect
+  hidden:
+  - marketplacev2
+  - platform
 - additionalinfo: When selected, closing the Cortex XSOAR incident is mirrored in Freshservice.
   defaultvalue: 'false'
   display: Close Mirrored Freshservice Ticket
@@ -151,6 +157,9 @@ configuration:
   type: 8
   required: false
   section: Collect
+  hidden:
+  - marketplacev2
+  - platform
 - additionalinfo: Fetch tasks for each ticket type and consider them in the mirroring (requires an additional API request per ticket).
   defaultvalue: 'false'
   display: Fetch tickets tasks

--- a/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/README.md
+++ b/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/README.md
@@ -8995,7 +8995,9 @@ Gets the list of incidents that were modified since the last update time. Note t
 
 There is no context output for this command.
 
-## Incident Mirroring
+## Incident Mirroring (Cortex XSOAR only)
+
+**Note:** Incident mirroring is supported on Cortex XSOAR only. The mirroring configuration parameters (**Incident Mirroring Direction**, **Close Mirrored XSOAR Incident**, **Close Mirrored Freshservice Ticket**, and **Fetch tickets tasks**) are hidden on Cortex XSIAM and the Cortex platform.
 
 You can enable incident mirroring between Cortex XSOAR incidents and Freshworks Freshservice corresponding events (available from Cortex XSOAR version 6.0.0).
 To set up the mirroring:

--- a/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/README.md
+++ b/Packs/FreshworksFreshservice/Integrations/FreshworksFreshservice/README.md
@@ -8997,8 +8997,6 @@ There is no context output for this command.
 
 ## Incident Mirroring (Cortex XSOAR only)
 
-**Note:** Incident mirroring is supported on Cortex XSOAR only. The mirroring configuration parameters (**Incident Mirroring Direction**, **Close Mirrored XSOAR Incident**, **Close Mirrored Freshservice Ticket**, and **Fetch tickets tasks**) are hidden on Cortex XSIAM and the Cortex platform.
-
 You can enable incident mirroring between Cortex XSOAR incidents and Freshworks Freshservice corresponding events (available from Cortex XSOAR version 6.0.0).
 To set up the mirroring:
 

--- a/Packs/FreshworksFreshservice/ReleaseNotes/1_1_7.md
+++ b/Packs/FreshworksFreshservice/ReleaseNotes/1_1_7.md
@@ -1,0 +1,2 @@
+
+- Documentation and metadata improvements.

--- a/Packs/FreshworksFreshservice/ReleaseNotes/1_1_7.md
+++ b/Packs/FreshworksFreshservice/ReleaseNotes/1_1_7.md
@@ -1,2 +1,6 @@
 
-- Documentation and metadata improvements.
+#### Integrations
+
+##### Freshworks Freshservice
+
+- Metadata and documentation improvements.

--- a/Packs/FreshworksFreshservice/pack_metadata.json
+++ b/Packs/FreshworksFreshservice/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Freshworks Freshservice",
     "description": "Freshservice is a service management solution that allows customers to manage service requests, incidents, change requests tasks, and problem investigation.",
     "support": "xsoar",
-    "currentVersion": "1.1.6",
+    "currentVersion": "1.1.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-69099

## Description
Hides mirror related parameters for unsupported platforms.