### PR TITLE
Wiz content pack v2.0.5: 115s request timeout to fix Toxic Combination hangs

### DIFF
--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -6,7 +6,7 @@ import demistomock as demisto
 from urllib import parse
 
 DEMISTO_OCCURRED_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-WIZ_API_TIMEOUT = 300  # Increase timeout for Wiz API
+API_REQUEST_TIMEOUT = 115  # seconds; keep under the upstream gateway timeout to avoid hangs
 WIZ_HTTP_QUERIES_LIMIT = 500  # Request limit during run
 WIZ_API_LIMIT = 500  # limit number of returned records from the Wiz API
 MAX_NOTE_LENGTH = 1400  # Hard limit for issue note text length enforced by the Wiz API
@@ -1745,7 +1745,13 @@ def get_token():
     auth_payload = parse.urlencode(
         {"grant_type": "client_credentials", "audience": audience, "client_id": said, "client_secret": sasecret}
     )
-    response = requests.post(AUTH_E, headers=HEADERS_AUTH, data=auth_payload)
+    try:
+        response = requests.post(AUTH_E, headers=HEADERS_AUTH, data=auth_payload, timeout=API_REQUEST_TIMEOUT)
+    except requests.Timeout:
+        raise Exception(
+            f"Wiz authentication request timed out after {API_REQUEST_TIMEOUT}s. "
+            "Check Wiz API availability and retry."
+        )
 
     if response.status_code != requests.codes.ok:
         raise Exception(f"Error authenticating to Wiz [{response.status_code}] - {response.text}")
@@ -1772,7 +1778,13 @@ def checkAPIerrors(query, variables):
 
     demisto.info(f"Invoking the API with {json.dumps(data)}")
 
-    response = requests.post(url=URL, json=data, headers=HEADERS)
+    try:
+        response = requests.post(url=URL, json=data, headers=HEADERS, timeout=API_REQUEST_TIMEOUT)
+    except requests.Timeout:
+        raise Exception(
+            f"Wiz API request timed out after {API_REQUEST_TIMEOUT}s. "
+            "Heavy queries (e.g., TOXIC_COMBINATION issue_type) may need a narrower filter."
+        )
     response_json = response.json()
 
     demisto.info(f"Wiz API response status code is {response.status_code}")

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -3132,3 +3132,31 @@ def test_known_phantom_exemptions_are_actually_referenced():
 
     stale = [name for name in _KNOWN_PHANTOM_SOURCES if name not in referenced]
     assert not stale, f"Phantom exemption(s) no longer referenced anywhere — remove from " f"_KNOWN_PHANTOM_SOURCES: {stale}"
+
+
+def test_check_api_errors_wraps_request_timeout(mocker):
+    """REGRESSION: heavy queries (e.g. TOXIC_COMBINATION issue_type) used to block
+    indefinitely until the 5-min Docker hard-kill because requests.post had no
+    timeout. checkAPIerrors must now bound the call with API_REQUEST_TIMEOUT and
+    raise an actionable error on timeout."""
+    import requests as _requests
+    import Wiz as _wiz
+
+    mocker.patch.object(_wiz, "TOKEN", "fake-token")
+    mocker.patch.object(_wiz.requests, "post", side_effect=_requests.Timeout("simulated"))
+
+    with pytest.raises(Exception, match=r"Wiz API request timed out after \d+s"):
+        _wiz.checkAPIerrors(query="query {}", variables={})
+
+
+def test_get_token_wraps_request_timeout(mocker):
+    """Auth POST must also be bounded by API_REQUEST_TIMEOUT and surface a
+    clear actionable error rather than hanging."""
+    import requests as _requests
+    import Wiz as _wiz
+
+    mocker.patch.object(_wiz, "AUTH_E", "https://auth.app.wiz.io/oauth/token")
+    mocker.patch.object(_wiz.requests, "post", side_effect=_requests.Timeout("simulated"))
+
+    with pytest.raises(Exception, match=r"Wiz authentication request timed out after \d+s"):
+        _wiz.get_token()

--- a/Packs/Wiz/ReleaseNotes/2_0_5.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_5.md
@@ -1,0 +1,7 @@
+<~PLATFORM>
+
+## Wiz
+
+- Fixed `wiz-get-issues` (and the fetch-incidents path) hanging indefinitely on heavy queries such as `issue_type=TOXIC_COMBINATION`. The Wiz GraphQL API call and the authentication call are now bounded by a 115-second request timeout; on timeout the integration raises an actionable error instead of being killed by the 5-minute Docker script timeout.
+
+</~PLATFORM>

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Wiz",
     "description": "Integrate with Wiz for bidirectional Issue management, Detections investigation, and fetching of resource information. \n",
     "support": "partner",
-    "currentVersion": "2.0.4",
+    "currentVersion": "2.0.5",
     "author": "Wiz Inc.",
     "url": "https://wiz.io/",
     "email": "support@wiz.io",


### PR DESCRIPTION
## Summary

The Wiz integration's `requests.post` calls (both the GraphQL API and the OAuth token endpoint) had no `timeout=` argument. Heavy queries — most prominently `wiz-get-issues` with `issue_type=TOXIC_COMBINATION` — would hang indefinitely until the XSOAR 5-minute Docker hard-kill, leaving the customer with no actionable error.

Both calls are now bounded by `API_REQUEST_TIMEOUT = 115s` (same pattern as WizDefend, kept under the upstream Wiz gateway timeout). On timeout they raise a clear error suggesting either filter narrowing (API path) or retry (auth path). Combined with the existing `_fetch_all_issue_nodes` budgeted pagination, the integration now either returns partial results or fails fast within seconds instead of silently hanging for 5 minutes.

Reported by AT&T and McKinsey via partner support.

## Changes

- `Packs/Wiz/Integrations/Wiz/Wiz.py`
  - Replaced unused `WIZ_API_TIMEOUT = 300` constant with `API_REQUEST_TIMEOUT = 115`.
  - `get_token`: wrapped `requests.post(AUTH_E, …)` in `try/except requests.Timeout` and pass `timeout=API_REQUEST_TIMEOUT`.
  - `checkAPIerrors`: same treatment on the `requests.post(URL, …)` call; the raised error mentions `TOXIC_COMBINATION` so customers see an actionable hint.
- `Packs/Wiz/Integrations/Wiz/Wiz_test.py`
  - Added `test_check_api_errors_wraps_request_timeout` and `test_get_token_wraps_request_timeout`.
- `Packs/Wiz/pack_metadata.json` → version bump `2.0.4` → `2.0.5` (rebased after upstream v2.0.4 docs release).
- `Packs/Wiz/ReleaseNotes/2_0_5.md` → customer-facing note.

## Test plan

- [x] `pytest Packs/Wiz/Integrations/Wiz/Wiz_test.py` → **241 passed** (incl. 2 new timeout tests).
- [x] `demisto-sdk validate -i Packs/Wiz` → All validations passed.
- [x] `autopep8 --diff` clean.
- [ ] Smoke test on XSOAR 6.14 instance:
  - [ ] `!wiz-get-issues issue_type=THREAT_DETECTION severity=CRITICAL` still returns issues.
  - [ ] Simulate slow upstream → confirm Timeout error surfaces within ~115s instead of being killed at 5 min.

## Customer impact

Customers running `wiz-get-issues` against TOXIC_COMBINATION issues — or any other heavy issue query — will now see a fast, actionable error when the Wiz GraphQL backend is slow, rather than a silent multi-minute hang followed by Docker termination.

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16867