### PR TITLE
Deprecate and hide KELARaDark pack

### DIFF
--- a/Packs/KELARaDark/Integrations/RaDark/RaDark.yml
+++ b/Packs/KELARaDark/Integrations/RaDark/RaDark.yml
@@ -3,6 +3,7 @@ provider: KELA
 commonfields:
   id: RaDark
   version: -1
+  deprecated: true
 configuration:
 - additionalinfo: API Key generated from RaDark by your user.
   display: API Key
@@ -60,7 +61,7 @@ configuration:
   - Hacking Discussions
   required: true
   type: 16
-description: This integration enables you to fetch incidents and manage your RaDark monitor from Cortex XSOAR.
+description: Use Generic Webhooks instead. (This integration enables you to fetch incidents and manage your RaDark monitor from Cortex XSOAR.)
 display: RaDark
 name: RaDark
 script:

--- a/Packs/KELARaDark/pack_metadata.json
+++ b/Packs/KELARaDark/pack_metadata.json
@@ -1,7 +1,8 @@
 {
-    "name": "KELA RaDark",
-    "description": "This content pack enables you to fetch incidents and manage your RaDark monitor from Cortex XSOAR.",
+    "name": "KELA RaDark (Deprecated)",
+    "description": "Deprecated. Use Generic Webhooks instead. - This content pack enables you to fetch incidents and manage your RaDark monitor from Cortex XSOAR.",
     "support": "partner",
+    "hidden": true,
     "currentVersion": "1.1.13",
     "author": "KELA",
     "url": "ke-la.com",


### PR DESCRIPTION
This PR deprecates and hides the KELARaDark pack from the Cortex XSOAR Marketplace.

Changes included:
Added deprecated: true to the integration YAML
Added deprecation notice to the integration description
Renamed the pack to include (Deprecated)
Added deprecation notice to the pack description
Added "hidden": true to pack_metadata.json

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16815