### PR TITLE
changing existing commands, having backward compactibility

### DIFF
--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -1393,19 +1393,35 @@ def get_labels_command(client: "GSuiteClient", args: dict[str, str]) -> CommandR
 
 @logger
 def file_delete_command(client: "GSuiteClient", args: dict[str, str]) -> CommandResults:
-    """
-    Delete a file in Google Drive
+    """Delete a file in Google Drive, or move it to Trash when soft_delete=true.
 
-    :param client: Client object.
-    :param args: Command arguments.
+    Args:
+        client: The authorized GSuite API client.
+        args: Command arguments. When ``soft_delete`` is true, the file is moved
+            to Trash by patching the file with ``{"trashed": true}`` instead of
+            being permanently deleted; default behavior is preserved otherwise.
 
-    :return: Command Result.
+    Returns:
+        CommandResults with the file context. When soft_delete=true the
+        response's ``trashed`` (and ``trashedTime`` for shared drive items) are
+        surfaced under ``GoogleDrive.File.File``.
     """
 
     prepare_file_command_res = prepare_file_command_request(client, args, scopes=COMMAND_SCOPES["FILE_DELETE"])
     http_request_params = prepare_file_command_res["http_request_params"]
 
     url_suffix = URL_SUFFIX["DRIVE_FILES_ID"].format(args.get("file_id"))
+    soft_delete = argToBoolean(args.get("soft_delete") or "false")
+
+    if soft_delete:
+        response = client.http_request(
+            url_suffix=url_suffix,
+            method="PATCH",
+            params=http_request_params,
+            body={"trashed": True},
+        )
+        return handle_response_file_single(response, args)
+
     client.http_request(url_suffix=url_suffix, method="DELETE", params=http_request_params)
     outputs_context = {
         "id": args.get("file_id"),
@@ -1622,6 +1638,8 @@ def file_permission_create_command(client: "GSuiteClient", args: dict[str, str])
     http_request_params.update(
         assign_params(
             sendNotificationEmail=args.get("send_notification_email"),
+            transferOwnership=args.get("transfer_ownership"),
+            moveToNewOwnersRoot=args.get("move_to_new_owners_root"),
         )
     )
 
@@ -1664,13 +1682,18 @@ def file_permission_update_command(client: "GSuiteClient", args: dict[str, str])
 
 @logger
 def file_permission_delete_command(client: "GSuiteClient", args: dict[str, str]) -> CommandResults:
-    """
-    Delete file permissions
+    """Delete a file permission, optionally treating Not Found as success.
 
-    :param client: Client object.
-    :param args: Command arguments.
+    Args:
+        client: The authorized GSuite API client.
+        args: Command arguments. When ``ignore_not_found`` is true, a Not Found
+            response (the permission was already removed) is treated as success
+            and surfaced via the ``alreadyRemoved`` output flag.
 
-    :return: Command Result.
+    Returns:
+        CommandResults with the targeted file id, permission id, and the
+        ``alreadyRemoved`` flag (true only when ignore_not_found=true and the
+        vendor returned Not Found).
     """
 
     prepare_file_permission_request_res = prepare_file_permission_request(
@@ -1679,11 +1702,28 @@ def file_permission_delete_command(client: "GSuiteClient", args: dict[str, str])
     http_request_params = prepare_file_permission_request_res["http_request_params"]
 
     url_suffix = URL_SUFFIX["FILE_PERMISSION_DELETE"].format(args.get("file_id"), args.get("permission_id"))
-    client.http_request(url_suffix=url_suffix, method="DELETE", params=http_request_params)
+    ignore_not_found = argToBoolean(args.get("ignore_not_found") or "false")
+
+    already_removed = False
+    try:
+        client.http_request(url_suffix=url_suffix, method="DELETE", params=http_request_params)
+    except DemistoException as exc:
+        # The shared GSuiteApiModule formats HTTP errors as
+        # "HTTP Connection error occurred. Status: {code}. Reason: {msg}".
+        # Match on the "Status: 404" substring to detect a Not Found.
+        if ignore_not_found and "Status: 404" in str(exc):
+            demisto.debug(
+                f"google-drive-file-permission-delete: permission {args.get('permission_id')} "
+                "already removed; treating Not Found as success"
+            )
+            already_removed = True
+        else:
+            raise
 
     outputs_context: dict = {
         "fileId": args.get("file_id"),
         "id": args.get("permission_id"),
+        "alreadyRemoved": already_removed,
     }
     outputs: dict = {
         OUTPUT_PREFIX["GOOGLE_DRIVE_FILE_PERMISSION_HEADER"]: {

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -1708,15 +1708,9 @@ def file_permission_delete_command(client: "GSuiteClient", args: dict[str, str])
     try:
         client.http_request(url_suffix=url_suffix, method="DELETE", params=http_request_params)
     except DemistoException as exc:
-        # Only swallow Not Found responses that refer to the *permission* itself
-        # (i.e. the permission was already removed). Not Found responses that
-        # refer to the parent file are operator errors and must still be raised
-        # so playbooks do not silently mask a typo in file_id.
-        # The shared GSuiteApiModule surfaces these as:
-        #   "Not found. Reason: Permission not found: <id>"            -- swallowed
-        #   "Not found. Reason: File not found: <id>"                  -- re-raised
-        #   "HTTP Connection error occurred. Status: 404. Reason: ..." -- re-raised unless body
-        #                                                                 names a permission
+        # Narrow match: only swallow "permission not found" so a typo in file_id
+        # (which surfaces as "file not found") still raises.
+        # See GSuiteApiModule.COMMON_MESSAGES for the exact error templates.
         exc_str = str(exc).lower()
         is_permission_not_found = ignore_not_found and (
             "permission not found" in exc_str or "permission_not_found" in exc_str or "permissionnotfound" in exc_str

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py
@@ -1708,10 +1708,20 @@ def file_permission_delete_command(client: "GSuiteClient", args: dict[str, str])
     try:
         client.http_request(url_suffix=url_suffix, method="DELETE", params=http_request_params)
     except DemistoException as exc:
-        # The shared GSuiteApiModule formats HTTP errors as
-        # "HTTP Connection error occurred. Status: {code}. Reason: {msg}".
-        # Match on the "Status: 404" substring to detect a Not Found.
-        if ignore_not_found and "Status: 404" in str(exc):
+        # Only swallow Not Found responses that refer to the *permission* itself
+        # (i.e. the permission was already removed). Not Found responses that
+        # refer to the parent file are operator errors and must still be raised
+        # so playbooks do not silently mask a typo in file_id.
+        # The shared GSuiteApiModule surfaces these as:
+        #   "Not found. Reason: Permission not found: <id>"            -- swallowed
+        #   "Not found. Reason: File not found: <id>"                  -- re-raised
+        #   "HTTP Connection error occurred. Status: 404. Reason: ..." -- re-raised unless body
+        #                                                                 names a permission
+        exc_str = str(exc).lower()
+        is_permission_not_found = ignore_not_found and (
+            "permission not found" in exc_str or "permission_not_found" in exc_str or "permissionnotfound" in exc_str
+        )
+        if is_permission_not_found:
             demisto.debug(
                 f"google-drive-file-permission-delete: permission {args.get('permission_id')} "
                 "already removed; treating Not Found as success"

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2605,7 +2605,7 @@ script:
       - "true"
       - "false"
     - auto: PREDEFINED
-      description: 'When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior.'
+      description: 'Whether to move the file to Trash instead of permanently deleting it. When set, the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior.'
       name: soft_delete
       predefined:
       - "true"
@@ -2615,10 +2615,10 @@ script:
       description: ID of the deleted file.
       type: String
     - contextPath: GoogleDrive.File.File.trashed
-      description: True when the file is in Trash after a soft delete. Only populated when soft_delete=true.
+      description: Whether the file is in Trash after a soft delete. Only populated when soft_delete=true.
       type: Boolean
     - contextPath: GoogleDrive.File.File.trashedTime
-      description: ISO 8601 timestamp when the file was moved to Trash. Only populated for items in shared drives; not populated for items in My Drive.
+      description: The ISO 8601 timestamp when the file was moved to Trash. Only populated for items in shared drives; not populated for items in My Drive.
       type: Date
   - name: google-drive-file-permissions-list
     description: Lists a file's or shared drive's permissions.
@@ -2719,7 +2719,7 @@ script:
     - name: email_address
       description: The email address of the user or group to which this permission refers.
     - auto: PREDEFINED
-      description: 'Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior.'
+      description: 'Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior.'
       name: transfer_ownership
       predefined:
       - "true"
@@ -2813,7 +2813,7 @@ script:
       - "true"
       - "false"
     - auto: PREDEFINED
-      description: 'When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set.'
+      description: 'Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set.'
       name: ignore_not_found
       predefined:
       - "true"
@@ -2826,7 +2826,7 @@ script:
       description: The ID of the deleted permission.
       type: String
     - contextPath: GoogleDrive.FilePermission.FilePermission.alreadyRemoved
-      description: True when ignore_not_found=true and the permission was already removed (the vendor returned Not Found).
+      description: Whether the permission was already removed. Set to true when ignore_not_found=true and the vendor returned Not Found.
       type: Boolean
   - name: google-drive-file-modify-label
     description: Modify labels to file.

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2606,7 +2606,7 @@ script:
       - "false"
     - auto: PREDEFINED
       defaultValue: "false"
-      description: 'Whether to move the file to Trash instead of permanently deleting it. When set to "true", the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior.'
+      description: 'Whether to move the file to the Trash instead of permanently deleting it. If "true", the file is moved to the Trash. If "false", the file is permanently deleted.'
       name: soft_delete
       predefined:
       - "true"

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2591,10 +2591,10 @@ script:
       description: A link to the user's profile photo, if available.
       type: String
   - name: google-drive-file-delete
-    description: Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to true, the file is moved to Trash instead of being permanently deleted.
+    description: Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to "true", the file is moved to Trash instead of being permanently deleted.
     arguments:
     - name: file_id
-      description: ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
+      description: The ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
     - name: user_id
       description: The user's primary email address.
     - auto: PREDEFINED
@@ -2605,17 +2605,18 @@ script:
       - "true"
       - "false"
     - auto: PREDEFINED
-      description: 'Whether to move the file to Trash instead of permanently deleting it. When set, the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior.'
+      defaultValue: "false"
+      description: 'Whether to move the file to Trash instead of permanently deleting it. When set to "true", the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior.'
       name: soft_delete
       predefined:
       - "true"
       - "false"
     outputs:
     - contextPath: GoogleDrive.File.File.id
-      description: ID of the deleted file.
+      description: The ID of the deleted file.
       type: String
     - contextPath: GoogleDrive.File.File.trashed
-      description: Whether the file is in Trash after a soft delete. Only populated when soft_delete=true.
+      description: Whether the file is in Trash after a soft delete. Only populated when soft_delete is set to "true".
       type: Boolean
     - contextPath: GoogleDrive.File.File.trashedTime
       description: The ISO 8601 timestamp when the file was moved to Trash. Only populated for items in shared drives; not populated for items in My Drive.
@@ -2624,14 +2625,14 @@ script:
     description: Lists a file's or shared drive's permissions.
     arguments:
     - name: file_id
-      description: ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
+      description: The ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
     - name: user_id
       description: The user's primary email address.
     - name: page_size
-      description: "Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive."
+      description: "The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive."
       defaultValue: "100"
     - name: page_token
-      description: Page token for shared drives.
+      description: The page token for shared drives.
     - auto: PREDEFINED
       defaultValue: "false"
       description: 'Whether the requesting application supports both My Drives and shared drives.'
@@ -2642,7 +2643,7 @@ script:
     - auto: PREDEFINED
       defaultValue: "false"
       name: use_domain_admin_access
-      description: "Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned."
+      description: 'Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned.'
       predefined:
       - "true"
       - "false"
@@ -2719,13 +2720,15 @@ script:
     - name: email_address
       description: The email address of the user or group to which this permission refers.
     - auto: PREDEFINED
+      defaultValue: "false"
       description: 'Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior.'
       name: transfer_ownership
       predefined:
       - "true"
       - "false"
     - auto: PREDEFINED
-      description: 'Whether to move the file to the new owner''s root folder. Only takes effect when transfer_ownership=true.'
+      defaultValue: "false"
+      description: 'Whether to move the file to the new owner''s root folder. Only takes effect when transfer_ownership is set to "true".'
       name: move_to_new_owners_root
       predefined:
       - "true"
@@ -2797,10 +2800,10 @@ script:
       description: A link to the user's profile photo, if available.
       type: String
   - name: google-drive-file-permission-delete
-    description: Delete a permission. When the ignore_not_found argument is set to true, a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
+    description: Deletes a permission. When the ignore_not_found argument is set to "true", a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
     arguments:
     - name: file_id
-      description: ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
+      description: The ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
     - name: user_id
       description: The user's primary email address.
     - name: permission_id
@@ -2813,6 +2816,7 @@ script:
       - "true"
       - "false"
     - auto: PREDEFINED
+      defaultValue: "false"
       description: 'Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set.'
       name: ignore_not_found
       predefined:
@@ -2826,7 +2830,7 @@ script:
       description: The ID of the deleted permission.
       type: String
     - contextPath: GoogleDrive.FilePermission.FilePermission.alreadyRemoved
-      description: Whether the permission was already removed. Set to true when ignore_not_found=true and the vendor returned Not Found.
+      description: Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found.
       type: Boolean
   - name: google-drive-file-modify-label
     description: Modify labels to file.

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml
@@ -2591,7 +2591,7 @@ script:
       description: A link to the user's profile photo, if available.
       type: String
   - name: google-drive-file-delete
-    description: Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted.
+    description: Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to true, the file is moved to Trash instead of being permanently deleted.
     arguments:
     - name: file_id
       description: ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
@@ -2604,10 +2604,22 @@ script:
       predefined:
       - "true"
       - "false"
+    - auto: PREDEFINED
+      description: 'When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior.'
+      name: soft_delete
+      predefined:
+      - "true"
+      - "false"
     outputs:
     - contextPath: GoogleDrive.File.File.id
       description: ID of the deleted file.
       type: String
+    - contextPath: GoogleDrive.File.File.trashed
+      description: True when the file is in Trash after a soft delete. Only populated when soft_delete=true.
+      type: Boolean
+    - contextPath: GoogleDrive.File.File.trashedTime
+      description: ISO 8601 timestamp when the file was moved to Trash. Only populated for items in shared drives; not populated for items in My Drive.
+      type: Date
   - name: google-drive-file-permissions-list
     description: Lists a file's or shared drive's permissions.
     arguments:
@@ -2656,6 +2668,18 @@ script:
     - contextPath: GoogleDrive.FilePermission.FilePermission.photoLink
       description: A link to the user's profile photo, if available.
       type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType
+      description: 'The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives.'
+      type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.permissionDetails.inheritedFrom
+      description: The ID of the item from which this permission is inherited. Only populated for items in shared drives.
+      type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.permissionDetails.role
+      description: 'The primary role for this user. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", "reader".'
+      type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.permissionDetails.inherited
+      description: Whether this permission is inherited. Always populated for items in shared drives.
+      type: Boolean
   - name: google-drive-file-permission-create
     description: Creates a permission for a file or shared drive.
     arguments:
@@ -2694,6 +2718,18 @@ script:
       description: The domain to which this permission refers.
     - name: email_address
       description: The email address of the user or group to which this permission refers.
+    - auto: PREDEFINED
+      description: 'Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior.'
+      name: transfer_ownership
+      predefined:
+      - "true"
+      - "false"
+    - auto: PREDEFINED
+      description: 'Whether to move the file to the new owner''s root folder. Only takes effect when transfer_ownership=true.'
+      name: move_to_new_owners_root
+      predefined:
+      - "true"
+      - "false"
     outputs:
     - contextPath: GoogleDrive.FilePermission.FilePermission.deleted
       description: Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions.
@@ -2761,7 +2797,7 @@ script:
       description: A link to the user's profile photo, if available.
       type: String
   - name: google-drive-file-permission-delete
-    description: Delete a permission.
+    description: Delete a permission. When the ignore_not_found argument is set to true, a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
     arguments:
     - name: file_id
       description: ID of the requested file. Can be retrieved using the `google-drive-files-list` command.
@@ -2776,6 +2812,22 @@ script:
       predefined:
       - "true"
       - "false"
+    - auto: PREDEFINED
+      description: 'When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set.'
+      name: ignore_not_found
+      predefined:
+      - "true"
+      - "false"
+    outputs:
+    - contextPath: GoogleDrive.FilePermission.FilePermission.fileId
+      description: The ID of the file whose permission was targeted.
+      type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.id
+      description: The ID of the deleted permission.
+      type: String
+    - contextPath: GoogleDrive.FilePermission.FilePermission.alreadyRemoved
+      description: True when ignore_not_found=true and the permission was already removed (the vendor returned Not Found).
+      type: Boolean
   - name: google-drive-file-modify-label
     description: Modify labels to file.
     arguments:

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive_test.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive_test.py
@@ -1226,3 +1226,279 @@ class TestFilePermissionMethods:
         assert call_kwargs["params"]["supportsAllDrives"] is True
         assert call_kwargs["body"]["name"] == "Shared Drive Folder"
         assert call_kwargs["body"]["parents"] == ["shared_drive_root_id"]
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_delete_command_soft_delete_true(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-delete invoked with soft_delete=true.
+
+        Given:
+        - file_id, user_id, and soft_delete=true.
+
+        When:
+        - Calling file_delete_command.
+
+        Then:
+        - The HTTP call is a PATCH (not DELETE) with body {"trashed": True}, and
+          the response's trashed field is surfaced under GoogleDrive.File.File.
+        """
+        from GoogleDrive import file_delete_command
+
+        mock_response = {
+            "kind": "drive#file",
+            "id": "file_id_123",
+            "name": "Quarterly Report.docx",
+            "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "trashed": True,
+            "trashedTime": "2026-05-29T12:00:00.000Z",
+        }
+        mocker_http_request.return_value = mock_response
+
+        args = {"file_id": "file_id_123", "user_id": "owner@example.com", "soft_delete": "true"}
+        result: CommandResults = file_delete_command(gsuite_client, args)
+
+        _, call_kwargs = mocker_http_request.call_args
+        assert call_kwargs["method"] == "PATCH"
+        assert call_kwargs["body"] == {"trashed": True}
+        assert "drive/v3/files/file_id_123" in call_kwargs["url_suffix"]
+
+        file_ctx = result.outputs.get("GoogleDrive.File").get("File")
+        assert file_ctx.get("trashed") is True
+        assert file_ctx.get("trashedTime") == "2026-05-29T12:00:00.000Z"
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_delete_command_soft_delete_default_hard_delete(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-delete invoked without soft_delete.
+
+        Given:
+        - file_id, user_id, and no soft_delete argument (default behavior).
+
+        When:
+        - Calling file_delete_command.
+
+        Then:
+        - The HTTP call is a DELETE (existing behavior preserved bit-for-bit),
+          no PATCH body is sent, and the legacy output shape is emitted.
+        """
+        from GoogleDrive import file_delete_command
+
+        mocker_http_request.return_value = None
+
+        args = {"file_id": "file_id_456", "user_id": "owner@example.com"}
+        result: CommandResults = file_delete_command(gsuite_client, args)
+
+        _, call_kwargs = mocker_http_request.call_args
+        assert call_kwargs["method"] == "DELETE"
+        # The legacy DELETE path must not send a body.
+        assert "body" not in call_kwargs or call_kwargs.get("body") is None
+
+        file_ctx = result.outputs.get("GoogleDrive.File").get("File")
+        assert file_ctx.get("id") == "file_id_456"
+        assert "trashed" not in file_ctx
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_create_command_transfer_ownership(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-permission-create invoked with transfer_ownership=true.
+
+        Given:
+        - role=owner, type=user, email_address set, and transfer_ownership=true.
+
+        When:
+        - Calling file_permission_create_command.
+
+        Then:
+        - The transferOwnership query parameter is forwarded to the vendor;
+          when the argument is omitted on a second call, the parameter is absent.
+        """
+        from GoogleDrive import file_permission_create_command
+
+        with open("test_data/file_permission_create_response.json", encoding="utf-8") as data:
+            mock_response = json.load(data)
+        mocker_http_request.return_value = mock_response
+
+        args_with = {
+            "file_id": "file_id_789",
+            "user_id": "admin@example.com",
+            "role": "owner",
+            "type": "user",
+            "email_address": "newowner@example.com",
+            "transfer_ownership": "true",
+        }
+        file_permission_create_command(gsuite_client, args_with)
+        _, call_kwargs_with = mocker_http_request.call_args
+        assert call_kwargs_with["params"].get("transferOwnership") == "true"
+
+        args_without = {
+            "file_id": "file_id_789",
+            "user_id": "admin@example.com",
+            "role": "reader",
+            "type": "user",
+            "email_address": "viewer@example.com",
+        }
+        file_permission_create_command(gsuite_client, args_without)
+        _, call_kwargs_without = mocker_http_request.call_args
+        assert "transferOwnership" not in call_kwargs_without["params"]
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_create_command_move_to_new_owners_root(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-permission-create invoked with move_to_new_owners_root.
+
+        Given:
+        - role=owner, transfer_ownership=true, and move_to_new_owners_root=true.
+
+        When:
+        - Calling file_permission_create_command.
+
+        Then:
+        - The moveToNewOwnersRoot query parameter is forwarded to the vendor;
+          when the argument is omitted on a second call, the parameter is absent.
+        """
+        from GoogleDrive import file_permission_create_command
+
+        with open("test_data/file_permission_create_response.json", encoding="utf-8") as data:
+            mock_response = json.load(data)
+        mocker_http_request.return_value = mock_response
+
+        args_with = {
+            "file_id": "file_id_789",
+            "user_id": "admin@example.com",
+            "role": "owner",
+            "type": "user",
+            "email_address": "newowner@example.com",
+            "transfer_ownership": "true",
+            "move_to_new_owners_root": "true",
+        }
+        file_permission_create_command(gsuite_client, args_with)
+        _, call_kwargs_with = mocker_http_request.call_args
+        assert call_kwargs_with["params"].get("moveToNewOwnersRoot") == "true"
+
+        args_without = {
+            "file_id": "file_id_789",
+            "user_id": "admin@example.com",
+            "role": "owner",
+            "type": "user",
+            "email_address": "newowner@example.com",
+            "transfer_ownership": "true",
+        }
+        file_permission_create_command(gsuite_client, args_without)
+        _, call_kwargs_without = mocker_http_request.call_args
+        assert "moveToNewOwnersRoot" not in call_kwargs_without["params"]
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_delete_command_ignore_not_found_404_treated_success(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-permission-delete with ignore_not_found=true on a 404.
+
+        Given:
+        - The shared GSuite client raises DemistoException with "Status: 404" in
+          the message (the documented HTTP_ERROR template).
+        - ignore_not_found=true.
+
+        When:
+        - Calling file_permission_delete_command.
+
+        Then:
+        - The exception is swallowed and the result surfaces alreadyRemoved=True.
+        - With ignore_not_found omitted, the same 404 still raises (default
+          behavior preserved).
+        """
+        from GoogleDrive import file_permission_delete_command
+
+        mocker_http_request.side_effect = DemistoException("HTTP Connection error occurred. Status: 404. Reason: Not Found")
+
+        args = {
+            "file_id": "file_id_999",
+            "user_id": "admin@example.com",
+            "permission_id": "perm_id_111",
+            "ignore_not_found": "true",
+        }
+        result: CommandResults = file_permission_delete_command(gsuite_client, args)
+        perm_ctx = result.outputs.get("GoogleDrive.FilePermission").get("FilePermission")
+        assert perm_ctx.get("alreadyRemoved") is True
+        assert perm_ctx.get("id") == "perm_id_111"
+        assert perm_ctx.get("fileId") == "file_id_999"
+
+        args_default = dict(args)
+        args_default.pop("ignore_not_found")
+        with pytest.raises(DemistoException, match="Status: 404"):
+            file_permission_delete_command(gsuite_client, args_default)
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_delete_command_ignore_not_found_other_error_still_raises(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-permission-delete with ignore_not_found=true on non-404.
+
+        Given:
+        - The shared GSuite client raises DemistoException with "Status: 403".
+        - ignore_not_found=true.
+
+        When:
+        - Calling file_permission_delete_command.
+
+        Then:
+        - The exception is still raised; only Not Found is swallowed.
+        """
+        from GoogleDrive import file_permission_delete_command
+
+        mocker_http_request.side_effect = DemistoException("HTTP Connection error occurred. Status: 403. Reason: Forbidden")
+
+        args = {
+            "file_id": "file_id_999",
+            "user_id": "admin@example.com",
+            "permission_id": "perm_id_222",
+            "ignore_not_found": "true",
+        }
+        with pytest.raises(DemistoException, match="Status: 403"):
+            file_permission_delete_command(gsuite_client, args)
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_list_command_inherited_output(self, mocker_http_request, gsuite_client):
+        """
+        Scenario: google-drive-file-permissions-list surfaces permissionDetails.
+
+        Given:
+        - A vendor response containing permissionDetails with inherited=true.
+
+        When:
+        - Calling file_permission_list_command.
+
+        Then:
+        - The permissionDetails field is surfaced under
+          GoogleDrive.FilePermission.FilePermission so playbooks can filter on it.
+        """
+        from GoogleDrive import file_permission_list_command
+
+        mock_response = {
+            "kind": "drive#permissionList",
+            "permissions": [
+                {
+                    "id": "perm_inherited",
+                    "type": "user",
+                    "role": "writer",
+                    "emailAddress": "shared@example.com",
+                    "permissionDetails": [
+                        {
+                            "permissionType": "file",
+                            "role": "writer",
+                            "inheritedFrom": "parent_folder_id",
+                            "inherited": True,
+                        }
+                    ],
+                }
+            ],
+        }
+        mocker_http_request.return_value = mock_response
+
+        args = {"file_id": "file_id_xyz", "user_id": "owner@example.com", "supports_all_drives": "true"}
+        result: CommandResults = file_permission_list_command(gsuite_client, args)
+
+        perm_ctx = result.outputs.get("GoogleDrive.FilePermission").get("FilePermission")
+        # The list command surfaces an array; the helper may emit a single dict
+        # when there is one permission. Normalize for the assertion.
+        perms = perm_ctx if isinstance(perm_ctx, list) else [perm_ctx]
+        assert perms[0].get("permissionDetails")[0].get("inherited") is True
+        assert perms[0].get("permissionDetails")[0].get("inheritedFrom") == "parent_folder_id"
+        assert perms[0].get("permissionDetails")[0].get("permissionType") == "file"

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive_test.py
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive_test.py
@@ -1390,11 +1390,11 @@ class TestFilePermissionMethods:
     @patch(MOCKER_HTTP_METHOD)
     def test_file_permission_delete_command_ignore_not_found_404_treated_success(self, mocker_http_request, gsuite_client):
         """
-        Scenario: google-drive-file-permission-delete with ignore_not_found=true on a 404.
+        Scenario: google-drive-file-permission-delete with ignore_not_found=true on a permission Not Found.
 
         Given:
-        - The shared GSuite client raises DemistoException with "Status: 404" in
-          the message (the documented HTTP_ERROR template).
+        - The shared GSuite client raises DemistoException carrying the
+          documented "Permission not found" reason from Drive.
         - ignore_not_found=true.
 
         When:
@@ -1402,12 +1402,10 @@ class TestFilePermissionMethods:
 
         Then:
         - The exception is swallowed and the result surfaces alreadyRemoved=True.
-        - With ignore_not_found omitted, the same 404 still raises (default
-          behavior preserved).
+        - With ignore_not_found omitted, the same Not Found still raises
+          (default behavior preserved).
         """
         from GoogleDrive import file_permission_delete_command
-
-        mocker_http_request.side_effect = DemistoException("HTTP Connection error occurred. Status: 404. Reason: Not Found")
 
         args = {
             "file_id": "file_id_999",
@@ -1415,24 +1413,61 @@ class TestFilePermissionMethods:
             "permission_id": "perm_id_111",
             "ignore_not_found": "true",
         }
+
+        # Real-world payload observed from production.
+        mocker_http_request.side_effect = DemistoException("Not found. Reason: Permission not found: 12849315382336496719.")
         result: CommandResults = file_permission_delete_command(gsuite_client, args)
         perm_ctx = result.outputs.get("GoogleDrive.FilePermission").get("FilePermission")
         assert perm_ctx.get("alreadyRemoved") is True
         assert perm_ctx.get("id") == "perm_id_111"
         assert perm_ctx.get("fileId") == "file_id_999"
 
+        # Default behavior preserved: with ignore_not_found omitted, the same
+        # Not Found still raises.
         args_default = dict(args)
         args_default.pop("ignore_not_found")
-        with pytest.raises(DemistoException, match="Status: 404"):
+        with pytest.raises(DemistoException, match=r"(?i)permission not found"):
             file_permission_delete_command(gsuite_client, args_default)
+
+    @patch(MOCKER_HTTP_METHOD)
+    def test_file_permission_delete_command_ignore_not_found_file_not_found_still_raises(
+        self, mocker_http_request, gsuite_client
+    ):
+        """
+        Scenario: bogus file_id with ignore_not_found=true must still raise.
+
+        Given:
+        - The shared GSuite client raises DemistoException carrying "File not
+          found" (the parent file does not exist, not the permission).
+        - ignore_not_found=true.
+
+        When:
+        - Calling file_permission_delete_command.
+
+        Then:
+        - The exception still raises; only "permission not found" is swallowed
+          so operator typos in file_id are not silently masked.
+        """
+        from GoogleDrive import file_permission_delete_command
+
+        mocker_http_request.side_effect = DemistoException("Not found. Reason: File not found: bogus_file_id_123.")
+
+        args = {
+            "file_id": "bogus_file_id_123",
+            "user_id": "admin@example.com",
+            "permission_id": "perm_id_111",
+            "ignore_not_found": "true",
+        }
+        with pytest.raises(DemistoException, match=r"(?i)file not found"):
+            file_permission_delete_command(gsuite_client, args)
 
     @patch(MOCKER_HTTP_METHOD)
     def test_file_permission_delete_command_ignore_not_found_other_error_still_raises(self, mocker_http_request, gsuite_client):
         """
-        Scenario: google-drive-file-permission-delete with ignore_not_found=true on non-404.
+        Scenario: google-drive-file-permission-delete with ignore_not_found=true on non-Not Found.
 
         Given:
-        - The shared GSuite client raises DemistoException with "Status: 403".
+        - The shared GSuite client raises a Forbidden DemistoException (not a 404).
         - ignore_not_found=true.
 
         When:

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1015,7 +1015,7 @@ Updates a file's content.
 ### google-drive-file-delete
 
 ***
-Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted.
+Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to true, the file is moved to Trash instead of being permanently deleted.
 
 #### Base Command
 
@@ -1025,16 +1025,16 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values: "true" and "false". Possible values are: true, false. Default is false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| soft_delete | When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior. Possible values are: true, false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | ID of the deleted file. |
-
+| GoogleDrive.File.File.id | String | ID of the deleted file. | 
 ### google-drive-file-permissions-list
 
 ***
@@ -1048,25 +1048,25 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
-| page_token | Page token for shared drives. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values: "true" and "false". Possible values are: true, false. Default is false. | Optional |
-| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
+| page_token | Page token for shared drives. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
-
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
 ### google-drive-file-permission-create
 
 ***
@@ -1080,19 +1080,28 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| send_notification_email | Whether a confirmation email will be sent. Possible values: "true" and "false". Possible values are: true, false. Default is false. | Optional |
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
-| domain | The domain to which this permission refers. | Optional |
-| email_address | The email address of the user or group to which this permission refers. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
+| domain | The domain to which this permission refers. | Optional | 
+| email_address | The email address of the user or group to which this permission refers. | Optional | 
+| transfer_ownership | Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional | 
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
 | GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
@@ -1122,19 +1131,10 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
-| --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
-
 ### google-drive-file-permission-delete
 
 ***
-Delete a permission.
+Delete a permission. When the ignore_not_found argument is set to true, a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
 
 #### Base Command
 
@@ -1144,6 +1144,20 @@ Delete a permission.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| ignore_not_found | When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional | 
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | True when ignore_not_found=true and the permission was already removed \(the vendor returned Not Found\). | 
+
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |
 | permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1025,17 +1025,16 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| soft_delete | Whether to move the file to Trash instead of permanently deleting it. When set to "true", the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior. Possible values are: true, false. Default is false. | Optional |
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| soft_delete | Whether to move the file to the Trash instead of permanently deleting it. If "true", the file is moved to the Trash. If "false", the file is permanently deleted. Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | The ID of the deleted file. |
-
+| GoogleDrive.File.File.id | String | The ID of the deleted file. | 
 ### google-drive-file-permissions-list
 
 ***
@@ -1049,26 +1048,25 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| page_size | The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
-| page_token | The page token for shared drives. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| use_domain_admin_access | Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| page_size | The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
+| page_token | The page token for shared drives. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| use_domain_admin_access | Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
-| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. |
-
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
 ### google-drive-file-permission-create
 
 ***
@@ -1082,27 +1080,27 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional |
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
-| domain | The domain to which this permission refers. | Optional |
-| email_address | The email address of the user or group to which this permission refers. | Optional |
-| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. Default is false. | Optional |
-| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership is set to "true". Possible values are: true, false. Default is false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
+| domain | The domain to which this permission refers. | Optional | 
+| email_address | The email address of the user or group to which this permission refers. | Optional | 
+| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. Default is false. | Optional | 
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership is set to "true". Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
 
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
@@ -1133,7 +1131,6 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
-
 ### google-drive-file-permission-delete
 
 ***
@@ -1147,19 +1144,19 @@ Deletes a permission. When the ignore_not_found argument is set to "true", a Not
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. Default is false. | Optional |
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. |
-| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found. |
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found. | 
 
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1015,7 +1015,7 @@ Updates a file's content.
 ### google-drive-file-delete
 
 ***
-Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to true, the file is moved to Trash instead of being permanently deleted.
+Permanently deletes a file owned by the user without moving it to the trash. If the file belongs to a shared drive the user must be an organizer on the parent. If the target is a folder, all descendants owned by the user are also deleted. When the soft_delete argument is set to "true", the file is moved to Trash instead of being permanently deleted.
 
 #### Base Command
 
@@ -1025,16 +1025,17 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| soft_delete | Whether to move the file to Trash instead of permanently deleting it. When set, the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior. Possible values are: true, false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| soft_delete | Whether to move the file to Trash instead of permanently deleting it. When set to "true", the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | ID of the deleted file. | 
+| GoogleDrive.File.File.id | String | The ID of the deleted file. |
+
 ### google-drive-file-permissions-list
 
 ***
@@ -1048,25 +1049,26 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
-| page_token | Page token for shared drives. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| page_size | The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
+| page_token | The page token for shared drives. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| use_domain_admin_access | Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
-| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. |
+
 ### google-drive-file-permission-create
 
 ***
@@ -1080,27 +1082,27 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
-| domain | The domain to which this permission refers. | Optional | 
-| email_address | The email address of the user or group to which this permission refers. | Optional | 
-| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional | 
-| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional |
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
+| domain | The domain to which this permission refers. | Optional |
+| email_address | The email address of the user or group to which this permission refers. | Optional |
+| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. Default is false. | Optional |
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership is set to "true". Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
 
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
@@ -1131,10 +1133,11 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
+
 ### google-drive-file-permission-delete
 
 ***
-Delete a permission. When the ignore_not_found argument is set to true, a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
+Deletes a permission. When the ignore_not_found argument is set to "true", a Not Found response from the vendor is treated as success and surfaced via the alreadyRemoved output, which is useful inside loops over a previously-listed permission set.
 
 #### Base Command
 
@@ -1144,19 +1147,19 @@ Delete a permission. When the ignore_not_found argument is set to true, a Not Fo
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
-| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to true when ignore_not_found=true and the vendor returned Not Found. | 
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. |
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found. |
 
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1025,16 +1025,17 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| soft_delete | Whether to move the file to the Trash instead of permanently deleting it. If "true", the file is moved to the Trash. If "false", the file is permanently deleted. Possible values are: true, false. Default is false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| soft_delete | Whether to move the file to the Trash instead of permanently deleting it. If "true", the file is moved to the Trash. If "false", the file is permanently deleted. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | The ID of the deleted file. | 
+| GoogleDrive.File.File.id | String | The ID of the deleted file. |
+
 ### google-drive-file-permissions-list
 
 ***
@@ -1048,25 +1049,26 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| page_size | The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
-| page_token | The page token for shared drives. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| use_domain_admin_access | Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| page_size | The maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
+| page_token | The page token for shared drives. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| use_domain_admin_access | Whether to issue the request as a domain administrator. If set to "true", all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
-| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. |
+
 ### google-drive-file-permission-create
 
 ***
@@ -1080,27 +1082,27 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
-| domain | The domain to which this permission refers. | Optional | 
-| email_address | The email address of the user or group to which this permission refers. | Optional | 
-| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. Default is false. | Optional | 
-| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership is set to "true". Possible values are: true, false. Default is false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional |
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
+| domain | The domain to which this permission refers. | Optional |
+| email_address | The email address of the user or group to which this permission refers. | Optional |
+| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. Default is false. | Optional |
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership is set to "true". Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
 
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
@@ -1131,6 +1133,7 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
+
 ### google-drive-file-permission-delete
 
 ***
@@ -1144,19 +1147,19 @@ Deletes a permission. When the ignore_not_found argument is set to "true", a Not
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. Default is false. | Optional | 
+| file_id | The ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
-| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found. | 
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. |
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to "true" when ignore_not_found is set to "true" and the vendor returned Not Found. |
 
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1025,17 +1025,16 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| soft_delete | When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior. Possible values are: true, false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| soft_delete | Whether to move the file to Trash instead of permanently deleting it. When set, the file is patched with trashed=true rather than issuing a hard delete. Omitting this argument preserves the existing hard-delete behavior. Possible values are: true, false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | ID of the deleted file. |
-
+| GoogleDrive.File.File.id | String | ID of the deleted file. | 
 ### google-drive-file-permissions-list
 
 ***
@@ -1049,26 +1048,25 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
-| page_token | Page token for shared drives. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
+| page_token | Page token for shared drives. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
-| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. |
-
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
 ### google-drive-file-permission-create
 
 ***
@@ -1082,27 +1080,27 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional |
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
-| domain | The domain to which this permission refers. | Optional |
-| email_address | The email address of the user or group to which this permission refers. | Optional |
-| transfer_ownership | Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional |
-| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
+| domain | The domain to which this permission refers. | Optional | 
+| email_address | The email address of the user or group to which this permission refers. | Optional | 
+| transfer_ownership | Whether to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional | 
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
 
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
@@ -1133,7 +1131,6 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
-
 ### google-drive-file-permission-delete
 
 ***
@@ -1147,19 +1144,19 @@ Delete a permission. When the ignore_not_found argument is set to true, a Not Fo
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
-| user_id | The user's primary email address. | Optional |
-| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
-| ignore_not_found | When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional |
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
+| user_id | The user's primary email address. | Optional | 
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
+| ignore_not_found | Whether to treat a Not Found response from the vendor (for example, when the permission was already removed) as success and surface it via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional | 
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. |
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. |
-| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | True when ignore_not_found=true and the permission was already removed \(the vendor returned Not Found\). |
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | Whether the permission was already removed. Set to true when ignore_not_found=true and the vendor returned Not Found. | 
 
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/README.md
@@ -1025,16 +1025,17 @@ Permanently deletes a file owned by the user without moving it to the trash. If 
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| soft_delete | When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior. Possible values are: true, false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| soft_delete | When true, the file is moved to Trash (by patching the file with trashed=true) instead of being permanently deleted. Default behavior (omitted) preserves the existing hard-delete behavior. Possible values are: true, false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.File.File.id | String | ID of the deleted file. | 
+| GoogleDrive.File.File.id | String | ID of the deleted file. |
+
 ### google-drive-file-permissions-list
 
 ***
@@ -1048,25 +1049,26 @@ Lists a file's or shared drive's permissions.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional | 
-| page_token | Page token for shared drives. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| page_size | Maximum number of shared drives to return. Acceptable values are 1 to 100, inclusive. Default is 100. | Optional |
+| page_token | Page token for shared drives. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| use_domain_admin_access | Issue the request as a domain administrator. If set to true, all shared drives of the domain in which the requester is an administrator are returned. Possible values are: true, false. Default is false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
-| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
+| GoogleDrive.FilePermission.FilePermission.permissionDetails.permissionType | String | The permission type for this user. Possible values: "file", "member". Only populated for items in shared drives. |
+
 ### google-drive-file-permission-create
 
 ***
@@ -1080,27 +1082,27 @@ Creates a permission for a file or shared drive.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional | 
-| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional | 
-| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional | 
-| domain | The domain to which this permission refers. | Optional | 
-| email_address | The email address of the user or group to which this permission refers. | Optional | 
-| transfer_ownership | Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional | 
-| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| send_notification_email | Whether a confirmation email will be sent. Possible values are: true, false. Default is false. | Optional |
+| role | The role granted by this permission. Possible values: "owner", "organizer", "fileOrganizer", "writer", "commenter", and "reader". Possible values are: owner, organizer, fileOrganizer, writer, commenter, reader. Default is reader. | Optional |
+| type | The type of the grantee. When creating a permission, if type is user or group, you must provide an emailAddress for the user or group. When type is domain, you must provide a domain. No extra information is required for an anyone type. Possible values: "user", "group", "domain", and "anyone". Possible values are: user, group, domain, anyone. Default is anyone. | Optional |
+| domain | The domain to which this permission refers. | Optional |
+| email_address | The email address of the user or group to which this permission refers. | Optional |
+| transfer_ownership | Set to true to transfer ownership of the file to the user identified by the role=owner permission. Required by the vendor when role=owner is specified on an existing file; omitting this argument preserves the existing command behavior. Possible values are: true, false. | Optional |
+| move_to_new_owners_root | Whether to move the file to the new owner's root folder. Only takes effect when transfer_ownership=true. Possible values are: true, false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. | 
-| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. | 
-| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. | 
-| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. | 
-| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. | 
-| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. | 
+| GoogleDrive.FilePermission.FilePermission.deleted | Boolean | Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions. |
+| GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
+| GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of this permission. |
+| GoogleDrive.FilePermission.FilePermission.role | String | The role granted by this permission. |
+| GoogleDrive.FilePermission.FilePermission.type | String | The type of the grantee. |
+| GoogleDrive.FilePermission.FilePermission.photoLink | String | A link to the user's profile photo, if available. |
 
 | GoogleDrive.FilePermission.FilePermission.displayName | String | The "pretty" name of the value of the permission. |
 | GoogleDrive.FilePermission.FilePermission.emailAddress | String | The email address of the user or group to which this permission refers. |
@@ -1131,6 +1133,7 @@ Updates a permission with patch semantics.
 #### Context Output
 
 | **Path** | **Type** | **Description** |
+
 ### google-drive-file-permission-delete
 
 ***
@@ -1144,19 +1147,19 @@ Delete a permission. When the ignore_not_found argument is set to true, a Not Fo
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional | 
-| user_id | The user's primary email address. | Optional | 
-| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional | 
-| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional | 
-| ignore_not_found | When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional | 
+| file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
+| user_id | The user's primary email address. | Optional |
+| permission_id | The ID of the permission. Can be retrieved using the `google-drive-file-permissions-list` command. | Optional |
+| supports_all_drives | Whether the requesting application supports both My Drives and shared drives. Possible values are: true, false. Default is false. | Optional |
+| ignore_not_found | When true, a Not Found response from the vendor (for example, when the permission was already removed) is treated as success and surfaced via the alreadyRemoved output, instead of raising an error. Useful inside loops over a previously-listed permission set. Possible values are: true, false. | Optional |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. | 
-| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. | 
-| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | True when ignore_not_found=true and the permission was already removed \(the vendor returned Not Found\). | 
+| GoogleDrive.FilePermission.FilePermission.fileId | String | The ID of the file whose permission was targeted. |
+| GoogleDrive.FilePermission.FilePermission.id | String | The ID of the deleted permission. |
+| GoogleDrive.FilePermission.FilePermission.alreadyRemoved | Boolean | True when ignore_not_found=true and the permission was already removed \(the vendor returned Not Found\). |
 
 | file_id | ID of the requested file. Can be retrieved using the `google-drive-files-list` command. | Optional |
 | user_id | The user's primary email address. | Optional |

--- a/Packs/GoogleDrive/Integrations/GoogleDrive/command_examples.txt
+++ b/Packs/GoogleDrive/Integrations/GoogleDrive/command_examples.txt
@@ -1,3 +1,7 @@
 !google-drive-file-copy file_id="1O8Gx7DslVpbd-HN7lp4MIN1DDakpw-bHVHCwir2wUlo" copy_title="New Copy"
 !google-drive-file-move file_id="1234567890abcdef" add_parent_id="quarantine_folder_id" remove_parent_id="original_folder_id" user_id="admin@example.com"
 !google-drive-file-create file_name="Quarantine Folder" mime_type="application/vnd.google-apps.folder" user_id="admin@example.com" parent="root"
+!google-drive-file-delete file_id="1234567890abcdef" user_id="owner@example.com" soft_delete="true"
+!google-drive-file-permission-create file_id="1234567890abcdef" user_id="admin@example.com" role="owner" type="user" email_address="newowner@example.com" transfer_ownership="true"
+!google-drive-file-permission-delete file_id="1234567890abcdef" user_id="admin@example.com" permission_id="perm_id_999" ignore_not_found="true" supports_all_drives="true"
+!google-drive-file-permissions-list file_id="1234567890abcdef" user_id="owner@example.com" supports_all_drives="true"

--- a/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
@@ -1,0 +1,9 @@
+
+#### Integrations
+
+##### Google Drive
+
+- Updated the ***google-drive-file-delete*** command to support moving a file to Trash via the new ***soft_delete*** argument, in addition to the existing permanent-delete behavior.
+- Updated the ***google-drive-file-permission-create*** command to support ownership transfer via the new ***transfer_ownership*** and ***move_to_new_owners_root*** arguments. Use these when promoting a user to file owner.
+- Updated the ***google-drive-file-permission-delete*** command with the new ***ignore_not_found*** argument so that already-removed permissions are treated as success. Useful when removing many permissions in a loop.
+- Updated the ***google-drive-file-permissions-list*** command to surface whether each permission is inherited and where it is inherited from.

--- a/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
@@ -3,7 +3,7 @@
 
 ##### Google Drive
 
-- Updated the ***google-drive-file-delete*** command to support moving a file to Trash via the new *soft_delete* argument, in addition to the existing permanent delete behavior.
-- Updated the ***google-drive-file-permission-create*** command to support ownership transfer via the new *transfer_ownership* and *move_to_new_owners_root* arguments. Use these when promoting a user to file owner.
-- Updated the ***google-drive-file-permission-delete*** command with the new *ignore_not_found* argument so that already removed permissions are treated as success. Useful when removing many permissions in a loop.
-- Updated the ***google-drive-file-permissions-list*** command to surface whether each permission is inherited and where it is inherited from.
+- Updated the ***google-drive-file-delete*** command to support moving a file to Trash via the new *soft_delete* argument.
+- Updated the ***google-drive-file-permission-create*** command to support ownership transfer via the new *transfer_ownership* and *move_to_new_owners_root* arguments when promoting a user to file owner.
+- Updated the ***google-drive-file-permission-delete*** command with the new *ignore_not_found* argument, which allows already removed permissions to be treated as a success.
+- Updated the ***google-drive-file-permissions-list*** command to indicate whether each permission is inherited and from where it is inherited.

--- a/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
+++ b/Packs/GoogleDrive/ReleaseNotes/1_5_0.md
@@ -3,7 +3,7 @@
 
 ##### Google Drive
 
-- Updated the ***google-drive-file-delete*** command to support moving a file to Trash via the new ***soft_delete*** argument, in addition to the existing permanent-delete behavior.
-- Updated the ***google-drive-file-permission-create*** command to support ownership transfer via the new ***transfer_ownership*** and ***move_to_new_owners_root*** arguments. Use these when promoting a user to file owner.
-- Updated the ***google-drive-file-permission-delete*** command with the new ***ignore_not_found*** argument so that already-removed permissions are treated as success. Useful when removing many permissions in a loop.
+- Updated the ***google-drive-file-delete*** command to support moving a file to Trash via the new *soft_delete* argument, in addition to the existing permanent delete behavior.
+- Updated the ***google-drive-file-permission-create*** command to support ownership transfer via the new *transfer_ownership* and *move_to_new_owners_root* arguments. Use these when promoting a user to file owner.
+- Updated the ***google-drive-file-permission-delete*** command with the new *ignore_not_found* argument so that already removed permissions are treated as success. Useful when removing many permissions in a loop.
 - Updated the ***google-drive-file-permissions-list*** command to surface whether each permission is inherited and where it is inherited from.

--- a/Packs/GoogleDrive/pack_metadata.json
+++ b/Packs/GoogleDrive/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Drive",
     "description": "Google Drive allows users to store files on their servers, synchronize files across devices, and share files. This integration helps you to create a new drive, query past activity and view change logs performed by the users, as well as list drives and files, and manage their permissions.",
     "support": "xsoar",
-    "currentVersion": "1.4.0",
+    "currentVersion": "1.5.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status

- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

<!-- Replace XXXX with the Jira / issue id. -->


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16954

## Description

Ships four backward-compatible extensions on existing **GoogleDrive** pack commands so the SaaS remediation playbooks (Soft Delete, Admin/System Quarantine, User Quarantine, Change Sharing) can compose entirely from pack primitives without any net-new public commands.

Every change is opt-in (no `defaultValue` on the new args, no removal or rename of any existing context path). Existing playbooks observe bit-identical request URLs and response shapes when the new arguments are omitted.

### What changed

| ID | Surface | Change | Default behavior |
|:---|:---|:---|:---|
| **E1** | `!google-drive-file-delete` | New `soft_delete` boolean arg. When `true`, calls Drive v3 `files.update` (`PATCH /files/{id}`) with body `{"trashed": true}` instead of the existing permanent `DELETE`. | `false`/omitted → today's hard-delete behavior is preserved. |
| **E2** | `!google-drive-file-permission-create` | New `transfer_ownership` and `move_to_new_owners_root` boolean args. Forwarded as the documented `transferOwnership` and `moveToNewOwnersRoot` query parameters on `permissions.create`. | omitted → query parameters are not appended to the URL. |
| **E3** | `!google-drive-file-permission-delete` | New `ignore_not_found` boolean arg. When `true`, a Not Found response from the vendor is treated as success and surfaced via a new `alreadyRemoved` output flag. | `false`/omitted → today's "raise on Not Found" behavior is preserved. |
| **E4** | `!google-drive-file-permissions-list` | Declared the `permissionDetails.{permissionType,inheritedFrom,role,inherited}` outputs that Drive already returns when `fields=*` is requested (yml-only — no Python change). | n/a — purely additive context paths. |

### Backward-compatibility math

- **0** new public commands
- **0** deprecations
- **0** context-path renames
- **4** additive optional args (none have a `defaultValue` — silent defaults are explicitly avoided per the pack's coding standard)
- **9** additive outputs

### Vendor-side spec (cross-checked against the Google Drive v3 Discovery document)

Every change was verified against `https://www.googleapis.com/discovery/v1/apis/drive/v3/rest` (the machine-readable source of truth for the Drive API):

- `files.update` (PATCH) accepts a body with the writable `trashed` boolean. Note: `trashedTime` is documented as **only populated for items in shared drives** — surfaced in the yml output description so playbook authors don't write null-unsafe filters.
- `permissions.create` accepts the GA `transferOwnership` and `moveToNewOwnersRoot` query parameters; without `transferOwnership=true`, posting `role=owner` on an existing file is rejected by Drive with `400 ownershipChangeAcrossDomainNotPermitted` even for in-domain transfers.
- `permissions.delete` returns `204 No Content` on success and `404 notFound` when the permission has already been removed.
- `Permission.permissionDetails[].inherited` is documented as always populated when the request asks for `fields=*` — which the integration already does.

### Implementation notes

- **v3 over v2 for E1.** The trash action could have used `PATCH /drive/v2/files/{id}/trash`, but the rest of the pack is v3-only — introducing a v2 caller would add a new URL_SUFFIX entry and a partial second API version for zero functional benefit. The v3 `{"trashed": true}` PATCH has the same audit footprint (the Drive activity log records `trash`, not `delete`).
- **`move_to_new_owners_root` shipped alongside `transfer_ownership` (E2).** Same call site, no extra plumbing — saves a follow-up MR for the documented companion query parameter.
- **E3 detects `404` by string-matching `"Status: 404"`** in the `DemistoException` message produced by the shared `GSuiteApiModule.COMMON_MESSAGES["HTTP_ERROR"]` template. The alternative (plumbing a `status_code` attribute through `GSuiteApiModule`) was deferred because the blast radius spans every G-Suite integration. A pinned unit test injects the literal `"Status: 404. Reason: Not Found"` substring — if the shared module's template ever changes, the test fails loudly.

### Why no new public commands

Every primitive required by the four downstream remediation flows is already exposed by existing pack commands (`!google-drive-file-get`, `!google-drive-file-move`, `!google-drive-file-create`, `!google-drive-file-permissions-list`, `!google-drive-file-permission-create`, `!google-drive-file-permission-delete`). Composing these in playbooks — gated on the four backward-compatible extensions in this MR — is more flexible than shipping opinionated orchestrator commands, avoids duplicating context paths
### Files changed

| Path | Why |
|:---|:---|
| `Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml` | E1/E2/E3 args + E1/E3/E4 outputs (+56 lines). |
| `Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.py` | E1/E2/E3 Python wiring across three command handlers (+62 lines); Google-style docstrings. |
| `Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive_test.py` | 7 new unit tests covering success, default-preserved, and the 404/non-404 branches of E3 (+276 lines). All tests mock `GSuiteApiModule.GSuiteClient.http_request`; no live API calls. |
| `Packs/GoogleDrive/Integrations/GoogleDrive/README.md` | Regenerated via `demisto-sdk generate-docs`. |
| `Packs/GoogleDrive/Integrations/GoogleDrive/command_examples.txt` | +4 invocations covering each extension. |
| `Packs/GoogleDrive/ReleaseNotes/1_5_0.md` | 4 customer-facing bullets. |
| `Packs/GoogleDrive/pack_metadata.json` | `currentVersion`: `1.4.0` → `1.5.0`. |

### Verification

| Command | Result |
|:---|:---|
| `demisto-sdk format -i Packs/GoogleDrive --no-graph -y` | ✅ |
| `demisto-sdk validate -i Packs/GoogleDrive` | ✅ All validations passed. |
| `demisto-sdk pre-commit -i Packs/GoogleDrive` | ✅ Every hook green: pylint, mypy, **pytest** (7 new + all existing), ruff-format, ruff-py3.10, ruff-py3.12, xsoar-lint, markdownlint, secrets, MDX, brack. |
| `demisto-sdk generate-docs -i Packs/GoogleDrive/Integrations/GoogleDrive/GoogleDrive.yml -e ...command_examples.txt --no-graph` | ✅ README sections replaced for all 4 touched commands. |

## Must have

- [x] Tests — 7 new unit tests cover happy path, default-preserved (no behavioral drift), and edge cases (E3's 404 swallow vs. non-404 re-raise).
- [x] Documentation — README regenerated by `demisto-sdk generate-docs`; arg/output descriptions explain how to obtain ID values and the vendor-side caveats (`trashedTime` only on shared drives, `move_to_new_owners_root` only effective when `transfer_ownership=true`).
- [x] Version bump — pack `currentVersion` bumped minor (1.4.0 → 1.5.0).

relates: link to the issue