### PR TITLE
EDL: fix cache rate parsing

### DIFF
--- a/Packs/ApiModules/ReleaseNotes/2_4_17.md
+++ b/Packs/ApiModules/ReleaseNotes/2_4_17.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### NGINXApiModule
+
+Fixed an issue where certain time values in the instance configuration produced an invalid nginx configuration.

--- a/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule.py
+++ b/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule.py
@@ -122,38 +122,30 @@ def create_nginx_server_conf(file_path: str, port: int, params: dict):
     template_str = params.get("nginx_server_conf") or NGINX_SERVER_CONF
     certificate: str = params.get("certificate", "")
     private_key: str = params.get("key", "")
-    timeout_param = str(params.get("timeout") or "3600")
-    cache_refresh_rate_param = str(params.get("cache_refresh_rate") or "300")
-
-    # Ensure cache_refresh_rate is at least as large as timeout
-    timeout_seconds = parse_nginx_time_to_seconds(timeout_param)
-    cache_refresh_seconds = parse_nginx_time_to_seconds(cache_refresh_rate_param)
-
-    if cache_refresh_seconds < timeout_seconds:
-        cache_refresh_rate_param = timeout_param
-
-    timeout = f"{timeout_param}s" if timeout_param.isdigit() else timeout_param
-    cache_refresh_rate = f"{cache_refresh_rate_param}s" if cache_refresh_rate_param.isdigit() else cache_refresh_rate_param
+    # Normalize all five `cache_*` time params (plus `timeout`) through a single helper so the
+    # rendered nginx directives are always a safe `<int>s` token.
+    timeout = _normalize_nginx_time(params.get("timeout"), default="3600", param_name="timeout")
+    cache_refresh_rate = _normalize_nginx_time(params.get("cache_refresh_rate"), default=timeout, param_name="cache_refresh_rate")
 
     # Ensure cache lock directives are at least as large as the upstream timeout. Otherwise, when an
     # upstream request takes longer than the lock timeout/age, waiting clients bypass the cache lock
     # and stampede the upstream (each waiter then produces an uncached response), defeating the purpose
     # of `proxy_cache_lock on`. Defaults match `timeout`; explicit smaller values are bumped up.
-    cache_lock_timeout_param = str(params.get("cache_lock_timeout") or timeout_param)
-    cache_lock_age_param = str(params.get("cache_lock_age") or timeout_param)
+    cache_lock_timeout = _normalize_nginx_time(params.get("cache_lock_timeout"), default=timeout, param_name="cache_lock_timeout")
+    cache_lock_age = _normalize_nginx_time(params.get("cache_lock_age"), default=timeout, param_name="cache_lock_age")
+    cache_404_ttl = _normalize_nginx_time(params.get("cache_404_ttl"), default="1m", param_name="cache_404_ttl")
+    cache_default_ttl = _normalize_nginx_time(params.get("cache_default_ttl"), default="1m", param_name="cache_default_ttl")
 
-    cache_lock_timeout_seconds = parse_nginx_time_to_seconds(cache_lock_timeout_param)
-    cache_lock_age_seconds = parse_nginx_time_to_seconds(cache_lock_age_param)
-
-    if cache_lock_timeout_seconds < timeout_seconds:
-        cache_lock_timeout_param = timeout_param
-    if cache_lock_age_seconds < timeout_seconds:
-        cache_lock_age_param = timeout_param
-
-    cache_lock_timeout = f"{cache_lock_timeout_param}s" if cache_lock_timeout_param.isdigit() else cache_lock_timeout_param
-    cache_lock_age = f"{cache_lock_age_param}s" if cache_lock_age_param.isdigit() else cache_lock_age_param
-    cache_404_ttl = params.get("cache_404_ttl") or "1m"
-    cache_default_ttl = params.get("cache_default_ttl") or "1m"
+    # Ensure cache_refresh_rate is at least as large as timeout, and apply the same anti-stampede
+    # floor to the cache lock directives. All values are now guaranteed to end in "s" (the helper
+    # always returns `<int>s`), so an O(1) integer compare on the prefix is safe.
+    timeout_seconds = int(timeout[:-1])
+    if int(cache_refresh_rate[:-1]) < timeout_seconds:
+        cache_refresh_rate = timeout
+    if int(cache_lock_timeout[:-1]) < timeout_seconds:
+        cache_lock_timeout = timeout
+    if int(cache_lock_age[:-1]) < timeout_seconds:
+        cache_lock_age = timeout
 
     ssl, extra_headers, sslcerts, proxy_set_range_header = "", "", "", ""
     serverport = port + 1
