### PR TITLE
AWS Access Analyzer: fix role-based auth test-module failure

### DIFF
--- a/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.py
+++ b/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.py
@@ -167,9 +167,8 @@ def get_findings(aws_client, args):
     return json.loads(json.dumps(response, cls=DatetimeEncoder))
 
 
-def get_earliest_fetch_time():
+def get_earliest_fetch_time(params):
     last_run = demisto.getLastRun()
-    params = demisto.params()
     earliest_fetch_time = last_run and last_run.get("time")
     demisto.debug(f"{last_run=}")
     # Handle first time fetch, fetch incidents retroactively
@@ -179,8 +178,7 @@ def get_earliest_fetch_time():
     return earliest_fetch_time
 
 
-def fetch_incidents(aws_client):
-    params = demisto.params()
+def fetch_incidents(aws_client, params):
     findings_args = {
         "roleArn": params.get("roleArn"),
         "region": params.get("region"),
@@ -190,7 +188,7 @@ def fetch_incidents(aws_client):
         "maxResults": int(params.get("max_fetch", 25)),
     }
 
-    latest_finding_time = earliest_fetch_time = get_earliest_fetch_time()
+    latest_finding_time = earliest_fetch_time = get_earliest_fetch_time(params)
     incidents: list = []
     should_stop_fetch = False
 
@@ -234,8 +232,8 @@ def main():
     aws_access_key_id = params.get("credentials", {}).get("identifier") or params.get("access_key")
     aws_secret_access_key = params.get("credentials", {}).get("password") or params.get("secret_key")
     verify_certificate = not params.get("insecure", True)
-    timeout = demisto.params().get("timeout")
-    retries = demisto.params().get("retries", 5)
+    timeout = params.get("timeout")
+    retries = params.get("retries", 5)
     validate_params(aws_default_region, aws_role_arn, aws_role_session_name, aws_access_key_id, aws_secret_access_key)
 
     aws_client = AWSClient(
@@ -265,7 +263,7 @@ def main():
     }
     try:
         if command == "fetch-incidents":
-            fetch_incidents(aws_client)
+            fetch_incidents(aws_client, params)
         else:
             return_results(commands[command](aws_client, args))
     except Exception as e:

--- a/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.py
+++ b/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.py
@@ -227,8 +227,8 @@ def fetch_incidents(aws_client):
 def main():
     params = demisto.params()
     aws_default_region = params.get("defaultRegion")
-    aws_role_arn = params.get("role_arn")
-    aws_role_session_name = params.get("role_session_name")
+    aws_role_arn = params.get("roleArn")
+    aws_role_session_name = params.get("roleSessionName")
     aws_role_session_duration = params.get("sessionDuration")
     aws_role_policy = None
     aws_access_key_id = params.get("credentials", {}).get("identifier") or params.get("access_key")

--- a/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.yml
+++ b/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.yml
@@ -3,6 +3,9 @@ provider: Amazon
 commonfields:
   id: AWS - AccessAnalyzer
   version: -1
+sectionorder:
+- Connect
+- Collect
 fromversion: 5.0.0
 configuration:
 - display: AWS Default Region
@@ -27,62 +30,74 @@ configuration:
   - us-gov-east-1
   - us-gov-west-1
   type: 15
+  section: Connect
   required: true
 - display: Role Arn
   additionalinfo: The Amazon Resource Name (ARN) role used for EC2 instance authentication. If this is used, an access key and secret key are not required.
   name: roleArn
   type: 0
+  section: Connect
   required: false
 - display: Role Session Name
   additionalinfo: A descriptive name for the assumed role session. For example, xsiam-IAM.integration-Role_SESSION
   name: roleSessionName
   type: 0
+  section: Connect
   required: false
 - display: Role Session Duration
   additionalinfo: The maximum length of each session in seconds. The integration will have the permissions assigned only when the session is initiated and for the defined duration.
   name: sessionDuration
   defaultvalue: 900
   type: 0
+  section: Connect
   required: false
 - display: Fetch incidents
   name: isFetch
   type: 8
+  section: Collect
   required: false
 - display: Incident type
   name: incidentType
   type: 13
+  section: Collect
   required: false
 - display: Access Key
   name: credentials
   type: 9
   displaypassword: Secret Key
+  section: Connect
   required: false
 - display: Access Key
   name: access_key
   type: 0
   hidden: true
+  section: Connect
   required: false
 - display: Secret Key
   name: secret_key
   type: 4
   hidden: true
+  section: Connect
   required: false
 - display: First fetch time interval
   additionalinfo: The time range to consider for the initial data fetch. (<number> <unit>, e.g., 2 minutes, 2 hours, 2 days, 2 months, 2 years).
   defaultvalue: 3 days
   name: first_fetch
   type: 0
