### PR TITLE
Fix/XSUP-69940/FortiManager parsing rule

### DIFF
--- a/Packs/FortiManager/ParsingRules/FortiManager/FortiManager.xif
+++ b/Packs/FortiManager/ParsingRules/FortiManager/FortiManager.xif
@@ -1,9 +1,9 @@
 [INGEST:vendor="fortinet", product="fortimanager", target_dataset="fortinet_fortimanager_raw", no_hit = keep]
-filter _raw_log ~= "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\stz=\"?[-+]\d{4}\"?"
+filter _raw_log ~= "date=\d{4}-\d{2}-\d{2}\s+time=\d{2}:\d{2}:\d{2}\s+tz=\"?[-+]\d{4}\"?"
 
-|alter tmp_date = arrayindex(regextract(_raw_log, "\d{4}-\d{2}-\d{2}"), 0),
-    tmp_time = arrayindex(regextract(_raw_log,"\d{2}:\d{2}:\d{2}"),0),
-    tmp_timezone = arrayindex(regextract(_raw_log ,"tz=\"?([-+]\d+)"), 0)
-| alter tmp_concat_string = concat(tmp_date, " ",tmp_time , " ",tmp_timezone )
-| alter _time = parse_timestamp("%F %X %z", tmp_concat_string  ) 
+|alter tmp_date = arrayindex(regextract(_raw_log, "date=(\d{4}-\d{2}-\d{2})"), 0),
+    tmp_time = arrayindex(regextract(_raw_log, "time=(\d{2}:\d{2}:\d{2})"), 0),
+    tmp_timezone = arrayindex(regextract(_raw_log, "tz=\"?([-+]\d+)"), 0)
+| alter tmp_concat_string = concat(tmp_date, " ", tmp_time, " ", tmp_timezone)
+| alter _time = parse_timestamp("%F %X %z", tmp_concat_string)
 |fields -tmp_* ;

--- a/Packs/FortiManager/ReleaseNotes/1_0_18.md
+++ b/Packs/FortiManager/ReleaseNotes/1_0_18.md
@@ -1,0 +1,6 @@
+
+#### Parsing Rules
+
+##### Fortinet FortiManager Parsing Rule
+
+- Fixed an issue where the parsing rule was storing the log ingestion time instead of the event time in the `_time` field. The rule now correctly extracts the event timestamp from the `date=` and `time=` fields in the raw log.

--- a/Packs/FortiManager/pack_metadata.json
+++ b/Packs/FortiManager/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "FortiManager",
     "description": "Manage your FortiNet firewall",
     "support": "xsoar",
-    "currentVersion": "1.0.17",
+    "currentVersion": "1.0.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-69940

## Description

### Root Cause:
The parsing rule in [FortiManager.xif](vscode-webview://03qtpcstba4ahu93ng75g9hoqh59p6gt6sthn73dor4rdhgbk9p1/Packs/FortiManager/ParsingRules/FortiManager/FortiManager.xif) used a generic regex regextract(_raw_log, "\d{2}:\d{2}:\d{2}") to extract the time component, which grabbed the first HH:MM:SS pattern found anywhere in the raw log — not necessarily the time= field. This caused the wrong timestamp (or the ingestion time fallback) to be stored in _time.

### Fix applied in [FortiManager.xif](vscode-webview://03qtpcstba4ahu93ng75g9hoqh59p6gt6sthn73dor4rdhgbk9p1/Packs/FortiManager/ParsingRules/FortiManager/FortiManager.xif):

Changed the filter to specifically match date=YYYY-MM-DD time=HH:MM:SS tz=... key-value format
Changed tmp_date extraction to use date=(\d{4}-\d{2}-\d{2}) — anchored to the date= field
Changed tmp_time extraction to use time=(\d{2}:\d{2}:\d{2}) — anchored to the time= field
The tz= extraction was already correct and unchanged

## Must have
- [ ] Tests
- [ ] Documentation