@@ -392,6 +384,101 @@ def parse_nginx_time_to_seconds(time_str: str) -> int:
         return int(time_str)
     except (ValueError, TypeError):
         raise DemistoException(f"Invalid NGINX time format: {time_str}")
+
+
+# Human-readable units accepted in the "<int> <unit>" form (e.g. "12 hours",
+# "1 minute"). Anything outside this allow-list is rejected up-front so we do
+# not silently inherit dateparser's permissive interpretation of unit-only
+# tokens (e.g. "hours" -> midnight today) or compound expressions
+# (e.g. "12 hours and 5 minutes" -> "12 hours ago at 23:25").
+_NORMALIZE_NGINX_TIME_HUMAN_UNITS = frozenset(
+    {
+        "second",
+        "seconds",
+        "minute",
+        "minutes",
+        "hour",
+        "hours",
+        "day",
+        "days",
+        "week",
+        "weeks",
+        "month",
+        "months",
+        "year",
+        "years",
+    }
+)
+
+
+def _normalize_nginx_time(value: Any, default: str, param_name: str) -> str:
+    """Normalize a user-supplied time value to an nginx-valid ``"<int>s"`` token.
+
+    Accepts:
+      * pure ints       : ``300``, ``"300"`` (must be non-negative)
+      * nginx-native    : ``"12h"``, ``"30m"``, ``"1d"``, ``"2w"``, ``"1M"``,
+                          ``"1y"``, ``"60s"``
+      * human-readable  : strict ``"<positive-int> <unit>"`` form, where unit
+                          is one of ``second(s)``, ``minute(s)``, ``hour(s)``,
+                          ``day(s)``, ``week(s)``, ``month(s)``, ``year(s)``.
+
+    Always returns ``f"{seconds}s"`` (e.g. ``"43200s"``) so the rendered nginx
+    directive is unambiguous and unit-safe — the entire class of unit-string
+    typo bugs in the template is eliminated.
+
+    Falls back to ``default`` (which is itself normalized through the same
+    helper) when ``value`` is ``None``, an empty string, or whitespace-only,
+    so callers can pass either form for the default.
+
+    Args:
+        value: The user-supplied value (may be ``None``, ``int``, or ``str``).
+        default: The fallback value used when ``value`` is empty/missing.
+            Accepts the same formats as ``value``.
+        param_name: Name of the originating parameter; included verbatim in
+            error messages so users can pinpoint the offending field.
+
+    Returns:
+        An nginx-valid time token of the form ``"<int>s"``.
+
+    Raises:
+        DemistoException: If ``value`` (or, when ``value`` is empty,
+            ``default``) is non-empty but cannot be parsed as a valid time
+            value, or resolves to a non-positive number of seconds. The
+            message includes ``param_name`` and the original ``value``.
+    """
+    raw = "" if value is None else str(value).strip()
+    if not raw:
+        raw = str(default).strip()
+
+    # Pre-validate the shape before delegating.
+    tokens = raw.split()
+    accepted_shape = (
+        # nginx-native single token: pure int, or <int><unit-letter>
+        (len(tokens) == 1 and (raw.isdigit() or (raw[:-1].isdigit() and raw[-1] in "smhdwMy")))
+        # strict "<int> <unit>" human-readable form
+        or (len(tokens) == 2 and tokens[0].isdigit() and tokens[1].lower() in _NORMALIZE_NGINX_TIME_HUMAN_UNITS)
+    )
+    if not accepted_shape:
+        raise DemistoException(
+            f"Invalid value for parameter '{param_name}': {value!r}. "
+            f"Expected an nginx-native value (e.g. '12h', '30m', '300') "
+            f"or a human-readable value (e.g. '12 hours', '30 minutes')."
+        )
+
+    try:
+        seconds = parse_nginx_time_to_seconds(raw)
+    except DemistoException as e:
+        raise DemistoException(
+            f"Invalid value for parameter '{param_name}': {value!r}. "
+            f"Expected an nginx-native value (e.g. '12h', '30m', '300') "
+            f"or a human-readable value (e.g. '12 hours', '30 minutes'). "
+            f"Original parser error: {e}"
+        )
+    if seconds <= 0:
+        raise DemistoException(
+            f"Invalid value for parameter '{param_name}': {value!r}. " f"Value must resolve to a positive number of seconds."
+        )
+    return f"{seconds}s"
 
 
 def get_params_port(params: dict = None) -> int:

