### PR TITLE
Improve zia-category-update command docs

### DIFF
--- a/Packs/Zscaler/Integrations/ZscalerZIdentity/README.md
+++ b/Packs/Zscaler/Integrations/ZscalerZIdentity/README.md
@@ -228,7 +228,7 @@ Updates the URL category for the specified ID.
 | --- | --- | --- |
 | category_id | The URL category for the specified ID. For more information about category ID values, see [the Zscaler documentation](https://automate.zscaler.com/docs/api-reference-and-guides/api-reference/zia/url-categories/get-url-categories). | Required |
 | url | A comma-separated list of URLs to update in the specified category. For example, pandora.com,spotify.com. Important: If any URL contains a comma (,), you must pass the url argument as a JSON list wrapped in backticks (\`). Example: url=\`["https://example.com/foo,bar"]\`. | Optional |
-| ip | A comma-separated list of IP ranges to update in the specified category. For example, 1.2.3.4,8.8.8.8. | Optional |
+| ip | A comma-separated list of custom IP address ranges to update in the specified category. Values must be in CIDR notation. For example, 1.2.3.4/32,8.8.8.8/32. Up to 2000 custom IP address ranges and retaining parent custom IP address ranges can be added, per organization, across all categories. Note: This field is available only if the option to configure custom IP ranges is enabled for your organization. To enable this option, contact Zscaler Support. | Optional |
 | action | The action applied to the URL category. Possible values are: ADD_TO_LIST, REMOVE_FROM_LIST, OVERWRITE. | Required |
 | keywords | Custom keywords associated with a URL category. Up to 2048 custom keywords can be added per organization across all categories. | Optional |
 | description | Description of the URL category. Contains tag name and needs to be localized on client side in case of predefined category. | Optional |

--- a/Packs/Zscaler/Integrations/ZscalerZIdentity/ZscalerZIdentity.yml
+++ b/Packs/Zscaler/Integrations/ZscalerZIdentity/ZscalerZIdentity.yml
@@ -237,7 +237,7 @@ script:
       description: A comma-separated list of URLs to update the specified category. For example, pandora.com,spotify.com. Important If any URL contains a comma (,), you must pass the url argument as a JSON list wrapped in backticks (`). Example url=`["https://example.com/foo,bar"]`.
       isArray: true
     - name: ip
-      description: A comma-separated list of IP ranges to update the specified category. For example, 1.2.3.4,8.8.8.8.
+      description: "A comma-separated list of custom IP address ranges to update the specified category. Values must be in CIDR notation. For example, 1.2.3.4/32,8.8.8.8/32. Up to 2000 custom IP address ranges and retaining parent custom IP address ranges can be added, per organization, across all categories. Note: This field is available only if the option to configure custom IP ranges is enabled for your organization. To enable this option, contact Zscaler Support."
       isArray: true
     - name: action
       description: The action applied to the URL category.
@@ -838,7 +838,7 @@ script:
       type: String
   script: ''
   subtype: python3
-  dockerimage: demisto/python3:3.12.12.6796194
+  dockerimage: demisto/python3:3.12.13.9059085
   type: python
 fromversion: 6.10.0
 tests:

--- a/Packs/Zscaler/ReleaseNotes/1_5_8.md
+++ b/Packs/Zscaler/ReleaseNotes/1_5_8.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### Zscaler Internet Access via ZIdentity
+
+- Improved the documentation of the *ip* argument in the ***zia-category-update*** command.
+
+- Updated the Docker image to: *demisto/python3:3.12.13.9059085*.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zscaler Internet Access",
     "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
     "support": "xsoar",
-    "currentVersion": "1.5.7",
+    "currentVersion": "1.5.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-69384](https://jira-dc.paloaltonetworks.com/browse/XSUP-69384)

## Description
- Improved the documentation of the *ip* argument in the ***zia-category-update*** command.
Based on the [API docs](https://automate.zscaler.com/docs/api-reference-and-guides/api-reference/zia/url-categories/update-category), this only accepts IP ranges (in the CIDR notation).