+  section: Collect
   required: false
 - display: Maximum number of incidents to fetch every time.
   defaultvalue: '25'
   name: max_fetch
   type: 0
+  section: Collect
   required: false
 - display: Fetch Analyzer ARN
   name: analyzerArn
   additionalinfo: The ARN to fetch findings for.
   defaultvalue: ""
   type: 0
+  section: Collect
   required: false
 - display: AWS STS Regional Endpoints
   additionalinfo: Sets the AWS_STS_REGIONAL_ENDPOINTS environment variable to specify the AWS STS endpoint resolution logic. By default, this option is set to “legacy” in AWS. Leave empty if the environment variable is already set using server configuration.
@@ -96,22 +111,26 @@ configuration:
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
+  section: Connect
   required: false
 - display: Use system proxy settings
   name: proxy
   type: 8
+  section: Connect
   required: false
 - display: Timeout
   name: timeout
   additionalinfo: The time in seconds until a timeout exception is reached. You can specify just the read timeout (for example 60) or also the connect timeout following a comma (for example 60,10). If a connect timeout is not specified, a default of 10 seconds will be used.
   defaultvalue: 60,10
   type: 0
+  section: Connect
   required: false
 - display: Retries
   name: retries
   defaultvalue: 5
   additionalinfo: "The maximum number of retry attempts when connection or throttling errors are encountered. Set to 0 to disable retries. The default value is 5 and the limit is 10. Note: Increasing the number of retries will increase the execution time."
   type: 0
+  section: Connect
   required: false
 description: Amazon Web Services IAM Access Analyzer.
 display: AWS - AccessAnalyzer

--- a/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.yml
+++ b/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer.yml
@@ -311,7 +311,7 @@ script:
       name: roleSessionDuration
     description: Updates findings with the new values provided in the request.
     name: aws-access-analyzer-update-findings
-  dockerimage: demisto/boto3py3:1.0.0.3575453
+  dockerimage: demisto/boto3py3:1.0.0.9311457
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer_test.py
+++ b/Packs/AWS-AccessAnalyzer/Integrations/AWS-AccessAnalyzer/AWS-AccessAnalyzer_test.py
@@ -15,8 +15,8 @@ def get_mocked_client(mocker):
 def mock_required_fields(mocker, command_name, mocked_method_name, method_return_value=None):
     mocked_params = {
         "defaultRegion": "test_region",
-        "role_arn": "test_role_arn",
-        "role_session_name": "test_role_session_name",
+        "roleArn": "test_role_arn",
+        "roleSessionName": "test_role_session_name",
         "credentials": {"identifier": "tets_access_key_id", "password": "test_secret_access_key"},
     }
     mocker.patch.object(demisto, "params", return_value=mocked_params)

--- a/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
+++ b/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
@@ -3,4 +3,4 @@
 
 ##### AWS - AccessAnalyzer
 
-- Fixed an issue where the **test-module** failed with `Missing required parameter in input: ...`.
+- Fixed an issue where connection testing failed with a missing RoleArn / RoleSessionName error when using role-based authentication.

--- a/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
+++ b/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
@@ -4,3 +4,4 @@
 ##### AWS - AccessAnalyzer
 
 - Fixed an issue where connection testing failed with a missing RoleArn / RoleSessionName error when using role-based authentication.
+- Updated the Docker image to: *demisto/boto3py3:1.0.0.9311457*.

--- a/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
+++ b/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### AWS - AccessAnalyzer
+
+- Fixed an issue where the **test-module** failed with `Missing required parameter in input: ...`.

--- a/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
+++ b/Packs/AWS-AccessAnalyzer/ReleaseNotes/1_1_43.md
@@ -3,5 +3,5 @@
 
 ##### AWS - AccessAnalyzer
 
-- Fixed an issue where connection testing failed with a missing RoleArn / RoleSessionName error when using role-based authentication.
+- Fixed an issue where connection testing failed with a missing **RoleArn** / **RoleSessionName** error when using role-based authentication.
 - Updated the Docker image to: *demisto/boto3py3:1.0.0.9311457*.

--- a/Packs/AWS-AccessAnalyzer/pack_metadata.json
+++ b/Packs/AWS-AccessAnalyzer/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS - AccessAnalyzer",
     "description": "Amazon Web Services IAM Access Analyzer",
     "support": "xsoar",
-    "currentVersion": "1.1.42",
+    "currentVersion": "1.1.43",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-69418](https://jira-dc.paloaltonetworks.com/browse/XSUP-69418)

## Description
Fixed an issue where the **test-module** failed with `Missing required parameter in input: ...` for the parameters `RoleArn` and `RoleSessionName `.