--- a/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule_test.py
+++ b/Packs/ApiModules/Scripts/NGINXApiModule/NGINXApiModule_test.py
@@ -422,3 +422,206 @@ def test_parse_nginx_time_to_seconds_fail(time_str):
 
     with pytest.raises(DemistoException, match="Invalid NGINX time format"):
         parse_nginx_time_to_seconds(time_str)
+
+
+def test_normalize_nginx_time_integer_string():
+    """
+    Given:  the pure-integer string "300".
+    When:   _normalize_nginx_time is called with it.
+    Then:   it returns the canonical "<int>s" form ("300s").
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    assert _normalize_nginx_time("300", default="1m", param_name="cache_404_ttl") == "300s"
+
+
+def test_normalize_nginx_time_integer_int():
+    """
+    Given:  an actual Python int (300).
+    When:   _normalize_nginx_time is called with it.
+    Then:   it is coerced through str() and returned as "300s".
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    assert _normalize_nginx_time(300, default="1m", param_name="cache_404_ttl") == "300s"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("12h", "43200s"),
+        ("30m", "1800s"),
+        ("1d", "86400s"),
+        ("2w", "1209600s"),
+        ("1M", "2592000s"),
+        ("1y", "31536000s"),
+        ("60s", "60s"),
+    ],
+)
+def test_normalize_nginx_time_nginx_native_single_token(value, expected):
+    """
+    Given:  an nginx-native single-token time string (e.g. "12h", "30m", "1M").
+    When:   _normalize_nginx_time is called with it.
+    Then:   it is converted to the equivalent "<seconds>s" form.
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    assert _normalize_nginx_time(value, default="1m", param_name="cache_refresh_rate") == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected_seconds",
+    [
+        ("12 hours", 43200),
+        ("30 minutes", 1800),
+        ("2 days", 172800),
+        ("2 weeks", 1209600),
+    ],
+)
+def test_normalize_nginx_time_human_readable_plural(value, expected_seconds):
+    """
+    Given:  a plural human-readable time string (e.g. "12 hours", "30 minutes").
+    When:   _normalize_nginx_time is called with it.
+    Then:   the returned "<int>s" token equals the expected number of seconds
+            (allowing ±2s tolerance for the live now() computation inside
+            parse_nginx_time_to_seconds — mirrors the pattern at L407-L408).
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    result = _normalize_nginx_time(value, default="1m", param_name="cache_refresh_rate")
+    assert result.endswith("s")
+    assert abs(int(result[:-1]) - expected_seconds) <= 2
+
+
+@pytest.mark.parametrize(
+    "value, expected_seconds",
+    [
+        ("1 hour", 3600),
+        ("1 minute", 60),
+        ("1 day", 86400),
+    ],
+)
+def test_normalize_nginx_time_human_readable_singular(value, expected_seconds):
+    """
+    Given:  a singular human-readable time string (e.g. "1 hour", "1 minute").
+    When:   _normalize_nginx_time is called with it.
+    Then:   the returned "<int>s" token equals the expected number of seconds
+            (±2s tolerance, same rationale as the plural case).
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    result = _normalize_nginx_time(value, default="1m", param_name="cache_refresh_rate")
+    assert result.endswith("s")
+    assert abs(int(result[:-1]) - expected_seconds) <= 2
+
+
+@pytest.mark.parametrize(
+    "value, default, expected",
+    [
+        (None, "1m", "60s"),
+        ("", "300", "300s"),
+        ("   ", "12h", "43200s"),
+    ],
+)
+def test_normalize_nginx_time_empty_uses_default(value, default, expected):
+    """
+    Given:  an empty / whitespace-only / None value plus a non-empty default.
+    When:   _normalize_nginx_time is called.
+    Then:   the default is normalized and returned in "<int>s" form.
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    assert _normalize_nginx_time(value, default=default, param_name="cache_404_ttl") == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "hours",
+        "12 hours and 5 minutes",
+        "abc",
+        "-5",
+    ],
+)
+def test_normalize_nginx_time_invalid_raises(value):
+    """
+    Given:  a non-empty but unparseable / non-positive time value.
+    When:   _normalize_nginx_time is called.
+    Then:   a DemistoException is raised whose message names the offending
+            parameter so users can pinpoint the misconfigured field.
+    """
+    from NGINXApiModule import _normalize_nginx_time
+
+    with pytest.raises(DemistoException, match="cache_refresh_rate"):
+        _normalize_nginx_time(value, default="1m", param_name="cache_refresh_rate")
+
+
+def test_create_nginx_server_conf_renders_seconds_for_all_five_params(tmp_path: Path, mocker):
+    """
+    Given:  a params dict that mixes nginx-native, human-readable and bare-integer
+            forms across all five cache_* params (plus a "timeout" of 3600s that
+            should floor-bump the lock + refresh values).
+    When:   create_nginx_server_conf renders the nginx server config.
+    Then:   every rendered cache directive is in the safe "<int>s" form, and no
+            occurrence of any human-readable unit word or original input token
+            survives into the rendered conf.
+    """
+    from NGINXApiModule import create_nginx_server_conf
+
+    mocker.patch.object(demisto, "callingContext", return_value={"context": {}})
+    conf_file = str(tmp_path / "nginx-test-server.conf")
+    create_nginx_server_conf(
+        conf_file,
+        12345,
+        params={
+            "timeout": "3600",
+            "cache_refresh_rate": "12 hours",
+            "cache_lock_timeout": "1h",
+            "cache_lock_age": "30m",
+            "cache_404_ttl": "5 minutes",
+            "cache_default_ttl": "300",
+        },
+    )
+    with open(conf_file) as f:
+        conf = f.read()
+
+    # cache_refresh_rate = "12 hours" -> 43200s (>= timeout, not floor-bumped)
+    assert "proxy_cache_valid 200 301 302 43200s;" in conf
+    # cache_lock_timeout = "1h" = 3600s == timeout (not bumped, already at floor)
+    assert "proxy_cache_lock_timeout 3600s;" in conf
+    # cache_lock_age = "30m" = 1800s < timeout (3600s) -> floor-bumped to "3600s"
+    assert "proxy_cache_lock_age 3600s;" in conf
+    # cache_404_ttl = "5 minutes" -> 300s
+    assert "proxy_cache_valid 404 300s;" in conf
+    # cache_default_ttl = "300" -> 300s
+    assert "proxy_cache_valid any 300s;" in conf
+
+    # Hardening: none of the original unit words / non-normalized tokens may
+    # survive into the rendered conf — those are exactly the failure surfaces
+    # that crashed `nginx -T` in the documented incident.
+    for forbidden in ("hours", "minutes", "12h", "30m", "5 minutes"):
+        assert forbidden not in conf, f"Rendered conf must not contain non-normalized substring {forbidden!r}: {conf}"
+
+
+def test_create_nginx_server_conf_rejects_invalid_param(tmp_path: Path, mocker, monkeypatch):
+    """
+    Given:  a params dict with an unparseable value for cache_404_ttl.
+    When:   create_nginx_server_conf is called.
+    Then:   a DemistoException naming the offending param is raised BEFORE any
+            subprocess (i.e. before `nginx -T`) is invoked — the failure is
+            surfaced fast and pointed at the right field.
+    """
+    from NGINXApiModule import create_nginx_server_conf
+
+    mocker.patch.object(demisto, "callingContext", return_value={"context": {}})
+
+    # If create_nginx_server_conf ever drifted to invoke subprocess on bad input,
+    # this fail-loud monkeypatch surfaces the regression instead of hiding it.
+    def _fail_loudly(*_args, **_kwargs):
+        raise AssertionError("subprocess.check_output must not be called for invalid params")
+
+    monkeypatch.setattr(subprocess, "check_output", _fail_loudly)
+
+    conf_file = str(tmp_path / "nginx-test-server.conf")
+    with pytest.raises(DemistoException, match="cache_404_ttl"):
+        create_nginx_server_conf(conf_file, 12345, params={"cache_404_ttl": "garbage"})

