### PR TITLE
Adding dthash value as XDM logon fingerprint

### DIFF
--- a/Packs/Okta/ModelingRules/OktaModelingRules_2_0/OktaModelingRules_2_0.xif
+++ b/Packs/Okta/ModelingRules/OktaModelingRules_2_0/OktaModelingRules_2_0.xif
@@ -155,7 +155,8 @@ filter
     xdm.source.host.os = json_extract_scalar(client, "$.userAgent.os"),
     xdm.source.application.name = json_extract_scalar(client, "$.userAgent.browser"),
     xdm.event.id = uuid,
-    xdm.source.asn.as_name = json_extract_scalar(securityContext,"$.asOrg");
+    xdm.source.asn.as_name = json_extract_scalar(securityContext,"$.asOrg"),
+    xdm.logon.fingerprint = json_extract_scalar(debugContext, "$.debugData.dtHash");
 
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example relates: link to the issue

## Description

`dtHash` is Okta's “de-identified token hash,” (cryptographic hash function that protects user identifiers within Okta sessions). It is extracted from `debugContext.debugData`, which Okta marks as non-stable/diagnostic, but the dtHash key is well-established in practice.

Use case: detect stolen session tokens by correlating events where the same
dtHash value appears alongside different source IPs or OS families — a strong
indicator that a device token has been stolen and replayed from another machine.

No change to existing tests or docs needed.

## Must have
- [ ] Tests
- [ ] Documentation
