### PR TITLE
Skip filtering IoC when full feed fetch is enabled in TAXII2 Server

### DIFF
--- a/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.py
+++ b/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2.py
@@ -166,7 +166,14 @@ def fetch_indicators_command(
             client.last_fetched_indicator__modified if client.last_fetched_indicator__modified else added_after
         )
 
-    indicators = filter_previously_fetched_indicators(indicators, last_run_ctx)
+    if not fetch_full_feed:
+        # In incremental mode, skip indicators that were already ingested and not modified since the last fetch.
+        # In full feed mode, all fetched indicators must be passed to demisto.createIndicators() on every cycle
+        # so that the suddenDeath expiration policy can accurately track what is still present in the feed.
+        demisto.debug("Incremental feed mode: filtering previously fetched indicators.")
+        indicators = filter_previously_fetched_indicators(indicators, last_run_ctx)
+    else:
+        demisto.debug(f"Full feed mode: skipping deduplication filter. Passing all {len(indicators)} fetched indicators.")
     demisto.debug(f"{indicators=}")
     return indicators, last_run_ctx
 

--- a/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2_test.py
+++ b/Packs/FeedTAXII/Integrations/FeedTAXII2/FeedTAXII2_test.py
@@ -23,6 +23,51 @@ class TestFetchIndicators:
     Scenario: Test fetch_indicators_command
     """
 
+    STABLE_INDICATORS = [
+        {"value": "1.1.1.1", "type": "IP", "rawJSON": {"id": "indicator--panda-1", "modified": "2023-01-01T00:00:00.000000Z"}},
+        {"value": "2.2.2.2", "type": "IP", "rawJSON": {"id": "indicator--panda-2", "modified": "2023-01-01T00:00:00.000000Z"}},
+    ]
+
+    @pytest.mark.parametrize(
+        "fetch_full_feed, expected_indicator_count",
+        [
+            pytest.param(True, 2, id="full_feed_returns_all_indicators_even_when_unmodified"),
+            pytest.param(False, 0, id="incremental_feed_skips_unmodified_indicators"),
+        ],
+    )
+    def test_full_feed_skips_deduplication_filter(self, mocker, fetch_full_feed, expected_indicator_count):
+        """
+        Scenario: Test that fetch_indicators_command skips the deduplication filter when Full Feed Fetch is enabled.
+
+        Given:
+        - A single collection with 2 stable indicators (not modified since the previous fetch).
+        - A last_run context that already contains those 2 indicators with the same modified date.
+        - Case 1: fetch_full_feed is True.
+        - Case 2: fetch_full_feed is False.
+
+        When:
+        - fetch_indicators_command is called.
+
+        Then:
+        - Case 1: All 2 indicators are returned (deduplication filter is skipped in full feed mode).
+        - Case 2: 0 indicators are returned (deduplication filter removes unchanged indicators in incremental mode).
+        """
+        mock_client = Taxii2FeedClient(url="", collection_to_fetch="default", proxies=[], verify=False, objects_to_fetch=[])
+        mock_client.collections = [MockCollection("col-1", "default")]
+        mock_client.collection_to_fetch = mock_client.collections[0]
+
+        mocker.patch.object(mock_client, "build_iterator", return_value=self.STABLE_INDICATORS)
+
+        last_run = {
+            "latest_indicators": [
+                {"indicator--panda-1": "2023-01-01T00:00:00.000000Z"},
+                {"indicator--panda-2": "2023-01-01T00:00:00.000000Z"},
+            ]
+        }
+
+        indicators, _ = fetch_indicators_command(mock_client, "1 day", -1, last_run, fetch_full_feed=fetch_full_feed)
+        assert len(indicators) == expected_indicator_count
+
     def test_single_no_context(self, mocker):
         """
         Scenario: Test single collection fetch with no last run

--- a/Packs/FeedTAXII/ReleaseNotes/1_2_51.md
+++ b/Packs/FeedTAXII/ReleaseNotes/1_2_51.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### TAXII 2 Feed
+
+- Fixed an issue where indicators that were not modified since the previous fetch were incorrectly skipped when *Full Feed Fetch* was enabled, causing active indicators to be expired by the *When removed from feed* expiration policy.

--- a/Packs/FeedTAXII/pack_metadata.json
+++ b/Packs/FeedTAXII/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "TAXII Feed",
     "description": "Ingest indicator feeds from TAXII 1 and TAXII 2 servers.",
     "support": "xsoar",
-    "currentVersion": "1.2.50",
+    "currentVersion": "1.2.51",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-16832](https://jira-dc.paloaltonetworks.com/browse/CIAC-16832)

## Description
Fixed an issue where indicators that were not modified since the previous fetch were incorrectly skipped when *Full Feed Fetch* was enabled, causing active indicators to be expired by the *When removed from feed* expiration policy.