--- a/Packs/ApiModules/pack_metadata.json
+++ b/Packs/ApiModules/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ApiModules",
     "description": "API Modules",
     "support": "xsoar",
-    "currentVersion": "2.4.16",
+    "currentVersion": "2.4.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -49,7 +49,7 @@ configuration:
   required: false
   type: 0
   section: Collect
-- additionalinfo: 'How often to refresh the list (e.g., less than 1 minute, 5 minutes, 12 hours, 7 days, 3 months, 1 year). For performance reasons, we do not recommend setting this value at less than 1 minute. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**. If using a bare integer, EDL will still set the HTTP `max-age` correctly, but the response header diagnostics may show a less precise human label.'
+- additionalinfo: How often to refresh the list (e.g., less than 1 minute, 5 minutes, 12 hours, 7 days, 3 months, 1 year). For performance reasons, we do not recommend setting this value at less than 1 minute.
   defaultvalue: 30 minutes
   display: Refresh Rate
   name: cache_refresh_rate
@@ -71,7 +71,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: 'How long a concurrent request waits for an in-flight upstream response before bypassing the cache lock. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout to prevent upstream stampedes when responses take longer than this value. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
+- additionalinfo: How long a concurrent request waits for an in-flight upstream response before bypassing the cache lock. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout to prevent upstream stampedes when responses take longer than this value.
   defaultvalue: 1h
   display: Cache Lock Timeout
   name: cache_lock_timeout
