### PR TITLE
Cs falcon spotlight catch error

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -3888,7 +3888,7 @@ def save_spotlight_state(context_store: ContentClientContextStore, spotlight_sta
     integration_context = context_store.read()
     integration_context["spotlight_assets"] = spotlight_state.to_dict()
     context_store.write(integration_context)
-    log_falcon_assets(f"Saved Spotlight state to integration context {integration_context=}")
+    log_falcon_assets(f"Saved Spotlight state to integration context (keys: {list(integration_context.keys())})")
 
 
 class AssetsDeviceHandler:
@@ -4677,8 +4677,29 @@ async def fetch_vulnerabilities_by_severity(
             after_token = new_after_token
 
     except ContentClientError as e:
-        # Check if this is an expired cursor error
+        # Check if this is an authentication error (HTTP 401)
+        # Authentication errors are not transient and should fail immediately
+        if e.response and e.response.status_code == 401:
+            error_msg = (
+                f"Authentication failed (HTTP 401) while fetching {severity} severity vulnerabilities. "
+                f"Invalid or expired credentials. Please verify the API credentials and try again. "
+                f"Error: {e}"
+            )
+            log_falcon_assets(f"[{severity}] {error_msg}", "error")
+            raise ContentClientError(error_msg) from e
+        
+        # Check for "Unauthorized" in error message as fallback
         error_str = str(e)
+        if "Unauthorized" in error_str or "401" in error_str:
+            error_msg = (
+                f"Authentication failed while fetching {severity} severity vulnerabilities. "
+                f"Invalid or expired credentials. Please verify the API credentials and try again. "
+                f"Error: {e}"
+            )
+            log_falcon_assets(f"[{severity}] {error_msg}", "error")
+            raise ContentClientError(error_msg) from e
+        
+        # Check if this is an expired cursor error
         if "Search context expired" in error_str or ('"code": 404' in error_str and "after" in error_str):
             log_falcon_assets(
                 f"[{severity}] Pagination cursor expired. This should not happen with continuous fetching. "

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -4687,7 +4687,7 @@ async def fetch_vulnerabilities_by_severity(
             )
             log_falcon_assets(f"[{severity}] {error_msg}", "error")
             raise ContentClientError(error_msg) from e
-        
+
         # Check for "Unauthorized" in error message as fallback
         error_str = str(e)
         if "Unauthorized" in error_str or "401" in error_str:
@@ -4698,7 +4698,7 @@ async def fetch_vulnerabilities_by_severity(
             )
             log_falcon_assets(f"[{severity}] {error_msg}", "error")
             raise ContentClientError(error_msg) from e
-        
+
         # Check if this is an expired cursor error
         if "Search context expired" in error_str or ('"code": 404' in error_str and "after" in error_str):
             log_falcon_assets(

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -9441,10 +9441,7 @@ class TestSpotlightSeverityBasedFetch:
         assert "Invalid or expired credentials" in error_message
 
         # Verify error was logged
-        assert any(
-            "Authentication failed" in str(call) and "error" in str(call)
-            for call in mock_log.call_args_list
-        )
+        assert any("Authentication failed" in str(call) and "error" in str(call) for call in mock_log.call_args_list)
 
     @pytest.mark.asyncio
     async def test_fetch_vulnerabilities_by_severity_401_error_string_match(self, mocker):
@@ -9496,10 +9493,7 @@ class TestSpotlightSeverityBasedFetch:
         assert "Invalid or expired credentials" in error_message
 
         # Verify error was logged
-        assert any(
-            "Authentication failed" in str(call) and "error" in str(call)
-            for call in mock_log.call_args_list
-        )
+        assert any("Authentication failed" in str(call) and "error" in str(call) for call in mock_log.call_args_list)
 
 
 class TestAssetsDeviceHandler:

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -9383,6 +9383,124 @@ class TestSpotlightSeverityBasedFetch:
         # Verify handler received empty set
         mock_handler.receive_new_aids.assert_awaited_once_with(set())
 
+    @pytest.mark.asyncio
+    async def test_fetch_vulnerabilities_by_severity_401_error(self, mocker):
+        """
+        Tests that HTTP 401 authentication errors fail fast without retrying.
+
+        Given:
+            - API returns HTTP 401 Unauthorized error.
+        When:
+            - fetch_vulnerabilities_by_severity is called.
+        Then:
+            - ContentClientError is raised immediately with clear authentication error message.
+            - Error message indicates authentication failure.
+            - No retry attempts are made.
+        """
+        from CrowdStrikeFalcon import fetch_vulnerabilities_by_severity
+        from ContentClientApiModule import ContentClientError
+
+        # Setup
+        mock_client = mocker.AsyncMock()
+        mock_handler = mocker.Mock()
+        mock_handler.receive_new_aids = mocker.AsyncMock()
+
+        # Create a mock response with 401 status code
+        mock_response = mocker.Mock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        # Create ContentClientError with 401 response
+        error_401 = ContentClientError("Unauthorized", response=mock_response)
+
+        # Mock fetch_spotlight_vulnerabilities_page to raise 401 error
+        mocker.patch(
+            "CrowdStrikeFalcon.fetch_spotlight_vulnerabilities_page",
+            side_effect=error_401,
+        )
+
+        # Mock logging
+        mock_log = mocker.patch("CrowdStrikeFalcon.log_falcon_assets")
+
+        # Execute and verify exception is raised
+        with pytest.raises(ContentClientError) as exc_info:
+            await fetch_vulnerabilities_by_severity(
+                client=mock_client,
+                severity="CRITICAL",
+                context_store=mocker.Mock(),
+                spotlight_state=mocker.Mock(),
+                snapshot_id="snap123",
+                asset_handler=mock_handler,
+            )
+
+        # Verify error message contains authentication failure details
+        error_message = str(exc_info.value)
+        assert "Authentication failed" in error_message
+        assert "HTTP 401" in error_message
+        assert "CRITICAL" in error_message
+        assert "Invalid or expired credentials" in error_message
+
+        # Verify error was logged
+        assert any(
+            "Authentication failed" in str(call) and "error" in str(call)
+            for call in mock_log.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_vulnerabilities_by_severity_401_error_string_match(self, mocker):
+        """
+        Tests that 401 errors are detected via string matching when response object is not available.
+
+        Given:
+            - ContentClientError with "Unauthorized" or "401" in error message.
+        When:
+            - fetch_vulnerabilities_by_severity is called.
+        Then:
+            - ContentClientError is raised with clear authentication error message.
+        """
+        from CrowdStrikeFalcon import fetch_vulnerabilities_by_severity
+        from ContentClientApiModule import ContentClientError
+
+        # Setup
+        mock_client = mocker.AsyncMock()
+        mock_handler = mocker.Mock()
+        mock_handler.receive_new_aids = mocker.AsyncMock()
+
+        # Create ContentClientError with "Unauthorized" in message but no response object
+        error_unauthorized = ContentClientError("Request failed: Unauthorized access")
+
+        # Mock fetch_spotlight_vulnerabilities_page to raise error
+        mocker.patch(
+            "CrowdStrikeFalcon.fetch_spotlight_vulnerabilities_page",
+            side_effect=error_unauthorized,
+        )
+
+        # Mock logging
+        mock_log = mocker.patch("CrowdStrikeFalcon.log_falcon_assets")
+
+        # Execute and verify exception is raised
+        with pytest.raises(ContentClientError) as exc_info:
+            await fetch_vulnerabilities_by_severity(
+                client=mock_client,
+                severity="HIGH",
+                context_store=mocker.Mock(),
+                spotlight_state=mocker.Mock(),
+                snapshot_id="snap123",
+                asset_handler=mock_handler,
+            )
+
+        # Verify error message contains authentication failure details
+        error_message = str(exc_info.value)
+        assert "Authentication failed" in error_message
+        assert "HIGH" in error_message
+        assert "Invalid or expired credentials" in error_message
+
+        # Verify error was logged
+        assert any(
+            "Authentication failed" in str(call) and "error" in str(call)
+            for call in mock_log.call_args_list
+        )
+
 
 class TestAssetsDeviceHandler:
     @pytest.mark.asyncio

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_10_2.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_10_2.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Fixed an issue in Spotlight asset collection where HTTP 401 authentication errors were retried instead of failing immediately with a clear error message.
+

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.10.1",
+    "currentVersion": "2.10.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready


## Related Issues
related: https://jira-dc.paloaltonetworks.com/browse/XSUP-66416

## Description
- Fixed an issue in Spotlight asset collection where HTTP 401 authentication errors were retried instead of failing immediately with a clear error message.


## Must have
- [x] Tests

