### PR TITLE
Fix iManage test button raising a timeout instead of error

### DIFF
--- a/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager.py
+++ b/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager.py
@@ -694,7 +694,7 @@ def test_module_command(client: Client, params: dict[str, Any], event_types: Lis
         # Test each configured event type
         for event_type in event_types:
             demisto.debug(f"Testing connectivity for event type: {event_type}")
-            client._fetch_alerts(event_type, start_time, end_time, 1)
+            client._fetch_alerts(event_type, start_time, end_time, 1, enable_retries=False)
 
     except Exception as e:
         error_str = str(e)

--- a/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager.yml
+++ b/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager.yml
@@ -95,7 +95,7 @@ script:
           required: false
       description: Fetches events from iManage Threat Manager.
       name: imanage-threat-manager-get-events
-  dockerimage: demisto/fastapi:0.125.0.7178097
+  dockerimage: demisto/fastapi:0.125.0.9094740
   isfetchevents: true
   runonce: false
   script: "-"

--- a/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager_test.py
+++ b/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager_test.py
@@ -1015,9 +1015,9 @@ class TestTestModuleCommand:
         test_module_command(client, {}, [BEHAVIOR_ANALYTICS])
 
         mock_fetch.assert_called_once()
-        _, kwargs = mock_fetch.call_args
+        call_kwargs = mock_fetch.call_args.kwargs
         assert (
-            kwargs.get("enable_retries") is False or mock_fetch.call_args[0][4] is False
+            call_kwargs.get("enable_retries") is False
         ), "test_module_command must call _fetch_alerts with enable_retries=False to prevent timeout"
 
 

--- a/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager_test.py
+++ b/Packs/iManageThreatManager/Integrations/iManageThreatManager/iManageThreatManager_test.py
@@ -996,6 +996,30 @@ class TestTestModuleCommand:
             result = test_module_command(client, {}, [BEHAVIOR_ANALYTICS])
             assert "Authorization Error" in result
 
+    @freeze_time("2021-01-10T00:00:00Z")
+    def test_test_module_calls_fetch_alerts_without_retries(self, client, mocker):
+        """
+        Given:
+            - Valid client with credentials
+            - Behavior Analytics event type
+        When:
+            - Calling test_module_command
+        Then:
+            - Ensure _fetch_alerts is called with enable_retries=False
+              to avoid long retry delays that cause platform timeouts
+        """
+        from iManageThreatManager import test_module_command
+
+        mock_fetch = mocker.patch.object(client, "_fetch_alerts", return_value=[])
+
+        test_module_command(client, {}, [BEHAVIOR_ANALYTICS])
+
+        mock_fetch.assert_called_once()
+        _, kwargs = mock_fetch.call_args
+        assert (
+            kwargs.get("enable_retries") is False or mock_fetch.call_args[0][4] is False
+        ), "test_module_command must call _fetch_alerts with enable_retries=False to prevent timeout"
+
 
 class TestGetEventsCommand:
     """Tests for get_events_command function"""

--- a/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
+++ b/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
@@ -3,4 +3,4 @@
 
 ##### iManage Threat Manager
 
-- Fixed an issue where the *Test* button raised a timeout error instead of displaying the actual authentication error.
+- Fixed an issue where the **Test** button raised a timeout error instead of displaying the actual authentication error.

--- a/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
+++ b/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### iManage Threat Manager
+- Updated the Docker image to: *demisto/fastapi:0.125.0.9094740*.
 
 - Fixed an issue where the **Test** button raised a timeout error instead of displaying the actual authentication error.

--- a/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
+++ b/Packs/iManageThreatManager/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### iManage Threat Manager
+
+- Fixed an issue where the *Test* button raised a timeout error instead of displaying the actual authentication error.

--- a/Packs/iManageThreatManager/pack_metadata.json
+++ b/Packs/iManageThreatManager/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "iManage Threat Manager",
     "description": "iManage Threat Manager uses modern techniques including machine learning and user Behavior Analytics to protect privileged information against internal and external threat actors.",
     "support": "xsoar",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "author": "Cortex",
     "created": "2026-02-17T00:00:00Z",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/XSUP-68930

## Description
Fixed an issue where the *Test* button raised a timeout error instead of displaying the actual authentication error
## Must have
- [ ] Tests
- [ ] Documentation