@@ -79,7 +79,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: 'How long the cache lock holder is allowed to populate the cache before another request is permitted to retry. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
+- additionalinfo: How long the cache lock holder is allowed to populate the cache before another request is permitted to retry. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout.
   defaultvalue: 1h
   display: Cache Lock Age
   name: cache_lock_age
@@ -87,7 +87,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: 'The TTL for 404 responses in the cache. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
+- additionalinfo: The TTL for 404 responses in the cache.
   defaultvalue: 1m
   display: Cache 404 TTL
   name: cache_404_ttl
@@ -95,7 +95,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: 'The default TTL for responses in the cache. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
+- additionalinfo: The default TTL for responses in the cache.
   defaultvalue: 1m
   display: Cache Default TTL
   name: cache_default_ttl

--- a/Packs/EDL/Integrations/EDL/EDL.yml
+++ b/Packs/EDL/Integrations/EDL/EDL.yml
@@ -49,7 +49,7 @@ configuration:
   required: false
   type: 0
   section: Collect
-- additionalinfo: How often to refresh the list (e.g., less than 1 minute, 5 minutes, 12 hours, 7 days, 3 months, 1 year). For performance reasons, we do not recommend setting this value at less than 1 minute.
+- additionalinfo: 'How often to refresh the list (e.g., less than 1 minute, 5 minutes, 12 hours, 7 days, 3 months, 1 year). For performance reasons, we do not recommend setting this value at less than 1 minute. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**. If using a bare integer, EDL will still set the HTTP `max-age` correctly, but the response header diagnostics may show a less precise human label.'
   defaultvalue: 30 minutes
   display: Refresh Rate
   name: cache_refresh_rate
@@ -71,7 +71,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: How long a concurrent request waits for an in-flight upstream response before bypassing the cache lock. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout to prevent upstream stampedes when responses take longer than this value.
+- additionalinfo: 'How long a concurrent request waits for an in-flight upstream response before bypassing the cache lock. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout to prevent upstream stampedes when responses take longer than this value. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
   defaultvalue: 1h
   display: Cache Lock Timeout
   name: cache_lock_timeout
@@ -79,7 +79,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: How long the cache lock holder is allowed to populate the cache before another request is permitted to retry. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout.
+- additionalinfo: 'How long the cache lock holder is allowed to populate the cache before another request is permitted to retry. Should be greater than or equal to the Request Timeout; smaller values will be automatically raised to the Request Timeout. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
   defaultvalue: 1h
   display: Cache Lock Age
   name: cache_lock_age
@@ -87,7 +87,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: The TTL for 404 responses in the cache.
+- additionalinfo: 'The TTL for 404 responses in the cache. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
   defaultvalue: 1m
   display: Cache 404 TTL
   name: cache_404_ttl
@@ -95,7 +95,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-- additionalinfo: The default TTL for responses in the cache.
+- additionalinfo: 'The default TTL for responses in the cache. Accepts nginx-native time values (e.g. `12h`, `30m`, `300s`, or a bare integer treated as seconds) or human-readable values (e.g. `12 hours`, `30 minutes`, `1 day`). Invalid values are rejected on **Test**.'
   defaultvalue: 1m
   display: Cache Default TTL
   name: cache_default_ttl

--- a/Packs/EDL/ReleaseNotes/3_3_33.md
+++ b/Packs/EDL/ReleaseNotes/3_3_33.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Generic Export Indicators Service
+
+Fixed an issue where certain time values in the instance configuration produced an invalid nginx configuration.

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Export Indicators Service",
     "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to any product in your network, such as firewalls, agents or SIEMs. This pack supports ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
-    "currentVersion": "3.3.32",
+    "currentVersion": "3.3.33",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_23.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_23.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Export Indicators Service (Deprecated)
+
+Maintenance and stability improvements.

--- a/Packs/ExportIndicators/ReleaseNotes/1_0_23.md
+++ b/Packs/ExportIndicators/ReleaseNotes/1_0_23.md
@@ -3,4 +3,4 @@
 
 ##### Export Indicators Service (Deprecated)
 
-Maintenance and stability improvements.
+- Maintenance and stability improvements.

--- a/Packs/ExportIndicators/pack_metadata.json
+++ b/Packs/ExportIndicators/pack_metadata.json
@@ -3,7 +3,7 @@
     "description": "Deprecated. Use Generic Export Indicators Service instead.",
     "support": "xsoar",
     "hidden": true,
-    "currentVersion": "1.0.22",
+    "currentVersion": "1.0.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/TAXIIServer/ReleaseNotes/2_2_10.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_2_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TAXII2 Server
+
+Maintenance and stability improvements.

--- a/Packs/TAXIIServer/ReleaseNotes/2_2_10.md
+++ b/Packs/TAXIIServer/ReleaseNotes/2_2_10.md
@@ -3,4 +3,4 @@
 
 ##### TAXII2 Server
 
-Maintenance and stability improvements.
+- Maintenance and stability improvements.

--- a/Packs/TAXIIServer/pack_metadata.json
+++ b/Packs/TAXIIServer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Server",
     "description": "This pack provides TAXII Services for system indicators (Outbound feed).",
     "support": "xsoar",
-    "currentVersion": "2.2.9",
+    "currentVersion": "2.2.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: XSUP-69229

## Description
Fixes EDL error (nginx: invalid time value "hours") by normalizing all cache/time params in NGINXApiModule to canonical "<int>s" and rejecting invalid values on Test